### PR TITLE
Clean structural mechanics python solver scripts

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/check_and_prepare_model_process_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/check_and_prepare_model_process_structural.py
@@ -10,7 +10,13 @@ def Factory(settings, Model):
 
 ##all the processes python processes should be derived from "python_process"
 class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
-    def __init__(self, main_model_part, Parameters ):
+    """Prepare the computing model part.
+
+    The computing model part is created if it does not exist. Nodes and elements
+    from the domain sub model parts are added to the computing model part.
+    Conditions are added from the processes sub model parts.
+    """
+    def __init__(self, main_model_part, Parameters):
         self.main_model_part = main_model_part
         
         self.computing_model_part_name  = Parameters["computing_model_part_name"].GetString()
@@ -28,10 +34,10 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
             processes_parts.append(self.main_model_part.GetSubModelPart(self.processes_model_part_names[i].GetString()))
         
         #construct a model part which contains both the skin and the volume
-        if (self.main_model_part.HasSubModelPart(self.computing_model_part_name )):
-            structural_computational_model_part = self.main_model_part.GetSubModelPart(self.computing_model_part_name )
+        if (self.main_model_part.HasSubModelPart(self.computing_model_part_name)):
+            structural_computational_model_part = self.main_model_part.GetSubModelPart(self.computing_model_part_name)
         else:
-            structural_computational_model_part = self.main_model_part.CreateSubModelPart(self.computing_model_part_name )
+            structural_computational_model_part = self.main_model_part.CreateSubModelPart(self.computing_model_part_name)
         structural_computational_model_part.ProcessInfo = self.main_model_part.ProcessInfo
         structural_computational_model_part.Properties  = self.main_model_part.Properties
         
@@ -53,10 +59,11 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         #structural_computational_model_part.AddConditions(list(cond_ids)) 
         
         for part in structural_parts:
-            transfer_process = KratosMultiphysics.FastTransferBetweenModelPartsProcess( structural_computational_model_part, part, "NodesAndElements")
+            transfer_process = KratosMultiphysics.FastTransferBetweenModelPartsProcess(structural_computational_model_part, part, "NodesAndElements")
             transfer_process.Execute()
         for part in processes_parts:
-            transfer_process = KratosMultiphysics.FastTransferBetweenModelPartsProcess( structural_computational_model_part, part, "Conditions")
+            transfer_process = KratosMultiphysics.FastTransferBetweenModelPartsProcess(structural_computational_model_part, part, "Conditions")
             transfer_process.Execute()
-                
+
+        print("Computing model part:")        
         print(structural_computational_model_part)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
@@ -18,12 +18,10 @@ class EigenSolver(structural_mechanics_solver.MechanicalSolver):
     This class creates the mechanical solvers for eigenvalue analysis.
     It currently supports the Feast solver.
 
-    Member variables from base class:
-    settings -- Kratos parameters containing general solver settings.
-    main_model_part -- the model part used to construct the solver.
-
-    Additional member variables:
+    Public member variables:
     eigensolver_settings -- settings for the eigenvalue solvers.
+
+    See structural_mechanics_solver.py for more information.
     """
     def __init__(self, main_model_part, custom_settings):
         settings = custom_settings.Clone()

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
@@ -52,24 +52,6 @@ class EigenSolver(structural_mechanics_solver.MechanicalSolver):
         self.eigensolver_settings.ValidateAndAssignDefaults(default_eigensolver_settings)
         print("::[EigenSolver]:: Construction finished")
 
-    def Initialize(self):
-        print("::[EigenSolver]:: Initializing ...")
-        # The solver is created here.
-        super().Initialize()
-        print("::[EigenSolver]:: Finished initialization.")
-
-    def AddDofs(self):
-        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_X, KratosMultiphysics.REACTION_X,self.main_model_part)
-        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_Y, KratosMultiphysics.REACTION_Y,self.main_model_part)
-        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_Z, KratosMultiphysics.REACTION_Z,self.main_model_part)
-        if self.settings["rotation_dofs"].GetBool():
-            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ROTATION_X, KratosMultiphysics.TORQUE_X,self.main_model_part)
-            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ROTATION_Y, KratosMultiphysics.TORQUE_Y,self.main_model_part)
-            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ROTATION_Z, KratosMultiphysics.TORQUE_Z,self.main_model_part)
-        if self.settings["pressure_dofs"].GetBool():    
-            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.PRESSURE, KratosMultiphysics.PRESSURE_REACTION,self.main_model_part)
-        print("::[Structural EigenSolver]:: DOF's ADDED")
-
     #### Private functions ####
 
     def _create_solution_scheme(self):

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
@@ -27,7 +27,11 @@ class EigenSolver(structural_mechanics_solver.MechanicalSolver):
     """
     def __init__(self, main_model_part, custom_settings):
         settings = custom_settings.Clone()
-        self.eigensolver_settings = self.remove_settings(settings, "eigensolver_settings")
+        if settings.Has("eigensolver_settings"):
+            self.eigensolver_settings = settings["eigensolver_settings"].Clone()
+            settings.RemoveValue("eigensolver_settings")
+        else:
+            self.eigensolver_settings = KratosMultiphysics.Parameters("{}")
 
         # Construct the base solver.
         super().__init__(main_model_part, settings)
@@ -35,7 +39,16 @@ class EigenSolver(structural_mechanics_solver.MechanicalSolver):
         # Set defaults and validate custom settings.
         default_eigensolver_settings = KratosMultiphysics.Parameters("""
         {
-            "solver_type": "FEAST"
+            "solver_type": "FEAST",
+            "print_feast_output": true,
+            "perform_stochastic_estimate": true,
+            "solve_eigenvalue_problem": true,
+            "lambda_min": 0.0,
+            "lambda_max": 1.0,
+            "search_dimension": 10,
+            "linear_solver_settings": {
+                "solver_type": "skyline_lu"
+            }
         }
         """)
         self.eigensolver_settings.ValidateAndAssignDefaults(default_eigensolver_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -15,14 +15,12 @@ class ImplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
     """The structural mechanics implicit dynamic solver.
 
     This class creates the mechanical solvers for implicit dynamic analysis.
-    It supports Newmark, Bossak and dynamic relaxation schemes.
+    It currently supports Newmark, Bossak and dynamic relaxation schemes.
 
-    Member variables from base class:
-    settings -- Kratos parameters containing general solver settings.
-    main_model_part -- the model part used to construct the solver.
-
-    Additional member variables:
+    Public member variables:
     dynamic_settings -- settings for the implicit dynamic solvers.
+
+    See structural_mechanics_solver.py for more information.
     """
     def __init__(self, main_model_part, custom_settings):
         settings = custom_settings.Clone()

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -24,16 +24,17 @@ class ImplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
     Additional member variables:
     dynamic_settings -- settings for the implicit dynamic solvers.
     """
-    def __init__(self, main_model_part, custom_settings): 
+    def __init__(self, main_model_part, custom_settings):
         settings = custom_settings.Clone()
         self.dynamic_settings = KratosMultiphysics.Parameters("{}")
         if settings.Has("damp_factor_m"):
-            self.dynamic_settings.AddValue("damp_factor_m", settings["damp_factor_m"])
+            self.dynamic_settings.AddEmptyValue("damp_factor_m")
+            self.dynamic_settings["damp_factor_m"].SetDouble(settings["damp_factor_m"].GetDouble())
             settings.RemoveValue("damp_factor_m")
         if not settings.Has("scheme_type"): # Assign the default dynamic scheme.
             settings.AddEmptyValue("scheme_type")
             settings["scheme_type"].SetString("Newmark")
-
+        
         # Construct the base solver.
         super().__init__(main_model_part, settings)
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -45,18 +45,34 @@ class ImplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
         self.dynamic_settings.ValidateAndAssignDefaults(default_dynamic_settings)
         print("::[ImplicitMechanicalSolver]:: Construction finished")
 
-    def Initialize(self):
-        print("::[ImplicitMechanicalSolver]:: Initializing ...")
-        # The solver is created here.
-        super().Initialize()
-        print("::[ImplicitMechanicalSolver]:: Finished initialization.")
-
     def AddVariables(self):
         super().AddVariables()
+        # Add dynamic variables.
+        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
+        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ACCELERATION)
         if self.settings["rotation_dofs"].GetBool():
+            self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_VELOCITY)
+            self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_ACCELERATION)
             self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_TORQUE)
         print("::[ImplicitMechanicalSolver]:: Variables ADDED")
     
+    def AddDofs(self):
+        super().AddDofs()
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_X,self.main_model_part)
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_Y,self.main_model_part)
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_Z,self.main_model_part)
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ACCELERATION_X,self.main_model_part)
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ACCELERATION_Y,self.main_model_part)
+        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ACCELERATION_Z,self.main_model_part)
+        if(self.settings["rotation_dofs"].GetBool()):
+            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_VELOCITY_X,self.main_model_part)
+            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_VELOCITY_Y,self.main_model_part)
+            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_VELOCITY_Z,self.main_model_part)
+            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_X,self.main_model_part)
+            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Y,self.main_model_part)
+            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Z,self.main_model_part)
+        print("::[ImplicitMechanicalSolver]:: DOF's ADDED")
+
     #### Private functions ####
 
     def _create_solution_scheme(self):

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -23,26 +23,20 @@ class ImplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
     See structural_mechanics_solver.py for more information.
     """
     def __init__(self, main_model_part, custom_settings):
-        settings = custom_settings.Clone()
-        self.dynamic_settings = KratosMultiphysics.Parameters("{}")
-        if settings.Has("damp_factor_m"):
-            self.dynamic_settings.AddEmptyValue("damp_factor_m")
-            self.dynamic_settings["damp_factor_m"].SetDouble(settings["damp_factor_m"].GetDouble())
-            settings.RemoveValue("damp_factor_m")
-        if not settings.Has("scheme_type"): # Assign the default dynamic scheme.
-            settings.AddEmptyValue("scheme_type")
-            settings["scheme_type"].SetString("Newmark")
-        
-        # Construct the base solver.
-        super().__init__(main_model_part, settings)
-
         # Set defaults and validate custom settings.
-        default_dynamic_settings = KratosMultiphysics.Parameters("""
+        self.dynamic_settings = KratosMultiphysics.Parameters("""
         {
-            "damp_factor_m" : -0.01
+            "damp_factor_m" :-0.01
         }
         """)
-        self.dynamic_settings.ValidateAndAssignDefaults(default_dynamic_settings)
+        self.validate_and_transfer_matching_settings(custom_settings, self.dynamic_settings)
+        # Validate the remaining settings in the base class.
+        if not custom_settings.Has("scheme_type"): # Override defaults in the base class.
+            custom_settings.AddEmptyValue("scheme_type")
+            custom_settings["scheme_type"].SetString("Newmark")
+        
+        # Construct the base solver.
+        super().__init__(main_model_part, custom_settings)
         print("::[ImplicitMechanicalSolver]:: Construction finished")
 
     def AddVariables(self):

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -53,7 +53,6 @@ class ImplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
         if self.settings["rotation_dofs"].GetBool():
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_VELOCITY)
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_ACCELERATION)
-            self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_TORQUE)
         print("::[ImplicitMechanicalSolver]:: Variables ADDED")
     
     def AddDofs(self):

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -1,193 +1,122 @@
 from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-#import kratos core and applications
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
+import structural_mechanics_solver
 
 # Check that KratosMultiphysics was imported in the main script
 KratosMultiphysics.CheckForPreviousImport()
 
-# Import the implicit solver (the explicit one is derived from it)
-import structural_mechanics_solver
 
 def CreateSolver(main_model_part, custom_settings):
     return ImplicitMechanicalSolver(main_model_part, custom_settings)
 
+
 class ImplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
-    
-    ##constructor. the constructor shall only take care of storing the settings 
-    ##and the pointer to the main_model part. This is needed since at the point of constructing the 
-    ##model part is still not filled and the variables are not yet allocated
-    ##
-    ##real construction shall be delayed to the function "Initialize" which 
-    ##will be called once the model is already filled
+    """The structural mechanics implicit dynamic solver.
+
+    This class creates the mechanical solvers for implicit dynamic analysis.
+    It supports Newmark, Bossak and dynamic relaxation schemes.
+
+    Member variables from base class:
+    settings -- Kratos parameters containing general solver settings.
+    main_model_part -- the model part used to construct the solver.
+
+    Additional member variables:
+    dynamic_settings -- settings for the implicit dynamic solvers.
+    """
     def __init__(self, main_model_part, custom_settings): 
-        
-        #TODO: shall obtain the computing_model_part from the MODEL once the object is implemented
-        self.main_model_part = main_model_part    
-        
-        ##settings string in json format
-        default_settings = KratosMultiphysics.Parameters("""
+        settings = custom_settings.Clone()
+        self.dynamic_settings = KratosMultiphysics.Parameters("{}")
+        if settings.Has("damp_factor_m"):
+            self.dynamic_settings.AddValue("damp_factor_m", settings["damp_factor_m"])
+            settings.RemoveValue("damp_factor_m")
+        if not settings.Has("scheme_type"): # Assign the default dynamic scheme.
+            settings.AddEmptyValue("scheme_type")
+            settings["scheme_type"].SetString("Newmark")
+
+        # Construct the base solver.
+        super().__init__(main_model_part, settings)
+
+        # Set defaults and validate custom settings.
+        default_dynamic_settings = KratosMultiphysics.Parameters("""
         {
-            "solver_type": "structural_mechanics_implicit_dynamic_solver",
-            "model_import_settings": {
-                "input_type": "mdpa",
-                "input_filename": "unknown_name"
-            },
-            "material_import_settings" :{
-                "materials_filename": ""
-            },
-            "echo_level": 0,
-            "buffer_size": 2,
-            "solution_type": "Dynamic",
-            "scheme_type": "Newmark",
-            "damp_factor_m" : -0.1,
-            "time_integration_method": "Implicit",
-            "analysis_type": "Non-Linear",
-            "rotation_dofs": false,
-            "pressure_dofs": false,
-            "stabilization_factor": 1.0,
-            "reform_dofs_at_each_step": false,
-            "line_search": false,
-            "compute_reactions": true,
-            "compute_contact_forces": false,
-            "block_builder": true,
-            "clear_storage": false,
-            "move_mesh_flag": true,
-            "convergence_criterion": "Residual_criteria",
-            "displacement_relative_tolerance": 1.0e-4,
-            "displacement_absolute_tolerance": 1.0e-9,
-            "residual_relative_tolerance": 1.0e-4,
-            "residual_absolute_tolerance": 1.0e-4,
-            "max_iteration": 10,
-            "split_factor": 10.0,
-            "max_number_splits": 3,
-            "linear_solver_settings":{
-                "solver_type": "Super LU",
-                "max_iteration": 500,
-                "tolerance": 1e-9,
-                "scaling": false,
-                "verbosity": 1
-            },
-            "processes_sub_model_part_list": [""],
-            "problem_domain_sub_model_part_list": ["solid_model_part"]
+            "damp_factor_m" : -0.01
         }
         """)
-        
-        ##overwrite the default settings with user-provided parameters
-        self.settings = custom_settings
-        self.settings.ValidateAndAssignDefaults(default_settings)
-        
-        #construct the linear solver
-        import linear_solver_factory
-        self.linear_solver = linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
-        
-        print("Construction of MechanicalSolver finished")
+        self.dynamic_settings.ValidateAndAssignDefaults(default_dynamic_settings)
+        print("::[ImplicitMechanicalSolver]:: Construction finished")
 
     def Initialize(self):
-
-        print("::[Mechanical Solver]:: -START-")
-        
-        # Get the solid computing model part
-        self.computing_model_part = self.GetComputingModelPart()
-        
-        # Builder and solver creation
-        builder_and_solver = self._GetBuilderAndSolver(self.settings["block_builder"].GetBool())
-        
-        # Solution scheme creation
-        mechanical_scheme = self._GetSolutionScheme(self.settings["scheme_type"].GetString())
-        
-        # Get the convergence criterion
-        mechanical_convergence_criterion = self._GetConvergenceCriterion()
-        
-        # Mechanical solver creation
-        self._CreateMechanicalSolver(mechanical_scheme,
-                                     mechanical_convergence_criterion,
-                                     builder_and_solver,
-                                     self.settings["max_iteration"].GetInt(),
-                                     self.settings["compute_reactions"].GetBool(),
-                                     self.settings["reform_dofs_at_each_step"].GetBool(),
-                                     self.settings["move_mesh_flag"].GetBool(),
-                                     self.settings["line_search"].GetBool()
-                                     )
-
-        # Set echo_level
-        self.mechanical_solver.SetEchoLevel(self.settings["echo_level"].GetInt())
-
-        # Set initialize flag
-        if( self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED] == True ):
-            self.mechanical_solver.SetInitializePerformedFlag(True)
-        
-        # Check if everything is assigned correctly
-        self.Check();
-
-        print("::[Mechanical Solver]:: -END- ")
+        print("::[ImplicitMechanicalSolver]:: Initializing ...")
+        # The solver is created here.
+        super().Initialize()
+        print("::[ImplicitMechanicalSolver]:: Finished initialization.")
 
     def AddVariables(self):
-        
-        structural_mechanics_solver.MechanicalSolver.AddVariables(self)
-            
+        super().AddVariables()
         if self.settings["rotation_dofs"].GetBool():
-            # Add specific variables for the problem (rotation dofs)
-            self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.StructuralMechanicsApplication.POINT_TORQUE)
-   
-        print("::[Mechanical Solver]:: Variables ADDED")
-
+            self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_TORQUE)
+        print("::[ImplicitMechanicalSolver]:: Variables ADDED")
     
-    def _GetSolutionScheme(self, scheme_type):
+    #### Private functions ####
 
-        if(scheme_type == "Newmark") or (scheme_type == "Bossak"):
-            if(scheme_type == "Newmark"):
-                self.settings.AddEmptyValue("damp_factor_m")  
-                self.settings.AddEmptyValue("dynamic_factor")
-                self.settings["damp_factor_m"].SetDouble(0.0)
-                self.settings["dynamic_factor"].SetDouble(1.0)
-                                                                            
-            elif(scheme_type == "Bossak"):
-                self.settings.AddEmptyValue("damp_factor_m")  
-                self.settings.AddEmptyValue("dynamic_factor")
-                self.settings["damp_factor_m"].SetDouble(-0.01)
-                self.settings["dynamic_factor"].SetDouble(1.0)    
-            
-            # Creating the implicit solution scheme:  
-            #self.main_model_part.ProcessInfo[KratosStructural.RAYLEIGH_ALPHA] = 0.0
-            #self.main_model_part.ProcessInfo[KratosStructural.RAYLEIGH_BETA ] = 0.0
-            
-            mechanical_scheme = KratosMultiphysics.ResidualBasedBossakDisplacementScheme(self.settings["damp_factor_m"].GetDouble())
-
+    def _create_solution_scheme(self):
+        scheme_type = self.settings["scheme_type"].GetString()
+        if(scheme_type == "Newmark"):
+            damp_factor_m = 0.0
+            mechanical_scheme = KratosMultiphysics.ResidualBasedBossakDisplacementScheme(damp_factor_m)
+        elif(scheme_type == "Bossak"):
+            damp_factor_m = self.dynamic_settings["damp_factor_m"].GetDouble()
+            mechanical_scheme = KratosMultiphysics.ResidualBasedBossakDisplacementScheme(damp_factor_m)
         elif(scheme_type == "Relaxation"):
-          #~ self.main_model_part.GetSubModelPart(self.settings["volume_model_part_name"].GetString()).AddNodalSolutionStepVariable(DISPLACEMENT)  
-            
-            self.settings.AddEmptyValue("damp_factor_f")  
-            self.settings.AddEmptyValue("dynamic_factor_m")
-            self.settings["damp_factor_f"].SetDouble(-0.3)
-            self.settings["dynamic_factor_m"].SetDouble(10.0) 
-            
-            mechanical_scheme = KratosMultiphysics.StructuralMechanicsApplication.ResidualBasedRelaxationScheme(self.settings["damp_factor_f"].GetDouble(),
-                                                                                            self.settings["dynamic_factor_m"].GetDouble())
-                                
+            damp_factor_f =-0.3
+            dynamic_factor_m = 10.0
+            mechanical_scheme = StructuralMechanicsApplication.ResidualBasedRelaxationScheme(
+                                                                       damp_factor_f, dynamic_factor_m)
+        else:
+            raise Exception("Unsupported scheme_type: " + scheme_type)
         return mechanical_scheme
 
-        
-    def _CreateMechanicalSolver(self, mechanical_scheme, mechanical_convergence_criterion, builder_and_solver, max_iters, compute_reactions, reform_step_dofs, move_mesh_flag, line_search):
-        if(line_search):
-            self.mechanical_solver = KratosMultiphysics.LineSearchStrategy(self.computing_model_part, 
-                                                                            mechanical_scheme, 
-                                                                            self.linear_solver, 
-                                                                            mechanical_convergence_criterion, 
-                                                                            builder_and_solver, 
-                                                                            max_iters, 
-                                                                            compute_reactions, 
-                                                                            reform_step_dofs, 
-                                                                            move_mesh_flag)
-
-
+    def _create_mechanical_solver(self):
+        computing_model_part = self.GetComputingModelPart()
+        mechanical_scheme = self.get_solution_scheme()
+        linear_solver = self.get_linear_solver()
+        mechanical_convergence_criterion = self.get_convergence_criterion()
+        builder_and_solver = self.get_builder_and_solver()
+        if self.settings["line_search"].GetBool():
+            mechanical_solver = self._create_line_search_strategy()
         else:
-            self.mechanical_solver = KratosMultiphysics.ResidualBasedNewtonRaphsonStrategy(self.computing_model_part, 
-                                                                                            mechanical_scheme, 
-                                                                                            self.linear_solver, 
-                                                                                            mechanical_convergence_criterion, 
-                                                                                            builder_and_solver, 
-                                                                                            max_iters, 
-                                                                                            compute_reactions, 
-                                                                                            reform_step_dofs, 
-                                                                                            move_mesh_flag)
+            mechanical_solver = self._create_newton_raphson_strategy()
+        return mechanical_solver
+
+    def _create_line_search_strategy(self):
+        computing_model_part = self.GetComputingModelPart()
+        mechanical_scheme = self.get_solution_scheme()
+        linear_solver = self.get_linear_solver()
+        mechanical_convergence_criterion = self.get_convergence_criterion()
+        builder_and_solver = self.get_builder_and_solver()
+        return KratosMultiphysics.LineSearchStrategy(computing_model_part, 
+                                                     mechanical_scheme, 
+                                                     linear_solver, 
+                                                     mechanical_convergence_criterion, 
+                                                     builder_and_solver, 
+                                                     self.settings["max_iteration"].GetInt(),
+                                                     self.settings["compute_reactions"].GetBool(),
+                                                     self.settings["reform_dofs_at_each_step"].GetBool(),
+                                                     self.settings["move_mesh_flag"].GetBool())
+
+    def _create_newton_raphson_strategy(self):
+        computing_model_part = self.GetComputingModelPart()
+        mechanical_scheme = self.get_solution_scheme()
+        linear_solver = self.get_linear_solver()
+        mechanical_convergence_criterion = self.get_convergence_criterion()
+        builder_and_solver = self.get_builder_and_solver()
+        return KratosMultiphysics.ResidualBasedNewtonRaphsonStrategy(computing_model_part, 
+                                                                     mechanical_scheme, 
+                                                                     linear_solver, 
+                                                                     mechanical_convergence_criterion, 
+                                                                     builder_and_solver,
+                                                                     self.settings["max_iteration"].GetInt(),
+                                                                     self.settings["compute_reactions"].GetBool(),
+                                                                     self.settings["reform_dofs_at_each_step"].GetBool(),
+                                                                     self.settings["move_mesh_flag"].GetBool())

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -279,6 +279,65 @@ class MechanicalSolver(object):
         else:
             materials_imported = False
         return materials_imported
+    
+    def validate_and_transfer_matching_settings(self, origin_settings, destination_settings):
+        """Transfer matching settings from origin to destination.
+
+        If a name in origin matches a name in destination, then the setting is
+        validated against the destination.
+
+        The typical use is for validating and extracting settings in derived classes:
+
+        class A:
+            def __init__(self, model_part, a_settings):
+                default_a_settings = Parameters('''{
+                    ...
+                }''')
+                a_settings.ValidateAndAssignDefaults(default_a_settings)
+        class B(A):
+            def __init__(self, model_part, custom_settings):
+                b_settings = Parameters('''{
+                    ...
+                }''') # Here the settings contain default values.
+                self.validate_and_transfer_matching_settings(custom_settings, b_settings)
+                super().__init__(model_part, custom_settings)
+        """
+        for name, dest_value in destination_settings.items():
+            if origin_settings.Has(name): # Validate and transfer value.
+                orig_value = origin_settings[name]
+                if dest_value.IsDouble() and orig_value.IsDouble():
+                    destination_settings[name].SetDouble(origin_settings[name].GetDouble())
+                elif dest_value.IsInt() and orig_value.IsInt():
+                    destination_settings[name].SetInt(origin_settings[name].GetInt())
+                elif dest_value.IsBool() and orig_value.IsBool():
+                    destination_settings[name].SetBool(origin_settings[name].GetBool())
+                elif dest_value.IsString() and orig_value.IsString():
+                    destination_settings[name].SetString(origin_settings[name].GetString())
+                elif dest_value.IsArray() and orig_value.IsArray():
+                    if dest_value.size() != orig_value.size():
+                        raise Exception('len("' + name + '") != ' + str(dest_value.size()))
+                    for i in range(dest_value.size()):
+                        if dest_value[i].IsDouble() and orig_value[i].IsDouble():
+                            dest_value[i].SetDouble(orig_value[i].GetDouble())
+                        elif dest_value[i].IsInt() and orig_value[i].IsInt():
+                            dest_value[i].SetInt(orig_value[i].GetInt())
+                        elif dest_value[i].IsBool() and orig_value[i].IsBool():
+                            dest_value[i].SetBool(orig_value[i].GetBool())
+                        elif dest_value[i].IsString() and orig_value[i].IsString():
+                            dest_value[i].SetString(orig_value[i].GetString())
+                        elif dest_value[i].IsSubParameter() and orig_value[i].IsSubParameter():
+                            self.validate_and_transfer_matching_settings(orig_value[i], dest_value[i])
+                            if len(orig_value[i].items()) != 0:
+                                raise Exception('Json settings not found in default settings: ' + orig_value[i].PrettyPrintJsonString())
+                        else:
+                            raise Exception('Unsupported parameter type.')
+                elif dest_value.IsSubParameter() and orig_value.IsSubParameter():
+                    self.validate_and_transfer_matching_settings(orig_value, dest_value)
+                    if len(orig_value.items()) != 0:
+                        raise Exception('Json settings not found in default settings: ' + orig_value.PrettyPrintJsonString())
+                else:
+                    raise Exception('Unsupported parameter type.')
+                origin_settings.RemoveValue(name)
 
     #### Private functions ####
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -14,14 +14,26 @@ def CreateSolver(main_model_part, custom_settings):
 class MechanicalSolver(object):
     """The base class for structural mechanics solvers.
 
-    This class provides functions for importing and exporting models, calling
-    the solving strategy, getting the computing model part and adding nodal
-    variables and dofs which are common to all structural mechanics solvers.
+    This class provides functions for importing and exporting models,
+    adding nodal variables and dofs and solving each solution step.
 
-    Derived classes must override the _create* functions to create custom
-    solvers.
+    Derived classes must override the function _create_mechanical_solver which
+    constructs and returns a valid solving strategy. Depending on the type of
+    solver, derived classes may also need to override the following functions:
 
-    Member variables:
+    _create_solution_scheme
+    _create_convergence_criterion
+    _create_linear_solver
+    _create_builder_and_solver
+    _create_mechanical_solver
+
+    The mechanical_solver, builder_and_solver, etc. should alway be retrieved
+    using the getter functions get_mechanical_solver, get_builder_and_solver,
+    etc. from this base class.
+    
+    Only the member variables listed below should be accessed directly.
+
+    Public member variables:
     settings -- Kratos parameters containing solver settings.
     main_model_part -- the model part used to construct the solver.
     """
@@ -370,4 +382,3 @@ class MechanicalSolver(object):
         The mechanical solver must provide the functions defined in SolutionStrategy.
         """
         raise Exception("Mechanical solver must be implemented in the derived class.")
-

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -71,6 +71,7 @@ class MechanicalSolver(object):
             "displacement_absolute_tolerance": 1.0e-9,
             "residual_relative_tolerance": 1.0e-4,
             "residual_absolute_tolerance": 1.0e-9,
+            "component_wise" : false,
             "max_iteration": 10,
             "linear_solver_settings":{
                 "solver_type": "SuperLUSolver",
@@ -109,7 +110,9 @@ class MechanicalSolver(object):
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ROTATION)
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.TORQUE)
             self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.LOCAL_POINT_MOMENT)
+            # TODO: Can we combine POINT_TORQUE and POINT_MOMENT???
             self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_MOMENT)
+            self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_TORQUE)
         if self.settings["pressure_dofs"].GetBool(): # TODO: The creation of UP and USigma elements is pending
             # Add specific variables for the problem (pressure dofs).
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PRESSURE)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -1,30 +1,31 @@
 from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import os
-#import kratos core and applications
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Check that KratosMultiphysics was imported in the main script
 KratosMultiphysics.CheckForPreviousImport()
 
+
 def CreateSolver(main_model_part, custom_settings):
     return MechanicalSolver(main_model_part, custom_settings)
 
-#Base class to develop other solvers
+
 class MechanicalSolver(object):
+    """The base class for structural mechanics solvers.
 
-    ##constructor. the constructor shall only take care of storing the settings
-    ##and the pointer to the main_model part. This is needed since at the point of constructing the
-    ##model part is still not filled and the variables are not yet allocated
-    ##
-    ##real construction shall be delayed to the function "Initialize" which
-    ##will be called once the model is already filled
+    This class provides functions for importing and exporting models, calling
+    the solving strategy, getting the computing model part and adding nodal
+    variables and dofs which are common to all structural mechanics solvers.
+
+    Derived classes must override the _create* functions to create custom
+    solvers.
+
+    Member variables:
+    settings -- Kratos parameters containing solver settings.
+    main_model_part -- the model part used to construct the solver.
+    """
     def __init__(self, main_model_part, custom_settings):
-
-        #TODO: shall obtain the computing_model_part from the MODEL once the object is implemented
-        self.main_model_part = main_model_part
-
-        ##settings string in json format
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type": "structural_mechanics_solver",
@@ -33,12 +34,13 @@ class MechanicalSolver(object):
             "solution_type": "Dynamic",
             "analysis_type": "Non-Linear",
             "time_integration_method": "Implicit",
-            "scheme_type": "Newmark",
+            "scheme_type": "Static",
             "model_import_settings": {
                 "input_type": "mdpa",
                 "input_filename": "unknown_name",
-                "input_file_label": 0,
+                "input_file_label": 0
             },
+            "computing_model_part_name" : "computing_domain",
             "material_import_settings" :{
                 "materials_filename": ""
             },
@@ -52,7 +54,7 @@ class MechanicalSolver(object):
             "block_builder": true,
             "clear_storage": false,
             "move_mesh_flag": true,
-            "convergence_criterion": "Residual_criteria",
+            "convergence_criterion": "Residual_criterion",
             "displacement_relative_tolerance": 1.0e-4,
             "displacement_absolute_tolerance": 1.0e-9,
             "residual_relative_tolerance": 1.0e-4,
@@ -71,37 +73,31 @@ class MechanicalSolver(object):
         }
         """)
 
-        ##overwrite the default settings with user-provided parameters
+        # Overwrite the default settings with user-provided parameters.
         self.settings = custom_settings
         self.settings.ValidateAndAssignDefaults(default_settings)
 
-        #construct the linear solver
-        import linear_solver_factory
-        self.linear_solver = linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
-
-        print("Warning: Construction of Base Mechanical Solver finished")
+        #TODO: shall obtain the computing_model_part from the MODEL once the object is implemented
+        self.main_model_part = main_model_part
+        print("::[MechanicalSolver]:: Construction finished")
 
     def AddVariables(self):
-
-        # Add displacements
+        # Add displacements.
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION)
-
-        # Add dynamic variables
+        # Add dynamic variables.
         if(self.settings["solution_type"].GetString() == "Dynamic"):
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ACCELERATION)
-
-        # Add specific variables for the problem conditions
+        # Add specific variables for the problem conditions.
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.POSITIVE_FACE_PRESSURE)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NEGATIVE_FACE_PRESSURE)
         self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_LOAD)
         self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.LINE_LOAD)
         self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.SURFACE_LOAD)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VOLUME_ACCELERATION)
-
         if self.settings["rotation_dofs"].GetBool():
-            # Add specific variables for the problem (rotation dofs)
+            # Add specific variables for the problem (rotation dofs).
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ROTATION)
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.TORQUE)
             self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.LOCAL_POINT_MOMENT)
@@ -110,120 +106,102 @@ class MechanicalSolver(object):
                 self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_VELOCITY)
                 self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_ACCELERATION)
         if self.settings["pressure_dofs"].GetBool(): # TODO: The creation of UP and USigma elements is pending
-            # Add specific variables for the problem (pressure dofs)
+            # Add specific variables for the problem (pressure dofs).
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PRESSURE)
             self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.PRESSURE_REACTION)
-
-        print("::[Mechanical Solver]:: Variables ADDED")
-
+        print("::[MechanicalSolver]:: Variables ADDED")
 
     def GetMinimumBufferSize(self):
-        return 2;
+        return 2
 
     def AddDofs(self):
-
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_X, KratosMultiphysics.REACTION_X,self.main_model_part)
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_Y, KratosMultiphysics.REACTION_Y,self.main_model_part)
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_Z, KratosMultiphysics.REACTION_Z,self.main_model_part)
-
-
-
         if(self.settings["solution_type"].GetString() == "Dynamic"):
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_X,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_Y,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_Z,self.main_model_part)
-
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ACCELERATION_X,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ACCELERATION_Y,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ACCELERATION_Z,self.main_model_part)
-
-
         if self.settings["rotation_dofs"].GetBool():
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ROTATION_X, KratosMultiphysics.TORQUE_X,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ROTATION_Y, KratosMultiphysics.TORQUE_Y,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ROTATION_Z, KratosMultiphysics.TORQUE_Z,self.main_model_part)
-
-
         if(self.settings["solution_type"].GetString() == "Dynamic" and self.settings["rotation_dofs"].GetBool()):
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_VELOCITY_X,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_VELOCITY_Y,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_VELOCITY_Z,self.main_model_part)
-
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_X,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Y,self.main_model_part)
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Z,self.main_model_part)
-
-
         if self.settings["pressure_dofs"].GetBool():
             KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.PRESSURE, KratosMultiphysics.PRESSURE_REACTION,self.main_model_part)
-
         if not self.settings["stabilization_factor"].IsNull():
             self.main_model_part.ProcessInfo[KratosMultiphysics.STABILIZATION_FACTOR] = self.settings["stabilization_factor"].GetDouble()
-
-        print("::[Mechanical Solver]:: DOF's ADDED")
-
+        print("::[MechanicalSolver]:: DOF's ADDED")
 
     def ImportModelPart(self):
-
-        print("::[Mechanical Solver]:: Model reading starts.")
-
-        self.computing_model_part_name = "computing_domain" #this submodelpart will be labeled with KratosMultiphysics.ACTIVE flag, you can recover it checking the flag.
-
+        print("::[MechanicalSolver]:: Importing model part.")
+        problem_path = os.getcwd()
+        input_filename = self.settings["model_import_settings"]["input_filename"].GetString()
         if(self.settings["model_import_settings"]["input_type"].GetString() == "mdpa"):
-
-            # Model part reading
-            KratosMultiphysics.ModelPartIO(self.settings["model_import_settings"]["input_filename"].GetString()).ReadModelPart(self.main_model_part)
-            print("    Import input model part.")
-
-            # Check and prepare model process and construct constitutive law
-            self._ExecuteAfterReading()
-
-            # Set and fill buffer
-            self._SetAndFillBuffer()
-
+            # Import model part from mdpa file.
+            print("    Reading model part from file: " + os.path.join(problem_path, input_filename) + ".mdpa")
+            KratosMultiphysics.ModelPartIO(input_filename).ReadModelPart(self.main_model_part)
+            print("    Finished reading model part from mdpa file.")
+            # Check and prepare computing model part and import constitutive laws.
+            self._execute_after_reading()
+            self._set_and_fill_buffer()
         elif(self.settings["model_import_settings"]["input_type"].GetString() == "rest"):
-
+            # Import model part from restart file.
             problem_path = os.getcwd()
-            restart_path = os.path.join(problem_path, self.settings["model_import_settings"]["input_filename"].GetString() + "__" + self.settings["model_import_settings"]["input_file_label"].GetString() )
-
+            restart_path = os.path.join(problem_path, input_filename + "__" + self.settings["model_import_settings"]["input_file_label"].GetString())
             if(os.path.exists(restart_path+".rest") == False):
-                print("    rest file does not exist , check the restart step selected ")
-
-            print("    Load Restart file: ", self.settings["model_import_settings"]["input_filename"].GetString() + "__" + self.settings["model_import_settings"]["input_file_label"].GetString())
-            # set serializer flag
-            self.serializer_flag = KratosMultiphysics.SerializerTraceType.SERIALIZER_NO_TRACE      # binary
-            # self.serializer_flag = KratosMultiphysics.SerializerTraceType.SERIALIZER_TRACE_ERROR # ascii
-            # self.serializer_flag = KratosMultiphysics.SerializerTraceType.SERIALIZER_TRACE_ALL   # ascii
-
-            serializer = KratosMultiphysics.Serializer(restart_path, self.serializer_flag)
-
+                raise Exception("Restart file not found: " + restart_path + ".rest")
+            print("    Loading Restart file: ", restart_path + ".rest")
+            serializer_flag = KratosMultiphysics.SerializerTraceType.SERIALIZER_NO_TRACE      # binary
+            # serializer_flag = KratosMultiphysics.SerializerTraceType.SERIALIZER_TRACE_ERROR # ascii
+            # serializer_flag = KratosMultiphysics.SerializerTraceType.SERIALIZER_TRACE_ALL   # ascii
+            serializer = KratosMultiphysics.Serializer(restart_path, serializer_flag)
             serializer.Load(self.main_model_part.Name, self.main_model_part)
-
             self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED] = True
             #I use it to rebuild the contact conditions.
-            load_step = self.main_model_part.ProcessInfo[KratosMultiphysics.STEP] +1;
+            load_step = self.main_model_part.ProcessInfo[KratosMultiphysics.STEP] + 1
             self.main_model_part.ProcessInfo[KratosMultiphysics.LOAD_RESTART] = load_step
-
-            print(self.main_model_part)
-
+            print("    Finished loading model part from restart file.")
         else:
-            raise Exception("Other input options are not yet implemented.")
-
-        print ("::[Mechanical Solver]:: Model reading finished.")
-
+            raise Exception("Other model part input options are not yet implemented.")
+        print(self.main_model_part)
+        print ("::[MechanicalSolver]:: Finished importing model part.")
 
     def ExportModelPart(self):
         name_out_file = self.settings["model_import_settings"]["input_filename"].GetString()+".out"
         file = open(name_out_file + ".mdpa","w")
         file.close()
-        # Model part writing
         KratosMultiphysics.ModelPartIO(name_out_file, KratosMultiphysics.IO.WRITE).WriteModelPart(self.main_model_part)
 
     def Initialize(self):
-        raise Exception("please implement the Custom Initialization of your solver")
+        """Perform initialization after adding nodal variables and dofs to the main model part. """
+        print("::[MechanicalSolver]:: Initializing ...")
+        # The mechanical solver is created here if it does not already exist.
+        if self.settings["clear_storage"].GetBool():
+            self.Clear()
+        mechanical_solver = self.get_mechanical_solver()
+        mechanical_solver.SetEchoLevel(self.settings["echo_level"].GetInt())
+        if (self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED] == False):
+            mechanical_solver.Initialize()
+        else:
+            # SetInitializePerformedFlag is not a member of SolvingStrategy but
+            # is used by ResidualBasedNewtonRaphsonStrategy.
+            if hasattr(mechanical_solver, SetInitializePerformedFlag):
+                mechanical_solver.SetInitializePerformedFlag(True)
+        self.Check()
+        print("::[StaticMechanicalSolver]:: Finished initialization.")
 
     def GetComputingModelPart(self):
-        return self.main_model_part.GetSubModelPart(self.computing_model_part_name)
+        return self.main_model_part.GetSubModelPart(self.settings["computing_model_part_name"].GetString())
 
     def GetOutputVariables(self):
         pass
@@ -237,115 +215,130 @@ class MechanicalSolver(object):
     def Solve(self):
         if self.settings["clear_storage"].GetBool():
             self.Clear()
-
-        # We can solve all at once
-        self.mechanical_solver.Solve()
-
-        ## Or considering the phases
-        #Initialize()
-        #InitializeSolutionStep()
-        #Predict()
-        #is_converged = SolveSolutionStep()
-        #FinalizeSolutionStep()
-
-    # solve :: sequencial calls
-
-    def InitializeStrategy(self):
-        if self.settings["clear_storage"].GetBool():
-            self.Clear()
-
-        if( self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED] == False ):
-            self.mechanical_solver.Initialize()
-        else:
-            self.mechanical_solver.SetInitializePerformedFlag(True)
-
+        mechanical_solver = self.get_mechanical_solver()
+        mechanical_solver.Solve()
+        
     def InitializeSolutionStep(self):
-        self.mechanical_solver.InitializeSolutionStep()
+        self.get_mechanical_solver().InitializeSolutionStep()
 
     def Predict(self):
-        self.mechanical_solver.Predict()
+        self.get_mechanical_solver().Predict()
 
     def SolveSolutionStep(self):
-        is_converged = self.mechanical_solver.SolveSolutionStep()
+        is_converged = self.get_mechanical_solver().SolveSolutionStep()
         return is_converged
 
     def FinalizeSolutionStep(self):
-        self.mechanical_solver.FinalizeSolutionStep()
-
-    # solve :: sequencial calls
+        self.get_mechanical_solver().FinalizeSolutionStep()
 
     def SetEchoLevel(self, level):
-        self.mechanical_solver.SetEchoLevel(level)
+        self.get_mechanical_solver().SetEchoLevel(level)
 
     def Clear(self):
-        self.mechanical_solver.Clear()
+        self.get_mechanical_solver().Clear()
 
     def Check(self):
-        self.mechanical_solver.Check()
+        self.get_mechanical_solver().Check()
 
     #### Specific internal functions ####
 
-    def _ExecuteAfterReading(self):
-        self.computing_model_part_name = "computing_domain" #this submodelpart will be labeled with KratosMultiphysics.ACTIVE flag, you can recover it checking the flag.
+    def get_solution_scheme(self):
+        if not hasattr(self, '_solution_scheme'):
+            self._solution_scheme = self._create_solution_scheme()
+        return self._solution_scheme
 
-        # Auxiliary Kratos parameters object to be called by the CheckAndPepareModelProcess
-        params = KratosMultiphysics.Parameters("{}")
-        params.AddEmptyValue("computing_model_part_name").SetString(self.computing_model_part_name)
-        params.AddValue("problem_domain_sub_model_part_list",self.settings["problem_domain_sub_model_part_list"])
-        params.AddValue("processes_sub_model_part_list",self.settings["processes_sub_model_part_list"])
+    def get_convergence_criterion(self):
+        if not hasattr(self, '_convergence_criterion'):
+            self._convergence_criterion = self._create_convergence_criterion()
+        return self._convergence_criterion
 
-        if( self.settings.Has("bodies_list") ):
-            params.AddValue("bodies_list",self.settings["bodies_list"])
+    def get_linear_solver(self):
+        if not hasattr(self, '_linear_solver'):
+            self._linear_solver = self._create_linear_solver()
+        return self._linear_solver
 
-        # CheckAndPrepareModelProcess creates the solid_computational model part
-        import check_and_prepare_model_process_structural
-        check_and_prepare_model_process_structural.CheckAndPrepareModelProcess(self.main_model_part, params).Execute()
-
-        # Constitutive law import
-        if (self.settings["material_import_settings"]["materials_filename"].GetString() != ""):
+    def get_builder_and_solver(self):
+        if not hasattr(self, '_builder_and_solver'):
+            self._builder_and_solver = self._create_builder_and_solver()
+        return self._builder_and_solver
+    
+    def get_mechanical_solver(self):
+        if not hasattr(self, '_mechanical_solver'):
+            self._mechanical_solver = self._create_mechanical_solver()
+        return self._mechanical_solver
+    
+    def import_constitutive_laws(self):
+        materials_filename = self.settings["material_import_settings"]["materials_filename"].GetString()
+        if (materials_filename != ""):
             import read_materials_process
-            Model = {"Main" : self.main_model_part} # The process requires a model
+            # Create a dictionary of model parts.
+            Model = {self.main_model_part.Name : self.main_model_part}
             for i in range(self.settings["problem_domain_sub_model_part_list"].size()):
                 part_name = self.settings["problem_domain_sub_model_part_list"][i].GetString()
                 Model.update({part_name: self.main_model_part.GetSubModelPart(part_name)})
             for i in range(self.settings["processes_sub_model_part_list"].size()):
                 part_name = self.settings["processes_sub_model_part_list"][i].GetString()
                 Model.update({part_name: self.main_model_part.GetSubModelPart(part_name)})
+            # Add constitutive laws and material properties from json file to model parts.
             read_materials_process.ReadMaterialsProcess(Model, self.settings["material_import_settings"])
-            print("    Constitutive law initialized.")
+            materials_imported = True
         else:
-            #raise NameError("    Constitutive law not initialized.")
-            print("    Constitutive law not initialized.")
+            materials_imported = False
+        return materials_imported
 
-    def _SetAndFillBuffer(self):
-        # Set buffer size
-        self.main_model_part.SetBufferSize( self.settings["buffer_size"].GetInt() )
+    #### Private functions ####
 
-        current_buffer_size = self.main_model_part.GetBufferSize()
-        if(self.GetMinimumBufferSize() > current_buffer_size):
-            current_buffer_size = self.GetMinimumBufferSize()
+    def _execute_after_reading(self):
+        """Prepare computing model part and import constitutive laws. """
+        # Auxiliary parameters object for the CheckAndPepareModelProcess
+        params = KratosMultiphysics.Parameters("{}")
+        params.AddValue("computing_model_part_name",self.settings["computing_model_part_name"])
+        params.AddValue("problem_domain_sub_model_part_list",self.settings["problem_domain_sub_model_part_list"])
+        params.AddValue("processes_sub_model_part_list",self.settings["processes_sub_model_part_list"])
+        if( self.settings.Has("bodies_list") ):
+            params.AddValue("bodies_list",self.settings["bodies_list"])
+        # Assign mesh entities from domain and process sub model parts to the computing model part.
+        import check_and_prepare_model_process_structural
+        check_and_prepare_model_process_structural.CheckAndPrepareModelProcess(self.main_model_part, params).Execute()
 
-        self.main_model_part.SetBufferSize( current_buffer_size )
+        # Import constitutive laws.
+        materials_imported = self.import_constitutive_laws()
+        if materials_imported:
+            print("    Constitutive law was successfully imported.")
+        else:
+            print("    Constitutive law was not imported.")
 
-        # Fill buffer
+    def _set_and_fill_buffer(self):
+        """Prepare nodal solution step data containers and time step information. """
+        # Set the buffer size for the nodal solution steps data. Existing nodal
+        # solution step data may be lost.
+        buffer_size = self.settings["buffer_size"].GetInt()
+        if buffer_size < self.GetMinimumBufferSize():
+            buffer_size = self.GetMinimumBufferSize()
+        self.main_model_part.SetBufferSize(buffer_size)
+        # Cycle the buffer. This sets all historical nodal solution step data to
+        # the current value and initializes the time stepping in the process info.
         delta_time = self.main_model_part.ProcessInfo[KratosMultiphysics.DELTA_TIME]
         time = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
-        time = time - delta_time * (current_buffer_size)
+        step =-buffer_size
+        time = time - delta_time * buffer_size
         self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.TIME, time)
-        for size in range(0, current_buffer_size):
-            step = size - (current_buffer_size -1)
-            self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, step)
+        for i in range(0, buffer_size):
+            step = step + 1
             time = time + delta_time
-            #delta_time is computed from previous time in process_info
+            self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.STEP, step)
             self.main_model_part.CloneTimeStep(time)
-
         self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED] = False
 
-    def _GetSolutionScheme(self, analysis_type):
-        raise Exception("please implement the Custom Choice of your Scheme (_GetSolutionScheme) in your solver")
+    def _create_solution_scheme(self):
+        if self.settings["scheme_type"].GetString() == "Static":
+            solution_scheme = KratosMultiphysics.ResidualBasedIncrementalUpdateStaticScheme()
+        else:
+            raise Exception("Unsupported scheme_type: " + self.settings["scheme_type"].GetString())
+        return solution_scheme
 
-    def _GetConvergenceCriterion(self):
-        # Creation of an auxiliar Kratos parameters object to store the convergence settings
+    def _create_convergence_criterion(self):
+        # Create an auxiliary Kratos parameters object to store the convergence settings.
         conv_params = KratosMultiphysics.Parameters("{}")
         conv_params.AddValue("convergence_criterion",self.settings["convergence_criterion"])
         conv_params.AddValue("rotation_dofs",self.settings["rotation_dofs"])
@@ -354,22 +347,27 @@ class MechanicalSolver(object):
         conv_params.AddValue("displacement_absolute_tolerance",self.settings["displacement_absolute_tolerance"])
         conv_params.AddValue("residual_relative_tolerance",self.settings["residual_relative_tolerance"])
         conv_params.AddValue("residual_absolute_tolerance",self.settings["residual_absolute_tolerance"])
-
-        # Construction of the class convergence_criterion
         import convergence_criteria_factory
         convergence_criterion = convergence_criteria_factory.convergence_criterion(conv_params)
-
         return convergence_criterion.mechanical_convergence_criterion
+    
+    def _create_linear_solver(self):
+        import linear_solver_factory
+        linear_solver = linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
+        return linear_solver
 
-    def _GetBuilderAndSolver(self, block_builder):
-        # Creating the builder and solver
-        if(block_builder):
-            # To keep matrix blocks in builder
-            builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(self.linear_solver)
+    def _create_builder_and_solver(self):
+        linear_solver = self.get_linear_solver()
+        if(self.settings["block_builder"].GetBool() == True):
+            builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver)
         else:
-            builder_and_solver = KratosMultiphysics.ResidualBasedEliminationBuilderAndSolver(self.linear_solver)
-
+            builder_and_solver = KratosMultiphysics.ResidualBasedEliminationBuilderAndSolver(linear_solver)
         return builder_and_solver
 
-    def _CreateMechanicalSolver(self, mechanical_scheme, mechanical_convergence_criterion, builder_and_solver, max_iters, compute_reactions, reform_step_dofs, move_mesh_flag, component_wise, line_search, implex):
-        raise Exception("please implement the Custom Choice of your Mechanical Solver (_GetMechanicalSolver) in your solver")
+    def _create_mechanical_solver(self):
+        """Create the mechanical solver for the structural problem.
+        
+        The mechanical solver must provide the functions defined in SolutionStrategy.
+        """
+        raise Exception("Mechanical solver must be implemented in the derived class.")
+

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -14,15 +14,14 @@ def CreateSolver(main_model_part, custom_settings):
 class StaticMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
     """The structural mechanics static solver.
 
-    This class creates the mechanical solvers for static analysis. It supports
-    line search, linear, arc-length, formfinding and Newton-Raphson strategies.
+    This class creates the mechanical solvers for static analysis. It currently
+    supports line search, linear, arc-length, form-finding and Newton-Raphson
+    strategies.
 
-    Member variables from base class:
-    settings -- Kratos parameters containing general solver settings.
-    main_model_part -- the model part used to construct the solver.
-
-    Additional member variables:
+    Public member variables:
     arc_length_settings -- settings for the arc length method.
+
+    See structural_mechanics_solver.py for more information.
     """
     def __init__(self, main_model_part, custom_settings):
         settings = custom_settings.Clone()

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -56,12 +56,6 @@ class StaticMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
         self.arc_length_settings.ValidateAndAssignDefaults(default_arc_length_settings)
         print("::[StaticMechanicalSolver]:: Construction finished")
 
-    def AddVariables(self):
-        super().AddVariables()
-        if self.settings["rotation_dofs"].GetBool():
-            self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_TORQUE)
-        print("::[StaticMechanicalSolver]:: Variables ADDED")
-    
     def Initialize(self):
         print("::[StaticMechanicalSolver]:: Initializing ...")
         if self.settings["analysis_type"].GetString() == "Arc-Length":

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -27,7 +27,7 @@ class StaticMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
     def __init__(self, main_model_part, custom_settings):
         settings = custom_settings.Clone()
         if settings.Has("arc_length_settings"):
-            self.arc_length_settings = settings["arc_length_settings"]
+            self.arc_length_settings = settings["arc_length_settings"].Clone()
             settings.RemoveValue("arc_length_settings")
         else:
             self.arc_length_settings = KratosMultiphysics.Parameters("{}")

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -24,36 +24,33 @@ class StaticMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
     See structural_mechanics_solver.py for more information.
     """
     def __init__(self, main_model_part, custom_settings):
-        settings = custom_settings.Clone()
-        if settings.Has("arc_length_settings"):
-            self.arc_length_settings = settings["arc_length_settings"].Clone()
-            settings.RemoveValue("arc_length_settings")
-        else:
-            self.arc_length_settings = KratosMultiphysics.Parameters("{}")
-        if not settings.Has("scheme_type"):
-            settings.AddEmptyValue("scheme_type")
-            settings["scheme_type"].SetString("Static")
-
-        # Construct the base solver.
-        super().__init__(main_model_part, settings)
-
         # Set defaults and validate custom settings.
-        default_arc_length_settings = KratosMultiphysics.Parameters("""
+        static_settings = KratosMultiphysics.Parameters("""
         {
-            "Ide": 5,
-            "factor_delta_lmax": 1.00,
-            "max_iteration": 20,
-            "max_recursive": 50,
-            "toler": 1.0E-10,
-            "norm": 1.0E-7,
-            "MaxLineSearchIterations": 20,
-            "tolls": 0.000001,
-            "amp": 1.618,
-            "etmxa": 5,
-            "etmna": 0.1
+            "arc_length_settings" : {
+                "Ide": 5,
+                "factor_delta_lmax": 1.00,
+                "max_iteration": 20,
+                "max_recursive": 50,
+                "toler": 1.0E-10,
+                "norm": 1.0E-7,
+                "MaxLineSearchIterations": 20,
+                "tolls": 0.000001,
+                "amp": 1.618,
+                "etmxa": 5,
+                "etmna": 0.1
+            }
         }
         """)
-        self.arc_length_settings.ValidateAndAssignDefaults(default_arc_length_settings)
+        self.validate_and_transfer_matching_settings(custom_settings, static_settings)
+        self.arc_length_settings = static_settings["arc_length_settings"]
+        # Validate the remaining settings in the base class.
+        if not custom_settings.Has("scheme_type"): # Override defaults in the base class.
+            custom_settings.AddEmptyValue("scheme_type")
+            custom_settings["scheme_type"].SetString("Static")
+
+        # Construct the base solver.
+        super().__init__(main_model_part, custom_settings)
         print("::[StaticMechanicalSolver]:: Construction finished")
 
     def Initialize(self):

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -1,264 +1,202 @@
 from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-#import kratos core and applications
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
+import structural_mechanics_solver
 
 # Check that KratosMultiphysics was imported in the main script
 KratosMultiphysics.CheckForPreviousImport()
 
-# Import the implicit solver (the explicit one is derived from it)
-import structural_mechanics_solver
 
 def CreateSolver(main_model_part, custom_settings):
     return StaticMechanicalSolver(main_model_part, custom_settings)
 
+
 class StaticMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
-    
-    
-    ##constructor. the constructor shall only take care of storing the settings 
-    ##and the pointer to the main_model part. This is needed since at the point of constructing the 
-    ##model part is still not filled and the variables are not yet allocated
-    ##
-    ##real construction shall be delayed to the function "Initialize" which 
-    ##will be called once the model is already filled
-    def __init__(self, main_model_part, custom_settings): 
-        
-        #TODO: shall obtain the computing_model_part from the MODEL once the object is implemented
-        self.main_model_part = main_model_part    
-        
-        ##settings string in json format
-        default_settings = KratosMultiphysics.Parameters("""
+    """The structural mechanics static solver.
+
+    This class creates the mechanical solvers for static analysis. It supports
+    line search, linear, arc-length, formfinding and Newton-Raphson strategies.
+
+    Member variables from base class:
+    settings -- Kratos parameters containing general solver settings.
+    main_model_part -- the model part used to construct the solver.
+
+    Additional member variables:
+    arc_length_settings -- settings for the arc length method.
+    """
+    def __init__(self, main_model_part, custom_settings):
+        settings = custom_settings.Clone()
+        if settings.Has("arc_length_settings"):
+            self.arc_length_settings = settings["arc_length_settings"]
+            settings.RemoveValue("arc_length_settings")
+        else:
+            self.arc_length_settings = KratosMultiphysics.Parameters("{}")
+
+        # Construct the base solver.
+        super().__init__(main_model_part, settings)
+
+        # Set defaults and validate custom settings.
+        default_arc_length_settings = KratosMultiphysics.Parameters("""
         {
-            "solver_type": "structural_mechanics_static_solver",
-            "echo_level": 0,
-            "buffer_size": 2,
-            "solution_type": "Static",
-            "analysis_type": "Non-Linear",
-            "model_import_settings": {
-                "input_type": "mdpa",
-                "input_filename": "unknown_name"
-            },
-            "material_import_settings" :{
-                "materials_filename": ""
-            },
-            "rotation_dofs": false,
-            "pressure_dofs": false,
-            "stabilization_factor": 1.0,
-            "reform_dofs_at_each_step": false,
-            "line_search": false,
-            "compute_reactions": true,
-            "compute_contact_forces": false,
-            "block_builder": true,
-            "clear_storage": false,
-            "move_mesh_flag": true,
-            "convergence_criterion": "Residual_criterion",
-            "displacement_relative_tolerance": 1.0e-4,
-            "displacement_absolute_tolerance": 1.0e-9,
-            "residual_relative_tolerance": 1.0e-4,
-            "residual_absolute_tolerance": 1.0e-4,
-            "max_iteration": 10,
-            "linear_solver_settings":{
-                "solver_type": "SuperLUSolver",
-                "max_iteration": 500,
-                "tolerance": 1e-9,
-                "scaling": false,
-                "verbosity": 1
-            },
-            "arc_length_settings": {
-                "Ide": 5,
-                "factor_delta_lmax": 1.00,
-                "max_iteration": 20,
-                "max_recursive": 50,
-                "toler": 1.0E-10,
-                "norm": 1.0E-7,
-                "MaxLineSearchIterations": 20,
-                "tolls": 0.000001,
-                "amp": 1.618,
-                "etmxa": 5,
-                "etmna": 0.1
-            },
-            "problem_domain_sub_model_part_list": ["solid_model_part"],
-            "processes_sub_model_part_list": [""]
+            "Ide": 5,
+            "factor_delta_lmax": 1.00,
+            "max_iteration": 20,
+            "max_recursive": 50,
+            "toler": 1.0E-10,
+            "norm": 1.0E-7,
+            "MaxLineSearchIterations": 20,
+            "tolls": 0.000001,
+            "amp": 1.618,
+            "etmxa": 5,
+            "etmna": 0.1
         }
         """)
-        
-        ##overwrite the default settings with user-provided parameters
-        self.settings = custom_settings
-        self.settings.ValidateAndAssignDefaults(default_settings)
-        
-        #construct the linear solver
-        import linear_solver_factory
-        self.linear_solver = linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
-        
-        echo_level =  self.settings["echo_level"].GetInt()
-        print(self.settings["echo_level"].GetInt())
-        
-        print("Construction of MechanicalSolver finished")
+        self.arc_length_settings.ValidateAndAssignDefaults(default_arc_length_settings)
+        print("::[StaticMechanicalSolver]:: Construction finished")
         
     def Initialize(self):
+        print("::[StaticMechanicalSolver]:: Initializing ...")
+        # The solver is created here.
+        super().Initialize()
+        print("::[StaticMechanicalSolver]:: Finished initialization.")
 
-        print("::[Mechanical Solver]:: -START-")
-        
-        # Get the solid computing model part
-        self.computing_model_part = self.GetComputingModelPart()
-                
-        # Solution scheme choice
-        mechanical_scheme = self._GetSolutionScheme(self.settings["analysis_type"].GetString())
-        
-        # Get the convergence choice
-        mechanical_convergence_criterion = self._GetConvergenceCriterion()
-        
-        # Builder and solver choice
-        builder_and_solver = self._GetBuilderAndSolver(self.settings["block_builder"].GetBool())
-
-        # Mechanical solver choice
-        self._CreateMechanicalSolver(mechanical_scheme,
-                                     mechanical_convergence_criterion,
-                                     builder_and_solver,
-                                     self.settings["max_iteration"].GetInt(),
-                                     self.settings["compute_reactions"].GetBool(),
-                                     self.settings["reform_dofs_at_each_step"].GetBool(),
-                                     self.settings["move_mesh_flag"].GetBool(),
-                                     self.settings["line_search"].GetBool()
-                                     )
-
-        # Set echo_level
-        self.mechanical_solver.SetEchoLevel(self.settings["echo_level"].GetInt())
-
-        # Set initialize flag
-        if( self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED] == True ):
-            self.mechanical_solver.SetInitializePerformedFlag(True)
-            
-        # Check if everything is assigned correctly
-        self.Check()
-
-        print("::[Mechanical Solver]:: -END- ")
-        
     def AddVariables(self):
-        
-        structural_mechanics_solver.MechanicalSolver.AddVariables(self)
-
+        super().AddVariables()
         if self.settings["rotation_dofs"].GetBool():
-            # Add specific variables for the problem (rotation dofs)
-            self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.StructuralMechanicsApplication.POINT_TORQUE)
-        
+            self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_TORQUE)
         if self.settings["analysis_type"].GetString() == "Arc-Length":
-            self.main_model_part.ProcessInfo[KratosMultiphysics.StructuralMechanicsApplication.LAMBDA] = 0.00;
-   
-        print("::[Mechanical Solver]:: Variables ADDED")
+            self.main_model_part.ProcessInfo[StructuralMechanicsApplication.LAMBDA] = 0.0
+        print("::[StaticMechanicalSolver]:: Variables ADDED")
     
     def Solve(self):
-        KratosMultiphysics.VariableUtils().CheckVariableKeys()
-        if self.settings["clear_storage"].GetBool():
-            self.Clear()
-        
-        self.mechanical_solver.Solve()
-        
+        super().Solve()
         if self.settings["analysis_type"].GetString() == "Arc-Length":
-            echo_level =  self.settings["echo_level"].GetInt()
-            lambda_value = self.main_model_part.ProcessInfo[KratosMultiphysics.StructuralMechanicsApplication.LAMBDA]
-            if echo_level > 0:
+            lambda_value = self.main_model_part.ProcessInfo[StructuralMechanicsApplication.LAMBDA]
+            if self.settings["echo_level"].GetInt() > 0:
                 print("LAMBDA: ", lambda_value)
-            self._ChangeCondition(lambda_value)
+            self._update_arclength_point_load(lambda_value)
+
+    #### Private functions ####
     
-    def _IncreasePointLoad(forcing_nodes_list, Load):
-        for node in forcing_nodes_list:
-            node.SetSolutionStepValue(KratosMultiphysics.StructuralMechanicsApplication.POINT_LOAD, 0, Load)
+    #def _IncreasePointLoad(forcing_nodes_list, Load):
+    #    for node in forcing_nodes_list:
+    #        node.SetSolutionStepValue(KratosMultiphysics.StructuralMechanicsApplication.POINT_LOAD, 0, Load)
 
-    def _IncreaseDisplacement(forcing_nodes_list, disp):
-        for node in forcing_nodes_list:
-            node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT, 0, disp)
+    #def _IncreaseDisplacement(forcing_nodes_list, disp):
+    #    for node in forcing_nodes_list:
+    #        node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT, 0, disp)
 
-    def _ChangeCondition(self, lambda_value):
-        echo_level =  self.settings["echo_level"].GetInt()
+    def _update_arclength_point_load(self, lambda_value):
         force_x = 0.0
         force_y = 0.0
         force_z = 0.0
         for node in self.main_model_part.Nodes:
-            new_load = node.GetSolutionStepValue(KratosMultiphysics.StructuralMechanicsApplication.POINT_LOAD, 0) * lambda_value;
+            new_load = node.GetSolutionStepValue(StructuralMechanicsApplication.POINT_LOAD, 0) * lambda_value;
             force_x += new_load[0]
             force_y += new_load[1]
             force_z += new_load[2]
-            node.SetSolutionStepValue(KratosMultiphysics.StructuralMechanicsApplication.POINT_LOAD, 0, new_load)
+            node.SetSolutionStepValue(StructuralMechanicsApplication.POINT_LOAD, 0, new_load)
         
-        if (echo_level > 0):
+        if (self.settings["echo_level"].GetInt() > 0):
             print("*********************** ")
             print("The total load applied: ")
             print("POINT_LOAD_X: ", force_x)
             print("POINT_LOAD_Y: ", force_y)
             print("POINT_LOAD_Z: ", force_z)
             print("*********************** ")
-    
-    def _GetSolutionScheme(self, analysis_type):
-        mechanical_scheme = KratosMultiphysics.ResidualBasedIncrementalUpdateStaticScheme()
-                                
-        return mechanical_scheme
         
-    def _CreateMechanicalSolver(self, mechanical_scheme, mechanical_convergence_criterion, builder_and_solver, max_iters, compute_reactions, reform_step_dofs, move_mesh_flag, line_search):
-        
-        if(line_search):
-            self.mechanical_solver = KratosMultiphysics.LineSearchStrategy(
-                                                        self.computing_model_part, 
-                                                        mechanical_scheme, 
-                                                        self.linear_solver, 
-                                                        mechanical_convergence_criterion, 
-                                                        builder_and_solver, 
-                                                        max_iters, 
-                                                        compute_reactions, 
-                                                        reform_step_dofs, 
-                                                        move_mesh_flag)
-
+    def _create_mechanical_solver(self):
+        if(self.settings["line_search"].GetBool()):
+            mechanical_solver = self._create_line_search_strategy()
         else:
             if self.settings["analysis_type"].GetString() == "Linear":
-                self.mechanical_solver = KratosMultiphysics.ResidualBasedLinearStrategy(
-                                                                        self.computing_model_part, 
-                                                                        mechanical_scheme, 
-                                                                        self.linear_solver, 
-                                                                        builder_and_solver, 
-                                                                        compute_reactions, 
-                                                                        reform_step_dofs, 
-                                                                        False, 
-                                                                        move_mesh_flag)
-                
+                mechanical_solver = self._create_linear_strategy()
             elif self.settings["analysis_type"].GetString() == "Arc-Length":
-                Ide = self.settings["arc_length_settings"]["Ide"].GetInt()
-                max_iteration = self.settings["arc_length_settings"]["max_iteration"].GetInt()
-                max_recursive = self.settings["arc_length_settings"]["max_recursive"].GetInt()
-                factor_delta_lmax = self.settings["arc_length_settings"]["factor_delta_lmax"].GetDouble()
-                self.mechanical_solver = KratosMultiphysics.StructuralMechanicsApplication.ResidualBasedArcLengthStrategy(
-                                                                        self.computing_model_part, 
-                                                                        mechanical_scheme, 
-                                                                        self.linear_solver, 
-                                                                        mechanical_convergence_criterion, 
-                                                                        Ide,
-                                                                        max_iteration,
-                                                                        max_recursive,
-                                                                        factor_delta_lmax,
-                                                                        compute_reactions, 
-                                                                        reform_step_dofs, 
-                                                                        move_mesh_flag)
-
+                mechanical_solver = self._create_arc_length_strategy()
             elif self.settings["analysis_type"].GetString() == "Formfinding":
-                print("::[Mechanical Solver]::StructuralMechanicsApplication::Formfinding ")
-                self.mechanical_solver = StructuralMechanicsApplication.FormfindingUpdatedReferenceStrategy(
-                                                                        self.computing_model_part, 
-                                                                        mechanical_scheme, 
-                                                                        self.linear_solver, 
-                                                                        mechanical_convergence_criterion, 
-                                                                        builder_and_solver, 
-                                                                        max_iters, 
-                                                                        compute_reactions, 
-                                                                        reform_step_dofs, 
-                                                                        move_mesh_flag)
-
+                mechanical_solver = self._create_formfinding_strategy()
             else:
-                self.mechanical_solver = KratosMultiphysics.ResidualBasedNewtonRaphsonStrategy(
-                                                                        self.computing_model_part, 
+                mechanical_solver = self._create_newton_raphson_strategy()
+        return mechanical_solver
+
+    def _create_line_search_strategy(self):
+        computing_model_part = self.GetComputingModelPart()
+        mechanical_scheme = self.get_solution_scheme()
+        linear_solver = self.get_linear_solver()
+        mechanical_convergence_criterion = self.get_convergence_criterion()
+        builder_and_solver = self.get_builder_and_solver()
+        return KratosMultiphysics.LineSearchStrategy(computing_model_part, 
+                                                     mechanical_scheme, 
+                                                     linear_solver, 
+                                                     mechanical_convergence_criterion, 
+                                                     builder_and_solver, 
+                                                     self.settings["max_iteration"].GetInt(), 
+                                                     self.settings["compute_reactions"].GetBool(), 
+                                                     self.settings["reform_dofs_at_each_step"].GetBool(), 
+                                                     self.settings["move_mesh_flag"].GetBool())
+
+    def _create_linear_strategy(self):
+        computing_model_part = self.GetComputingModelPart()
+        mechanical_scheme = self.get_solution_scheme()
+        linear_solver = self.get_linear_solver()
+        builder_and_solver = self.get_builder_and_solver()
+        return KratosMultiphysics.ResidualBasedLinearStrategy(computing_model_part, 
+                                                              mechanical_scheme, 
+                                                              linear_solver, 
+                                                              builder_and_solver, 
+                                                              self.settings["compute_reactions"].GetBool(), 
+                                                              self.settings["reform_dofs_at_each_step"].GetBool(), 
+                                                              False, 
+                                                              self.settings["move_mesh_flag"].GetBool())
+
+    def _create_arc_length_strategy(self):
+        computing_model_part = self.GetComputingModelPart()
+        mechanical_scheme = self.get_solution_scheme()
+        linear_solver = self.get_linear_solver()
+        mechanical_convergence_criterion = self.get_convergence_criterion()
+        builder_and_solver = self.get_builder_and_solver()
+        return StructuralMechanicsApplication.ResidualBasedArcLengthStrategy(
+                                                                computing_model_part, 
+                                                                mechanical_scheme, 
+                                                                linear_solver, 
+                                                                mechanical_convergence_criterion, 
+                                                                self.arc_length_settings["Ide"].GetInt(),
+                                                                self.arc_length_settings["max_iteration"].GetInt(),
+                                                                self.arc_length_settings["max_recursive"].GetInt(),
+                                                                self.arc_length_settings["factor_delta_lmax"].GetDouble(),
+                                                                self.settings["compute_reactions"].GetBool(), 
+                                                                self.settings["reform_dofs_at_each_step"].GetBool(), 
+                                                                self.settings["move_mesh_flag"].GetBool())
+    
+    def _create_formfinding_strategy(self):
+        computing_model_part = self.GetComputingModelPart()
+        mechanical_scheme = self.get_solution_scheme()
+        linear_solver = self.get_linear_solver()
+        mechanical_convergence_criterion = self.get_convergence_criterion()
+        builder_and_solver = self.get_builder_and_solver()
+        return StructuralMechanicsApplication.FormfindingUpdatedReferenceStrategy(
+                                                                        computing_model_part, 
                                                                         mechanical_scheme, 
-                                                                        self.linear_solver, 
+                                                                        linear_solver, 
                                                                         mechanical_convergence_criterion, 
                                                                         builder_and_solver, 
-                                                                        max_iters, 
-                                                                        compute_reactions, 
-                                                                        reform_step_dofs, 
-                                                                        move_mesh_flag)
+                                                                        self.settings["max_iteration"].GetInt(), 
+                                                                        self.settings["compute_reactions"].GetBool(), 
+                                                                        self.settings["reform_dofs_at_each_step"].GetBool(), 
+                                                                        self.settings["move_mesh_flag"].GetBool())
+
+    def _create_newton_raphson_strategy(self):
+        computing_model_part = self.GetComputingModelPart()
+        mechanical_scheme = self.get_solution_scheme()
+        linear_solver = self.get_linear_solver()
+        mechanical_convergence_criterion = self.get_convergence_criterion()
+        builder_and_solver = self.get_builder_and_solver()
+        return KratosMultiphysics.ResidualBasedNewtonRaphsonStrategy(computing_model_part, 
+                                                                     mechanical_scheme, 
+                                                                     linear_solver, 
+                                                                     mechanical_convergence_criterion, 
+                                                                     builder_and_solver, 
+                                                                     self.settings["max_iteration"].GetInt(), 
+                                                                     self.settings["compute_reactions"].GetBool(), 
+                                                                     self.settings["reform_dofs_at_each_step"].GetBool(), 
+                                                                     self.settings["move_mesh_flag"].GetBool())

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
@@ -2,163 +2,53 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 #import kratos core and applications
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
-
-# MPI
 import KratosMultiphysics.mpi as mpi
 import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 import KratosMultiphysics.MetisApplication as MetisApplication
+import trilinos_structural_mechanics_solver
 
 # Check that KratosMultiphysics was imported in the main script
 KratosMultiphysics.CheckForPreviousImport()
 
-# Import the mechanical solver base class
-import trilinos_structural_mechanics_solver
 
 def CreateSolver(main_model_part, custom_settings):
     return TrilinosImplicitMechanicalSolver(main_model_part, custom_settings)
 
+
 class TrilinosImplicitMechanicalSolver(trilinos_structural_mechanics_solver.TrilinosMechanicalSolver):
+    """The trilinos structural mechanics implicit dynamic solver.
 
-    ##constructor. the constructor shall only take care of storing the settings
-    ##and the pointer to the main_model part. This is needed since at the point of constructing the
-    ##model part is still not filled and the variables are not yet allocated
-    ##
-    ##real construction shall be delayed to the function "Initialize" which
-    ##will be called once the model is already filled
+    Public member variables:
+    dynamic_settings -- settings for the implicit dynamic solvers.
+
+    For more information see:
+    structural_mechanics_solver.py
+    trilinos_structural_mechanics_solver.py
+    """
     def __init__(self, main_model_part, custom_settings):
-
-        #TODO: shall obtain the computing_model_part from the MODEL once the object is implemented
-        self.main_model_part = main_model_part
-
-        ##settings string in json format
-        default_settings = KratosMultiphysics.Parameters("""
+        # Set defaults and validate custom settings.
+        self.dynamic_settings = KratosMultiphysics.Parameters("""
         {
-            "solver_type": "trilinos_structural_mechanics_implicit_dynamic_solver",
-            "echo_level": 0,
-            "buffer_size": 2,
-            "solution_type": "Dynamic",
-            "time_integration_method": "Implicit",
-            "scheme_type": "Newmark",
-            "model_import_settings": {
-                "input_type": "mdpa",
-                "input_filename": "unknown_name",
-                "input_file_label": 0
-            },
-            "rotation_dofs": false,
-            "pressure_dofs": false,
-            "stabilization_factor": 1.0,
-            "reform_dofs_at_each_step": false,
-            "line_search": false,
-            "implex": false,
-            "compute_reactions": false,
-            "compute_contact_forces": false,
-            "block_builder": true,
-            "clear_storage": false,
-            "component_wise": false,
-            "move_mesh_flag": true,
-            "convergence_criterion": "Residual_criteria",
-            "displacement_relative_tolerance": 1.0e-4,
-            "displacement_absolute_tolerance": 1.0e-9,
-            "residual_relative_tolerance": 1.0e-4,
-            "residual_absolute_tolerance": 1.0e-9,
-            "max_iteration": 10,
-            "linear_solver_settings":{
-                "solver_type" : "Klu",
-                "scaling": false
-            },
-            "bodies_list": [],
-            "problem_domain_sub_model_part_list": ["solid_model_part"],
-            "processes_sub_model_part_list": [""]
-
+            "damp_factor_m" :-0.01
         }
         """)
+        self.validate_and_transfer_matching_settings(custom_settings, self.dynamic_settings)
+        # Validate the remaining settings in the base class.
+        if not custom_settings.Has("scheme_type"): # Override defaults in the base class.
+            custom_settings.AddEmptyValue("scheme_type")
+            custom_settings["scheme_type"].SetString("Newmark")
+        # Construct the base solver.
+        super().__init__(main_model_part, custom_settings)
 
-        ##overwrite the default settings with user-provided parameters
-        self.settings = custom_settings
-        self.settings.ValidateAndAssignDefaults(default_settings)
+    #### Private functions ####
 
-        #construct the linear solver
-        import trilinos_linear_solver_factory
-        self.linear_solver = trilinos_linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
-
-        print("Construction of Implicit Mechanical MPI Solver finished")
-
-    def AddVariables(self):
-
-        super(TrilinosImplicitMechanicalSolver, self).AddVariables()
-
-        if self.settings["rotation_dofs"].GetBool():
-            # Add specific variables for the problem (rotation dofs)
-            self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_TORQUE)
-
-    def Initialize(self):
-
-        print("::[Mechanical MPI Solver]:: -START-")
-        # Construct the communicator
-        self.EpetraCommunicator = TrilinosApplication.CreateCommunicator()
-
-        # Get the solid computing model part
-        self.computing_model_part = self.GetComputingModelPart()
-
-        # Builder and solver creation
-        builder_and_solver = self._GetBuilderAndSolver(self.settings["component_wise"].GetBool(),
-                                                       self.settings["block_builder"].GetBool())
-
-        # Solution scheme creation
-        mechanical_scheme = self._GetSolutionScheme(self.settings["scheme_type"].GetString(),
-                                                    self.settings["component_wise"].GetBool(),
-                                                    self.settings["compute_contact_forces"].GetBool())
-
-        # Get the convergence criterion
-        mechanical_convergence_criterion = self._GetConvergenceCriterion()
-
-        # Mechanical solver creation
-        self._CreateMechanicalSolver(mechanical_scheme,
-                                     mechanical_convergence_criterion,
-                                     builder_and_solver,
-                                     self.settings["max_iteration"].GetInt(),
-                                     self.settings["compute_reactions"].GetBool(),
-                                     self.settings["reform_dofs_at_each_step"].GetBool(),
-                                     self.settings["move_mesh_flag"].GetBool(),
-                                     self.settings["component_wise"].GetBool(),
-                                     self.settings["line_search"].GetBool(),
-                                     self.settings["implex"].GetBool())
-
-        # Set echo_level
-        self.mechanical_solver.SetEchoLevel(self.settings["echo_level"].GetInt())
-
-        # Check if everything is assigned correctly
-        self.Check();
-
-        print("::[Mechanical MPI Solver]:: -END- ")
-
-
-    #### Decomposed Newton-Raphson resolution functions ####
-
-    def SolverInitialize(self):
-        self.mechanical_solver.Initialize()
-
-    def SolverInitializeSolutionStep(self):
-        self.mechanical_solver.InitializeSolutionStep()
-
-    def SolverPredict(self):
-        self.mechanical_solver.Predict()
-
-    def SolverSolveSolutionStep(self):
-        self.mechanical_solver.SolveSolutionStep()
-
-    def SolverFinalizeSolutionStep(self):
-        self.mechanical_solver.FinalizeSolutionStep()
-
-    #### Specific internal functions ####
-
-    def _GetSolutionScheme(self, scheme_type, component_wise, compute_contact_forces):
-
-        if(scheme_type == "Newmark") or (scheme_type == "Bossak"):
-            if (scheme_type == "Newmark"):
-                mechanical_scheme = TrilinosApplication.TrilinosResidualBasedBossakDisplacementScheme(0.0)
-            else:
-                alpha = self.settings["damp_factor_m"].GetDouble()
-                mechanical_scheme = TrilinosApplication.TrilinosResidualBasedBossakDisplacementScheme(alpha)
-
+    def _create_solution_scheme(self):
+        scheme_type = self.settings["scheme_type"].GetString()
+        if (scheme_type == "Newmark"):
+            damp_factor_m = 0.0
+        elif (scheme_type == "Bossak"):
+            damp_factor_m = self.dynamic_settings["damp_factor_m"].GetDouble()
+        else:
+            raise Exception("Unsupported scheme_type: " + scheme_type)
+        mechanical_scheme = TrilinosApplication.TrilinosResidualBasedBossakDisplacementScheme(damp_factor_m)
         return mechanical_scheme

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
@@ -2,109 +2,73 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 #import kratos core and applications
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
-
-# MPI
 import KratosMultiphysics.mpi as mpi
 import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 import KratosMultiphysics.MetisApplication as MetisApplication
+import structural_mechanics_solver
 
 # Check that KratosMultiphysics was imported in the main script
 KratosMultiphysics.CheckForPreviousImport()
 
-# Import the implicit solver (the explicit one is derived from it)
-import solid_mechanics_solver
 
 def CreateSolver(main_model_part, custom_settings):
     return TrilinosMechanicalSolver(main_model_part, custom_settings)
 
-class TrilinosMechanicalSolver(solid_mechanics_solver.MechanicalSolver):
 
-    ##constructor. the constructor shall only take care of storing the settings
-    ##and the pointer to the main_model part. This is needed since at the point of constructing the
-    ##model part is still not filled and the variables are not yet allocated
-    ##
-    ##real construction shall be delayed to the function "Initialize" which
-    ##will be called once the model is already filled
+class TrilinosMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
+    """The base class for trilinos structural mechanics solver.
+
+    See structural_mechanics_solver.py for more information.
+    """
     def __init__(self, main_model_part, custom_settings):
-
-        #TODO: shall obtain the computing_model_part from the MODEL once the object is implemented
-        self.main_model_part = main_model_part
-
-        ##settings string in json format
-        default_settings = KratosMultiphysics.Parameters("""
-        {
-            "solver_type": "trilinos_structural_mechanics_solver",
-            "echo_level": 0,
-            "buffer_size": 2,
-            "solution_type": "Dynamic",
-            "analysis_type": "Non-Linear",
-            "time_integration_method": "Implicit",
-            "scheme_type": "Newmark",
-            "model_import_settings": {
-                "input_type": "mdpa",
-                "input_filename": "unknown_name",
-                "input_file_label": 0
-            },
-            "rotation_dofs": false,
-            "pressure_dofs": false,
-            "stabilization_factor": null,
-            "reform_dofs_at_each_step": false,
-            "line_search": false,
-            "implex": false,
-            "compute_reactions": false,
-            "compute_contact_forces": false,
-            "block_builder": true,
-            "clear_storage": false,
-            "component_wise": false,
-            "move_mesh_flag": true,
-            "convergence_criterion": "Residual_criteria",
-            "displacement_relative_tolerance": 1.0e-4,
-            "displacement_absolute_tolerance": 1.0e-9,
-            "residual_relative_tolerance": 1.0e-4,
-            "residual_absolute_tolerance": 1.0e-9,
-            "max_iteration": 10,
-            "linear_solver_settings":{
+        if not custom_settings.Has("linear_solver_settings"): # Override defaults in the base class.
+            linear_solver_settings = KratosMultiphysics.Parameters("""{
                 "solver_type" : "Klu",
-                "scaling": false
-            },
-            "bodies_list": [],
-            "problem_domain_sub_model_part_list": ["solid"],
-            "processes_sub_model_part_list": [""]
-        }
-        """)
+                "scaling" : false
+            }""")
+            custom_settings.AddValue("linear_solver_settings", linear_solver_settings)
 
-        ##overwrite the default settings with user-provided parameters
-        self.settings = custom_settings
-        self.settings.ValidateAndAssignDefaults(default_settings)
-
-        #construct the linear solver
-        import trilinos_linear_solver_factory # TODO: Is new_trilinos_linear_solver_factory or trilinos_linear_solver_factory?
-        self.linear_solver = trilinos_linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
+        # Construct the base solver.
+        super().__init__(main_model_part, custom_settings)
+        print("::[TrilinosMechanicalSolver]:: Construction finished")
 
     def AddVariables(self):
-        super(TrilinosMechanicalSolver, self).AddVariables()
-
+        super().AddVariables()
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)
+        print("::[TrilinosMechanicalSolver]:: Variables ADDED")
 
     def ImportModelPart(self):
-        # Construct the Trilinos import model part utility
+        print("::[TrilinosMechanicalSolver]:: Importing model part.")
+        # Construct the Trilinos import model part utility.
         import trilinos_import_model_part_utility
         TrilinosModelPartImporter = trilinos_import_model_part_utility.TrilinosImportModelPartUtility(self.main_model_part, self.settings)
-
-        # Execute the Metis partitioning and reading
+        # Execute the Metis partitioning and reading.
         TrilinosModelPartImporter.ExecutePartitioningAndReading()
-
-        # Call the base class execute after reading (check and prepare model process and set the constitutive law)
-        super(TrilinosMechanicalSolver, self)._ExecuteAfterReading()
-
-        # Call the base class set and fill buffer size
-        super(TrilinosMechanicalSolver, self)._SetAndFillBuffer()
-
+        # Call the base class execute after reading (check and prepare model process and set the constitutive law).
+        super()._execute_after_reading()
+        # Call the base class set and fill buffer size.
+        super()._set_and_fill_buffer()
         # Construct the communicators
         TrilinosModelPartImporter.CreateCommunicators()
+        print ("::[TrilinosMechanicalSolver]:: Finished importing model part.")
 
-    def _GetConvergenceCriterion(self):
-        # Creation of an auxiliar Kratos parameters object to store the convergence settings
+    #### Specific internal functions ####
+
+    def get_epetra_communicator(self):
+        if not hasattr(self, '_epetra_communicator'):
+            self._epetra_communicator = self._create_epetra_communicator()
+        return self._epetra_communicator
+
+    #### Private functions ####
+
+    def _create_epetra_communicator(self):
+        return TrilinosApplication.CreateCommunicator()
+
+    def _create_solution_scheme(self):
+        return TrilinosApplication.TrilinosResidualBasedIncrementalUpdateStaticScheme()
+
+    def _create_convergence_criterion(self):
+        # Create an auxiliary Kratos parameters object to store the convergence settings.
         conv_params = KratosMultiphysics.Parameters("{}")
         conv_params.AddValue("convergence_criterion",self.settings["convergence_criterion"])
         conv_params.AddValue("rotation_dofs",self.settings["rotation_dofs"])
@@ -114,43 +78,44 @@ class TrilinosMechanicalSolver(solid_mechanics_solver.MechanicalSolver):
         conv_params.AddValue("displacement_absolute_tolerance",self.settings["displacement_absolute_tolerance"])
         conv_params.AddValue("residual_relative_tolerance",self.settings["residual_relative_tolerance"])
         conv_params.AddValue("residual_absolute_tolerance",self.settings["residual_absolute_tolerance"])
-
-        # Construction of the class convergence_criterion
         import trilinos_convergence_criteria_factory
         convergence_criterion = trilinos_convergence_criteria_factory.convergence_criterion(conv_params)
-
         return convergence_criterion.mechanical_convergence_criterion
 
-    def _GetBuilderAndSolver(self, component_wise, block_builder):
+    def _create_linear_solver(self):
+        import trilinos_linear_solver_factory # TODO: Is new_trilinos_linear_solver_factory or trilinos_linear_solver_factory?
+        linear_solver = trilinos_linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
+        return linear_solver
 
+    def _create_builder_and_solver(self):
+        linear_solver = self.get_linear_solver()
+        epetra_communicator = self.get_epetra_communicator()
         if(self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 2):
             guess_row_size = 15
         else:
             guess_row_size = 45
-
-        if(block_builder):
-            # To keep matrix blocks in builder
-            builder_and_solver = TrilinosApplication.TrilinosBlockBuilderAndSolver(self.EpetraCommunicator,
+        if(self.settings["block_builder"].GetBool() == True):
+            builder_and_solver = TrilinosApplication.TrilinosBlockBuilderAndSolver(epetra_communicator,
                                                                                    guess_row_size,
-                                                                                   self.linear_solver
-                                                                                   )
+                                                                                   linear_solver)
         else:
-            builder_and_solver = TrilinosApplication.TrilinosEliminationBuilderAndSolver(self.EpetraCommunicator,
+            builder_and_solver = TrilinosApplication.TrilinosEliminationBuilderAndSolver(epetra_communicator,
                                                                                          guess_row_size,
-                                                                                         self.linear_solver
-                                                                                         )
+                                                                                         linear_solver)
         return builder_and_solver
 
-
-    def _CreateMechanicalSolver(self, mechanical_scheme, mechanical_convergence_criterion, builder_and_solver, max_iters, compute_reactions, reform_step_dofs, move_mesh_flag, component_wise, line_search, implex):
-
-        self.mechanical_solver = TrilinosApplication.TrilinosNewtonRaphsonStrategy(self.main_model_part,
-                                                                                   mechanical_scheme,
-                                                                                   self.linear_solver,
-                                                                                   mechanical_convergence_criterion,
-                                                                                   builder_and_solver,
-                                                                                   max_iters,
-                                                                                   compute_reactions,
-                                                                                   reform_step_dofs,
-                                                                                   move_mesh_flag
-                                                                                   )
+    def _create_mechanical_solver(self):
+        computing_model_part = self.GetComputingModelPart()
+        solution_scheme = self.get_solution_scheme()
+        linear_solver = self.get_linear_solver()
+        convergence_criterion = self.get_convergence_criterion()
+        builder_and_solver = self.get_builder_and_solver()
+        return TrilinosApplication.TrilinosNewtonRaphsonStrategy(computing_model_part,
+                                                                 solution_scheme,
+                                                                 linear_solver,
+                                                                 convergence_criterion,
+                                                                 builder_and_solver,
+                                                                 self.settings["max_iteration"].GetInt(),
+                                                                 self.settings["compute_reactions"].GetBool(),
+                                                                 self.settings["reform_dofs_at_each_step"].GetBool(),
+                                                                 self.settings["move_mesh_flag"].GetBool())

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_static_solver.py
@@ -2,131 +2,28 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 #import kratos core and applications
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
-
-#
 import KratosMultiphysics.mpi as mpi
 import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 import KratosMultiphysics.MetisApplication as MetisApplication
+import trilinos_structural_mechanics_solver
+
 
 # Check that KratosMultiphysics was imported in the main script
 KratosMultiphysics.CheckForPreviousImport()
 
-# Import the mechanical solver base class
-import trilinos_structural_mechanics_solver
 
 def CreateSolver(main_model_part, custom_settings):
     return TrilinosStaticMechanicalSolver(main_model_part, custom_settings)
 
+
 class TrilinosStaticMechanicalSolver(trilinos_structural_mechanics_solver.TrilinosMechanicalSolver):
+    """The trilinos structural mechanics static solver.
 
+    For more information see:
+    structural_mechanics_solver.py
+    trilinos_structural_mechanics_solver.py
+    """
     def __init__(self, main_model_part, custom_settings):
-
-        #TODO: shall obtain the computing_model_part from the MODEL once the object is implemented
-        self.main_model_part = main_model_part
-
-        ##settings string in json format
-        default_settings = KratosMultiphysics.Parameters("""
-        {
-            "solver_type": "trilinos_structural_mechanics_static_solver",
-            "echo_level": 0,
-            "buffer_size": 2,
-            "solution_type": "Static",
-            "analysis_type": "Non-Linear",
-            "model_import_settings": {
-                "input_type": "mdpa",
-                "input_filename": "unknown_name",
-                "input_file_label": 0
-            },
-            "rotation_dofs": false,
-            "pressure_dofs": false,
-            "stabilization_factor": 1.0,
-            "reform_dofs_at_each_step": false,
-            "line_search": false,
-            "implex": false,
-            "compute_reactions": false,
-            "compute_contact_forces": false,
-            "block_builder": true,
-            "clear_storage": false,
-            "component_wise": false,
-            "move_mesh_flag": true,
-            "convergence_criterion": "Residual_criteria",
-            "displacement_relative_tolerance": 1.0e-4,
-            "displacement_absolute_tolerance": 1.0e-9,
-            "residual_relative_tolerance": 1.0e-4,
-            "residual_absolute_tolerance": 1.0e-4,
-            "max_iteration": 10,
-            "linear_solver_settings":{
-                "solver_type" : "Klu",
-                "scaling": false
-            },
-            "bodies_list": [],
-            "problem_domain_sub_model_part_list": ["solid_model_part"],
-            "processes_sub_model_part_list": [""]
-        }
-        """)
-
-        ##overwrite the default settings with user-provided parameters
-        self.settings = custom_settings
-        self.settings.ValidateAndAssignDefaults(default_settings)
-
-        #construct the linear solver
-        import trilinos_linear_solver_factory # TODO: Is new_trilinos_linear_solver_factory or trilinos_linear_solver_factory?
-        self.linear_solver = trilinos_linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
-
-        print("Construction of Static Mechanical MPI Solver finished")
-
-    def AddVariables(self):
-
-        super(TrilinosStaticMechanicalSolver, self).AddVariables()
-
-        if self.settings["rotation_dofs"].GetBool():
-            # Add specific variables for the problem (rotation dofs)
-            self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_TORQUE)
-
-    def Initialize(self):
-
-        print("::[Mechanical MPI Solver]:: -START-")
-        # Construct the communicator
-        self.EpetraCommunicator = TrilinosApplication.CreateCommunicator()
-
-        # Get the solid computing model part
-        self.computing_model_part = self.GetComputingModelPart()
-
-        # Solution scheme choice
-        mechanical_scheme = self._GetSolutionScheme(self.settings["analysis_type"].GetString(),
-                                                    self.settings["component_wise"].GetBool(),
-                                                    self.settings["compute_contact_forces"].GetBool())
-
-        # Get the convergence choice
-        mechanical_convergence_criterion = self._GetConvergenceCriterion()
-
-        # Builder and solver choice
-        builder_and_solver = self._GetBuilderAndSolver(self.settings["component_wise"].GetBool(),
-                                                       self.settings["block_builder"].GetBool())
-
-        # Mechanical solver choice
-        self._CreateMechanicalSolver(mechanical_scheme,
-                                     mechanical_convergence_criterion,
-                                     builder_and_solver,
-                                     self.settings["max_iteration"].GetInt(),
-                                     self.settings["compute_reactions"].GetBool(),
-                                     self.settings["reform_dofs_at_each_step"].GetBool(),
-                                     self.settings["move_mesh_flag"].GetBool(),
-                                     self.settings["component_wise"].GetBool(),
-                                     self.settings["line_search"].GetBool(),
-                                     self.settings["implex"].GetBool())
-
-        # Set echo_level
-        self.mechanical_solver.SetEchoLevel(self.settings["echo_level"].GetInt())
-
-        # Check if everything is assigned correctly
-        self.Check();
-
-        print("::[Mechanical MPI Solver]:: -END- ")
-
-    #### Specific internal functions ####
-
-    def _GetSolutionScheme(self, analysis_type, component_wise, compute_contact_forces):
-        mechanical_scheme = TrilinosApplication.TrilinosResidualBasedIncrementalUpdateStaticScheme()
-
-        return mechanical_scheme
+        # Construct the base solver.
+        super().__init__(main_model_part, custom_settings)
+        print("::[TrilinosStaticMechanicalSolver]:: Construction finished")

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__BendingRollUp_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__BendingRollUp_test_parameters.json
@@ -11,7 +11,8 @@
     "solver_settings"          : {
         "solver_type"                        : "structural_mechanics_static_solver",
         "solution_type"                      : "Static",
-        "echo_level"      					 : 0,
+        "analysis_type"                      : "Non-Linear",
+        "echo_level"                         : 0,
         "model_import_settings"              : {
             "input_type"     : "mdpa",
             "input_filename" : "shell_test/Shell_Q4_Thick__BendingRollUp"

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__DrillingRollUp_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__DrillingRollUp_test_parameters.json
@@ -11,7 +11,8 @@
         "solver_settings"          : {
             "solver_type"                        : "structural_mechanics_static_solver",
             "solution_type"                      : "Static",
-            "echo_level"      					 : 0,
+            "analysis_type"                      : "Non-Linear",
+            "echo_level"                         : 0,
             "model_import_settings"              : {
                 "input_type"     : "mdpa",
                 "input_filename" : "shell_test/Shell_Q4_Thick__DrillingRollUp"

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Isotropic_Scordelis_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Isotropic_Scordelis_test_parameters.json
@@ -11,7 +11,8 @@
     "solver_settings"          : {
         "solver_type"                        : "structural_mechanics_static_solver",
         "solution_type"                      : "Static",
-        "echo_level"      					 : 0,
+        "analysis_type"                      : "Non-Linear",
+        "echo_level"                         : 0,
         "model_import_settings"              : {
             "input_type"     : "mdpa",
             "input_filename" : "shell_test/Shell_T3_Isotropic_Scordelis"

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin__DrillingRollUp_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin__DrillingRollUp_test_parameters.json
@@ -11,7 +11,8 @@
         "solver_settings"          : {
             "solver_type"                        : "structural_mechanics_static_solver",
             "solution_type"                      : "Static",
-            "echo_level"      					 : 0,
+            "analysis_type"                      : "Non-Linear",
+            "echo_level"                         : 0,
             "model_import_settings"              : {
                 "input_type"     : "mdpa",
                 "input_filename" : "shell_test/Shell_T3_Thin__DrillingRollUp"


### PR DESCRIPTION
The point of this PR is to clean up the code structure in the python solver scripts.

The main issues were:
- having a common interface to all solvers (through the base class)
- providing internal getter methods to access linear solver, schemes, builder, etc. without having to check if or where they were created. 
- reducing copies of the default settings and other code as much as possible

All structural mechanics tests passed.
