### PR TITLE
Implemented testing exit code

### DIFF
--- a/kratos/python_interface/kratos_unittest.py
+++ b/kratos/python_interface/kratos_unittest.py
@@ -1,5 +1,5 @@
 from __future__ import print_function, absolute_import, division
-from unittest import *
+from unittest import TestLoader, TextTestRunner, TestCase, TestSuite
 
 import getopt
 import sys
@@ -131,7 +131,9 @@ def runTests(tests):
             '[Warning]: "{}" test suite is empty'.format(level),
             file=sys.stderr)
     else:
-        TextTestRunner(verbosity=verbosity, buffer=True).run(tests[level])
+        ret = not TextTestRunner(verbosity=verbosity, buffer=True).run(tests[level]).wasSuccessful()
+        sys.exit(ret)
+
 
 KratosSuites = {
     'small': TestSuite(),

--- a/kratos/python_interface/kratos_unittest.py
+++ b/kratos/python_interface/kratos_unittest.py
@@ -131,8 +131,8 @@ def runTests(tests):
             '[Warning]: "{}" test suite is empty'.format(level),
             file=sys.stderr)
     else:
-        ret = not TextTestRunner(verbosity=verbosity, buffer=True).run(tests[level]).wasSuccessful()
-        sys.exit(ret)
+        result = not TextTestRunner(verbosity=verbosity, buffer=True).run(tests[level]).wasSuccessful()
+        sys.exit(result)
 
 
 KratosSuites = {

--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -299,7 +299,6 @@ def main():
             signalTime
         )
 
-    print(commander.exitCode)
     sys.exit(commander.exitCode)
 
 

--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -72,6 +72,7 @@ def handler(signum, frame):
 class Commander(object):
     def __init__(self):
         self.process = None
+        self.exitCode = 1
 
     def RunTestSuitInTime(self, application, applicationPath, path, level, verbose, command, timeout):
         if(timeout > -1):
@@ -87,10 +88,12 @@ class Commander(object):
                 self.process.terminate()
                 t.join()
                 print('\nABORT: Tests for {} took to long. Process Killed.'.format(application), file=sys.stderr)
+                return 1
             else:
                 print('\nTests for {} finished in time ({}s).'.format(application, timeout))
+                return
         else:
-            self.RunTestSuit(application, applicationPath, path, level, verbose, command)
+            return self.RunTestSuit(application, applicationPath, path, level, verbose, command)
 
     def RunTestSuit(self, application, applicationPath, path, level, verbose, command):
         ''' Calls the script that will run the tests.
@@ -158,7 +161,7 @@ class Commander(object):
                 ])
 
                 # Used instead of wait to "soft-block" the process and prevent deadlocks
-                self.process.communicate()
+                self.exitCode = self.process.communicate()
             else:
                 if verbose > 0:
                     print(

--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -72,7 +72,7 @@ def handler(signum, frame):
 class Commander(object):
     def __init__(self):
         self.process = None
-        self.exitCode = 1
+        self.exitCode = 0
 
     def RunTestSuitInTime(self, application, applicationPath, path, level, verbose, command, timeout):
         if(timeout > -1):

--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -157,7 +157,7 @@ class Commander(object):
                     '-v'+str(verbose)
                 ])
 
-                # Used instrad of wait to "soft-block" the process and prevent deadlocks
+                # Used instead of wait to "soft-block" the process and prevent deadlocks
                 self.process.communicate()
             else:
                 if verbose > 0:

--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -88,10 +88,8 @@ class Commander(object):
                 self.process.terminate()
                 t.join()
                 print('\nABORT: Tests for {} took to long. Process Killed.'.format(application), file=sys.stderr)
-                return 1
             else:
                 print('\nTests for {} finished in time ({}s).'.format(application, timeout))
-                return
         else:
             self.RunTestSuit(application, applicationPath, path, level, verbose, command)
 

--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -93,7 +93,7 @@ class Commander(object):
                 print('\nTests for {} finished in time ({}s).'.format(application, timeout))
                 return
         else:
-            return self.RunTestSuit(application, applicationPath, path, level, verbose, command)
+            self.RunTestSuit(application, applicationPath, path, level, verbose, command)
 
     def RunTestSuit(self, application, applicationPath, path, level, verbose, command):
         ''' Calls the script that will run the tests.
@@ -161,7 +161,10 @@ class Commander(object):
                 ])
 
                 # Used instead of wait to "soft-block" the process and prevent deadlocks
-                self.exitCode = self.process.communicate()
+                # and capture the first exit code different from OK
+                self.process.communicate()
+                if(not self.exitCode):
+                    self.process.returncode
             else:
                 if verbose > 0:
                     print(
@@ -295,6 +298,9 @@ def main():
             cmd,
             signalTime
         )
+
+    print(commander.exitCode)
+    sys.exit(commander.exitCode)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR allows KratosUnittests run function to be aware of the correctness of a tests and return an exit code according to it.
It also allows the run_tests.py script to return the correct exit code in case one or more than one test suits fail.

This PR is needed prior to merge #38 since otherwise is impossible to correctly check for the tests to be passing.