### PR TITLE
Particularizing Jacobian determinants computation

### DIFF
--- a/kratos/geometries/line_2d.h
+++ b/kratos/geometries/line_2d.h
@@ -304,14 +304,14 @@ public:
     */
     virtual double Length() const
     {
-        
+
         const TPointType& point0 = BaseType::GetPoint(0);
         const TPointType& point1 = BaseType::GetPoint(1);
         const double lx = point0.X() - point1.X();
         const double ly = point0.Y() - point1.Y();
-        
+
         const double length = lx * lx + ly * ly;
-        
+
         return sqrt( length );
     }
 
@@ -348,9 +348,9 @@ public:
         const TPointType& point1 = BaseType::GetPoint(1);
         const double lx = point0.X() - point1.X();
         const double ly = point0.Y() - point1.Y();
-        
+
         const double length = lx * lx + ly * ly;
-        
+
         return sqrt( length );
     }
 
@@ -403,7 +403,7 @@ public:
     point index of given integration method.
 
     @param DeltaPosition Matrix with the nodes position increment which describes
-    the configuration where the jacobian has to be calculated.     
+    the configuration where the jacobian has to be calculated.
 
     @see DeterminantOfJacobian
     @see InverseOfJacobian
@@ -481,7 +481,17 @@ public:
     */
     virtual Vector& DeterminantOfJacobian(Vector& rResult, IntegrationMethod ThisMethod) const
     {
-        KRATOS_ERROR << "Jacobian is not square" <<  std::endl;
+        const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
+        if(rResult.size() != integration_points_number)
+        {
+            rResult.resize(integration_points_number,false);
+        }
+
+        for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
+        {
+            rResult[pnt] = 0.5*(this->Length());
+        }
+        return rResult;
     }
 
     /** Determinant of jacobian in specific integration point of
@@ -504,7 +514,7 @@ public:
     */
     virtual double DeterminantOfJacobian(IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const
     {
-        KRATOS_ERROR << "Jacobian is not square" <<  std::endl;
+        return 0.5*(this->Length());
     }
 
     /** Determinant of jacobian in given point. This method calculate determinant of jacobian
@@ -521,7 +531,7 @@ public:
     */
     virtual double DeterminantOfJacobian(const CoordinatesArrayType& rPoint) const
     {
-        KRATOS_ERROR << "Jacobian is not square" <<  std::endl;
+        return 0.5*(this->Length());
     }
 
 
@@ -897,77 +907,4 @@ const GeometryData Line2D<TPointType>::msGeometryData(2,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_LINE_2D_H_INCLUDED  defined 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+#endif // KRATOS_LINE_2D_H_INCLUDED  defined

--- a/kratos/geometries/line_2d.h
+++ b/kratos/geometries/line_2d.h
@@ -487,9 +487,11 @@ public:
             rResult.resize(integration_points_number,false);
         }
 
+        const double detJ = 0.5*(this->Length());
+
         for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
         {
-            rResult[pnt] = 0.5*(this->Length());
+            rResult[pnt] = detJ;
         }
         return rResult;
     }

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -266,7 +266,7 @@ public:
         return typename BaseType::Pointer( new Line2D2( ThisPoints ) );
     }
 
-    
+
     virtual Geometry< Point<3> >::Pointer Clone() const
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
@@ -318,9 +318,9 @@ public:
         const TPointType& SecondPoint = BaseType::GetPoint(1);
         const double lx = FirstPoint.X() - SecondPoint.X();
         const double ly = FirstPoint.Y() - SecondPoint.Y();
-        
+
         const double length = lx * lx + ly * ly;
-        
+
         return std::sqrt( length );
     }
 
@@ -357,9 +357,9 @@ public:
         const TPointType& SecondPoint = BaseType::GetPoint(1);
         const double lx = FirstPoint.X() - SecondPoint.X();
         const double ly = FirstPoint.Y() - SecondPoint.Y();
-        
+
         const double length = lx * lx + ly * ly;
-        
+
         return std::sqrt( length );
     }
 
@@ -422,7 +422,7 @@ public:
     point index of given integration method.
 
     @param DeltaPosition Matrix with the nodes position increment which describes
-    the configuration where the jacobian has to be calculated.     
+    the configuration where the jacobian has to be calculated.
 
     @see DeterminantOfJacobian
     @see InverseOfJacobian
@@ -504,7 +504,16 @@ public:
     */
     virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const
     {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
+        if(rResult.size() != integration_points_number)
+        {
+            rResult.resize(integration_points_number,false);
+        }
+
+        for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
+        {
+            rResult[pnt] = 0.5*(this->Length());
+        }
         return rResult;
     }
 
@@ -528,8 +537,7 @@ public:
     */
     virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const
     {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return 0.0;
+        return 0.5*(this->Length());
     }
 
     /** Determinant of jacobian in given point. This method calculate determinant of jacobian
@@ -546,8 +554,7 @@ public:
     */
     virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const
     {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return 0.0;
+        return 0.5*(this->Length());
     }
 
 
@@ -650,7 +657,7 @@ public:
         NodesInFaces(1,0)=1;
 
     }
-    
+
     ///@}
     ///@name Shape Function
     ///@{
@@ -854,20 +861,20 @@ public:
 
         // Project point
         const double tol = 1e-14; // Tolerance
-        
+
         // Normal
         array_1d<double,2> Normal = ZeroVector(2);
         Normal[0] = SecondPoint[1] -  FirstPoint[1];
         Normal[1] =  FirstPoint[0] - SecondPoint[0];
         const double norm = std::sqrt(Normal[0] * Normal[0] + Normal[1] * Normal[1]);
         Normal /= norm;
-        
+
         // Vector point and distance
         array_1d<double,2> VectorPoint = ZeroVector(2);
         VectorPoint[0] = rPoint[0] - FirstPoint[0];
         VectorPoint[1] = rPoint[1] - FirstPoint[1];
         const double dist_proy = VectorPoint[0] * Normal[0] + VectorPoint[1] * Normal[1];
-        
+
 //        KRATOS_WATCH(rPoint);
 //        KRATOS_WATCH(Point_projected);
 //        KRATOS_WATCH(dist_proy);
@@ -875,13 +882,13 @@ public:
         if (dist_proy < tol)
         {
             const double L  = Length();
-            
+
             const double l1 = std::sqrt((rPoint[0] - FirstPoint[0]) * (rPoint[0] - FirstPoint[0])
                       + (rPoint[1] - FirstPoint[1]) * (rPoint[1] - FirstPoint[1]));
-            
+
             const double l2 = std::sqrt((rPoint[0] - SecondPoint[0]) * (rPoint[0] - SecondPoint[0])
                       + (rPoint[1] - SecondPoint[1]) * (rPoint[1] - SecondPoint[1]));
-            
+
 //            std::cout << "L: " << L << " l1: " << l1 << " l2: " << l2 << std::endl;
 
             if (l1 <= (L + tol) && l2 <= (L + tol))
@@ -900,7 +907,7 @@ public:
             {
                 rResult[0] = 2.0; // Out of the line!!! TODO: Check if this value gives problems
             }
-            
+
         }
         else
         {
@@ -1172,4 +1179,4 @@ const GeometryData Line2D2<TPointType>::msGeometryData( 2,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_LINE_2D_H_INCLUDED  defined 
+#endif // KRATOS_LINE_2D_H_INCLUDED  defined

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -510,9 +510,11 @@ public:
             rResult.resize(integration_points_number,false);
         }
 
+        const double detJ = 0.5*(this->Length());
+
         for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
         {
-            rResult[pnt] = 0.5*(this->Length());
+            rResult[pnt] = detJ;
         }
         return rResult;
     }

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -259,7 +259,7 @@ public:
       return typename BaseType::Pointer( new Line2D3( ThisPoints ) );
     }
 
-    
+
     virtual Geometry< Point<3> >::Pointer Clone() const
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
@@ -309,9 +309,9 @@ public:
         const TPointType& point1 = BaseType::GetPoint(2);
         const double lx = point0.X() - point1.X();
         const double ly = point0.Y() - point1.Y();
-        
+
         const double length = lx * lx + ly * ly;
-        
+
         return sqrt( length );
     }
 
@@ -348,9 +348,9 @@ public:
         const TPointType& point1 = BaseType::GetPoint(2);
         const double lx = point0.X() - point1.X();
         const double ly = point0.Y() - point1.Y();
-        
+
         const double length = lx * lx + ly * ly;
-        
+
         return sqrt( length );
     }
 
@@ -368,7 +368,7 @@ public:
 
         return false;
     }
-    
+
     ///@}
     ///@name Jacobian
     ///@{
@@ -414,15 +414,15 @@ public:
                 jacobian( 0, 0 ) += ( this->GetPoint( i ).X() ) * ( shape_functions_gradients[pnt]( i, 0 ) );
                 jacobian( 1, 0 ) += ( this->GetPoint( i ).Y() ) * ( shape_functions_gradients[pnt]( i, 0 ) );
 
-		
+
             }
 
             rResult[pnt] = jacobian;
 
-	    
+
         }//end of loop over all integration points
 
-	
+
 
         return rResult;
     }
@@ -563,7 +563,8 @@ public:
      */
     virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const
     {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        BaseType::DeterminantOfJacobian(rResult, ThisMethod);
+        return rResult;
     }
 
     /** Determinant of jacobian in specific integration point of
@@ -586,7 +587,7 @@ public:
      */
     virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const
     {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return BaseType::DeterminantOfJacobian(IntegrationPointIndex, ThisMethod);
     }
 
     /** Determinant of jacobian in given point. This method calculate determinant of jacobian
@@ -603,7 +604,7 @@ public:
      */
     virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const
     {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        return BaseType::DeterminantOfJacobian(rPoint);
     }
 
     /** Inverse of jacobians for given integration method. This method
@@ -680,7 +681,7 @@ public:
     {
       return EdgesNumber();
     }
-    
+
     ///@}
     ///@name Shape Function
     ///@{
@@ -1104,5 +1105,4 @@ const GeometryData Line2D3<TPointType>::msGeometryData( 2,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_LINE_2D_3_H_INCLUDED  defined 
-
+#endif // KRATOS_LINE_2D_3_H_INCLUDED  defined

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -550,63 +550,6 @@ public:
         return rResult;
     }
 
-    /** Determinant of jacobians for given integration method. This
-     * method calculate determinant of jacobian in all
-     * integrations points of given integration method.
-     *
-     * @return Vector of double which is vector of determinants of
-     * jacobians \f$ |J|_i \f$ where \f$ i=1,2,...,n \f$ is the
-     * integration point index of given integration method.
-     *
-     * @see Jacobian
-     * @see InverseOfJacobian
-     */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const
-    {
-        BaseType::DeterminantOfJacobian(rResult, ThisMethod);
-        return rResult;
-    }
-
-    /** Determinant of jacobian in specific integration point of
-     * given integration method. This method calculate determinant
-     * of jacobian in given integration point of given integration
-     * method.
-     *
-     * @param IntegrationPointIndex index of integration point which jacobians has to
-     * be calculated in it.
-     *
-     * @param IntegrationPointIndex index of integration point
-     * which determinant of jacobians has to be calculated in it.
-     *
-     * @return Determinamt of jacobian matrix \f$ |J|_i \f$ where \f$
-     * i \f$ is the given integration point index of given
-     * integration method.
-     *
-     * @see Jacobian
-     * @see InverseOfJacobian
-     */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const
-    {
-        return BaseType::DeterminantOfJacobian(IntegrationPointIndex, ThisMethod);
-    }
-
-    /** Determinant of jacobian in given point. This method calculate determinant of jacobian
-     * matrix in given point.
-     *
-     * @param rPoint point which determinant of jacobians has to
-     * be calculated in it.
-     *
-     * @return Determinamt of jacobian matrix \f$ |J| \f$ in given
-     * point.
-     *
-     * @see DeterminantOfJacobian
-     * @see InverseOfJacobian
-     */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const
-    {
-        return BaseType::DeterminantOfJacobian(rPoint);
-    }
-
     /** Inverse of jacobians for given integration method. This method
      * calculate inverse of jacobians matrices in all integrations points of
      * given integration method.

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -502,9 +502,11 @@ public:
             rResult.resize(integration_points_number,false);
         }
 
+        const double detJ = 0.5*(this->Length());
+
         for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
         {
-            rResult[pnt] = 0.5*(this->Length());
+            rResult[pnt] = detJ;
         }
         return rResult;
     }

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -314,9 +314,9 @@ public:
         const double lx = point0.X() - point1.X();
         const double ly = point0.Y() - point1.Y();
         const double lz = point0.Z() - point1.Z();
-        
+
         const double length = lx * lx + ly * ly + lz * lz;
-        
+
         return sqrt( length );
     }
 
@@ -354,9 +354,9 @@ public:
         const double lx = point0.X() - point1.X();
         const double ly = point0.Y() - point1.Y();
         const double lz = point0.Z() - point1.Z();
-        
+
         const double length = lx * lx + ly * ly + lz * lz;
-        
+
         return sqrt( length );
     }
 
@@ -409,9 +409,9 @@ public:
     @return JacobiansType a Vector of jacobian
     matrices \f$ J_i \f$ where \f$ i=1,2,...,n \f$ is the integration
     point index of given integration method.
-    
+
     @param DeltaPosition Matrix with the nodes position increment which describes
-    the configuration where the jacobian has to be calculated.     
+    the configuration where the jacobian has to be calculated.
 
     @see DeterminantOfJacobian
     @see InverseOfJacobian
@@ -496,8 +496,16 @@ public:
     */
     virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const
     {
-        rResult = ZeroVector( 1 );
-        rResult[0] = 0.5 * MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) );
+        const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
+        if(rResult.size() != integration_points_number)
+        {
+            rResult.resize(integration_points_number,false);
+        }
+
+        for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
+        {
+            rResult[pnt] = 0.5*(this->Length());
+        }
         return rResult;
     }
 
@@ -521,7 +529,7 @@ public:
     */
     virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const
     {
-        return( 0.5*MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) ) );
+        return 0.5*(this->Length());
     }
 
     /** Determinant of jacobian in given point. This method calculate determinant of jacobian
@@ -538,7 +546,7 @@ public:
     */
     virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const
     {
-        return( 0.5*MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) ) );
+        return 0.5*(this->Length());
     }
 
 
@@ -646,10 +654,10 @@ public:
     virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const
     {
-        rResult = ZeroMatrix( 2, 1 ); 
+        rResult = ZeroMatrix( 2, 1 );
         rResult( 0, 0 ) = -0.5;
-        rResult( 1, 0 ) =  0.5; 
-        return( rResult ); 
+        rResult( 1, 0 ) =  0.5;
+        return( rResult );
     }
 
 
@@ -922,5 +930,4 @@ const GeometryData Line3D2<TPointType>::msGeometryData( 3,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_LINE_3D_2_H_INCLUDED  defined 
-
+#endif // KRATOS_LINE_3D_2_H_INCLUDED  defined

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -274,7 +274,7 @@ public:
 
         return p_clone;
     }
-    
+
     //lumping factors for the calculation of the lumped mass matrix
     virtual Vector& LumpingFactors( Vector& rResult ) const
     {
@@ -309,9 +309,9 @@ public:
         const double lx = point0.X() - point1.X();
         const double ly = point0.Y() - point1.Y();
         const double lz = point0.Z() - point1.Z();
-        
+
         const double length = lx * lx + ly * ly + lz * lz;
-        
+
         return sqrt( length );
     }
 
@@ -349,9 +349,9 @@ public:
         const double lx = point0.X() - point1.X();
         const double ly = point0.Y() - point1.Y();
         const double lz = point0.Z() - point1.Z();
-        
+
         const double length = lx * lx + ly * ly + lz * lz;
-        
+
         return sqrt( length );
     }
 
@@ -561,7 +561,7 @@ public:
      */
     virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const
     {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
+        BaseType::DeterminantOfJacobian(rResult, ThisMethod);
         return rResult;
     }
 
@@ -585,8 +585,7 @@ public:
      */
     virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const
     {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return 0.0;
+        return BaseType::DeterminantOfJacobian(IntegrationPointIndex, ThisMethod);
     }
 
     /** Determinant of jacobian in given point. This method calculate determinant of jacobian
@@ -603,8 +602,7 @@ public:
      */
     virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const
     {
-        KRATOS_ERROR << "Jacobian is not square" << std::endl;
-        return 0.0;
+        return BaseType::DeterminantOfJacobian(rPoint);
     }
 
     /** Inverse of jacobians for given integration method. This method
@@ -697,7 +695,7 @@ public:
             return( 0.5*( rPoint[0] + 1.0 )*rPoint[0] );
         case 2:
 	    return( 1.0 -rPoint[0]*rPoint[0] );
-            
+
         default:
             KRATOS_ERROR << "Wrong index of shape function!" << *this << std::endl;
         }
@@ -1096,5 +1094,4 @@ const GeometryData Line3D3<TPointType>::msGeometryData( 3,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_LINE_3D_3_H_INCLUDED  defined 
-
+#endif // KRATOS_LINE_3D_3_H_INCLUDED  defined

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -548,63 +548,6 @@ public:
         return rResult;
     }
 
-    /** Determinant of jacobians for given integration method. This
-     * method calculate determinant of jacobian in all
-     * integrations points of given integration method.
-     *
-     * @return Vector of double which is vector of determinants of
-     * jacobians \f$ |J|_i \f$ where \f$ i=1,2,...,n \f$ is the
-     * integration point index of given integration method.
-     *
-     * @see Jacobian
-     * @see InverseOfJacobian
-     */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const
-    {
-        BaseType::DeterminantOfJacobian(rResult, ThisMethod);
-        return rResult;
-    }
-
-    /** Determinant of jacobian in specific integration point of
-     * given integration method. This method calculate determinant
-     * of jacobian in given integration point of given integration
-     * method.
-     *
-     * @param IntegrationPointIndex index of integration point which jacobians has to
-     * be calculated in it.
-     *
-     * @param IntegrationPointIndex index of integration point
-     * which determinant of jacobians has to be calculated in it.
-     *
-     * @return Determinamt of jacobian matrix \f$ |J|_i \f$ where \f$
-     * i \f$ is the given integration point index of given
-     * integration method.
-     *
-     * @see Jacobian
-     * @see InverseOfJacobian
-     */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const
-    {
-        return BaseType::DeterminantOfJacobian(IntegrationPointIndex, ThisMethod);
-    }
-
-    /** Determinant of jacobian in given point. This method calculate determinant of jacobian
-     * matrix in given point.
-     *
-     * @param rPoint point which determinant of jacobians has to
-     * be calculated in it.
-     *
-     * @return Determinamt of jacobian matrix \f$ |J| \f$ in given
-     * point.
-     *
-     * @see DeterminantOfJacobian
-     * @see InverseOfJacobian
-     */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const
-    {
-        return BaseType::DeterminantOfJacobian(rPoint);
-    }
-
     /** Inverse of jacobians for given integration method. This method
      * calculate inverse of jacobians matrices in all integrations points of
      * given integration method.

--- a/kratos/geometries/triangle_2d_3.h
+++ b/kratos/geometries/triangle_2d_3.h
@@ -952,9 +952,11 @@ public:
             rResult.resize(integration_points_number,false);
         }
 
+        const double detJ = 2.0*(this->Area());
+
         for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
         {
-            rResult[pnt] = 2.0*(this->Area());
+            rResult[pnt] = detJ;
         }
         return rResult;
     }

--- a/kratos/geometries/triangle_2d_3.h
+++ b/kratos/geometries/triangle_2d_3.h
@@ -932,6 +932,77 @@ public:
         return rResult;
     }
 
+    /**
+     * Determinant of jacobians for given integration method.
+     * This method calculates determinant of jacobian in all
+     * integrations points of given integration method.
+     *
+     * @return Vector of double which is vector of determinants of
+     * jacobians \f$ |J|_i \f$ where \f$ i=1,2,...,n \f$ is the
+     * integration point index of given integration method.
+     *
+     * @see Jacobian
+     * @see InverseOfJacobian
+     */
+    virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const
+    {
+        const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
+        if(rResult.size() != integration_points_number)
+        {
+            rResult.resize(integration_points_number,false);
+        }
+
+        for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
+        {
+            rResult[pnt] = 2.0*(this->Area());
+        }
+        return rResult;
+    }
+
+    /**
+     * Determinant of jacobian in specific integration point of
+     * given integration method. This method calculate determinant
+     * of jacobian in given integration point of given integration
+     * method.
+     *
+     * @param IntegrationPointIndex index of integration point which jacobians has to
+     * be calculated in it.
+     *
+     * @param IntegrationPointIndex index of integration point
+     * which determinant of jacobians has to be calculated in it.
+     *
+     * @return Determinamt of jacobian matrix \f$ |J|_i \f$ where \f$
+     * i \f$ is the given integration point index of given
+     * integration method.
+     *
+     * @see Jacobian
+     * @see InverseOfJacobian
+     */
+    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex,
+                                          IntegrationMethod ThisMethod ) const
+    {
+        return 2.0*(this->Area());
+    }
+
+    /**
+     * Determinant of jacobian in given point.
+     * This method calculate determinant of jacobian
+     * matrix in given point.
+     * @param rPoint point which determinant of jacobians has to
+     * be calculated in it.
+     *
+     * @return Determinamt of jacobian matrix \f$ |J| \f$ in given
+     * point.
+     *
+     * @see DeterminantOfJacobian
+     * @see InverseOfJacobian
+     *
+     */
+    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const
+    {
+        return 2.0*(this->Area());
+    }
+
 
     ///@}
     ///@name Input and output

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -917,9 +917,11 @@ public:
             rResult.resize(integration_points_number,false);
         }
 
+        const double detJ = 2.0*(this->Area());
+
         for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
         {
-            rResult[pnt] = 2.0*(this->Area());
+            rResult[pnt] = detJ;
         }
         return rResult;
     }

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -898,9 +898,6 @@ public:
     }
 
     /**
-     * TODO: implemented but not yet tested
-     */
-    /**
      * Determinant of jacobians for given integration method.
      * This method calculates determinant of jacobian in all
      * integrations points of given integration method.
@@ -912,16 +909,21 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult,
-                                           IntegrationMethod ThisMethod ) const
+    virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const
     {
-        KRATOS_ERROR << "Triangle3D::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
+        const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
+        if(rResult.size() != integration_points_number)
+        {
+            rResult.resize(integration_points_number,false);
+        }
+
+        for ( unsigned int pnt = 0; pnt < integration_points_number; pnt++ )
+        {
+            rResult[pnt] = 2.0*(this->Area());
+        }
         return rResult;
     }
 
-    /**
-     * TODO: implemented but not yet tested
-     */
     /**
      * Determinant of jacobian in specific integration point of
      * given integration method. This method calculate determinant
@@ -944,13 +946,9 @@ public:
     virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex,
                                           IntegrationMethod ThisMethod ) const
     {
-        KRATOS_ERROR << "Triangle3D::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
-        return 0.0;
+        return 2.0*(this->Area());
     }
 
-    /**
-     * TODO: implemented but not yet tested
-     */
     /**
      * Determinant of jacobian in given point.
      * This method calculate determinant of jacobian
@@ -963,20 +961,10 @@ public:
      *
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
-     *
-     * KLUDGE: PointType needed for proper functionality
-     * KLUDGE: works only with explicitly generated Matrix object
-     */
-    /**
-     * :TODO: needs to be changed to Point<3> again. As PointType can
-     * be a Node with unique ID or an IntegrationPoint or any arbitrary
-     * point in space this needs to be reviewed
-     * (comment by janosch)
      */
     virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const
     {
-        KRATOS_ERROR << "Triangle3D::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
-        return 0.0;
+        return 2.0*(this->Area());
     }
 
     /**

--- a/kratos/tests/geometries/test_triangle_2d_3.cpp
+++ b/kratos/tests/geometries/test_triangle_2d_3.cpp
@@ -295,6 +295,54 @@ namespace Testing {
     }
   }
 
+  /** Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+   * Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+   */
+  KRATOS_TEST_CASE_IN_SUITE(Triangle2D3DeterminantOfJacobianArray3, KratosCoreGeometriesFastSuite) {
+    auto geom = GenerateRightTriangle2D3<Node<3>>();
+    const double ExpectedJacobian = 1.0;
+
+    Vector JacobianDeterminants;
+    geom->DeterminantOfJacobian( JacobianDeterminants, GeometryData::GI_GAUSS_3 );
+
+    for (unsigned int i=0; i<JacobianDeterminants.size(); ++i)
+    {
+        KRATOS_CHECK_NEAR(JacobianDeterminants[i], ExpectedJacobian, TOLERANCE);
+    }
+  }
+
+  /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+   * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+   */
+  KRATOS_TEST_CASE_IN_SUITE(Triangle2D3DeterminantOfJacobianArray4, KratosCoreGeometriesFastSuite) {
+    auto geom = GenerateRightTriangle2D3<Node<3>>();
+    const double ExpectedJacobian = 1.0;
+
+    Vector JacobianDeterminants;
+    geom->DeterminantOfJacobian( JacobianDeterminants, GeometryData::GI_GAUSS_4 );
+
+    for (unsigned int i=0; i<JacobianDeterminants.size(); ++i)
+    {
+        KRATOS_CHECK_NEAR(JacobianDeterminants[i], ExpectedJacobian, TOLERANCE);
+    }
+  }
+
+  /** Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+   * Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+   */
+  KRATOS_TEST_CASE_IN_SUITE(Triangle2D3DeterminantOfJacobianArray5, KratosCoreGeometriesFastSuite) {
+    auto geom = GenerateRightTriangle2D3<Node<3>>();
+    const double ExpectedJacobian = 1.0;
+
+    Vector JacobianDeterminants;
+    geom->DeterminantOfJacobian( JacobianDeterminants, GeometryData::GI_GAUSS_5 );
+
+    for (unsigned int i=0; i<JacobianDeterminants.size(); ++i)
+    {
+        KRATOS_CHECK_NEAR(JacobianDeterminants[i], ExpectedJacobian, TOLERANCE);
+    }
+  }
+
   /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
    * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
    */
@@ -318,6 +366,69 @@ namespace Testing {
     KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
 
     JacobianDeterminant = geom->DeterminantOfJacobian( 2, GeometryData::GI_GAUSS_2 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+  }
+
+  /** Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+   * Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+   */
+  KRATOS_TEST_CASE_IN_SUITE(Triangle2D3DeterminantOfJacobianIndex3, KratosCoreGeometriesFastSuite) {
+    auto geom = GenerateRightTriangle2D3<Node<3>>();
+    double JacobianDeterminant = 0.0;
+    const double ExpectedJacobian = 1.0;
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 1, GeometryData::GI_GAUSS_3 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 2, GeometryData::GI_GAUSS_3 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 3, GeometryData::GI_GAUSS_3 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+  }
+
+  /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+   * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+   */
+  KRATOS_TEST_CASE_IN_SUITE(Triangle2D3DeterminantOfJacobianIndex4, KratosCoreGeometriesFastSuite) {
+    auto geom = GenerateRightTriangle2D3<Node<3>>();
+    double JacobianDeterminant = 0.0;
+    const double ExpectedJacobian = 1.0;
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 1, GeometryData::GI_GAUSS_4 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 2, GeometryData::GI_GAUSS_4 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 3, GeometryData::GI_GAUSS_4 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 4, GeometryData::GI_GAUSS_4 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+  }
+
+  /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+   * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+   */
+  KRATOS_TEST_CASE_IN_SUITE(Triangle2D3DeterminantOfJacobianIndex5, KratosCoreGeometriesFastSuite) {
+    auto geom = GenerateRightTriangle2D3<Node<3>>();
+    double JacobianDeterminant = 0.0;
+    const double ExpectedJacobian = 1.0;
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 1, GeometryData::GI_GAUSS_5 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 2, GeometryData::GI_GAUSS_5 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 3, GeometryData::GI_GAUSS_5 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 4, GeometryData::GI_GAUSS_5 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 5, GeometryData::GI_GAUSS_5 );
     KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
   }
 

--- a/kratos/tests/geometries/test_triangle_2d_3.cpp
+++ b/kratos/tests/geometries/test_triangle_2d_3.cpp
@@ -263,5 +263,63 @@ namespace Testing {
     VerifyStrainExactness(*geom, GeometryData::GI_GAUSS_5);
   }
 
+  /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+   * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+   */
+  KRATOS_TEST_CASE_IN_SUITE(Triangle2D3DeterminantOfJacobianArray1, KratosCoreGeometriesFastSuite) {
+    auto geom = GenerateRightTriangle2D3<Node<3>>();
+    const double ExpectedJacobian = 1.0;
+
+    Vector JacobianDeterminants;
+    geom->DeterminantOfJacobian( JacobianDeterminants, GeometryData::GI_GAUSS_1 );
+
+    for (unsigned int i=0; i<JacobianDeterminants.size(); ++i)
+    {
+        KRATOS_CHECK_NEAR(JacobianDeterminants[i], ExpectedJacobian, TOLERANCE);
+    }
+  }
+
+  /** Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+   * Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+   */
+  KRATOS_TEST_CASE_IN_SUITE(Triangle2D3DeterminantOfJacobianArray2, KratosCoreGeometriesFastSuite) {
+    auto geom = GenerateRightTriangle2D3<Node<3>>();
+    const double ExpectedJacobian = 1.0;
+
+    Vector JacobianDeterminants;
+    geom->DeterminantOfJacobian( JacobianDeterminants, GeometryData::GI_GAUSS_2 );
+
+    for (unsigned int i=0; i<JacobianDeterminants.size(); ++i)
+    {
+        KRATOS_CHECK_NEAR(JacobianDeterminants[i], ExpectedJacobian, TOLERANCE);
+    }
+  }
+
+  /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+   * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+   */
+  KRATOS_TEST_CASE_IN_SUITE(Triangle2D3DeterminantOfJacobianIndex1, KratosCoreGeometriesFastSuite) {
+    auto geom = GenerateRightTriangle2D3<Node<3>>();
+    const double ExpectedJacobian = 1.0;
+
+    double JacobianDeterminant = geom->DeterminantOfJacobian( 1, GeometryData::GI_GAUSS_1 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+  }
+
+  /** Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+   * Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+   */
+  KRATOS_TEST_CASE_IN_SUITE(Triangle2D3DeterminantOfJacobianIndex2, KratosCoreGeometriesFastSuite) {
+    auto geom = GenerateRightTriangle2D3<Node<3>>();
+    double JacobianDeterminant = 0.0;
+    const double ExpectedJacobian = 1.0;
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 1, GeometryData::GI_GAUSS_2 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+    JacobianDeterminant = geom->DeterminantOfJacobian( 2, GeometryData::GI_GAUSS_2 );
+    KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+  }
+
 } // namespace Testing.
 } // namespace Kratos.

--- a/kratos/tests/geometries/test_triangle_3d_3.cpp
+++ b/kratos/tests/geometries/test_triangle_3d_3.cpp
@@ -168,7 +168,6 @@ namespace Testing {
     KRATOS_CHECK(geom->IsInside(PointInEdge, LocalCoords, EPSILON));
   }
 
-
     /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
      * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
      */
@@ -201,6 +200,54 @@ namespace Testing {
       }
     }
 
+    /** Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+     * Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3DeterminantOfJacobianArray3, KratosCoreGeometriesFastSuite) {
+      auto geom = GenerateRightTriangle3D3<Node<3>>();
+      const double ExpectedJacobian = 1.0;
+
+      Vector JacobianDeterminants;
+      geom->DeterminantOfJacobian( JacobianDeterminants, GeometryData::GI_GAUSS_3 );
+
+      for (unsigned int i=0; i<JacobianDeterminants.size(); ++i)
+      {
+          KRATOS_CHECK_NEAR(JacobianDeterminants[i], ExpectedJacobian, TOLERANCE);
+      }
+    }
+
+    /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+     * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3DeterminantOfJacobianArray4, KratosCoreGeometriesFastSuite) {
+      auto geom = GenerateRightTriangle3D3<Node<3>>();
+      const double ExpectedJacobian = 1.0;
+
+      Vector JacobianDeterminants;
+      geom->DeterminantOfJacobian( JacobianDeterminants, GeometryData::GI_GAUSS_4 );
+
+      for (unsigned int i=0; i<JacobianDeterminants.size(); ++i)
+      {
+          KRATOS_CHECK_NEAR(JacobianDeterminants[i], ExpectedJacobian, TOLERANCE);
+      }
+    }
+
+    /** Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+     * Tests the Jacobian determinants using 'GI_GAUSS_5' integration method.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3DeterminantOfJacobianArray5, KratosCoreGeometriesFastSuite) {
+      auto geom = GenerateRightTriangle3D3<Node<3>>();
+      const double ExpectedJacobian = 1.0;
+
+      Vector JacobianDeterminants;
+      geom->DeterminantOfJacobian( JacobianDeterminants, GeometryData::GI_GAUSS_5 );
+
+      for (unsigned int i=0; i<JacobianDeterminants.size(); ++i)
+      {
+          KRATOS_CHECK_NEAR(JacobianDeterminants[i], ExpectedJacobian, TOLERANCE);
+      }
+    }
+
     /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
      * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
      */
@@ -224,6 +271,69 @@ namespace Testing {
       KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
 
       JacobianDeterminant = geom->DeterminantOfJacobian( 2, GeometryData::GI_GAUSS_2 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+    }
+
+    /** Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+     * Tests the Jacobian determinants using 'GI_GAUSS_3' integration method.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3DeterminantOfJacobianIndex3, KratosCoreGeometriesFastSuite) {
+      auto geom = GenerateRightTriangle3D3<Node<3>>();
+      double JacobianDeterminant = 0.0;
+      const double ExpectedJacobian = 1.0;
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 1, GeometryData::GI_GAUSS_3 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 2, GeometryData::GI_GAUSS_3 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 3, GeometryData::GI_GAUSS_3 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+    }
+
+    /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+     * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3DeterminantOfJacobianIndex4, KratosCoreGeometriesFastSuite) {
+      auto geom = GenerateRightTriangle3D3<Node<3>>();
+      double JacobianDeterminant = 0.0;
+      const double ExpectedJacobian = 1.0;
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 1, GeometryData::GI_GAUSS_4 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 2, GeometryData::GI_GAUSS_4 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 3, GeometryData::GI_GAUSS_4 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 4, GeometryData::GI_GAUSS_4 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+    }
+
+    /** Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+     * Tests the Jacobian determinants using 'GI_GAUSS_4' integration method.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3DeterminantOfJacobianIndex5, KratosCoreGeometriesFastSuite) {
+      auto geom = GenerateRightTriangle3D3<Node<3>>();
+      double JacobianDeterminant = 0.0;
+      const double ExpectedJacobian = 1.0;
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 1, GeometryData::GI_GAUSS_5 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 2, GeometryData::GI_GAUSS_5 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 3, GeometryData::GI_GAUSS_5 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 4, GeometryData::GI_GAUSS_5 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 5, GeometryData::GI_GAUSS_5 );
       KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
     }
 

--- a/kratos/tests/geometries/test_triangle_3d_3.cpp
+++ b/kratos/tests/geometries/test_triangle_3d_3.cpp
@@ -168,5 +168,64 @@ namespace Testing {
     KRATOS_CHECK(geom->IsInside(PointInEdge, LocalCoords, EPSILON));
   }
 
+
+    /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+     * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3DeterminantOfJacobianArray1, KratosCoreGeometriesFastSuite) {
+      auto geom = GenerateRightTriangle3D3<Node<3>>();
+      const double ExpectedJacobian = 1.0;
+
+      Vector JacobianDeterminants;
+      geom->DeterminantOfJacobian( JacobianDeterminants, GeometryData::GI_GAUSS_1 );
+
+      for (unsigned int i=0; i<JacobianDeterminants.size(); ++i)
+      {
+          KRATOS_CHECK_NEAR(JacobianDeterminants[i], ExpectedJacobian, TOLERANCE);
+      }
+    }
+
+    /** Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+     * Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3DeterminantOfJacobianArray2, KratosCoreGeometriesFastSuite) {
+      auto geom = GenerateRightTriangle3D3<Node<3>>();
+      const double ExpectedJacobian = 1.0;
+
+      Vector JacobianDeterminants;
+      geom->DeterminantOfJacobian( JacobianDeterminants, GeometryData::GI_GAUSS_2 );
+
+      for (unsigned int i=0; i<JacobianDeterminants.size(); ++i)
+      {
+          KRATOS_CHECK_NEAR(JacobianDeterminants[i], ExpectedJacobian, TOLERANCE);
+      }
+    }
+
+    /** Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+     * Tests the Jacobian determinants using 'GI_GAUSS_1' integration method.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3DeterminantOfJacobianIndex1, KratosCoreGeometriesFastSuite) {
+      auto geom = GenerateRightTriangle3D3<Node<3>>();
+      const double ExpectedJacobian = 1.0;
+
+      double JacobianDeterminant = geom->DeterminantOfJacobian( 1, GeometryData::GI_GAUSS_1 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+    }
+
+    /** Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+     * Tests the Jacobian determinants using 'GI_GAUSS_2' integration method.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3DeterminantOfJacobianIndex2, KratosCoreGeometriesFastSuite) {
+      auto geom = GenerateRightTriangle3D3<Node<3>>();
+      double JacobianDeterminant = 0.0;
+      const double ExpectedJacobian = 1.0;
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 1, GeometryData::GI_GAUSS_2 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+
+      JacobianDeterminant = geom->DeterminantOfJacobian( 2, GeometryData::GI_GAUSS_2 );
+      KRATOS_CHECK_NEAR(JacobianDeterminant, ExpectedJacobian, TOLERANCE);
+    }
+
 } // namespace Testing.
 } // namespace Kratos.


### PR DESCRIPTION
Particularization of the Jacobian determinant computation in those cases where it is known and constant. In the other cases the base class method (generalized determinant) is called.