### PR TITLE
Fixed tests in geometries

### DIFF
--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -681,7 +681,11 @@ public:
       double se = (e[0]*e[0]) + (e[1]*e[1]) + (e[2]*e[2]);
       double sf = (f[0]*f[0]) + (f[1]*f[1]) + (f[2]*f[2]);
 
-      return normFactor * std::pow(3*Volume(), 2.0 / 3.0) / (sa + sb + sc + sd + se + sf);
+      double vol = Volume();
+      double absVol = std::abs(Volume());
+      double isInv = vol < 0.0 ? -1.0 : 1.0;
+
+      return normFactor * isInv * std::pow(3*absVol, 2.0 / 3.0) / (sa + sb + sc + sd + se + sf);
     }
 
     /** Calculates the volume to average edge lenght quality metric.
@@ -711,7 +715,7 @@ public:
      * @return [description]
      */
     virtual double VolumeToRMSEdgeLength() const override {
-      constexpr double normFactor = 3.0 * 1.41421356237309504880;
+      constexpr double normFactor = 6.0 * 1.41421356237309504880;
 
       auto a = this->GetPoint(0) - this->GetPoint(1);
       auto b = this->GetPoint(1) - this->GetPoint(2);
@@ -727,7 +731,7 @@ public:
       double se = (e[0]*e[0])+(e[1]*e[1])+(e[2]*e[2]);
       double sf = (f[0]*f[0])+(f[1]*f[1])+(f[2]*f[2]);
 
-      return normFactor * Volume() / std::sqrt(1.0/6.0 * (sa + sb + sc + sd + se + sf));
+      return normFactor * Volume() / std::pow(std::sqrt(1.0/6.0 * (sa + sb + sc + sd + se + sf)), 3.0);
     }
 
     /**

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -682,10 +682,8 @@ public:
       double sf = (f[0]*f[0]) + (f[1]*f[1]) + (f[2]*f[2]);
 
       double vol = Volume();
-      double absVol = std::abs(Volume());
-      double isInv = vol < 0.0 ? -1.0 : 1.0;
 
-      return normFactor * isInv * std::pow(3*absVol, 2.0 / 3.0) / (sa + sb + sc + sd + se + sf);
+      return std::copysign(normFactor * std::pow(9 * vol * vol, 1.0 / 3.0) / (sa + sb + sc + sd + se + sf), vol);
     }
 
     /** Calculates the volume to average edge lenght quality metric.

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -30,7 +30,7 @@ namespace Kratos {
     typedef GeometryType::Pointer     GeometryPtrType;
 
     static bool exceptionThrown = false;
-    
+
     /** Generates a sample Tetrahedra3D4.
      * Generates a tetrahedra defined by three random points in the space.
      * @return  Pointer to a Tetrahedra3D4
@@ -400,12 +400,12 @@ namespace Kratos {
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      auto criteria = GeometryType::QualityCriteria::VOLUME_TO_EDGE_LENGTH;
+      auto criteria = GeometryType::QualityCriteria::VOLUME_TO_RMS_EDGE_LENGTH;
 
       KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), -1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria),  1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria),  1.000000, TOLERANCE);
-      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria),  0.839947, TOLERANCE);
+      KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria),  0.769800, TOLERANCE);
     }
 
 


### PR DESCRIPTION
This fixes:

* TestTetrahedra3D4VolumeToEdgeLengthQuality

Which was failing when trying to calculate the quality function of tetrahedras with negative volume due to a negative number being elevated to a fraction power, resulting into a imaginary number that different compilers were handling... imaginatively:

Gcc -> 1
Clang -> -nan
Msvc -> -0

That was the reason that it was "working" both in win and clang but not in GCC. Even when GCC was the only not not giving nan....

* TestTetrahedra3D4VolumeToRMSEdgeLength:

This tests was calculating the wring quality metric (which happened to be the one failing). 
It has been fixed and now it calculates the correct metric.
