### PR TITLE
Avoiding assert in debug mode

### DIFF
--- a/external_libraries/gidpost/CMakeLists.txt
+++ b/external_libraries/gidpost/CMakeLists.txt
@@ -11,6 +11,7 @@ set( GIDPOST_SOURCES
      )
 ##gidpostfor.c gidpostforAPI.c
 
+add_definitions(-DNDEBUG)
 add_definitions( -DUSE_CONST )
 add_definitions( -w )
 

--- a/external_libraries/gidpost/CMakeLists.txt
+++ b/external_libraries/gidpost/CMakeLists.txt
@@ -12,6 +12,7 @@ set( GIDPOST_SOURCES
 ##gidpostfor.c gidpostforAPI.c
 
 add_definitions(-DNDEBUG)
+message("WARNING: YOUR GIDPOST IS BEING COMPILED  WITHOUT DEBUG (ALL ASSERTS WILL BE AVOIDED)")
 add_definitions( -DUSE_CONST )
 add_definitions( -w )
 

--- a/external_libraries/gidpost/source/CMakeLists.txt
+++ b/external_libraries/gidpost/source/CMakeLists.txt
@@ -4,6 +4,7 @@ set (gidpost_source
   gidpostHash.c hashtab.c recycle.c lookupa.c)
 
 add_definitions(-DNDEBUG)
+message("WARNING: YOUR GIDPOST IS BEING COMPILED  WITHOUT DEBUG (ALL ASSERTS WILL BE AVOIDED)")
 
 find_package(HDF5)
 if (HDF5_FOUND)

--- a/external_libraries/gidpost/source/CMakeLists.txt
+++ b/external_libraries/gidpost/source/CMakeLists.txt
@@ -3,6 +3,8 @@ set (gidpost_source
   gidpost.c gidpostInt.c  gidpostfor.c gidpostforAPI.c
   gidpostHash.c hashtab.c recycle.c lookupa.c)
 
+add_definitions(-DNDEBUG)
+
 find_package(HDF5)
 if (HDF5_FOUND)
   option (HDF5 "Use HDF5" OFF)

--- a/kratos/includes/gid_io.h
+++ b/kratos/includes/gid_io.h
@@ -101,6 +101,8 @@ public:
 //                 mMeshFileName += ".post.msh";
         SetUpMeshContainers();
         SetUpGaussPointContainers();
+        
+        GiD_PostInit();
     }
 
     ///Destructor.
@@ -113,6 +115,8 @@ public:
             GiD_fClosePostResultFile( mResultFile );
             mResultFileOpen = false;
         }
+        
+        GiD_PostDone();
     }
 
     ///initialization functions
@@ -1090,7 +1094,7 @@ public:
                     mResultFile = GiD_fOpenPostResultFile((char*)(file_name.str()).c_str(), mMode);
                     mResultFileOpen = true;
                 }
-				mMeshFile = mResultFile;
+                mMeshFile = mResultFile;
             }
         }
         if ( mUseMultiFile == SingleFile )
@@ -1099,8 +1103,8 @@ public:
             {
                 std::stringstream file_name;
                 file_name << mResultFileName << ".post.bin";
-		         //KRATOS_WATCH(file_name.str())
-		        mResultFile = GiD_fOpenPostResultFile((char*)(file_name.str()).c_str(), mMode);
+                //KRATOS_WATCH(file_name.str())
+                mResultFile = GiD_fOpenPostResultFile((char*)(file_name.str()).c_str(), mMode);
                 if ( mResultFile == 0) //error handler can not be zero
                 {
                     std::stringstream buffer;
@@ -1108,7 +1112,7 @@ public:
                     KRATOS_THROW_ERROR(std::runtime_error, buffer.str(), "");
                 }
                 mResultFileOpen = true;
-				mMeshFile = mResultFile;
+                mMeshFile = mResultFile;
             }
             if ( mMode == GiD_PostAscii && ! mMeshFileOpen )
             {
@@ -1117,7 +1121,6 @@ public:
                 mMeshFile = GiD_fOpenPostMeshFile( (char *)(file_name.str()).c_str(), mMode);
                 mMeshFileOpen = true;
             }
-
         }
     }
 
@@ -1165,7 +1168,7 @@ public:
                 GiD_fWriteCoordinates(mMeshFile, node_iterator->Id(), node_iterator->X(),
                                       node_iterator->Y(), node_iterator->Z() );
             else
-                KRATOS_THROW_ERROR( std::logic_error,"undefined WriteDeformedMeshFlag","" );
+                KRATOS_ERROR << "Undefined WriteDeformedMeshFlag" << std::endl;
         }
         GiD_fEndCoordinates(mMeshFile);
         int nodes_id[1];
@@ -1210,7 +1213,7 @@ public:
                 GiD_fWriteCoordinates( mMeshFile, node_iterator->Id(), node_iterator->X(),
                                       node_iterator->Y(), node_iterator->Z() );
             else
-                KRATOS_THROW_ERROR( std::logic_error,"undefined WriteDeformedMeshFlag","" );
+                KRATOS_ERROR << "Undefined WriteDeformedMeshFlag" << std::endl;
         }
         GiD_fEndCoordinates( mMeshFile );
 
@@ -1259,7 +1262,7 @@ void WriteCircleMesh( MeshType& rThisMesh )
                 GiD_fWriteCoordinates( mMeshFile, node_iterator->Id(), node_iterator->X(),
                                       node_iterator->Y(), node_iterator->Z() );
             else
-                KRATOS_THROW_ERROR( std::logic_error,"undefined WriteDeformedMeshFlag","" );
+                KRATOS_ERROR << "Undefined WriteDeformedMeshFlag" << std::endl;
         }
         GiD_fEndCoordinates( mMeshFile );
         int nodes_id[1];
@@ -1301,7 +1304,7 @@ void WriteClusterMesh( MeshType& rThisMesh )
                 GiD_fWriteCoordinates( mMeshFile, node_iterator->Id(), node_iterator->X(),
                                       node_iterator->Y(), node_iterator->Z() );
             else
-                KRATOS_THROW_ERROR( std::logic_error,"undefined WriteDeformedMeshFlag","" );
+                KRATOS_ERROR << "Undefined WriteDeformedMeshFlag" << std::endl;
         }
         GiD_fEndCoordinates( mMeshFile );
 
@@ -1376,7 +1379,7 @@ void WriteClusterMesh( MeshType& rThisMesh )
             else if ( mWriteDeformed == WriteUndeformed )
                 it->WriteMesh(mMeshFile,false);
             else
-                KRATOS_THROW_ERROR( std::logic_error, "undefined WriteDeformedMeshFlag" , "" );
+                KRATOS_ERROR << "Undefined WriteDeformedMeshFlag" << std::endl;
 
             ModelPart::NodesContainerType tempNodes = it->GetMeshNodes();
             for( ModelPart::NodesContainerType::iterator iter = tempNodes.begin(); iter != tempNodes.end(); iter++ )


### PR DESCRIPTION
This is temporal solution, the new gidpost library is giving problems with the new versions of gcc, so instead of updating the whole library I just added that in case of debug mode we avoid the assertions (Jorge from giD group recommended that)