### PR TITLE
Predefined mesh size preserved after remeshing

### DIFF
--- a/applications/PoromechanicsApplication/custom_problemtype/Poromechanics_Application.gid/FracturePropagation2DAuxProcs.tcl
+++ b/applications/PoromechanicsApplication/custom_problemtype/Poromechanics_Application.gid/FracturePropagation2DAuxProcs.tcl
@@ -117,9 +117,9 @@ proc WriteBodySurfacesList {FileVar BodySurfacesDict} {
     puts $MyFileVar "    \"body_surfaces_list\": \[\{"
     dict for {Id BodySurface} $BodySurfacesDict {
         incr iter
-        puts $MyFileVar "        \"id\":     $Id,"
+        puts $MyFileVar "        \"id\":        $Id,"
         if {[llength [dict get $BodySurface Groups]] eq 0} {
-            puts $MyFileVar "        \"groups\": \[\],"
+            puts $MyFileVar "        \"groups\":    \[\],"
         } else {
             set PutStrings \[
             for {set i 0} {$i < [llength [dict get $BodySurface Groups]]} {incr i} {
@@ -127,7 +127,7 @@ proc WriteBodySurfacesList {FileVar BodySurfacesDict} {
             }
             set PutStrings [string trimright $PutStrings ,]
             append PutStrings \]
-            puts $MyFileVar "        \"groups\": $PutStrings,"
+            puts $MyFileVar "        \"groups\":    $PutStrings,"
         }
         set PutStrings \[
         for {set i 0} {$i < [llength [dict get $BodySurface Lines]]} {incr i} {
@@ -135,7 +135,9 @@ proc WriteBodySurfacesList {FileVar BodySurfacesDict} {
         }
         set PutStrings [string trimright $PutStrings ,]
         append PutStrings \]
-        puts $MyFileVar "        \"lines\":  $PutStrings"
+        puts $MyFileVar "        \"lines\":     $PutStrings,"
+        puts $MyFileVar "        \"elem_type\": \"[dict get $BodySurface ElemType]\","
+        puts $MyFileVar "        \"mesh_size\": [dict get $BodySurface MeshSize]"
         if {$iter < [dict size $BodySurfacesDict]} {
             puts $MyFileVar "    \},\{"
         } else {

--- a/applications/PoromechanicsApplication/custom_problemtype/Poromechanics_Application.gid/FracturePropagation3DAuxProcs.tcl
+++ b/applications/PoromechanicsApplication/custom_problemtype/Poromechanics_Application.gid/FracturePropagation3DAuxProcs.tcl
@@ -173,9 +173,9 @@ proc WriteBodyVolumesList {FileVar BodyVolumesDict} {
     puts $MyFileVar "    \"body_volumes_list\": \[\{"
     dict for {Id BodyVolume} $BodyVolumesDict {
         incr iter
-        puts $MyFileVar "        \"id\":       $Id,"
+        puts $MyFileVar "        \"id\":        $Id,"
         if {[llength [dict get $BodyVolume Groups]] eq 0} {
-            puts $MyFileVar "        \"groups\":   \[\],"
+            puts $MyFileVar "        \"groups\":    \[\],"
         } else {
             set PutStrings \[
             for {set i 0} {$i < [llength [dict get $BodyVolume Groups]]} {incr i} {
@@ -183,7 +183,7 @@ proc WriteBodyVolumesList {FileVar BodyVolumesDict} {
             }
             set PutStrings [string trimright $PutStrings ,]
             append PutStrings \]
-            puts $MyFileVar "        \"groups\":   $PutStrings,"
+            puts $MyFileVar "        \"groups\":    $PutStrings,"
         }
         set PutStrings \[
         for {set i 0} {$i < [llength [dict get $BodyVolume Surfaces]]} {incr i} {
@@ -191,7 +191,8 @@ proc WriteBodyVolumesList {FileVar BodyVolumesDict} {
         }
         set PutStrings [string trimright $PutStrings ,]
         append PutStrings \]
-        puts $MyFileVar "        \"surfaces\": $PutStrings"
+        puts $MyFileVar "        \"surfaces\":  $PutStrings,"
+        puts $MyFileVar "        \"mesh_size\": [dict get $BodyVolume MeshSize]"
         if {$iter < [dict size $BodyVolumesDict]} {
             puts $MyFileVar "    \},\{"
         } else {

--- a/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_2D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_2D_utilities.hpp
@@ -336,6 +336,8 @@ protected:
                 PropDataFile << "lappend Lines " << rParameters["body_surfaces_list"][i]["lines"][j].GetInt() << std::endl;
             }
             PropDataFile << "dict set BodySurfacesDict " << Id << " Lines $Lines" << std::endl;
+            PropDataFile << "dict set BodySurfacesDict " << Id << " ElemType " << rParameters["body_surfaces_list"][i]["elem_type"].GetString() << std::endl;
+            PropDataFile << "dict set BodySurfacesDict " << Id << " MeshSize " << rParameters["body_surfaces_list"][i]["mesh_size"].GetDouble() << std::endl;
         }
         PropDataFile << "lappend PropagationData $BodySurfacesDict" << std::endl;
 

--- a/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_3D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_3D_utilities.hpp
@@ -367,6 +367,7 @@ protected:
                 PropDataFile << "lappend Surfaces " << rParameters["body_volumes_list"][i]["surfaces"][j].GetInt() << std::endl;
             }
             PropDataFile << "dict set BodyVolumesDict " << Id << " Surfaces $Surfaces" << std::endl;
+            PropDataFile << "dict set BodyVolumesDict " << Id << " MeshSize " << rParameters["body_volumes_list"][i]["mesh_size"].GetDouble() << std::endl;
         }
         PropDataFile << "lappend PropagationData $BodyVolumesDict" << std::endl;
                 

--- a/applications/PoromechanicsApplication/test_examples/fluid_pumping_2D_fracture.gid/FracturesData.json
+++ b/applications/PoromechanicsApplication/test_examples/fluid_pumping_2D_fracture.gid/FracturesData.json
@@ -11,9 +11,11 @@
         "interface_domain_sub_model_part_list": ["Interface_Part-auto-1"]
     },
     "body_surfaces_list": [{
-        "id":     2,
-        "groups": ["Body_Part-auto-1"],
-        "lines":  [1,2,3,4,9,8,7,6,5]
+        "id":        2,
+        "groups":    ["Body_Part-auto-1"],
+        "lines":     [1,2,3,4,9,8,7,6,5],
+        "elem_type": "Triangle",
+        "mesh_size": 0
     }],
     "fractures_list": [{
         "id":                0,


### PR DESCRIPTION
This is a minor modification on the remeshing tcl procedure that allows preserving the size of the mesh defined on surface (2D) or volume (3D) entities.