### PR TITLE
Updating test to use new process (fix by @rubenzorrilla).

### DIFF
--- a/applications/FluidDynamicsApplication/tests/NavierStokesWallConditionTest/NavierSokesWallConditionTest_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/NavierStokesWallConditionTest/NavierSokesWallConditionTest_parameters.json
@@ -93,10 +93,10 @@
             "value"           : 0.0
         }
     },{
-        "python_module" : "experimental_assign_value_process",
+        "python_module" : "assign_scalar_variable_process",
         "kratos_module" : "KratosMultiphysics",
         "help"          : "This process fixes the selected components of a given vector variable",
-        "process_name"  : "AssignValueProcess",
+        "process_name"  : "AssignScalarVariableProcess",
         "Parameters"    : {
             "mesh_id"         : 0,
             "model_part_name" : "Parts_Fluid",


### PR DESCRIPTION
Updating a test in the FluidDynamicsApplication that was using a process deleted in PR #464 