### PR TITLE
backporting iterator capabilities from nlohmann branch

### DIFF
--- a/kratos/python/add_kratos_parameters_to_python.cpp
+++ b/kratos/python/add_kratos_parameters_to_python.cpp
@@ -2,9 +2,9 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
@@ -27,45 +27,84 @@ namespace Kratos
 namespace Python
 {
 
-    
+Parameters::iterator NonConstBegin(Parameters& el)
+{
+    return el.begin();
+}
+Parameters::iterator NonConstEnd(Parameters& el)
+{
+    return el.end();
+}
+
+boost::python::list items(Parameters const& self)
+{
+    boost::python::list t;
+    for(Parameters::const_iterator it=self.begin(); it!=self.end(); ++it)
+        t.append( boost::python::make_tuple(it.name(), *it) );
+    return t;
+}
+
+boost::python::list keys(Parameters const& self)
+{
+    boost::python::list t;
+    for(Parameters::const_iterator it=self.begin(); it!=self.end(); ++it)
+        t.append(it.name());
+    return t;
+}
+
+boost::python::list values(Parameters const& self)
+{
+    boost::python::list t;
+    for(Parameters::const_iterator it=self.begin(); it!=self.end(); ++it)
+        t.append(*it);
+    return t;
+}
+
 void  AddKratosParametersToPython()
 {
     using namespace boost::python;
 
+
+
     class_<Parameters, Parameters::Pointer >("Parameters", init<const std::string>()) //init<rapidjson::Value& >())
-        .def(init<Parameters const&>())
-        .def("WriteJsonString", &Parameters::WriteJsonString)
-        .def("PrettyPrintJsonString", &Parameters::PrettyPrintJsonString)
-        .def("Has", &Parameters::Has)
-        .def("Clone", &Parameters::Clone)
-        .def("AddValue", &Parameters::AddValue)
-        .def("AddEmptyValue", &Parameters::AddEmptyValue)
-        .def("ValidateAndAssignDefaults",&Parameters::ValidateAndAssignDefaults)
-        .def("RecursivelyValidateAndAssignDefaults",&Parameters::RecursivelyValidateAndAssignDefaults)
-        //.def("GetValue", &Parameters::GetValue) //Do not export this method. users shall adopt the operator [] syntax
-        .def("IsNull", &Parameters::IsNull)
-        .def("IsNumber", &Parameters::IsNumber)
-        .def("IsDouble", &Parameters::IsDouble)
-        .def("IsInt", &Parameters::IsInt)
-        .def("IsBool", &Parameters::IsBool)
-        .def("IsString", &Parameters::IsString)
-        .def("IsArray", &Parameters::IsArray)
-        .def("IsSubParameter", &Parameters::IsSubParameter)
-        .def("GetDouble", &Parameters::GetDouble)
-        .def("GetInt", &Parameters::GetInt)
-        .def("GetBool", &Parameters::GetBool)
-        .def("GetString", &Parameters::GetString)
-        .def("SetDouble", &Parameters::SetDouble)
-        .def("SetInt", &Parameters::SetInt)
-        .def("SetBool", &Parameters::SetBool)
-        .def("SetString", &Parameters::SetString)
-        .def("size", &Parameters::size)
-        //.def("GetArrayItem", &Parameters::GetArrayItem) //Do not export this method. users shall adopt the operator [] syntax
-        .def("__setitem__", &Parameters::SetValue)
-        .def("__getitem__", &Parameters::GetValue)
-        .def("__setitem__", &Parameters::SetArrayItem)
-        .def("__getitem__", &Parameters::GetArrayItem)
-        ; 
+    .def(init<Parameters const&>())
+    .def("WriteJsonString", &Parameters::WriteJsonString)
+    .def("PrettyPrintJsonString", &Parameters::PrettyPrintJsonString)
+    .def("Has", &Parameters::Has)
+    .def("Clone", &Parameters::Clone)
+    .def("AddValue", &Parameters::AddValue)
+    .def("AddEmptyValue", &Parameters::AddEmptyValue)
+    .def("ValidateAndAssignDefaults",&Parameters::ValidateAndAssignDefaults)
+    .def("RecursivelyValidateAndAssignDefaults",&Parameters::RecursivelyValidateAndAssignDefaults)
+    //.def("GetValue", &Parameters::GetValue) //Do not export this method. users shall adopt the operator [] syntax
+    .def("IsNull", &Parameters::IsNull)
+    .def("IsNumber", &Parameters::IsNumber)
+    .def("IsDouble", &Parameters::IsDouble)
+    .def("IsInt", &Parameters::IsInt)
+    .def("IsBool", &Parameters::IsBool)
+    .def("IsString", &Parameters::IsString)
+    .def("IsArray", &Parameters::IsArray)
+    .def("IsSubParameter", &Parameters::IsSubParameter)
+    .def("GetDouble", &Parameters::GetDouble)
+    .def("GetInt", &Parameters::GetInt)
+    .def("GetBool", &Parameters::GetBool)
+    .def("GetString", &Parameters::GetString)
+    .def("SetDouble", &Parameters::SetDouble)
+    .def("SetInt", &Parameters::SetInt)
+    .def("SetBool", &Parameters::SetBool)
+    .def("SetString", &Parameters::SetString)
+    .def("size", &Parameters::size)
+    //.def("GetArrayItem", &Parameters::GetArrayItem) //Do not export this method. users shall adopt the operator [] syntax
+    .def("__setitem__", &Parameters::SetValue)
+    .def("__getitem__", &Parameters::GetValue)
+    .def("__setitem__", &Parameters::SetArrayItem)
+    .def("__getitem__", &Parameters::GetArrayItem)
+    .def("__iter__", range(&NonConstBegin, &NonConstEnd) )
+    .def("items", &items )
+    .def("keys", &keys )
+    .def("values", &values )
+    .def(self_ns::str(self))
+    ;
 
 
 }

--- a/kratos/tests/test_kratos_parameters.py
+++ b/kratos/tests/test_kratos_parameters.py
@@ -227,6 +227,46 @@ class TestParameters(KratosUnittest.TestCase):
         self.assertEqual(kp.PrettyPrintJsonString(), expected_validation_output)
 
         self.assertEqual(kp["level1"]["tmp"].GetDouble(), 5.0)  # not 2, since kp overwrites the defaults
+        
+    def test_add_value(self):
+        kp = Parameters("{}")
+        kp.AddEmptyValue("new_double").SetDouble(1.0)
+        
+        self.assertTrue(kp.Has("new_double"))
+        self.assertEqual(kp["new_double"].GetDouble(), 1.0)
+        
+    def test_iterators(self):
+        kp = Parameters(json_string)
+        
+        #iteration by range
+        nitems = 0
+        for iterator in kp:
+            nitems = nitems + 1
+        self.assertEqual(nitems, 5)
+            
+        #iteration by items
+        for key,value in kp.items():
+            #print(value.PrettyPrintJsonString())
+            self.assertEqual(kp[key].PrettyPrintJsonString(), value.PrettyPrintJsonString())
+            #print(key,value)
+            
+        #testing values
+                          
+
+        expected_values = ['10', '2.0', 'true', '"hello"', '{"list_value":[3,"hi",false],"tmp":5.0}']
+        counter = 0
+        
+        for value in kp.values():
+            self.assertEqual(value.WriteJsonString(), expected_values[counter])
+            counter += 1
+
+        #testing values
+        expected_keys = ['int_value', 'double_value', 'bool_value', 'string_value', 'level1'] 
+        counter = 0
+        for key in kp.keys():
+            self.assertEqual(key, expected_keys[counter])
+            counter += 1 
+
 
 
 if __name__ == '__main__':

--- a/kratos/tests/test_variable_utils.py
+++ b/kratos/tests/test_variable_utils.py
@@ -11,6 +11,7 @@ def GetFilePath(fileName):
 class TestVariableUtils(KratosUnittest.TestCase):
 
     def test_set_variable(self):
+        print("aaa")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VISCOSITY)
@@ -36,6 +37,7 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertEqual(node.GetSolutionStepValue(VISCOSITY), viscosity)
 
     def test_copy_var(self):
+        print("bbb")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(DENSITY)
@@ -57,6 +59,7 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertEqual(node.GetSolutionStepValue(VISCOSITY), node.GetSolutionStepValue(DENSITY))
 
     def test_save_var(self):
+        print("ccc")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(DENSITY)
@@ -69,6 +72,7 @@ class TestVariableUtils(KratosUnittest.TestCase):
         ##save the variable values
         VariableUtils().SaveScalarVar(VISCOSITY, DENSITY, model_part.Nodes)
         VariableUtils().SaveVectorVar(DISPLACEMENT, VELOCITY, model_part.Nodes)
+        print("ssss")
 
         ##verify the result
         for node in model_part.Nodes:
@@ -78,6 +82,7 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertEqual(node.GetSolutionStepValue(VISCOSITY), node.GetValue(DENSITY))
 
     def test_set_to_zero(self):
+        print("eee")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VISCOSITY)
@@ -97,6 +102,7 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertEqual(node.GetSolutionStepValue(VISCOSITY), 0.0)
 
     def test_select_node_list(self):
+        print("fff")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VISCOSITY)
@@ -117,6 +123,7 @@ class TestVariableUtils(KratosUnittest.TestCase):
         self.assertTrue(model_part.Nodes[974].Id in ids_list)
 
     def test_apply_fixity(self):
+        print("eeeeeee")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VISCOSITY)
@@ -136,6 +143,7 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertFalse(node.IsFixed(DISPLACEMENT_Y))
 
     def test_apply_vector(self):
+        print("fffgggggggggggg")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VISCOSITY)
@@ -159,8 +167,10 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertEqual(node.GetSolutionStepValue(VISCOSITY), data_vector_x1[i])
             self.assertEqual(node.GetSolutionStepValue(DISPLACEMENT_X), data_vector_x2[i])
             i+=1
+        print("uuuu")
 
     def test_sum_variable(self):
+        print("xxxxxxx")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(DENSITY)

--- a/kratos/tests/test_variable_utils.py
+++ b/kratos/tests/test_variable_utils.py
@@ -11,7 +11,6 @@ def GetFilePath(fileName):
 class TestVariableUtils(KratosUnittest.TestCase):
 
     def test_set_variable(self):
-        print("aaa")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VISCOSITY)
@@ -37,7 +36,6 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertEqual(node.GetSolutionStepValue(VISCOSITY), viscosity)
 
     def test_copy_var(self):
-        print("bbb")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(DENSITY)
@@ -59,7 +57,6 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertEqual(node.GetSolutionStepValue(VISCOSITY), node.GetSolutionStepValue(DENSITY))
 
     def test_save_var(self):
-        print("ccc")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(DENSITY)
@@ -72,7 +69,6 @@ class TestVariableUtils(KratosUnittest.TestCase):
         ##save the variable values
         VariableUtils().SaveScalarVar(VISCOSITY, DENSITY, model_part.Nodes)
         VariableUtils().SaveVectorVar(DISPLACEMENT, VELOCITY, model_part.Nodes)
-        print("ssss")
 
         ##verify the result
         for node in model_part.Nodes:
@@ -82,7 +78,6 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertEqual(node.GetSolutionStepValue(VISCOSITY), node.GetValue(DENSITY))
 
     def test_set_to_zero(self):
-        print("eee")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VISCOSITY)
@@ -102,7 +97,6 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertEqual(node.GetSolutionStepValue(VISCOSITY), 0.0)
 
     def test_select_node_list(self):
-        print("fff")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VISCOSITY)
@@ -123,7 +117,6 @@ class TestVariableUtils(KratosUnittest.TestCase):
         self.assertTrue(model_part.Nodes[974].Id in ids_list)
 
     def test_apply_fixity(self):
-        print("eeeeeee")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VISCOSITY)
@@ -143,7 +136,6 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertFalse(node.IsFixed(DISPLACEMENT_Y))
 
     def test_apply_vector(self):
-        print("fffgggggggggggg")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VISCOSITY)
@@ -167,10 +159,8 @@ class TestVariableUtils(KratosUnittest.TestCase):
             self.assertEqual(node.GetSolutionStepValue(VISCOSITY), data_vector_x1[i])
             self.assertEqual(node.GetSolutionStepValue(DISPLACEMENT_X), data_vector_x2[i])
             i+=1
-        print("uuuu")
 
     def test_sum_variable(self):
-        print("xxxxxxx")
         ##set the model part
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(DENSITY)


### PR DESCRIPTION
This branch backports capabilities from the nlohmann branch so to have iterators to work with the "old" rapidjson based parameters