### PR TITLE
fixed error when Clear() called with trilinos sparse space

### DIFF
--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -259,6 +259,7 @@ public:
      
     virtual ~ResidualBasedNewtonRaphsonStrategy()
     {
+        Clear();
     }
 
     /**
@@ -452,22 +453,20 @@ public:
     {
         KRATOS_TRY;
 
-        SparseSpaceType::Clear(mpA);
-        TSystemMatrixType& A = *mpA;
-        SparseSpaceType::Resize(A, 0, 0);
+        // if the preconditioner is saved between solves, it
+        // should be cleared here.
+        GetBuilderAndSolver()->GetLinearSystemSolver()->Clear();
 
-        SparseSpaceType::Clear(mpDx);
-        TSystemVectorType& Dx = *mpDx;
-        SparseSpaceType::Resize(Dx, 0);
-
-        SparseSpaceType::Clear(mpb);
-        TSystemVectorType& b = *mpb;
-        SparseSpaceType::Resize(b, 0);
+        if (mpA != nullptr)
+            SparseSpaceType::Clear(mpA);
+        if (mpDx != nullptr)
+            SparseSpaceType::Clear(mpDx);
+        if (mpb != nullptr)
+            SparseSpaceType::Clear(mpb);
 
         //setting to zero the internal flag to ensure that the dof sets are recalculated
         GetBuilderAndSolver()->SetDofSetIsInitializedFlag(false);
         GetBuilderAndSolver()->Clear();
-
         GetScheme()->Clear();
 
         if (this->GetEchoLevel() > 0)


### PR DESCRIPTION
I noticed that when Clear() was called with trilinos sparse space it was calling the sparse space method clear on the matrix and then trying to resize the matrix to zero. The resize functionality is not implemented in trilinos sparse space so this throws an error. On the other hand, if the ublas space is used, the resize to zero is already done in the clear function so it is redundant. I updated the Clear() function to have the same behavior as the ResidualBasedLinearStrategy() so that it also correctly clears the linear solver. This prevents some segmentation fault when the trilinos ML package is used with the preconditioner storing a reference to the system matrix by clearing the memory in the correct order.