### PR TITLE
Fix bug in process

### DIFF
--- a/applications/SolidMechanicsApplication/python_scripts/assign_modulus_and_direction_to_conditions_process.py
+++ b/applications/SolidMechanicsApplication/python_scripts/assign_modulus_and_direction_to_conditions_process.py
@@ -64,8 +64,8 @@ class AssignModulusAndDirectionToConditionsProcess(KratosMultiphysics.Process):
         if( self.settings["interval"][1].IsString() ):
             if( self.settings["interval"][1].GetString() == "End" ):
                 self.interval.append(sys.float_info.max)
-            elif( self.settings["interval"][1].IsDouble() or  self.settings["interval"][1].IsInt() ):
-                self.interval.append(self.settings["interval"][1].GetDouble());
+        elif( self.settings["interval"][1].IsDouble() or  self.settings["interval"][1].IsInt() ):
+            self.interval.append(self.settings["interval"][1].GetDouble());
 
         if( self.model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED] == False ):
             self.model_part.ProcessInfo.SetValue(KratosMultiphysics.INTERVAL_END_TIME, self.interval[1])


### PR DESCRIPTION
This seems to be a bug.
Without this fix I get the following error msg:
`  File "/home/philippb/software/Kratos/applications/SolidMechanicsApplication/python_scripts/assign_modulus_and_direction_to_conditions_process.py", line 21, in Factory
    return AssignModulusAndDirectionToConditionsProcess(Model, custom_settings["Parameters"])
  File "/home/philippb/software/Kratos/applications/SolidMechanicsApplication/python_scripts/assign_modulus_and_direction_to_conditions_process.py", line 71, in __init__
    self.model_part.ProcessInfo.SetValue(KratosMultiphysics.INTERVAL_END_TIME, self.interval[1])
IndexError: list index out of range`