### PR TITLE
fixing parsing errors in adjoint tests

### DIFF
--- a/applications/AdjointFluidApplication/tests/test_input_output/input_test_parameters.json
+++ b/applications/AdjointFluidApplication/tests/test_input_output/input_test_parameters.json
@@ -17,7 +17,6 @@
         "oss_switch"                    : 0,
         "echo_level"                    : 0,
         "consider_periodic_conditions"  : false,
-        "time_order"                    : 2,
         "compute_reactions"             : false,
         "divergence_clearance_steps"    : 0,
         "reform_dofs_at_each_step"      : false,

--- a/applications/AdjointFluidApplication/tests/test_input_output/output_test_parameters.json
+++ b/applications/AdjointFluidApplication/tests/test_input_output/output_test_parameters.json
@@ -17,7 +17,6 @@
         "oss_switch"                    : 0,
         "echo_level"                    : 0,
         "consider_periodic_conditions"  : false,
-        "time_order"                    : 2,
         "compute_reactions"             : false,
         "divergence_clearance_steps"    : 0,
         "reform_dofs_at_each_step"      : false,

--- a/applications/AdjointFluidApplication/tests/test_vms_sensitivity_2d/cylinder_test_parameters.json
+++ b/applications/AdjointFluidApplication/tests/test_vms_sensitivity_2d/cylinder_test_parameters.json
@@ -47,7 +47,6 @@
         "oss_switch"                   : 0,
         "echo_level"                   : 0,
         "consider_periodic_conditions" : false,
-        "time_order"                   : 2,
         "compute_reactions"            : true,
         "divergence_clearance_steps"   : 0,
         "reform_dofs_at_each_step"     : false,

--- a/applications/AdjointFluidApplication/tests/test_vms_sensitivity_2d/one_element_test_parameters.json
+++ b/applications/AdjointFluidApplication/tests/test_vms_sensitivity_2d/one_element_test_parameters.json
@@ -17,7 +17,6 @@
         "oss_switch"                    : 0,
         "echo_level"                    : 0,
         "consider_periodic_conditions"  : false,
-        "time_order"                    : 2,
         "compute_reactions"             : false,
         "divergence_clearance_steps"    : 0,
         "reform_dofs_at_each_step"      : false,

--- a/applications/AdjointFluidApplication/tests/test_vms_sensitivity_2d/steady_cylinder_test_parameters.json
+++ b/applications/AdjointFluidApplication/tests/test_vms_sensitivity_2d/steady_cylinder_test_parameters.json
@@ -49,7 +49,6 @@
         "oss_switch"                   : 0,
         "echo_level"                   : 0,
         "consider_periodic_conditions" : false,
-        "time_order"                   : 2,
         "compute_reactions"            : true,
         "divergence_clearance_steps"   : 0,
         "reform_dofs_at_each_step"     : false,

--- a/applications/FluidDynamicsApplication/python_scripts/steady_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/steady_navier_stokes_solver_vmsmonolithic.py
@@ -80,13 +80,12 @@ class SteadyNavierStokesSolver_VMSMonolithic(navier_stokes_solver_vmsmonolithic.
                                                                             self.settings["maximum_iterations"].GetInt(),
                                                                             self.settings["compute_reactions"].GetBool(),
                                                                             self.settings["reform_dofs_at_each_step"].GetBool(),
-                                                                            self.settings["MoveMeshFlag"].GetBool())
+                                                                            self.settings["move_mesh_flag"].GetBool())
 
         (self.solver).SetEchoLevel(self.settings["echo_level"].GetInt())
         (self.solver).Check()
 
         self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DYNAMIC_TAU, self.settings["dynamic_tau"].GetDouble())
         self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.OSS_SWITCH, self.settings["oss_switch"].GetInt())
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.M, self.settings["regularization_coef"].GetDouble())
 
         print ("Monolithic solver initialization finished.")


### PR DESCRIPTION
@jcotela can you review since the only change outside the adjoint app is in fluid dynamics?

I'm using the steady_navier_stokes_solver_vms_monolithic.py there as a wrapper to the usual transient solver to solve steady problems. After default json parameters were changed the steady script no longer works. This fixes the immediate problem. A better solution would require modifying the json in navier_stokes_solver_vmsmonolithic.py to include a "scheme_type" allowing different schemes to be combined with the solver. This could also replace the "consider_periodic_conditions" parameter.