### PR TITLE
Feature win compatible flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,36 +65,34 @@ else(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   endif(${CMAKE_C_COMPILER} MATCHES "icc.*$")
 endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
+# Old non-compatible versions of VS
 if(${MSVC80})
-  message("detected compiler as MSVC80")
-  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
+  message( FATAL_ERROR "DEPRECARED: detected compiler as MSVC80")
 endif(${MSVC80})
 
 if(${MSVC90})
-  message("detected compiler as MSVC90")
-  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
+  message( FATAL_ERROR "DEPRECARED: detected compiler as MSVC90")
 endif(${MSVC90})
 
 if(${MSVC10})
-  message("detected compiler as MSVC10")
-  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS -D_USE_MATH_DEFINES")
+  message( FATAL_ERROR "DEPRECARED: detected compiler as MSVC10")
 endif(${MSVC10})
 
 if(${MSVC11})
-  message("detected compiler as MSVC11")
-  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
+  message( FATAL_ERROR "DEPRECARED: detected compiler as MSVC11")
 endif(${MSVC11})
 
 if(${MSVC12})
-  message("detected compiler as MSVC12")
-  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
+  message( FATAL_ERROR "DEPRECARED: detected compiler as MSVC12")
 endif(${MSVC12})
 
+# Common flags for MSVC
+if(${MSVC})
+  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
+  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
+endif(${MSVC})
+
+# Specific flags for different versions of MSVC
 if(${MSVC14})
   message("detected compiler as MSVC14")
   SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,35 +67,40 @@ endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 # Old non-compatible versions of VS
 if(${MSVC80})
-  message( FATAL_ERROR "DEPRECATED: detected compiler as MSVC80")
+  message( "DEPRECATED: detected compiler as MSVC80")
+  message( FATAL_ERROR "Please use VisualStudio 2015 or greater")
 endif(${MSVC80})
 
 if(${MSVC90})
-  message( FATAL_ERROR "DEPRECATED: detected compiler as MSVC90")
+  message( "DEPRECATED: detected compiler as MSVC90")
+  message( FATAL_ERROR "Please use VisualStudio 2015 or greater")
 endif(${MSVC90})
 
 if(${MSVC10})
-  message( FATAL_ERROR "DEPRECATED: detected compiler as MSVC10")
+  message( "DEPRECATED: detected compiler as MSVC10")
+  message( FATAL_ERROR "Please use VisualStudio 2015 or greater")
 endif(${MSVC10})
 
 if(${MSVC11})
-  message( FATAL_ERROR "DEPRECATED: detected compiler as MSVC11")
+  message( "DEPRECATED: detected compiler as MSVC11")
+  message( FATAL_ERROR "Please use VisualStudio 2015 or greater")
 endif(${MSVC11})
 
 if(${MSVC12})
-  message( FATAL_ERROR "DEPRECATED: detected compiler as MSVC12")
+  message( "DEPRECATED: detected compiler as MSVC12")
+  message( FATAL_ERROR "Please use VisualStudio 2015 or greater")
 endif(${MSVC12})
 
 # Common flags for MSVC
 if(${MSVC})
   message("Detected compiler as MSVC")
-  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
+  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W1 /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
+  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W1 /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
 endif(${MSVC})
 
 # Specific flags for different versions of MSVC
 if(${MSVC14})
-  message("Adding additional flags for MSVC14")
+  # message("Adding additional flags for MSVC14")
   # Nothing needed right now
 endif(${MSVC14})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,23 +67,23 @@ endif(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 # Old non-compatible versions of VS
 if(${MSVC80})
-  message( FATAL_ERROR "DEPRECARED: detected compiler as MSVC80")
+  message( FATAL_ERROR "DEPRECATED: detected compiler as MSVC80")
 endif(${MSVC80})
 
 if(${MSVC90})
-  message( FATAL_ERROR "DEPRECARED: detected compiler as MSVC90")
+  message( FATAL_ERROR "DEPRECATED: detected compiler as MSVC90")
 endif(${MSVC90})
 
 if(${MSVC10})
-  message( FATAL_ERROR "DEPRECARED: detected compiler as MSVC10")
+  message( FATAL_ERROR "DEPRECATED: detected compiler as MSVC10")
 endif(${MSVC10})
 
 if(${MSVC11})
-  message( FATAL_ERROR "DEPRECARED: detected compiler as MSVC11")
+  message( FATAL_ERROR "DEPRECATED: detected compiler as MSVC11")
 endif(${MSVC11})
 
 if(${MSVC12})
-  message( FATAL_ERROR "DEPRECARED: detected compiler as MSVC12")
+  message( FATAL_ERROR "DEPRECATED: detected compiler as MSVC12")
 endif(${MSVC12})
 
 # Common flags for MSVC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,15 +88,15 @@ endif(${MSVC12})
 
 # Common flags for MSVC
 if(${MSVC})
-  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
+  message("Detected compiler as MSVC")
+  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W4 /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
+  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
 endif(${MSVC})
 
 # Specific flags for different versions of MSVC
 if(${MSVC14})
-  message("detected compiler as MSVC14")
-  SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
-  SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /bigobj /EHsc -D_SCL_SECURE_NO_WARNINGS")
+  message("Adding additional flags for MSVC14")
+  # Nothing needed right now
 endif(${MSVC14})
 
 # Tell the linker to give an error if undefined functions are found

--- a/applications/DEM_application/CMakeLists.txt
+++ b/applications/DEM_application/CMakeLists.txt
@@ -107,10 +107,12 @@ if(${ACTIVATE_DEBUG_MACRO} MATCHES ON)        #MSI: Flag defined for debug Macro
 endif(${ACTIVATE_DEBUG_MACRO} MATCHES ON)
 
 # Warn about overriding virtual fuctions not marked as override
-# Warding since it is not compatible with any version of MSVC
-if(${CMAKE_COMPILER_IS_GNUCXX})
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
-endif(${CMAKE_COMPILER_IS_GNUCXX})
+# Warding since it is not compatible with any version of MSVC and GCC > 5.1
+if(GCC_VERSION VERSION_GREATER 5.1 OR GCC_VERSION VERSION_EQUAL 5.1)
+  if(${CMAKE_COMPILER_IS_GNUCXX})
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
+  endif(${CMAKE_COMPILER_IS_GNUCXX})
+endif()
 
 # changing the .dll suffix to .pyd
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/applications/DEM_application/CMakeLists.txt
+++ b/applications/DEM_application/CMakeLists.txt
@@ -106,7 +106,8 @@ if(${ACTIVATE_DEBUG_MACRO} MATCHES ON)        #MSI: Flag defined for debug Macro
     add_definitions(-DDEBUG_MACRO)
 endif(${ACTIVATE_DEBUG_MACRO} MATCHES ON)
 
-add_definitions( -Wsuggest-override )
+# Warn about overriding virtual fuctions not marked as override
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
 
 # changing the .dll suffix to .pyd
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/applications/DEM_application/CMakeLists.txt
+++ b/applications/DEM_application/CMakeLists.txt
@@ -107,7 +107,10 @@ if(${ACTIVATE_DEBUG_MACRO} MATCHES ON)        #MSI: Flag defined for debug Macro
 endif(${ACTIVATE_DEBUG_MACRO} MATCHES ON)
 
 # Warn about overriding virtual fuctions not marked as override
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
+# Warding since it is not compatible with any version of MSVC
+if(${CMAKE_COMPILER_IS_GNUCXX})
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
+endif(${CMAKE_COMPILER_IS_GNUCXX})
 
 # changing the .dll suffix to .pyd
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")

--- a/external_libraries/gidpost/CMakeLists.txt
+++ b/external_libraries/gidpost/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 ## generate variables with the sources
-set( GIDPOST_SOURCES     
+set( GIDPOST_SOURCES
  	${CMAKE_CURRENT_SOURCE_DIR}/source/gidpost.c
  	${CMAKE_CURRENT_SOURCE_DIR}/source/gidpostInt.c
  	${CMAKE_CURRENT_SOURCE_DIR}/source/gidpostHash.c
@@ -14,7 +14,13 @@ set( GIDPOST_SOURCES
 add_definitions(-DNDEBUG)
 message("WARNING: YOUR GIDPOST IS BEING COMPILED  WITHOUT DEBUG (ALL ASSERTS WILL BE AVOIDED)")
 add_definitions( -DUSE_CONST )
-add_definitions( -w )
+
+# Ignore
+if(MSVC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W0")
+else(MSVC)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
+endif(MSVC)
 
 ###############################################################
 add_library(gidpost STATIC ${GIDPOST_SOURCES})
@@ -40,4 +46,3 @@ endif (Threads_FOUND)
 if (UNIX)
   target_link_libraries(gidpost m)
 endif (UNIX)
-

--- a/external_libraries/gidpost/CMakeLists.txt
+++ b/external_libraries/gidpost/CMakeLists.txt
@@ -14,13 +14,7 @@ set( GIDPOST_SOURCES
 add_definitions(-DNDEBUG)
 message("WARNING: YOUR GIDPOST IS BEING COMPILED  WITHOUT DEBUG (ALL ASSERTS WILL BE AVOIDED)")
 add_definitions( -DUSE_CONST )
-
-# Ignore
-if(MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /w")
-else(MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
-endif(MSVC)
+add_definitions( -w )
 
 ###############################################################
 add_library(gidpost STATIC ${GIDPOST_SOURCES})

--- a/external_libraries/gidpost/CMakeLists.txt
+++ b/external_libraries/gidpost/CMakeLists.txt
@@ -17,7 +17,7 @@ add_definitions( -DUSE_CONST )
 
 # Ignore
 if(MSVC)
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W0")
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /w")
 else(MSVC)
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w")
 endif(MSVC)


### PR DESCRIPTION
This fixes #473. Let me test it before with clang as well. 

@pooyan-dadvand, @RiccardoRossi . I have also changed some MSVC in the main CMakeLists.
It disables the old versions of VS by default and sets the default warning lvl to W4 (Wall + Pedantic).

Is this too much? maybe we can set it to W2 or W3. As @maceligueta said is a good idea to have some more warnings. Specially in win, since right now only the default ones are enabled. 