### PR TITLE
Added detection of Python interpreter to cmake, for correct detection…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,6 +147,7 @@ link_directories(${Boost_LIBRARY_DIRS})
 
 ##*****************************
 # Finding and including PYTHON
+find_package(PythonInterp REQUIRED)
 find_package(PythonLibs REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS})
 link_directories(${PYTHON_LIBRARIES})


### PR DESCRIPTION
… of python libraries in Acuario cluster.

When compiling Kratos in acuario cluster, cmake is not detecting the correct python library version  loaded by module python/3.5.1 (using 2.7 instead of 3.5). Detecting the interpreter before the library fixes this. After the fix, cmake doesn't need -DPYTHON_LIBRARY and -DPYTHON_INCLUDE_DIR arguments.