### PR TITLE
Removing warning geometry test

### DIFF
--- a/kratos/tests/geometries/test_geometry.h
+++ b/kratos/tests/geometries/test_geometry.h
@@ -29,7 +29,6 @@ namespace Kratos {
 namespace Testing {
 
     static std::streambuf *coutbuf = std::cout.rdbuf();
-    static bool exceptionThrown = false;
 
     // FIXME: EXCPETION -> EXCEPTION
     // TODO: Move to 'include/checks.h' once is confirmed to work as intended


### PR DESCRIPTION
~~~
In file included from /home/vicente/bin/Kratos/kratos/tests/geometries/test_non_rectangular_jacobian.cpp:21:0:
/home/vicente/bin/Kratos/kratos/tests/geometries/test_geometry.h:32:17: warning: ‘Kratos::Testing::exceptionThrown’ defined but not used [-Wunused-variable]
     static bool exceptionThrown = false;
~~~