### PR TITLE
remove second test_importing.TestImporting

### DIFF
--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -96,7 +96,6 @@ def AssambleTestSuites():
             test_processes.TestProcesses,
             test_importing.TestImporting,
             test_connectivity_preserve_modeler.TestConnectivityPreserveModeler,
-            test_importing.TestImporting,
             test_model.TestModel,
             test_redistance.TestRedistance,
             test_variable_utils.TestVariableUtils


### PR DESCRIPTION
test_importing.TestImporting was added twice to the allSuite. This caused the test to fail on my machine.