### PR TITLE
Fixed error with boost libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -328,6 +328,11 @@ install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/kratos_globals.py" DE
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/application_importer.py" DESTINATION KratosMultiphysics )
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/kratos_unittest.py" DESTINATION KratosMultiphysics RENAME KratosUnittest.py )
 
+# Remove the tags in the event of multiple versions of boost being found
+# in the same directory
+list(REMOVE_ITEM Boost_LIBRARIES "debug" "optimized")
+
+# Install the libraries in the libs folder
 install(FILES ${Boost_LIBRARIES} DESTINATION libs)
 install(FILES ${EXTRA_INSTALL_LIBS} DESTINATION libs)
 


### PR DESCRIPTION
This fixed the error trying to install boost libraries in windows when two or more versions of the same library using different release types are found in the same dir.

For the record the problem is caused by CMake adding the "optimized" and "debug" keywords before the library name in the BOOST_Libraries variable, which expands to:

optimized
libraryA.lib
debug
libraryB.lib

which fools some process in cmake and ends making the cmake_install.txt trying to create the C:\InstallDir\Optimized and C:\InstallDir\Debug directories.