### PR TITLE
Calculate method fixed (was ignoring all the capabilities of the base class)

### DIFF
--- a/applications/DEM_application/custom_elements/spheric_continuum_particle.cpp
+++ b/applications/DEM_application/custom_elements/spheric_continuum_particle.cpp
@@ -798,6 +798,8 @@ namespace Kratos {
             }
             return;
         }//CRITICAL DELTA CALCULATION
+        
+        SphericParticle::Calculate(rVariable, Output, r_process_info);
 
         KRATOS_CATCH("")
     }//Calculate


### PR DESCRIPTION
I added a call to the same function of the base class