### PR TITLE
Feature fix quality metrics

### DIFF
--- a/embedded_python/CMakeLists.txt
+++ b/embedded_python/CMakeLists.txt
@@ -7,9 +7,9 @@ link_directories(${PYTHON_LIBRARIES})
 include(InstallRequiredSystemLibraries)
 
 ## generate variables with the sources
-set( EMBEDDED_PYTHON_SOURCES     
+set( EMBEDDED_PYTHON_SOURCES
  	${CMAKE_CURRENT_SOURCE_DIR}/krun_main.cpp
-     ) 
+     )
 
 
 ###############################################################
@@ -19,4 +19,3 @@ install(TARGETS runkratos DESTINATION . )
 
 message("python libraries to be installed are: " ${PYTHON_LIBRARIES} )
 install(FILES ${PYTHON_LIBRARIES} DESTINATION .)
-

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -331,8 +331,8 @@ public:
      */
     virtual double Length() const
     {
-        constexpr double factor = 12.0/std::sqrt(2.0);                          //2.0396489026555;  // 12/sqrt(2);
-        return factor * pow(std::fabs(Volume()), 0.33333333333333);            //sqrt(fabs( DeterminantOfJacobian(PointType())));
+        constexpr double factor = 2.0396489026555;  // 12/sqrt(2);
+        return  factor * pow(std::fabs(Volume()), 0.33333333333333); //sqrt(fabs( DeterminantOfJacobian(PointType())));
     }
 
     /**

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -500,9 +500,9 @@ public:
       double y30 = rP2[1] - rP3[1];
       double z30 = rP2[2] - rP3[2];
 
-      double detJMX = s10 * y20 * z30 + y10 * z20 * s30 + z10 * s20 * y30 - s30 * y20 * z30 - y30 * z20 * s10 - z30 * s20 * y10;
-      double detJMY = s10 * x20 * z30 + x10 * z20 * s30 + z10 * s20 * x30 - s30 * x20 * z30 - x30 * z20 * s10 - z30 * s20 * x10;
-      double detJMZ = s10 * x20 * y30 + x10 * y20 * s30 + y10 * s20 * x30 - s30 * x20 * y30 - x30 * y20 * s10 - y30 * s20 * x10;
+      double detJMX = s10 * y20 * z30 + y10 * z20 * s30 + z10 * s20 * y30 - s30 * y20 * z10 - y30 * z20 * s10 - z30 * s20 * y10;
+      double detJMY = s10 * x20 * z30 + x10 * z20 * s30 + z10 * s20 * x30 - s30 * x20 * z10 - x30 * z20 * s10 - z30 * s20 * x10;
+      double detJMZ = s10 * x20 * y30 + x10 * y20 * s30 + y10 * s20 * x30 - s30 * x20 * y10 - x30 * y20 * s10 - y30 * s20 * x10;
       double detJAL = x10 * y20 * z30 + y10 * z20 * x30 + z10 * x20 * y30 - x30 * y20 * z10 - y30 * z20 * x10 - z30 * x20 * y10;
 
       return std::sqrt( (detJMX*detJMX + detJMY*detJMY + detJMZ*detJMZ)) / (2*std::abs(detJAL));

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -331,8 +331,8 @@ public:
      */
     virtual double Length() const
     {
-        const double param = 2.0396489026555;  //12/raiz(2);
-        return  param * pow(Volume(), 0.33333333333333); //sqrt(fabs( DeterminantOfJacobian(PointType())));
+        constexpr double factor = 12.0/std::sqrt(2.0);                          //2.0396489026555;  // 12/sqrt(2);
+        return factor * pow(std::fabs(Volume()), 0.33333333333333);            //sqrt(fabs( DeterminantOfJacobian(PointType())));
     }
 
     /**

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -700,9 +700,9 @@ public:
      * @return [description]
      */
     virtual double VolumeToAverageEdgeLength() const {
-      constexpr double normFactor = 3.0 * 1.41421356237309504880;
+      constexpr double normFactor = 6.0 * 1.41421356237309504880;
 
-      return normFactor * Volume() / AverageEdgeLength();
+      return normFactor * Volume() / std::pow(AverageEdgeLength(), 3);
     }
 
     /** Calculates the volume to average edge length quality metric.

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -331,8 +331,8 @@ public:
      */
     virtual double Length() const
     {
-        constexpr double factor = 2.0396489026555;  // 12/sqrt(2);
-        return  factor * pow(std::fabs(Volume()), 0.33333333333333); //sqrt(fabs( DeterminantOfJacobian(PointType())));
+        constexpr double factor = 2.0396489026555;                              // (12/sqrt(2)) ^ 1/3);
+        return  factor * pow(std::fabs(Volume()), 0.33333333333333);            // sqrt(fabs( DeterminantOfJacobian(PointType())));
     }
 
     /**

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -357,13 +357,7 @@ public:
     /** This method calculates and returns the volume of this geometry.
      * This method calculates and returns the volume of this geometry.
      *
-     * Please note that the folling simplification is used during the
-     * calculus of the determinant in order to reduce the number of operations:
-     *
-     * | a e i 1 |   | a-d e-h i-l |
-     * | b f j 1 | = | b-d f-h j-l |
-     * | c g k 1 |   | c-d g-h k-l |
-     * | d h l 1 |
+     * This method uses the V = (A x B) * C / 6 formula.
      *
      * @return double value contains length, area or volume.
      *

--- a/kratos/testing/tester.cpp
+++ b/kratos/testing/tester.cpp
@@ -227,19 +227,18 @@ namespace Kratos
 		void Tester::SelectTestCasesByPattern(std::string const& TestCasesNamePattern)
 		{
 			// creating the regex pattern replacing * with ".*"
-
-#if __cplusplus <= 199711L
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ < 4 || (__GNUC__ == 4 && (__GNUC_MINOR__ < 9))) 
 			KRATOS_ERROR << "This method is not compiled well. You should use a GCC 4.9 or higher" << std::endl;
-#else
-			 std::regex replace_star("\\*");
-			 std::stringstream regex_pattern_string;
-			 std::regex_replace(std::ostreambuf_iterator<char>(regex_pattern_string),
-			 	TestCasesNamePattern.begin(), TestCasesNamePattern.end(), replace_star, ".*");
-			 for (auto i_test = GetInstance().mTestCases.begin();
-			 i_test != GetInstance().mTestCases.end(); i_test++)
-			 	if (std::regex_match(i_test->second->Name(), std::regex(regex_pattern_string.str())))
-			 		i_test->second->Select();
-#endif
+#else  
+			std::regex replace_star("\\*");
+			std::stringstream regex_pattern_string;
+			std::regex_replace(std::ostreambuf_iterator<char>(regex_pattern_string),
+				TestCasesNamePattern.begin(), TestCasesNamePattern.end(), replace_star, ".*");
+			for (auto i_test = GetInstance().mTestCases.begin();
+				i_test != GetInstance().mTestCases.end(); i_test++)
+				if (std::regex_match(i_test->second->Name(), std::regex(regex_pattern_string.str())))
+					i_test->second->Select();
+#endif  
 		}
 
 		void Tester::RunSelectedTestCases()

--- a/kratos/testing/tester.cpp
+++ b/kratos/testing/tester.cpp
@@ -228,8 +228,7 @@ namespace Kratos
 		{
 			// creating the regex pattern replacing * with ".*"
 
-#if defined(__GNUC__) &&( __GNUC__ < 4 || \
-              (__GNUC__ == 4 && (__GNUC_MINOR__ < 9))) 
+#if __cplusplus <= 199711L
 			KRATOS_ERROR << "This method is not compiled well. You should use a GCC 4.9 or higher" << std::endl;
 #else
 			 std::regex replace_star("\\*");

--- a/kratos/tests/geometries/test_geometry.h
+++ b/kratos/tests/geometries/test_geometry.h
@@ -28,14 +28,13 @@
 namespace Kratos {
 namespace Testing {
 
-    static std::ofstream out("/dev/null");
     static std::streambuf *coutbuf = std::cout.rdbuf();
     static bool exceptionThrown = false;
 
     // FIXME: EXCPETION -> EXCEPTION
     // TODO: Move to 'include/checks.h' once is confirmed to work as intended
-    #define KRATOS_CHECK_EXCEPTION_RAISED(STATEMENT, EXCEPTION_TYPE)               \
-      std::cout.rdbuf(out.rdbuf());                                               \
+    #define KRATOS_CHECK_EXCEPTION_RAISED(STATEMENT, EXCEPTION_TYPE)              \
+      std::cout.rdbuf(nullptr);                                                   \
       exceptionThrown = false;                                                    \
                                                                                   \
       try {                                                                       \

--- a/kratos/tests/geometries/test_geometry.h
+++ b/kratos/tests/geometries/test_geometry.h
@@ -28,14 +28,15 @@
 namespace Kratos {
 namespace Testing {
 
+    static std::ofstream out("/dev/null");
+    static std::streambuf *coutbuf = std::cout.rdbuf();
+    static bool exceptionThrown = false;
+
     // FIXME: EXCPETION -> EXCEPTION
     // TODO: Move to 'include/checks.h' once is confirmed to work as intended
-    #define KRATOS_CHECK_EXCEPTION_RAISED(STATEMENT, EXCEPTION_TYPE)              \
-      std::ofstream out("/dev/null");                                             \
-      std::streambuf *coutbuf = std::cout.rdbuf();                                \
+    #define KRATOS_CHECK_EXCEPTION_RAISED(STATEMENT, EXCEPTION_TYPE)               \
       std::cout.rdbuf(out.rdbuf());                                               \
-                                                                                  \
-      bool exceptionThrown = false;                                               \
+      exceptionThrown = false;                                                    \
                                                                                   \
       try {                                                                       \
         STATEMENT;                                                                \

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -105,7 +105,7 @@ namespace Kratos {
       // that for planar geometries it also return the number of edges.
       KRATOS_CHECK_EQUAL(geomRegLen1->FacesNumber(), 4);
       KRATOS_CHECK_EQUAL(geomRegLen2->FacesNumber(), 4);
-      KRATOS_CHECK_EQUAL(geomTriRect->FacesNumber(), 6);
+      KRATOS_CHECK_EQUAL(geomTriRect->FacesNumber(), 4);
     }
 
     /** Checks if the area of the triangle is calculated correctly.
@@ -117,7 +117,7 @@ namespace Kratos {
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       KRATOS_CHECK_NEAR(geomRegLen1->Area(), 1.0/3.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Area(), 2.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Area(), 8.0/3.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Area(), 1.0/6.0, TOLERANCE);
     }
 
@@ -131,7 +131,7 @@ namespace Kratos {
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       KRATOS_CHECK_NEAR(geomRegLen1->Volume(), 1.0/3.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Volume(), 2.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Volume(), 8.0/3.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Volume(), 1.0/6.0, TOLERANCE);
   	}
 

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -301,9 +301,9 @@ namespace Kratos {
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_EDGE_LENGTH;
 
-      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.839947, TOLERANCE);
     }
 
     /** Checks if the volume to average edge length quality metric is correctly calculated.
@@ -318,9 +318,9 @@ namespace Kratos {
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_AVERAGE_EDGE_LENGTH;
 
-      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.804041, TOLERANCE);
     }
 
     /** Checks if the volume to RMS edge length quality metric is correctly calculated.
@@ -335,9 +335,9 @@ namespace Kratos {
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_EDGE_LENGTH;
 
-      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.839947, TOLERANCE);
     }
 
 

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -42,7 +42,7 @@ namespace Kratos {
     }
 
     /** Generates a sample Tetrahedra3D4.
-     * Generates a trirectangular tetrahedra on the origin with leg size 1 with positive volume.
+     * Generates a trirectangular tetrahedra on the origin with positive volume and side 1.
      * @return  Pointer to a Tetrahedra3D4
      */
     GeometryPtrType GenerateTriRectangularTetrahedra3D4() {
@@ -55,7 +55,20 @@ namespace Kratos {
     }
 
     /** Generates a sample Tetrahedra3D4.
-     * Generates a regular tetrahedra with positive volume with side 1.
+     * Generates a regular tetrahedra with positive volume and side 1.
+     * @return  Pointer to a Tetrahedra3D4
+     */
+    GeometryPtrType GenerateRegInvtLen1Tetrahedra3D4() {
+      return GeometryPtrType(new GeometryType(
+        GeneratePoint<PointType>(0.0, 1.0, 1.0),
+        GeneratePoint<PointType>(1.0, 0.0, 1.0),
+        GeneratePoint<PointType>(1.0, 1.0, 0.0),
+        GeneratePoint<PointType>(0.0, 0.0, 0.0)
+      ));
+    }
+
+    /** Generates a sample Tetrahedra3D4.
+     * Generates a regular tetrahedra with negative volume and side 1.
      * @return  Pointer to a Tetrahedra3D4
      */
     GeometryPtrType GenerateRegularLen1Tetrahedra3D4() {
@@ -85,9 +98,11 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4EdgesNumber, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
+      KRATOS_CHECK_EQUAL(geomInvLen1->EdgesNumber(), 6);
       KRATOS_CHECK_EQUAL(geomRegLen1->EdgesNumber(), 6);
       KRATOS_CHECK_EQUAL(geomRegLen2->EdgesNumber(), 6);
       KRATOS_CHECK_EQUAL(geomTriRect->EdgesNumber(), 6);
@@ -98,11 +113,13 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4FacesNumber, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       // Charlie: I will let this to 3 but probably 'FacesNumber' needs to be documented to state
       // that for planar geometries it also return the number of edges.
+      KRATOS_CHECK_EQUAL(geomInvLen1->FacesNumber(), 4);
       KRATOS_CHECK_EQUAL(geomRegLen1->FacesNumber(), 4);
       KRATOS_CHECK_EQUAL(geomRegLen2->FacesNumber(), 4);
       KRATOS_CHECK_EQUAL(geomTriRect->FacesNumber(), 4);
@@ -113,12 +130,14 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Area, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      KRATOS_CHECK_NEAR(geomRegLen1->Area(), 1.0/3.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Area(), 8.0/3.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Area(), 1.0/6.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomInvLen1->Area(), -1.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Area(),  1.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Area(),  8.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->Area(),  1.0/6.0, TOLERANCE);
     }
 
     /** Checks if the volume of the triangle is calculated correctly.
@@ -127,12 +146,14 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Volume, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      KRATOS_CHECK_NEAR(geomRegLen1->Volume(), 1.0/3.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Volume(), 8.0/3.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Volume(), 1.0/6.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomInvLen1->Volume(), -1.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Volume(),  1.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Volume(),  8.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->Volume(),  1.0/6.0, TOLERANCE);
   	}
 
     /** Checks if the minimum edge length is calculated correctly.
@@ -140,6 +161,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4MinEdgeLength, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -154,6 +176,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4MaxEdgeLength, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -168,6 +191,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4AverageEdgeLength, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -181,6 +205,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Circumradius, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -195,6 +220,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Inradius, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -211,6 +237,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4InradiusToCircumradiusQuality, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -228,6 +255,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4InradiusToLongestEdgeQuality, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -245,6 +273,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4ShortestToLongestEdgeQuality, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -262,6 +291,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4RegualrityQuiality, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -283,6 +313,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToSurfaceAreaQuality, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -304,6 +335,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToEdgeLengthQuality, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -321,6 +353,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToAverageEdgeLength, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -338,6 +371,7 @@ namespace Kratos {
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToRMSEdgeLength, KratosCoreGeometriesFastSuite) {
       auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -97,8 +97,8 @@ namespace Kratos {
      * Checks if the number of edges is correct.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4EdgesNumber, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -112,8 +112,8 @@ namespace Kratos {
      * Checks if the number of faces is correct.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4FacesNumber, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -129,8 +129,8 @@ namespace Kratos {
      * Checks if the length of the triangle is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Length, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -144,8 +144,8 @@ namespace Kratos {
      * Checks if the area of the triangle is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Area, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -160,8 +160,8 @@ namespace Kratos {
      * For triangle 2D3 'volume()' call defaults to 'area()'
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Volume, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -175,12 +175,12 @@ namespace Kratos {
      * Checks if the minimum edge length is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4MinEdgeLength, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      // Should NOT be the same
+      KRATOS_CHECK_NEAR(geomInvLen1->MinEdgeLength(), 1.414213, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->MinEdgeLength(), 1.414213, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen2->MinEdgeLength(), 2.828427, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->MinEdgeLength(), 1.000000, TOLERANCE);
@@ -190,12 +190,12 @@ namespace Kratos {
      * Checks if the maximum edge length is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4MaxEdgeLength, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      // Should be the same
+      KRATOS_CHECK_NEAR(geomInvLen1->MaxEdgeLength(), 1.414213, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->MaxEdgeLength(), 1.414213, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen2->MaxEdgeLength(), 2.828427, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->MaxEdgeLength(), 1.414213, TOLERANCE);
@@ -205,11 +205,12 @@ namespace Kratos {
      * Checks if the average edge length is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4AverageEdgeLength, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
+      KRATOS_CHECK_NEAR(geomInvLen1->AverageEdgeLength(), 1.414213, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->AverageEdgeLength(), 1.414213, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen2->AverageEdgeLength(), 2.828427, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->AverageEdgeLength(), 1.207106, TOLERANCE);
@@ -219,12 +220,12 @@ namespace Kratos {
      * Checks if the circumradius is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Circumradius, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      // Should be the same
+      KRATOS_CHECK_NEAR(geomInvLen1->Circumradius(), 0.866025, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Circumradius(), 0.866025, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen2->Circumradius(), 1.732050, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Circumradius(), 0.866025, TOLERANCE);
@@ -234,12 +235,12 @@ namespace Kratos {
      * Checks if the inradius is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Inradius, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      // Should NOT be the same
+      KRATOS_CHECK_NEAR(geomInvLen1->Inradius(), 0.288675, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Inradius(), 0.288675, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen2->Inradius(), 0.577350, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Inradius(), 0.211324, TOLERANCE);
@@ -251,13 +252,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4InradiusToCircumradiusQuality, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::INRADIUS_TO_CIRCUMRADIUS;
 
+      KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.732051, TOLERANCE);
@@ -269,13 +271,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4InradiusToLongestEdgeQuality, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::INRADIUS_TO_LONGEST_EDGE;
 
+      KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.732051, TOLERANCE);
@@ -287,13 +290,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4ShortestToLongestEdgeQuality, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::SHORTEST_TO_LONGEST_EDGE;
 
+      KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.707106, TOLERANCE);
@@ -305,8 +309,8 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4RegualrityQuiality, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -316,6 +320,7 @@ namespace Kratos {
       // KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
       // KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
 
+      KRATOS_CHECK_EXCEPTION_RAISED(geomInvLen1->Quality(criteria), Exception);
       KRATOS_CHECK_EXCEPTION_RAISED(geomRegLen1->Quality(criteria), Exception);
       KRATOS_CHECK_EXCEPTION_RAISED(geomRegLen2->Quality(criteria), Exception);
       KRATOS_CHECK_EXCEPTION_RAISED(geomTriRect->Quality(criteria), Exception);
@@ -327,8 +332,8 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToSurfaceAreaQuality, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
@@ -338,6 +343,7 @@ namespace Kratos {
       // KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
       // KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
 
+      KRATOS_CHECK_EXCEPTION_RAISED(geomInvLen1->Quality(criteria), Exception);
       KRATOS_CHECK_EXCEPTION_RAISED(geomRegLen1->Quality(criteria), Exception);
       KRATOS_CHECK_EXCEPTION_RAISED(geomRegLen2->Quality(criteria), Exception);
       KRATOS_CHECK_EXCEPTION_RAISED(geomTriRect->Quality(criteria), Exception);
@@ -349,16 +355,17 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToEdgeLengthQuality, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_EDGE_LENGTH;
 
-      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.839947, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), -1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria),  1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria),  1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria),  0.839947, TOLERANCE);
     }
 
     /** Checks if the volume to average edge length quality metric is correctly calculated.
@@ -367,16 +374,17 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToAverageEdgeLength, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_AVERAGE_EDGE_LENGTH;
 
-      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.804041, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), -1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria),  1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria),  1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria),  0.804041, TOLERANCE);
     }
 
     /** Checks if the volume to RMS edge length quality metric is correctly calculated.
@@ -385,16 +393,17 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToRMSEdgeLength, KratosCoreGeometriesFastSuite) {
-      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_EDGE_LENGTH;
 
-      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.839947, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), -1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria),  1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria),  1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria),  0.839947, TOLERANCE);
     }
 
 

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -167,9 +167,13 @@ namespace Kratos {
      * Checks if the average edge length is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4AverageEdgeLength, KratosCoreGeometriesFastSuite) {
-      auto geom = GenerateTriRectangularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
+      auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      KRATOS_CHECK_NEAR(geom->AverageEdgeLength(), 1.207106, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->AverageEdgeLength(), 1.414213, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->AverageEdgeLength(), 2.828427, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->AverageEdgeLength(), 1.207106, TOLERANCE);
     }
 
     /** Checks if the circumradius is calculated correctly.
@@ -182,6 +186,7 @@ namespace Kratos {
 
       // Should be the same
       KRATOS_CHECK_NEAR(geomRegLen1->Circumradius(), 0.866025, TOLERANCE);
+      // KRATOS_CHECK_NEAR(geomRegLen1->Circumradius(), 0.866025, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Circumradius(), 0.866025, TOLERANCE);
     }
 
@@ -195,6 +200,7 @@ namespace Kratos {
 
       // Should NOT be the same
       KRATOS_CHECK_NEAR(geomRegLen1->Inradius(), 0.288675, TOLERANCE);
+      // KRATOS_CHECK_NEAR(geomRegLen1->Inradius(), 0.288675, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Inradius(), 0.211324, TOLERANCE);
     }
 

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -125,6 +125,21 @@ namespace Kratos {
       KRATOS_CHECK_EQUAL(geomTriRect->FacesNumber(), 4);
     }
 
+    /** Checks if the length of the triangle is calculated correctly.
+     * Checks if the length of the triangle is calculated correctly.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Length, KratosCoreGeometriesFastSuite) {
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
+      auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
+
+      KRATOS_CHECK_NEAR(geomInvLen1->Length(), 1.414213, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Length(), 1.414213, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Length(), 2.828427, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->Length(), 1.122462, TOLERANCE);
+    }
+
     /** Checks if the area of the triangle is calculated correctly.
      * Checks if the area of the triangle is calculated correctly.
      */

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -74,9 +74,9 @@ namespace Kratos {
     GeometryPtrType GenerateRegularLen2Tetrahedra3D4() {
       return GeometryPtrType(new GeometryType(
         GeneratePoint<PointType>(0.0, 0.0, 0.0),
-        GeneratePoint<PointType>(0.0, 1.0, 1.0),
-        GeneratePoint<PointType>(1.0, 0.0, 1.0),
-        GeneratePoint<PointType>(1.0, 1.0, 0.0)
+        GeneratePoint<PointType>(0.0, 2.0, 2.0),
+        GeneratePoint<PointType>(2.0, 0.0, 2.0),
+        GeneratePoint<PointType>(2.0, 2.0, 0.0)
       ));
     }
 
@@ -104,7 +104,7 @@ namespace Kratos {
       // Charlie: I will let this to 3 but probably 'FacesNumber' needs to be documented to state
       // that for planar geometries it also return the number of edges.
       KRATOS_CHECK_EQUAL(geomRegLen1->FacesNumber(), 4);
-      KRATOS_CHECK_EQUAL(geomRegLen1->FacesNumber(), 4);
+      KRATOS_CHECK_EQUAL(geomRegLen2->FacesNumber(), 4);
       KRATOS_CHECK_EQUAL(geomTriRect->FacesNumber(), 6);
     }
 
@@ -117,7 +117,7 @@ namespace Kratos {
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       KRATOS_CHECK_NEAR(geomRegLen1->Area(), 1.0/3.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen1->Area(), 2.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Area(), 2.0/3.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Area(), 1.0/6.0, TOLERANCE);
     }
 
@@ -131,7 +131,7 @@ namespace Kratos {
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       KRATOS_CHECK_NEAR(geomRegLen1->Volume(), 1.0/3.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen1->Volume(), 2.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Volume(), 2.0/3.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Volume(), 1.0/6.0, TOLERANCE);
   	}
 
@@ -159,7 +159,7 @@ namespace Kratos {
 
       // Should be the same
       KRATOS_CHECK_NEAR(geomRegLen1->MaxEdgeLength(), 1.414213, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen1->MaxEdgeLength(), 2.828427, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->MaxEdgeLength(), 2.828427, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->MaxEdgeLength(), 1.414213, TOLERANCE);
     }
 
@@ -186,7 +186,7 @@ namespace Kratos {
 
       // Should be the same
       KRATOS_CHECK_NEAR(geomRegLen1->Circumradius(), 0.866025, TOLERANCE);
-      // KRATOS_CHECK_NEAR(geomRegLen1->Circumradius(), 0.866025, TOLERANCE);
+      // KRATOS_CHECK_NEAR(geomRegLen2->Circumradius(), 0.866025, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Circumradius(), 0.866025, TOLERANCE);
     }
 
@@ -200,7 +200,7 @@ namespace Kratos {
 
       // Should NOT be the same
       KRATOS_CHECK_NEAR(geomRegLen1->Inradius(), 0.288675, TOLERANCE);
-      // KRATOS_CHECK_NEAR(geomRegLen1->Inradius(), 0.288675, TOLERANCE);
+      // KRATOS_CHECK_NEAR(geomRegLen2->Inradius(), 0.288675, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Inradius(), 0.211324, TOLERANCE);
     }
 

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -186,7 +186,7 @@ namespace Kratos {
 
       // Should be the same
       KRATOS_CHECK_NEAR(geomRegLen1->Circumradius(), 0.866025, TOLERANCE);
-      // KRATOS_CHECK_NEAR(geomRegLen2->Circumradius(), 0.866025, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Circumradius(), 1.732050, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Circumradius(), 0.866025, TOLERANCE);
     }
 
@@ -200,7 +200,7 @@ namespace Kratos {
 
       // Should NOT be the same
       KRATOS_CHECK_NEAR(geomRegLen1->Inradius(), 0.288675, TOLERANCE);
-      // KRATOS_CHECK_NEAR(geomRegLen2->Inradius(), 0.288675, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Inradius(), 0.577350, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Inradius(), 0.211324, TOLERANCE);
     }
 
@@ -267,9 +267,13 @@ namespace Kratos {
 
       auto criteria = GeometryType::QualityCriteria::REGULARITY;
 
-      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
+      // KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
+      // KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
+      // KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
+
+      KRATOS_CHECK_EXCEPTION_RAISED(geomRegLen1->Quality(criteria), Exception);
+      KRATOS_CHECK_EXCEPTION_RAISED(geomRegLen2->Quality(criteria), Exception);
+      KRATOS_CHECK_EXCEPTION_RAISED(geomTriRect->Quality(criteria), Exception);
     }
 
     /** Checks if the volume to surface area quality metric is correctly calculated.
@@ -284,9 +288,13 @@ namespace Kratos {
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_SURFACE_AREA;
 
-      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
+      // KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
+      // KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
+      // KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
+
+      KRATOS_CHECK_EXCEPTION_RAISED(geomRegLen1->Quality(criteria), Exception);
+      KRATOS_CHECK_EXCEPTION_RAISED(geomRegLen2->Quality(criteria), Exception);
+      KRATOS_CHECK_EXCEPTION_RAISED(geomTriRect->Quality(criteria), Exception);
     }
 
     /** Checks if the volume to edge length quality metric is correctly calculated.

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -125,8 +125,8 @@ namespace Kratos {
       KRATOS_CHECK_EQUAL(geomTriRect->FacesNumber(), 4);
     }
 
-    /** Checks if the length of the tetrahedra is calculated correctly.
-     * Checks if the length of the tetrahedra is calculated correctly.
+    /** Checks if the characteristic length of the tetrahedra is calculated correctly.
+     * Checks if the characteristic length of the tetrahedra is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Length, KratosCoreGeometriesFastSuite) {
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -30,7 +30,7 @@ namespace Kratos {
     typedef GeometryType::Pointer     GeometryPtrType;
 
     /** Generates a sample Tetrahedra3D4.
-     * Generates a triangle defined by three random points in the space.
+     * Generates a tetrahedra defined by three random points in the space.
      * @return  Pointer to a Tetrahedra3D4
      */
     GeometryPtrType GenerateTetrahedra3D4(
@@ -125,8 +125,8 @@ namespace Kratos {
       KRATOS_CHECK_EQUAL(geomTriRect->FacesNumber(), 4);
     }
 
-    /** Checks if the length of the triangle is calculated correctly.
-     * Checks if the length of the triangle is calculated correctly.
+    /** Checks if the length of the tetrahedra is calculated correctly.
+     * Checks if the length of the tetrahedra is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Length, KratosCoreGeometriesFastSuite) {
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
@@ -140,8 +140,8 @@ namespace Kratos {
       KRATOS_CHECK_NEAR(geomTriRect->Length(), 1.122462, TOLERANCE);
     }
 
-    /** Checks if the area of the triangle is calculated correctly.
-     * Checks if the area of the triangle is calculated correctly.
+    /** Checks if the area of the tetrahedra is calculated correctly.
+     * Checks if the area of the tetrahedra is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Area, KratosCoreGeometriesFastSuite) {
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();
@@ -155,9 +155,9 @@ namespace Kratos {
       KRATOS_CHECK_NEAR(geomTriRect->Area(),  1.0/6.0, TOLERANCE);
     }
 
-    /** Checks if the volume of the triangle is calculated correctly.
-     * Checks if the volume of the triangle is calculated correctly.
-     * For triangle 2D3 'volume()' call defaults to 'area()'
+    /** Checks if the volume of the tetrahedra is calculated correctly.
+     * Checks if the volume of the tetrahedra is calculated correctly.
+     * For tetrahedra 3D4 'volume()' call defaults to 'area()'
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Volume, KratosCoreGeometriesFastSuite) {
       auto geomInvLen1 = GenerateRegInvtLen1Tetrahedra3D4();

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -55,10 +55,23 @@ namespace Kratos {
     }
 
     /** Generates a sample Tetrahedra3D4.
-     * Generates a regular tetrahedra with positive volume.
+     * Generates a regular tetrahedra with positive volume with side 1.
      * @return  Pointer to a Tetrahedra3D4
      */
-    GeometryPtrType GenerateRegularTetrahedra3D4() {
+    GeometryPtrType GenerateRegularLen1Tetrahedra3D4() {
+      return GeometryPtrType(new GeometryType(
+        GeneratePoint<PointType>(0.0, 0.0, 0.0),
+        GeneratePoint<PointType>(0.0, 1.0, 1.0),
+        GeneratePoint<PointType>(1.0, 0.0, 1.0),
+        GeneratePoint<PointType>(1.0, 1.0, 0.0)
+      ));
+    }
+
+    /** Generates a sample Tetrahedra3D4.
+     * Generates a regular tetrahedra with positive volume with side 2.
+     * @return  Pointer to a Tetrahedra3D4
+     */
+    GeometryPtrType GenerateRegularLen2Tetrahedra3D4() {
       return GeometryPtrType(new GeometryType(
         GeneratePoint<PointType>(0.0, 0.0, 0.0),
         GeneratePoint<PointType>(0.0, 1.0, 1.0),
@@ -71,10 +84,12 @@ namespace Kratos {
      * Checks if the number of edges is correct.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4EdgesNumber, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      KRATOS_CHECK_EQUAL(geomRegular->EdgesNumber(), 6);
+      KRATOS_CHECK_EQUAL(geomRegLen1->EdgesNumber(), 6);
+      KRATOS_CHECK_EQUAL(geomRegLen2->EdgesNumber(), 6);
       KRATOS_CHECK_EQUAL(geomTriRect->EdgesNumber(), 6);
     }
 
@@ -82,23 +97,27 @@ namespace Kratos {
      * Checks if the number of faces is correct.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4FacesNumber, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       // Charlie: I will let this to 3 but probably 'FacesNumber' needs to be documented to state
       // that for planar geometries it also return the number of edges.
-      KRATOS_CHECK_EQUAL(geomRegular->FacesNumber(), 4);
-      KRATOS_CHECK_EQUAL(geomTriRect->EdgesNumber(), 6);
+      KRATOS_CHECK_EQUAL(geomRegLen1->FacesNumber(), 4);
+      KRATOS_CHECK_EQUAL(geomRegLen1->FacesNumber(), 4);
+      KRATOS_CHECK_EQUAL(geomTriRect->FacesNumber(), 6);
     }
 
     /** Checks if the area of the triangle is calculated correctly.
      * Checks if the area of the triangle is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Area, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      KRATOS_CHECK_NEAR(geomRegular->Area(), 1.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Area(), 1.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Area(), 2.0/3.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Area(), 1.0/6.0, TOLERANCE);
     }
 
@@ -107,10 +126,12 @@ namespace Kratos {
      * For triangle 2D3 'volume()' call defaults to 'area()'
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Volume, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      KRATOS_CHECK_NEAR(geomRegular->Volume(), 1.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Volume(), 1.0/3.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Volume(), 2.0/3.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Volume(), 1.0/6.0, TOLERANCE);
   	}
 
@@ -118,11 +139,13 @@ namespace Kratos {
      * Checks if the minimum edge length is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4MinEdgeLength, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       // Should NOT be the same
-      KRATOS_CHECK_NEAR(geomRegular->MinEdgeLength(), 1.414213, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->MinEdgeLength(), 1.414213, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->MinEdgeLength(), 2.828427, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->MinEdgeLength(), 1.000000, TOLERANCE);
     }
 
@@ -130,11 +153,13 @@ namespace Kratos {
      * Checks if the maximum edge length is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4MaxEdgeLength, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       // Should be the same
-      KRATOS_CHECK_NEAR(geomRegular->MaxEdgeLength(), 1.414213, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->MaxEdgeLength(), 1.414213, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->MaxEdgeLength(), 2.828427, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->MaxEdgeLength(), 1.414213, TOLERANCE);
     }
 
@@ -151,11 +176,12 @@ namespace Kratos {
      * Checks if the circumradius is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Circumradius, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       // Should be the same
-      KRATOS_CHECK_NEAR(geomRegular->Circumradius(), 0.866025, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Circumradius(), 0.866025, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Circumradius(), 0.866025, TOLERANCE);
     }
 
@@ -163,11 +189,12 @@ namespace Kratos {
      * Checks if the inradius is calculated correctly.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4Inradius, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       // Should NOT be the same
-      KRATOS_CHECK_NEAR(geomRegular->Inradius(), 0.288675, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Inradius(), 0.288675, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Inradius(), 0.211324, TOLERANCE);
     }
 
@@ -177,12 +204,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4InradiusToCircumradiusQuality, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::INRADIUS_TO_CIRCUMRADIUS;
 
-      KRATOS_CHECK_NEAR(geomRegular->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.732051, TOLERANCE);
     }
 
@@ -192,12 +221,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4InradiusToLongestEdgeQuality, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::INRADIUS_TO_LONGEST_EDGE;
 
-      KRATOS_CHECK_NEAR(geomRegular->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.732051, TOLERANCE);
     }
 
@@ -207,12 +238,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4ShortestToLongestEdgeQuality, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::SHORTEST_TO_LONGEST_EDGE;
 
-      KRATOS_CHECK_NEAR(geomRegular->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), 0.707106, TOLERANCE);
     }
 
@@ -222,12 +255,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4RegualrityQuiality, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::REGULARITY;
 
-      KRATOS_CHECK_NEAR(geomRegular->Quality(criteria), 1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
     }
 
@@ -237,12 +272,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToSurfaceAreaQuality, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_SURFACE_AREA;
 
-      KRATOS_CHECK_NEAR(geomRegular->Quality(criteria), 1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
     }
 
@@ -252,12 +289,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToEdgeLengthQuality, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_EDGE_LENGTH;
 
-      KRATOS_CHECK_NEAR(geomRegular->Quality(criteria), 1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
     }
 
@@ -267,12 +306,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToAverageEdgeLength, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_AVERAGE_EDGE_LENGTH;
 
-      KRATOS_CHECK_NEAR(geomRegular->Quality(criteria), 1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
     }
 
@@ -282,12 +323,14 @@ namespace Kratos {
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
     KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4VolumeToRMSEdgeLength, KratosCoreGeometriesFastSuite) {
-      auto geomRegular = GenerateRegularTetrahedra3D4();
+      auto geomRegLen1 = GenerateRegularLen1Tetrahedra3D4();
+      auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       auto criteria = GeometryType::QualityCriteria::VOLUME_TO_EDGE_LENGTH;
 
-      KRATOS_CHECK_NEAR(geomRegular->Quality(criteria), 1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria), -1.0, TOLERANCE);
     }
 


### PR DESCRIPTION
This should fix #94 and fix #85. 

As a resume this PR:
* Corrects the problem with the `VolumeToAverageEdgeLength` quality function for tetrahedras
* Fixed a bug that was causing an error if tests were compiled with clang
* Completed the missing tests
* Extended the tests for tetrahedras so a non-unitary geometry is also tested
* Non implemented functions (regualrity and surface area) are now check that the excpetion is trown rather than the correct value.
* Fixed KRATOS_CHECK_EXCEPTION while being called multiple times inside the same test