### PR TITLE
Tolerance addition to Json check results process

### DIFF
--- a/kratos/python_scripts/from_json_check_result_process.py
+++ b/kratos/python_scripts/from_json_check_result_process.py
@@ -21,14 +21,14 @@ def linear_interpolation(x, x_list, y_list):
         if x_list[-(1 + i)] >= x:
             ind_sup = -(1 + i)
             x_sup = x_list[ind_sup]
-    
+
     if (x_sup-x_inf == 0):
         y = y_list[ind_inf]
     else:
         prop_sup = (x-x_inf)/(x_sup-x_inf)
         prop_inf = 1.0 - prop_sup
-        y = y_list[ind_inf] * prop_inf + y_list[ind_sup] * prop_sup 
-    
+        y = y_list[ind_inf] * prop_inf + y_list[ind_sup] * prop_sup
+
     return y
 
 def Factory(settings, Model):
@@ -37,9 +37,9 @@ def Factory(settings, Model):
     return FromJsonCheckResultProcess(Model, settings["Parameters"])
 
 class FromJsonCheckResultProcess(KratosMultiphysics.Process, KratosUnittest.TestCase):
-  
+
     def __init__(self,model_part,params):
-        
+
         ## Settings string in json format
         default_parameters = KratosMultiphysics.Parameters("""
         {
@@ -47,14 +47,15 @@ class FromJsonCheckResultProcess(KratosMultiphysics.Process, KratosUnittest.Test
             "input_file_name"      : "",
             "model_part_name"      : "",
             "sub_model_part_name"  : "",
+            "tolerance"            : 1e-3,
             "time_frequency"       : 1.00
         }
         """)
-        
+
         ## Overwrite the default settings with user-provided parameters
         self.params = params
         self.params.ValidateAndAssignDefaults(default_parameters)
-        
+
         self.model_part = model_part
 
         self.params = params
@@ -63,7 +64,7 @@ class FromJsonCheckResultProcess(KratosMultiphysics.Process, KratosUnittest.Test
         self.frequency    = 0.0
         self.time_counter = 0.0
         self.data = {}
-        
+
     def ExecuteInitialize(self):
         input_file_name = self.params["input_file_name"].GetString()
         if (len(self.params["sub_model_part_name"].GetString()) > 0):
@@ -73,14 +74,15 @@ class FromJsonCheckResultProcess(KratosMultiphysics.Process, KratosUnittest.Test
         self.check_variables = self.__generate_variable_list_from_input(self.params["check_variables"])
         self.frequency = self.params["time_frequency"].GetDouble()
         self.data =  read_external_json(input_file_name)
-        
+
     def ExecuteBeforeSolutionLoop(self):
         pass
-    
+
     def ExecuteInitializeSolutionStep(self):
         pass
 
     def ExecuteFinalizeSolutionStep(self):
+        tol = self.params["tolerance"].GetDouble()
         time = self.sub_model_part.ProcessInfo.GetValue(KratosMultiphysics.TIME)
         dt = self.sub_model_part.ProcessInfo.GetValue(KratosMultiphysics.DELTA_TIME)
         self.time_counter += dt
@@ -98,25 +100,26 @@ class FromJsonCheckResultProcess(KratosMultiphysics.Process, KratosUnittest.Test
                         value_scalar = False
 
                     value = node.GetSolutionStepValue(variable, 0)
+                    # Scalar variable
                     if value_scalar:
                         values_json = self.data["NODE_"+str(node.Id)][out.GetString() ]
                         value_json = linear_interpolation(time, input_time_list, values_json)
-                        #value_json = np.interp(time, input_time_list, values_json)
-                        self.assertAlmostEqual(value, value_json, 4)
-                    else: # It is a vector
+                        self.assertAlmostEqual(value, value_json, msg=("Error checking node "+str(node.Id)+" "+out.GetString()+" results."), delta=tol)
+                    # Vector variable
+                    else:
+                        # X-component
                         values_json = self.data["NODE_"+str(node.Id)][out.GetString()  + "_X"]
                         value_json = linear_interpolation(time, input_time_list, values_json)
-                        #value_json = np.interp(time, input_time_list, values_json)
-                        self.assertAlmostEqual(value[0], value_json, 4)
+                        self.assertAlmostEqual(value[0], value_json, msg=("Error checking node "+str(node.Id)+" "+out.GetString()+" X-component results."), delta=tol)
+                        # Y-component
                         values_json = self.data["NODE_"+str(node.Id)][out.GetString()  + "_Y"]
                         value_json = linear_interpolation(time, input_time_list, values_json)
-                        #value_json = np.interp(time, input_time_list, values_json)
-                        self.assertAlmostEqual(value[1], value_json, 4)
+                        self.assertAlmostEqual(value[1], value_json, msg=("Error checking node "+str(node.Id)+" "+out.GetString()+" Y-component results."), delta=tol)
+                        # Z-component
                         values_json = self.data["NODE_"+str(node.Id)][out.GetString()  + "_Z"]
                         value_json = linear_interpolation(time, input_time_list, values_json)
-                        #value_json = np.interp(time, input_time_list, values_json)
-                        self.assertAlmostEqual(value[2], value_json, 4)
-              
+                        self.assertAlmostEqual(value[2], value_json, msg=("Error checking node "+str(node.Id)+" "+out.GetString()+" Z-component results."), delta=tol)
+
     def ExecuteBeforeOutputStep(self):
         pass
 
@@ -125,7 +128,7 @@ class FromJsonCheckResultProcess(KratosMultiphysics.Process, KratosUnittest.Test
 
     def ExecuteFinalize(self):
         pass
-      
+
     def __generate_variable_list_from_input(self,param):
       '''Parse a list of variables from input.'''
       # At least verify that the input is a string
@@ -134,4 +137,3 @@ class FromJsonCheckResultProcess(KratosMultiphysics.Process, KratosUnittest.Test
 
       # Retrieve variable name from input (a string) and request the corresponding C++ object to the kernel
       return [ KratosMultiphysics.KratosGlobals.GetVariable( param[i].GetString() ) for i in range( 0,param.size() ) ]
-


### PR DESCRIPTION
Now the check is performed according to a tolerance instead of using a number of places. An error message describing which node and variable is failing has been added too.