### PR TITLE
Check that variable exists for KRATOS_DEBUG only

### DIFF
--- a/kratos/containers/variables_list_data_value_container.h
+++ b/kratos/containers/variables_list_data_value_container.h
@@ -734,6 +734,11 @@ public:
 
     BlockType* Data(VariableData const & rThisVariable)
     {
+        #ifdef KRATOS_DEBUG
+        if ( !mpVariablesList->Has(rThisVariable) ) {            
+            KRATOS_ERROR << "Variable " << rThisVariable.Name() << " is not added to this variables list. Stopping" << std::endl;
+        }
+        #endif      
         return Position(rThisVariable);
     }
 


### PR DESCRIPTION
I found code calling this method in the swimming dem app, with the variable missing in the list. If it happened before, it might happen in the future as well. That's why I propose to insert this check.