### PR TITLE
reading the nodes in parallel so that a first touching is performed

### DIFF
--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -1275,13 +1275,6 @@ namespace Kratos
             }
         }
 
-// 	for(map_type::const_iterator it = read_coordinates.begin(); it!=read_coordinates.end(); ++it)
-//         {
-//             const unsigned int node_id = it->first;
-//             const array_1d<double,3>& coords = it->second;
-//             rModelPart.CreateNewNode(node_id,coords[0],coords[1],coords[2]);
-//         }
-
 	std::cout << number_of_nodes_read << " nodes read]" << std::endl;
 	if(rModelPart.Nodes().size() - old_size != number_of_nodes_read)
             std::cout << "attention! we read " << number_of_nodes_read << " but there are only " << rModelPart.Nodes().size() - old_size<< " non repeated nodes" << std::endl;

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -15,6 +15,7 @@
 #include "includes/model_part_io.h"
 #include "input_output/logger.h"
 #include "utilities/quaternion.h"
+#include "utilities/openmp_utils.h"
 
 namespace Kratos
 {
@@ -1247,13 +1248,39 @@ namespace Kratos
          read_coordinates[ReorderedNodeId(id)] = coords;
 	  number_of_nodes_read++;
 	}
-
-	for(map_type::const_iterator it = read_coordinates.begin(); it!=read_coordinates.end(); ++it)
+	
+	
+	//make this to construct the nodes "in parallel" - the idea is that first touch is being done in parallel but the reading is actually sequential
+	const int nnodes = read_coordinates.size();
+	const int nthreads = OpenMPUtils::GetNumThreads();
+        std::vector<int> partition;
+        OpenMPUtils::DivideInPartitions(nnodes, nthreads, partition);
+        
+        map_type::const_iterator it = read_coordinates.begin();
+        for(int ithread=0; ithread<nthreads; ithread++)
         {
-            const unsigned int node_id = it->first;
-            const array_1d<double,3>& coords = it->second;
-            rModelPart.CreateNewNode(node_id,coords[0],coords[1],coords[2]);
+            #pragma omp parallel
+            {
+                //note that the reading is only done by one of the threads
+                if(OpenMPUtils::ThisThread() == ithread)
+                {
+                    for(int i=partition[ithread]; i<partition[ithread+1]; i++)
+                    {
+                        const unsigned int node_id = it->first;
+                        const array_1d<double,3>& coords = it->second;
+                        rModelPart.CreateNewNode(node_id,coords[0],coords[1],coords[2]);
+                        it++;
+                    }
+                }
+            }
         }
+
+// 	for(map_type::const_iterator it = read_coordinates.begin(); it!=read_coordinates.end(); ++it)
+//         {
+//             const unsigned int node_id = it->first;
+//             const array_1d<double,3>& coords = it->second;
+//             rModelPart.CreateNewNode(node_id,coords[0],coords[1],coords[2]);
+//         }
 
 	std::cout << number_of_nodes_read << " nodes read]" << std::endl;
 	if(rModelPart.Nodes().size() - old_size != number_of_nodes_read)


### PR DESCRIPTION
the idea is that nodes are still constructed sequentially, however their allocation is done thread-by-thread so to benefit of first touch policy.

