### PR TITLE
Using KratosGlobals.GetVariable() in experimental_assign_value_process

### DIFF
--- a/kratos/python_scripts/experimental_assign_value_process.py
+++ b/kratos/python_scripts/experimental_assign_value_process.py
@@ -79,7 +79,6 @@ class AssignValueProcess(KratosMultiphysics.Process):
 
 
         self.model_part = Model[settings["model_part_name"].GetString()]
-        # self.variable = getattr(KratosMultiphysics, settings["variable_name"].GetString())
         self.variable = KratosMultiphysics.KratosGlobals.GetVariable(settings["variable_name"].GetString())
         self.mesh = self.model_part.GetMesh(settings["mesh_id"].GetInt())
         self.interval = KratosMultiphysics.Vector(2)

--- a/kratos/python_scripts/experimental_assign_value_process.py
+++ b/kratos/python_scripts/experimental_assign_value_process.py
@@ -79,7 +79,8 @@ class AssignValueProcess(KratosMultiphysics.Process):
 
 
         self.model_part = Model[settings["model_part_name"].GetString()]
-        self.variable = getattr(KratosMultiphysics, settings["variable_name"].GetString())
+        # self.variable = getattr(KratosMultiphysics, settings["variable_name"].GetString())
+        self.variable = KratosMultiphysics.KratosGlobals.GetVariable(settings["variable_name"].GetString())
         self.mesh = self.model_part.GetMesh(settings["mesh_id"].GetInt())
         self.interval = KratosMultiphysics.Vector(2)
         self.interval[0] = settings["interval"][0].GetDouble()


### PR DESCRIPTION
Using KratosGlobals.GetVariable() to get the desired variable. Otherwise non core variables cannot be used. Note that this is just a temporary solution until the processes discussion is finished.