### PR TITLE
CMake changes on win

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,15 +318,25 @@ install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/application_importer.
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/kratos_unittest.py" DESTINATION KratosMultiphysics RENAME KratosUnittest.py )
 
 message("boost python lib used = " ${Boost_PYTHON_LIBRARY_RELEASE})
-install(FILES ${Boost_PYTHON_LIBRARY_RELEASE} DESTINATION libs)
-install(FILES ${EXTRA_INSTALL_LIBS} DESTINATION libs)
+
+# Replace .lib for .dll so it copies the files in windows automatically
+string(REPLACE ".lib" ".dll" BOOST_PYTHON_LIBS_TO_COPY "${Boost_PYTHON_LIBRARY_RELEASE}")
+string(REPLACE ".lib" ".dll" EXTRA_LIBS_TO_COPY "${EXTRA_INSTALL_LIBS}")
+
+# Install boost and extra libraires
+install(FILES ${BOOST_PYTHON_LIBS_TO_COPY} DESTINATION libs)
+install(FILES ${EXTRA_LIBS_TO_COPY} DESTINATION libs)
+message("installed libraries = " ${BLAS_LIBRARIES})
 
 # Install blas and lapack
 if(${BLAS_INCLUDE_NEEDED} MATCHES ON )
+  string(REPLACE ".lib" ".dll" BLAS_LIBRARIES_TO_INSTALL "${BLAS_LIBRARIES}")
+  install(FILES ${BLAS_LIBRARIES_TO_INSTALL} DESTINATION libs)
 	message("installed blas = " ${BLAS_LIBRARIES})
-	install(FILES ${BLAS_LIBRARIES} DESTINATION libs)
+
+  string(REPLACE ".lib" ".dll" LAPACK_LIBRARIES_TO_INSTALL "${LAPACK_LIBRARIES}")
+  install(FILES ${LAPACK_LIBRARIES_TO_INSTALL} DESTINATION libs)
 	message("installed lapack = " ${LAPACK_LIBRARIES})
-	install(FILES ${LAPACK_LIBRARIES} DESTINATION libs)
 endif(${BLAS_INCLUDE_NEEDED} MATCHES ON )
 
 # Kratos Testing


### PR DESCRIPTION
This is a first PR to fix #69.

At this point this should allow to install the .DLL files for boost.python, lapack and blas at the same time we remove some .lib files from the libs dir.
In this first PR I only added these because are the ones we can ensure that are located in the same dir as their *.lib files.

I still haven't found an elegant solution for python.

For the mingw libraries needed by blas, we could add an additional `-DMINGW_PATH` which would take effect only in windows that allow to copy the libs, but so far I haven't include that. 