### PR TITLE
Add missing functions to Fast qual spatial container

### DIFF
--- a/applications/DEM_application/custom_utilities/discrete_particle_configure.h
+++ b/applications/DEM_application/custom_utilities/discrete_particle_configure.h
@@ -9,7 +9,7 @@
 
 // System includes
 #include <string>
-#include <iostream> 
+#include <iostream>
 #include <cmath>
 
 // Kratos includes
@@ -40,14 +40,14 @@ namespace Kratos
   ///@name Kratos Classes
   ///@{
 
-    
+
 template <std::size_t TDimension>
 class DiscreteParticleConfigure
 {
 
 public:
-  
-    enum { 
+
+    enum {
         Dimension = TDimension,
         DIMENSION = TDimension,
         MAX_LEVEL = 16,
@@ -56,25 +56,25 @@ public:
 
     /// Pointer definition of SpatialContainersConfigure
     KRATOS_CLASS_POINTER_DEFINITION(DiscreteParticleConfigure);
-    
+
     typedef SpatialSearch                                           SearchType;
 
     typedef SearchType::PointType                                   PointType;
     typedef SearchType::ElementsContainerType::ContainerType        ContainerType;
     typedef SearchType::ElementsContainerType                       ElementsContainerType;
     typedef SearchType::NodesContainerType                          NodesContainerType;
-    
+
     typedef SearchType::ElementType                                 ElementType;
     typedef ContainerType::value_type                               PointerType;
     typedef ContainerType::iterator                                 IteratorType;
     typedef ElementsContainerType::iterator                         ElementIteratorType;
-    
+
     typedef SearchType::ElementsContainerType::ContainerType        ResultContainerType;
 //     typedef SearchType::ResultDistanceType::ContainerType             ResultDistanceType;
-    
+
     typedef ResultContainerType::iterator                           ResultIteratorType;
     typedef std::vector<double>::iterator                           DistanceIteratorType;
-    
+
     typedef ContactPair<PointerType>                                ContactPairType;
     typedef std::vector<ContactPairType>                            ContainerContactType;
     typedef ContainerContactType::iterator                          IteratorContactType;
@@ -107,19 +107,19 @@ public:
 
     static void GetMinPoint()
     {
-        return mDomainMin;
+        // return mDomainMin;
     }
 
     static void GetMaxPoint()
     {
-        return mDomainMax;
+        // return mDomainMax;
     }
 
     static void GetPeriods(double periods[3])
     {
         periods[0] = mDomainPeriods[0];
         periods[1] = mDomainPeriods[1];
-        periods[2] = mDomainPeriods[2];        
+        periods[2] = mDomainPeriods[2];
     }
 
     static bool GetDomainPeriodicity()
@@ -193,7 +193,7 @@ public:
     {
         double rObj_2_to_rObj_1[3];
         PeriodicSubstract(rObj_1->GetGeometry()[0], rObj_2->GetGeometry()[0], rObj_2_to_rObj_1);
-        
+
         double distance_2 = DEM_INNER_PRODUCT_3(rObj_2_to_rObj_1, rObj_2_to_rObj_1);
 
         SphericParticle* p_particle1 = static_cast<SphericParticle*>(&*rObj_1);
@@ -218,20 +218,20 @@ public:
     }
 
     //******************************************************************************************************************
-    
+
     static inline bool IntersectionBox(const PointerType& rObject,  const PointType& rLowPoint, const PointType& rHighPoint)
     {
         const array_1d<double, 3>& center_of_particle = rObject->GetGeometry()[0];
- 
+
         SphericParticle* p_particle = static_cast<SphericParticle*>(&*rObject);
         const double& radius = p_particle->GetSearchRadius();
 
         bool intersect = (
-          floatle(rLowPoint[0]  - radius,center_of_particle[0]) && 
-          floatle(rLowPoint[1]  - radius,center_of_particle[1]) && 
+          floatle(rLowPoint[0]  - radius,center_of_particle[0]) &&
+          floatle(rLowPoint[1]  - radius,center_of_particle[1]) &&
           floatle(rLowPoint[2]  - radius,center_of_particle[2]) &&
-          floatge(rHighPoint[0] + radius,center_of_particle[0]) && 
-          floatge(rHighPoint[1] + radius,center_of_particle[1]) && 
+          floatge(rHighPoint[0] + radius,center_of_particle[0]) &&
+          floatge(rHighPoint[1] + radius,center_of_particle[1]) &&
           floatge(rHighPoint[2] + radius,center_of_particle[2]));
 
         if (mDomainIsPeriodic && !intersect){
@@ -256,7 +256,7 @@ public:
 
         SphericParticle* p_particle = static_cast<SphericParticle*>(&*rObject);
         const double& radius = p_particle->GetSearchRadius();
-        
+
         bool intersect = (
             floatle(rLowPoint[0]  - radius,center_of_particle[0]) &&
             floatle(rLowPoint[1]  - radius,center_of_particle[1]) &&
@@ -287,16 +287,16 @@ public:
         PeriodicSubstract(rObj_1->GetGeometry()[0], rObj_2->GetGeometry()[0], rObj_2_to_rObj_1);
         distance = DEM_MODULUS_3(rObj_2_to_rObj_1);
     }
-    
+
     static inline double GetObjectRadius(const PointerType& rObject, const double& Radius)
     {
-        return GetObjectRadius(rObject);       
+        return GetObjectRadius(rObject);
     }
-    
+
     static inline double GetObjectRadius(const PointerType& rObject)
     {
         SphericParticle* p_particle = static_cast<SphericParticle*>(&*rObject);
-        return p_particle->GetSearchRadius();        
+        return p_particle->GetSearchRadius();
     }
 
     static double mDomainPeriods[3];
@@ -375,7 +375,7 @@ private:
         for (unsigned int i = 0; i < 3; ++i){
                 c[i] = a[i] - b[i];
         }
-        
+
         if (mDomainIsPeriodic){ // Periods have been set (the domain is periodic)
             for (unsigned int i = 0; i < 3; ++i){
                 if (fabs(c[i]) > 0.5 * mDomainPeriods[i]){ // the objects are closer through the boundary
@@ -388,11 +388,11 @@ private:
     static inline bool floateq(double a, double b) {
         return std::fabs(a - b) < std::numeric_limits<double>::epsilon();
     }
-    
+
     static inline bool floatle(double a, double b) {
         return a < b || std::fabs(a - b) < std::numeric_limits<double>::epsilon();
     }
-    
+
     static inline bool floatge(double a, double b) {
         return a > b || std::fabs(a - b) < std::numeric_limits<double>::epsilon();
     }

--- a/applications/DEM_application/custom_utilities/discrete_particle_configure.h
+++ b/applications/DEM_application/custom_utilities/discrete_particle_configure.h
@@ -105,14 +105,14 @@ public:
         mDomainPeriods[2] = domain_period_z;
     }
 
-    static void GetMinPoint()
+    static double* GetMinPoint()
     {
-        // return mDomainMin;
+        return mDomainMin;
     }
 
-    static void GetMaxPoint()
+    static double* GetMaxPoint()
     {
-        // return mDomainMax;
+        return mDomainMax;
     }
 
     static void GetPeriods(double periods[3])

--- a/applications/ParticleMechanicsApplication/custom_utilities/fast_quad_spatial_containers_configure.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/fast_quad_spatial_containers_configure.h
@@ -15,7 +15,7 @@
 
 // System includes
 #include <string>
-#include <iostream> 
+#include <iostream>
 #include <cmath>
 
 // kratos utils
@@ -44,14 +44,14 @@ namespace Kratos
   ///@name Kratos Classes
   ///@{
 
-    
+
 template <std::size_t TDimension>
 class FastQuadSpatialContainersConfigure
 {
 
 public:
-  
-    enum { 
+
+    enum {
         Dimension = TDimension,
         DIMENSION = TDimension,
         MAX_LEVEL = 16,
@@ -60,7 +60,7 @@ public:
 
     /// Pointer definition of FastQuadSpatialContainersConfigure
     KRATOS_CLASS_POINTER_DEFINITION(FastQuadSpatialContainersConfigure);
-    
+
     typedef Point<3, double>                                PointType;  /// always the point 3D
     typedef std::vector<double>::iterator                   DistanceIteratorType;
     typedef ModelPart::ElementsContainerType::ContainerType ContainerType;
@@ -73,26 +73,25 @@ public:
 
 
     /// Contact Pairs
-//       typedef std::pair<PointerType, PointerType>            ContactPairType;
-//       typedef std::vector<ContactPairType>                   ContainerContactType;
-//       typedef std::vector<ContactPairType>::iterator         IteraratorContactType;
+    // typedef std::pair<PointerType, PointerType>            ContactPairType;
+    // typedef std::vector<ContactPairType>                   ContainerContactType;
+    // typedef std::vector<ContactPairType>::iterator         IteraratorContactType;
 
     /// Contact Pairs
     typedef ContactPair<PointerType>                        ContactPairType;
-    //typedef array_1d<PointerType, 2>                       ContactPairType;
+    // typedef array_1d<PointerType, 2>                       ContactPairType;
     typedef  std::vector<ContactPairType>                   ContainerContactType;
     typedef  ContainerContactType::iterator                 IteratorContactType;
     typedef  ContainerContactType::value_type               PointerContactType;
     typedef  std::vector<PointerType>::iterator             PointerTypeIterator;
-    
-    
+
+
     ///@}
     ///@name Life Cycle
     ///@{
 
     FastQuadSpatialContainersConfigure(){};
-    virtual ~FastQuadSpatialContainersConfigure(){
-	}
+    virtual ~FastQuadSpatialContainersConfigure(){}
 
     ///@}
     ///@name Operators
@@ -102,8 +101,6 @@ public:
     ///@}
     ///@name Operations
     ///@{
-
-    //******************************************************************************************************************
 
     static inline void CalculateBoundingBox(const PointerType& rObject, PointType& rLowPoint, PointType& rHighPoint)
     {
@@ -119,24 +116,21 @@ public:
         }
     }
 
-   
-        
-   
     //******************************************************************************************************************
 
     static inline bool Intersection(const PointerType& rObj_1, const PointerType& rObj_2)
     {
         Element::GeometryType& geom_1 = rObj_1->GetGeometry();
         Element::GeometryType& geom_2 = rObj_2->GetGeometry();
-        
+
         PointType rHighPoint1 = geom_1.GetPoint(0);
         PointType rLowPoint1  = geom_1.GetPoint(0);
-        
+
         PointType rHighPoint2 = geom_2.GetPoint(0);
         PointType rLowPoint2  = geom_2.GetPoint(0);
-        
+
         //Firstly the Lowpoint and Highpoint are defined for both quadrilaterals
-        
+
         for (unsigned int point = 1; point<geom_1.PointsNumber(); point++)
         {
             for(std::size_t i = 0; i<TDimension; i++)
@@ -145,7 +139,7 @@ public:
                 rHighPoint1[i] =  (rHighPoint1[i] <  geom_1.GetPoint(point)[i] ) ?  geom_1.GetPoint(point)[i] : rHighPoint1[i];
             }
         }
-        
+
         for (unsigned int point = 1; point<geom_2.PointsNumber(); point++)
         {
             for(std::size_t i = 0; i<TDimension; i++)
@@ -154,93 +148,67 @@ public:
                 rHighPoint2[i] =  (rHighPoint2[i] <  geom_2.GetPoint(point)[i] ) ?  geom_2.GetPoint(point)[i] : rHighPoint2[i];
             }
         }
-        
+
         if (rHighPoint1[0] < rLowPoint2[0]) {
-			
-			return false;
-		}
-			
-		else if (rLowPoint1[0] > rHighPoint2[0]) {
-			
-			return false;
-		}
-				
-		else if (rLowPoint1[1] > rHighPoint2[1]) {
-			
-			return false;
-		}
-					
-		else if (rHighPoint1[1] < rLowPoint2[1]) {
-			
-			return false;
-		}
-		
-		
-		return true;
-        
+          return false;
+		    }
+    		else if (rLowPoint1[0] > rHighPoint2[0]) {
+    			return false;
+    		}
+    		else if (rLowPoint1[1] > rHighPoint2[1]) {
+    			return false;
+    		}
+    		else if (rHighPoint1[1] < rLowPoint2[1]) {
+    			return false;
+    		}
+
+        return true;
     }
 
-    
-
     //******************************************************************************************************************
-    
+
     static inline bool IntersectionBox(const PointerType& rObject,  const PointType& rLowPoint, const PointType& rHighPoint)
     {
-		Element::GeometryType& geom_1 = rObject->GetGeometry();
-        
+		    Element::GeometryType& geom_1 = rObject->GetGeometry();
+
         PointType rHighPoint1 = geom_1.GetPoint(0);
         PointType rLowPoint1  = geom_1.GetPoint(0);
-        
+
         // std::cout << "POINTINTERBOX" << std::endl;
         // std::cout << "_____________" << std::endl;
         // std::cout << "Point number: " << geom_1.PointsNumber() << std::endl;
         // std::cout << "_____________" << std::endl;
         for (unsigned int point = 1; point<geom_1.PointsNumber(); point++)
         {
-			// std::cout << "\t" << geom_1.GetPoint(point)[0] << " " << geom_1.GetPoint(point)[1] << std::endl;
+            // std::cout << "\t" << geom_1.GetPoint(point)[0] << " " << geom_1.GetPoint(point)[1] << std::endl;
             for(std::size_t i = 0; i<TDimension; i++)
             {
                 rLowPoint1[i]  =  (rLowPoint1[i]  >  geom_1.GetPoint(point)[i] ) ?  geom_1.GetPoint(point)[i] : rLowPoint1[i];
                 rHighPoint1[i] =  (rHighPoint1[i] <  geom_1.GetPoint(point)[i] ) ?  geom_1.GetPoint(point)[i] : rHighPoint1[i];
             }
         }
+
         // std::cout << "_____________" << std::endl;
         // std::cout << rLowPoint1[0] << " " << rLowPoint1[1] << std::endl;
         // std::cout << rHighPoint1[0] << " " << rHighPoint1[1] << std::endl;
         // std::cout << rLowPoint[0] << " " << rLowPoint[1] << std::endl;
         // std::cout << rHighPoint[0] << " " << rHighPoint[1] << std::endl;
-                
+
         if (rHighPoint1[0] < rLowPoint[0]) {
-			
-			return false;
-		}
-			
-		else if (rLowPoint1[0] > rHighPoint[0]) {
-			
-			return false;
-		}
-				
-		else if (rLowPoint1[1] > rHighPoint[1]) {
-			
-			return false;
-		}
-					
-		else if (rHighPoint1[1] < rLowPoint[1]) {
-			
-			return false;
-		}
-		
-		// std::cout << "LALALAL" << std::endl;
-		
-		
-		return true;
-        //return rObject->GetGeometry().HasIntersection(rLowPoint, rHighPoint);
+          return false;
+        }
+        else if (rLowPoint1[0] > rHighPoint[0]) {
+        	return false;
+        }
+        else if (rLowPoint1[1] > rHighPoint[1]) {
+        	return false;
+        }
+        else if (rHighPoint1[1] < rLowPoint[1]) {
+        	return false;
+        }
 
-        
- 
+		    return true;
     }
-
-    
 
     //static inline void Distance(const PointerType& rObj_1, const PointerType& rObj_2, double& distance)
     //{
@@ -251,7 +219,7 @@ public:
                         //(center_of_particle1[1] - center_of_particle2[1]) * (center_of_particle1[1] - center_of_particle2[1]) +
                         //(center_of_particle1[2] - center_of_particle2[2]) * (center_of_particle1[2] - center_of_particle2[2]) );
     //}
-     
+
     //******************************************************************************************************************
 
     ///@}
@@ -280,7 +248,7 @@ public:
     ///@}
     ///@name Friends
     ///@{
-      
+
 
     ///@}
 
@@ -329,15 +297,15 @@ private:
     ///@}
     ///@name Private Operations
     ///@{
-      
+
     //static inline bool floateq(double a, double b) {
         //return std::fabs(a - b) < std::numeric_limits<double>::epsilon();
     //}
-    
+
     //static inline bool floatle(double a, double b) {
         //return std::fabs(a - b) < std::numeric_limits<double>::epsilon() || a < b;
     //}
-    
+
     //static inline bool floatge(double a, double b) {
         //return std::fabs(a - b) < std::numeric_limits<double>::epsilon() || a > b;
     //}

--- a/applications/ParticleMechanicsApplication/custom_utilities/fast_quad_spatial_containers_configure.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/fast_quad_spatial_containers_configure.h
@@ -1,11 +1,13 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
 //
-//   Project Name:        KratosParticleMechanicsApplication $
-//   Last modified by:    $Author:                    ilaria $
-//   Date:                $Date:                  April 2016 $
-//   Revision:            $Revision:                     0.0 $
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
 //
-//
-
+//  Main authors:       Ilaria Iaconeta
 
 //A fast algorithm to check intersection between two axis-aligned quadrilateral is implemented.
 //This axis-aligned rect test is a special case of the separating axis theorem.
@@ -69,8 +71,6 @@ public:
     typedef ModelPart::ElementsContainerType::ContainerType ResultContainerType;
     typedef ResultContainerType::value_type                 ResultPointerType;
     typedef ResultContainerType::iterator                   ResultIteratorType;
-
-
 
     /// Contact Pairs
     // typedef std::pair<PointerType, PointerType>            ContactPairType;

--- a/applications/ParticleMechanicsApplication/custom_utilities/fast_quad_spatial_containers_configure.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/fast_quad_spatial_containers_configure.h
@@ -116,6 +116,11 @@ public:
         }
     }
 
+    static inline void CalculateBoundingBox(const PointerType& rObject, PointType& rLowPoint, PointType& rHighPoint, const double & Radius)
+    {
+        KRATOS_ERROR << "Fast Quad spatial does not define this function" << std::endl;
+    }
+
     //******************************************************************************************************************
 
     static inline bool Intersection(const PointerType& rObj_1, const PointerType& rObj_2)
@@ -165,6 +170,11 @@ public:
         return true;
     }
 
+    static inline bool Intersection(const PointerType& rObj_1, const PointerType& rObj_2, const double & Radius)
+    {
+        KRATOS_ERROR << "Fast Quad spatial does not define this function" << std::endl;
+    }
+
     //******************************************************************************************************************
 
     static inline bool IntersectionBox(const PointerType& rObject,  const PointType& rLowPoint, const PointType& rHighPoint)
@@ -208,6 +218,16 @@ public:
         }
 
 		    return true;
+    }
+
+    static inline bool IntersectionBox(const PointerType& rObject,  const PointType& rLowPoint, const PointType& rHighPoint, const double & Radius)
+    {
+        KRATOS_ERROR << "Fast Quad spatial does not define this function" << std::endl;
+    }
+
+    static inline void Distance(const PointerType& rObj_1, const PointerType& rObj_2, double& distance)
+    {
+        KRATOS_ERROR << "Fast Quad spatial does not define this function" << std::endl;
     }
 
     //static inline void Distance(const PointerType& rObj_1, const PointerType& rObj_2, double& distance)


### PR DESCRIPTION
This fixes #379.

Also, @GuillermoCasas I commented `GetMinPoint()` and `GetMaxPoint()` functions bodies from the `discrete_particle_configure.h` since the function states `void ...` but they are returning values. In modern compiler this is no longer a warning but an error. 

Not sure what is the mistake here so I leaving it like this, feel free to change it directly in this branch.