### PR TITLE
Feature move nighlty to git

### DIFF
--- a/scripts/build/nightly_build.sh
+++ b/scripts/build/nightly_build.sh
@@ -22,7 +22,7 @@ chmod 777 smtp-cli
 
 wget https://github.com/KratosMultiphysics/Kratos/archive/master.tar.gz
 tar xzf master.tar.gz
-mv ${HOME}master/Kratos-master ${HOME}/Kratos
+mv ${HOME}/Kratos-master ${HOME}/Kratos
 cd ${HOME}/Kratos
 
 mkdir -p cmake_gcc

--- a/scripts/build/nightly_build.sh
+++ b/scripts/build/nightly_build.sh
@@ -19,10 +19,11 @@ export PYTHONPATH=$PYTHONPATH:/home/ubuntu/Kratos
 cd ${HOME}
 wget http://www.logix.cz/michal/devel/smtp-cli/smtp-cli
 chmod 777 smtp-cli
-mkdir Kratos
 
+wget https://github.com/KratosMultiphysics/Kratos/archive/master.tar.gz
+tar xzf master.tar.gz
+mv ${HOME}master/Kratos-master ${HOME}/Kratos
 cd ${HOME}/Kratos
-svn co https://svn.cimne.upc.edu/p/kratos/kratos .
 
 mkdir -p cmake_gcc
 mkdir -p cmake_clang


### PR DESCRIPTION
This is related with #11 and makes the changes so the code is fetch from Github rather than svn.

I've selected to download it using `wget` rather than `git clone` mainly because git is not part of the ubuntu 16.04 LTS default packages ( as far as I know ), and trying to install it from apt-get could trigger a problem with https://help.ubuntu.com/lts/serverguide/automatic-updates.html

Pls do not close the issue yet...