### PR TITLE
Changing Element and Condition Check functions to use DomainSize instad of Area

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -853,7 +853,7 @@ public:
         KRATOS_ERROR_IF( this->Id() < 1 ) << "Condition found with Id " << this->Id() << std::endl;
 
         const double domain_size = this->GetGeometry().DomainSize();
-        KRATOS_ERROR_IF( domain_size < 0.0 ) << "Condition found with negative size " << domain_size << std::endl;
+        KRATOS_ERROR_IF( domain_size < 0.0 ) << "Condition " << this->Id() << " has negative size " << domain_size << std::endl;
 
         return 0;
 

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -849,15 +849,12 @@ public:
     virtual int Check(const ProcessInfo& rCurrentProcessInfo)
     {
         KRATOS_TRY
-        if (this->Id() < 1)
-        {
-            KRATOS_THROW_ERROR(std::logic_error, "Condition found with Id 0 or negative","")
-        }
-        if (this->GetGeometry().Area() < 0)
-        {
-            std::cout << "error on condition -> " << this->Id() << std::endl;
-            KRATOS_THROW_ERROR(std::logic_error, "Area cannot be less than 0","")
-        }
+
+        KRATOS_ERROR_IF( this->Id() < 1 ) << "Condition found with Id " << this->Id() << std::endl;
+
+        const double domain_size = this->GetGeometry().DomainSize();
+        KRATOS_ERROR_IF( domain_size < 0.0 ) << "Condition found with negative size " << domain_size << std::endl;
+
         return 0;
 
         KRATOS_CATCH("")

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -876,18 +876,15 @@ public:
     virtual int Check(const ProcessInfo& rCurrentProcessInfo)
     {
         KRATOS_TRY
-        if (this->Id() < 1)
-        {
-            KRATOS_THROW_ERROR(std::logic_error, "Element found with Id 0 or negative","")
-        }
-        if (this->GetGeometry().Area() <= 0)
-        {
-            std::cout << "error on element -> " << this->Id() << std::endl;
-            KRATOS_THROW_ERROR(std::logic_error, "Area cannot be less than or equal to 0","")
-        }
+
+        KRATOS_ERROR_IF( this->Id() < 1 ) << "Element found with Id " << this->Id() << std::endl;
+
+        const double domain_size = this->GetGeometry().DomainSize();
+        KRATOS_ERROR_IF( domain_size <= 0.0 ) << "Element found with non-positive size " << domain_size << std::endl;
+
         return 0;
 
-        KRATOS_CATCH("");
+        KRATOS_CATCH("")
     }
 
     //METHODS TO BE CLEANED: DEPRECATED start

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -880,7 +880,7 @@ public:
         KRATOS_ERROR_IF( this->Id() < 1 ) << "Element found with Id " << this->Id() << std::endl;
 
         const double domain_size = this->GetGeometry().DomainSize();
-        KRATOS_ERROR_IF( domain_size <= 0.0 ) << "Element found with non-positive size " << domain_size << std::endl;
+        KRATOS_ERROR_IF( domain_size <= 0.0 ) << "Element " << this->Id() << " has non-positive size " << domain_size << std::endl;
 
         return 0;
 


### PR DESCRIPTION
The current implementation erroneously checks for area always, regardless of domain size.