### PR TITLE
Remove external solver dependency in tests

### DIFF
--- a/applications/FluidDynamicsApplication/tests/KratosExecuteManufacturedSolutionTest.py
+++ b/applications/FluidDynamicsApplication/tests/KratosExecuteManufacturedSolutionTest.py
@@ -3,11 +3,6 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 # Import kratos core and applications
 import KratosMultiphysics
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
-try:
-    import KratosMultiphysics.ExternalSolversApplication
-    have_external_solvers = True
-except ImportError as e:
-    have_external_solvers = False
 
 import process_factory
 import KratosMultiphysics.KratosUnittest as KratosUnittest
@@ -124,10 +119,6 @@ class ManufacturedSolutionProblem:
         ## Fluid model part definition
         self.main_model_part = KratosMultiphysics.ModelPart(self.ProjectParameters["problem_data"]["model_part_name"].GetString())
         self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, self.ProjectParameters["problem_data"]["domain_size"].GetInt())
-
-        ## Do not use SuperLUSolver if it is not available
-        if not have_external_solvers:
-            self.ProjectParameters["solver_settings"]["linear_solver_settings"]["solver_type"].SetString("AMGCL")
 
         ###TODO replace this "model" for real one once available
         Model = {self.ProjectParameters["problem_data"]["model_part_name"].GetString() : self.main_model_part}

--- a/applications/FluidDynamicsApplication/tests/KratosExecuteManufacturedSolutionTest.py
+++ b/applications/FluidDynamicsApplication/tests/KratosExecuteManufacturedSolutionTest.py
@@ -3,6 +3,11 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 # Import kratos core and applications
 import KratosMultiphysics
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+try:
+    import KratosMultiphysics.ExternalSolversApplication
+    have_external_solvers = True
+except ImportError as e:
+    have_external_solvers = False
 
 import process_factory
 import KratosMultiphysics.KratosUnittest as KratosUnittest
@@ -119,6 +124,10 @@ class ManufacturedSolutionProblem:
         ## Fluid model part definition
         self.main_model_part = KratosMultiphysics.ModelPart(self.ProjectParameters["problem_data"]["model_part_name"].GetString())
         self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, self.ProjectParameters["problem_data"]["domain_size"].GetInt())
+
+        ## Do not use SuperLUSolver if it is not available
+        if not have_external_solvers:
+            self.ProjectParameters["solver_settings"]["linear_solver_settings"]["solver_type"].SetString("AMGCL")
 
         ###TODO replace this "model" for real one once available
         Model = {self.ProjectParameters["problem_data"]["model_part_name"].GetString() : self.main_model_part}

--- a/applications/FluidDynamicsApplication/tests/SmallTests.py
+++ b/applications/FluidDynamicsApplication/tests/SmallTests.py
@@ -3,6 +3,12 @@ import os
 # Import Kratos
 from KratosMultiphysics import *
 
+try:
+    import KratosMultiphysics.ExternalSolversApplication
+    have_external_solvers = True
+except ImportError as e:
+    have_external_solvers = False
+
 # Import KratosUnittest
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosExecuteEmbeddedTest as ExecuteEmbeddedTest
@@ -44,7 +50,6 @@ class EmbeddedTestFactory(KratosUnittest.TestCase):
     def tearDown(self):
         pass
 
-
 class ManufacturedSolutionTestFactory(KratosUnittest.TestCase):
 
     def setUp(self):
@@ -81,7 +86,7 @@ class EmbeddedCouetteImposedTest(EmbeddedTestFactory):
 class EmbeddedReservoirTest(EmbeddedTestFactory):
     file_name = "EmbeddedReservoirTest/EmbeddedReservoirTest"
 
-
+@KratosUnittest.skipUnless(have_external_solvers, "Missing required application: ExternalSolversApplication")
 class ManufacturedSolutionTest(ManufacturedSolutionTestFactory):
     file_name = "ManufacturedSolutionTest/ManufacturedSolutionTest"
 

--- a/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
+++ b/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
@@ -1,6 +1,5 @@
 # import Kratos
 from KratosMultiphysics import *
-#from KratosMultiphysics.ExternalSolversApplication import *
 from KratosMultiphysics.FluidDynamicsApplication import *
 
 # Import Kratos "wrapper" for unittests

--- a/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
+++ b/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
@@ -1,6 +1,6 @@
 # import Kratos
 from KratosMultiphysics import *
-from KratosMultiphysics.ExternalSolversApplication import *
+#from KratosMultiphysics.ExternalSolversApplication import *
 from KratosMultiphysics.FluidDynamicsApplication import *
 
 # Import Kratos "wrapper" for unittests


### PR DESCRIPTION
I have set the manufactured solution tests to skip unless the ExternalSolversApplication is available (since they use SuperLU)