### PR TITLE
Add versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ cmake_build/*
 !cmake_build/example_configure.bat.do_not_touch
 !cmake_build/example_configure.sh.do_not_touch
 
+# Version
+kratos/includes/kratos_version.h
+
 # Prerequisites
 *.d
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,18 +14,19 @@ find_package(Git)
 if(GIT_FOUND)
   execute_process(
     COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
-    OUTPUT_VARIABLE KratosMultiphysics_VERSION_GSHA1
+    OUTPUT_VARIABLE KratosMultiphysics_SHA1_NUMBER
     OUTPUT_STRIP_TRAILING_WHITESPACE
   )
+else(GIT_FOUND)
+  message("Git was not found on your system. SHA1 number will be set to 0.")
+  set (KratosMultiphysics_SHA1_NUMBER 0)
 endif(GIT_FOUND)
+
 
 configure_file(
   "${PROJECT_SOURCE_DIR}/kratos_version.h.in"
   "${PROJECT_SOURCE_DIR}/kratos/includes/kratos_version.h"
 )
-
-include(GetGitRevisionDescription)
-get_git_head_revision(GIT_REFSPEC GIT_SHA1)
 
 # Set compiler flags
 if(${CMAKE_COMPILER_IS_GNUCXX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,30 @@ cmake_minimum_required (VERSION 2.8.6)
 project (KratosMultiphysics)
 
 # Set here the version number **** only update upon tagging a release!
-set (KratosMultiphysics_VERSION_MAJOR 5)
-set (KratosMultiphysics_VERSION_MINOR 0)
+set (KratosMultiphysics_MAJOR_VERSION 5)
+set (KratosMultiphysics_MINOR_VERSION 0)
+set (KratosMultiphysics_PATCH_VERSION 0)
 
 # Get subversion data. This is done automagically by the cmakes
 include (GenerateExportHeader)
 
-set (KRATOS_SVN_REVISION_WC_REVISION 0)
+# Search the SHA1 Associated with the commit in the HEAD
+find_package(Git)
+if(GIT_FOUND)
+  execute_process(
+    COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+    OUTPUT_VARIABLE KratosMultiphysics_VERSION_GSHA1
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+endif(GIT_FOUND)
+
 configure_file(
   "${PROJECT_SOURCE_DIR}/kratos_version.h.in"
   "${PROJECT_SOURCE_DIR}/kratos/includes/kratos_version.h"
 )
+
+include(GetGitRevisionDescription)
+get_git_head_revision(GIT_REFSPEC GIT_SHA1)
 
 # Set compiler flags
 if(${CMAKE_COMPILER_IS_GNUCXX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,11 @@
 cmake_minimum_required (VERSION 2.8.6)
 project (KratosMultiphysics)
 
-#set here the version number **** only update upon tagging a release!
+# Set here the version number **** only update upon tagging a release!
 set (KratosMultiphysics_VERSION_MAJOR 5)
 set (KratosMultiphysics_VERSION_MINOR 0)
 
-#get subversion data. This is done automagically by the cmakes
+# Get subversion data. This is done automagically by the cmakes
 include (GenerateExportHeader)
 
 set (KRATOS_SVN_REVISION_WC_REVISION 0)
@@ -14,7 +14,7 @@ configure_file(
   "${PROJECT_SOURCE_DIR}/kratos/includes/kratos_version.h"
 )
 
-#set compiler flags
+# Set compiler flags
 if(${CMAKE_COMPILER_IS_GNUCXX})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops -ffast-math -Wall -std=c++11")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funroll-loops -ffast-math -Wall")
@@ -87,7 +87,7 @@ if(${MSVC14})
   SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
 endif(${MSVC14})
 
-#tell the linker to give an error if undefined functions are found
+# Tell the linker to give an error if undefined functions are found
 # set(CMAKE_SHARED_LINKER_FLAGS "-Wl,--no-undefined")
 
 # Set kratos specific module path
@@ -102,9 +102,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake_modules")
 #     find_library(EXTRA_LINK_LIBS ${KRATOS_EXTRA_LINK_LIBRARIES} PATH ${KRATOS_EXTRA_LINK_PATH} )
 # endif(DEFINED KRATOS_EXTRA_LINK_LIBRARIES)
 
-
-
-##find all dependencies
+## Find all dependencies
 
 ##*****************************
 #find and include OpenMP if possible

--- a/kratos_version.h.in
+++ b/kratos_version.h.in
@@ -1,8 +1,9 @@
 //defines for the kratos version
-#define KRATOS_MAJOR_VERSION  @KratosMultiphysics_VERSION_MAJOR@
-#define KRATOS_MINOR_VERSION  @KratosMultiphysics_VERSION_MINOR@
+#define KRATOS_MAJOR_VERSION  @KratosMultiphysics_MAJOR_VERSION@
+#define KRATOS_MINOR_VERSION  @KratosMultiphysics_MINOR_VERSION@
+#define KRATOS_PATCH_VERSION  @KratosMultiphysics_PATCH_VERSION@
 
 //svn version at configure time
-#define KRATOS_SVN_REVISION  @KRATOS_SVN_REVISION_WC_REVISION@ 
+#define KRATOS_SHA1_NUMBER  @KratosMultiphysics_SHA1_NUMBER@
 
-#define KRATOS_VERSION  "@KratosMultiphysics_VERSION_MAJOR@.@KratosMultiphysics_VERSION_MINOR@.@KRATOS_SVN_REVISION_WC_REVISION@"
+#define KRATOS_VERSION  "@KratosMultiphysics_MAJOR_VERSION@.@KratosMultiphysics_MINOR_VERSION@.@KratosMultiphysics_PATCH_VERSION@-@KratosMultiphysics_SHA1_NUMBER@"


### PR DESCRIPTION
This PR fixes #5 by adding the short version of the SHA1 associated with the git commit in the HEAD. This replaces the old svn revision.

I also added a "patch" number so the version is more familiar with the one we had before the migration:

* MAJOR.MINOR.PATCH-NUMBER

For example:

* 5.0.0-9b5b07fe7