### PR TITLE
Feature check precondition in ale ns solvers

### DIFF
--- a/applications/ALEapplication/python_scripts/ale_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/ALEapplication/python_scripts/ale_navier_stokes_solver_vmsmonolithic.py
@@ -15,6 +15,9 @@ class ALENavierStokesSolverVMSMonolithic(navier_stokes_solver_vmsmonolithic.Navi
     def __init__(self, model_part, custom_settings):
         # get ale solver type
         self.ale_solver_type = custom_settings["ale_solver_type"].GetString()
+        valid_ale_solver_types = ["mesh_solver_structural_similarity"]
+        if self.ale_solver_type not in valid_ale_solver_types:
+            raise Exception("Invalid ale_solver_type:" + self.ale_solver_type)
         # remove the ale solver type from settings so we can reuse the navier stokes constructor
         navier_stokes_settings = custom_settings
         navier_stokes_settings.RemoveValue("ale_solver_type")

--- a/applications/ALEapplication/python_scripts/ale_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/ALEapplication/python_scripts/ale_navier_stokes_solver_vmsmonolithic.py
@@ -17,7 +17,7 @@ class ALENavierStokesSolverVMSMonolithic(navier_stokes_solver_vmsmonolithic.Navi
         self.ale_solver_type = custom_settings["ale_solver_type"].GetString()
         valid_ale_solver_types = ["mesh_solver_structural_similarity"]
         if self.ale_solver_type not in valid_ale_solver_types:
-            raise Exception("Invalid ale_solver_type:" + self.ale_solver_type)
+            raise Exception("Invalid ale_solver_type: " + self.ale_solver_type)
         # remove the ale solver type from settings so we can reuse the navier stokes constructor
         navier_stokes_settings = custom_settings
         navier_stokes_settings.RemoveValue("ale_solver_type")

--- a/applications/ALEapplication/python_scripts/ale_trilinos_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/ALEapplication/python_scripts/ale_trilinos_navier_stokes_solver_vmsmonolithic.py
@@ -19,7 +19,7 @@ class ALETrilinosNavierStokesSolverVMSMonolithic(trilinos_navier_stokes_solver_v
         self.ale_solver_type = custom_settings["ale_solver_type"].GetString()
         valid_ale_solver_types = ["trilinos_mesh_solver_structural_similarity"]
         if self.ale_solver_type not in valid_ale_solver_types:
-            raise Exception("Invalid ale_solver_type:" + self.ale_solver_type)
+            raise Exception("Invalid ale_solver_type: " + self.ale_solver_type)
         # remove the ale solver type from settings so we can reuse the navier stokes constructor
         navier_stokes_settings = custom_settings
         navier_stokes_settings.RemoveValue("ale_solver_type")

--- a/applications/ALEapplication/python_scripts/ale_trilinos_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/ALEapplication/python_scripts/ale_trilinos_navier_stokes_solver_vmsmonolithic.py
@@ -17,6 +17,9 @@ class ALETrilinosNavierStokesSolverVMSMonolithic(trilinos_navier_stokes_solver_v
     def __init__(self, model_part, custom_settings):
         # get ale solver type
         self.ale_solver_type = custom_settings["ale_solver_type"].GetString()
+        valid_ale_solver_types = ["trilinos_mesh_solver_structural_similarity"]
+        if self.ale_solver_type not in valid_ale_solver_types:
+            raise Exception("Invalid ale_solver_type:" + self.ale_solver_type)
         # remove the ale solver type from settings so we can reuse the navier stokes constructor
         navier_stokes_settings = custom_settings
         navier_stokes_settings.RemoveValue("ale_solver_type")


### PR DESCRIPTION
Added a check for the ale_solver_type. @adityaghantasala found that without such a check, the trilinos ale navier stokes solver runs with incorrect serial mesh motion. This check ensures that only valid mesh motion solvers added to the list valid_ale_solver_types are allowed.