### PR TITLE
Fixing issue with ml_solver constructor.

### DIFF
--- a/applications/trilinos_application/external_includes/ml_solver.h
+++ b/applications/trilinos_application/external_includes/ml_solver.h
@@ -155,6 +155,8 @@ public:
         mmax_iter = nit_max;
         mScalingType = LeftScaling;
 
+        mMLPrecIsInitialized = false;
+        mReformPrecAtEachStep = true;
     }
 
     /**


### PR DESCRIPTION
Adding missing initialization of member variables to ml solver constructor. It used to be there, but we mistakenly deleted them when adding a new JSON style constructor.

@msandre Can you please check that I didn't break anything?