### PR TITLE
Adding os.path.abspath to autogenerated KratosLoader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,19 +353,11 @@ endif(${INSTALL_TESTING_FILES} MATCHES ON)
 if(${INSTALL_PYTHON_FILES} MATCHES ON)
     #take care: do not indent the lines below
 file(WRITE ${CMAKE_SOURCE_DIR}/packaging_aux/KratosLoader.py "import sys
-# # kratos_libs=\"${CMAKE_INSTALL_PREFIX}/libs\"
-# # kratos_applications=\"${CMAKE_INSTALL_PREFIX}/applications\"
-# # kratos_scripts=\"${CMAKE_INSTALL_PREFIX}/kratos/python_scripts\"
-# # kratos_tests=\"${CMAKE_INSTALL_PREFIX}/kratos/tests\"
-# # sys.path.append(kratos_libs)
-# # sys.path.append(kratos_applications)
-# # sys.path.append(kratos_scripts)
-# # sys.path.append(kratos_tests)
 import os.path
-kratos_libs=os.path.join(os.path.dirname(__file__),'../libs')
-kratos_applications=os.path.join(os.path.dirname(__file__),'../applications')
-kratos_scripts=os.path.join(os.path.dirname(__file__),'../kratos/python_scripts')
-kratos_tests=os.path.join(os.path.dirname(__file__),'../kratos/tests')
+kratos_libs=os.path.abspath(os.path.join(os.path.dirname(__file__),'../libs'))
+kratos_applications=os.path.abspath(os.path.join(os.path.dirname(__file__),'../applications'))
+kratos_scripts=os.path.abspath(os.path.join(os.path.dirname(__file__),'../kratos/python_scripts'))
+kratos_tests=os.path.abspath(os.path.join(os.path.dirname(__file__),'../kratos/tests'))
 sys.path.append(kratos_libs)
 sys.path.append(kratos_applications)
 sys.path.append(kratos_scripts)


### PR DESCRIPTION
This is in response to issue #421 