### PR TITLE
Extending Find boost-python options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,7 @@ install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/kratos_globals.py" DE
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/application_importer.py" DESTINATION KratosMultiphysics )
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/kratos_unittest.py" DESTINATION KratosMultiphysics RENAME KratosUnittest.py )
 
+install(FILES ${Boost_LIBRARIES} DESTINATION libs)
 install(FILES ${EXTRA_INSTALL_LIBS} DESTINATION libs)
 
 # Install blas and lapack

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,12 +143,12 @@ set(Boost_USE_MULTITHREADED ON)
 set(Boost_REALPATH ON)
 
 # Select python3 by default unless its specified in the configure file
-message("Using component: python${BOOST_PYTHON_SUFIX}")
-if(BOOST_PYTHON_SUFIX)
-  FIND_PACKAGE(Boost COMPONENTS "python${BOOST_PYTHON_SUFIX}" REQUIRED)
-else(BOOST_PYTHON_SUFIX)
+message("Using component: python${BOOST_PYTHON_SUFFIX}")
+if(BOOST_PYTHON_SUFFIX)
+  FIND_PACKAGE(Boost COMPONENTS "python${BOOST_PYTHON_SUFFIX}" REQUIRED)
+else(BOOST_PYTHON_SUFFIX)
   FIND_PACKAGE(Boost COMPONENTS python REQUIRED)
-endif(BOOST_PYTHON_SUFIX)
+endif(BOOST_PYTHON_SUFFIX)
 
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,9 +141,21 @@ endif(${KRATOS_EXCLUDE_OPENMP} MATCHES ON)
 set(Boost_USE_STATIC_LIBS   OFF)
 set(Boost_USE_MULTITHREADED ON)
 set(Boost_REALPATH ON)
-find_package(Boost COMPONENTS python REQUIRED)
+
+# Select python3 by default unless its specified in the configure file
+message("Using component: python${BOOST_PYTHON_SUFIX}")
+if(BOOST_PYTHON_SUFIX)
+  FIND_PACKAGE(Boost COMPONENTS "python${BOOST_PYTHON_SUFIX}" REQUIRED)
+else(BOOST_PYTHON_SUFIX)
+  FIND_PACKAGE(Boost COMPONENTS python REQUIRED)
+endif(BOOST_PYTHON_SUFIX)
+
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 link_directories(${Boost_LIBRARY_DIRS})
+
+message("Boost Include: ${Boost_INCLUDE_DIRS}")
+message("Boost Linkdir: ${Boost_LIBRARY_DIRS}")
+message("Boostlib used: ${Boost_LIBRARIES}")
 
 ##*****************************
 # Finding and including PYTHON
@@ -317,8 +329,6 @@ install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/kratos_globals.py" DE
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/application_importer.py" DESTINATION KratosMultiphysics )
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/kratos_unittest.py" DESTINATION KratosMultiphysics RENAME KratosUnittest.py )
 
-message("boost python lib used = " ${Boost_PYTHON_LIBRARY_RELEASE})
-install(FILES ${Boost_PYTHON_LIBRARY_RELEASE} DESTINATION libs)
 install(FILES ${EXTRA_INSTALL_LIBS} DESTINATION libs)
 
 # Install blas and lapack

--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -123,7 +123,7 @@ endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 ###############################################################
 ## define library KratosCore to be included in all of the others
 add_library(KratosCore SHARED ${KRATOS_CORE_SOURCES} ${KRATOS_CORE_TESTING_SOURCES} ${KRATOS_TESTING_SOURCES} ${KRATOS_CORE_INPUT_OUTPUT_SOURCES})
-target_link_libraries(KratosCore ${Boost_PYTHON_LIBRARIES} ${PYTHON_LIBRARIES} gidpost )
+target_link_libraries(KratosCore ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} gidpost )
 set_target_properties(KratosCore PROPERTIES COMPILE_DEFINITIONS "KRATOS_CORE=IMPORT,API")
 install(TARGETS KratosCore DESTINATION libs )
 


### PR DESCRIPTION
This PR adds the option to specify the suffix of the libboost library that will be linked with Kratos.

What this PR **does not** change:
* This change is backwards compatible and does not change the current behaviour and it is 100% transparent for the user.

What this PR **does** change:
* If the `BOOST_PYTHON_SUFIX` is defined, the `python${BOOST_PYTHON_SUFIX}` will be selected instead of the `python` component.
* Kratos now has `boost_LIBRARIES` instead of `boost_PYTHON_LIBRARIES`, since the later does not store the correct libboost_pythonXXX.so in case a prefix is specified
* Moves some messages about what is included and from where it is included.

Among other goodies, this will allow to compile with the system boost libraries, easing the compilation process in linux.