### PR TITLE
Correction in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Recovery files
-*.~
+*~
 
 # Compiled python
 *.pyc


### PR DESCRIPTION
This is a correction in gitignore

recovery files has not *.~ , just ignore *~