### PR TITLE
added calculation of integration weight to kinetic linear element

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/kinematic_linear.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/kinematic_linear.cpp
@@ -278,6 +278,52 @@ namespace Kratos
         return F;
     }
 
+//************************************************************************************
+//************************************************************************************
+
+    void KinematicLinear::CalculateOnIntegrationPoints(
+        const Variable<double>& rVariable,
+        std::vector<double>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo
+        )
+    {
+        const GeometryType::IntegrationPointsArrayType &integration_points = GetGeometry().IntegrationPoints();
+
+        if ( rOutput.size() != GetGeometry().IntegrationPoints(  ).size() )
+        {
+            rOutput.resize( GetGeometry().IntegrationPoints(  ).size() );
+        }
+
+        if (rVariable == INTEGRATION_WEIGHT)
+        {
+            const unsigned int nr_of_nodes = GetGeometry().size();
+            const unsigned int dim = GetGeometry().WorkingSpaceDimension();
+            const unsigned int strain_size = GetProperties().GetValue(CONSTITUTIVE_LAW)->GetStrainSize();
+
+            KinematicVariables this_kinematic_variables(strain_size, dim, nr_of_nodes);
+            for (unsigned int point_number = 0; point_number < integration_points.size(); point_number++)
+            {
+                this_kinematic_variables.detJ0 = CalculateDerivativesOnReference(this_kinematic_variables.J0,
+                                                                                 this_kinematic_variables.InvJ0,
+                                                                                 this_kinematic_variables.DN_DX,
+                                                                                 point_number,
+                                                                                 GetGeometry().GetDefaultIntegrationMethod());
+                double integration_weight = GetIntegrationWeight(integration_points,
+                                                                 point_number,
+                                                                 this_kinematic_variables.detJ0);
+                if (dim == 2 && this->GetProperties().Has(THICKNESS))
+                {
+                    integration_weight *= this->GetProperties()[THICKNESS];
+                }
+                rOutput[point_number] = integration_weight;
+            }
+        }
+        else
+        {
+            BaseSolidElement::CalculateOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        }
+    }
+
     //************************************************************************************
     //************************************************************************************
     

--- a/applications/StructuralMechanicsApplication/custom_elements/kinematic_linear.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/kinematic_linear.h
@@ -209,6 +209,12 @@ protected:
      */
     virtual Matrix ComputeEquivalentF(const Vector& StrainVector);
 
+    void CalculateOnIntegrationPoints(
+        const Variable<double>& rVariable,
+        std::vector<double>& rOutput,
+        const ProcessInfo& rCurrentProcessInfo
+    );
+
     ///@}
     ///@name Protected Operations
     ///@{


### PR DESCRIPTION
One more try.

This PR adds the computation of the integration point weight in the CalculateOnIntegrationPoints function of the kinematic linear element of the Structural Mechanics Application. It uses the INTEGRATION_WEIGHT variable, now in the core for this purpose.