### PR TITLE
using older syntax for super()

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
@@ -49,7 +49,7 @@ class EigenSolver(structural_mechanics_solver.MechanicalSolver):
             custom_settings["scheme_type"].SetString("Dynamic")
         
         # Construct the base solver.
-        super().__init__(main_model_part, custom_settings)
+        super(EigenSolver, self).__init__(main_model_part, custom_settings)
         print("::[EigenSolver]:: Construction finished")
 
     #### Private functions ####

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -36,11 +36,11 @@ class ImplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
             custom_settings["scheme_type"].SetString("Newmark")
         
         # Construct the base solver.
-        super().__init__(main_model_part, custom_settings)
+        super(ImplicitMechanicalSolver, self).__init__(main_model_part, custom_settings)
         print("::[ImplicitMechanicalSolver]:: Construction finished")
 
     def AddVariables(self):
-        super().AddVariables()
+        super(ImplicitMechanicalSolver, self).AddVariables()
         # Add dynamic variables.
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ACCELERATION)
@@ -50,7 +50,7 @@ class ImplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
         print("::[ImplicitMechanicalSolver]:: Variables ADDED")
     
     def AddDofs(self):
-        super().AddDofs()
+        super(ImplicitMechanicalSolver, self).AddDofs()
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_X,self.main_model_part)
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_Y,self.main_model_part)
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_Z,self.main_model_part)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -50,18 +50,18 @@ class StaticMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
             custom_settings["scheme_type"].SetString("Static")
 
         # Construct the base solver.
-        super().__init__(main_model_part, custom_settings)
+        super(StaticMechanicalSolver, self).__init__(main_model_part, custom_settings)
         print("::[StaticMechanicalSolver]:: Construction finished")
 
     def Initialize(self):
         print("::[StaticMechanicalSolver]:: Initializing ...")
         if self.settings["analysis_type"].GetString() == "Arc-Length":
             self.main_model_part.ProcessInfo[StructuralMechanicsApplication.LAMBDA] = 0.0
-        super().Initialize() # The mechanical solver is created here.
+        super(StaticMechanicalSolver, self).Initialize() # The mechanical solver is created here.
         print("::[StaticMechanicalSolver]:: Finished initialization.")
     
     def Solve(self):
-        super().Solve()
+        super(StaticMechanicalSolver, self).Solve()
         if self.settings["analysis_type"].GetString() == "Arc-Length":
             lambda_value = self.main_model_part.ProcessInfo[StructuralMechanicsApplication.LAMBDA]
             if self.settings["echo_level"].GetInt() > 0:

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
@@ -38,7 +38,7 @@ class TrilinosImplicitMechanicalSolver(trilinos_structural_mechanics_solver.Tril
             custom_settings.AddEmptyValue("scheme_type")
             custom_settings["scheme_type"].SetString("Newmark")
         # Construct the base solver.
-        super().__init__(main_model_part, custom_settings)
+        super(TrilinosImplicitMechanicalSolver, self).__init__(main_model_part, custom_settings)
 
     #### Private functions ####
 

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
@@ -29,11 +29,11 @@ class TrilinosMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
             custom_settings.AddValue("linear_solver_settings", linear_solver_settings)
 
         # Construct the base solver.
-        super().__init__(main_model_part, custom_settings)
+        super(TrilinosMechanicalSolver, self).__init__(main_model_part, custom_settings)
         print("::[TrilinosMechanicalSolver]:: Construction finished")
 
     def AddVariables(self):
-        super().AddVariables()
+        super(TrilinosMechanicalSolver, self).AddVariables()
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)
         print("::[TrilinosMechanicalSolver]:: Variables ADDED")
 
@@ -45,9 +45,9 @@ class TrilinosMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
         # Execute the Metis partitioning and reading.
         TrilinosModelPartImporter.ExecutePartitioningAndReading()
         # Call the base class execute after reading (check and prepare model process and set the constitutive law).
-        super()._execute_after_reading()
+        super(TrilinosMechanicalSolver, self)._execute_after_reading()
         # Call the base class set and fill buffer size.
-        super()._set_and_fill_buffer()
+        super(TrilinosMechanicalSolver, self)._set_and_fill_buffer()
         # Construct the communicators
         TrilinosModelPartImporter.CreateCommunicators()
         print ("::[TrilinosMechanicalSolver]:: Finished importing model part.")

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_static_solver.py
@@ -25,5 +25,5 @@ class TrilinosStaticMechanicalSolver(trilinos_structural_mechanics_solver.Trilin
     """
     def __init__(self, main_model_part, custom_settings):
         # Construct the base solver.
-        super().__init__(main_model_part, custom_settings)
+        super(TrilinosStaticMechanicalSolver, self).__init__(main_model_part, custom_settings)
         print("::[TrilinosStaticMechanicalSolver]:: Construction finished")


### PR DESCRIPTION
This pr changes the super() syntax to be backwards compatible with python 2. It is in response to the comment in #541. 
