### PR TITLE
Adding references to definition of mrModelPart

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -73,10 +73,9 @@ public:
     ///@{
 
     /// Constructor.
-    DistanceModificationProcess(ModelPart& rModelPart, const bool& rCheckAtEachStep, const bool& rRecoverOriginalDistance)
+    DistanceModificationProcess(ModelPart& rModelPart, const bool& rCheckAtEachStep, const bool& rRecoverOriginalDistance): mrModelPart(rModelPart)
     {
         mFactorCoeff = 2.0;
-        mrModelPart = rModelPart;
         mrCheckAtEachStep = rCheckAtEachStep;
         mrRecoverOriginalDistance = rRecoverOriginalDistance;
     }
@@ -185,7 +184,7 @@ protected:
     ///@name Protected member Variables
     ///@{
 
-    ModelPart                                               mrModelPart;
+    ModelPart&                                              mrModelPart;
     double                                                 mFactorCoeff;
     bool                                              mrCheckAtEachStep;
     bool                                      mrRecoverOriginalDistance;
@@ -420,13 +419,13 @@ private:
     ///@{
 
     /// Default constructor.
-    DistanceModificationProcess(){}
+    DistanceModificationProcess() = delete;
 
     /// Assignment operator.
-    DistanceModificationProcess& operator=(DistanceModificationProcess const& rOther){return *this;}
+    DistanceModificationProcess& operator=(DistanceModificationProcess const& rOther) = delete;
 
     /// Copy constructor.
-    DistanceModificationProcess(DistanceModificationProcess const& rOther){}
+    DistanceModificationProcess(DistanceModificationProcess const& rOther) = delete;
 
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_nodes_initialization_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_nodes_initialization_process.h
@@ -73,9 +73,8 @@ public:
     ///@{
 
     /// Constructor.
-    EmbeddedNodesInitializationProcess(ModelPart& rModelPart, unsigned int MaxIterations = 10)
+    EmbeddedNodesInitializationProcess(ModelPart& rModelPart, unsigned int MaxIterations = 10) : mrModelPart(rModelPart)
     {
-        mrModelPart = rModelPart;
         mMaxIterations = MaxIterations;
     }
 
@@ -231,7 +230,7 @@ protected:
     ///@name Protected member Variables
     ///@{
 
-    ModelPart                                  mrModelPart;
+    ModelPart&                                 mrModelPart;
     unsigned int                            mMaxIterations;
 
     ///@}
@@ -291,13 +290,13 @@ private:
     ///@{
 
     /// Default constructor.
-    EmbeddedNodesInitializationProcess(){}
+    EmbeddedNodesInitializationProcess() = delete;
 
     /// Assignment operator.
-    EmbeddedNodesInitializationProcess& operator=(EmbeddedNodesInitializationProcess const& rOther){return *this;}
+    EmbeddedNodesInitializationProcess& operator=(EmbeddedNodesInitializationProcess const& rOther) = delete;
 
     /// Copy constructor.
-    EmbeddedNodesInitializationProcess(EmbeddedNodesInitializationProcess const& rOther){}
+    EmbeddedNodesInitializationProcess(EmbeddedNodesInitializationProcess const& rOther) = delete;
 
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_postprocess_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_postprocess_process.h
@@ -69,9 +69,9 @@ public:
     ///@{
 
     /// Constructor.
-    EmbeddedPostprocessProcess(ModelPart& rModelPart)
+    EmbeddedPostprocessProcess(ModelPart& rModelPart) : mrModelPart(rModelPart)
     {
-        mrModelPart = rModelPart;
+
     }
 
     /// Destructor.
@@ -166,7 +166,7 @@ protected:
     ///@name Protected member Variables
     ///@{
 
-    ModelPart                                  mrModelPart;
+    ModelPart&                                  mrModelPart;
 
     ///@}
     ///@name Protected Operators
@@ -230,13 +230,13 @@ private:
     ///@{
 
     /// Default constructor.
-    EmbeddedPostprocessProcess(){}
+    EmbeddedPostprocessProcess() = delete;
 
     /// Assignment operator.
-    EmbeddedPostprocessProcess& operator=(EmbeddedPostprocessProcess const& rOther){return *this;}
+    EmbeddedPostprocessProcess& operator=(EmbeddedPostprocessProcess const& rOther) = delete;
 
     /// Copy constructor.
-    EmbeddedPostprocessProcess(EmbeddedPostprocessProcess const& rOther){}
+    EmbeddedPostprocessProcess(EmbeddedPostprocessProcess const& rOther) = delete;
 
 
     ///@}

--- a/applications/PfemSolidMechanicsApplication/custom_processes/set_mechanical_initial_state_process.hpp
+++ b/applications/PfemSolidMechanicsApplication/custom_processes/set_mechanical_initial_state_process.hpp
@@ -104,7 +104,7 @@ namespace Kratos
 
          std::vector<double> mInitialStress;
 
-         ModelPart mrModelPart;
+         ModelPart& mrModelPart;
 
    }; //end class SetMechanicalInitialStateProcess
 


### PR DESCRIPTION
I have notice that some classes in Kratos are storing mrModelPart as a copy and not as a reference. Although it may work in these cases but results in a memory overhead by having several copies of the modelpart and its sub modelparts.

So I have added references to definition of mrModelPart and change the corresponding constructors. I found them by a grep of mrModelPart. So if there are classes with other member name I have not found them.