### PR TITLE
Feature add all overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.6)
+cmake_minimum_required (VERSION 2.8.10)
 project (KratosMultiphysics)
 
 # Set here the version number **** only update upon tagging a release!
@@ -33,6 +33,11 @@ if(${CMAKE_COMPILER_IS_GNUCXX})
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -funroll-loops -ffast-math -Wall -std=c++11")
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funroll-loops -ffast-math -Wall")
   set(CMAKE_SHARED_LINKER_FLAGS " -Wl,--no-undefined")
+
+  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
+  endif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.2)
+
   message("additional default options were set for gcc")
   message("CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}")
   message("CMAKE_C_FLAGS = ${CMAKE_C_FLAGS}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 2.8.10)
+cmake_minimum_required (VERSION 2.8.6)
 project (KratosMultiphysics)
 
 # Set here the version number **** only update upon tagging a release!
@@ -34,9 +34,9 @@ if(${CMAKE_COMPILER_IS_GNUCXX})
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -funroll-loops -ffast-math -Wall")
   set(CMAKE_SHARED_LINKER_FLAGS " -Wl,--no-undefined")
 
-  if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
-  endif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 4.2)
+#   if(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0)
+#     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wsuggest-override")
+#   endif(CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 5.0)
 
   message("additional default options were set for gcc")
   message("CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}")

--- a/applications/AdjointFluidApplication/adjoint_fluid_application.h
+++ b/applications/AdjointFluidApplication/adjoint_fluid_application.h
@@ -49,32 +49,32 @@ public:
 
   KratosAdjointFluidApplication();
 
-  virtual ~KratosAdjointFluidApplication() {}
+  ~KratosAdjointFluidApplication() override {}
 
   ///@}
   ///@name Operations
   ///@{
 
-  virtual void Register();
+  void Register() override;
 
   ///@}
   ///@name Input and output
   ///@{
 
-  virtual std::string Info() const
+  std::string Info() const override
   {
     return "KratosAdjointFluidApplication";
   }
 
   /// Print information about this object.
-  virtual void PrintInfo(std::ostream& rOStream) const
+  void PrintInfo(std::ostream& rOStream) const override
   {
     rOStream << Info();
     PrintData(rOStream);
   }
 
   /// Print object's data.
-  virtual void PrintData(std::ostream& rOStream) const
+  void PrintData(std::ostream& rOStream) const override
   {
     std::cout << "in KratosAdjointFluidApplication" << std::endl;
     KRATOS_WATCH( KratosComponents<VariableData>::GetComponents().size() )

--- a/applications/AdjointFluidApplication/custom_elements/vms_adjoint_element.h
+++ b/applications/AdjointFluidApplication/custom_elements/vms_adjoint_element.h
@@ -97,7 +97,7 @@ public:
     Element(NewId, pGeometry, pProperties)
     {}
 
-    virtual ~VMSAdjointElement()
+    ~VMSAdjointElement() override
     {}
 
     ///@}
@@ -109,9 +109,9 @@ public:
      *
      * @return pointer to the newly created element
      */
-    virtual Element::Pointer Create(IndexType NewId,
+    Element::Pointer Create(IndexType NewId,
             NodesArrayType const& ThisNodes,
-            PropertiesType::Pointer pProperties) const
+            PropertiesType::Pointer pProperties) const override
     {
         KRATOS_TRY
 
@@ -123,9 +123,9 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual Element::Pointer Create(IndexType NewId,
+    Element::Pointer Create(IndexType NewId,
             GeometryType::Pointer pGeom,
-            PropertiesType::Pointer pProperties) const
+            PropertiesType::Pointer pProperties) const override
     {
         KRATOS_TRY
 
@@ -140,7 +140,7 @@ public:
      *
      * @return 0 after successful completion.
      */
-    virtual int Check(const ProcessInfo &/*rCurrentProcessInfo*/)
+    int Check(const ProcessInfo &/*rCurrentProcessInfo*/) override
     {
         KRATOS_TRY
 
@@ -219,7 +219,7 @@ public:
     }
 
     /// Returns the adjoint values stored in this element's nodes.
-    virtual void GetFirstDerivativesVector(VectorType& rValues, int Step = 0)
+    void GetFirstDerivativesVector(VectorType& rValues, int Step = 0) override
     {
         if (rValues.size() != TFluidLocalSize)
             rValues.resize(TFluidLocalSize, false);
@@ -238,7 +238,7 @@ public:
     }
 
     /// Returns the adjoint acceleration values stored in this element's nodes.
-    virtual void GetSecondDerivativesVector(VectorType& rValues, int Step = 0)
+    void GetSecondDerivativesVector(VectorType& rValues, int Step = 0) override
     {
         if (rValues.size() != TFluidLocalSize)
             rValues.resize(TFluidLocalSize, false);
@@ -255,9 +255,9 @@ public:
         }
     }
 
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
             VectorType& rRightHandSideVector,
-            ProcessInfo& rCurrentProcessInfo)
+            ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -267,8 +267,8 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-            ProcessInfo& /*rCurrentProcessInfo*/)
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+            ProcessInfo& /*rCurrentProcessInfo*/) override
     {
         KRATOS_TRY
 
@@ -278,8 +278,8 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void CalculateMassMatrix(MatrixType& rMassMatrix,
-            ProcessInfo& /*rCurrentProcessInfo*/)
+    void CalculateMassMatrix(MatrixType& rMassMatrix,
+            ProcessInfo& /*rCurrentProcessInfo*/) override
     {
         KRATOS_TRY
 
@@ -289,8 +289,8 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void CalculateDampingMatrix(MatrixType& rDampingMatrix,
-            ProcessInfo& /*rCurrentProcessInfo*/)
+    void CalculateDampingMatrix(MatrixType& rDampingMatrix,
+            ProcessInfo& /*rCurrentProcessInfo*/) override
     {
         KRATOS_TRY
 
@@ -359,9 +359,9 @@ public:
      * adjoint step is the \f$(n+1)^{th}\f$ time step.
      *
      */
-    virtual void Calculate(const Variable<Matrix >& rVariable,
+    void Calculate(const Variable<Matrix >& rVariable,
             Matrix& rOutput,
-            const ProcessInfo& rCurrentProcessInfo)
+            const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -397,17 +397,17 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void GetDofList(DofsVectorType& rElementalDofList,
-            ProcessInfo& /*rCurrentProcessInfo*/);
+    void GetDofList(DofsVectorType& rElementalDofList,
+            ProcessInfo& /*rCurrentProcessInfo*/) override;
 
-    virtual void EquationIdVector(EquationIdVectorType& rResult,
-            ProcessInfo& /*rCurrentProcessInfo*/);
+    void EquationIdVector(EquationIdVectorType& rResult,
+            ProcessInfo& /*rCurrentProcessInfo*/) override;
 
     ///@}
     ///@name Input and output
     ///@{
 
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "VMSAdjointElement" << this->GetGeometry().WorkingSpaceDimension()
@@ -415,7 +415,7 @@ public:
         return buffer.str();
     }
 
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "VMSAdjointElement"
         << this->GetGeometry().WorkingSpaceDimension() << "D #"
@@ -424,7 +424,7 @@ public:
         << std::endl;
     }
 
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
         this->PrintInfo(rOStream);
         rOStream << "Geometry Data: " << std::endl;
@@ -1542,7 +1542,7 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_TRY;
 
@@ -1551,7 +1551,7 @@ private:
         KRATOS_CATCH("");
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_TRY;
 

--- a/applications/AdjointFluidApplication/custom_processes/input_primal_solution_process.h
+++ b/applications/AdjointFluidApplication/custom_processes/input_primal_solution_process.h
@@ -108,7 +108,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~InputPrimalSolutionProcess() {}
+    ~InputPrimalSolutionProcess() override {}
 
     ///@}
     ///@name Operators
@@ -124,9 +124,9 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() {}
+    void Execute() override {}
 
-    virtual void ExecuteInitialize()
+    void ExecuteInitialize() override
     {
         KRATOS_TRY
 
@@ -165,11 +165,11 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void ExecuteBeforeSolutionLoop()
+    void ExecuteBeforeSolutionLoop() override
     {
     }
 
-    virtual void ExecuteInitializeSolutionStep()
+    void ExecuteInitializeSolutionStep() override
     {
         KRATOS_TRY
 
@@ -242,19 +242,19 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void ExecuteFinalizeSolutionStep()
+    void ExecuteFinalizeSolutionStep() override
     {
     }
 
-    virtual void ExecuteBeforeOutputStep()
+    void ExecuteBeforeOutputStep() override
     {
     }
 
-    virtual void ExecuteAfterOutputStep()
+    void ExecuteAfterOutputStep() override
     {
     }
 
-    virtual void ExecuteFinalize()
+    void ExecuteFinalize() override
     {
     }
 
@@ -271,19 +271,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         return "InputPrimalSolutionProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << this->Info();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/applications/AdjointFluidApplication/custom_processes/output_primal_solution_process.h
+++ b/applications/AdjointFluidApplication/custom_processes/output_primal_solution_process.h
@@ -111,7 +111,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~OutputPrimalSolutionProcess() {}
+    ~OutputPrimalSolutionProcess() override {}
 
     ///@}
     ///@name Operators
@@ -127,9 +127,9 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() {}
+    void Execute() override {}
 
-    virtual void ExecuteInitialize()
+    void ExecuteInitialize() override
     {
         KRATOS_TRY
 
@@ -192,15 +192,15 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void ExecuteBeforeSolutionLoop()
+    void ExecuteBeforeSolutionLoop() override
     {
     }
 
-    virtual void ExecuteInitializeSolutionStep()
+    void ExecuteInitializeSolutionStep() override
     {
     }
 
-    virtual void ExecuteFinalizeSolutionStep()
+    void ExecuteFinalizeSolutionStep() override
     {
         KRATOS_TRY
 
@@ -306,15 +306,15 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void ExecuteBeforeOutputStep()
+    void ExecuteBeforeOutputStep() override
     {
     }
 
-    virtual void ExecuteAfterOutputStep()
+    void ExecuteAfterOutputStep() override
     {
     }
 
-    virtual void ExecuteFinalize()
+    void ExecuteFinalize() override
     {
     }
 
@@ -331,19 +331,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         return "OutputPrimalSolutionProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << this->Info();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/applications/AdjointFluidApplication/custom_schemes/adjoint_bossak_scheme.h
+++ b/applications/AdjointFluidApplication/custom_schemes/adjoint_bossak_scheme.h
@@ -158,7 +158,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~AdjointBossakScheme()
+    ~AdjointBossakScheme() override
     {
     }
 
@@ -170,7 +170,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Initialize(ModelPart& rModelPart) override
+    void Initialize(ModelPart& rModelPart) override
     {
         KRATOS_TRY
 
@@ -220,7 +220,7 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void InitializeSolutionStep(ModelPart& rModelPart,
+    void InitializeSolutionStep(ModelPart& rModelPart,
                                         SystemMatrixType& rA,
                                         SystemVectorType& rDx,
                                         SystemVectorType& rb) override
@@ -255,7 +255,7 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void FinalizeSolutionStep(ModelPart& rModelPart,
+    void FinalizeSolutionStep(ModelPart& rModelPart,
                                       SystemMatrixType& rA,
                                       SystemVectorType& rDx,
                                       SystemVectorType& rb) override
@@ -274,7 +274,7 @@ public:
     }
 
     /// Update adjoint and adjoint acceleration.
-    virtual void Update(ModelPart& rModelPart,
+    void Update(ModelPart& rModelPart,
                         DofsArrayType& rDofSet,
                         SystemMatrixType& rA,
                         SystemVectorType& rDx,
@@ -414,7 +414,7 @@ public:
     }
 
     /// Calculate residual based element contributions to transient adjoint.
-    virtual void CalculateSystemContributions(Element::Pointer pCurrentElement,
+    void CalculateSystemContributions(Element::Pointer pCurrentElement,
                                               LocalSystemMatrixType& rLHS_Contribution,
                                               LocalSystemVectorType& rRHS_Contribution,
                                               Element::EquationIdVectorType& rEquationId,
@@ -486,7 +486,7 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void Calculate_LHS_Contribution(Element::Pointer pCurrentElement,
+    void Calculate_LHS_Contribution(Element::Pointer pCurrentElement,
                                             LocalSystemMatrixType& LHS_Contribution,
                                             Element::EquationIdVectorType& EquationId,
                                             ProcessInfo& CurrentProcessInfo) override
@@ -503,7 +503,7 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void Condition_CalculateSystemContributions(
+    void Condition_CalculateSystemContributions(
         Condition::Pointer pCurrentCondition,
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
@@ -518,7 +518,7 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void Condition_Calculate_LHS_Contribution(Condition::Pointer pCurrentCondition,
+    void Condition_Calculate_LHS_Contribution(Condition::Pointer pCurrentCondition,
                                                       LocalSystemMatrixType& LHS_Contribution,
                                                       Condition::EquationIdVectorType& EquationId,
                                                       ProcessInfo& CurrentProcessInfo) override
@@ -531,7 +531,7 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void GetElementalDofList(Element::Pointer rCurrentElement,
+    void GetElementalDofList(Element::Pointer rCurrentElement,
                                      Element::DofsVectorType& ElementalDofList,
                                      ProcessInfo& CurrentProcessInfo) override
     {

--- a/applications/AdjointFluidApplication/custom_schemes/adjoint_steady_scheme.h
+++ b/applications/AdjointFluidApplication/custom_schemes/adjoint_steady_scheme.h
@@ -112,7 +112,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~AdjointSteadyScheme()
+    ~AdjointSteadyScheme() override
     {
     }
 
@@ -124,7 +124,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Initialize(ModelPart& rModelPart)
+    void Initialize(ModelPart& rModelPart) override
     {
         KRATOS_TRY
 
@@ -156,10 +156,10 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void InitializeSolutionStep(ModelPart& rModelPart,
+    void InitializeSolutionStep(ModelPart& rModelPart,
                                         SystemMatrixType& rA,
                                         SystemVectorType& rDx,
-                                        SystemVectorType& rb)
+                                        SystemVectorType& rb) override
     {
         KRATOS_TRY
 
@@ -183,10 +183,10 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void FinalizeSolutionStep(ModelPart& rModelPart,
+    void FinalizeSolutionStep(ModelPart& rModelPart,
                                       SystemMatrixType& rA,
                                       SystemVectorType& rDx,
-                                      SystemVectorType& rb)
+                                      SystemVectorType& rb) override
     {
         KRATOS_TRY
 
@@ -200,11 +200,11 @@ public:
     }
 
     /// Update adjoint.
-    virtual void Update(ModelPart& rModelPart,
+    void Update(ModelPart& rModelPart,
                         DofsArrayType& rDofSet,
                         SystemMatrixType& rA,
                         SystemVectorType& rDx,
-                        SystemVectorType& rb)
+                        SystemVectorType& rb) override
     {
         KRATOS_TRY
 
@@ -234,11 +234,11 @@ public:
     }
 
     /// Calculate residual based element contributions to steady adjoint.
-    virtual void CalculateSystemContributions(Element::Pointer pCurrentElement,
+    void CalculateSystemContributions(Element::Pointer pCurrentElement,
                                               LocalSystemMatrixType& rLHS_Contribution,
                                               LocalSystemVectorType& rRHS_Contribution,
                                               Element::EquationIdVectorType& rEquationId,
-                                              ProcessInfo& rCurrentProcessInfo)
+                                              ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -265,10 +265,10 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void Calculate_LHS_Contribution(Element::Pointer pCurrentElement,
+    void Calculate_LHS_Contribution(Element::Pointer pCurrentElement,
                                             LocalSystemMatrixType& LHS_Contribution,
                                             Element::EquationIdVectorType& EquationId,
-                                            ProcessInfo& CurrentProcessInfo)
+                                            ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -282,31 +282,31 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void Condition_CalculateSystemContributions(
+    void Condition_CalculateSystemContributions(
         Condition::Pointer pCurrentCondition,
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
         Condition::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo)
+        ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
         KRATOS_CATCH("")
     }
 
-    virtual void Condition_Calculate_LHS_Contribution(Condition::Pointer pCurrentCondition,
+    void Condition_Calculate_LHS_Contribution(Condition::Pointer pCurrentCondition,
                                                       LocalSystemMatrixType& LHS_Contribution,
                                                       Condition::EquationIdVectorType& EquationId,
-                                                      ProcessInfo& CurrentProcessInfo)
+                                                      ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
         KRATOS_CATCH("")
     }
 
-    virtual void GetElementalDofList(Element::Pointer rCurrentElement,
+    void GetElementalDofList(Element::Pointer rCurrentElement,
                                      Element::DofsVectorType& ElementalDofList,
-                                     ProcessInfo& CurrentProcessInfo)
+                                     ProcessInfo& CurrentProcessInfo) override
     {
         rCurrentElement->GetDofList(ElementalDofList, CurrentProcessInfo);
     }

--- a/applications/AdjointFluidApplication/custom_utilities/drag_objective_function.h
+++ b/applications/AdjointFluidApplication/custom_utilities/drag_objective_function.h
@@ -98,7 +98,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~DragObjectiveFunction()
+    ~DragObjectiveFunction() override
     {
     }
 
@@ -110,7 +110,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Initialize(ModelPart& rModelPart)
+    void Initialize(ModelPart& rModelPart) override
     {
         KRATOS_TRY
 
@@ -143,7 +143,7 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void InitializeSolutionStep(ModelPart& rModelPart)
+    void InitializeSolutionStep(ModelPart& rModelPart) override
     {
         KRATOS_TRY
 
@@ -166,10 +166,10 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void CalculateAdjointVelocityContribution(const Element& rElem,
+    void CalculateAdjointVelocityContribution(const Element& rElem,
                                                       const Matrix& rAdjointMatrix,
                                                       Vector& rRHSContribution,
-                                                      ProcessInfo& rProcessInfo)
+                                                      ProcessInfo& rProcessInfo) override
     {
         KRATOS_TRY
 
@@ -182,10 +182,10 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void CalculateAdjointAccelerationContribution(const Element& rElem,
+    void CalculateAdjointAccelerationContribution(const Element& rElem,
                                                           const Matrix& rAdjointMatrix,
                                                           Vector& rRHSContribution,
-                                                          ProcessInfo& rProcessInfo)
+                                                          ProcessInfo& rProcessInfo) override
     {
         KRATOS_TRY
 
@@ -198,10 +198,10 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void CalculateSensitivityContribution(const Element& rElem,
+    void CalculateSensitivityContribution(const Element& rElem,
                                                   const Matrix& rDerivativesMatrix,
                                                   Vector& rRHSContribution,
-                                                  ProcessInfo& rProcessInfo)
+                                                  ProcessInfo& rProcessInfo) override
     {
         KRATOS_TRY
 

--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
@@ -71,7 +71,7 @@ public:
 	KratosCompressiblePotentialFlowApplication();
 
 	/// Destructor.
-	virtual ~KratosCompressiblePotentialFlowApplication(){}
+	~KratosCompressiblePotentialFlowApplication() override{}
 
 
 	///@}
@@ -83,7 +83,7 @@ public:
 	///@name Operations
 	///@{
 
-	virtual void Register();
+	void Register() override;
 
 
 
@@ -102,18 +102,18 @@ public:
 	///@{
 
 	/// Turn back information as a string.
-	virtual std::string Info() const {
+	std::string Info() const override {
 		return "KratosCompressiblePotentialFlowApplication";
 	}
 
 	/// Print information about this object.
-	virtual void PrintInfo(std::ostream& rOStream) const {
+	void PrintInfo(std::ostream& rOStream) const override {
 		rOStream << Info();
 		PrintData(rOStream);
 	}
 
 	///// Print object's data.
-	virtual void PrintData(std::ostream& rOStream) const {
+	void PrintData(std::ostream& rOStream) const override {
   		KRATOS_WATCH("in my application");
   		KRATOS_WATCH(KratosComponents<VariableData>::GetComponents().size() );
 

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
@@ -148,7 +148,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~PotentialWallCondition() {}
+    ~PotentialWallCondition() override {}
 
 
     ///@}
@@ -173,13 +173,13 @@ public:
       @param ThisNodes An array containing the nodes of the new condition
       @param pProperties Pointer to the element's properties
       */
-    virtual Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
+    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
     {
         return Condition::Pointer(new PotentialWallCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
     }
 
 
-    virtual Condition::Pointer Create(IndexType NewId, Condition::GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override
+    Condition::Pointer Create(IndexType NewId, Condition::GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override
     {
         return Condition::Pointer(new PotentialWallCondition(NewId, pGeom, pProperties));
     }
@@ -192,7 +192,7 @@ public:
      * @return a Pointer to the new element
      */
 
-    virtual Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override
+    Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override
     {
         Condition::Pointer pNewCondition = Create(NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
 
@@ -203,7 +203,7 @@ public:
     }
 
 
-    virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
                                        ProcessInfo& rCurrentProcessInfo) override
     {
         VectorType RHS;
@@ -218,7 +218,7 @@ public:
       @param rRightHandSideVector Right-hand side vector
       @param rCurrentProcessInfo ProcessInfo instance (unused)
       */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
                                       ProcessInfo& rCurrentProcessInfo) override
     {
@@ -244,7 +244,7 @@ public:
 
 
     /// Check that all data required by this condition is available and reasonable
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY;
 
@@ -288,7 +288,7 @@ public:
          * @param rResult A vector containing the global Id of each row
          * @param rCurrentProcessInfo the current process info object (unused)
          */
-        virtual void EquationIdVector(EquationIdVectorType& rResult,
+        void EquationIdVector(EquationIdVectorType& rResult,
                                       ProcessInfo& rCurrentProcessInfo) override
         {
             if (rResult.size() != TNumNodes)
@@ -304,7 +304,7 @@ public:
          * @param ElementalDofList the list of DOFs
          * @param rCurrentProcessInfo the current process info instance
          */
-        virtual void GetDofList(DofsVectorType& ConditionDofList,
+        void GetDofList(DofsVectorType& ConditionDofList,
                                 ProcessInfo& CurrentProcessInfo) override
         {
             if (ConditionDofList.size() != TNumNodes)
@@ -334,7 +334,7 @@ public:
         ///@{
 
         /// Turn back information as a string.
-        virtual std::string Info() const override
+        std::string Info() const override
         {
             std::stringstream buffer;
             this->PrintInfo(buffer);
@@ -342,13 +342,13 @@ public:
         }
 
         /// Print information about this object.
-        virtual void PrintInfo(std::ostream& rOStream) const override
+        void PrintInfo(std::ostream& rOStream) const override
         {
             rOStream << "PotentialWallCondition" << TDim << "D #" << this->Id();
         }
 
         /// Print object's data.
-        virtual void PrintData(std::ostream& rOStream) const override
+        void PrintData(std::ostream& rOStream) const override
         {
             this->pGetGeometry()->PrintData(rOStream);
         }
@@ -446,12 +446,12 @@ private:
 
         friend class Serializer;
 
-        virtual void save(Serializer& rSerializer) const override
+        void save(Serializer& rSerializer) const override
         {
             KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition );
         }
 
-        virtual void load(Serializer& rSerializer) override
+        void load(Serializer& rSerializer) override
         {
             KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
         }

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
@@ -111,7 +111,7 @@ public:
     /**
      * Destructor
      */
-    virtual ~CompressiblePotentialFlowElement() {};
+    ~CompressiblePotentialFlowElement() override {};
 
     ///@}
     ///@name Operators
@@ -177,7 +177,7 @@ public:
      * @param rResult: the elemental equation ID vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo) override
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo) override
     {
         if(this->IsNot(MARKER)) //normal element
         {
@@ -224,7 +224,7 @@ public:
      * @param ElementalDofList: the list of DOFs
      * @param rCurrentProcessInfo: the current process info instance
      */
-    virtual void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& CurrentProcessInfo) override
+    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& CurrentProcessInfo) override
     {
         if(this->IsNot(MARKER)) //normal element
         {
@@ -278,7 +278,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side
      * @param rCurrentProcessInfo: the current process info instance
      */
-    virtual void CalculateLocalSystem(
+    void CalculateLocalSystem(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
         ProcessInfo& rCurrentProcessInfo) override
@@ -450,7 +450,7 @@ public:
      * @param rRightHandSideVector: the elemental right hand side vector
      * @param rCurrentProcessInfo: the current process info instance
      */
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override
     {
         //TODO: improve speed
         Matrix tmp;
@@ -467,7 +467,7 @@ public:
      * @param rCurrentProcessInfo
      * this method is: MANDATORY
      */
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
 
         KRATOS_TRY
@@ -495,7 +495,7 @@ public:
         KRATOS_CATCH("");
     }
 
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
             const ProcessInfo& rCurrentProcessInfo) override
     {
@@ -536,7 +536,7 @@ public:
         }
     }
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable,
             std::vector< array_1d<double,3> >& rValues,
             const ProcessInfo& rCurrentProcessInfo) override
     {
@@ -589,7 +589,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "CompressiblePotentialFlowElement #" << Id();
@@ -598,14 +598,14 @@ public:
 
 /// Print information about this object.
 
-    void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "CompressiblePotentialFlowElement #" << Id();
     }
 
 /// Print object's data.
 
-    void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
         pGetGeometry()->PrintData(rOStream);
     }
@@ -726,12 +726,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element );
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element );
     }

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/kutta_condition_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/kutta_condition_process.h
@@ -69,7 +69,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~KuttaConditionProcess() {}
+    ~KuttaConditionProcess() override {}
 
 
     ///@}
@@ -89,7 +89,7 @@ public:
 
 
     /// Check elements to make sure that their jacobian is positive and conditions to ensure that their face normals point outwards
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
 
@@ -223,19 +223,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "KuttaConditionProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "KuttaConditionProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         this->PrintInfo(rOStream);
     }

--- a/applications/ExternalSolversApplication/external_includes/feast_solver.h
+++ b/applications/ExternalSolversApplication/external_includes/feast_solver.h
@@ -69,7 +69,7 @@ public:
     
     typedef amgcl::solver::skyline_lu<DataType> SolverType;
 
-    ~SkylineLUSolver()
+    ~SkylineLUSolver() override
     {
         Clear();
     }
@@ -221,7 +221,7 @@ public:
     FEASTSolver(const FEASTSolver& Other) = delete;
 
     /// Destructor.
-    virtual ~FEASTSolver() {}
+    ~FEASTSolver() override {}
 
     ///@}
     ///@name Operators
@@ -238,11 +238,11 @@ public:
     /**
      * K is a symmetric matrix. M is a symmetric positive-definite matrix.
      */
-    virtual void Solve(
+    void Solve(
             SparseMatrixType& K,
             SparseMatrixType& M,
             DenseVectorType& Eigenvalues,
-            DenseMatrixType& Eigenvectors)
+            DenseMatrixType& Eigenvectors) override
     {
         const auto SystemSize = K.size1();
 
@@ -286,13 +286,13 @@ public:
     ///@{
 
     /// Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "FEAST solver.";
     }
 
     /// Print object's data.
-    void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/applications/ExternalSolversApplication/external_includes/gmres_solver.h
+++ b/applications/ExternalSolversApplication/external_includes/gmres_solver.h
@@ -131,7 +131,7 @@ public:
     GMRESSolver(const GMRESSolver& Other) : BaseType(Other) {}
 
     /// Destructor.
-    virtual ~GMRESSolver() {}
+    ~GMRESSolver() override {}
 
 
     ///@}
@@ -157,7 +157,7 @@ public:
     guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB)
+    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         if(this->IsNotConsistent(rA, rX, rB))
             return false;
@@ -257,7 +257,7 @@ public:
     guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB)
+    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
     {
         //DOES NOTHING AT THE MOMENT
         bool is_solved = true;
@@ -282,7 +282,7 @@ public:
     ///@{
 
     /// Return information about this object.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "GMRES iterative solver [at the moment unfortunately without] with " << BaseType::GetPreconditioner()->Info();
@@ -290,14 +290,14 @@ public:
     }
 
     /// Print information about this object.
-    void  PrintInfo(std::ostream& OStream) const
+    void  PrintInfo(std::ostream& OStream) const override
     {
         OStream << "GMRES iterative solver [at the moment unfortunately without] with ";
         BaseType::GetPreconditioner()->PrintInfo(OStream);
     }
 
     /// Print object's data.
-    void  PrintData(std::ostream& OStream) const
+    void  PrintData(std::ostream& OStream) const override
     {
         OStream << "GMRES "<<mNumberOfRestarts<<" times restarted"<<std::endl;
         BaseType::PrintData(OStream);

--- a/applications/ExternalSolversApplication/external_includes/pastix_complex_solver.h
+++ b/applications/ExternalSolversApplication/external_includes/pastix_complex_solver.h
@@ -82,7 +82,7 @@ public:
 
     PastixComplexSolver(const PastixComplexSolver& Other) = delete;
 
-    virtual ~PastixComplexSolver()
+    ~PastixComplexSolver() override
 	{
 	}
 

--- a/applications/ExternalSolversApplication/external_includes/pastix_solver.h
+++ b/applications/ExternalSolversApplication/external_includes/pastix_solver.h
@@ -147,7 +147,7 @@ public:
 	/**
 	 * Destructor
 	 */
-	virtual ~PastixSolver() {};
+	~PastixSolver() override {};
 
 	/**
 	 * Normal solve method.
@@ -157,7 +157,7 @@ public:
 	 * @param rX. Solution vector.
 	 * @param rB. Right hand side vector.
 	 */
-	bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB)
+	bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
 	{
 	        //KRATOS_WATCH(__LINE__);
 				
@@ -175,7 +175,7 @@ public:
 	 * @param rX. Solution vector.
 	 * @param rB. Right hand side vector.
 	 */
-	bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB)
+	bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
 	{
 
 		bool is_solved = true;
@@ -187,7 +187,7 @@ public:
 	/**
 	 * Print information about this object.
 	 */
-	void  PrintInfo(std::ostream& rOStream) const
+	void  PrintInfo(std::ostream& rOStream) const override
 	{
 		rOStream << "Pastix solver finished.";
 	}
@@ -195,7 +195,7 @@ public:
 	/**
 	 * Print object's data.
 	 */
-	void  PrintData(std::ostream& rOStream) const
+	void  PrintData(std::ostream& rOStream) const override
 	{
 	}
 	
@@ -205,7 +205,7 @@ public:
      * which require knowledge on the spatial position of the nodes associated to a given dof.
      * This function tells if the solver requires such data
      */
-    virtual bool AdditionalPhysicalDataIsNeeded()
+    bool AdditionalPhysicalDataIsNeeded() override
     {
         return true;
     }
@@ -222,7 +222,7 @@ public:
         VectorType& rB,
         typename ModelPart::DofsArrayType& rdof_set,
         ModelPart& r_model_part
-    )
+    ) override
     {
         int old_ndof = -1;
 		unsigned int old_node_id = rdof_set.begin()->Id();

--- a/applications/ExternalSolversApplication/external_includes/superlu_iterative_solver.h
+++ b/applications/ExternalSolversApplication/external_includes/superlu_iterative_solver.h
@@ -227,7 +227,7 @@ public:
     /**
      * Destructor
      */
-    virtual ~SuperLUIterativeSolver() {};
+    ~SuperLUIterativeSolver() override {};
 
     /**
      * Normal solve method.
@@ -237,7 +237,7 @@ public:
      * @param rX. Solution vector.
      * @param rB. Right hand side vector.
      */
-    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB)
+    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         //void dmatvec_mult(double alpha, double x[], double beta, double y[]);
         //void dpsolve(int n, double x[], double y[]);
@@ -639,7 +639,7 @@ public:
      * @param rX. Solution vector.
      * @param rB. Right hand side vector.
      */
-    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB)
+    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
     {
         /**
          * TODO:
@@ -684,7 +684,7 @@ public:
     /**
      * Print information about this object.
      */
-    void  PrintInfo(std::ostream& rOStream) const
+    void  PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "SuperLU solver finished.";
     }
@@ -692,7 +692,7 @@ public:
     /**
      * Print object's data.
      */
-    void  PrintData(std::ostream& rOStream) const
+    void  PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/applications/ExternalSolversApplication/external_includes/superlu_solver.h
+++ b/applications/ExternalSolversApplication/external_includes/superlu_solver.h
@@ -91,7 +91,7 @@ public:
     /**
      * Destructor
      */
-    virtual ~SuperLUSolver() {}
+    ~SuperLUSolver() override {}
 
     /**
      * Normal solve method.
@@ -101,7 +101,7 @@ public:
      * @param rX. Solution vector.
      * @param rB. Right hand side vector.
      */
-    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB)
+    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         //std::cout << "matrix size in solver:  " << rA.size1() << std::endl;
         //std::cout << "RHS size in solver SLU: " << rB.size() << std::endl;
@@ -233,7 +233,7 @@ public:
      * @param rX. Solution vector.
      * @param rB. Right hand side vector.
      */
-    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB)
+    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
     {
         /**
          * TODO:
@@ -278,7 +278,7 @@ public:
     /**
      * Print information about this object.
      */
-    void  PrintInfo(std::ostream& rOStream) const
+    void  PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "SuperLU solver finished.";
     }
@@ -286,7 +286,7 @@ public:
     /**
      * Print object's data.
      */
-    void  PrintData(std::ostream& rOStream) const
+    void  PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/applications/ExternalSolversApplication/externalsolvers_application.h
+++ b/applications/ExternalSolversApplication/externalsolvers_application.h
@@ -71,7 +71,7 @@ public:
     KratosExternalSolversApplication() {}
 
     /// Destructor.
-    virtual ~KratosExternalSolversApplication() {}
+    ~KratosExternalSolversApplication() override {}
 
 
     ///@}
@@ -83,7 +83,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Register();
+    void Register() override;
 
 
 
@@ -102,20 +102,20 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         return "KratosExternalSolversApplication";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
         PrintData(rOStream);
     }
 
     ///// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
         KRATOS_WATCH("in KratosALEApplication application");
         KRATOS_WATCH(KratosComponents<VariableData>::GetComponents().size() );

--- a/applications/FluidDynamicsApplication/custom_conditions/fs_generalized_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/fs_generalized_wall_condition.h
@@ -188,7 +188,7 @@ public:
 	}
 
 	/// Destructor.
-	virtual ~FSGeneralizedWallCondition()
+	~FSGeneralizedWallCondition() override
 	{}
 
 	///@}
@@ -214,16 +214,16 @@ public:
 	 @param ThisNodes An array containing the nodes of the new condition
 	 @param pProperties Pointer to the condition's properties
 	 */
-	virtual Condition::Pointer Create(IndexType NewId,
+	Condition::Pointer Create(IndexType NewId,
 			NodesArrayType const& ThisNodes,
-			PropertiesType::Pointer pProperties) const
+			PropertiesType::Pointer pProperties) const override
 	{
 		return Condition::Pointer(new FSGeneralizedWallCondition(NewId,
 						GetGeometry().Create(ThisNodes), pProperties));
 	}
 
 	/// Find the condition's parent element.
-	void Initialize()
+	void Initialize() override
 	{
 		KRATOS_TRY;
 
@@ -311,8 +311,8 @@ public:
 		KRATOS_CATCH("");
 	}
 
-	virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-			ProcessInfo& rCurrentProcessInfo)
+	void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+			ProcessInfo& rCurrentProcessInfo) override
 	{
 		VectorType RHS;
 		this->CalculateLocalSystem(rLeftHandSideMatrix, RHS, rCurrentProcessInfo);
@@ -324,9 +324,9 @@ public:
 	 @param rRightHandSideVector Right-hand side vector
 	 @param rCurrentProcessInfo ProcessInfo instance
 	 */
-	virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+	void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
 			VectorType& rRightHandSideVector,
-			ProcessInfo& rCurrentProcessInfo)
+			ProcessInfo& rCurrentProcessInfo) override
 	{
 		KRATOS_TRY;
 
@@ -392,7 +392,7 @@ public:
 	}
 
 	/// Check that all data required by this condition is available and reasonable.
-	virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+	int Check(const ProcessInfo& rCurrentProcessInfo) override
 	{
 		KRATOS_TRY;
 
@@ -452,23 +452,23 @@ public:
 	 * @param rResult A vector containing the global Id of each row
 	 * @param rCurrentProcessInfo the current process info object
 	 */
-	virtual void EquationIdVector(EquationIdVectorType& rResult,
-			ProcessInfo& rCurrentProcessInfo);
+	void EquationIdVector(EquationIdVectorType& rResult,
+			ProcessInfo& rCurrentProcessInfo) override;
 
 	/// Returns a list of the condition's Dofs.
 	/**
 	 * @param ConditionDofList the list of DOFs
 	 * @param rCurrentProcessInfo the current process info instance
 	 */
-	virtual void GetDofList(DofsVectorType& rConditionDofList,
-			ProcessInfo& rCurrentProcessInfo);
+	void GetDofList(DofsVectorType& rConditionDofList,
+			ProcessInfo& rCurrentProcessInfo) override;
 
 	/// Returns VELOCITY_X, VELOCITY_Y, (VELOCITY_Z) for each node.
 	/**
 	 * @param Values Vector of nodal unknowns
 	 * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
 	 */
-	virtual void GetValuesVector(Vector& Values, int Step = 0)
+	void GetValuesVector(Vector& Values, int Step = 0) override
 	{
 		const SizeType LocalSize = TDim * TNumNodes;
 		unsigned int LocalIndex = 0;
@@ -501,7 +501,7 @@ public:
 	///@{
 
 	/// Turn back information as a string.
-	virtual std::string Info() const
+	std::string Info() const override
 	{
 		std::stringstream buffer;
 		buffer << "FSGeneralizedWallCondition" << TDim << "D";
@@ -509,11 +509,11 @@ public:
 	}
 
 	/// Print information about this object.
-	virtual void PrintInfo(std::ostream& rOStream) const
+	void PrintInfo(std::ostream& rOStream) const override
 	{	rOStream << "FSGeneralizedWallCondition";}
 
 	/// Print object's data.
-	virtual void PrintData(std::ostream& rOStream) const
+	void PrintData(std::ostream& rOStream) const override
 	{}
 
 	///@}
@@ -912,12 +912,12 @@ private:
 
 	friend class Serializer;
 
-	virtual void save(Serializer& rSerializer) const
+	void save(Serializer& rSerializer) const override
 	{
 		KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition );
 	}
 
-	virtual void load(Serializer& rSerializer)
+	void load(Serializer& rSerializer) override
 	{
 		KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
 	}

--- a/applications/FluidDynamicsApplication/custom_conditions/fs_periodic_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/fs_periodic_condition.h
@@ -178,7 +178,7 @@ public:
 
 
     /// Destructor.
-    virtual ~FSPeriodicCondition();
+    ~FSPeriodicCondition() override;
 
 
     ///@}
@@ -195,20 +195,20 @@ public:
     /// Create a new FSPeriodicCondition instance
     Condition::Pointer Create(IndexType NewId,
                               NodesArrayType const& ThisNodes,
-                              PropertiesType::Pointer pProperties) const;
+                              PropertiesType::Pointer pProperties) const override;
 
     /// Check input to ensure that it makes sense.
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo);
+    int Check(const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo);
+                                      ProcessInfo& rCurrentProcessInfo) override;
 
-   virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                       ProcessInfo& rCurrentProcessInfo);
+   void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                                       ProcessInfo& rCurrentProcessInfo) override;
 
-   virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo);
+   void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                        ProcessInfo& rCurrentProcessInfo) override;
 
     /// Provides the global indices for each one of this element's local rows
     /**
@@ -217,19 +217,19 @@ public:
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo ProcessInfo instance (unused)
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult,
-                                  ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult,
+                                  ProcessInfo& rCurrentProcessInfo) override;
 
     /// Returns a list of the element's Dofs
     /**
      * @param ElementalDofList the list of DOFs
      * @param rCurrentProcessInfo ProcessInfo instance (unused)
      */
-    virtual void GetDofList(DofsVectorType& ElementalDofList,
-                            ProcessInfo& CurrentProcessInfo);
+    void GetDofList(DofsVectorType& ElementalDofList,
+                            ProcessInfo& CurrentProcessInfo) override;
 
     /// Returns the values of the unknowns for each node
-    virtual void GetValuesVector(Vector& Values, int Step = 0);
+    void GetValuesVector(Vector& Values, int Step = 0) override;
 
     ///@}
     ///@name Conditional Data
@@ -250,7 +250,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "FSPeriodicCondition #" << Id();
@@ -258,13 +258,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "FSPeriodicCondition #" << Id();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
         Condition::PrintData(rOStream);
     }
@@ -337,9 +337,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer);
+    void load(Serializer& rSerializer) override;
 
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_conditions/fs_werner_wengle_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/fs_werner_wengle_wall_condition.h
@@ -190,7 +190,7 @@ public:
 	}
 
 	/// Destructor.
-	virtual ~FSWernerWengleWallCondition()
+	~FSWernerWengleWallCondition() override
 	{}
 
 	///@}
@@ -216,16 +216,16 @@ public:
 	 @param ThisNodes An array containing the nodes of the new condition
 	 @param pProperties Pointer to the condition's properties
 	 */
-	virtual Condition::Pointer Create(IndexType NewId,
+	Condition::Pointer Create(IndexType NewId,
 			NodesArrayType const& ThisNodes,
-			PropertiesType::Pointer pProperties) const
+			PropertiesType::Pointer pProperties) const override
 	{
 		return Condition::Pointer(new FSWernerWengleWallCondition(NewId,
 						GetGeometry().Create(ThisNodes), pProperties));
 	}
 
 	/// Find the condition's parent element.
-	void Initialize()
+	void Initialize() override
 	{
 		KRATOS_TRY;
 
@@ -313,8 +313,8 @@ public:
 		KRATOS_CATCH("");
 	}
 
-	virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-			ProcessInfo& rCurrentProcessInfo)
+	void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+			ProcessInfo& rCurrentProcessInfo) override
 	{
 		VectorType RHS;
 		this->CalculateLocalSystem(rLeftHandSideMatrix, RHS, rCurrentProcessInfo);
@@ -326,9 +326,9 @@ public:
 	 @param rRightHandSideVector Right-hand side vector
 	 @param rCurrentProcessInfo ProcessInfo instance
 	 */
-	virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+	void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
 			VectorType& rRightHandSideVector,
-			ProcessInfo& rCurrentProcessInfo)
+			ProcessInfo& rCurrentProcessInfo) override
 	{
 		KRATOS_TRY;
 
@@ -394,7 +394,7 @@ public:
 	}
 
 	/// Check that all data required by this condition is available and reasonable.
-	virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+	int Check(const ProcessInfo& rCurrentProcessInfo) override
 	{
 		KRATOS_TRY;
 
@@ -454,23 +454,23 @@ public:
 	 * @param rResult A vector containing the global Id of each row
 	 * @param rCurrentProcessInfo the current process info object
 	 */
-	virtual void EquationIdVector(EquationIdVectorType& rResult,
-			ProcessInfo& rCurrentProcessInfo);
+	void EquationIdVector(EquationIdVectorType& rResult,
+			ProcessInfo& rCurrentProcessInfo) override;
 
 	/// Returns a list of the condition's Dofs.
 	/**
 	 * @param ConditionDofList the list of DOFs
 	 * @param rCurrentProcessInfo the current process info instance
 	 */
-	virtual void GetDofList(DofsVectorType& rConditionDofList,
-			ProcessInfo& rCurrentProcessInfo);
+	void GetDofList(DofsVectorType& rConditionDofList,
+			ProcessInfo& rCurrentProcessInfo) override;
 
 	/// Returns VELOCITY_X, VELOCITY_Y, (VELOCITY_Z) for each node.
 	/**
 	 * @param Values Vector of nodal unknowns
 	 * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
 	 */
-	virtual void GetValuesVector(Vector& Values, int Step = 0)
+	void GetValuesVector(Vector& Values, int Step = 0) override
 	{
 		const SizeType LocalSize = TDim * TNumNodes;
 		unsigned int LocalIndex = 0;
@@ -494,28 +494,28 @@ public:
 	///@name Access
 	///@{
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
             std::vector<array_1d<double, 3 > >& rValues,
-            const ProcessInfo& rCurrentProcessInfo);
+            const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
-            const ProcessInfo& rCurrentProcessInfo);
+            const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
             std::vector<array_1d<double, 6 > >& rValues,
-            const ProcessInfo& rCurrentProcessInfo);
+            const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
             std::vector<Vector>& rValues,
-            const ProcessInfo& rCurrentProcessInfo);
+            const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
             std::vector<Matrix>& rValues,
-            const ProcessInfo& rCurrentProcessInfo);
+            const ProcessInfo& rCurrentProcessInfo) override;
 
 	///@}
 	///@name Inquiry
@@ -526,7 +526,7 @@ public:
 	///@{
 
 	/// Turn back information as a string.
-	virtual std::string Info() const
+	std::string Info() const override
 	{
 		std::stringstream buffer;
 		buffer << "FSWernerWengleWallCondition" << TDim << "D";
@@ -534,11 +534,11 @@ public:
 	}
 
 	/// Print information about this object.
-	virtual void PrintInfo(std::ostream& rOStream) const
+	void PrintInfo(std::ostream& rOStream) const override
 	{	rOStream << "FSWernerWengleWallCondition";}
 
 	/// Print object's data.
-	virtual void PrintData(std::ostream& rOStream) const
+	void PrintData(std::ostream& rOStream) const override
 	{}
 
 	///@}
@@ -701,7 +701,7 @@ private:
 
 	friend class Serializer;
 
-	virtual void save(Serializer& rSerializer) const
+	void save(Serializer& rSerializer) const override
 	{
 		KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition );
         rSerializer.save("mInitializeWasPerformed",mInitializeWasPerformed);
@@ -709,7 +709,7 @@ private:
         rSerializer.save("mpElement",mpElement);
 	}
 
-	virtual void load(Serializer& rSerializer)
+	void load(Serializer& rSerializer) override
 	{
 		KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
         rSerializer.load("mInitializeWasPerformed",mInitializeWasPerformed);

--- a/applications/FluidDynamicsApplication/custom_conditions/monolithic_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/monolithic_wall_condition.h
@@ -155,7 +155,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~MonolithicWallCondition() {}
+    ~MonolithicWallCondition() override {}
 
 
     ///@}
@@ -180,13 +180,13 @@ public:
       @param ThisNodes An array containing the nodes of the new condition
       @param pProperties Pointer to the element's properties
       */
-    virtual Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const
+    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
     {
         return Condition::Pointer(new MonolithicWallCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
     }
-    virtual Condition::Pointer Create(IndexType NewId,
+    Condition::Pointer Create(IndexType NewId,
                            GeometryType::Pointer pGeom,
-                           PropertiesType::Pointer pProperties) const
+                           PropertiesType::Pointer pProperties) const override
     {
         return boost::make_shared< MonolithicWallCondition >(NewId, pGeom, pProperties);
     }
@@ -199,7 +199,7 @@ public:
      * @return a Pointer to the new element
      */
     
-    virtual Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const
+    Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override
     {
         Condition::Pointer pNewCondition = Create(NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
         
@@ -213,9 +213,9 @@ public:
     /** The actual local contributions are computed in the Damping functions
       @see CalculateLocalVelocityContribution
       */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo)
+                                      ProcessInfo& rCurrentProcessInfo) override
     {
         const SizeType BlockSize = TDim + 1;
         const SizeType LocalSize = BlockSize * TNumNodes;
@@ -234,8 +234,8 @@ public:
     /** The actual local contributions are computed in the Damping functions
       @see DampingMatrix
       */
-    virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                       ProcessInfo& rCurrentProcessInfo)
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                                       ProcessInfo& rCurrentProcessInfo) override
     {
         const SizeType BlockSize = TDim + 1;
         const SizeType LocalSize = BlockSize * TNumNodes;
@@ -250,8 +250,8 @@ public:
     /** The actual local contributions are computed in the Damping functions
       @see CalculateLocalVelocityContribution
       */
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo)
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                        ProcessInfo& rCurrentProcessInfo) override
     {
         const SizeType BlockSize = TDim + 1;
         const SizeType LocalSize = BlockSize * TNumNodes;
@@ -264,8 +264,8 @@ public:
 
 
 
-    virtual void CalculateDampingMatrix(MatrixType& rDampingMatrix,
-                            ProcessInfo& rCurrentProcessInfo)
+    void CalculateDampingMatrix(MatrixType& rDampingMatrix,
+                            ProcessInfo& rCurrentProcessInfo) override
     {
         VectorType RHS;
         this->CalculateLocalVelocityContribution(rDampingMatrix,RHS,rCurrentProcessInfo);
@@ -279,13 +279,13 @@ public:
       @param rRightHandSideVector Right-hand side vector
       @param rCurrentProcessInfo ProcessInfo instance (unused)
       */
-    virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
+    void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
             VectorType& rRightHandSideVector,
-            ProcessInfo& rCurrentProcessInfo);
+            ProcessInfo& rCurrentProcessInfo) override;
 
 
     /// Check that all data required by this condition is available and reasonable
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY;
 
@@ -353,8 +353,8 @@ public:
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo the current process info object (unused)
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult,
-                                  ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult,
+                                  ProcessInfo& rCurrentProcessInfo) override;
 
 
     /// Returns a list of the element's Dofs
@@ -362,8 +362,8 @@ public:
      * @param ElementalDofList the list of DOFs
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void GetDofList(DofsVectorType& ConditionDofList,
-                            ProcessInfo& CurrentProcessInfo);
+    void GetDofList(DofsVectorType& ConditionDofList,
+                            ProcessInfo& CurrentProcessInfo) override;
 
 
     /// Returns VELOCITY_X, VELOCITY_Y, (VELOCITY_Z,) PRESSURE for each node
@@ -371,8 +371,8 @@ public:
      * @param Values Vector of nodal unknowns
      * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
      */
-    virtual void GetFirstDerivativesVector(Vector& Values,
-                                           int Step = 0)
+    void GetFirstDerivativesVector(Vector& Values,
+                                           int Step = 0) override
     {
         const SizeType LocalSize = (TDim + 1) * TNumNodes;
         unsigned int LocalIndex = 0;
@@ -395,8 +395,8 @@ public:
      * @param Values Vector of nodal second derivatives
      * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
      */
-    virtual void GetSecondDerivativesVector(Vector& Values,
-                                            int Step = 0)
+    void GetSecondDerivativesVector(Vector& Values,
+                                            int Step = 0) override
     {
         const SizeType LocalSize = (TDim + 1) * TNumNodes;
         unsigned int LocalIndex = 0;
@@ -414,29 +414,29 @@ public:
     }
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
                                              std::vector<array_1d<double, 3 > >& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+                                             const ProcessInfo& rCurrentProcessInfo) override;
 
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
                                              std::vector<double>& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+                                             const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
                                              std::vector<array_1d<double, 6 > >& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+                                             const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
                                              std::vector<Vector>& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+                                             const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
                                              std::vector<Matrix>& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+                                             const ProcessInfo& rCurrentProcessInfo) override;
 
 
     ///@}
@@ -454,7 +454,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "MonolithicWallCondition" << TDim << "D";
@@ -462,13 +462,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "MonolithicWallCondition";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
     ///@}
@@ -627,12 +627,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition );
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
     }

--- a/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.h
@@ -153,7 +153,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~NavierStokesWallCondition() {}
+    ~NavierStokesWallCondition() override {}
 
 
     ///@}
@@ -177,7 +177,7 @@ public:
       @param ThisNodes An array containing the nodes of the new condition
       @param pProperties Pointer to the element's properties
       */
-    virtual Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const
+    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
     {
         return Condition::Pointer(new NavierStokesWallCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
     }
@@ -188,7 +188,7 @@ public:
       @param pGeom A pointer to the condition's geometry
       @param pProperties Pointer to the element's properties
       */
-    virtual Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override
     {
         return boost::make_shared< NavierStokesWallCondition >(NewId, pGeom, pProperties);
     }
@@ -199,7 +199,7 @@ public:
      * @param ThisNodes: the nodes of the new element
      * @return a Pointer to the new element
      */
-    virtual Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const
+    Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override
     {
         Condition::Pointer pNewCondition = Create(NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
 
@@ -216,9 +216,9 @@ public:
      * @param rRightHandSideVector: reference to the RHS matrix
      * @param rCurrentProcessInfo: reference to the ProcessInfo (unused)
      */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo)
+                                      ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -281,8 +281,8 @@ public:
      * @param rLeftHandSideMatrix: reference to the LHS matrix
      * @param rCurrentProcessInfo: reference to the ProcessInfo (unused)
      */
-    virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                       ProcessInfo& rCurrentProcessInfo)
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                                       ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -303,8 +303,8 @@ public:
      * @param rRightHandSideVector: reference to the RHS matrix
      * @param rCurrentProcessInfo: reference to the ProcessInfo (unused)
      */
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo)
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                        ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -358,7 +358,7 @@ public:
     /**
      * @param rCurrentProcessInfo: reference to the ProcessInfo
      */
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY;
 
@@ -419,14 +419,14 @@ public:
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo the current process info object (unused)
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
 
     /// Returns a list of the element's Dofs
     /**
      * @param ElementalDofList the list of DOFs
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void GetDofList(DofsVectorType& ConditionDofList, ProcessInfo& CurrentProcessInfo);
+    void GetDofList(DofsVectorType& ConditionDofList, ProcessInfo& CurrentProcessInfo) override;
 
     ///@}
     ///@name Access
@@ -443,7 +443,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "NavierStokesWallCondition" << TDim << "D";
@@ -451,13 +451,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "NavierStokesWallCondition";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
     ///@}
@@ -527,12 +527,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition );
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
     }

--- a/applications/FluidDynamicsApplication/custom_conditions/stokes_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/stokes_wall_condition.h
@@ -151,7 +151,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~StokesWallCondition() {}
+    ~StokesWallCondition() override {}
 
 
     ///@}
@@ -176,7 +176,7 @@ public:
       @param ThisNodes An array containing the nodes of the new condition
       @param pProperties Pointer to the element's properties
       */
-    virtual Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const
+    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
     {
         return Condition::Pointer(new StokesWallCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
     }
@@ -186,9 +186,9 @@ public:
     /** The actual local contributions are computed in the Damping functions
       @see CalculateLocalVelocityContribution
       */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo)
+                                      ProcessInfo& rCurrentProcessInfo) override
     {
         const SizeType BlockSize = TDim + 1;
         const SizeType LocalSize = BlockSize * TNumNodes;
@@ -207,8 +207,8 @@ public:
     /** The actual local contributions are computed in the Damping functions
       @see DampingMatrix
       */
-    virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                       ProcessInfo& rCurrentProcessInfo)
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                                       ProcessInfo& rCurrentProcessInfo) override
     {
         const SizeType BlockSize = TDim + 1;
         const SizeType LocalSize = BlockSize * TNumNodes;
@@ -223,8 +223,8 @@ public:
     /** The actual local contributions are computed in the Damping functions
       @see CalculateLocalVelocityContribution
       */
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo)
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                        ProcessInfo& rCurrentProcessInfo) override
     {
         const SizeType BlockSize = TDim + 1;
         const SizeType LocalSize = BlockSize * TNumNodes;
@@ -238,7 +238,7 @@ public:
 
 
     /// Check that all data required by this condition is available and reasonable
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY;
 
@@ -296,8 +296,8 @@ public:
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo the current process info object (unused)
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult,
-                                  ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult,
+                                  ProcessInfo& rCurrentProcessInfo) override;
 
 
     /// Returns a list of the element's Dofs
@@ -305,8 +305,8 @@ public:
      * @param ElementalDofList the list of DOFs
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void GetDofList(DofsVectorType& ConditionDofList,
-                            ProcessInfo& CurrentProcessInfo);
+    void GetDofList(DofsVectorType& ConditionDofList,
+                            ProcessInfo& CurrentProcessInfo) override;
 
 
     ///@}
@@ -324,7 +324,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "StokesWallCondition" << TDim << "D";
@@ -332,13 +332,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "StokesWallCondition";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
     ///@}
@@ -406,12 +406,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition );
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
     }

--- a/applications/FluidDynamicsApplication/custom_conditions/wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/wall_condition.h
@@ -183,7 +183,7 @@ namespace Kratos
         }
 
         /// Destructor.
-        virtual ~WallCondition(){}
+        ~WallCondition() override{}
 
 
         ///@}
@@ -208,13 +208,13 @@ namespace Kratos
           @param ThisNodes An array containing the nodes of the new condition
           @param pProperties Pointer to the element's properties
           */
-        virtual Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
+        Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
         {
             return Condition::Pointer(new WallCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
         }
 
 
-        virtual Condition::Pointer Create(IndexType NewId, Condition::GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override
+        Condition::Pointer Create(IndexType NewId, Condition::GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override
         {
 	  		return Condition::Pointer(new WallCondition(NewId, pGeom, pProperties));
         }
@@ -227,7 +227,7 @@ namespace Kratos
          * @return a Pointer to the new element
          */
 
-        virtual Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override
+        Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override
         {
             Condition::Pointer pNewCondition = Create(NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
 
@@ -238,7 +238,7 @@ namespace Kratos
         }
 
 
-        virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+        void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
                                            ProcessInfo& rCurrentProcessInfo) override
         {
             VectorType RHS;
@@ -253,7 +253,7 @@ namespace Kratos
           @param rRightHandSideVector Right-hand side vector
           @param rCurrentProcessInfo ProcessInfo instance (unused)
           */
-        virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+        void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                           VectorType& rRightHandSideVector,
                                           ProcessInfo& rCurrentProcessInfo) override
         {
@@ -317,7 +317,7 @@ namespace Kratos
 
 
         /// Check that all data required by this condition is available and reasonable
-        virtual int Check(const ProcessInfo& rCurrentProcessInfo) override
+        int Check(const ProcessInfo& rCurrentProcessInfo) override
         {
             KRATOS_TRY;
 
@@ -371,7 +371,7 @@ namespace Kratos
          * @param rResult A vector containing the global Id of each row
          * @param rCurrentProcessInfo the current process info object (unused)
          */
-        virtual void EquationIdVector(EquationIdVectorType& rResult,
+        void EquationIdVector(EquationIdVectorType& rResult,
                                       ProcessInfo& rCurrentProcessInfo) override;
 
 
@@ -380,7 +380,7 @@ namespace Kratos
          * @param ElementalDofList the list of DOFs
          * @param rCurrentProcessInfo the current process info instance
          */
-        virtual void GetDofList(DofsVectorType& ConditionDofList,
+        void GetDofList(DofsVectorType& ConditionDofList,
                                 ProcessInfo& CurrentProcessInfo) override;
 
 
@@ -389,7 +389,7 @@ namespace Kratos
          * @param Values Vector of nodal unknowns
          * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
          */
-        virtual void GetValuesVector(Vector& Values,
+        void GetValuesVector(Vector& Values,
                                      int Step = 0) override
         {
             const SizeType LocalSize = TDim * TNumNodes;
@@ -430,7 +430,7 @@ namespace Kratos
 //        }
 
 
-        virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+        void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
                                                  std::vector<array_1d<double, 3 > >& rValues,
                                                  const ProcessInfo& rCurrentProcessInfo) override
         {
@@ -454,7 +454,7 @@ namespace Kratos
 
 
 
-        virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+        void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
                                                  std::vector<double>& rValues,
                                                  const ProcessInfo& rCurrentProcessInfo) override
         {
@@ -470,7 +470,7 @@ namespace Kratos
         }
 
 
-        virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+        void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
                                                  std::vector<array_1d<double, 6 > >& rValues,
                                                  const ProcessInfo& rCurrentProcessInfo) override
         {
@@ -480,7 +480,7 @@ namespace Kratos
         }
 
 
-        virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+        void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
                                                  std::vector<Vector>& rValues,
                                                  const ProcessInfo& rCurrentProcessInfo) override
         {
@@ -490,7 +490,7 @@ namespace Kratos
         }
 
 
-        virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+        void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
                                                  std::vector<Matrix>& rValues,
                                                  const ProcessInfo& rCurrentProcessInfo) override
         {
@@ -516,7 +516,7 @@ namespace Kratos
         ///@{
 
         /// Turn back information as a string.
-        virtual std::string Info() const override
+        std::string Info() const override
         {
             std::stringstream buffer;
 			this->PrintInfo(buffer);
@@ -524,13 +524,13 @@ namespace Kratos
         }
 
         /// Print information about this object.
-        virtual void PrintInfo(std::ostream& rOStream) const override
+        void PrintInfo(std::ostream& rOStream) const override
 	   	{
 			rOStream << "WallCondition" << TDim << "D #" << this->Id();
 		}
 
         /// Print object's data.
-        virtual void PrintData(std::ostream& rOStream) const override
+        void PrintData(std::ostream& rOStream) const override
 	   	{
 			this->pGetGeometry()->PrintData(rOStream);
 		}
@@ -700,12 +700,12 @@ namespace Kratos
 
         friend class Serializer;
 
-        virtual void save(Serializer& rSerializer) const override
+        void save(Serializer& rSerializer) const override
         {
             KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition );
         }
 
-        virtual void load(Serializer& rSerializer) override
+        void load(Serializer& rSerializer) override
         {
             KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
         }

--- a/applications/FluidDynamicsApplication/custom_conditions/wall_condition_discontinuous.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/wall_condition_discontinuous.h
@@ -181,7 +181,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~WallConditionDiscontinuous() {}
+    ~WallConditionDiscontinuous() override {}
 
 
     ///@}
@@ -206,14 +206,14 @@ public:
       @param ThisNodes An array containing the nodes of the new condition
       @param pProperties Pointer to the element's properties
       */
-    virtual Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
+    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
     {
         return Condition::Pointer(new WallConditionDiscontinuous(NewId, this->GetGeometry().Create(ThisNodes), pProperties));
     }
 
 
 
-       virtual Condition::Pointer Create(IndexType NewId, Condition::GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override
+       Condition::Pointer Create(IndexType NewId, Condition::GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override
         {
 			return Condition::Pointer(new WallConditionDiscontinuous(NewId, pGeom, pProperties));
 		}
@@ -225,7 +225,7 @@ public:
       @param rRightHandSideVector Right-hand side vector
       @param rCurrentProcessInfo ProcessInfo instance (unused)
       */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
                                       ProcessInfo& rCurrentProcessInfo) override
     {
@@ -336,7 +336,7 @@ public:
 
 
     /// Check that all data required by this condition is available and reasonable
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY;
 
@@ -475,7 +475,7 @@ public:
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo the current process info object (unused)
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult,
+    void EquationIdVector(EquationIdVectorType& rResult,
                                   ProcessInfo& rCurrentProcessInfo) override;
 
 
@@ -484,7 +484,7 @@ public:
      * @param ElementalDofList the list of DOFs
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void GetDofList(DofsVectorType& ConditionDofList,
+    void GetDofList(DofsVectorType& ConditionDofList,
                             ProcessInfo& CurrentProcessInfo) override;
 
 
@@ -503,7 +503,7 @@ public:
     ///@{
 
 	/// Turn back information as a string.
-	virtual std::string Info() const override
+	std::string Info() const override
 	{
 		std::stringstream buffer;
 		this->PrintInfo(buffer);
@@ -511,13 +511,13 @@ public:
 	}
 
 	/// Print information about this object.
-	virtual void PrintInfo(std::ostream& rOStream) const override
+	void PrintInfo(std::ostream& rOStream) const override
 	{
 		rOStream << "WallConditionDiscontinuous" << TDim << "D #" << this->Id();
 	}
 
 	/// Print object's data.
-	virtual void PrintData(std::ostream& rOStream) const override
+	void PrintData(std::ostream& rOStream) const override
 	{
 		this->pGetGeometry()->PrintData(rOStream);
 	}
@@ -586,13 +586,13 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         typedef WallCondition<TDim,TNumNodes> BaseType;
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseType );
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         typedef WallCondition<TDim,TNumNodes> BaseType;
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseType );

--- a/applications/FluidDynamicsApplication/custom_constitutive/bingham_3d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/bingham_3d_law.h
@@ -54,7 +54,7 @@ public:
      * Clone function (has to be implemented by any derived class)
      * @return a pointer to a new instance of this constitutive law
      */
-    ConstitutiveLaw::Pointer Clone() const;
+    ConstitutiveLaw::Pointer Clone() const override;
 
     /**
      * Copy constructor.
@@ -72,7 +72,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~Bingham3DLaw();
+    ~Bingham3DLaw() override;
 
     /**
      * Operators
@@ -81,13 +81,13 @@ public:
     /**
      * Operations needed by the base class:
      */
-    virtual void CalculateMaterialResponseCauchy (Parameters& rValues);
+    void CalculateMaterialResponseCauchy (Parameters& rValues) override;
 
     /**
      * This function is designed to be called once to check compatibility with element
      * @param rFeatures
      */
-    void GetLawFeatures(Features& rFeatures);
+    void GetLawFeatures(Features& rFeatures) override;
 
 
     /**
@@ -99,7 +99,7 @@ public:
      * @param rCurrentProcessInfo
      * @return
      */
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo);
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Input and output
@@ -163,12 +163,12 @@ private:
     ///@{
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw  )
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw )
     }

--- a/applications/FluidDynamicsApplication/custom_constitutive/herschel_bulkey_3d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/herschel_bulkey_3d_law.h
@@ -55,7 +55,7 @@ public:
      * Clone function (has to be implemented by any derived class)
      * @return a pointer to a new instance of this constitutive law
      */
-    ConstitutiveLaw::Pointer Clone() const;
+    ConstitutiveLaw::Pointer Clone() const override;
 
     /**
      * Copy constructor.
@@ -73,7 +73,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~HerschelBulkey3DLaw();
+    ~HerschelBulkey3DLaw() override;
 
     /**
      * Operators
@@ -82,13 +82,13 @@ public:
     /**
      * Operations needed by the base class:
      */
-    virtual void CalculateMaterialResponseCauchy (Parameters& rValues);
+    void CalculateMaterialResponseCauchy (Parameters& rValues) override;
 
     /**
      * This function is designed to be called once to check compatibility with element
      * @param rFeatures
      */
-    void GetLawFeatures(Features& rFeatures);
+    void GetLawFeatures(Features& rFeatures) override;
 
 
     /**
@@ -100,7 +100,7 @@ public:
      * @param rCurrentProcessInfo
      * @return
      */
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo);
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Input and output
@@ -164,12 +164,12 @@ private:
     ///@{
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw )
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw )
     }

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_2d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_2d_law.h
@@ -52,7 +52,7 @@ public:
      * Clone function (has to be implemented by any derived class)
      * @return a pointer to a new instance of this constitutive law
      */
-    ConstitutiveLaw::Pointer Clone() const;
+    ConstitutiveLaw::Pointer Clone() const override;
 
     /**
      * Copy constructor.
@@ -70,7 +70,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~Newtonian2DLaw();
+    ~Newtonian2DLaw() override;
 
     /**
      * Operators
@@ -79,13 +79,13 @@ public:
     /**
      * Operations needed by the base class:
      */
-    virtual void CalculateMaterialResponseCauchy (Parameters& rValues);
+    void CalculateMaterialResponseCauchy (Parameters& rValues) override;
 
     /**
      * This function is designed to be called once to check compatibility with element
      * @param rFeatures
      */
-    void GetLawFeatures(Features& rFeatures);
+    void GetLawFeatures(Features& rFeatures) override;
 
 
     /**
@@ -97,7 +97,7 @@ public:
      * @param rCurrentProcessInfo
      * @return
      */
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo);
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Input and output
@@ -161,12 +161,12 @@ private:
     ///@{
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw )
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw )
     }

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_3d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_3d_law.h
@@ -52,7 +52,7 @@ public:
      * Clone function (has to be implemented by any derived class)
      * @return a pointer to a new instance of this constitutive law
      */
-    ConstitutiveLaw::Pointer Clone() const;
+    ConstitutiveLaw::Pointer Clone() const override;
 
     /**
      * Copy constructor.
@@ -70,7 +70,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~Newtonian3DLaw();
+    ~Newtonian3DLaw() override;
 
     /**
      * Operators
@@ -79,13 +79,13 @@ public:
     /**
      * Operations needed by the base class:
      */
-    virtual void CalculateMaterialResponseCauchy (Parameters& rValues);
+    void CalculateMaterialResponseCauchy (Parameters& rValues) override;
 
     /**
      * This function is designed to be called once to check compatibility with element
      * @param rFeatures
      */
-    void GetLawFeatures(Features& rFeatures);
+    void GetLawFeatures(Features& rFeatures) override;
 
 
     /**
@@ -97,7 +97,7 @@ public:
      * @param rCurrentProcessInfo
      * @return
      */
-    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo);
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * Input and output
@@ -161,12 +161,12 @@ private:
     ///@{
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw )
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw )
     }

--- a/applications/FluidDynamicsApplication/custom_elements/bingham_fluid.h
+++ b/applications/FluidDynamicsApplication/custom_elements/bingham_fluid.h
@@ -121,7 +121,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~BinghamFluid()
+    ~BinghamFluid() override
     {}
 
     ///@}
@@ -144,14 +144,14 @@ public:
      */
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const
+                            PropertiesType::Pointer pProperties) const override
     {
         return Element::Pointer(new BinghamFluid<TBaseElement>(NewId, this->GetGeometry().Create(ThisNodes), pProperties));
     }
 
 
 
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY;
 
@@ -183,7 +183,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "BinghamFluid " ;
@@ -192,14 +192,14 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "BinghamFluid ";
         TBaseElement::PrintInfo(rOStream);
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
     ///@}
@@ -255,11 +255,11 @@ protected:
      * @param rProcessInfo ProcessInfo instance passed from the ModelPart, containing additional data
      * @return The effective viscosity, in dynamic units (Pa*s or equivalent).
      */
-    virtual double EffectiveViscosity(double Density,
+    double EffectiveViscosity(double Density,
                                       const TShapeFunctionValues &rN,
                                       const TShapeFunctionGradients &rDN_DX,
                                       double ElemSize,
-                                      const ProcessInfo &rProcessInfo)
+                                      const ProcessInfo &rProcessInfo) override
     {
         // Read the viscosity for the fluidified phase from the nodes
         // In Kratos, the viscosity is assumed to be given in kinematic units (m^2/s)
@@ -321,12 +321,12 @@ protected:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, TBaseElement );
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, TBaseElement );
     }

--- a/applications/FluidDynamicsApplication/custom_elements/dpg_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/dpg_vms.h
@@ -145,7 +145,7 @@ public:
     {
     }
     /// Destructor.
-    virtual ~DPGVMS()
+    ~DPGVMS() override
     {
     }
     ///@}
@@ -163,14 +163,14 @@ public:
      * @return a Pointer to the new element
      */
     Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const
+                            PropertiesType::Pointer pProperties) const override
     {
         return Element::Pointer(new DPGVMS(NewId, (this->GetGeometry()).Create(ThisNodes), pProperties));
     }
     /// Call at teh begining of each step, ita decides if element is cutted or no!
     /**    
       */  
-    virtual void InitializeSolutionStep(ProcessInfo &rCurrentProcessInfo)
+    void InitializeSolutionStep(ProcessInfo &rCurrentProcessInfo) override
     {
 // 	for (unsigned int jj = 0; jj < 4; jj++){
 // 	      this->GetGeometry()[jj].FastGetSolutionStepValue(WET_VOLUME ) = 0.0;  
@@ -181,7 +181,7 @@ public:
     /// Call at teh begining of each iteration, ita decides if element is cutted or no!
     /**    
       */  
-    virtual void InitializeNonLinearIteration(ProcessInfo &rCurrentProcessInfo)
+    void InitializeNonLinearIteration(ProcessInfo &rCurrentProcessInfo) override
     {
 	  // Calculate this element's geometric parameters
 	  double Area;
@@ -231,9 +231,9 @@ public:
      * @param rRightHandSideVector: the elemental right hand side
      * @param rCurrentProcessInfo: the current process info
      */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo)
+                                      ProcessInfo& rCurrentProcessInfo) override
     {
 //         this->IsCutted();
         unsigned int LocalSize = (TDim + 1) * TNumNodes;
@@ -272,8 +272,8 @@ public:
      * @param rCurrentProcessInfo ProcessInfo instance from the ModelPart. It is
      * expected to contain values for OSS_SWITCH, DYNAMIC_TAU and DELTA_TIME
      */
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo)
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                        ProcessInfo& rCurrentProcessInfo) override
     { 
       	if( this->is_cutted == 1)
 	{
@@ -358,7 +358,7 @@ public:
      * @param rMassMatrix Will be filled with the elemental mass matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override
     {
 //       this->IsCutted();     
       if( this->is_cutted == 0)
@@ -454,9 +454,9 @@ public:
      * @param rRightHandSideVector the elemental right hand side vector
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
+    void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
             VectorType& rRightHandSideVector,
-            ProcessInfo& rCurrentProcessInfo)
+            ProcessInfo& rCurrentProcessInfo) override
     {
 //       this->IsCutted();     
       if( this->is_cutted == 0){
@@ -703,7 +703,7 @@ public:
     }
     
     /// Implementation of FinalizeNonLinearIteration to compute enriched pressure.   
-    virtual void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
+    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override
     {
 //       this->IsCutted();     
       if( this->is_cutted == 0)
@@ -756,7 +756,7 @@ public:
      * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
      */
 
-    void GetFirstDerivativesVector(Vector& values, int Step)
+    void GetFirstDerivativesVector(Vector& values, int Step) override
     {
 // 	this->IsCutted();     
 	if( this->is_cutted == 0)  
@@ -785,7 +785,7 @@ public:
      * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
      */
 
-      void GetSecondDerivativesVector(Vector& values, int Step)
+      void GetSecondDerivativesVector(Vector& values, int Step) override
       {
 // 	this->IsCutted();     
 	if( this->is_cutted == 0)  
@@ -821,9 +821,9 @@ public:
      * @param Output Will be overwritten with the elemental momentum error
      * @param rCurrentProcessInfo Process info instance (unused)
      */
-    virtual void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
+    void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
                            array_1d<double, 3 > & rOutput,
-                           const ProcessInfo& rCurrentProcessInfo)
+                           const ProcessInfo& rCurrentProcessInfo) override
     {
         if (rVariable == ADVPROJ) // Compute residual projections for OSS
         {
@@ -983,7 +983,7 @@ public:
  * @see DPGVMS::GetValueOnIntegrationPoints
  */
 
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo)
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override
       {
 
 	  if (rVariable == PRESSUREAUX)
@@ -1025,7 +1025,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
         // Perform basic element checks
@@ -1111,14 +1111,14 @@ public:
     ///@name Input and output
     ///@{
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "DPGVMS #" << this->Id();
         return buffer.str();
     }
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "DPGVMS" << TDim << "D";
     }
@@ -1185,9 +1185,9 @@ protected:
      * @param rShapeFunc: The values of the form functions in the point
      * @param Step: The time Step (Defaults to 0 = Current)
      */
-    virtual void EvaluateInPoint(double& rResult,
+    void EvaluateInPoint(double& rResult,
                                  const Variable< double >& rVariable,
-                                 const array_1d< double, TNumNodes >& rShapeFunc)
+                                 const array_1d< double, TNumNodes >& rShapeFunc) override
     {
         //compute sign of distance on gauss point
         double dist = 0.0;
@@ -1241,9 +1241,9 @@ protected:
      * @param rVariable: The nodal variable to be read
      * @param rShapeFunc: The values of the form functions in the point
      */
-    virtual void EvaluateInPoint(array_1d< double, 3 > & rResult,
+    void EvaluateInPoint(array_1d< double, 3 > & rResult,
                                  const Variable< array_1d< double, 3 > >& rVariable,
-                                 const array_1d< double, TNumNodes >& rShapeFunc)
+                                 const array_1d< double, TNumNodes >& rShapeFunc) override
     {
         //compute sign of distance on gauss point
         double dist = 0.0;
@@ -1503,11 +1503,11 @@ private:
     ///@name Serialization
     ///@{
     friend class Serializer;
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ElementBaseType);
     }
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ElementBaseType);
     }

--- a/applications/FluidDynamicsApplication/custom_elements/dynamic_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/dynamic_vms.h
@@ -199,7 +199,7 @@ public:
     DynamicVMS(IndexType NewId, GeometryType::Pointer pGeometry, Properties::Pointer pProperties, const GeometryData::IntegrationMethod ThisIntegrationMethod);
 
     /// Destructor.
-    virtual ~DynamicVMS();
+    ~DynamicVMS() override;
 
     ///@}
     ///@name Operators
@@ -219,33 +219,33 @@ public:
      * @param pProperties: the properties assigned to the new element.
      * @return a Pointer to the new element.
      */
-    virtual Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,
-                                    PropertiesType::Pointer pProperties) const;
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,
+                                    PropertiesType::Pointer pProperties) const override;
 
     /// Initialize containters for subscales on integration points.
-    virtual void Initialize();
+    void Initialize() override;
 
     /**
      * @brief Prepare the element for a new solution step.
      * Update the values on the subscales and evaluate elemental shape functions.
      * @param rCurrentProcessInfo. ProcessInfo instance (unused).
      */
-    virtual void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo);
+    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
 
     /// Calculate a new value for the velocity subscale.
     /**
      * @param rCurrentProcessInfo ProcessInfo instance containig the time step as DELTA_TIME
      */
-    virtual void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo);
+    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void CalculateLocalSystem(MatrixType &rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType &rLeftHandSideMatrix,
                                       VectorType &rRightHandSideVector,
-                                      ProcessInfo &rCurrentProcessInfo);
+                                      ProcessInfo &rCurrentProcessInfo) override;
 
 
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo);
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                        ProcessInfo& rCurrentProcessInfo) override;
 
 
     /// Computes the local contribution associated to 'new' velocity and pressure values
@@ -257,11 +257,11 @@ public:
      * @param rRightHandSideVector the elemental right hand side vector
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
+    void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
             VectorType& rRightHandSideVector,
-            ProcessInfo& rCurrentProcessInfo);
+            ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void CalculateMassMatrix(MatrixType &rMassMatrix, ProcessInfo &rCurrentProcessInfo);
+    void CalculateMassMatrix(MatrixType &rMassMatrix, ProcessInfo &rCurrentProcessInfo) override;
 
 
     /// Provides the global indices for each one of this element's local rows
@@ -271,68 +271,68 @@ public:
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo the current process info object (unused)
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult,
-                                  ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult,
+                                  ProcessInfo& rCurrentProcessInfo) override;
 
     /// Returns a list of the element's Dofs
     /**
      * @param ElementalDofList the list of DOFs
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void GetDofList(DofsVectorType& rElementalDofList,
-                            ProcessInfo& rCurrentProcessInfo);
+    void GetDofList(DofsVectorType& rElementalDofList,
+                            ProcessInfo& rCurrentProcessInfo) override;
 
     /// Returns VELOCITY_X, VELOCITY_Y, (VELOCITY_Z,) PRESSURE for each node
     /**
      * @param Values Vector of nodal unknowns
      * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
      */
-    virtual void GetFirstDerivativesVector(Vector& rValues, int Step = 0);
+    void GetFirstDerivativesVector(Vector& rValues, int Step = 0) override;
 
     /// Returns ACCELERATION_X, ACCELERATION_Y, (ACCELERATION_Z,) 0 for each node
     /**
      * @param Values Vector of nodal second derivatives
      * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
      */
-    virtual void GetSecondDerivativesVector(Vector& rValues, int Step = 0);
+    void GetSecondDerivativesVector(Vector& rValues, int Step = 0) override;
 
 
 //    virtual void Calculate(const Variable<double>& rVariable,
 //                           double& rOutput,
 //                           const ProcessInfo& rCurrentProcessInfo);
 
-    virtual void Calculate(const Variable< array_1d<double,3> >& rVariable,
+    void Calculate(const Variable< array_1d<double,3> >& rVariable,
                            array_1d<double,3>& rOutput,
-                           const ProcessInfo& rCurrentProcessInfo);
+                           const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
             std::vector<array_1d<double, 3 > >& rOutput,
-            const ProcessInfo& rCurrentProcessInfo);
+            const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
-            const ProcessInfo& rCurrentProcessInfo);
+            const ProcessInfo& rCurrentProcessInfo) override;
 
     /// Empty implementation of unused CalculateOnIntegrationPoints overloads to avoid compilation warning
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
             std::vector<array_1d<double, 6 > >& rValues,
-            const ProcessInfo& rCurrentProcessInfo)
+            const ProcessInfo& rCurrentProcessInfo) override
     {}
 
     /// Empty implementation of unused CalculateOnIntegrationPoints overloads to avoid compilation warning
-    virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
             std::vector<Vector>& rValues,
-            const ProcessInfo& rCurrentProcessInfo)
+            const ProcessInfo& rCurrentProcessInfo) override
     {}
 
     /// Empty implementation of unused CalculateOnIntegrationPoints overloads to avoid compilation warning
-    virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
             std::vector<Matrix>& rValues,
-            const ProcessInfo& rCurrentProcessInfo)
+            const ProcessInfo& rCurrentProcessInfo) override
     {}
 
-    virtual void SetValueOnIntegrationPoints(const Variable<double> &rVariable, std::vector<double> &rValues, const ProcessInfo &rCurrentProcessInfo);
+    void SetValueOnIntegrationPoints(const Variable<double> &rVariable, std::vector<double> &rValues, const ProcessInfo &rCurrentProcessInfo) override;
 
     ///@}
     ///@name Access
@@ -341,7 +341,7 @@ public:
     /// Accessor to the integration method.
     /** GiDIO uses it to determine the number of Gauss Points on each element.
      */
-    virtual GeometryData::IntegrationMethod GetIntegrationMethod() const;
+    GeometryData::IntegrationMethod GetIntegrationMethod() const override;
 
     ///@}
     ///@name Inquiry
@@ -353,12 +353,12 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const;
+    std::string Info() const override;
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const;
+    void PrintInfo(std::ostream& rOStream) const override;
 
-    virtual void PrintData(std::ostream &rOStream) const;
+    void PrintData(std::ostream &rOStream) const override;
 
     ///@}
     ///@name Friends
@@ -581,10 +581,10 @@ private:
     /// Default constructor
     DynamicVMS();
 
-    virtual void save(Serializer& rSerializer) const;
+    void save(Serializer& rSerializer) const override;
 
 
-    virtual void load(Serializer& rSerializer);
+    void load(Serializer& rSerializer) override;
 
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_navier_stokes.h
@@ -124,7 +124,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~EmbeddedNavierStokes() {};
+    ~EmbeddedNavierStokes() override {};
 
     ///@}
     ///@name Operators
@@ -239,7 +239,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY;
 
@@ -403,7 +403,7 @@ public:
 
     /// Turn back information as a string.
 
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "EmbeddedNavierStokes3D #";
     }
@@ -1688,12 +1688,12 @@ private:
     ///@{
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }

--- a/applications/FluidDynamicsApplication/custom_elements/fractional_step.h
+++ b/applications/FluidDynamicsApplication/custom_elements/fractional_step.h
@@ -149,7 +149,7 @@ namespace Kratos
         {}
 
         /// Destructor.
-        virtual ~FractionalStep()
+        ~FractionalStep() override
         {}
 
 
@@ -171,7 +171,7 @@ namespace Kratos
          * @return a Pointer to the new element
          */
 	Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,
-                            Element::PropertiesType::Pointer pProperties) const
+                            Element::PropertiesType::Pointer pProperties) const override
 	{
             return boost::make_shared< FractionalStep<TDim> >(NewId, this->GetGeometry().Create(ThisNodes), pProperties);
 	}
@@ -184,7 +184,7 @@ namespace Kratos
          * @return a Pointer to the new element
          */
 		
-        Element::Pointer Create(IndexType NewId, Element::GeometryType::Pointer pGeom, Element::PropertiesType::Pointer pProperties) const
+        Element::Pointer Create(IndexType NewId, Element::GeometryType::Pointer pGeom, Element::PropertiesType::Pointer pProperties) const override
         {
             return boost::make_shared< FractionalStep<TDim> >(NewId, pGeom, pProperties);
         }
@@ -197,7 +197,7 @@ namespace Kratos
          * @return a Pointer to the new element
          */
         
-        Element::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const
+        Element::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override
         {
             Element::Pointer pNewElement = Create(NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
             
@@ -207,30 +207,30 @@ namespace Kratos
             return pNewElement;
         }
         
-        virtual void Initialize();
+        void Initialize() override;
 
         /// Initializes the element and all geometric information required for the problem.
-        virtual void InitializeSolutionStep(ProcessInfo &rCurrentProcessInfo);
+        void InitializeSolutionStep(ProcessInfo &rCurrentProcessInfo) override;
 
 
-        virtual void InitializeNonLinearIteration(ProcessInfo &rCurrentProcessInfo);
+        void InitializeNonLinearIteration(ProcessInfo &rCurrentProcessInfo) override;
 
         /// Calculate the element's local contribution to the system for the current step.
-        virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+        void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                           VectorType& rRightHandSideVector,
-                                          ProcessInfo& rCurrentProcessInfo);
+                                          ProcessInfo& rCurrentProcessInfo) override;
 
 
-        virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                           ProcessInfo& rCurrentProcessInfo)
+        void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                                           ProcessInfo& rCurrentProcessInfo) override
         {
             KRATOS_TRY;
             KRATOS_THROW_ERROR(std::logic_error,"FractionalStep::CalculateLeftHandSide not implemented","");
             KRATOS_CATCH("");
         }
 
-        virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                            ProcessInfo& rCurrentProcessInfo)
+        void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                            ProcessInfo& rCurrentProcessInfo) override
         {
             KRATOS_TRY;
             KRATOS_THROW_ERROR(std::logic_error,"FractionalStep::CalculateRightHandSide not implemented","");
@@ -242,9 +242,9 @@ namespace Kratos
          * @param rOutput (unused)
          * @param rCurrentProcessInfo Process info instance (unused)
          */
-        virtual void Calculate(const Variable<double>& rVariable,
+        void Calculate(const Variable<double>& rVariable,
                                double& rOutput,
-                               const ProcessInfo& rCurrentProcessInfo);
+                               const ProcessInfo& rCurrentProcessInfo) override;
 
 
         /**
@@ -252,9 +252,9 @@ namespace Kratos
          * @param Output (unused)
          * @param rCurrentProcessInfo Process info instance (unused)
          */
-        virtual void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
+        void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
                                array_1d<double, 3 > & rOutput,
-                               const ProcessInfo& rCurrentProcessInfo);
+                               const ProcessInfo& rCurrentProcessInfo) override;
 
 
         // The following methods have different implementations depending on TDim
@@ -265,19 +265,19 @@ namespace Kratos
          * @param rResult A vector containing the global Id of each row
          * @param rCurrentProcessInfo the current process info object (unused)
          */
-        virtual void EquationIdVector(EquationIdVectorType& rResult,
-                                      ProcessInfo& rCurrentProcessInfo);
+        void EquationIdVector(EquationIdVectorType& rResult,
+                                      ProcessInfo& rCurrentProcessInfo) override;
 
         /// Returns a list of the element's Dofs
         /**
          * @param ElementalDofList the list of DOFs
          * @param rCurrentProcessInfo the current process info instance
          */
-        virtual void GetDofList(DofsVectorType& rElementalDofList,
-                                ProcessInfo& rCurrentProcessInfo);
+        void GetDofList(DofsVectorType& rElementalDofList,
+                                ProcessInfo& rCurrentProcessInfo) override;
 
     
-        virtual GeometryData::IntegrationMethod GetIntegrationMethod() const;
+        GeometryData::IntegrationMethod GetIntegrationMethod() const override;
 
         /// Obtain an array_1d<double,3> elemental variable, evaluated on gauss points.
         /**
@@ -285,9 +285,9 @@ namespace Kratos
          * @param Output Will be filled with the values of the variable on integrartion points
          * @param rCurrentProcessInfo Process info instance
          */
-        virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+        void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
                 std::vector<array_1d<double, 3 > >& rValues,
-                const ProcessInfo& rCurrentProcessInfo);
+                const ProcessInfo& rCurrentProcessInfo) override;
 
         /// Obtain a double elemental variable, evaluated on gauss points.
         /**
@@ -295,9 +295,9 @@ namespace Kratos
          * @param Output Will be filled with the values of the variable on integrartion points
          * @param rCurrentProcessInfo Process info instance
          */
-        virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+        void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
                 std::vector<double>& rValues,
-                const ProcessInfo& rCurrentProcessInfo);
+                const ProcessInfo& rCurrentProcessInfo) override;
 
         /// Obtain an array_1d<double,6> elemental variable, evaluated on gauss points.
         /**
@@ -305,9 +305,9 @@ namespace Kratos
          * @param Output Will be filled with the values of the variable on integrartion points
          * @param rCurrentProcessInfo Process info instance
          */
-        virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+        void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
                 std::vector<array_1d<double, 6 > >& rValues,
-                const ProcessInfo& rCurrentProcessInfo)
+                const ProcessInfo& rCurrentProcessInfo) override
         {
             this->GetElementalValueForOutput< array_1d<double,6> >(rVariable,rValues);
         }
@@ -318,9 +318,9 @@ namespace Kratos
          * @param Output Will be filled with the values of the variable on integrartion points
          * @param rCurrentProcessInfo Process info instance
          */
-        virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+        void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
                 std::vector<Vector>& rValues,
-                const ProcessInfo& rCurrentProcessInfo)
+                const ProcessInfo& rCurrentProcessInfo) override
         {
             this->GetElementalValueForOutput< Vector >(rVariable,rValues);
         }
@@ -331,9 +331,9 @@ namespace Kratos
          * @param Output Will be filled with the values of the variable on integrartion points
          * @param rCurrentProcessInfo Process info instance
          */
-        virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+        void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
                 std::vector<Matrix>& rValues,
-                const ProcessInfo& rCurrentProcessInfo)
+                const ProcessInfo& rCurrentProcessInfo) override
         {
             this->GetElementalValueForOutput< Matrix >(rVariable,rValues);
         }
@@ -355,7 +355,7 @@ namespace Kratos
          * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
          * @return 0 if no errors were found.
          */
-        virtual int Check(const ProcessInfo& rCurrentProcessInfo);
+        int Check(const ProcessInfo& rCurrentProcessInfo) override;
 
         ///@}
         ///@name Inquiry
@@ -367,7 +367,7 @@ namespace Kratos
         ///@{
 
         /// Turn back information as a string.
-        virtual std::string Info() const
+        std::string Info() const override
         {
             std::stringstream buffer;
             buffer << "FractionalStep #" << Id();
@@ -375,7 +375,7 @@ namespace Kratos
         }
 
         /// Print information about this object.
-        virtual void PrintInfo(std::ostream& rOStream) const
+        void PrintInfo(std::ostream& rOStream) const override
         {
             rOStream << "FractionalStep" << TDim << "D";
         }
@@ -721,12 +721,12 @@ namespace Kratos
 
         friend class Serializer;
 
-        virtual void save(Serializer& rSerializer) const
+        void save(Serializer& rSerializer) const override
         {
             KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element );
         }
 
-        virtual void load(Serializer& rSerializer)
+        void load(Serializer& rSerializer) override
         {
             KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
         }

--- a/applications/FluidDynamicsApplication/custom_elements/fractional_step_discontinuous.h
+++ b/applications/FluidDynamicsApplication/custom_elements/fractional_step_discontinuous.h
@@ -154,7 +154,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~FractionalStepDiscontinuous()
+    ~FractionalStepDiscontinuous() override
     {}
 
 
@@ -165,9 +165,9 @@ public:
     /// this function is essentially identical to the one of the father element, to which it only
     /// adds a term in the momentum equation to allow imposing weakly the tangential component of the velocity
     /// on the cut elements
-        virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+        void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                           VectorType& rRightHandSideVector,
-                                          ProcessInfo& rCurrentProcessInfo);
+                                          ProcessInfo& rCurrentProcessInfo) override;
 
     ///@}
     ///@name Operations
@@ -182,11 +182,11 @@ public:
      * @return a Pointer to the new element
      */
     Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,
-                            Element::PropertiesType::Pointer pProperties) const
+                            Element::PropertiesType::Pointer pProperties) const override
     {
 	return boost::make_shared< FractionalStepDiscontinuous<TDim> >(NewId, this->GetGeometry().Create(ThisNodes), pProperties);
     }
-        Element::Pointer Create(IndexType NewId, Element::GeometryType::Pointer pGeom, Element::PropertiesType::Pointer pProperties) const
+        Element::Pointer Create(IndexType NewId, Element::GeometryType::Pointer pGeom, Element::PropertiesType::Pointer pProperties) const override
         {
 	  return boost::make_shared< FractionalStepDiscontinuous<TDim> >(NewId, pGeom, pProperties);
         }
@@ -216,17 +216,17 @@ public:
             * @param rOutput (unused)
             * @param rCurrentProcessInfo Process info instance (unused)
             */
-    virtual void Calculate(const Variable<double>& rVariable,
+    void Calculate(const Variable<double>& rVariable,
                            double& rOutput,
-                           const ProcessInfo& rCurrentProcessInfo);
+                           const ProcessInfo& rCurrentProcessInfo) override;
     /**
              * @param rVariable Use ADVPROJ or VELOCITY
              * @param Output (unused)
              * @param rCurrentProcessInfo Process info instance (unused)
              */
-    virtual void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
+    void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
                            array_1d<double, 3 > & rOutput,
-                           const ProcessInfo& rCurrentProcessInfo);
+                           const ProcessInfo& rCurrentProcessInfo) override;
 
     ///@}
     ///@name Inquiry
@@ -238,7 +238,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "FractionalStepDiscontinuous #" << this->Id();
@@ -246,7 +246,7 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "FractionalStepDiscontinuous" << TDim << "D";
     }
@@ -275,11 +275,11 @@ protected:
     ///@}
     ///@name Protected Operators
     ///@{
-    virtual void CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalPressureSystem(MatrixType& rLeftHandSideMatrix,
             VectorType& rRightHandSideVector,
-            ProcessInfo& rCurrentProcessInfo);
+            ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void AddMomentumSystemTerms(Matrix& rLHSMatrix,
+    void AddMomentumSystemTerms(Matrix& rLHSMatrix,
                                         Vector& rRHSVector,
                                         const double Density,
                                         const Vector& rConvOperator,
@@ -291,15 +291,15 @@ protected:
                                         const double MassProjection,
                                         const ShapeFunctionsType& rN,
                                         const ShapeFunctionDerivativesType& rDN_DX,
-                                        const double Weight);
+                                        const double Weight) override;
     ///@}
     ///@name Protected Operations
     ///@{
 
     /// Determine integration point weights and shape funcition derivatives from the element's geometry.
-    virtual void CalculateGeometryData(ShapeFunctionDerivativesArrayType& rDN_DX,
+    void CalculateGeometryData(ShapeFunctionDerivativesArrayType& rDN_DX,
                                        Matrix& rNContainer,
-                                       Vector& rGaussWeights);
+                                       Vector& rGaussWeights) override;
 
 
 
@@ -336,13 +336,13 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         typedef FractionalStep<TDim> basetype;
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, basetype );
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         typedef FractionalStep<TDim> basetype;
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, basetype );

--- a/applications/FluidDynamicsApplication/custom_elements/herschel_bulkley_fluid.h
+++ b/applications/FluidDynamicsApplication/custom_elements/herschel_bulkley_fluid.h
@@ -122,7 +122,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~HerschelBulkleyFluid()
+    ~HerschelBulkleyFluid() override
     {}
 
     ///@}
@@ -145,14 +145,14 @@ public:
      */
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const
+                            PropertiesType::Pointer pProperties) const override
     {
         return Element::Pointer(new HerschelBulkleyFluid<TBaseElement>(NewId, this->GetGeometry().Create(ThisNodes), pProperties));
     }
 
 
 
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY;
 
@@ -184,7 +184,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "HerschelBulkleyFluid " ;
@@ -193,14 +193,14 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "HerschelBulkleyFluid ";
         TBaseElement::PrintInfo(rOStream);
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
     ///@}
@@ -245,11 +245,11 @@ protected:
      * @param rProcessInfo ProcessInfo instance passed from the ModelPart, containing additional data
      * @return The effective viscosity, in dynamic units (Pa*s or equivalent).
      */
-    virtual double EffectiveViscosity(double Density,
+    double EffectiveViscosity(double Density,
                                       const TShapeFunctionValues &rN,
                                       const TShapeFunctionGradients &rDN_DX,
                                       double ElemSize,
-                                      const ProcessInfo &rProcessInfo)
+                                      const ProcessInfo &rProcessInfo) override
     {
         double GammaDot = this->EquivalentStrainRate(rDN_DX);
 
@@ -309,12 +309,12 @@ protected:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, TBaseElement );
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, TBaseElement );
     }

--- a/applications/FluidDynamicsApplication/custom_elements/navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/navier_stokes.h
@@ -106,7 +106,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~NavierStokes() {};
+    ~NavierStokes() override {};
 
 
     ///@}
@@ -235,7 +235,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -285,7 +285,7 @@ public:
     }
 
 
-    virtual void Calculate(const Variable<double>& rVariable,
+    void Calculate(const Variable<double>& rVariable,
                            double& rOutput,
                            const ProcessInfo& rCurrentProcessInfo) override
     {
@@ -318,13 +318,13 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "NavierStokes #";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info() << Id();
     }
@@ -583,12 +583,12 @@ private:
     ///@{
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }

--- a/applications/FluidDynamicsApplication/custom_elements/spalart_allmaras.h
+++ b/applications/FluidDynamicsApplication/custom_elements/spalart_allmaras.h
@@ -131,7 +131,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~SpalartAllmaras()
+    ~SpalartAllmaras() override
     {}
 
     ///@}
@@ -144,18 +144,18 @@ public:
     ///@{
 
     /// Create a new SpalartAllmaras element and return a pointer to it
-    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties)  const;
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties)  const override;
 
     /// Check that all required data containers are properly initialized and registered in Kratos
     /** @return 0 if no errors are detected.
       */
-    virtual int Check(const ProcessInfo &rCurrentProcessInfo);
+    int Check(const ProcessInfo &rCurrentProcessInfo) override;
 
     /// Calculate Shape function derivatives for the element
-    virtual void Initialize();
+    void Initialize() override;
 
     /// Calculates the projection term for stabilization
-    virtual void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo);
+    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
 
 //    /// Compute projection of convective term for stabilization
 //    virtual void InitializeNonLinearIteration(ProcessInfo &CurrentProcessInfo);
@@ -166,21 +166,21 @@ public:
      * @param rRightHandSideVector Elemental right hand side vector
      * @param rCurrentProcessInfo Reference to the ProcessInfo from the ModelPart containg the element
      */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 //    {
 //        KRATOS_THROW_ERROR(std::logic_error, "SplartAllmaras::CalculateRightHandSide method not implemented", "");
 //    }
 
     /// Fill given array with containing the element's degrees of freedom
-    virtual void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo);
+    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
 
     /// Fill given vector with the linear system row index for the element's degrees of freedom
-    virtual void EquationIdVector(Element::EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(Element::EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
 
     /// Fill given vector with nodal values of the problem variable (TURBULENT_VISCOSITY)
-    virtual void GetValuesVector(Vector& rValues, int Step = 0);
+    void GetValuesVector(Vector& rValues, int Step = 0) override;
 
     ///@}
     ///@name Access
@@ -197,7 +197,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "SpalartAllmaras" << this->GetGeometry().WorkingSpaceDimension() << "D #" << Id();
@@ -205,7 +205,7 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "SpalartAllmaras" << this->GetGeometry().WorkingSpaceDimension() << "D #" << Id() << std::endl;
         rOStream << "Number of Nodes: " << this->GetGeometry().PointsNumber() << std::endl;
@@ -213,7 +213,7 @@ public:
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
         this->PrintInfo(rOStream);
         rOStream << "Geometry Data: " << std::endl;
@@ -349,7 +349,7 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_TRY;
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element );
@@ -382,7 +382,7 @@ private:
         KRATOS_CATCH("");
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_TRY;
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer,Element);

--- a/applications/FluidDynamicsApplication/custom_elements/stationary_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/stationary_stokes.h
@@ -122,7 +122,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~StationaryStokes()
+    ~StationaryStokes() override
     {}
 
     ///@}
@@ -135,15 +135,15 @@ public:
     ///@{
 
     /// Create a new StationaryStokes element and return a pointer to it
-    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties)  const;
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties)  const override;
 
     /// Check that all required data containers are properly initialized and registered in Kratos
     /** @return 0 if no errors are detected.
       */
-    virtual int Check(const ProcessInfo &rCurrentProcessInfo);
+    int Check(const ProcessInfo &rCurrentProcessInfo) override;
 
     /// Calculate Shape function derivatives and Jacobian at each integration point
-    virtual void Initialize();
+    void Initialize() override;
 
     /// Evaluate the elemental contribution to the problem.
     /**
@@ -151,21 +151,21 @@ public:
      * @param rRightHandSideVector Elemental right hand side vector
      * @param rCurrentProcessInfo Reference to the ProcessInfo from the ModelPart containg the element
      */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override
     {
         MatrixType TmpLHS;
         this->CalculateLocalSystem(TmpLHS,rRightHandSideVector,rCurrentProcessInfo);
     }
 
     /// Fill given array with containing the element's degrees of freedom
-    virtual void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo);
+    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
 
     /// Fill given vector with the linear system row index for the element's degrees of freedom
-    virtual void EquationIdVector(Element::EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(Element::EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void GetFirstDerivativesVector(Vector &rValues, int Step = 0);
+    void GetFirstDerivativesVector(Vector &rValues, int Step = 0) override;
 
     ///@}
     ///@name Access
@@ -182,7 +182,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "StationaryStokes" << this->GetGeometry().WorkingSpaceDimension() << "D #" << Id();
@@ -190,7 +190,7 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "StationaryStokes" << this->GetGeometry().WorkingSpaceDimension() << "D #" << Id() << std::endl;
         rOStream << "Number of Nodes: " << this->GetGeometry().PointsNumber() << std::endl;
@@ -198,7 +198,7 @@ public:
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
         this->PrintInfo(rOStream);
         rOStream << "Geometry Data: " << std::endl;
@@ -312,7 +312,7 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_TRY;
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element );
@@ -345,7 +345,7 @@ private:
         KRATOS_CATCH("");
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_TRY;
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer,Element);

--- a/applications/FluidDynamicsApplication/custom_elements/stokes_3D.h
+++ b/applications/FluidDynamicsApplication/custom_elements/stokes_3D.h
@@ -104,7 +104,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~Stokes3D() {};
+    ~Stokes3D() override {};
 
 
     ///@}
@@ -116,7 +116,7 @@ public:
     ///@name Operations
     ///@{
 
-    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
     {
         KRATOS_TRY
         return boost::make_shared< Stokes3D >(NewId, GetGeometry().Create(ThisNodes), pProperties);
@@ -124,13 +124,13 @@ public:
     }
     Element::Pointer Create(IndexType NewId,
                            GeometryType::Pointer pGeom,
-                           PropertiesType::Pointer pProperties) const
+                           PropertiesType::Pointer pProperties) const override
     {
         return boost::make_shared< Stokes3D >(NewId, pGeom, pProperties);
     }
 
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -223,7 +223,7 @@ public:
     
     
     
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
         
@@ -302,7 +302,7 @@ public:
     
     
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -329,7 +329,7 @@ public:
     
     
 
-    void GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& rCurrentProcessInfo)
+    void GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -359,7 +359,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -408,9 +408,9 @@ public:
         KRATOS_CATCH("");
     }
     
-    virtual void Calculate(const Variable<double>& rVariable,
+    void Calculate(const Variable<double>& rVariable,
                            double& Output,
-                           const ProcessInfo& rCurrentProcessInfo)
+                           const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
         
@@ -495,14 +495,14 @@ public:
 
     /// Turn back information as a string.
 
-    virtual std::string Info() const
+    std::string Info() const override
     {
         return "Stokes3D #";
     }
 
     /// Print information about this object.
 
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info() << Id();
     }
@@ -638,7 +638,7 @@ protected:
     }
     
     
-    void Initialize()
+    void Initialize() override
     {
         KRATOS_TRY
 
@@ -682,12 +682,12 @@ private:
     ///@{
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }

--- a/applications/FluidDynamicsApplication/custom_elements/stokes_3D_twofluid.h
+++ b/applications/FluidDynamicsApplication/custom_elements/stokes_3D_twofluid.h
@@ -89,7 +89,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~Stokes3DTwoFluid() {};
+    ~Stokes3DTwoFluid() override {};
 
 
     ///@}
@@ -101,7 +101,7 @@ public:
     ///@name Operations
     ///@{
 
-    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
     {
         KRATOS_TRY
         return boost::make_shared< Stokes3DTwoFluid >(NewId, GetGeometry().Create(ThisNodes), pProperties);
@@ -110,13 +110,13 @@ public:
     
     Element::Pointer Create(IndexType NewId,
                            GeometryType::Pointer pGeom,
-                           PropertiesType::Pointer pProperties) const
+                           PropertiesType::Pointer pProperties) const override
     {
         return boost::make_shared< Stokes3DTwoFluid >(NewId, pGeom, pProperties);
     }
 
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -210,7 +210,7 @@ public:
 
 
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -235,7 +235,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -293,9 +293,9 @@ public:
         KRATOS_CATCH("");
     }
 
-    virtual void Calculate(const Variable<double>& rVariable,
+    void Calculate(const Variable<double>& rVariable,
                            double& Output,
-                           const ProcessInfo& rCurrentProcessInfo)
+                           const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -602,14 +602,14 @@ public:
 
     /// Turn back information as a string.
 
-    virtual std::string Info() const
+    std::string Info() const override
     {
         return "Stokes3DTwoFluid #";
     }
 
     /// Print information about this object.
 
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info() << Id();
     }
@@ -837,12 +837,12 @@ private:
 ///@{
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
@@ -171,7 +171,7 @@ public:
     {
     }
     /// Destructor.
-    virtual ~TwoFluidVMS()
+    ~TwoFluidVMS() override
     {
     }
     ///@}
@@ -189,13 +189,13 @@ public:
      * @return a Pointer to the new element
      */
     Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const
+                            PropertiesType::Pointer pProperties) const override
     {
         return boost::make_shared< TwoFluidVMS >(NewId, (this->GetGeometry()).Create(ThisNodes), pProperties);
     }
     Element::Pointer Create(IndexType NewId,
                            GeometryType::Pointer pGeom,
-                           PropertiesType::Pointer pProperties) const
+                           PropertiesType::Pointer pProperties) const override
     {
         return boost::make_shared< TwoFluidVMS >(NewId, pGeom, pProperties);
     }
@@ -209,8 +209,8 @@ public:
      * @param rCurrentProcessInfo ProcessInfo instance from the ModelPart. It is
      * expected to contain values for DYNAMIC_TAU and DELTA_TIME
      */
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo)
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                        ProcessInfo& rCurrentProcessInfo) override
     {
         const unsigned int local_size = (TDim+1)*(TDim+1);
         Matrix tmp(local_size,local_size);
@@ -225,7 +225,7 @@ public:
      * @param rMassMatrix Will be filled with the elemental mass matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_THROW_ERROR(std::logic_error,"MassMatrix function shall not be called when using this type of element","");
     }
@@ -235,9 +235,9 @@ public:
     /// this function is essentially identical to the one of the father element, to which it only
     /// adds a term in the momentum equation to allow imposing weakly the tangential component of the velocity
     /// on the cut elements
-        virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+        void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                           VectorType& rRightHandSideVector,
-                                          ProcessInfo& rCurrentProcessInfo)
+                                          ProcessInfo& rCurrentProcessInfo) override
     {
         const unsigned int LocalSize = (TDim + 1) * TNumNodes;
     
@@ -717,9 +717,9 @@ KRATOS_WATCH(Ngauss);  */
      * @param Output 
      * @param rCurrentProcessInfo 
      */
-    virtual void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
+    void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
                            array_1d<double, 3 > & rOutput,
-                           const ProcessInfo& rCurrentProcessInfo)
+                           const ProcessInfo& rCurrentProcessInfo) override
     {
 
     }
@@ -732,7 +732,7 @@ KRATOS_WATCH(Ngauss);  */
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
         // Perform basic element checks
@@ -812,14 +812,14 @@ KRATOS_WATCH(Ngauss);  */
     ///@name Input and output
     ///@{
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "TwoFluidVMS #" << this->Id();
         return buffer.str();
     }
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "TwoFluidVMS" << TDim << "D";
     }
@@ -912,9 +912,9 @@ protected:
      * @param rShapeFunc: The values of the form functions in the point
      * @param Step: The time Step (Defaults to 0 = Current)
      */
-    virtual void EvaluateInPoint(double& rResult,
+    void EvaluateInPoint(double& rResult,
                                  const Variable< double >& rVariable,
-                                 const array_1d< double, TNumNodes >& rShapeFunc)
+                                 const array_1d< double, TNumNodes >& rShapeFunc) override
     {
         //compute sign of distance on gauss point
         double dist = 0.0;
@@ -967,9 +967,9 @@ protected:
      * @param rVariable: The nodal variable to be read
      * @param rShapeFunc: The values of the form functions in the point
      */
-    virtual void EvaluateInPoint(array_1d< double, 3 > & rResult,
+    void EvaluateInPoint(array_1d< double, 3 > & rResult,
                                  const Variable< array_1d< double, 3 > >& rVariable,
-                                 const array_1d< double, TNumNodes >& rShapeFunc)
+                                 const array_1d< double, TNumNodes >& rShapeFunc) override
     {
         //compute sign of distance on gauss point
         double dist = 0.0;
@@ -1111,11 +1111,11 @@ private:
     ///@name Serialization
     ///@{
     friend class Serializer;
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, ElementBaseType);
     }
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, ElementBaseType);
     }

--- a/applications/FluidDynamicsApplication/custom_elements/vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/vms.h
@@ -189,7 +189,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~VMS()
+    ~VMS() override
     {}
 
 
@@ -211,14 +211,14 @@ public:
      * @return a Pointer to the new element
      */
     Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const
+                            PropertiesType::Pointer pProperties) const override
     {
 	return boost::make_shared< VMS<TDim, TNumNodes> >(NewId, GetGeometry().Create(ThisNodes), pProperties);
     }
     
     Element::Pointer Create(IndexType NewId,
                            GeometryType::Pointer pGeom,
-                           PropertiesType::Pointer pProperties) const
+                           PropertiesType::Pointer pProperties) const override
     {
         return boost::make_shared< VMS<TDim, TNumNodes> >(NewId, pGeom, pProperties);
     }
@@ -233,9 +233,9 @@ public:
      * @param rRightHandSideVector: the elemental right hand side
      * @param rCurrentProcessInfo: the current process info
      */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo)
+                                      ProcessInfo& rCurrentProcessInfo) override
     {
         const unsigned int LocalSize = (TDim + 1) * TNumNodes;
 
@@ -254,8 +254,8 @@ public:
      * @param rLeftHandSideMatrix Local matrix, will be filled with zeros
      * @param rCurrentProcessInfo Process info instance
      */
-    virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                       ProcessInfo& rCurrentProcessInfo)
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                                       ProcessInfo& rCurrentProcessInfo) override
     {
         const unsigned int LocalSize = (TDim + 1) * TNumNodes;
 
@@ -275,8 +275,8 @@ public:
      * @param rCurrentProcessInfo ProcessInfo instance from the ModelPart. It is
      * expected to contain values for OSS_SWITCH, DYNAMIC_TAU and DELTA_TIME
      */
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo)
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                        ProcessInfo& rCurrentProcessInfo) override
     {
         const unsigned int LocalSize = (TDim + 1) * TNumNodes;
 
@@ -324,7 +324,7 @@ public:
      * @param rMassMatrix Will be filled with the elemental mass matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override
     {
         const unsigned int LocalSize = (TDim + 1) * TNumNodes;
 
@@ -379,9 +379,9 @@ public:
      * @param rRightHandSideVector the elemental right hand side vector
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
+    void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
             VectorType& rRightHandSideVector,
-            ProcessInfo& rCurrentProcessInfo)
+            ProcessInfo& rCurrentProcessInfo) override
     {
         const unsigned int LocalSize = (TDim + 1) * TNumNodes;
 
@@ -434,7 +434,7 @@ public:
         noalias(rRightHandSideVector) -= prod(rDampingMatrix, U);
     }
 
-    virtual void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
+    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override
     {
     }
 
@@ -451,9 +451,9 @@ public:
      * @param rCurrentProcessInfo Process info instance (will be checked for OSS_SWITCH)
      * @see MarkForRefinement for a use of the error ratio
      */
-    virtual void Calculate(const Variable<double>& rVariable,
+    void Calculate(const Variable<double>& rVariable,
                            double& rOutput,
-                           const ProcessInfo& rCurrentProcessInfo)
+                           const ProcessInfo& rCurrentProcessInfo) override
     {
         if (rVariable == ERROR_RATIO)
         {
@@ -490,9 +490,9 @@ public:
      * @param Output Will be overwritten with the elemental momentum error
      * @param rCurrentProcessInfo Process info instance (unused)
      */
-    virtual void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
+    void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
                            array_1d<double, 3 > & rOutput,
-                           const ProcessInfo& rCurrentProcessInfo)
+                           const ProcessInfo& rCurrentProcessInfo) override
     {
         if (rVariable == ADVPROJ) // Compute residual projections for OSS
         {
@@ -607,30 +607,30 @@ public:
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo the current process info object (unused)
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult,
-                                  ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult,
+                                  ProcessInfo& rCurrentProcessInfo) override;
 
     /// Returns a list of the element's Dofs
     /**
      * @param ElementalDofList the list of DOFs
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void GetDofList(DofsVectorType& rElementalDofList,
-                            ProcessInfo& rCurrentProcessInfo);
+    void GetDofList(DofsVectorType& rElementalDofList,
+                            ProcessInfo& rCurrentProcessInfo) override;
 
     /// Returns VELOCITY_X, VELOCITY_Y, (VELOCITY_Z,) PRESSURE for each node
     /**
      * @param Values Vector of nodal unknowns
      * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
      */
-    virtual void GetFirstDerivativesVector(Vector& Values, int Step = 0);
+    void GetFirstDerivativesVector(Vector& Values, int Step = 0) override;
 
     /// Returns ACCELERATION_X, ACCELERATION_Y, (ACCELERATION_Z,) 0 for each node
     /**
      * @param Values Vector of nodal second derivatives
      * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
      */
-    virtual void GetSecondDerivativesVector(Vector& Values, int Step = 0);
+    void GetSecondDerivativesVector(Vector& Values, int Step = 0) override;
 
     /// Obtain an array_1d<double,3> elemental variable, evaluated on gauss points.
     /**
@@ -642,9 +642,9 @@ public:
      * @param Output Will be filled with the values of the variable on integrartion points
      * @param rCurrentProcessInfo Process info instance
      */
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
             std::vector<array_1d<double, 3 > >& rOutput,
-            const ProcessInfo& rCurrentProcessInfo);
+            const ProcessInfo& rCurrentProcessInfo) override;
 
     /// Obtain a double elemental variable, evaluated on gauss points.
     /**
@@ -658,9 +658,9 @@ public:
      * @param Output Will be filled with the values of the variable on integrartion points
      * @param rCurrentProcessInfo Process info instance
      */
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
-            const ProcessInfo& rCurrentProcessInfo)
+            const ProcessInfo& rCurrentProcessInfo) override
     {
         if (rVariable == TAUONE || rVariable == TAUTWO || rVariable == MU || rVariable == TAU)
         {
@@ -793,21 +793,21 @@ public:
     }
 
     /// Empty implementation of unused CalculateOnIntegrationPoints overloads to avoid compilation warning
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
             std::vector<array_1d<double, 6 > >& rValues,
-            const ProcessInfo& rCurrentProcessInfo)
+            const ProcessInfo& rCurrentProcessInfo) override
     {}
 
     /// Empty implementation of unused CalculateOnIntegrationPoints overloads to avoid compilation warning
-    virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
             std::vector<Vector>& rValues,
-            const ProcessInfo& rCurrentProcessInfo)
+            const ProcessInfo& rCurrentProcessInfo) override
     {}
 
     /// Empty implementation of unused CalculateOnIntegrationPoints overloads to avoid compilation warning
-    virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
             std::vector<Matrix>& rValues,
-            const ProcessInfo& rCurrentProcessInfo)
+            const ProcessInfo& rCurrentProcessInfo) override
     {}
 
     ///@}
@@ -827,7 +827,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo)
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -914,7 +914,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "VMS #" << Id();
@@ -922,7 +922,7 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "VMS" << TDim << "D";
     }
@@ -1826,12 +1826,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element );
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }

--- a/applications/FluidDynamicsApplication/custom_processes/Boundary_Windkessel_model.h
+++ b/applications/FluidDynamicsApplication/custom_processes/Boundary_Windkessel_model.h
@@ -86,7 +86,7 @@ public:
 
     /// Destructor.
 
-    virtual ~WindkesselModel()
+    ~WindkesselModel() override
     {
     }
 
@@ -101,7 +101,7 @@ public:
     ///@{
 
     /// Solve an iteration of the turbulent viscosity
-    void Execute()
+    void Execute() override
     {
         KRATOS_TRY
         double Flow_total=0.0;
@@ -175,7 +175,7 @@ public:
 
     /// Turn back information as a string.
 
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "WindkesselModel";
@@ -184,14 +184,14 @@ public:
 
     /// Print information about this object.
 
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "WindkesselModel";
     }
 
     /// Print object's data.
 
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/applications/FluidDynamicsApplication/custom_processes/boussinesq_force_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/boussinesq_force_process.h
@@ -86,7 +86,7 @@ namespace Kratos
       BoussinesqForceProcess(ModelPart::Pointer pModelPart, Parameters& rParameters);
 
       /// Destructor.
-      virtual ~BoussinesqForceProcess() override;
+      ~BoussinesqForceProcess() override;
 
 
       ///@}
@@ -98,11 +98,11 @@ namespace Kratos
       ///@name Operations
       ///@{
 
-      virtual void Execute() override;
+      void Execute() override;
 
-      virtual void ExecuteInitialize() override;
+      void ExecuteInitialize() override;
 
-      virtual void ExecuteInitializeSolutionStep() override;
+      void ExecuteInitializeSolutionStep() override;
 
       ///@}
       ///@name Access
@@ -119,13 +119,13 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override;
+      void PrintInfo(std::ostream& rOStream) const override;
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override;
+      void PrintData(std::ostream& rOStream) const override;
 
 
       ///@}

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -81,7 +81,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~DistanceModificationProcess(){}
+    ~DistanceModificationProcess() override{}
 
     ///@}
     ///@name Operators
@@ -155,7 +155,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "DistanceModificationProcess" ;
@@ -163,10 +163,10 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override {rOStream << "DistanceModificationProcess";}
+    void PrintInfo(std::ostream& rOStream) const override {rOStream << "DistanceModificationProcess";}
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_nodes_initialization_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_nodes_initialization_process.h
@@ -79,7 +79,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~EmbeddedNodesInitializationProcess(){}
+    ~EmbeddedNodesInitializationProcess() override{}
 
     ///@}
     ///@name Operators
@@ -201,7 +201,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "EmbeddedNodesInitializationProcess" ;
@@ -209,10 +209,10 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override {rOStream << "EmbeddedNodesInitializationProcess";}
+    void PrintInfo(std::ostream& rOStream) const override {rOStream << "EmbeddedNodesInitializationProcess";}
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_postprocess_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_postprocess_process.h
@@ -75,7 +75,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~EmbeddedPostprocessProcess(){}
+    ~EmbeddedPostprocessProcess() override{}
 
     ///@}
     ///@name Operators
@@ -137,7 +137,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "EmbeddedPostprocessProcess" ;
@@ -145,10 +145,10 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override {rOStream << "EmbeddedPostprocessProcess";}
+    void PrintInfo(std::ostream& rOStream) const override {rOStream << "EmbeddedPostprocessProcess";}
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_processes/move_rotor_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/move_rotor_process.h
@@ -91,7 +91,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~MoveRotorProcess(){}
+    ~MoveRotorProcess() override{}
 
 
     void ExecuteBeforeSolutionLoop() override
@@ -165,7 +165,7 @@ public:
     }
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "MoveRotorProcess" ;
@@ -173,10 +173,10 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override {rOStream << "MoveRotorProcess";}
+    void PrintInfo(std::ostream& rOStream) const override {rOStream << "MoveRotorProcess";}
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
 protected:

--- a/applications/FluidDynamicsApplication/custom_processes/spalart_allmaras_turbulence_model.h
+++ b/applications/FluidDynamicsApplication/custom_processes/spalart_allmaras_turbulence_model.h
@@ -176,7 +176,7 @@ public:
 
     /// Destructor.
 
-    virtual ~SpalartAllmarasTurbulenceModel()
+    ~SpalartAllmarasTurbulenceModel() override
     {
     }
 
@@ -191,7 +191,7 @@ public:
     ///@{
 
     /// Solve an iteration of the turbulent viscosity
-    void Execute()
+    void Execute() override
     {
         KRATOS_TRY
 
@@ -311,7 +311,7 @@ public:
 
     /// Turn back information as a string.
 
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "SpalartAllmarasTurbulenceModel";
@@ -320,14 +320,14 @@ public:
 
     /// Print information about this object.
 
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "SpalartAllmarasTurbulenceModel";
     }
 
     /// Print object's data.
 
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/applications/FluidDynamicsApplication/custom_processes/stokes_initialization_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/stokes_initialization_process.h
@@ -139,7 +139,7 @@ public:
 
     /// Destructor.
 
-    virtual ~StokesInitializationProcess()
+    ~StokesInitializationProcess() override
     {
        // mpSolutionStrategy->Clear();
     }
@@ -155,7 +155,7 @@ public:
     ///@{
 
     /// Solve a stationary Stokes problem
-    virtual void Execute()
+    void Execute() override
     {
         KRATOS_TRY;
 
@@ -196,7 +196,7 @@ public:
 
     /// Turn back information as a string.
 
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << " StokesInitializationProcess";
@@ -205,14 +205,14 @@ public:
 
     /// Print information about this object.
 
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << " StokesInitializationProcess";
     }
 
     /// Print object's data.
 
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/applications/FluidDynamicsApplication/custom_strategies/builder_and_solvers/residualbased_block_builder_and_solver_periodic.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/builder_and_solvers/residualbased_block_builder_and_solver_periodic.h
@@ -114,7 +114,7 @@ public:
 
     /** Destructor.
      */
-    virtual ~ResidualBasedBlockBuilderAndSolverPeriodic()
+    ~ResidualBasedBlockBuilderAndSolverPeriodic() override
     {
     }
 
@@ -129,7 +129,7 @@ public:
     /*@{ */
 
 
-    virtual void SetUpSystem(ModelPart &r_model_part)
+    void SetUpSystem(ModelPart &r_model_part) override
     {
         // Assign an Equation Id to all non-duplicate nodes
         unsigned int EqId = 0;
@@ -167,11 +167,11 @@ public:
         BaseType::mEquationSystemSize = EqId;
     }
 
-    virtual void ApplyDirichletConditions(typename TSchemeType::Pointer pScheme,
+    void ApplyDirichletConditions(typename TSchemeType::Pointer pScheme,
                                           ModelPart &r_model_part,
                                           TSystemMatrixType &A,
                                           TSystemVectorType &Dx,
-                                          TSystemVectorType &b)
+                                          TSystemVectorType &b) override
     {
         double* Avalues = A.value_data().begin();
         std::size_t* Arow_indices = A.index1_data().begin();

--- a/applications/FluidDynamicsApplication/custom_strategies/convergence_criteria/vel_pr_criteria.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/convergence_criteria/vel_pr_criteria.h
@@ -86,7 +86,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~VelPrCriteria() {}
+    ~VelPrCriteria() override {}
 
     ///@}
     ///@name Operators
@@ -105,7 +105,7 @@ public:
                         DofsArrayType& rDofSet,
                         const TSystemMatrixType& A,
                         const TSystemVectorType& Dx,
-                        const TSystemVectorType& b )
+                        const TSystemVectorType& b ) override
     {
         if (SparseSpaceType::Size(Dx) != 0) //if we are solving for something
         {
@@ -200,7 +200,7 @@ public:
     /**
      * @param rModelPart Reference to the ModelPart containing the fluid problem. (unused)
      */
-    void Initialize( ModelPart& rModelPart	)
+    void Initialize( ModelPart& rModelPart	) override
     {
         BaseType::mConvergenceCriteriaIsInitialized = true;
     }
@@ -209,14 +209,14 @@ public:
                                     DofsArrayType& rDofSet,
                                     const TSystemMatrixType& A,
                                     const TSystemVectorType& Dx,
-                                    const TSystemVectorType& b )
+                                    const TSystemVectorType& b ) override
     {}
 
     void FinalizeSolutionStep(  ModelPart& rModelPart,
                                 DofsArrayType& rDofSet,
                                 const TSystemMatrixType& A,
                                 const TSystemVectorType& Dx,
-                                const TSystemVectorType& b )
+                                const TSystemVectorType& b ) override
     {}
 
     ///@} // Operations

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
@@ -216,7 +216,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~FSStrategy(){}
+    ~FSStrategy() override{}
 
     ///@}
     ///@name Operators
@@ -227,7 +227,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual int Check()
+    int Check() override
     {
         KRATOS_TRY;
 
@@ -266,7 +266,7 @@ public:
         KRATOS_CATCH("");
     }
 
-    virtual double Solve()
+    double Solve() override
     {
         // Initialize BDF2 coefficients
         ModelPart& rModelPart = BaseType::GetModelPart();
@@ -386,7 +386,7 @@ public:
         mExtraIterationSteps.clear();
     }
 
-    virtual void Clear()
+    void Clear() override
     {
         mpMomentumStrategy->Clear();
         mpPressureStrategy->Clear();
@@ -397,7 +397,7 @@ public:
     ///@name Access
     ///@{
 
-    virtual void SetEchoLevel(int Level)
+    void SetEchoLevel(int Level) override
     {
         BaseType::SetEchoLevel(Level);
         int StrategyLevel = Level > 0 ? Level - 1 : 0;

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/gear_scheme.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/gear_scheme.h
@@ -109,7 +109,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~GearScheme()
+    ~GearScheme() override
     {}
 
     ///@}
@@ -126,7 +126,7 @@ public:
      * @param rModelPart The fluid's ModelPart
      * @return 0 if no errors were found
      */
-    virtual int Check(ModelPart& rModelPart)
+    int Check(ModelPart& rModelPart) override
     {
         KRATOS_TRY
 
@@ -169,10 +169,10 @@ public:
     }
 
     /// Set the time iteration coefficients
-    virtual void InitializeSolutionStep(ModelPart& rModelPart,
+    void InitializeSolutionStep(ModelPart& rModelPart,
                                         TSystemMatrixType& A,
                                         TSystemVectorType& Dx,
-                                        TSystemVectorType& b)
+                                        TSystemVectorType& b) override
     {
         this->SetTimeCoefficients(rModelPart.GetProcessInfo());
 
@@ -210,10 +210,10 @@ public:
         }
     }
 
-    virtual void InitializeNonLinIteration(ModelPart& rModelPart,
+    void InitializeNonLinIteration(ModelPart& rModelPart,
                                            TSystemMatrixType& A,
                                            TSystemVectorType& Dx,
-                                           TSystemVectorType& b)
+                                           TSystemVectorType& b) override
     {
         KRATOS_TRY
 
@@ -222,10 +222,10 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void FinalizeNonLinIteration(ModelPart &rModelPart,
+    void FinalizeNonLinIteration(ModelPart &rModelPart,
                                          TSystemMatrixType &A,
                                          TSystemVectorType &Dx,
-                                         TSystemVectorType &b)
+                                         TSystemVectorType &b) override
     {
         const ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
 
@@ -239,11 +239,11 @@ public:
     }
 
     /// Start the iteration by providing a first approximation to the solution.
-    virtual void Predict(ModelPart& rModelPart,
+    void Predict(ModelPart& rModelPart,
                          DofsArrayType& rDofSet,
                          TSystemMatrixType& A,
                          TSystemVectorType& Dx,
-                         TSystemVectorType& b)
+                         TSystemVectorType& b) override
     {
         KRATOS_TRY
 
@@ -292,11 +292,11 @@ public:
      * @param Dx Newton-Raphson iteration solution
      * @param b Newton-Raphson right hand side (unused)
      */
-    virtual void Update(ModelPart& rModelPart,
+    void Update(ModelPart& rModelPart,
                         DofsArrayType& rDofSet,
                         TSystemMatrixType& A,
                         TSystemVectorType& Dx,
-                        TSystemVectorType& b)
+                        TSystemVectorType& b) override
     {
         KRATOS_TRY
 
@@ -309,11 +309,11 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void CalculateSystemContributions(Element::Pointer rCurrentElement,
+    void CalculateSystemContributions(Element::Pointer rCurrentElement,
             LocalSystemMatrixType& LHS_Contribution,
             LocalSystemVectorType& RHS_Contribution,
             Element::EquationIdVectorType& rEquationId,
-            ProcessInfo& rCurrentProcessInfo)
+            ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -342,7 +342,7 @@ public:
     void Calculate_RHS_Contribution(Element::Pointer rCurrentElement,
                                     LocalSystemVectorType& RHS_Contribution,
                                     Element::EquationIdVectorType& rEquationId,
-                                    ProcessInfo& rCurrentProcessInfo)
+                                    ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -366,11 +366,11 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void Condition_CalculateSystemContributions(Condition::Pointer rCurrentCondition,
+    void Condition_CalculateSystemContributions(Condition::Pointer rCurrentCondition,
             LocalSystemMatrixType& LHS_Contribution,
             LocalSystemVectorType& RHS_Contribution,
             Element::EquationIdVectorType& rEquationId,
-            ProcessInfo& rCurrentProcessInfo)
+            ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -396,10 +396,10 @@ public:
     }
 
 
-    virtual void Condition_Calculate_RHS_Contribution(Condition::Pointer rCurrentCondition,
+    void Condition_Calculate_RHS_Contribution(Condition::Pointer rCurrentCondition,
             LocalSystemVectorType& RHS_Contribution,
             Element::EquationIdVectorType& rEquationId,
-            ProcessInfo& rCurrentProcessInfo)
+            ProcessInfo& rCurrentProcessInfo) override
     {
         KRATOS_TRY
 

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/residualbased_predictorcorrector_velocity_bdf_scheme_turbulent.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/residualbased_predictorcorrector_velocity_bdf_scheme_turbulent.h
@@ -141,7 +141,7 @@ namespace Kratos {
 
         /** Destructor.
          */
-        virtual ~ResidualBasedPredictorCorrectorBDFSchemeTurbulent() {
+        ~ResidualBasedPredictorCorrectorBDFSchemeTurbulent() override {
         }
 
 
@@ -155,11 +155,11 @@ namespace Kratos {
          */
         //***************************************************************************
 
-        virtual void Update(ModelPart& r_model_part,
+        void Update(ModelPart& r_model_part,
                             DofsArrayType& rDofSet,
                             TSystemMatrixType& A,
                             TSystemVectorType& Dv,
-                            TSystemVectorType& b)
+                            TSystemVectorType& b) override
         {
             KRATOS_TRY;
 
@@ -210,11 +210,11 @@ namespace Kratos {
         //***************************************************************************
         //predicts the solution at the current step as
         // v = vold
-        virtual void Predict(ModelPart& rModelPart,
+        void Predict(ModelPart& rModelPart,
                              DofsArrayType& rDofSet,
                              TSystemMatrixType& A,
                              TSystemVectorType& Dv,
-                             TSystemVectorType& b)
+                             TSystemVectorType& b) override
         {
             ProcessInfo& rCurrentProcessInfo = rModelPart.GetProcessInfo();
             double Dt = rCurrentProcessInfo[DELTA_TIME];
@@ -283,7 +283,7 @@ namespace Kratos {
                                           LocalSystemMatrixType& LHS_Contribution,
                                           LocalSystemVectorType& RHS_Contribution,
                                           Element::EquationIdVectorType& EquationId,
-                                          ProcessInfo& CurrentProcessInfo)
+                                          ProcessInfo& CurrentProcessInfo) override
         {
             KRATOS_TRY
 
@@ -306,7 +306,7 @@ namespace Kratos {
         void Calculate_RHS_Contribution(Element::Pointer rCurrentElement,
                                         LocalSystemVectorType& RHS_Contribution,
                                         Element::EquationIdVectorType& EquationId,
-                                        ProcessInfo& CurrentProcessInfo)
+                                        ProcessInfo& CurrentProcessInfo) override
         {
             //Initializing the non linear iteration for the current element
             (rCurrentElement) -> InitializeNonLinearIteration(CurrentProcessInfo);
@@ -326,11 +326,11 @@ namespace Kratos {
         /** functions totally analogous to the precedent but applied to
         the "condition" objects
          */
-        virtual void Condition_CalculateSystemContributions(Condition::Pointer rCurrentCondition,
+        void Condition_CalculateSystemContributions(Condition::Pointer rCurrentCondition,
                                                             LocalSystemMatrixType& LHS_Contribution,
                                                             LocalSystemVectorType& RHS_Contribution,
                                                             Element::EquationIdVectorType& EquationId,
-                                                            ProcessInfo& CurrentProcessInfo)
+                                                            ProcessInfo& CurrentProcessInfo) override
         {
             KRATOS_TRY
 
@@ -347,10 +347,10 @@ namespace Kratos {
             KRATOS_CATCH("")
         }
 
-        virtual void Condition_Calculate_RHS_Contribution(Condition::Pointer rCurrentCondition,
+        void Condition_Calculate_RHS_Contribution(Condition::Pointer rCurrentCondition,
                                                           LocalSystemVectorType& RHS_Contribution,
                                                           Element::EquationIdVectorType& EquationId,
-                                                          ProcessInfo& rCurrentProcessInfo)
+                                                          ProcessInfo& rCurrentProcessInfo) override
         {
             KRATOS_TRY;
 
@@ -375,7 +375,7 @@ namespace Kratos {
         void InitializeSolutionStep(ModelPart& r_model_part,
                                     TSystemMatrixType& A,
                                     TSystemVectorType& Dx,
-                                    TSystemVectorType& b)
+                                    TSystemVectorType& b) override
         {
             ProcessInfo& rCurrentProcessInfo = r_model_part.GetProcessInfo();
 
@@ -409,10 +409,10 @@ namespace Kratos {
         //*************************************************************************************
         //*************************************************************************************
 
-        virtual void InitializeNonLinIteration(ModelPart& r_model_part,
+        void InitializeNonLinIteration(ModelPart& r_model_part,
                                                TSystemMatrixType& A,
                                                TSystemVectorType& Dx,
-                                               TSystemVectorType& b)
+                                               TSystemVectorType& b) override
         {
             KRATOS_TRY
 
@@ -422,7 +422,7 @@ namespace Kratos {
             KRATOS_CATCH("")
         }
 
-        virtual void FinalizeNonLinIteration(ModelPart &rModelPart, TSystemMatrixType &A, TSystemVectorType &Dx, TSystemVectorType &b)
+        void FinalizeNonLinIteration(ModelPart &rModelPart, TSystemMatrixType &A, TSystemVectorType &Dx, TSystemVectorType &b) override
         {
             ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
 
@@ -469,7 +469,7 @@ namespace Kratos {
             }
         }
 
-        void FinalizeSolutionStep(ModelPart &rModelPart, TSystemMatrixType &A, TSystemVectorType &Dx, TSystemVectorType &b)
+        void FinalizeSolutionStep(ModelPart &rModelPart, TSystemMatrixType &A, TSystemVectorType &Dx, TSystemVectorType &b) override
         {
 			ComputeReactions(rModelPart, A, Dx, b);
             //Element::EquationIdVectorType EquationId;

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/residualbased_predictorcorrector_velocity_bdf_scheme_turbulent_no_reaction.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/residualbased_predictorcorrector_velocity_bdf_scheme_turbulent_no_reaction.h
@@ -128,7 +128,7 @@ namespace Kratos {
 		//************************************************************************************************
 		//************************************************************************************************
 
-		void ComputeReactions(ModelPart &rModelPart, TSystemMatrixType &A, TSystemVectorType &Dx, TSystemVectorType &b)
+		void ComputeReactions(ModelPart &rModelPart, TSystemMatrixType &A, TSystemVectorType &Dx, TSystemVectorType &b) override
 		{}
 		/*@} */
 		/**@name Operations */

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/residualbased_predictorcorrector_velocity_bossak_scheme_turbulent.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/residualbased_predictorcorrector_velocity_bossak_scheme_turbulent.h
@@ -225,7 +225,7 @@ namespace Kratos {
 
         /** Destructor.
          */
-        virtual ~ResidualBasedPredictorCorrectorVelocityBossakSchemeTurbulent() {
+        ~ResidualBasedPredictorCorrectorVelocityBossakSchemeTurbulent() override {
         }
 
 
@@ -239,11 +239,11 @@ namespace Kratos {
          */
         //***************************************************************************
 
-        virtual void Update(ModelPart& r_model_part,
+        void Update(ModelPart& r_model_part,
                             DofsArrayType& rDofSet,
                             TSystemMatrixType& A,
                             TSystemVectorType& Dv,
-                            TSystemVectorType& b)
+                            TSystemVectorType& b) override
         {
             KRATOS_TRY;
 
@@ -342,11 +342,11 @@ namespace Kratos {
         //***************************************************************************
         //predicts the solution at the current step as
         // v = vold
-        virtual void Predict(ModelPart& rModelPart,
+        void Predict(ModelPart& rModelPart,
                              DofsArrayType& rDofSet,
                              TSystemMatrixType& A,
                              TSystemVectorType& Dv,
-                             TSystemVectorType& b)
+                             TSystemVectorType& b) override
         {
             // if (rModelPart.GetCommunicator().MyPID() == 0)
             //     std::cout << "prediction" << std::endl;
@@ -427,7 +427,7 @@ namespace Kratos {
                                           LocalSystemMatrixType& LHS_Contribution,
                                           LocalSystemVectorType& RHS_Contribution,
                                           Element::EquationIdVectorType& EquationId,
-                                          ProcessInfo& CurrentProcessInfo)
+                                          ProcessInfo& CurrentProcessInfo) override
         {
             KRATOS_TRY
             int k = OpenMPUtils::ThisThread();
@@ -459,7 +459,7 @@ namespace Kratos {
         void Calculate_RHS_Contribution(Element::Pointer rCurrentElement,
                                         LocalSystemVectorType& RHS_Contribution,
                                         Element::EquationIdVectorType& EquationId,
-                                        ProcessInfo& CurrentProcessInfo)
+                                        ProcessInfo& CurrentProcessInfo) override
         {
             int k = OpenMPUtils::ThisThread();
 
@@ -486,11 +486,11 @@ namespace Kratos {
         /** functions totally analogous to the precedent but applied to
         the "condition" objects
          */
-        virtual void Condition_CalculateSystemContributions(Condition::Pointer rCurrentCondition,
+        void Condition_CalculateSystemContributions(Condition::Pointer rCurrentCondition,
                                                             LocalSystemMatrixType& LHS_Contribution,
                                                             LocalSystemVectorType& RHS_Contribution,
                                                             Element::EquationIdVectorType& EquationId,
-                                                            ProcessInfo& CurrentProcessInfo)
+                                                            ProcessInfo& CurrentProcessInfo) override
         {
             KRATOS_TRY
             int k = OpenMPUtils::ThisThread();
@@ -515,10 +515,10 @@ namespace Kratos {
             KRATOS_CATCH("")
         }
 
-        virtual void Condition_Calculate_RHS_Contribution(Condition::Pointer rCurrentCondition,
+        void Condition_Calculate_RHS_Contribution(Condition::Pointer rCurrentCondition,
                                                           LocalSystemVectorType& RHS_Contribution,
                                                           Element::EquationIdVectorType& EquationId,
-                                                          ProcessInfo& rCurrentProcessInfo)
+                                                          ProcessInfo& rCurrentProcessInfo) override
         {
             KRATOS_TRY;
 
@@ -549,10 +549,10 @@ namespace Kratos {
         //*************************************************************************************
         //*************************************************************************************
 
-        virtual void InitializeSolutionStep(ModelPart& r_model_part,
+        void InitializeSolutionStep(ModelPart& r_model_part,
                                             TSystemMatrixType& A,
                                             TSystemVectorType& Dx,
-                                            TSystemVectorType& b)
+                                            TSystemVectorType& b) override
         {
             ProcessInfo& CurrentProcessInfo = r_model_part.GetProcessInfo();
 
@@ -575,10 +575,10 @@ namespace Kratos {
         //*************************************************************************************
         //*************************************************************************************
 
-        virtual void InitializeNonLinIteration(ModelPart& r_model_part,
+        void InitializeNonLinIteration(ModelPart& r_model_part,
                                                TSystemMatrixType& A,
                                                TSystemVectorType& Dx,
-                                               TSystemVectorType& b)
+                                               TSystemVectorType& b) override
         {
             KRATOS_TRY
 
@@ -588,7 +588,7 @@ namespace Kratos {
             KRATOS_CATCH("")
         }
 
-        virtual void FinalizeNonLinIteration(ModelPart &rModelPart, TSystemMatrixType &A, TSystemVectorType &Dx, TSystemVectorType &b)
+        void FinalizeNonLinIteration(ModelPart &rModelPart, TSystemMatrixType &A, TSystemVectorType &Dx, TSystemVectorType &b) override
         {
             ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
 
@@ -649,7 +649,7 @@ namespace Kratos {
             }
         }
 
-        void FinalizeSolutionStep(ModelPart &rModelPart, TSystemMatrixType &A, TSystemVectorType &Dx, TSystemVectorType &b)
+        void FinalizeSolutionStep(ModelPart &rModelPart, TSystemMatrixType &A, TSystemVectorType &Dx, TSystemVectorType &b) override
         {
             Element::EquationIdVectorType EquationId;
             LocalSystemVectorType RHS_Contribution;

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/residualbased_simple_steady_scheme.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/residualbased_simple_steady_scheme.h
@@ -78,7 +78,7 @@ public:
 
   {}
 
-  virtual ~ResidualBasedSimpleSteadyScheme() {}
+  ~ResidualBasedSimpleSteadyScheme() override {}
 
 
   ///@}
@@ -104,11 +104,11 @@ public:
     mPressureRelaxationFactor = factor;
   }
 
-  virtual void Update(ModelPart& rModelPart,
+  void Update(ModelPart& rModelPart,
                       DofsArrayType& rDofSet,
                       TSystemMatrixType& rA,
                       TSystemVectorType& rDx,
-                      TSystemVectorType& rb)
+                      TSystemVectorType& rb) override
   {
     KRATOS_TRY;
 
@@ -137,12 +137,12 @@ public:
     KRATOS_CATCH("");
   }
 
-  virtual void CalculateSystemContributions(
+  void CalculateSystemContributions(
       Element::Pointer rCurrentElement,
       LocalSystemMatrixType& LHS_Contribution,
       LocalSystemVectorType& RHS_Contribution,
       Element::EquationIdVectorType& EquationId,
-      ProcessInfo& CurrentProcessInfo)
+      ProcessInfo& CurrentProcessInfo) override
   {
     KRATOS_TRY;
 
@@ -166,12 +166,12 @@ public:
     KRATOS_CATCH("");
   }
 
-  virtual void Condition_CalculateSystemContributions(
+  void Condition_CalculateSystemContributions(
       Condition::Pointer rCurrentCondition,
       LocalSystemMatrixType& LHS_Contribution,
       LocalSystemVectorType& RHS_Contribution,
       Condition::EquationIdVectorType& EquationId,
-      ProcessInfo& CurrentProcessInfo)
+      ProcessInfo& CurrentProcessInfo) override
   {
     KRATOS_TRY;
 
@@ -195,11 +195,11 @@ public:
     KRATOS_CATCH("");
   }
 
-  virtual void Calculate_RHS_Contribution(
+  void Calculate_RHS_Contribution(
       Element::Pointer rCurrentElement,
       LocalSystemVectorType& rRHS_Contribution,
       Element::EquationIdVectorType& rEquationId,
-      ProcessInfo& rCurrentProcessInfo)
+      ProcessInfo& rCurrentProcessInfo) override
   {
     KRATOS_TRY;
 
@@ -210,11 +210,11 @@ public:
     KRATOS_CATCH("");
   }
 
-  virtual void Condition_Calculate_RHS_Contribution(
+  void Condition_Calculate_RHS_Contribution(
       Condition::Pointer rCurrentCondition,
       LocalSystemVectorType& rRHS_Contribution,
       Element::EquationIdVectorType& rEquationId,
-      ProcessInfo& rCurrentProcessInfo)
+      ProcessInfo& rCurrentProcessInfo) override
   {
     KRATOS_TRY;
 
@@ -226,10 +226,10 @@ public:
     KRATOS_CATCH("");
   }
 
-  virtual void InitializeNonLinIteration(ModelPart& rModelPart,
+  void InitializeNonLinIteration(ModelPart& rModelPart,
                                          TSystemMatrixType& rA,
                                          TSystemVectorType& rDx,
-                                         TSystemVectorType& rb)
+                                         TSystemVectorType& rb) override
   {
     KRATOS_TRY;
 
@@ -251,10 +251,10 @@ public:
     KRATOS_CATCH("");
   }
 
-  virtual void FinalizeNonLinIteration(ModelPart &rModelPart,
+  void FinalizeNonLinIteration(ModelPart &rModelPart,
                                        TSystemMatrixType &rA,
                                        TSystemVectorType &rDx,
-                                       TSystemVectorType &rb)
+                                       TSystemVectorType &rb) override
   {
     ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
 
@@ -297,7 +297,7 @@ public:
   void FinalizeSolutionStep(ModelPart &rModelPart,
                             TSystemMatrixType &rA,
                             TSystemVectorType &rDx,
-                            TSystemVectorType &rb)
+                            TSystemVectorType &rb) override
   {
     LocalSystemVectorType RHS_Contribution;
     LocalSystemMatrixType LHS_Contribution;

--- a/applications/FluidDynamicsApplication/custom_utilities/fractional_step_settings.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fractional_step_settings.h
@@ -88,7 +88,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~FractionalStepSettings(){}
+    ~FractionalStepSettings() override{}
 
     ///@}
     ///@name Operators
@@ -103,10 +103,10 @@ public:
     ///@name Access
     ///@{
 
-    virtual void SetStrategy(StrategyLabel const& rStrategyLabel,
+    void SetStrategy(StrategyLabel const& rStrategyLabel,
                              typename TLinearSolver::Pointer pLinearSolver,
                              const double Tolerance,
-                             const unsigned int MaxIter)
+                             const unsigned int MaxIter) override
     {
         KRATOS_TRY;
 
@@ -175,10 +175,10 @@ public:
         KRATOS_CATCH("");
     }
 
-    virtual void SetTurbulenceModel(TurbulenceModelLabel const& rTurbulenceModel,
+    void SetTurbulenceModel(TurbulenceModelLabel const& rTurbulenceModel,
                                     typename TLinearSolver::Pointer pLinearSolver,
                                     const double Tolerance,
-                                    const unsigned int MaxIter)
+                                    const unsigned int MaxIter) override
     {
         KRATOS_TRY;
 
@@ -202,7 +202,7 @@ public:
         KRATOS_CATCH("");
     }
 
-    virtual void SetTurbulenceModel(ProcessPointerType pTurbulenceModel)
+    void SetTurbulenceModel(ProcessPointerType pTurbulenceModel) override
     {
         BaseType::SetTurbulenceModel(pTurbulenceModel);
     }
@@ -216,7 +216,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "FractionalStepSettings" ;
@@ -224,10 +224,10 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const {rOStream << "FractionalStepSettings";}
+    void PrintInfo(std::ostream& rOStream) const override {rOStream << "FractionalStepSettings";}
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_utilities/fractional_step_settings_periodic.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fractional_step_settings_periodic.h
@@ -88,7 +88,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~FractionalStepSettingsPeriodic(){}
+    ~FractionalStepSettingsPeriodic() override{}
 
     ///@}
     ///@name Operators
@@ -103,10 +103,10 @@ public:
     ///@name Access
     ///@{
 
-    virtual void SetStrategy(StrategyLabel const& rStrategyLabel,
+    void SetStrategy(StrategyLabel const& rStrategyLabel,
                              typename TLinearSolver::Pointer pLinearSolver,
                              const double Tolerance,
-                             const unsigned int MaxIter)
+                             const unsigned int MaxIter) override
     {
         KRATOS_TRY;
 
@@ -174,10 +174,10 @@ public:
         KRATOS_CATCH("");
     }
 
-    virtual void SetTurbulenceModel(TurbulenceModelLabel const& rTurbulenceModel,
+    void SetTurbulenceModel(TurbulenceModelLabel const& rTurbulenceModel,
                                     typename TLinearSolver::Pointer pLinearSolver,
                                     const double Tolerance,
-                                    const unsigned int MaxIter)
+                                    const unsigned int MaxIter) override
     {
         KRATOS_TRY;
 
@@ -201,7 +201,7 @@ public:
         KRATOS_CATCH("");
     }
 
-    virtual void SetTurbulenceModel(ProcessPointerType pTurbulenceModel)
+    void SetTurbulenceModel(ProcessPointerType pTurbulenceModel) override
     {
         BaseType::SetTurbulenceModel(pTurbulenceModel);
     }
@@ -215,7 +215,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "FractionalStepSettingsPeriodic" ;
@@ -223,10 +223,10 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const {rOStream << "FractionalStepSettingsPeriodic";}
+    void PrintInfo(std::ostream& rOStream) const override {rOStream << "FractionalStepSettingsPeriodic";}
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const {}
+    void PrintData(std::ostream& rOStream) const override {}
 
 
     ///@}

--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.h
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.h
@@ -106,7 +106,7 @@ public:
     KratosFluidDynamicsApplication();
 
     /// Destructor.
-    virtual ~KratosFluidDynamicsApplication() {}
+    ~KratosFluidDynamicsApplication() override {}
 
 
     ///@}
@@ -118,7 +118,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Register();
+    void Register() override;
 
 
 
@@ -137,20 +137,20 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         return "KratosFluidDynamicsApplication";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
         PrintData(rOStream);
     }
 
     ///// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
         KRATOS_WATCH("in Fluid Dynamics application");
         KRATOS_WATCH(KratosComponents<VariableData>::GetComponents().size() );

--- a/applications/StructuralMechanicsApplication/custom_elements/kinematic_linear.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/kinematic_linear.h
@@ -213,7 +213,7 @@ protected:
         const Variable<double>& rVariable,
         std::vector<double>& rOutput,
         const ProcessInfo& rCurrentProcessInfo
-    );
+    ) override;
 
     ///@}
     ///@name Protected Operations

--- a/kratos/containers/variable.h
+++ b/kratos/containers/variable.h
@@ -126,7 +126,7 @@ public:
     Variable(const VariableType& rOtherVariable) : VariableData(rOtherVariable), mZero(rOtherVariable.mZero) {}
 
     /// Destructor.
-    virtual ~Variable() {}
+    ~Variable() override {}
 
     ///@}
     ///@name Operators
@@ -180,18 +180,18 @@ public:
         rOStream << Name() << " : " << *static_cast<const TDataType* >(pSource) ;
     }
 
-    virtual void Save(Serializer& rSerializer, void* pData) const override
+    void Save(Serializer& rSerializer, void* pData) const override
     {
         // I'm saving by the value, it can be done by the pointer to detect shared data. Pooyan.
         rSerializer.save("Data",*static_cast<TDataType* >(pData));
     }
 
-    virtual void Allocate(void** pData) const override
+    void Allocate(void** pData) const override
     {
         *pData = new TDataType;
     }
 
-    virtual void Load(Serializer& rSerializer, void* pData) const override
+    void Load(Serializer& rSerializer, void* pData) const override
     {
         rSerializer.load("Data",*static_cast<TDataType* >(pData));
     }
@@ -220,7 +220,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << Name() << " variable";
@@ -228,7 +228,7 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Name() << " variable";
     }
@@ -308,13 +308,13 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, VariableData );
         rSerializer.save("Zero",mZero);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, VariableData );
         rSerializer.load("Zero",mZero);

--- a/kratos/containers/variable_component.h
+++ b/kratos/containers/variable_component.h
@@ -133,7 +133,7 @@ public:
         : BaseType(rOther), mAdaptor(rOther.mAdaptor) {}
 
     /// Destructor.
-    virtual ~VariableComponent() {}
+    ~VariableComponent() override {}
 
 
     ///@}
@@ -190,7 +190,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << Name() << " component of " <<  mAdaptor.GetSourceVariable().Name() << " variable";
@@ -198,7 +198,7 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Name() << " component of " <<  mAdaptor.GetSourceVariable().Name() << " variable";
     }

--- a/kratos/elements/distance_calculation_element_simplex.h
+++ b/kratos/elements/distance_calculation_element_simplex.h
@@ -167,7 +167,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~DistanceCalculationElementSimplex()
+    ~DistanceCalculationElementSimplex() override
     {}
 
 
@@ -195,7 +195,7 @@ public:
     }
 
     /// Calculate the element's local contribution to the system for the current step.
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
                                       ProcessInfo& rCurrentProcessInfo) override
     {
@@ -384,7 +384,7 @@ public:
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo the current process info object (unused)
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult,
+    void EquationIdVector(EquationIdVectorType& rResult,
                                   ProcessInfo& rCurrentProcessInfo) override
     {
 
@@ -406,7 +406,7 @@ public:
      * @param ElementalDofList the list of DOFs
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void GetDofList(DofsVectorType& rElementalDofList,
+    void GetDofList(DofsVectorType& rElementalDofList,
                             ProcessInfo& rCurrentProcessInfo) override
     {
         unsigned int number_of_nodes = TDim+1;
@@ -452,7 +452,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
 {
         KRATOS_TRY
 
@@ -504,7 +504,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "DistanceCalculationElementSimplex #" << Id();
@@ -512,7 +512,7 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "DistanceCalculationElementSimplex" << TDim << "D";
     }
@@ -683,12 +683,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element );
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }

--- a/kratos/elements/levelset_convection_element_simplex.h
+++ b/kratos/elements/levelset_convection_element_simplex.h
@@ -92,7 +92,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~LevelSetConvectionElementSimplex() {};
+    ~LevelSetConvectionElementSimplex() override {};
 
 
     ///@}
@@ -313,14 +313,14 @@ public:
 
     /// Turn back information as a string.
 
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "LevelSetConvectionElementSimplex #";
     }
 
     /// Print information about this object.
 
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info() << Id();
     }
@@ -429,12 +429,12 @@ private:
     //         {
     //         }
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -316,7 +316,7 @@ public:
     }
 
     /// Destructor. Do nothing!!!
-    virtual ~Geometry() {}
+    ~Geometry() override {}
 
     virtual GeometryData::KratosGeometryFamily GetGeometryFamily()
     {
@@ -2017,7 +2017,7 @@ public:
      *
      * @see Name()
      */
-    virtual std::string Info() const override {
+    std::string Info() const override {
       std::stringstream buffer;
       buffer << Dimension() << " dimensional geometry in " << WorkingSpaceDimension() << "D space";
 
@@ -2047,7 +2047,7 @@ public:
      * @see PrintName()
      * @see PrintData()
      */
-    virtual void PrintInfo(std::ostream& rOStream) const override {
+    void PrintInfo(std::ostream& rOStream) const override {
       rOStream << Dimension()  << " dimensional geometry in " << WorkingSpaceDimension() << "D space";
     }
 
@@ -2072,7 +2072,7 @@ public:
      * @see PrintInfo()
      * @see PrintName()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override {
+    void PrintData( std::ostream& rOStream ) const override {
       if(mpGeometryData) {
         mpGeometryData->PrintData( rOStream );
       }
@@ -2345,13 +2345,13 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
 //                 rSerializer.save( "Geometry Data", mpGeometryData );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
         //rSerializer.load( "Geometry Data", const_cast<GeometryData*>( mpGeometryData ) );

--- a/kratos/geometries/hexahedra_3d_20.h
+++ b/kratos/geometries/hexahedra_3d_20.h
@@ -279,7 +279,7 @@ public:
     /**
      * Destructor. Does nothing!!!
      */
-    virtual ~Hexahedra3D20() {}
+    ~Hexahedra3D20() override {}
 
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
@@ -342,7 +342,7 @@ public:
     }
 
 
-        virtual Geometry< Point<3> >::Pointer Clone() const override
+        Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -363,7 +363,7 @@ public:
     /**
      */
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	    if(rResult.size() != 20)
             rResult.resize( 20, false );
@@ -395,7 +395,7 @@ public:
      *
      * :TODO: might need to be changed to be useful!
      */
-    virtual double Length() const override
+    double Length() const override
     {
         return sqrt( fabs( this->DeterminantOfJacobian( PointType() ) ) );
     }
@@ -413,7 +413,7 @@ public:
      *
      * :TODO: might need to be changed to be useful!
      */
-    virtual double Area() const override
+    double Area() const override
     {
          return Volume(); 
          
@@ -421,7 +421,7 @@ public:
 
 
 
-    virtual double Volume() const override //Not a closed formula for a hexahedra
+    double Volume() const override //Not a closed formula for a hexahedra
     {
 
         Vector temp;
@@ -454,7 +454,7 @@ public:
      *
      * :TODO: might need to be changed to be useful!
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return Volume(); 
     }
@@ -463,7 +463,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -488,12 +488,12 @@ public:
     @see Edge()
      */
     // will be used by refinement algorithm, thus uncommented. janosch.
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 12;
     }
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 6;
     }
@@ -504,7 +504,7 @@ public:
     @see EdgesNumber()
     @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer EdgePointerType;
@@ -564,7 +564,7 @@ public:
         return edges;
     }
 
-    virtual GeometriesArrayType Faces( void ) override
+    GeometriesArrayType Faces( void ) override
     {
         GeometriesArrayType faces = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer FacePointerType;
@@ -640,7 +640,7 @@ public:
      * @return the value of the shape function at the given point
      * TODO: implemented but not yet tested
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -732,7 +732,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
       if(rResult.size() != 20) rResult.resize(20,false);
         rResult[0] = -(( 1.0 + rCoordinates[0] )*( 1.0 - rCoordinates[1] )*( 2.0
@@ -795,7 +795,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "3 dimensional hexahedra with 20 nodes and quadratic shape functions in 3D space";
     }
@@ -807,7 +807,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "3 dimensional hexahedra with 20 nodes and quadratic shape functions in 3D space";
     }
@@ -821,7 +821,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -841,7 +841,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& result,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& result,
             const CoordinatesArrayType& rPoint ) const override
     {
         //setting up result matrix
@@ -1020,13 +1020,13 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
 
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/hexahedra_3d_27.h
+++ b/kratos/geometries/hexahedra_3d_27.h
@@ -300,7 +300,7 @@ public:
     }
 
     /// Destructor. Does nothing!!!
-    virtual ~Hexahedra3D27() {}
+    ~Hexahedra3D27() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -362,7 +362,7 @@ public:
         return typename BaseType::Pointer( new Hexahedra3D27( ThisPoints ) );
     }
 
-        virtual Geometry< Point<3> >::Pointer Clone() const override
+        Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -380,7 +380,7 @@ public:
 
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
         if(rResult.size() != 27)
             rResult.resize( 27, false );
@@ -417,7 +417,7 @@ public:
     /**
      * :TODO: TO BE VERIFIED
      */
-    virtual double Length() const override
+    double Length() const override
     {
         return sqrt( fabs( this->DeterminantOfJacobian( PointType() ) ) );
     }
@@ -437,14 +437,14 @@ public:
     /**
      * :TODO: TO BE VERIFIED
      */
-    virtual double Area() const override
+    double Area() const override
     {
         return Volume();
     }
 
 
 
-    virtual double Volume() const override  //Not a closed formula for a hexahedra
+    double Volume() const override  //Not a closed formula for a hexahedra
     {
 
         Vector temp;
@@ -478,7 +478,7 @@ public:
     /**
      * :TODO: TO BE VERIFIED
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return Volume();
     }
@@ -486,7 +486,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -511,12 +511,12 @@ public:
     @see Edge()
      */
     // will be used by refinement algorithm, thus uncommented. janosch.
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 12;
     }
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 6;
     }
@@ -527,7 +527,7 @@ public:
     @see EdgesNumber()
     @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer EdgePointerType;
@@ -587,7 +587,7 @@ public:
         return edges;
     }
 
-    virtual GeometriesArrayType Faces( void ) override
+    GeometriesArrayType Faces( void ) override
     {
         GeometriesArrayType faces = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer FacePointerType;
@@ -670,7 +670,7 @@ public:
      * @return the value of the shape function at the given point
      * TODO: TO BE VERIFIED
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         double fx1 = 0.5 * ( rPoint[0] - 1.0 ) * ( rPoint[0] );
@@ -758,7 +758,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
       if(rResult.size() != 27) rResult.resize(27,false);
       
@@ -813,7 +813,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "3 dimensional hexahedra with 27 nodes and quadratic shape functions in 3D space";
     }
@@ -825,7 +825,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "3 dimensional hexahedra with 27 nodes and quadratic shape functions in 3D space";
     }
@@ -839,7 +839,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -859,7 +859,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& result,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& result,
             const CoordinatesArrayType& rPoint ) const override
     {
         double fx1 = 0.5 * ( rPoint[0] - 1.0 ) * ( rPoint[0] );
@@ -1075,12 +1075,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/hexahedra_3d_8.h
+++ b/kratos/geometries/hexahedra_3d_8.h
@@ -243,7 +243,7 @@ public:
     }
 
     /// Destructor. Does nothing!!!
-    virtual ~Hexahedra3D8() {}
+    ~Hexahedra3D8() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -305,7 +305,7 @@ public:
         return typename BaseType::Pointer( new Hexahedra3D8( ThisPoints ) );
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -322,7 +322,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
         if(rResult.size() != 8)
             rResult.resize( 8, false );
@@ -350,7 +350,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Length() const override
+    double Length() const override
     {
         return sqrt( fabs( this->DeterminantOfJacobian( PointType() ) ) );
     }
@@ -369,12 +369,12 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Area() const override
+    double Area() const override
     {
         return Volume();
     }
 
-    virtual double Volume() const override //Not a closed formula for a hexahedra
+    double Volume() const override //Not a closed formula for a hexahedra
     {
         Vector temp;
         this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
@@ -403,7 +403,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return Volume();
     }
@@ -413,7 +413,7 @@ public:
      * @param rResult a Matrix that will be overwritten by the results
      * @return the coordinates of all points of the current geometry
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         if ( rResult.size1() != 8 || rResult.size2() != 3 )
             rResult.resize( 8, 3, false );
@@ -456,7 +456,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -476,12 +476,12 @@ public:
     @see Edge()
      */
     // will be used by refinement algorithm, thus uncommented. janosch.
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 12;
     }
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 6;
     }
@@ -492,7 +492,7 @@ public:
     @see EdgesNumber()
     @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer EdgePointerType;
@@ -535,7 +535,7 @@ public:
         return edges;
     }
 
-    virtual GeometriesArrayType Faces( void ) override
+    GeometriesArrayType Faces( void ) override
     {
         GeometriesArrayType faces = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer FacePointerType;
@@ -586,7 +586,7 @@ public:
      * @return the value of the shape function at the given point
      * TODO: TO BE VERIFIED
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -625,7 +625,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
       if(rResult.size() != 8) rResult.resize(8,false);
       rResult[0] =  0.125*( 1.0 - rCoordinates[0] )*( 1.0 - rCoordinates[1] )*( 1.0 - rCoordinates[2] ) ;
@@ -647,7 +647,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size1() != 8 || rResult.size2() != 3 )
             rResult.resize( 8, 3, false );
@@ -689,7 +689,7 @@ public:
      * @param rPoint the given local coordinates the derivatives will be evaluated for.
      * @return a third order tensor containing the second order derivatives for each shape function
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -799,7 +799,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "3 dimensional hexahedra with eight nodes in 3D space";
     }
@@ -811,7 +811,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "3 dimensional hexahedra with eight nodes in 3D space";
     }
@@ -825,7 +825,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -854,12 +854,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/line_2d.h
+++ b/kratos/geometries/line_2d.h
@@ -201,7 +201,7 @@ public:
     }
 
     /// Destructor. Do nothing!!!
-    virtual ~Line2D() {}
+    ~Line2D() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -260,7 +260,7 @@ public:
         return typename BaseType::Pointer(new Line2D(ThisPoints));
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -277,7 +277,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors(Vector& rResult) const override
+    Vector& LumpingFactors(Vector& rResult) const override
     {
 	if(rResult.size() != 2)
            rResult.resize(2, false);
@@ -302,7 +302,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Length() const override
+    double Length() const override
     {
 
         const TPointType& point0 = BaseType::GetPoint(0);
@@ -326,7 +326,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Area() const override
+    double Area() const override
     {
         return 0.00;
     }
@@ -342,7 +342,7 @@ public:
     @see Area()
     @see Volume()
     */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         const TPointType& point0 = BaseType::GetPoint(0);
         const TPointType& point1 = BaseType::GetPoint(1);
@@ -375,7 +375,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod) const override
+    JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod) const override
     {
         Matrix jacobian(2,1);
         jacobian(0,0)=(BaseType::GetPoint(1).X()-BaseType::GetPoint(0).X())*0.5;	//on the Gauss points (J is	constant at	each element)
@@ -408,7 +408,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
+    JacobiansType& Jacobian(JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
     {
         Matrix jacobian(2,1);
         jacobian(0,0)=(BaseType::GetPoint(1).X() - DeltaPosition(1,0) - BaseType::GetPoint(0).X() - DeltaPosition(0,0))*0.5;	//on the Gauss points (J is	constant at	each element)
@@ -441,7 +441,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& Jacobian(Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
+    Matrix& Jacobian(Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
     {
         Matrix jacobian(2,1);
         jacobian(0,0)=(BaseType::GetPoint(1).X()-BaseType::GetPoint(0).X())*0.5;	//on the Gauss points (J is	constant at	each element)
@@ -460,7 +460,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& Jacobian(Matrix& rResult, const CoordinatesArrayType& rPoint) const override
+    Matrix& Jacobian(Matrix& rResult, const CoordinatesArrayType& rPoint) const override
     {
         Matrix jacobian(2,1);
         jacobian(0,0)=(BaseType::GetPoint(1).X()-BaseType::GetPoint(0).X())*0.5;	//on the Gauss points (J is	constant at	each element)
@@ -479,7 +479,7 @@ public:
     @see Jacobian
     @see InverseOfJacobian
     */
-    virtual Vector& DeterminantOfJacobian(Vector& rResult, IntegrationMethod ThisMethod) const override
+    Vector& DeterminantOfJacobian(Vector& rResult, IntegrationMethod ThisMethod) const override
     {
         const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
         if(rResult.size() != integration_points_number)
@@ -514,7 +514,7 @@ public:
     @see Jacobian
     @see InverseOfJacobian
     */
-    virtual double DeterminantOfJacobian(IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
+    double DeterminantOfJacobian(IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
     {
         return 0.5*(this->Length());
     }
@@ -531,7 +531,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual double DeterminantOfJacobian(const CoordinatesArrayType& rPoint) const override
+    double DeterminantOfJacobian(const CoordinatesArrayType& rPoint) const override
     {
         return 0.5*(this->Length());
     }
@@ -551,7 +551,7 @@ public:
     @see Jacobian
     @see DeterminantOfJacobian
     */
-    virtual JacobiansType& InverseOfJacobian(JacobiansType& rResult, IntegrationMethod ThisMethod) const override
+    JacobiansType& InverseOfJacobian(JacobiansType& rResult, IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" <<  std::endl;
     }
@@ -573,7 +573,7 @@ public:
     @see Jacobian
     @see DeterminantOfJacobian
     */
-    virtual Matrix& InverseOfJacobian(Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
+    Matrix& InverseOfJacobian(Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" <<  std::endl;
     }
@@ -589,7 +589,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& InverseOfJacobian(Matrix& rResult, const CoordinatesArrayType& rPoint) const override
+    Matrix& InverseOfJacobian(Matrix& rResult, const CoordinatesArrayType& rPoint) const override
     {
         KRATOS_ERROR << "Jacobian is not square" <<  std::endl;
     }
@@ -598,7 +598,7 @@ public:
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 2;
     }
@@ -607,7 +607,7 @@ public:
     ///@name Shape Function
     ///@{
 
-    virtual double ShapeFunctionValue(IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue(IndexType ShapeFunctionIndex,
                                       const CoordinatesArrayType& rPoint) const override
     {
         KRATOS_ERROR <<"This method is not implemented yet!" << *this << std::endl;
@@ -616,7 +616,7 @@ public:
 
 
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod) const override
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod) const override
     {
         KRATOS_ERROR << "Jacobian is not square" <<  std::endl;
     }
@@ -632,7 +632,7 @@ public:
     @see PrintData()
     @see PrintInfo()
     */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "1 dimensional line in 2D space";
     }
@@ -643,7 +643,7 @@ public:
     @see PrintData()
     @see Info()
     */
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "1 dimensional line in 2D space";
     }
@@ -656,7 +656,7 @@ public:
     @see PrintInfo()
     @see Info()
     */
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         BaseType::PrintData(rOStream);
         std::cout << std::endl;
@@ -726,12 +726,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -206,7 +206,7 @@ public:
     }
 
     /// Destructor. Do nothing!!!
-    virtual ~Line2D2() {}
+    ~Line2D2() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -266,7 +266,7 @@ public:
         return typename BaseType::Pointer( new Line2D2( ThisPoints ) );
     }
     
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -283,7 +283,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
         if(rResult.size() != 2)
         {
@@ -311,7 +311,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Length() const override
+    double Length() const override
     {
         const TPointType& FirstPoint  = BaseType::GetPoint(0);
         const TPointType& SecondPoint = BaseType::GetPoint(1);
@@ -334,7 +334,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Area() const override
+    double Area() const override
     {
       return Length();
     }
@@ -350,7 +350,7 @@ public:
     @see Area()
     @see Volume()
     */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         const TPointType& FirstPoint = BaseType::GetPoint(0);
         const TPointType& SecondPoint = BaseType::GetPoint(1);
@@ -391,7 +391,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         Matrix jacobian( 2, 1 );
         jacobian( 0, 0 ) = ( BaseType::GetPoint( 1 ).X() - BaseType::GetPoint( 0 ).X() ) * 0.5; //on the Gauss points (J is constant at each element)
@@ -426,7 +426,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
     {
         Matrix jacobian( 2, 1 );
         jacobian( 0, 0 ) = ( (BaseType::GetPoint( 1 ).X() - DeltaPosition(1,0)) - (BaseType::GetPoint( 0 ).X() - DeltaPosition(0,0)) ) * 0.5; //on the Gauss points (J is constant at each element)
@@ -461,7 +461,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         rResult.resize( 2, 1, false );
         //on the Gauss points (J is constant at each element)
@@ -481,7 +481,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         rResult.resize( 2, 1, false );
         //on the Gauss points (J is constant at each element)
@@ -501,7 +501,7 @@ public:
     @see Jacobian
     @see InverseOfJacobian
     */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
+    Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
     {
         const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
         if(rResult.size() != integration_points_number)
@@ -536,7 +536,7 @@ public:
     @see Jacobian
     @see InverseOfJacobian
     */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         return 0.5*(this->Length());
     }
@@ -553,7 +553,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         return 0.5*(this->Length());
     }
@@ -573,7 +573,7 @@ public:
     @see Jacobian
     @see DeterminantOfJacobian
     */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
@@ -596,7 +596,7 @@ public:
     @see Jacobian
     @see DeterminantOfJacobian
     */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
@@ -613,7 +613,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
@@ -622,7 +622,7 @@ public:
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 2;
     }
@@ -631,7 +631,7 @@ public:
     /** FacesNumber
     @return SizeType containes number of this geometry edges/faces.
     */
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
       return EdgesNumber();
     }
@@ -639,7 +639,7 @@ public:
 
 
     //Connectivities of faces required
-    virtual void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
+    void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
     {
         if(NumberNodesInFaces.size() != 2 )
             NumberNodesInFaces.resize(2,false);
@@ -649,7 +649,7 @@ public:
 
     }
 
-    virtual void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
+    void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
     {
         if(NodesInFaces.size1() != 2 || NodesInFaces.size2() != 2)
             NodesInFaces.resize(2,2,false);
@@ -663,7 +663,7 @@ public:
     ///@name Shape Function
     ///@{
 
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
         if(rResult.size() != 2)
         {
@@ -676,7 +676,7 @@ public:
         return rResult;
     }
 
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -696,7 +696,7 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
@@ -713,7 +713,7 @@ public:
     @see PrintData()
     @see PrintInfo()
     */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "1 dimensional line in 2D space";
     }
@@ -724,7 +724,7 @@ public:
     @see PrintData()
     @see Info()
     */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "1 dimensional line in 2D space";
     }
@@ -737,7 +737,7 @@ public:
     @see PrintInfo()
     @see Info()
     */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -776,7 +776,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         // Setting up result matrix
@@ -796,7 +796,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         if(rResult.size1() != 2 || rResult.size2() != 1)
         {
@@ -833,7 +833,7 @@ public:
      * Returns whether given arbitrary point is inside the Geometry and the respective
      * local point for the given global point
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         PointLocalCoordinates( rResult, rPoint );
 
@@ -851,7 +851,7 @@ public:
     /**
       * Returns the local coordinates of a given arbitrary point
       */
-    virtual CoordinatesArrayType& PointLocalCoordinates(
+    CoordinatesArrayType& PointLocalCoordinates(
             CoordinatesArrayType& rResult,
             const CoordinatesArrayType& rPoint ) override
     {
@@ -978,12 +978,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -202,7 +202,7 @@ public:
     }
 
     /// Destructor. Do nothing!!!
-    virtual ~Line2D3() {}
+    ~Line2D3() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -259,7 +259,7 @@ public:
       return typename BaseType::Pointer( new Line2D3( ThisPoints ) );
     }
     
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -276,7 +276,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	if(rResult.size() != 3)
            rResult.resize( 3, false );
@@ -302,7 +302,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Length() const override
+    double Length() const override
     {
         const TPointType& point0 = BaseType::GetPoint(0);
         const TPointType& point1 = BaseType::GetPoint(2);
@@ -325,7 +325,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Area() const override
+    double Area() const override
     {
       return Length();
     }
@@ -341,7 +341,7 @@ public:
     @see Area()
     @see Volume()
     */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         const TPointType& point0 = BaseType::GetPoint(0);
         const TPointType& point1 = BaseType::GetPoint(2);
@@ -358,7 +358,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -386,7 +386,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         //getting derivatives of shape functions
         ShapeFunctionsGradientsType shape_functions_gradients =
@@ -443,7 +443,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
     {
         //getting derivatives of shape functions
         ShapeFunctionsGradientsType shape_functions_gradients =
@@ -493,7 +493,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 2, 1, false );
@@ -530,7 +530,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 2, 1, false );
@@ -563,7 +563,7 @@ public:
      * @see Jacobian
      * @see DeterminantOfJacobian
      */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
     }
@@ -585,7 +585,7 @@ public:
      * @see Jacobian
      * @see DeterminantOfJacobian
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex,
+    Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex,
                                        IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
@@ -602,7 +602,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
     }
@@ -610,7 +610,7 @@ public:
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 2;
     }
@@ -619,7 +619,7 @@ public:
     /** FacesNumber
     @return SizeType containes number of this geometry edges/faces.
     */
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
       return EdgesNumber();
     }
@@ -628,7 +628,7 @@ public:
     ///@name Shape Function
     ///@{
 
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -650,7 +650,7 @@ public:
     ///@name Shape Function Integration Points Gradient
     ///@{
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
     }
@@ -665,7 +665,7 @@ public:
     @see PrintData()
     @see PrintInfo()
     */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "1 dimensional line with 3 nodes in 2D space";
     }
@@ -676,7 +676,7 @@ public:
     @see PrintData()
     @see Info()
     */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "1 dimensional line with 3 nodes in 2D space";
     }
@@ -689,7 +689,7 @@ public:
     @see PrintInfo()
     @see Info()
     */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -748,7 +748,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         // Setting up result matrix
@@ -768,7 +768,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         if(rResult.size1() != 3 || rResult.size2() != 1)
         {
@@ -864,12 +864,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -205,7 +205,7 @@ public:
     }
 
     /// Destructor. Do nothing!!!
-    virtual ~Line3D2() {}
+    ~Line3D2() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -265,7 +265,7 @@ public:
         return typename BaseType::Pointer( new Line3D2( ThisPoints ) );
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -282,7 +282,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	if(rResult.size() != 2)
            rResult.resize( 2, false );
@@ -307,7 +307,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Length() const override
+    double Length() const override
     {
         const TPointType& point0 = BaseType::GetPoint(0);
         const TPointType& point1 = BaseType::GetPoint(1);
@@ -331,7 +331,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Area() const override
+    double Area() const override
     {
       return Length();
     }
@@ -347,7 +347,7 @@ public:
     @see Area()
     @see Volume()
     */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         const TPointType& point0 = BaseType::GetPoint(0);
         const TPointType& point1 = BaseType::GetPoint(1);
@@ -380,7 +380,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         Matrix jacobian( 3, 1 );
         jacobian( 0, 0 ) = ( this->GetPoint( 1 ).X() - this->GetPoint( 0 ).X() ) * 0.5; //on the Gauss points (J is constant at each element)
@@ -416,7 +416,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
     {
         Matrix jacobian( 3, 1 );
         jacobian( 0, 0 ) = ( (this->GetPoint( 1 ).X() - DeltaPosition(1,0)) - (this->GetPoint( 0 ).X() - DeltaPosition(0,0)) ) * 0.5; //on the Gauss points (J is constant at each element)
@@ -452,7 +452,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         rResult.resize( 3, 1, false );
         //on the Gauss points (J is constant at each element)
@@ -473,7 +473,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         rResult.resize( 3, 1, false );
         //on the Gauss points (J is constant at each element)
@@ -494,7 +494,7 @@ public:
     @see Jacobian
     @see InverseOfJacobian
     */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
+    Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
     {
         const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
         if(rResult.size() != integration_points_number)
@@ -529,7 +529,7 @@ public:
     @see Jacobian
     @see InverseOfJacobian
     */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         return 0.5*(this->Length());
     }
@@ -546,7 +546,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         return 0.5*(this->Length());
     }
@@ -566,7 +566,7 @@ public:
     @see Jacobian
     @see DeterminantOfJacobian
     */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         rResult[0] = ZeroMatrix( 1, 1 );
         rResult[0]( 0, 0 ) = 2.0 * MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) );
@@ -590,7 +590,7 @@ public:
     @see Jacobian
     @see DeterminantOfJacobian
     */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         rResult = ZeroMatrix( 1, 1 );
         rResult( 0, 0 ) = 2.0 * MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) );
@@ -608,7 +608,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         rResult = ZeroMatrix( 1, 1 );
         rResult( 0, 0 ) = 2.0 * MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) );
@@ -619,13 +619,13 @@ public:
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 2;
     }
 
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 2;
     }
@@ -634,7 +634,7 @@ public:
     ///@name Shape Function
     ///@{
 
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -653,7 +653,7 @@ public:
         return 0;
     }
 
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         rResult = ZeroMatrix( 2, 1 );
@@ -664,7 +664,7 @@ public:
 
 
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
     }
@@ -676,7 +676,7 @@ public:
     @see PrintData()
     @see PrintInfo()
     */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "1 dimensional line with 2 nodes in 3D space";
     }
@@ -687,7 +687,7 @@ public:
     @see PrintData()
     @see Info()
     */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "1 dimensional line with 2 nodes in 3D space";
     }
@@ -700,7 +700,7 @@ public:
     @see PrintInfo()
     @see Info()
     */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -769,12 +769,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -202,7 +202,7 @@ public:
     }
 
     /// Destructor. Do nothing!!!
-    virtual ~Line3D3() {}
+    ~Line3D3() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -259,7 +259,7 @@ public:
       return typename BaseType::Pointer( new Line3D3( ThisPoints ) );
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -276,7 +276,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	if(rResult.size() != 3)
            rResult.resize( 3, false );
@@ -302,7 +302,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Length() const override
+    double Length() const override
     {
         const TPointType& point0 = BaseType::GetPoint(0);
         const TPointType& point1 = BaseType::GetPoint(2);
@@ -326,7 +326,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Area() const override
+    double Area() const override
     {
       return Length();
     }
@@ -342,7 +342,7 @@ public:
     @see Area()
     @see Volume()
     */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         const TPointType& point0 = BaseType::GetPoint(0);
         const TPointType& point1 = BaseType::GetPoint(2);
@@ -358,7 +358,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -386,7 +386,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         //getting derivatives of shape functions
         ShapeFunctionsGradientsType shape_functions_gradients =
@@ -439,7 +439,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
     {
         //getting derivatives of shape functions
         ShapeFunctionsGradientsType shape_functions_gradients =
@@ -490,7 +490,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 3, 1, false );
@@ -528,7 +528,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 3, 1, false );
@@ -559,7 +559,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
+    Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
@@ -594,7 +594,7 @@ public:
      * @see Jacobian
      * @see DeterminantOfJacobian
      */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
@@ -617,7 +617,7 @@ public:
      * @see Jacobian
      * @see DeterminantOfJacobian
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex,
+    Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex,
                                        IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
@@ -635,7 +635,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
@@ -645,12 +645,12 @@ public:
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 2;
     }
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 2;
     }
@@ -659,7 +659,7 @@ public:
     ///@name Shape Function
     ///@{
 
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -680,7 +680,7 @@ public:
 
 
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
         return rResult;
@@ -697,7 +697,7 @@ public:
     @see PrintData()
     @see PrintInfo()
     */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "1 dimensional line with 3 nodes in 3D space";
     }
@@ -708,7 +708,7 @@ public:
     @see PrintData()
     @see Info()
     */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "1 dimensional line with 3 nodes in 3D space";
     }
@@ -721,7 +721,7 @@ public:
     @see PrintInfo()
     @see Info()
     */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -780,7 +780,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         //setting up result matrix
@@ -797,7 +797,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         rResult.resize( 3, 1, false );
         noalias( rResult ) = ZeroMatrix( 3, 1 );
@@ -887,12 +887,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/line_gl_3d_2.h
+++ b/kratos/geometries/line_gl_3d_2.h
@@ -203,7 +203,7 @@ public:
     }
 
     /// Destructor. Do nothing!!!
-    virtual ~LineGL3D2() {}
+    ~LineGL3D2() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -263,7 +263,7 @@ public:
         return typename BaseType::Pointer( new LineGL3D2( ThisPoints ) );
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -281,7 +281,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	if(rResult.size() != 2)
            rResult.resize( 2, false );
@@ -306,7 +306,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Length() const override
+    double Length() const override
     {
         const TPointType& point0 = BaseType::GetPoint(0);
         const TPointType& point1 = BaseType::GetPoint(1);
@@ -330,7 +330,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Area() const override
+    double Area() const override
     {
       return Length();
     }
@@ -346,7 +346,7 @@ public:
     @see Area()
     @see Volume()
     */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         const TPointType& point0 = BaseType::GetPoint(0);
         const TPointType& point1 = BaseType::GetPoint(1);
@@ -379,7 +379,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         Matrix jacobian( 3, 1 );
         jacobian( 0, 0 ) = ( this->GetPoint( 1 ).X() - this->GetPoint( 0 ).X() ) * 0.5; //on the Gauss points (J is constant at each element)
@@ -415,7 +415,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
     {
         Matrix jacobian( 3, 1 );
         jacobian( 0, 0 ) = ( (this->GetPoint( 1 ).X() - DeltaPosition(1,0)) - (this->GetPoint( 0 ).X() - DeltaPosition(0,0)) ) * 0.5; //on the Gauss points (J is constant at each element)
@@ -451,7 +451,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         rResult.resize( 3, 1, false );
         //on the Gauss points (J is constant at each element)
@@ -472,7 +472,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         rResult.resize( 3, 1, false );
         //on the Gauss points (J is constant at each element)
@@ -493,7 +493,7 @@ public:
     @see Jacobian
     @see InverseOfJacobian
     */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
+    Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
     {
         rResult = ZeroVector( 1 );
         rResult[0] = 0.5 * MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) );
@@ -518,7 +518,7 @@ public:
     @see Jacobian
     @see InverseOfJacobian
     */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         return( 0.5*MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) ) );
     }
@@ -535,7 +535,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         return( 0.5*MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) ) );
     }
@@ -555,7 +555,7 @@ public:
     @see Jacobian
     @see DeterminantOfJacobian
     */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         rResult[0] = ZeroMatrix( 1, 1 );
         rResult[0]( 0, 0 ) = 2.0 * MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) );
@@ -579,7 +579,7 @@ public:
     @see Jacobian
     @see DeterminantOfJacobian
     */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         rResult = ZeroMatrix( 1, 1 );
         rResult( 0, 0 ) = 2.0 * MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) );
@@ -597,7 +597,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         rResult = ZeroMatrix( 1, 1 );
         rResult( 0, 0 ) = 2.0 * MathUtils<double>::Norm3(( this->GetPoint( 1 ) ) - ( this->GetPoint( 0 ) ) );
@@ -608,13 +608,13 @@ public:
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 2;
     }
 
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 2;
     }
@@ -624,7 +624,7 @@ public:
     ///@name Shape Function
     ///@{
 
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -643,7 +643,7 @@ public:
         return 0;
     }
 
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         rResult = ZeroMatrix( 2, 1 ); 
@@ -654,7 +654,7 @@ public:
 
 
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Jacobian is not square" << std::endl;
     }
@@ -666,7 +666,7 @@ public:
     @see PrintData()
     @see PrintInfo()
     */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "1 dimensional line with 2 nodes in 3D space";
     }
@@ -677,7 +677,7 @@ public:
     @see PrintData()
     @see Info()
     */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "1 dimensional line with 2 nodes in 3D space";
     }
@@ -690,7 +690,7 @@ public:
     @see PrintInfo()
     @see Info()
     */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -759,12 +759,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/point_2d.h
+++ b/kratos/geometries/point_2d.h
@@ -197,7 +197,7 @@ public:
     }
 
     /// Destructor. Do nothing!!!
-    virtual ~Point2D() {}
+    ~Point2D() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -256,7 +256,7 @@ public:
         return typename BaseType::Pointer(new Point2D(ThisPoints));
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -293,7 +293,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Length() const override
+    double Length() const override
     {
         return 0.00;
     }
@@ -309,7 +309,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Area() const override
+    double Area() const override
     {
         return 0.00;
     }
@@ -325,7 +325,7 @@ public:
     @see Area()
     @see Volume()
     */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return 0.00;
     }
@@ -507,12 +507,12 @@ public:
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 1;
     }
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 0;
     }
@@ -546,7 +546,7 @@ public:
     @see PrintData()
     @see PrintInfo()
     */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "a point geometry in 2D space";
     }
@@ -557,7 +557,7 @@ public:
     @see PrintData()
     @see Info()
     */
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "a point geometry in 2D space";
     }
@@ -570,7 +570,7 @@ public:
     @see PrintInfo()
     @see Info()
     */
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         rOStream << "a point geometry in 2D space";
     }
@@ -688,12 +688,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseType );
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseType );
     }

--- a/kratos/geometries/point_3d.h
+++ b/kratos/geometries/point_3d.h
@@ -197,7 +197,7 @@ public:
     }
 
     /// Destructor. Do nothing!!!
-    virtual ~Point3D() {}
+    ~Point3D() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -257,7 +257,7 @@ public:
     }
 
     
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -294,7 +294,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Length() const override
+    double Length() const override
     {
         return 0.00;
     }
@@ -310,7 +310,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Area() const override
+    double Area() const override
     {
         return 0.00;
     }
@@ -326,7 +326,7 @@ public:
     @see Area()
     @see Volume()
     */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return 0.00;
     }
@@ -508,12 +508,12 @@ public:
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 1;
     }
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 0;
     }
@@ -572,7 +572,7 @@ public:
     @see PrintData()
     @see PrintInfo()
     */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "a point in 3D space";
     }
@@ -583,7 +583,7 @@ public:
     @see PrintData()
     @see Info()
     */
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "a point in 3D space";
     }
@@ -596,7 +596,7 @@ public:
     @see PrintInfo()
     @see Info()
     */
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         rOStream << "a point in 3D space";
     }
@@ -713,12 +713,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseType );
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseType );
     }

--- a/kratos/geometries/prism_3d_15.h
+++ b/kratos/geometries/prism_3d_15.h
@@ -263,7 +263,7 @@ public:
     }
 
     /// Destructor. Does nothing!!!
-    virtual ~Prism3D15() {}
+    ~Prism3D15() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -325,7 +325,7 @@ public:
         return typename BaseType::Pointer( new Prism3D15( ThisPoints ) );
     }
 
-        virtual Geometry< Point<3> >::Pointer Clone() const override
+        Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -343,7 +343,7 @@ public:
 
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	if(rResult.size() != 15)
            rResult.resize( 15, false );
@@ -371,7 +371,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Length() const override
+    double Length() const override
     {
         return sqrt( fabs( DeterminantOfJacobian( PointType() ) ) );
     }
@@ -390,7 +390,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Area() const override
+    double Area() const override
     {
         return fabs( DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
@@ -398,7 +398,7 @@ public:
 
 
 
-    virtual double Volume() const override
+    double Volume() const override
     {
 
         Vector temp;
@@ -430,7 +430,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return fabs( DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
@@ -441,7 +441,7 @@ public:
     * @param rResult a Matrix that will be overwritten by the results
     * @return the coordinates of all points of the current geometry
     */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         if ( rResult.size1() != 15 || rResult.size2() != 3 )
             rResult.resize( 15, 3, false );
@@ -512,7 +512,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -547,7 +547,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod ) const override
     {
         //getting derivatives of shape functions
@@ -619,7 +619,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod,
 				     Matrix & DeltaPosition ) const override
     {
@@ -686,7 +686,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult,
+    Matrix& Jacobian( Matrix& rResult,
                               IndexType IntegrationPointIndex,
                               IntegrationMethod ThisMethod ) const override
     {
@@ -737,7 +737,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 3, 3, false );
@@ -780,7 +780,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult,
+    Vector& DeterminantOfJacobian( Vector& rResult,
                                            IntegrationMethod ThisMethod ) const override
     {
         //workaround by riccardo
@@ -823,7 +823,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex,
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex,
                                           IntegrationMethod ThisMethod ) const override
     {
         /**
@@ -853,7 +853,7 @@ public:
      * KLUDGE: PointType needed for proper functionality
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         Matrix jacobian = ZeroMatrix( 3, 3 );
         jacobian = Jacobian( jacobian, rPoint );
@@ -879,7 +879,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult,
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult,
             IntegrationMethod ThisMethod ) const override
     {
         //workaround by riccardo
@@ -925,7 +925,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult,
+    Matrix& InverseOfJacobian( Matrix& rResult,
                                        IndexType IntegrationPointIndex,
                                        IntegrationMethod ThisMethod ) const override
     {
@@ -955,7 +955,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         //current jacobian
         Matrix tempMatrix = ZeroMatrix( 3, 3 );
@@ -977,12 +977,12 @@ public:
     @see Edge()
      */
     // will be used by refinement algorithm, thus uncommented. janosch.
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 9;
     }
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 5;
     }
@@ -993,7 +993,7 @@ public:
     @see EdgesNumber()
     @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer EdgePointerType;
@@ -1036,7 +1036,7 @@ public:
         return edges;
     }
 
-    virtual GeometriesArrayType Faces( void ) override
+    GeometriesArrayType Faces( void ) override
     {
         GeometriesArrayType faces = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer FacePointerType;
@@ -1098,7 +1098,7 @@ public:
      * @return the value of the shape function at the given point
      * TODO: TO BE VERIFIED
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -1155,7 +1155,7 @@ public:
      *
      * :TODO: TESTING!!!
      */
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1213,7 +1213,7 @@ public:
      * @param rPoint the given local coordinates the gradients will be evaluated for
      * @return a matrix of gradients for each shape function
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         return CalculateShapeFunctionsLocalGradients( rResult, rPoint );
     }
@@ -1231,7 +1231,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "3 dimensional prism with fiftheen nodes in 3D space";
     }
@@ -1243,7 +1243,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "3 dimensional prism with fifthteen nodes in 3D space";
     }
@@ -1257,7 +1257,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -1286,12 +1286,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/prism_3d_6.h
+++ b/kratos/geometries/prism_3d_6.h
@@ -233,7 +233,7 @@ public:
     }
 
     /// Destructor. Does nothing!!!
-    virtual ~Prism3D6() {}
+    ~Prism3D6() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -296,7 +296,7 @@ public:
     }
 
 
-        virtual Geometry< Point<3> >::Pointer Clone() const override
+        Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -314,7 +314,7 @@ public:
 
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	if(rResult.size() != 6)
            rResult.resize( 6, false );
@@ -342,7 +342,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Length() const override
+    double Length() const override
     {
         Vector temp;
         this->DeterminantOfJacobian( temp, msGeometryData.DefaultIntegrationMethod() );
@@ -372,14 +372,14 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Area() const override
+    double Area() const override
     {
         return fabs( this->DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
 
 
 
-    virtual double Volume() const override
+    double Volume() const override
     {
 
         Vector temp;
@@ -412,7 +412,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return fabs( this->DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
@@ -423,7 +423,7 @@ public:
     * @param rResult a Matrix that will be overwritten by the results
     * @return the coordinates of all points of the current geometry
     */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         if ( rResult.size1() != 6 || rResult.size2() != 3 )
             rResult.resize( 6, 3 );
@@ -458,7 +458,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -480,12 +480,12 @@ public:
     @see Edge()
      */
     // will be used by refinement algorithm, thus uncommented. janosch.
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 9;
     }
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 5;
     }
@@ -496,7 +496,7 @@ public:
     @see EdgesNumber()
     @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer EdgePointerType;
@@ -530,7 +530,7 @@ public:
         return edges;
     }
 
-    virtual GeometriesArrayType Faces( void ) override
+    GeometriesArrayType Faces( void ) override
     {
         GeometriesArrayType faces = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer FacePointerType;
@@ -576,7 +576,7 @@ public:
      * @return the value of the shape function at the given point
      * TODO: TO BE VERIFIED
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -611,7 +611,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "3 dimensional prism with six nodes in 3D space";
     }
@@ -623,7 +623,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "3 dimensional prism with six nodes in 3D space";
     }
@@ -637,7 +637,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -666,12 +666,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/quadrilateral_2d_4.h
+++ b/kratos/geometries/quadrilateral_2d_4.h
@@ -259,7 +259,7 @@ public:
     /**
      * Destructor. Does nothing!!!
      */
-    virtual ~Quadrilateral2D4() {}
+    ~Quadrilateral2D4() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -320,7 +320,7 @@ public:
     }
 
     
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -340,7 +340,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
 	{
 		if (rResult.size1() != 4 || rResult.size2() != 2)
 			rResult.resize(4, 2, false);
@@ -356,7 +356,7 @@ public:
 	}
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
         if(rResult.size() != 4)
             rResult.resize( 4, false );
@@ -387,7 +387,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Length() const override
+    double Length() const override
     {
         //return sqrt(fabs( DeterminantOfJacobian(PointType())));
         double length = 0.000;
@@ -411,7 +411,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Area() const override
+    double Area() const override
     {
 
         Vector temp;
@@ -445,7 +445,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return fabs( this->DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
@@ -453,7 +453,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -476,7 +476,7 @@ public:
     @see Edges()
     @see Edge()
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 4;
     }
@@ -492,7 +492,7 @@ public:
     @see EdgesNumber()
     @see Edge()
     */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
@@ -518,7 +518,7 @@ public:
      *
      * @return the value of the shape function at the given point
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -549,7 +549,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
       if(rResult.size() != 4) rResult.resize(4,false);
       rResult[0] =  0.25*( 1.0 - rCoordinates[0] )*( 1.0 - rCoordinates[1] );
@@ -573,7 +573,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "2 dimensional quadrilateral with four nodes in 2D space";
     }
@@ -584,7 +584,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "2 dimensional quadrilateral with four nodes in 2D space";
     }
@@ -603,7 +603,7 @@ public:
      * :TODO: needs to be reviewed because it is not properly implemented yet
      * (comment by janosch)
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -663,7 +663,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         rResult.resize( 4, 2 );
@@ -710,7 +710,7 @@ public:
      * @param rResult a third order tensor which contains the second derivatives
      * @param rPoint the given point the second order derivatives are calculated in
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -754,7 +754,7 @@ public:
      * @param rResult a fourth order tensor which contains the third derivatives
      * @param rPoint the given point the third order derivatives are calculated in
      */
-    virtual ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -831,12 +831,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/quadrilateral_2d_8.h
+++ b/kratos/geometries/quadrilateral_2d_8.h
@@ -255,7 +255,7 @@ public:
     /**
      * Destructor. Does nothing!!!
      */
-    virtual ~Quadrilateral2D8() {}
+    ~Quadrilateral2D8() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -316,7 +316,7 @@ public:
         return typename BaseType::Pointer( new Quadrilateral2D8( ThisPoints ) );
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -339,7 +339,7 @@ public:
      * (comment by janosch)
      */
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	if(rResult.size() != 8)
            rResult.resize( 8, false );
@@ -371,7 +371,7 @@ public:
      * :TODO: the characteristic length is to be reviewed
      * (comment by janosch)
      */
-    virtual double Length() const override
+    double Length() const override
     {
         array_1d<double,3> point;
         point[0] = 1.0/3.0; point[1] = 1.0/3.0; point[2] = 1.0/3.0;
@@ -394,7 +394,7 @@ public:
      * :TODO: the characteristic area is to be reviewed
      * (comment by janosch)
      */
-    virtual double Area() const override
+    double Area() const override
     {
 
         Vector temp;
@@ -429,7 +429,7 @@ public:
      * :TODO: the characteristic domain size is to be reviewed
      * (comment by janosch)
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return fabs( DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
@@ -437,7 +437,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -469,7 +469,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod ) const override
     {
         //getting derivatives of shape functions
@@ -527,7 +527,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod,
 				     Matrix & DeltaPosition ) const override
     {
@@ -588,7 +588,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 2, 2 );
@@ -637,7 +637,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 2, 2 );
@@ -674,7 +674,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult,
+    Vector& DeterminantOfJacobian( Vector& rResult,
                                            IntegrationMethod ThisMethod ) const override
     {
         //workaround by riccardo
@@ -717,7 +717,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         Matrix jacobian = ZeroMatrix( 2, 2 );
         jacobian = Jacobian( jacobian, IntegrationPointIndex, ThisMethod );
@@ -741,7 +741,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         Matrix jacobian = ZeroMatrix( 2, 2 );
         jacobian = Jacobian( jacobian, rPoint );
@@ -768,7 +768,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         //workaround by riccardo
         if ( rResult.size() != this->IntegrationPointsNumber( ThisMethod ) )
@@ -813,7 +813,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         //current jacobian
         Matrix tempMatrix = ZeroMatrix( 2, 2 );
@@ -855,7 +855,7 @@ public:
      * @see InverseOfJacobian
      *
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         //current jacobian
         Matrix tempMatrix;
@@ -893,7 +893,7 @@ public:
     @see Edges()
     @see Edge()
      */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 4;
     }
@@ -909,7 +909,7 @@ public:
      * @see EdgesNumber()
      * @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
@@ -935,7 +935,7 @@ public:
      *
      * @return the value of the shape function at the given point
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -986,7 +986,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
         if(rResult.size() != 8) rResult.resize(8,false);
 
@@ -1031,7 +1031,7 @@ public:
      * KLUDGE: method call only works with explicit JacobiansType
      * rather than creating JacobiansType within argument list
      */
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1088,7 +1088,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "2 dimensional quadrilateral with eight nodes in 2D space";
     }
@@ -1099,7 +1099,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "2 dimensional quadrilateral with eight nodes in 2D space";
     }
@@ -1113,7 +1113,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -1172,7 +1172,7 @@ public:
     * @return the gradients of all shape functions
     * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         //setting up result matrix
@@ -1219,7 +1219,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         rResult.resize( 8, 2 );
         noalias( rResult ) = ZeroMatrix( 8, 2 );
@@ -1297,7 +1297,7 @@ public:
      * @param rResult a third order tensor which contains the second derivatives
      * @param rPoint the given point the second order derivatives are calculated in
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1372,7 +1372,7 @@ public:
     * @param rResult a fourth order tensor which contains the third derivatives
     * @param rPoint the given point the third order derivatives are calculated in
      */
-    virtual ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
 
         if ( rResult.size() != this->PointsNumber() )
@@ -1493,12 +1493,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/quadrilateral_2d_9.h
+++ b/kratos/geometries/quadrilateral_2d_9.h
@@ -257,7 +257,7 @@ public:
     /**
      * Destructor. Does nothing
      */
-    virtual ~Quadrilateral2D9() {}
+    ~Quadrilateral2D9() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -318,7 +318,7 @@ public:
         return typename BaseType::Pointer( new Quadrilateral2D9( ThisPoints ) );
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -337,7 +337,7 @@ public:
     /**
      * lumping factors for the calculation of the lumped mass matrix
      */
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
         if(rResult.size() != 9)
             rResult.resize( 9, false );
@@ -371,7 +371,7 @@ public:
      * @see Volume()
      * @see DomainSize()
      */
-    virtual double Length() const override
+    double Length() const override
     {
         return sqrt( fabs( this->DeterminantOfJacobian( PointType() ) ) );
     }
@@ -391,7 +391,7 @@ public:
      * @see Volume()
      * @see DomainSize()
      */
-    virtual double Area() const override
+    double Area() const override
     {
 
         Vector temp;
@@ -425,7 +425,7 @@ public:
      * @see Area()
      * @see Volume()
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return fabs( this->DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
@@ -433,7 +433,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -454,7 +454,7 @@ public:
     @see Edges()
     @see Edge()
      */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 4;
     }
@@ -470,7 +470,7 @@ public:
      * @see EdgesNumber()
      * @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
@@ -496,7 +496,7 @@ public:
      *
      * @return the value of the shape function at the given point
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         double fx1 = 0.5 * ( rPoint[0] - 1 ) * rPoint[0];
@@ -544,7 +544,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
         if(rResult.size() != 9) rResult.resize(9,false);
 
@@ -580,7 +580,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "2 dimensional quadrilateral with nine nodes in 2D space";
     }
@@ -591,7 +591,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "2 dimensional quadrilateral with nine nodes in 2D space";
     }
@@ -605,7 +605,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -664,7 +664,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         double fx1 = 0.5 * ( rPoint[0] - 1 ) * rPoint[0];
@@ -710,7 +710,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         rResult.resize( 9, 2, false );
         noalias( rResult ) = ZeroMatrix( 9, 2 );
@@ -789,7 +789,7 @@ public:
      * @param rResult a third order tensor which contains the second derivatives
      * @param rPoint the given point the second order derivatives are calculated in
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -880,7 +880,7 @@ public:
     * @param rResult a fourth order tensor which contains the third derivatives
     * @param rPoint the given point the third order derivatives are calculated in
      */
-    virtual ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
 
         if ( rResult.size() != this->PointsNumber() )
@@ -1036,12 +1036,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -257,7 +257,7 @@ public:
     /**
      * Destructor. Does nothing!!!
      */
-    virtual ~Quadrilateral3D4() {}
+    ~Quadrilateral3D4() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -318,7 +318,7 @@ public:
     }
 
     
-    virtual Geometry< Point<3> >::Pointer  Clone() const override
+    Geometry< Point<3> >::Pointer  Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -339,7 +339,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         rResult.resize( 4, 2, false );
         noalias( rResult ) = ZeroMatrix( 4, 2 );
@@ -355,7 +355,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	    if(rResult.size() != 4)
    	        rResult.resize( 4, false );
@@ -386,7 +386,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Length() const override
+    double Length() const override
     {
 		return std::sqrt( Area() );
     }
@@ -406,7 +406,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Area() const override
+    double Area() const override
     {
 		// Old
 
@@ -483,7 +483,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
 		// Old
 
@@ -495,7 +495,7 @@ public:
     }
 
 
-    virtual double Volume() const override
+    double Volume() const override
     {
 		// Old
 
@@ -522,7 +522,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         PointLocalCoordinates( rResult, rPoint );
 
@@ -534,7 +534,7 @@ public:
     }
 
 
-    virtual CoordinatesArrayType& PointLocalCoordinates( CoordinatesArrayType& rResult,
+    CoordinatesArrayType& PointLocalCoordinates( CoordinatesArrayType& rResult,
             const CoordinatesArrayType& rPoint ) override
     {
         boost::numeric::ublas::bounded_matrix<double,3,4> X;
@@ -631,7 +631,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod ) const override
     {
         //getting derivatives of shape functions
@@ -697,7 +697,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod,
 				     Matrix & DeltaPosition ) const override
     {
@@ -766,7 +766,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult,
+    Matrix& Jacobian( Matrix& rResult,
                               IndexType IntegrationPointIndex,
                               IntegrationMethod ThisMethod ) const override
     {
@@ -821,7 +821,7 @@ public:
     * @see DeterminantOfJacobian
     * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 3, 2, false );
@@ -862,7 +862,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult,
+    Vector& DeterminantOfJacobian( Vector& rResult,
                                            IntegrationMethod ThisMethod ) const override
     {
         const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
@@ -907,7 +907,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex,
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex,
                                           IntegrationMethod ThisMethod ) const override
     {
         Matrix jacobian ( 3, 2 );
@@ -944,7 +944,7 @@ public:
      * point in space this needs to be reviewed
      * (comment by janosch)
      */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         Matrix jacobian ( 3, 2 );
          
@@ -976,7 +976,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult,
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult,
             IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D4::InverseOfJacobian" << "Jacobian is not square" << std::endl;
@@ -1006,7 +1006,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult,
+    Matrix& InverseOfJacobian( Matrix& rResult,
                                        IndexType IntegrationPointIndex,
                                        IntegrationMethod ThisMethod ) const override
     {
@@ -1030,7 +1030,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult,
+    Matrix& InverseOfJacobian( Matrix& rResult,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D4::InverseOfJacobian" << "Jacobian is not square" << std::endl;
@@ -1047,7 +1047,7 @@ public:
     @see Edges()
     @see Edge()
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 4;
     }
@@ -1056,7 +1056,7 @@ public:
     /** FacesNumber
     @return SizeType containes number of this geometry edges/faces.
     */
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
       return EdgesNumber();
     }
@@ -1072,7 +1072,7 @@ public:
     @see EdgesNumber()
     @see Edge()
     */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer EdgePointerType;
@@ -1084,7 +1084,7 @@ public:
     }
 
     //Connectivities of faces required
-    virtual void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
+    void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
     {
         if(NumberNodesInFaces.size() != 4 )
             NumberNodesInFaces.resize(4,false);
@@ -1096,7 +1096,7 @@ public:
 
     }
 
-    virtual void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
+    void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
     {
         if(NodesInFaces.size1() != 3 || NodesInFaces.size2() != 4)
             NodesInFaces.resize(3,4,false);
@@ -1127,7 +1127,7 @@ public:
      * @see Edges
      * @see FacesNumber
     */
-    virtual GeometriesArrayType Faces( void ) override
+    GeometriesArrayType Faces( void ) override
     {
         return GeometriesArrayType();
     }
@@ -1148,7 +1148,7 @@ public:
      *
      * @return the value of the shape function at the given point
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -1179,7 +1179,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
       if(rResult.size() != 4) rResult.resize(4,false);
       rResult[0] =  0.25*( 1.0 - rCoordinates[0] )*( 1.0 - rCoordinates[1] );
@@ -1206,7 +1206,7 @@ public:
      * KLUDGE: method call only works with explicit JacobiansType rather than creating
      * JacobiansType within argument list
     */
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1264,7 +1264,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "3 dimensional quadrilateral with four nodes in 3D space";
     }
@@ -1275,7 +1275,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "3 dimensional quadrilateral with four nodes in 3D space";
     }
@@ -1294,7 +1294,7 @@ public:
      * :TODO: needs to be reviewed because it is not properly implemented yet
      * (comment by janosch)
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -1354,7 +1354,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         rResult.resize( 4, 2, false );
@@ -1401,7 +1401,7 @@ public:
      * @param rResult a third order tensor which contains the second derivatives
      * @param rPoint the given point the second order derivatives are calculated in
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1441,7 +1441,7 @@ public:
      * @param rResult a fourth order tensor which contains the third derivatives
      * @param rPoint the given point the third order derivatives are calculated in
      */
-    virtual ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1506,12 +1506,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, PointsArrayType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, PointsArrayType );
     }

--- a/kratos/geometries/quadrilateral_3d_8.h
+++ b/kratos/geometries/quadrilateral_3d_8.h
@@ -248,7 +248,7 @@ public:
     /**
      * Destructor. Does nothing!!!
      */
-    virtual ~Quadrilateral3D8() {}
+    ~Quadrilateral3D8() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -309,7 +309,7 @@ public:
         return typename BaseType::Pointer( new Quadrilateral3D8( ThisPoints ) );
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -331,7 +331,7 @@ public:
      * (comment by janosch)
      */
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	    if(rResult.size() != 8)
             rResult.resize( 8, false );
@@ -363,7 +363,7 @@ public:
      * :TODO: the characteristic length is to be reviewed
      * (comment by janosch)
      */
-    virtual double Length() const override
+    double Length() const override
     {
         return sqrt( fabs( DeterminantOfJacobian( PointType() ) ) );
     }
@@ -384,14 +384,14 @@ public:
      * :TODO: the characteristic area is to be reviewed
      * (comment by janosch)
      */
-    virtual double Area() const override
+    double Area() const override
     {
         Vector d = this->Points()[2] - this->Points()[0];
         return( sqrt( d[0]*d[0] + d[1]*d[1] + d[2]*d[2] ) );
     }
 
 
-    virtual double Volume() const override
+    double Volume() const override
     {
 
         Vector temp;
@@ -424,7 +424,7 @@ public:
      * :TODO: the characteristic domain size is to be reviewed
      * (comment by janosch)
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return fabs( DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
@@ -432,7 +432,7 @@ public:
     /**
               * Returns whether given arbitrary point is inside the Geometry
                           */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         PointLocalCoordinates( rResult, rPoint );
 
@@ -443,7 +443,7 @@ public:
         return false;
     }
 
-    virtual CoordinatesArrayType& PointLocalCoordinates( CoordinatesArrayType& rResult,
+    CoordinatesArrayType& PointLocalCoordinates( CoordinatesArrayType& rResult,
             const CoordinatesArrayType& rPoint ) override
     {
         double tol = 1.0e-8;
@@ -586,7 +586,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod ) const override
     {
         //getting derivatives of shape functions
@@ -647,7 +647,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod,
 				     Matrix & DeltaPosition ) const override
     {
@@ -710,7 +710,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 3, 2, false );
@@ -765,7 +765,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 3, 2, false );
@@ -805,7 +805,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult,
+    Vector& DeterminantOfJacobian( Vector& rResult,
                                            IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D8::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
@@ -834,7 +834,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D8::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
         return 0.0;
@@ -860,7 +860,7 @@ public:
      * KLUDGE: PointType needed for proper functionality
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D8::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
         return 0.0;
@@ -886,7 +886,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D8::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
         return rResult;
@@ -916,7 +916,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D8::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
         return rResult;
@@ -940,7 +940,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D8::DeterminantOfJacobian" << "Jacobian is not square"  << std::endl;
         return rResult;
@@ -956,7 +956,7 @@ public:
     @see Edges()
     @see Edge()
      */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 4;
     }
@@ -972,7 +972,7 @@ public:
      * @see EdgesNumber()
      * @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
@@ -998,7 +998,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -1049,7 +1049,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
         if(rResult.size() != 8) rResult.resize(8,false);
 
@@ -1095,7 +1095,7 @@ public:
      * KLUDGE: method call only works with explicit JacobiansType
      * rather than creating JacobiansType within argument list
      */
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1152,7 +1152,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "2 dimensional quadrilateral with eight nodes in 2D space";
     }
@@ -1163,7 +1163,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "2 dimensional quadrilateral with eight nodes in 2D space";
     }
@@ -1177,7 +1177,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -1236,7 +1236,7 @@ public:
     * @return the gradients of all shape functions
     * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         //setting up result matrix
@@ -1283,7 +1283,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         rResult.resize( 8, 2, false );
         noalias( rResult ) = ZeroMatrix( 8, 2 );
@@ -1361,7 +1361,7 @@ public:
      * @param rResult a third order tensor which contains the second derivatives
      * @param rPoint the given point the second order derivatives are calculated in
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1436,7 +1436,7 @@ public:
     * @param rResult a fourth order tensor which contains the third derivatives
     * @param rPoint the given point the third order derivatives are calculated in
      */
-    virtual ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
 
         if ( rResult.size() != this->PointsNumber() )
@@ -1556,12 +1556,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -257,7 +257,7 @@ public:
     /**
      * Destructor. Does nothing
      */
-    virtual ~Quadrilateral3D9() {}
+    ~Quadrilateral3D9() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -318,7 +318,7 @@ public:
         return typename BaseType::Pointer( new Quadrilateral3D9( ThisPoints ) );
     }
 
-        virtual Geometry< Point<3> >::Pointer Clone() const override
+        Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -338,7 +338,7 @@ public:
     /**
      * lumping factors for the calculation of the lumped mass matrix
      */
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	    if(rResult.size() != 9)
 	        rResult.resize( 9, false );
@@ -372,7 +372,7 @@ public:
      * @see Volume()
      * @see DomainSize()
      */
-    virtual double Length() const override
+    double Length() const override
     {
         Vector d = this->Points()[2] - this->Points()[0];
         return( sqrt( d[0]*d[0] + d[1]*d[1] + d[2]*d[2] ) );
@@ -393,14 +393,14 @@ public:
      * @see Volume()
      * @see DomainSize()
      */
-    virtual double Area() const override
+    double Area() const override
     {
         Vector d = this->Points()[2] - this->Points()[0];
         return( sqrt( d[0]*d[0] + d[1]*d[1] + d[2]*d[2] ) );
     }
 
 
-    virtual double Volume() const override
+    double Volume() const override
     {
         Vector d = this->Points()[2] - this->Points()[0];
         return( sqrt( d[0]*d[0] + d[1]*d[1] + d[2]*d[2] ) );
@@ -423,7 +423,7 @@ public:
      * @see Area()
      * @see Volume()
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return fabs( DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
@@ -431,7 +431,7 @@ public:
     /**
               * Returns whether given arbitrary point is inside the Geometry
                           */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         PointLocalCoordinates( rResult, rPoint );
 
@@ -443,7 +443,7 @@ public:
     }
 
 
-    virtual CoordinatesArrayType& PointLocalCoordinates( CoordinatesArrayType& rResult,
+    CoordinatesArrayType& PointLocalCoordinates( CoordinatesArrayType& rResult,
             const CoordinatesArrayType& rPoint ) override
     {
         double tol = 1.0e-8;
@@ -586,7 +586,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod ) const override
     {
         //getting derivatives of shape functions
@@ -645,7 +645,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod,
 				     Matrix & DeltaPosition ) const override
     {
@@ -709,7 +709,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult,
+    Matrix& Jacobian( Matrix& rResult,
                               IndexType IntegrationPointIndex,
                               IntegrationMethod ThisMethod ) const override
     {
@@ -756,7 +756,7 @@ public:
       * @see DeterminantOfJacobian
       * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 3, 2, false );
@@ -796,7 +796,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult,
+    Vector& DeterminantOfJacobian( Vector& rResult,
                                            IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D9::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
@@ -825,7 +825,7 @@ public:
      * @see InverseOfJacobian
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex,
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex,
                                           IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D9::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
@@ -853,7 +853,7 @@ public:
      * KLUDGE: PointType needed for proper functionality
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D9::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
         return 0.0;
@@ -880,7 +880,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult,
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult,
             IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D9::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
@@ -910,7 +910,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult,
+    Matrix& InverseOfJacobian( Matrix& rResult,
                                        IndexType IntegrationPointIndex,
                                        IntegrationMethod ThisMethod ) const override
     {
@@ -935,7 +935,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Quadrilateral3D9::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
         return rResult;
@@ -951,7 +951,7 @@ public:
     @see Edges()
     @see Edge()
      */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 4;
     }
@@ -967,7 +967,7 @@ public:
      * @see EdgesNumber()
      * @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
@@ -993,7 +993,7 @@ public:
      *
      * @return the value of the shape function at the given point
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         double fx1 = 0.5 * ( rPoint[0] - 1 ) * rPoint[0];
@@ -1041,7 +1041,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual Vector& ShapeFunctionsValues(Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues(Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
         if(rResult.size() != 9) rResult.resize(9,false);
 
@@ -1082,7 +1082,7 @@ public:
      * KLUDGE: method call only works with explicit JacobiansType rather than creating
      * JacobiansType within argument list
      */
-    virtual ShapeFunctionsGradientsType&
+    ShapeFunctionsGradientsType&
     ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
@@ -1140,7 +1140,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "2 dimensional quadrilateral with nine nodes in 3D space";
     }
@@ -1151,7 +1151,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "2 dimensional quadrilateral with nine nodes in 3D space";
     }
@@ -1165,7 +1165,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -1231,7 +1231,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         double fx1 = 0.5 * ( rPoint[0] - 1 ) * rPoint[0];
@@ -1277,7 +1277,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         rResult.resize( 9, 2, false );
         noalias( rResult ) = ZeroMatrix( 9, 2 );
@@ -1356,7 +1356,7 @@ public:
      * @param rResult a third order tensor which contains the second derivatives
      * @param rPoint the given point the second order derivatives are calculated in
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1447,7 +1447,7 @@ public:
     * @param rResult a fourth order tensor which contains the third derivatives
     * @param rPoint the given point the third order derivatives are calculated in
      */
-    virtual ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
 
         if ( rResult.size() != this->PointsNumber() )
@@ -1676,12 +1676,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/sphere_3d_1.h
+++ b/kratos/geometries/sphere_3d_1.h
@@ -201,7 +201,7 @@ public:
     }
 
     /// Destructor. Do nothing!!!
-    virtual ~Sphere3D1() {}
+    ~Sphere3D1() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -261,7 +261,7 @@ public:
         return typename BaseType::Pointer( new Sphere3D1( ThisPoints ) );
     }
     
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -278,7 +278,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
 	if(rResult.size() != 1)
            rResult.resize( 1, false );
@@ -302,7 +302,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Length() const override
+    double Length() const override
     {
         std::cout<<"This method (Length) has no meaning for this type of geometry (Sphere)."<<std::endl;
                 
@@ -320,7 +320,7 @@ public:
     @see Volume()
     @see DomainSize()
     */
-    virtual double Area() const override
+    double Area() const override
     {
         std::cout<<"This method (Area) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return 0.00;
@@ -337,7 +337,7 @@ public:
     @see Area()
     @see Volume()
     */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         std::cout<<"This method (DomainSize) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return 0.0;
@@ -368,7 +368,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {        
         std::cout<<"This method (Jacobian) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return rResult;
@@ -391,7 +391,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
     {
         std::cout<<"This method (Jacobian) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return rResult;
@@ -414,7 +414,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         std::cout<<"This method (Jacobian) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return rResult;
@@ -431,7 +431,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         std::cout<<"This method (Jacobian) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return rResult;
@@ -448,7 +448,7 @@ public:
     @see Jacobian
     @see InverseOfJacobian
     */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
+    Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
     {
         std::cout<<"This method (DeterminantOfJacobian) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return rResult;
@@ -472,7 +472,7 @@ public:
     @see Jacobian
     @see InverseOfJacobian
     */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         std::cout<<"This method (DeterminantOfJacobian) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return 0.0;
@@ -490,7 +490,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         std::cout<<"This method (DeterminantOfJacobian) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return 0.0;
@@ -511,7 +511,7 @@ public:
     @see Jacobian
     @see DeterminantOfJacobian
     */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         std::cout<<"This method (InverseOfJacobian) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return rResult;
@@ -534,7 +534,7 @@ public:
     @see Jacobian
     @see DeterminantOfJacobian
     */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         std::cout<<"This method (InverseOfJacobian) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return rResult;
@@ -551,7 +551,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& InverseOfJacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         std::cout<<"This method (InverseOfJacobian) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return rResult;
@@ -561,7 +561,7 @@ public:
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 1;
     }
@@ -570,14 +570,14 @@ public:
     ///@name Shape Function
     ///@{
 
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         std::cout<<"This method (ShapeFunctionValue) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return 0;
     }
 
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         std::cout<<"This method (ShapeFunctionsLocalGradients) has no meaning for this type of geometry (Sphere)."<<std::endl;
@@ -586,7 +586,7 @@ public:
 
 
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients( ShapeFunctionsGradientsType& rResult, IntegrationMethod ThisMethod ) const override
     {
         std::cout<<"This method (ShapeFunctionsLocalGradients) has no meaning for this type of geometry (Sphere)."<<std::endl;
         return( rResult );
@@ -599,7 +599,7 @@ public:
     @see PrintData()
     @see PrintInfo()
     */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "a sphere with 1 nodes in its center, in 3D space";
     }
@@ -610,7 +610,7 @@ public:
     @see PrintData()
     @see Info()
     */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "a sphere with 1 nodes in its center, in 3D space";
     }
@@ -623,7 +623,7 @@ public:
     @see PrintInfo()
     @see Info()
     */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         
     }
@@ -688,12 +688,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -248,7 +248,7 @@ public:
     }
 
     /// Destructor. Does nothing!!!
-    virtual ~Tetrahedra3D10() {}
+    ~Tetrahedra3D10() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -310,7 +310,7 @@ public:
         return typename BaseType::Pointer( new Tetrahedra3D10( ThisPoints ) );
     }
 
-        virtual Geometry< Point<3> >::Pointer Clone() const override
+        Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -328,7 +328,7 @@ public:
 
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
         if(rResult.size() != 10)
             rResult.resize( 10, false );
@@ -356,7 +356,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Length() const override
+    double Length() const override
     {
         return sqrt( fabs( this->DeterminantOfJacobian( PointType() ) ) );
     }
@@ -375,13 +375,13 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Area() const override
+    double Area() const override
     {
         return Volume();
     }
 
 
-    virtual double Volume() const override //Not a closed formula for a quadratic tetrahedra
+    double Volume() const override //Not a closed formula for a quadratic tetrahedra
     {
 
         Vector temp;
@@ -412,13 +412,13 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return  Volume();
     }
 
 
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -439,12 +439,12 @@ public:
     @see Edge()
      */
     // will be used by refinement algorithm, thus uncommented. janosch.
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 6;
     }
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 4;
     }
@@ -455,7 +455,7 @@ public:
     @see EdgesNumber()
     @see Edge()
     */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer EdgePointerType;
@@ -487,7 +487,7 @@ public:
         return edges;
     }
 
-    virtual GeometriesArrayType Faces( void ) override
+    GeometriesArrayType Faces( void ) override
     {
         GeometriesArrayType faces = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer FacePointerType;
@@ -538,7 +538,7 @@ public:
      * @return the value of the shape function at the given point
      * TODO: TO BE VERIFIED
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         double fourthCoord = 1.0 - ( rPoint[0] + rPoint[1] + rPoint[2] );
@@ -584,7 +584,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "3 dimensional tetrahedra with ten nodes in 3D space";
     }
@@ -596,7 +596,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "3 dimensional tetrahedra with ten nodes in 3D space";
     }
@@ -610,7 +610,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -639,12 +639,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -224,7 +224,7 @@ public:
     }
 
     /// Destructor. Does nothing!!!
-    virtual ~Tetrahedra3D4() {}
+    ~Tetrahedra3D4() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -285,7 +285,7 @@ public:
         return typename BaseType::Pointer(new Tetrahedra3D4(ThisPoints));
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -302,7 +302,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors(Vector& rResult) const override
+    Vector& LumpingFactors(Vector& rResult) const override
     {
         if(rResult.size() != 4)
             rResult.resize(4, false);
@@ -329,7 +329,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Length() const override
+    double Length() const override
     {
         constexpr double factor = 2.0396489026555;                              // (12/sqrt(2)) ^ 1/3);
         return  factor * pow(std::fabs(Volume()), 0.33333333333333);            // sqrt(fabs( DeterminantOfJacobian(PointType())));
@@ -349,7 +349,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Area() const override
+    double Area() const override
     {
         return this->Volume();
     }
@@ -367,7 +367,7 @@ public:
      *
      * :TODO: might be necessary to reimplement
      */
-    virtual double Volume() const override {
+    double Volume() const override {
         //closed formula for the linear triangle
         const double onesixth = 1.0/6.0;
 
@@ -392,7 +392,7 @@ public:
         return  detJ*onesixth;
     }
 
-    virtual double DomainSize() const override {
+    double DomainSize() const override {
       return Volume();
     }
 
@@ -403,7 +403,7 @@ public:
      * @see MaxEdgeLength()
      * @see AverageEdgeLength()
      */
-    virtual double MinEdgeLength() const override {
+    double MinEdgeLength() const override {
       auto a = this->GetPoint(0) - this->GetPoint(1);
       auto b = this->GetPoint(1) - this->GetPoint(2);
       auto c = this->GetPoint(2) - this->GetPoint(0);
@@ -429,7 +429,7 @@ public:
      * @see MinEdgeLength()
      * @see AverageEdgeLength()
      */
-    virtual double MaxEdgeLength() const override {
+    double MaxEdgeLength() const override {
       auto a = this->GetPoint(0) - this->GetPoint(1);
       auto b = this->GetPoint(1) - this->GetPoint(2);
       auto c = this->GetPoint(2) - this->GetPoint(0);
@@ -454,7 +454,7 @@ public:
      * @see MinEdgeLength()
      * @see MaxEdgeLength()
      */
-    virtual double AverageEdgeLength() const override {
+    double AverageEdgeLength() const override {
       return CalculateAvgEdgeLength(
         MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1)),
         MathUtils<double>::Norm3(this->GetPoint(1)-this->GetPoint(2)),
@@ -469,7 +469,7 @@ public:
      *
      * @return The circumradius of the geometry
      */
-    virtual double Circumradius() const override {
+    double Circumradius() const override {
       //    | s10 y10 z10 |           | s10 x10 z10 |           | s10 x10 y10 |           | x10 y10 z10 |
       // MX | s20 y20 z20 |        MY | s20 x20 z20 |        MZ | s20 x20 y20 |        AL | x20 y20 z20 |
       //    | s30 y30 z30 |           | s30 x30 z30 |           | s30 x30 y30 |           | x30 y30 z30 |
@@ -513,7 +513,7 @@ public:
      *
      * @return The inradius of the geometry
      */
-    virtual double Inradius() const override {
+    double Inradius() const override {
       //    | x10 y10 z10 |
       // AL | x20 y20 z20 |
       //    | x30 y30 z30 |
@@ -563,7 +563,7 @@ public:
      *
      * @return The inradius to circumradius quality metric.
      */
-    virtual double InradiusToCircumradiusQuality() const override {
+    double InradiusToCircumradiusQuality() const override {
       constexpr double normFactor = 3.0;
 
       return normFactor * Inradius() / Circumradius();
@@ -579,7 +579,7 @@ public:
      *
      * @return The inradius to longest edge quality metric.
      */
-    virtual double InradiusToLongestEdgeQuality() const override {
+    double InradiusToLongestEdgeQuality() const override {
       constexpr double normFactor = 4.89897982161;
 
       auto a = this->GetPoint(0) - this->GetPoint(1);
@@ -609,7 +609,7 @@ public:
      *
      * @return [description]
      */
-    virtual double ShortestToLongestEdgeQuality() const override {
+    double ShortestToLongestEdgeQuality() const override {
       auto a = this->GetPoint(0) - this->GetPoint(1);
       auto b = this->GetPoint(1) - this->GetPoint(2);
       auto c = this->GetPoint(2) - this->GetPoint(0);
@@ -636,7 +636,7 @@ public:
      *
      * @return regualirty quality.
      */
-    virtual double RegualrityQuiality() const override {
+    double RegualrityQuiality() const override {
       KRATOS_ERROR << "Method 'RegualrityQuiality' is not yet implemented for Tetrahedra3D4" << std::endl;
       return 0.0;
     }
@@ -650,7 +650,7 @@ public:
      *
      * @return volume to surface quality.
      */
-    virtual double VolumeToSurfaceAreaQuality() const override {
+    double VolumeToSurfaceAreaQuality() const override {
       KRATOS_ERROR << "Method 'VolumeToSurfaceAreaQuality' is not yet implemented for Tetrahedra3D4" << std::endl;
       return 0.0;
     }
@@ -664,7 +664,7 @@ public:
      *
      * @return Volume to edge length quality.
      */
-    virtual double VolumeToEdgeLengthQuality() const override {
+    double VolumeToEdgeLengthQuality() const override {
       constexpr double normFactor = 12.0;
 
       auto a = this->GetPoint(0) - this->GetPoint(1);
@@ -695,7 +695,7 @@ public:
      *
      * @return [description]
      */
-    virtual double VolumeToAverageEdgeLength() const override {
+    double VolumeToAverageEdgeLength() const override {
       constexpr double normFactor = 6.0 * 1.41421356237309504880;
 
       return normFactor * Volume() / std::pow(AverageEdgeLength(), 3);
@@ -712,7 +712,7 @@ public:
      *
      * @return [description]
      */
-    virtual double VolumeToRMSEdgeLength() const override {
+    double VolumeToRMSEdgeLength() const override {
       constexpr double normFactor = 6.0 * 1.41421356237309504880;
 
       auto a = this->GetPoint(0) - this->GetPoint(1);
@@ -737,7 +737,7 @@ public:
     * @param rResult a Matrix that will be overwritten by the results
     * @return the coordinates of all points of the current geometry
     */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         if(rResult.size1()!= 4 || rResult.size2()!= 3)
             rResult.resize(4, 3, false);
@@ -761,7 +761,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
         if( rResult[0] >= 0.0-Tolerance )
@@ -779,12 +779,12 @@ public:
     @see Edge()
      */
     // will be used by refinement algorithm, thus uncommented. janosch.
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 6;
     }
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 4;
     }
@@ -795,7 +795,7 @@ public:
     @see EdgesNumber()
     @see Edge()
      */
-    virtual GeometriesArrayType Edges(void) override
+    GeometriesArrayType Edges(void) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer EdgePointerType;
@@ -821,7 +821,7 @@ public:
         return edges;
     }
 
-    virtual GeometriesArrayType Faces(void) override
+    GeometriesArrayType Faces(void) override
     {
         GeometriesArrayType faces = GeometriesArrayType();
         typedef typename Geometry<TPointType>::Pointer FacePointerType;
@@ -845,7 +845,7 @@ public:
     }
 
     //Connectivities of faces required
-    virtual void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
+    void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
     {
         NumberNodesInFaces.resize(4, false);
         // Linear Tetrahedra have elements of 3 nodes as faces
@@ -857,7 +857,7 @@ public:
     }
 
 
-    virtual void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
+    void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
     {
         NodesInFaces.resize(4, 4, false);
         NodesInFaces(0,0)=0;//face or other node
@@ -896,7 +896,7 @@ public:
      * @return the value of the shape function at the given point
      * TODO: TO BE VERIFIED
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint) const override
     {
         switch( ShapeFunctionIndex )
@@ -928,7 +928,7 @@ public:
     @see ShapeFunctionsLocalGradients
     @see ShapeFunctionLocalGradient
     */
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
       if(rResult.size() != 4) rResult.resize(4,false);
       rResult[0] =  1.0-(rCoordinates[0]+rCoordinates[1]+rCoordinates[2]);
@@ -947,7 +947,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if(rResult.size1() != this->PointsNumber() || rResult.size2() != this->LocalSpaceDimension())
             rResult.resize(this->PointsNumber(),this->LocalSpaceDimension(),false);
@@ -972,7 +972,7 @@ public:
      *
      * :TODO: TESTING!!!
      */
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod) const override
     {
@@ -1023,7 +1023,7 @@ public:
     }
 
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult
         , Vector& determinants_of_jacobian
         , IntegrationMethod ThisMethod) const override
@@ -1085,7 +1085,7 @@ public:
 
 
     /// detect if two tetrahedra are intersected
-    virtual bool HasIntersection( const BaseType& rThisGeometry) override
+    bool HasIntersection( const BaseType& rThisGeometry) override
     {
 
         array_1d<Plane, 4>  plane;
@@ -1110,7 +1110,7 @@ public:
     }
 
 
-    virtual bool HasIntersection(const Point<3, double>& rLowPoint, const Point<3, double>& rHighPoint) override
+    bool HasIntersection(const Point<3, double>& rLowPoint, const Point<3, double>& rHighPoint) override
     {
         return true;
     }
@@ -1313,7 +1313,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "3 dimensional tetrahedra with four nodes in 3D space";
     }
@@ -1325,7 +1325,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "3 dimensional tetrahedra with four nodes in 3D space";
     }
@@ -1339,7 +1339,7 @@ public:
      * @see PrintInfo()
      * @see Info()
      */
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         BaseType::PrintData(rOStream);
         std::cout << std::endl;
@@ -1369,12 +1369,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseType );
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseType );
     }

--- a/kratos/geometries/triangle_2d_3.h
+++ b/kratos/geometries/triangle_2d_3.h
@@ -256,7 +256,7 @@ public:
     /**
      * Destructor. Does nothing!!!
      */
-    virtual ~Triangle2D3() {}
+    ~Triangle2D3() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -316,7 +316,7 @@ public:
         return typename BaseType::Pointer( new Triangle2D3( ThisPoints ) );
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -337,7 +337,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         rResult = ZeroMatrix( 3, 2 );
         rResult( 0, 0 ) =  0.0;
@@ -350,7 +350,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
         if(rResult.size() != 3)
             rResult.resize( 3, false );
@@ -381,7 +381,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Length() const override
+    double Length() const override
     {
         //return sqrt(fabs( DeterminantOfJacobian(PointType()))*0.5);
         double length = 0.000;
@@ -405,7 +405,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Area() const override {
+    double Area() const override {
         const PointType& p0 = this->operator [](0);
         const PointType& p1 = this->operator [](1);
         const PointType& p2 = this->operator [](2);
@@ -421,7 +421,7 @@ public:
     }
 
     /// detect if two triangle are intersected
-    virtual bool HasIntersection( const BaseType& rThisGeometry ) override {
+    bool HasIntersection( const BaseType& rThisGeometry ) override {
         const BaseType& geom_1 = *this;
         const BaseType& geom_2 = rThisGeometry;
         return  NoDivTriTriIsect(geom_1[0].Coordinates(), geom_1[1].Coordinates() , geom_1[2].Coordinates(),
@@ -429,7 +429,7 @@ public:
     }
 
     /// detect if  triangle and box are intersected
-    virtual bool HasIntersection( const Point<3, double>& rLowPoint, const Point<3, double>& rHighPoint ) override {
+    bool HasIntersection( const Point<3, double>& rLowPoint, const Point<3, double>& rHighPoint ) override {
         //return true;
         const BaseType& geom_1 = *this;
         //std::size_t dim        =  geom_1.WorkingSpaceDimension();
@@ -471,7 +471,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double DomainSize() const override {
+    double DomainSize() const override {
       return this->Area();
     }
     /// Class Interface
@@ -500,7 +500,7 @@ public:
      * @see MaxEdgeLength()
      * @see AverageEdgeLength()
      */
-    virtual double MinEdgeLength() const override {
+    double MinEdgeLength() const override {
       auto a = this->GetPoint(0) - this->GetPoint(1);
       auto b = this->GetPoint(1) - this->GetPoint(2);
       auto c = this->GetPoint(2) - this->GetPoint(0);
@@ -520,7 +520,7 @@ public:
      * @see MinEdgeLength()
      * @see AverageEdgeLength()
      */
-    virtual double MaxEdgeLength() const override {
+    double MaxEdgeLength() const override {
       auto a = this->GetPoint(0) - this->GetPoint(1);
       auto b = this->GetPoint(1) - this->GetPoint(2);
       auto c = this->GetPoint(2) - this->GetPoint(0);
@@ -540,7 +540,7 @@ public:
      * @see MinEdgeLength()
      * @see MaxEdgeLength()
      */
-    virtual double AverageEdgeLength() const override {
+    double AverageEdgeLength() const override {
       return CalculateAvgEdgeLength(
         MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1)),
         MathUtils<double>::Norm3(this->GetPoint(1)-this->GetPoint(2)),
@@ -555,7 +555,7 @@ public:
      *
      * @see Inradius()
      */
-    virtual double Circumradius() const override {
+    double Circumradius() const override {
       return CalculateCircumradius(
         MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1)),
         MathUtils<double>::Norm3(this->GetPoint(1)-this->GetPoint(2)),
@@ -570,7 +570,7 @@ public:
      *
      * @see Circumradius()
      */
-    virtual double Inradius() const override {
+    double Inradius() const override {
       return CalculateInradius(
         MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1)),
         MathUtils<double>::Norm3(this->GetPoint(1)-this->GetPoint(2)),
@@ -590,7 +590,7 @@ public:
      *
      * @return The inradius to circumradius quality metric.
      */
-    virtual double InradiusToCircumradiusQuality() const override {
+    double InradiusToCircumradiusQuality() const override {
       constexpr double normFactor = 1.0;
 
       double a = MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1));
@@ -610,7 +610,7 @@ public:
      *
      * @return The inradius to longest edge quality metric.
      */
-    virtual double InradiusToLongestEdgeQuality() const override {
+    double InradiusToLongestEdgeQuality() const override {
       constexpr double normFactor = 1.0; // TODO: This normalization coeficient is not correct.
 
       auto a = this->GetPoint(0) - this->GetPoint(1);
@@ -634,7 +634,7 @@ public:
      *
      * @return The Inradius to Circumradius Quality metric.
      */
-    virtual double AreaToEdgeLengthRatio() const override {
+    double AreaToEdgeLengthRatio() const override {
       constexpr double normFactor = 1.0;
 
       auto a = this->GetPoint(0) - this->GetPoint(1);
@@ -659,7 +659,7 @@ public:
      *
      * @return The shortest altitude to edge length quality metric.
      */
-    virtual double ShortestAltitudeToEdgeLengthRatio() const override {
+    double ShortestAltitudeToEdgeLengthRatio() const override {
       constexpr double normFactor = 1.0;
 
       auto a = this->GetPoint(0) - this->GetPoint(1);
@@ -680,7 +680,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
         if( rResult[0] >= (0.0-Tolerance) )
@@ -702,13 +702,13 @@ public:
     @see Edges()
     @see Edge()
      */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 3;
     }
 
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 3;
     }
@@ -725,7 +725,7 @@ public:
     @see EdgesNumber()
     @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
@@ -738,7 +738,7 @@ public:
 
 
     //Connectivities of faces required
-    virtual void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
+    void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
     {
         if(NumberNodesInFaces.size() != 3 )
             NumberNodesInFaces.resize(3,false);
@@ -749,7 +749,7 @@ public:
 
     }
 
-    virtual void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
+    void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
     {
         if(NodesInFaces.size1() != 3 || NodesInFaces.size2() != 3)
             NodesInFaces.resize(3,3,false);
@@ -786,7 +786,7 @@ public:
      *
      * @return the value of the shape function at the given point
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -818,7 +818,7 @@ public:
     @see ShapeFunctionLocalGradient
     */
 
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
       if(rResult.size() != 3) rResult.resize(3,false);
       rResult[0] =  1.0 -rCoordinates[0] - rCoordinates[1];
@@ -841,7 +841,7 @@ public:
      * @return the gradients of all shape functions with regard to the global coordinates
 
     */
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -883,7 +883,7 @@ public:
         return rResult;
     }
 
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         Vector& determinants_of_jacobian,
         IntegrationMethod ThisMethod ) const override
@@ -944,7 +944,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult,
+    Vector& DeterminantOfJacobian( Vector& rResult,
                                            IntegrationMethod ThisMethod ) const override
     {
         const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
@@ -981,7 +981,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex,
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex,
                                           IntegrationMethod ThisMethod ) const override
     {
         return 2.0*(this->Area());
@@ -1001,7 +1001,7 @@ public:
      * @see InverseOfJacobian
      *
      */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         return 2.0*(this->Area());
     }
@@ -1018,7 +1018,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "2 dimensional triangle with three nodes in 2D space";
     }
@@ -1029,7 +1029,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "2 dimensional triangle with three nodes in 2D space";
     }
@@ -1048,7 +1048,7 @@ public:
      * :TODO: needs to be reviewed because it is not properly implemented yet
      * (comment by janosch)
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         PrintInfo( rOStream );
         BaseType::PrintData( rOStream );
@@ -1109,7 +1109,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         rResult = ZeroMatrix( 3, 2 );
@@ -1151,7 +1151,7 @@ public:
      * @param rResult a third order tensor which contains the second derivatives
      * @param rPoint the given point the second order derivatives are calculated in
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1191,7 +1191,7 @@ public:
      * @param rResult a fourth order tensor which contains the third derivatives
      * @param rPoint the given point the third order derivatives are calculated in
      */
-    virtual ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1254,12 +1254,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/triangle_2d_6.h
+++ b/kratos/geometries/triangle_2d_6.h
@@ -268,7 +268,7 @@ public:
     /**
      * Destructor. Does nothing!!!
      */
-    virtual ~Triangle2D6() {}
+    ~Triangle2D6() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -328,7 +328,7 @@ public:
         return typename BaseType::Pointer( new Triangle2D6( ThisPoints ) );
     }
 
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -349,7 +349,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         rResult.resize( 6, 2,false );
         noalias( rResult ) = ZeroMatrix( 6, 2 );
@@ -369,7 +369,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
         if(rResult.size() != 6)
             rResult.resize( 6, false );
@@ -400,7 +400,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Length() const override
+    double Length() const override
     {
         return sqrt( fabs( Area() ) );
     }
@@ -420,7 +420,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Area() const override
+    double Area() const override
     {
 
         Vector temp;
@@ -451,7 +451,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return fabs( this->DeterminantOfJacobian( PointType() ) ) * 0.5;
     }
@@ -459,7 +459,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -488,7 +488,7 @@ public:
      *
      * @return the value of the shape function at the given point
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
 
@@ -527,7 +527,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "2 dimensional triangle with six nodes in 2D space";
     }
@@ -538,7 +538,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "2 dimensional triangle with six nodes in 2D space";
     }
@@ -557,7 +557,7 @@ public:
      * :TODO: needs to be reviewed because it is not properly implemented yet
      * (comment by janosch)
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         PrintInfo( rOStream );
         BaseType::PrintData( rOStream );
@@ -577,13 +577,13 @@ public:
     @see Edges()
     @see Edge()
      */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 3;
     }
 
 
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
         return 3;
     }
@@ -600,7 +600,7 @@ public:
     @see EdgesNumber()
     @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
@@ -612,7 +612,7 @@ public:
 
 
    //Connectivities of faces required
-    virtual void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
+    void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
     {
         if(NumberNodesInFaces.size() != 3 )
             NumberNodesInFaces.resize(3,false);
@@ -624,7 +624,7 @@ public:
     }
 
 
-    virtual void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
+    void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
     {
         if(NodesInFaces.size1() != 4 || NodesInFaces.size2() != 3)
             NodesInFaces.resize(4,3,false);
@@ -699,7 +699,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         rResult.resize( 6, 2 ,false);
@@ -763,7 +763,7 @@ public:
      * @param rResult a third order tensor which contains the second derivatives
      * @param rPoint the given point the second order derivatives are calculated in
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -814,7 +814,7 @@ public:
      * @param rResult a fourth order tensor which contains the third derivatives
      * @param rPoint the given point the third order derivatives are calculated in
      */
-    virtual ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -884,12 +884,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -254,7 +254,7 @@ public:
     /**
      * Destructor. Does nothing!!!
      */
-    virtual ~Triangle3D3() {}
+    ~Triangle3D3() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -315,7 +315,7 @@ public:
     }
 
 
-    virtual boost::shared_ptr< Geometry< Point<3> > > Clone() const override
+    boost::shared_ptr< Geometry< Point<3> > > Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -336,7 +336,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         rResult.resize( 3, 2 ,false);
         noalias( rResult ) = ZeroMatrix( 3, 2 );
@@ -350,7 +350,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
         rResult.resize( 3, false );
         std::fill( rResult.begin(), rResult.end(), 1.00 / 3.00 );
@@ -380,7 +380,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Length() const override {
+    double Length() const override {
 		  return std::sqrt(2.0 * Area());
     }
 
@@ -399,7 +399,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Area() const override {
+    double Area() const override {
       double a = MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1));
       double b = MathUtils<double>::Norm3(this->GetPoint(1)-this->GetPoint(2));
       double c = MathUtils<double>::Norm3(this->GetPoint(2)-this->GetPoint(0));
@@ -423,7 +423,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double DomainSize() const override {
+    double DomainSize() const override {
       return Area();
     }
 
@@ -437,7 +437,7 @@ public:
      * @see MaxEdgeLength()
      * @see AverageEdgeLength()
      */
-    virtual double MinEdgeLength() const override {
+    double MinEdgeLength() const override {
       auto a = this->GetPoint(0) - this->GetPoint(1);
       auto b = this->GetPoint(1) - this->GetPoint(2);
       auto c = this->GetPoint(2) - this->GetPoint(0);
@@ -457,7 +457,7 @@ public:
      * @see MinEdgeLength()
      * @see AverageEdgeLength()
      */
-    virtual double MaxEdgeLength() const override {
+    double MaxEdgeLength() const override {
       auto a = this->GetPoint(0) - this->GetPoint(1);
       auto b = this->GetPoint(1) - this->GetPoint(2);
       auto c = this->GetPoint(2) - this->GetPoint(0);
@@ -477,7 +477,7 @@ public:
      * @see MinEdgeLength()
      * @see MaxEdgeLength()
      */
-    virtual double AverageEdgeLength() const override {
+    double AverageEdgeLength() const override {
       return CalculateAvgEdgeLength(
         MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1)),
         MathUtils<double>::Norm3(this->GetPoint(1)-this->GetPoint(2)),
@@ -492,7 +492,7 @@ public:
      *
      * @see Inradius()
      */
-    virtual double Circumradius() const override {
+    double Circumradius() const override {
       return CalculateCircumradius(
         MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1)),
         MathUtils<double>::Norm3(this->GetPoint(1)-this->GetPoint(2)),
@@ -507,7 +507,7 @@ public:
      *
      * @see Circumradius()
      */
-    virtual double Inradius() const override {
+    double Inradius() const override {
       return CalculateInradius(
         MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1)),
         MathUtils<double>::Norm3(this->GetPoint(1)-this->GetPoint(2)),
@@ -629,7 +629,7 @@ public:
      *
      * @return The inradius to circumradius quality metric.
      */
-    virtual double InradiusToCircumradiusQuality() const override {
+    double InradiusToCircumradiusQuality() const override {
       constexpr double normFactor = 1.0;
 
       double a = MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1));
@@ -649,7 +649,7 @@ public:
      *
      * @return The inradius to longest edge quality metric.
      */
-    virtual double InradiusToLongestEdgeQuality() const override {
+    double InradiusToLongestEdgeQuality() const override {
       constexpr double normFactor = 1.0; // TODO: This normalization coeficient is not correct.
 
       auto a = this->GetPoint(0) - this->GetPoint(1);
@@ -674,7 +674,7 @@ public:
      *
      * @return The Inradius to Circumradius Quality metric.
      */
-    virtual double AreaToEdgeLengthRatio() const override {
+    double AreaToEdgeLengthRatio() const override {
       constexpr double normFactor = 1.0;
 
       auto a = this->GetPoint(0) - this->GetPoint(1);
@@ -699,7 +699,7 @@ public:
      *
      * @return The shortest altitude to edge length quality metric.
      */
-    virtual double ShortestAltitudeToEdgeLengthRatio() const override {
+    double ShortestAltitudeToEdgeLengthRatio() const override {
       constexpr double normFactor = 1.0;
 
       auto a = this->GetPoint(0) - this->GetPoint(1);
@@ -769,7 +769,7 @@ public:
      * Returns whether given arbitrary point is inside the Geometry
      */
 
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         PointLocalCoordinates( rResult, rPoint );
 
@@ -781,7 +781,7 @@ public:
         return false;
     }
 
-    virtual CoordinatesArrayType& PointLocalCoordinates( CoordinatesArrayType& rResult,
+    CoordinatesArrayType& PointLocalCoordinates( CoordinatesArrayType& rResult,
             const CoordinatesArrayType& rPoint ) override
     {
         boost::numeric::ublas::bounded_matrix<double,3,3> X;
@@ -874,7 +874,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod ) const override
     {
         Matrix jacobian( 3, 2 );
@@ -915,7 +915,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult,
+    JacobiansType& Jacobian( JacobiansType& rResult,
                                      IntegrationMethod ThisMethod,
 				     Matrix & DeltaPosition ) const override
     {
@@ -960,7 +960,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult,
+    Matrix& Jacobian( Matrix& rResult,
                               IndexType IntegrationPointIndex,
                               IntegrationMethod ThisMethod ) const override
     {
@@ -989,7 +989,7 @@ public:
     * @see DeterminantOfJacobian
     * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         rResult.resize( 3, 2 ,false);
         rResult( 0, 0 ) = -( BaseType::GetPoint( 0 ).X() ) + ( BaseType::GetPoint( 1 ).X() );
@@ -1013,7 +1013,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
+    Vector& DeterminantOfJacobian( Vector& rResult, IntegrationMethod ThisMethod ) const override
     {
         const unsigned int integration_points_number = msGeometryData.IntegrationPointsNumber( ThisMethod );
         if(rResult.size() != integration_points_number)
@@ -1049,7 +1049,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPoint,
+    double DeterminantOfJacobian( IndexType IntegrationPoint,
                                           IntegrationMethod ThisMethod ) const override
     {
         return 2.0*(this->Area());
@@ -1068,7 +1068,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         return 2.0*(this->Area());
     }
@@ -1094,7 +1094,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult,
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult,
             IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Triangle3D::InverseOfJacobian" << "Jacobian is not square" << std::endl;
@@ -1124,7 +1124,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult,
+    Matrix& InverseOfJacobian( Matrix& rResult,
                                        IndexType IntegrationPointIndex,
                                        IntegrationMethod ThisMethod ) const override
     {
@@ -1148,7 +1148,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult,
+    Matrix& InverseOfJacobian( Matrix& rResult,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Triangle3D::InverseOfJacobian" << "Jacobian is not square" << std::endl;
@@ -1158,7 +1158,7 @@ public:
     /** EdgesNumber
     @return SizeType containes number of this geometry edges.
     */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 3;
     }
@@ -1167,7 +1167,7 @@ public:
     /** FacesNumber
     @return SizeType containes number of this geometry edges/faces.
     */
-    virtual SizeType FacesNumber() const override
+    SizeType FacesNumber() const override
     {
       return EdgesNumber();
     }
@@ -1183,7 +1183,7 @@ public:
     @see EdgesNumber()
     @see Edge()
     */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
@@ -1195,7 +1195,7 @@ public:
 
 
     //Connectivities of faces required
-    virtual void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
+    void NumberNodesInFaces (boost::numeric::ublas::vector<unsigned int>& NumberNodesInFaces) const override
     {
         if(NumberNodesInFaces.size() != 3 )
             NumberNodesInFaces.resize(3,false);
@@ -1206,7 +1206,7 @@ public:
 
     }
 
-    virtual void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
+    void NodesInFaces (boost::numeric::ublas::matrix<unsigned int>& NodesInFaces) const override
     {
         if(NodesInFaces.size1() != 3 || NodesInFaces.size2() != 3)
             NodesInFaces.resize(3,3,false);
@@ -1234,7 +1234,7 @@ public:
      * @see Edges
      * @see FacesNumber
     */
-    virtual GeometriesArrayType Faces( void ) override
+    GeometriesArrayType Faces( void ) override
     {
         return GeometriesArrayType();
     }
@@ -1256,7 +1256,7 @@ public:
      *
      * @return the value of the shape function at the given point
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         switch ( ShapeFunctionIndex )
@@ -1286,7 +1286,7 @@ public:
      * @see ShapeFunctionLocalGradient
      */
 
-    virtual Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
+    Vector& ShapeFunctionsValues (Vector &rResult, const CoordinatesArrayType& rCoordinates) const override
     {
         if(rResult.size() != 3)
         {
@@ -1316,7 +1316,7 @@ public:
      * KLUDGE: method call only works with explicit JacobiansType rather than creating
      * JacobiansType within argument list
     */
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1374,7 +1374,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "2 dimensional triangle with three nodes in 3D space";
     }
@@ -1385,7 +1385,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "2 dimensional triangle with three nodes in 3D space";
     }
@@ -1404,7 +1404,7 @@ public:
      * :TODO: needs to be reviewed because it is not properly implemented yet
      * (comment by janosch)
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         BaseType::PrintData( rOStream );
         std::cout << std::endl;
@@ -1464,7 +1464,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         rResult.resize( 3, 2 ,false);
@@ -1508,7 +1508,7 @@ public:
      * @param rResult a third order tensor which contains the second derivatives
      * @param rPoint the given point the second order derivatives are calculated in
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1543,7 +1543,7 @@ public:
      * @param rResult a fourth order tensor which contains the third derivatives
      * @param rPoint the given point the third order derivatives are calculated in
      */
-    virtual ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1606,12 +1606,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/geometries/triangle_3d_6.h
+++ b/kratos/geometries/triangle_3d_6.h
@@ -267,7 +267,7 @@ public:
     /**
      * Destructor. Does nothing!!!
      */
-    virtual ~Triangle3D6() {}
+    ~Triangle3D6() override {}
 
     GeometryData::KratosGeometryFamily GetGeometryFamily() override
     {
@@ -328,7 +328,7 @@ public:
     }
 
     
-    virtual Geometry< Point<3> >::Pointer Clone() const override
+    Geometry< Point<3> >::Pointer Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -350,7 +350,7 @@ public:
      * @param rResult a Matrix object that will be overwritten by the result
      * @return the local coordinates of all nodes
      */
-    virtual Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
+    Matrix& PointsLocalCoordinates( Matrix& rResult ) const override
     {
         rResult.resize( 6, 2,false );
         noalias( rResult ) = ZeroMatrix( 6, 2 );
@@ -370,7 +370,7 @@ public:
     }
 
     //lumping factors for the calculation of the lumped mass matrix
-    virtual Vector& LumpingFactors( Vector& rResult ) const override
+    Vector& LumpingFactors( Vector& rResult ) const override
     {
         if(rResult.size() != 6)
             rResult.resize( 6, false );
@@ -401,7 +401,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Length() const override
+    double Length() const override
     {
         // return sqrt( fabs( DeterminantOfJacobian( PointType() ) ) );
         // Approximation to avoid errors. Can be improved. 
@@ -429,7 +429,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double Area() const override
+    double Area() const override
     {
         //return fabs( DeterminantOfJacobian( PointType() ) ) * 0.5;
         // Approximation to avoid errors. Can be improved.
@@ -462,7 +462,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    virtual double DomainSize() const override
+    double DomainSize() const override
     {
         return Area();
     }
@@ -470,7 +470,7 @@ public:
     /**
      * Returns whether given arbitrary point is inside the Geometry
      */
-    virtual bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
+    bool IsInside( const CoordinatesArrayType& rPoint, CoordinatesArrayType& rResult, const double Tolerance = std::numeric_limits<double>::epsilon() ) override
     {
         this->PointLocalCoordinates( rResult, rPoint );
 
@@ -503,7 +503,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod ) const override
     {
         ShapeFunctionsGradientsType shape_functions_gradients =
             CalculateShapeFunctionsIntegrationPointsLocalGradients( ThisMethod );
@@ -563,7 +563,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
+    JacobiansType& Jacobian( JacobiansType& rResult, IntegrationMethod ThisMethod, Matrix & DeltaPosition ) const override
     {
         ShapeFunctionsGradientsType shape_functions_gradients =
             CalculateShapeFunctionsIntegrationPointsLocalGradients( ThisMethod );
@@ -665,7 +665,7 @@ public:
      * @see DeterminantOfJacobian
      * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
+    Matrix& Jacobian( Matrix& rResult, IndexType IntegrationPointIndex, IntegrationMethod ThisMethod ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 3, 2 ,false);
@@ -739,7 +739,7 @@ public:
     * @see DeterminantOfJacobian
     * @see InverseOfJacobian
      */
-    virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
+    Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         //setting up size of jacobian matrix
         rResult.resize( 3, 2 ,false);
@@ -778,7 +778,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual Vector& DeterminantOfJacobian( Vector& rResult,
+    Vector& DeterminantOfJacobian( Vector& rResult,
                                            IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Triangle3D6::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
@@ -808,7 +808,7 @@ public:
      * @see Jacobian
      * @see InverseOfJacobian
      */
-    virtual double DeterminantOfJacobian( IndexType IntegrationPointIndex,
+    double DeterminantOfJacobian( IndexType IntegrationPointIndex,
                                           IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Triangle3D6::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
@@ -840,7 +840,7 @@ public:
      * point in space this needs to be reviewed
      * (comment by janosch)
      */
-    virtual double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
+    double DeterminantOfJacobian( const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Triangle3D6::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
         return 0.0;
@@ -867,7 +867,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual JacobiansType& InverseOfJacobian( JacobiansType& rResult,
+    JacobiansType& InverseOfJacobian( JacobiansType& rResult,
             IntegrationMethod ThisMethod ) const override
     {
         KRATOS_ERROR << "Triangle3D6::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
@@ -897,7 +897,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult,
+    Matrix& InverseOfJacobian( Matrix& rResult,
                                        IndexType IntegrationPointIndex,
                                        IntegrationMethod ThisMethod ) const override
     {
@@ -921,7 +921,7 @@ public:
      *
      * KLUDGE: works only with explicitly generated Matrix object
      */
-    virtual Matrix& InverseOfJacobian( Matrix& rResult,
+    Matrix& InverseOfJacobian( Matrix& rResult,
                                        const CoordinatesArrayType& rPoint ) const override
     {
         KRATOS_ERROR << "Triangle3D6::DeterminantOfJacobian" << "Jacobian is not square" << std::endl;
@@ -944,7 +944,7 @@ public:
      *
      * @return the value of the shape function at the given point
      */
-    virtual double ShapeFunctionValue( IndexType ShapeFunctionIndex,
+    double ShapeFunctionValue( IndexType ShapeFunctionIndex,
                                        const CoordinatesArrayType& rPoint ) const override
     {
 
@@ -988,7 +988,7 @@ public:
      * KLUDGE: method call only works with explicit JacobiansType rather than creating
      * JacobiansType within argument list
     */
-    virtual ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
+    ShapeFunctionsGradientsType& ShapeFunctionsIntegrationPointsGradients(
         ShapeFunctionsGradientsType& rResult,
         IntegrationMethod ThisMethod ) const override
     {
@@ -1046,7 +1046,7 @@ public:
      * @see PrintData()
      * @see PrintInfo()
      */
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "2 dimensional triangle with six nodes in 2D space";
     }
@@ -1057,7 +1057,7 @@ public:
      * @see PrintData()
      * @see Info()
      */
-    virtual void PrintInfo( std::ostream& rOStream ) const override
+    void PrintInfo( std::ostream& rOStream ) const override
     {
         rOStream << "2 dimensional triangle with six nodes in 2D space";
     }
@@ -1076,7 +1076,7 @@ public:
      * :TODO: needs to be reviewed because it is not properly implemented yet
      * (comment by janosch)
      */
-    virtual void PrintData( std::ostream& rOStream ) const override
+    void PrintData( std::ostream& rOStream ) const override
     {
         PrintInfo( rOStream );
         BaseType::PrintData( rOStream );
@@ -1096,7 +1096,7 @@ public:
     @see Edges()
     @see Edge()
      */
-    virtual SizeType EdgesNumber() const override
+    SizeType EdgesNumber() const override
     {
         return 3;
     }
@@ -1112,7 +1112,7 @@ public:
     @see EdgesNumber()
     @see Edge()
      */
-    virtual GeometriesArrayType Edges( void ) override
+    GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
@@ -1173,7 +1173,7 @@ public:
      * @return the gradients of all shape functions
      * \f$ \frac{\partial N^i}{\partial \xi_j} \f$
      */
-    virtual Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
+    Matrix& ShapeFunctionsLocalGradients( Matrix& rResult,
             const CoordinatesArrayType& rPoint ) const override
     {
         rResult.resize( 6, 2,false );
@@ -1237,7 +1237,7 @@ public:
      * @param rResult a third order tensor which contains the second derivatives
      * @param rPoint the given point the second order derivatives are calculated in
      */
-    virtual ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsSecondDerivativesType& ShapeFunctionsSecondDerivatives( ShapeFunctionsSecondDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1288,7 +1288,7 @@ public:
      * @param rResult a fourth order tensor which contains the third derivatives
      * @param rPoint the given point the third order derivatives are calculated in
      */
-    virtual ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
+    ShapeFunctionsThirdDerivativesType& ShapeFunctionsThirdDerivatives( ShapeFunctionsThirdDerivativesType& rResult, const CoordinatesArrayType& rPoint ) const override
     {
         if ( rResult.size() != this->PointsNumber() )
         {
@@ -1353,12 +1353,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save( Serializer& rSerializer ) const override
+    void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
     }
 
-    virtual void load( Serializer& rSerializer ) override
+    void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
     }

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -178,7 +178,7 @@ public:
 
     /// Destructor.
 
-    virtual ~Condition()
+    ~Condition() override
     {
     }
 
@@ -1046,7 +1046,7 @@ public:
 
     /// Turn back information as a string.
 
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "Condition #" << Id();
@@ -1055,14 +1055,14 @@ public:
 
     /// Print information about this object.
 
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "Condition #" << Id();
     }
 
     /// Print object's data.
 
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         pGetGeometry()->PrintData(rOStream);
     }
@@ -1124,7 +1124,7 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, GeometricalObject );
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Flags );
@@ -1132,7 +1132,7 @@ private:
         rSerializer.save("Properties", mpProperties);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, GeometricalObject );
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Flags );

--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -450,7 +450,7 @@ public:
     /**
      * Destructor.
      */
-    virtual ~ConstitutiveLaw(){};
+    ~ConstitutiveLaw() override{};
 
     /**
      * Clone function (has to be implemented by any derived class)
@@ -1056,7 +1056,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "ConstitutiveLaw";
@@ -1064,13 +1064,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "ConstitutiveLaw";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
       rOStream << "ConstitutiveLaw has no data";
     }
@@ -1207,12 +1207,12 @@ private:
     friend class Serializer;
 
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Flags );
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Flags );
     }

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -244,7 +244,7 @@ public:
 
 
     /// Destructor.
-    virtual ~Dof() {}
+    ~Dof() override {}
 
 
     ///@}
@@ -471,7 +471,7 @@ public:
 
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
 
@@ -488,14 +488,14 @@ public:
 
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
     }
 
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         rOStream << "    Variable               : " << GetVariable().Name() << std::endl;
         rOStream << "    Reaction               : " << GetReaction().Name() << std::endl;
@@ -624,7 +624,7 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, IndexedObject );
         rSerializer.save("Is Fixed", mIsFixed);
@@ -636,7 +636,7 @@ private:
         rSerializer.save("Reaction Type", mReactionType);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         std::string name;
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, IndexedObject );

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -176,7 +176,7 @@ public:
 
     /// Destructor.
 
-    virtual ~Element()
+    ~Element() override
     {
     }
 
@@ -1078,7 +1078,7 @@ public:
 
     /// Turn back information as a string.
 
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "Element #" << Id();
@@ -1087,14 +1087,14 @@ public:
 
     /// Print information about this object.
 
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "Element #" << Id();
     }
 
     /// Print object's data.
 
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         pGetGeometry()->PrintData(rOStream);
     }
@@ -1156,7 +1156,7 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, GeometricalObject );
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Flags );
@@ -1164,7 +1164,7 @@ private:
         rSerializer.save("Properties", mpProperties);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, GeometricalObject );
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Flags );

--- a/kratos/includes/exception.h
+++ b/kratos/includes/exception.h
@@ -59,7 +59,7 @@ namespace Kratos
       Exception(Exception const& Other);
 
       /// Destructor.
-      virtual ~Exception() noexcept;
+      ~Exception() noexcept override;
 
 
       ///@}

--- a/kratos/includes/geometrical_object.h
+++ b/kratos/includes/geometrical_object.h
@@ -100,7 +100,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~GeometricalObject() {}
+    ~GeometricalObject() override {}
 
     /// Copy constructor.
     GeometricalObject(GeometricalObject const& rOther) : BaseType(rOther.Id()),
@@ -158,7 +158,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "geometrical object # "
@@ -167,13 +167,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 
@@ -252,13 +252,13 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, IndexedObject );
         rSerializer.save("Geometry",mpGeometry);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, IndexedObject );
         rSerializer.load("Geometry",mpGeometry);

--- a/kratos/includes/gid_io.h
+++ b/kratos/includes/gid_io.h
@@ -110,7 +110,7 @@ public:
     }
 
     ///Destructor.
-    virtual ~GidIO()
+    ~GidIO() override
     {
         Timer::PrintTimingInformation();
 

--- a/kratos/includes/mesh.h
+++ b/kratos/includes/mesh.h
@@ -194,7 +194,7 @@ public:
 
 
     /// Destructor.
-    virtual ~Mesh() {}
+    ~Mesh() override {}
 
 
     ///@}
@@ -657,19 +657,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "Mesh";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         rOStream << "    Number of Nodes      : " << mpNodes->size() << std::endl;
         rOStream << "    Number of Properties : " << mpProperties->size() << std::endl;
@@ -771,7 +771,7 @@ private:
     friend class Serializer;
 
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, DataValueContainer );
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Flags );
@@ -781,7 +781,7 @@ private:
         rSerializer.save("Conditions",mpConditions);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, DataValueContainer );
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Flags );

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -255,7 +255,7 @@ public:
 
 
     /// Destructor.
-    virtual ~ModelPart();
+    ~ModelPart() override;
 
 
     ///@}
@@ -1234,13 +1234,13 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override;
+    std::string Info() const override;
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override;
+    void PrintInfo(std::ostream& rOStream) const override;
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override;
+    void PrintData(std::ostream& rOStream) const override;
 
     /// Print information about this object.
     virtual void PrintInfo(std::ostream& rOStream, std::string const& PrefixString) const;
@@ -1314,9 +1314,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer) override;
+    void load(Serializer& rSerializer) override;
 
     ///@}
     ///@name Private  Access

--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -97,7 +97,7 @@ public:
 
 
     /// Destructor.
-    virtual ~ModelPartIO();
+    ~ModelPartIO() override;
 
 
     ///@}
@@ -109,45 +109,45 @@ public:
     ///@name Operations
     ///@{
 
-    virtual bool ReadNode(NodeType& rThisNode) override;
+    bool ReadNode(NodeType& rThisNode) override;
 
-    virtual bool ReadNodes(NodesContainerType& rThisNodes) override;
+    bool ReadNodes(NodesContainerType& rThisNodes) override;
 
-    virtual std::size_t ReadNodesNumber() override;
+    std::size_t ReadNodesNumber() override;
 
-    virtual void WriteNodes(NodesContainerType const& rThisNodes) override;
+    void WriteNodes(NodesContainerType const& rThisNodes) override;
 
-    virtual void ReadProperties(Properties& rThisProperties) override;
+    void ReadProperties(Properties& rThisProperties) override;
 
-    virtual void ReadProperties(PropertiesContainerType& rThisProperties) override;
+    void ReadProperties(PropertiesContainerType& rThisProperties) override;
 
     virtual void WriteProperties(PropertiesContainerType& rThisProperties);
 
-    virtual void ReadElement(NodesContainerType& rThisNodes, PropertiesContainerType& rThisProperties, Element::Pointer& pThisElements) override;
+    void ReadElement(NodesContainerType& rThisNodes, PropertiesContainerType& rThisProperties, Element::Pointer& pThisElements) override;
 
-    virtual void ReadElements(NodesContainerType& rThisNodes, PropertiesContainerType& rThisProperties, ElementsContainerType& rThisElements) override;
+    void ReadElements(NodesContainerType& rThisNodes, PropertiesContainerType& rThisProperties, ElementsContainerType& rThisElements) override;
 
-    virtual std::size_t  ReadElementsConnectivities(ConnectivitiesContainerType& rElementsConnectivities) override;
+    std::size_t  ReadElementsConnectivities(ConnectivitiesContainerType& rElementsConnectivities) override;
 
-    virtual void WriteElements(ElementsContainerType const& rThisElements) override;
+    void WriteElements(ElementsContainerType const& rThisElements) override;
 
-    virtual void ReadConditions(NodesContainerType& rThisNodes, PropertiesContainerType& rThisProperties, ConditionsContainerType& rThisConditions) override;
+    void ReadConditions(NodesContainerType& rThisNodes, PropertiesContainerType& rThisProperties, ConditionsContainerType& rThisConditions) override;
 
-    virtual std::size_t  ReadConditionsConnectivities(ConnectivitiesContainerType& rConditionsConnectivities) override;
+    std::size_t  ReadConditionsConnectivities(ConnectivitiesContainerType& rConditionsConnectivities) override;
 
     virtual void WriteConditions(ConditionsContainerType const& rThisConditions);
 
-    virtual void ReadInitialValues(ModelPart& rThisModelPart) override;
+    void ReadInitialValues(ModelPart& rThisModelPart) override;
 
 //       void ReadGeometries(NodesContainerType& rThisNodes, GeometriesContainerType& rResults);
 
-    virtual void ReadMesh(MeshType & rThisMesh) override;
+    void ReadMesh(MeshType & rThisMesh) override;
 
     virtual void WriteMesh(MeshType & rThisMesh);
 
-    virtual void ReadModelPart(ModelPart & rThisModelPart) override;
+    void ReadModelPart(ModelPart & rThisModelPart) override;
 
-    virtual void WriteModelPart(ModelPart & rThisModelPart) override;
+    void WriteModelPart(ModelPart & rThisModelPart) override;
 
 
     /// Read the input file and create the nodal connectivities graph, stored in CSR format.
@@ -164,9 +164,9 @@ public:
      * to node k (counting from 0).
      * @return Number of nodes.
      */
-    virtual std::size_t ReadNodalGraph(ConnectivitiesContainerType& aux_connectivities) override;
+    std::size_t ReadNodalGraph(ConnectivitiesContainerType& aux_connectivities) override;
 
-    virtual void DivideInputToPartitions(SizeType NumberOfPartitions, GraphType const& DomainsColoredGraph,
+    void DivideInputToPartitions(SizeType NumberOfPartitions, GraphType const& DomainsColoredGraph,
                                          PartitionIndicesType const& NodesPartitions,
                                          PartitionIndicesType const& ElementsPartitions,
                                          PartitionIndicesType const& ConditionsPartitions,
@@ -174,7 +174,7 @@ public:
                                          PartitionIndicesContainerType const& ElementsAllPartitions,
                                          PartitionIndicesContainerType const& ConditionsAllPartitions) override;
 
-    virtual void DivideInputToPartitions(boost::shared_ptr<std::iostream> * Streams,
+    void DivideInputToPartitions(boost::shared_ptr<std::iostream> * Streams,
                                          SizeType NumberOfPartitions, GraphType const& DomainsColoredGraph,
                                          PartitionIndicesType const& NodesPartitions,
                                          PartitionIndicesType const& ElementsPartitions,

--- a/kratos/includes/node.h
+++ b/kratos/includes/node.h
@@ -357,7 +357,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~Node()
+    ~Node() override
     {
 #ifdef _OPENMP
         omp_destroy_lock(&mNodeLock);
@@ -1192,7 +1192,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "Node #" << Id();
@@ -1200,13 +1200,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         BaseType::PrintData(rOStream);
         if(!mDofs.empty())
@@ -1304,7 +1304,7 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
 // 	  int size = rSerializer.GetBuffer().end() - rSerializer.GetBuffer().begin();
 // 	  KRATOS_WATCH(rSerializer.GetBuffer().end() - rSerializer.GetBuffer().begin());
@@ -1321,7 +1321,7 @@ private:
 // 	  KRATOS_WATCH((rSerializer.GetBuffer().end() - rSerializer.GetBuffer().begin())-size);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
 // 	  int size = rSerializer.GetBuffer().end() - rSerializer.GetBuffer().begin();
 // 	  KRATOS_WATCH(rSerializer.GetBuffer().end() - rSerializer.GetBuffer().begin());

--- a/kratos/includes/periodic_condition.h
+++ b/kratos/includes/periodic_condition.h
@@ -164,7 +164,7 @@ public:
 
 
     /// Destructor.
-    virtual ~PeriodicCondition();
+    ~PeriodicCondition() override;
 
 
     ///@}
@@ -184,7 +184,7 @@ public:
                               PropertiesType::Pointer pProperties) const override;
 
     /// Check input to ensure that it makes sense.
-    virtual int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) override;
 
     /// Returns a matrix of penalty terms for the periodic variables.
     /**
@@ -195,7 +195,7 @@ public:
      * @param rRightHandSideVector Local right hand side vector (output)
      * @param rCurrentProcessInfo ProcessInfo instance (unused)
      */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
                                       ProcessInfo& rCurrentProcessInfo) override;
 
@@ -204,7 +204,7 @@ public:
      * @param rLeftHandSideMatrix Local left hand side matrix (output)
      * @param rCurrentProcessInfo ProcessInfo instance (unused)
      */
-    virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
                                        ProcessInfo& rCurrentProcessInfo) override;
 
     /// Returns RHS values for the penalized dofs.
@@ -212,7 +212,7 @@ public:
      * @param rRightHandSideVector Local right hand side vector (output)
      * @param rCurrentProcessInfo ProcessInfo instance (unused)
      */
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
                                         ProcessInfo& rCurrentProcessInfo) override;
 
     /// Provides the global indices for each one of this element's local rows
@@ -222,7 +222,7 @@ public:
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo ProcessInfo instance (unused)
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult,
+    void EquationIdVector(EquationIdVectorType& rResult,
                                   ProcessInfo& rCurrentProcessInfo) override;
 
     /// Returns a list of the element's Dofs
@@ -230,11 +230,11 @@ public:
      * @param ElementalDofList the list of DOFs
      * @param rCurrentProcessInfo ProcessInfo instance (unused)
      */
-    virtual void GetDofList(DofsVectorType& ElementalDofList,
+    void GetDofList(DofsVectorType& ElementalDofList,
                             ProcessInfo& CurrentProcessInfo) override;
 
     /// Returns the values of the unknowns for each node
-    virtual void GetValuesVector(Vector& Values, int Step = 0) override;
+    void GetValuesVector(Vector& Values, int Step = 0) override;
 
     ///@}
     ///@name Conditional Data
@@ -255,7 +255,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "PeriodicCondition #" << Id();
@@ -263,13 +263,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "PeriodicCondition #" << Id();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         Condition::PrintData(rOStream);
     }
@@ -335,9 +335,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const override;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer) override;
+    void load(Serializer& rSerializer) override;
 
 
     ///@}

--- a/kratos/includes/process_info.h
+++ b/kratos/includes/process_info.h
@@ -110,7 +110,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~ProcessInfo() {}
+    ~ProcessInfo() override {}
 
 
     ///@}
@@ -456,20 +456,20 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "Process Info";
     }
 
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         rOStream << "    Current solution step index : " << mSolutionStepIndex << std::endl;
         BaseType::PrintData(rOStream);
@@ -553,7 +553,7 @@ private:
     friend class Serializer;
 
 
-    virtual void save(Serializer& rSerializer) const override
+    void save(Serializer& rSerializer) const override
     {
 		KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseType );
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Flags );
@@ -563,7 +563,7 @@ private:
         rSerializer.save("Previous Time Step Info", mpPreviousTimeStepInfo);
     }
 
-    virtual void load(Serializer& rSerializer) override
+    void load(Serializer& rSerializer) override
     {
 		KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseType );
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Flags );

--- a/kratos/includes/properties.h
+++ b/kratos/includes/properties.h
@@ -97,7 +97,7 @@ public:
     Properties(const Properties& rOther) : BaseType(rOther), mData(rOther.mData), mTables(rOther.mTables) {}
 
     /// Destructor.
-    virtual ~Properties() {}
+    ~Properties() override {}
 
 
     ///@}
@@ -294,19 +294,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "Properties";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream <<  "Properties";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         mData.PrintData(rOStream);
 		rOStream << "This properties contains " << mTables.size() << " tables";

--- a/kratos/includes/reorder_consecutive_model_part_io.h
+++ b/kratos/includes/reorder_consecutive_model_part_io.h
@@ -106,7 +106,7 @@ public:
 
 
     /// Destructor.
-    virtual ~ReorderConsecutiveModelPartIO();
+    ~ReorderConsecutiveModelPartIO() override;
 
 
     ///@}

--- a/kratos/integration/integration_point.h
+++ b/kratos/integration/integration_point.h
@@ -156,7 +156,7 @@ public:
         : BaseType(rOtherCoordinates), mWeight(NewWeight) {}
 
     /// Destructor.
-    virtual ~IntegrationPoint() {}
+    ~IntegrationPoint() override {}
 
 
     ///@}
@@ -236,7 +236,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << TDimension << " dimensional integration point";
@@ -244,13 +244,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << TDimension << " dimensional integration point";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         if(!TDimension)
             return;

--- a/kratos/linear_solvers/amgcl_ns_solver.h
+++ b/kratos/linear_solvers/amgcl_ns_solver.h
@@ -162,7 +162,7 @@ public:
     /**
      * Destructor
      */
-    virtual ~AMGCL_NS_Solver() {};
+    ~AMGCL_NS_Solver() override {};
 
     /**
      * Normal solve method.
@@ -172,7 +172,7 @@ public:
      * @param rX. Solution vector.
      * @param rB. Right hand side vector.
      */
-    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB)
+    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         mprm.put("solver.tol", mTol);
         mprm.put("solver.maxiter", mmax_it);
@@ -248,7 +248,7 @@ public:
      * @param rX. Solution vector.
      * @param rB. Right hand side vector.
      */
-    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB)
+    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
     {
         return false;
 
@@ -257,7 +257,7 @@ public:
     /**
      * Print information about this object.
      */
-    void  PrintInfo(std::ostream& rOStream) const
+    void  PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "AMGCL NS Solver finished.";
     }
@@ -265,7 +265,7 @@ public:
     /**
      * Print object's data.
      */
-    void  PrintData(std::ostream& rOStream) const
+    void  PrintData(std::ostream& rOStream) const override
     {
     }
 
@@ -275,7 +275,7 @@ public:
      * which require knowledge on the spatial position of the nodes associated to a given dof.
      * This function tells if the solver requires such data
      */
-    virtual bool AdditionalPhysicalDataIsNeeded()
+    bool AdditionalPhysicalDataIsNeeded() override
     {
         return true;
     }
@@ -292,7 +292,7 @@ public:
         VectorType& rB,
         typename ModelPart::DofsArrayType& rdof_set,
         ModelPart& r_model_part
-    )
+    ) override
     {
 //         int old_ndof = -1;
 //         unsigned int old_node_id = rdof_set.begin()->Id();

--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -408,7 +408,7 @@ public:
     /**
      * Destructor
      */
-    virtual ~AMGCLSolver() {};
+    ~AMGCLSolver() override {};
 
     /**
      * Normal solve method.
@@ -418,7 +418,7 @@ public:
      * @param rX. Solution vector.
      * @param rB. Right hand side vector.
      */
-    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB)
+    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         if(rA.size1() != rA.size2() )
             KRATOS_ERROR << "matrix A is not square! sizes are " << rA.size1() << " and " << rA.size2() << std::endl;
@@ -558,7 +558,7 @@ public:
      * @param rX. Solution vector.
      * @param rB. Right hand side vector.
      */
-    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB)
+    bool Solve(SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
     {
         return false;
 
@@ -567,7 +567,7 @@ public:
     /**
      * Print information about this object.
      */
-    void  PrintInfo(std::ostream& rOStream) const
+    void  PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "AMGCL solver finished.";
     }
@@ -575,7 +575,7 @@ public:
     /**
      * Print object's data.
      */
-    void  PrintData(std::ostream& rOStream) const
+    void  PrintData(std::ostream& rOStream) const override
     {
     }
 
@@ -585,7 +585,7 @@ public:
      * which require knowledge on the spatial position of the nodes associated to a given dof.
      * This function tells if the solver requires such data
      */
-    virtual bool AdditionalPhysicalDataIsNeeded()
+    bool AdditionalPhysicalDataIsNeeded() override
     {
         return true;
     }
@@ -602,7 +602,7 @@ public:
         VectorType& rB,
         typename ModelPart::DofsArrayType& rdof_set,
         ModelPart& r_model_part
-    )
+    ) override
     {
         int old_ndof = -1;
         unsigned int old_node_id = rdof_set.begin()->Id();

--- a/kratos/linear_solvers/bicgstab_solver.h
+++ b/kratos/linear_solvers/bicgstab_solver.h
@@ -92,7 +92,7 @@ public:
     BICGSTABSolver(const BICGSTABSolver& Other) : BaseType(Other) {}
 
     /// Destructor.
-    virtual ~BICGSTABSolver() {}
+    ~BICGSTABSolver() override {}
 
 
     ///@}
@@ -186,7 +186,7 @@ public:
     ///@{
 
     /// Return information about this object.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "Biconjugate gradient stabilized linear solver with " << BaseType::GetPreconditioner()->Info();

--- a/kratos/linear_solvers/cg_solver.h
+++ b/kratos/linear_solvers/cg_solver.h
@@ -99,7 +99,7 @@ public:
 
 
     /// Destructor.
-    virtual ~CGSolver() {}
+    ~CGSolver() override {}
 
 
     ///@}
@@ -196,7 +196,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "Conjugate gradient linear solver with " << BaseType::GetPreconditioner()->Info();
@@ -204,13 +204,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         BaseType::PrintData(rOStream);
     }

--- a/kratos/linear_solvers/deflated_cg_solver.h
+++ b/kratos/linear_solvers/deflated_cg_solver.h
@@ -150,7 +150,7 @@ public:
 
     /// Destructor.
 
-    virtual ~DeflatedCGSolver()
+    ~DeflatedCGSolver() override
     {
     }
 
@@ -227,7 +227,7 @@ public:
 
     /// Turn back information as a string.
 
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "Deflated Conjugate gradient linear solver with " << BaseType::GetPreconditioner()->Info();
@@ -236,14 +236,14 @@ public:
 
     /// Print information about this object.
 
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
     }
 
     /// Print object's data.
 
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         BaseType::PrintData(rOStream);
     }

--- a/kratos/linear_solvers/deflated_gmres_solver.h
+++ b/kratos/linear_solvers/deflated_gmres_solver.h
@@ -123,7 +123,7 @@ public:
         KRATOS_THROW_ERROR (std::logic_error,"copy constructor not correctly implemented","");
     }
     /// Destructor.
-    virtual ~DeflatedGMRESSolver() {}
+    ~DeflatedGMRESSolver() override {}
     ///@}
     ///@name Operators
     ///@{
@@ -143,7 +143,7 @@ public:
     @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    virtual void Initialize (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void Initialize (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
 	if (mBlocksAreAllocated == true)
 	{
@@ -163,7 +163,7 @@ public:
     @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    virtual void InitializeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void InitializeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {     
         //copy to local matrices
         if (mBlocksAreAllocated == false)
@@ -187,7 +187,7 @@ public:
     @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    virtual void PerformSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void PerformSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         unsigned int m = mm;
         unsigned int max_iter = BaseType::GetMaxIterationsNumber();
@@ -200,7 +200,7 @@ public:
     @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    virtual void FinalizeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void FinalizeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         
     }
@@ -208,7 +208,7 @@ public:
      * Clear is designed to leave the solver object as if newly created.
      * After a clear a new Initialize is needed
      */
-    virtual void Clear() override
+    void Clear() override
     {
         mK.clear();
         mG.clear();
@@ -231,7 +231,7 @@ public:
     guess for iterative linear solvers.
      @param rB. Right hand side vector.
     */
-    virtual bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         if (mis_initialized == false)
             this->Initialize (rA,rX,rB);
@@ -253,13 +253,13 @@ public:
     guess for iterative linear solvers.
      @param rB. Right hand side vector.
     */
-    virtual bool Solve (SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
+    bool Solve (SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
     {
         return false;
     }
 
     /** Eigenvalue and eigenvector solve method for derived eigensolvers */
-    virtual  void Solve (SparseMatrixType& K,
+     void Solve (SparseMatrixType& K,
                          SparseMatrixType& M,
                          DenseVectorType& Eigenvalues,
                          DenseMatrixType& Eigenvectors) override
@@ -271,7 +271,7 @@ public:
      * which require knowledge on the spatial position of the nodes associated to a given dof.
      * This function tells if the solver requires such data
      */
-    virtual bool AdditionalPhysicalDataIsNeeded() override
+    bool AdditionalPhysicalDataIsNeeded() override
     {
         return true;
     }
@@ -415,17 +415,17 @@ public:
     ///@name Input and output
     ///@{
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "Linear solver";
     }
     /// Print information about this object.
-    virtual void PrintInfo (std::ostream& rOStream) const override
+    void PrintInfo (std::ostream& rOStream) const override
     {
         rOStream << "Linear solver";
     }
     /// Print object's data.
-    virtual void PrintData (std::ostream& rOStream) const override
+    void PrintData (std::ostream& rOStream) const override
     {
     }
     ///@}

--- a/kratos/linear_solvers/diagonal_preconditioner.h
+++ b/kratos/linear_solvers/diagonal_preconditioner.h
@@ -119,7 +119,7 @@ public:
         : BaseType(Other), mDiagonal(Other.mDiagonal), mTemp(Other.mTemp) {}
 
     /// Destructor.
-    virtual ~DiagonalPreconditioner() {}
+    ~DiagonalPreconditioner() override {}
 
 
     ///@}
@@ -284,13 +284,13 @@ public:
     ///@{
 
     /// Return information about this object.
-    virtual std::string  Info() const override
+    std::string  Info() const override
     {
         return "Diagonal preconditioner";
     }
 
     /// Print information about this object.
-    virtual void  PrintInfo(std::ostream& OStream) const override
+    void  PrintInfo(std::ostream& OStream) const override
     {
         OStream << "Diagonal preconditioner";
     }

--- a/kratos/linear_solvers/direct_solver.h
+++ b/kratos/linear_solvers/direct_solver.h
@@ -64,7 +64,7 @@ public:
     DirectSolver() {}
     DirectSolver(Parameters settings) {}
     /// Destructor.
-    virtual ~DirectSolver() {}
+    ~DirectSolver() override {}
 
     /// Copy constructor.
     DirectSolver(const DirectSolver& Other) {}

--- a/kratos/linear_solvers/ilu0_preconditioner.h
+++ b/kratos/linear_solvers/ilu0_preconditioner.h
@@ -131,7 +131,7 @@ public:
 
 
     /// Destructor.
-    virtual ~ILU0Preconditioner()
+    ~ILU0Preconditioner() override
     {
         if ( BaseType::L!=NULL) delete[]  BaseType::L;
         if (BaseType::iL!=NULL) delete[] BaseType::iL;
@@ -173,7 +173,7 @@ public:
     @param rX Unknows vector
     @param rB Right side linear system of equations.
     */
-    virtual void Initialize(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void Initialize(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         // ILU(0) preconditioner
         // Incomplete LU factorization with same sparcity pattern as original matrix.
@@ -431,20 +431,20 @@ public:
     ///@{
 
     /// Return information about this object.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "ILU0Preconditioner";
     }
 
 
     /// Print information about this object.
-    virtual void  PrintInfo(std::ostream& OStream) const override
+    void  PrintInfo(std::ostream& OStream) const override
     {
         OStream << "ILU0Preconditioner";
     }
 
 
-    virtual void PrintData(std::ostream& OStream) const override
+    void PrintData(std::ostream& OStream) const override
     {
     }
 

--- a/kratos/linear_solvers/ilu_preconditioner.h
+++ b/kratos/linear_solvers/ilu_preconditioner.h
@@ -90,7 +90,7 @@ public:
 
 
     /// Destructor.
-    virtual ~ILUPreconditioner()
+    ~ILUPreconditioner() override
     {
         if ( L!=NULL) delete[]  L;
         if (iL!=NULL) delete[] iL;
@@ -145,14 +145,14 @@ public:
 
 
 
-    virtual void Mult(SparseMatrixType& rA, VectorType& rX, VectorType& rY) override
+    void Mult(SparseMatrixType& rA, VectorType& rX, VectorType& rY) override
     {
         VectorType z = rX;
         TSparseSpaceType::Mult(rA,z, rY);
         ApplyLeft(rY);
     }
 
-    virtual void TransposeMult(SparseMatrixType& rA, VectorType& rX, VectorType& rY) override
+    void TransposeMult(SparseMatrixType& rA, VectorType& rX, VectorType& rY) override
     {
         VectorType z = rX;
         ApplyTransposeLeft(z);
@@ -163,7 +163,7 @@ public:
         then multiply temp by U^-1 and store result in rX
         @param rX  Unknows of preconditioner suystem
     */
-    virtual VectorType& ApplyLeft(VectorType& rX) override
+    VectorType& ApplyLeft(VectorType& rX) override
     {
         const int size = TSparseSpaceType::Size(rX);
         VectorType temp(size);
@@ -194,7 +194,7 @@ public:
         then multiply temp by L^-T and store result in rX
         @param rX  Unknows of preconditioner suystem
     */
-    virtual VectorType& ApplyTransposeLeft(VectorType& rX) override
+    VectorType& ApplyTransposeLeft(VectorType& rX) override
     {
         const int size = TSparseSpaceType::Size(rX);
         VectorType temp(size);
@@ -240,20 +240,20 @@ public:
     ///@{
 
     /// Return information about this object.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "ILUPreconditioner";
     }
 
 
     /// Print information about this object.
-    virtual void  PrintInfo(std::ostream& OStream) const override
+    void  PrintInfo(std::ostream& OStream) const override
     {
         OStream << "ILUPreconditioner";
     }
 
 
-    virtual void PrintData(std::ostream& OStream) const override
+    void PrintData(std::ostream& OStream) const override
     {
     }
 

--- a/kratos/linear_solvers/iterative_solver.h
+++ b/kratos/linear_solvers/iterative_solver.h
@@ -167,7 +167,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~IterativeSolver() {}
+    ~IterativeSolver() override {}
 
 
     ///@}
@@ -193,7 +193,7 @@ public:
     		@param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     		@param rB. Right hand side vector.
     		*/
-    virtual void InitializeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void InitializeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         GetPreconditioner()->InitializeSolutionStep(rA,rX,rB);
     }
@@ -204,7 +204,7 @@ public:
     @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    virtual void FinalizeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void FinalizeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         GetPreconditioner()->FinalizeSolutionStep(rA,rX,rB);
     }
@@ -213,7 +213,7 @@ public:
      * Clear is designed to leave the solver object as if newly created.
      * After a clear a new Initialize is needed
      */
-    virtual void Clear() override
+    void Clear() override
     {
         GetPreconditioner()->Clear();
     }
@@ -224,7 +224,7 @@ public:
      * which require knowledge on the spatial position of the nodes associated to a given dof.
      * This function tells if the solver requires such data
      */
-    virtual bool AdditionalPhysicalDataIsNeeded() override
+    bool AdditionalPhysicalDataIsNeeded() override
     {
         if (GetPreconditioner()->AdditionalPhysicalDataIsNeeded())
             return true;
@@ -304,12 +304,12 @@ public:
         return mIterationsNumber;
     }
 
-    virtual void SetTolerance(double NewTolerance) override
+    void SetTolerance(double NewTolerance) override
     {
         mTolerance = NewTolerance;
     }
 
-    virtual double GetTolerance() override
+    double GetTolerance() override
     {
         return mTolerance;
     }
@@ -345,7 +345,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "Iterative solver with " << GetPreconditioner()->Info();
@@ -353,13 +353,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         if (mBNorm == 0.00)
             if (mResidualNorm != 0.00)

--- a/kratos/linear_solvers/mixedup_linear_solver.h
+++ b/kratos/linear_solvers/mixedup_linear_solver.h
@@ -128,7 +128,7 @@ public:
         KRATOS_THROW_ERROR (std::logic_error,"copy constructor not correctly implemented","");
     }
     /// Destructor.
-    virtual ~MixedUPLinearSolver() {}
+    ~MixedUPLinearSolver() override {}
     ///@}
     ///@name Operators
     ///@{
@@ -148,7 +148,7 @@ public:
     @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    virtual void Initialize (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void Initialize (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
 	if (mBlocksAreAllocated == true)
 	{
@@ -170,7 +170,7 @@ public:
     @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    virtual void InitializeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void InitializeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {     
         //copy to local matrices
         if (mBlocksAreAllocated == false)
@@ -197,7 +197,7 @@ public:
     @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    virtual void PerformSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void PerformSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         unsigned int m = mm;
         unsigned int max_iter = BaseType::GetMaxIterationsNumber();
@@ -210,7 +210,7 @@ public:
     @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    virtual void FinalizeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void FinalizeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         mpsolver_UU_block->FinalizeSolutionStep(mK, mu, mru);
         mpsolver_PP_block->FinalizeSolutionStep(mS, mp, mrp);
@@ -219,7 +219,7 @@ public:
      * Clear is designed to leave the solver object as if newly created.
      * After a clear a new Initialize is needed
      */
-    virtual void Clear() override
+    void Clear() override
     {
         mK.clear();
         mG.clear();
@@ -243,7 +243,7 @@ public:
     guess for iterative linear solvers.
      @param rB. Right hand side vector.
     */
-    virtual bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         if (mis_initialized == false)
             this->Initialize (rA,rX,rB);
@@ -265,13 +265,13 @@ public:
     guess for iterative linear solvers.
      @param rB. Right hand side vector.
     */
-    virtual bool Solve (SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
+    bool Solve (SparseMatrixType& rA, DenseMatrixType& rX, DenseMatrixType& rB) override
     {
         return false;
     }
 
     /** Eigenvalue and eigenvector solve method for derived eigensolvers */
-    virtual  void Solve (SparseMatrixType& K,
+     void Solve (SparseMatrixType& K,
                          SparseMatrixType& M,
                          DenseVectorType& Eigenvalues,
                          DenseMatrixType& Eigenvectors) override
@@ -283,7 +283,7 @@ public:
      * which require knowledge on the spatial position of the nodes associated to a given dof.
      * This function tells if the solver requires such data
      */
-    virtual bool AdditionalPhysicalDataIsNeeded() override
+    bool AdditionalPhysicalDataIsNeeded() override
     {
         return true;
     }
@@ -365,17 +365,17 @@ public:
     ///@name Input and output
     ///@{
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "Linear solver";
     }
     /// Print information about this object.
-    virtual void PrintInfo (std::ostream& rOStream) const override
+    void PrintInfo (std::ostream& rOStream) const override
     {
         rOStream << "Linear solver";
     }
     /// Print object's data.
-    virtual void PrintData (std::ostream& rOStream) const override
+    void PrintData (std::ostream& rOStream) const override
     {
     }
     ///@}

--- a/kratos/linear_solvers/power_iteration_eigenvalue_solver.h
+++ b/kratos/linear_solvers/power_iteration_eigenvalue_solver.h
@@ -135,7 +135,7 @@ public:
 
 
     /// Destructor.
-    virtual ~PowerIterationEigenvalueSolver() {}
+    ~PowerIterationEigenvalueSolver() override {}
 
 
     ///@}
@@ -166,7 +166,7 @@ public:
     void Solve(SparseMatrixType& K,
                SparseMatrixType& M,
                DenseVectorType& Eigenvalues,
-               DenseMatrixType& Eigenvectors)
+               DenseMatrixType& Eigenvectors) override
     {
 
         using boost::numeric::ublas::trans;
@@ -257,7 +257,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "Power iteration eigenvalue solver with " << BaseType::GetPreconditioner()->Info();
@@ -265,13 +265,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         BaseType::PrintData(rOStream);
     }

--- a/kratos/linear_solvers/scaling_solver.h
+++ b/kratos/linear_solvers/scaling_solver.h
@@ -122,7 +122,7 @@ public:
 
 
     /// Destructor.
-    virtual ~ScalingSolver() {}
+    ~ScalingSolver() override {}
 
 
     ///@}
@@ -145,7 +145,7 @@ public:
     * which require knowledge on the spatial position of the nodes associated to a given dof.
     * This function tells if the solver requires such data
     */
-    virtual bool AdditionalPhysicalDataIsNeeded() override
+    bool AdditionalPhysicalDataIsNeeded() override
     {
         return mp_linear_solver->AdditionalPhysicalDataIsNeeded();
     }
@@ -167,7 +167,7 @@ public:
         mp_linear_solver->ProvideAdditionalData(rA,rX,rB,rdof_set,r_model_part);
     }
 
-    virtual void InitializeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void InitializeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         mp_linear_solver->InitializeSolutionStep(rA,rX,rB);
     }
@@ -178,7 +178,7 @@ public:
     @param rX. Solution vector. it's also the initial guess for iterative linear solvers.
     @param rB. Right hand side vector.
     */
-    virtual void FinalizeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
+    void FinalizeSolutionStep (SparseMatrixType& rA, VectorType& rX, VectorType& rB) override
     {
         mp_linear_solver->FinalizeSolutionStep(rA,rX,rB);
     }
@@ -187,7 +187,7 @@ public:
      * Clear is designed to leave the solver object as if newly created.
      * After a clear a new Initialize is needed
      */
-    virtual void Clear() override
+    void Clear() override
     {
         mp_linear_solver->Clear();
     }
@@ -263,7 +263,7 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         std::stringstream buffer;
         buffer << "Composite Linear Solver. Uses internally the following linear solver " << mp_linear_solver->Info();
@@ -271,13 +271,13 @@ public:
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info();
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         BaseType::PrintData(rOStream);
     }

--- a/kratos/linear_solvers/skyline_lu_factorization_solver.h
+++ b/kratos/linear_solvers/skyline_lu_factorization_solver.h
@@ -578,7 +578,7 @@ public:
     SkylineLUFactorizationSolver(Parameters settings): BaseType(settings) {}
     
     /// Destructor.
-    virtual ~SkylineLUFactorizationSolver() {}
+    ~SkylineLUFactorizationSolver() override {}
 
 
     /** Normal solve method.

--- a/kratos/linear_solvers/tfqmr_solver.h
+++ b/kratos/linear_solvers/tfqmr_solver.h
@@ -111,7 +111,7 @@ public:
 
 
     /// Destructor.
-    virtual ~TFQMRSolver() {}
+    ~TFQMRSolver() override {}
 
 
     /** Normal solve method.

--- a/kratos/processes/apply_constant_scalarvalue_process.h
+++ b/kratos/processes/apply_constant_scalarvalue_process.h
@@ -242,7 +242,7 @@ public:
 
 
     /// Destructor.
-    virtual ~ApplyConstantScalarValueProcess() {}
+    ~ApplyConstantScalarValueProcess() override {}
 
 
     ///@}
@@ -262,11 +262,11 @@ public:
 
 
     /// Execute method is used to execute the ApplyConstantScalarValueProcess algorithms.
-    virtual void Execute() override {}
+    void Execute() override {}
 
     /// this function is designed for being called at the beginning of the computations
     /// right after reading the model and the groups
-    virtual void ExecuteInitialize() override
+    void ExecuteInitialize() override
     {
         KRATOS_TRY;
         const bool is_fixed = this->Is(VARIABLE_IS_FIXED);
@@ -299,37 +299,37 @@ public:
 
     /// this function is designed for being execute once before the solution loop but after all of the
     /// solvers where built
-    virtual void ExecuteBeforeSolutionLoop() override
+    void ExecuteBeforeSolutionLoop() override
     {
     }
 
 
     /// this function will be executed at every time step BEFORE performing the solve phase
-    virtual void ExecuteInitializeSolutionStep() override
+    void ExecuteInitializeSolutionStep() override
     {
     }
 
     /// this function will be executed at every time step AFTER performing the solve phase
-    virtual void ExecuteFinalizeSolutionStep() override
+    void ExecuteFinalizeSolutionStep() override
     {
     }
 
 
     /// this function will be executed at every time step BEFORE  writing the output
-    virtual void ExecuteBeforeOutputStep() override
+    void ExecuteBeforeOutputStep() override
     {
     }
 
 
     /// this function will be executed at every time step AFTER writing the output
-    virtual void ExecuteAfterOutputStep() override
+    void ExecuteAfterOutputStep() override
     {
     }
 
 
     /// this function is designed for being called at the end of the computations
     /// right after reading the model and the groups
-    virtual void ExecuteFinalize() override
+    void ExecuteFinalize() override
     {
     }
 
@@ -349,19 +349,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "ApplyConstantScalarValueProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "ApplyConstantScalarValueProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/apply_constant_vectorvalue_process.h
+++ b/kratos/processes/apply_constant_vectorvalue_process.h
@@ -227,7 +227,7 @@ public:
     
 
     /// Destructor.
-    virtual ~ApplyConstantVectorValueProcess() {}
+    ~ApplyConstantVectorValueProcess() override {}
 
 
     ///@}
@@ -247,11 +247,11 @@ public:
 
 
     /// Execute method is used to execute the ApplyConstantVectorValueProcess algorithms.
-    virtual void Execute() override {}
+    void Execute() override {}
 
     /// this function is designed for being called at the beginning of the computations
     /// right after reading the model and the groups
-    virtual void ExecuteInitialize() override
+    void ExecuteInitialize() override
     {       
         //compute the value to be applied
         array_1d<double,3> value = mmodulus*mdirection;
@@ -268,37 +268,37 @@ public:
 
     /// this function is designed for being execute once before the solution loop but after all of the
     /// solvers where built
-    virtual void ExecuteBeforeSolutionLoop() override
+    void ExecuteBeforeSolutionLoop() override
     {
     }
 
 
     /// this function will be executed at every time step BEFORE performing the solve phase
-    virtual void ExecuteInitializeSolutionStep() override
+    void ExecuteInitializeSolutionStep() override
     {
     }
 
     /// this function will be executed at every time step AFTER performing the solve phase
-    virtual void ExecuteFinalizeSolutionStep() override
+    void ExecuteFinalizeSolutionStep() override
     {
     }
 
 
     /// this function will be executed at every time step BEFORE  writing the output
-    virtual void ExecuteBeforeOutputStep() override
+    void ExecuteBeforeOutputStep() override
     {
     }
 
 
     /// this function will be executed at every time step AFTER writing the output
-    virtual void ExecuteAfterOutputStep() override
+    void ExecuteAfterOutputStep() override
     {
     }
 
 
     /// this function is designed for being called at the end of the computations
     /// right after reading the model and the groups
-    virtual void ExecuteFinalize() override
+    void ExecuteFinalize() override
     {
     }
 
@@ -318,19 +318,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "ApplyConstantVectorValueProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "ApplyConstantVectorValueProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/assign_scalar_field_to_conditions_process.h
+++ b/kratos/processes/assign_scalar_field_to_conditions_process.h
@@ -84,7 +84,7 @@ public:
 
 
     /// Destructor.
-    virtual ~AssignScalarFieldToConditionsProcess() {}
+    ~AssignScalarFieldToConditionsProcess() override {}
 
 
     ///@}
@@ -104,7 +104,7 @@ public:
 
 
     /// Execute method is used to execute the AssignScalarFieldToConditionsProcess algorithms.
-    virtual void Execute() override
+    void Execute() override
     {
 
         KRATOS_TRY;
@@ -132,7 +132,7 @@ public:
     }
 
     /// this function will be executed at every time step BEFORE performing the solve phase
-    virtual void ExecuteInitializeSolutionStep() override
+    void ExecuteInitializeSolutionStep() override
     {
         Execute();
     }
@@ -153,19 +153,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "AssignScalarFieldToConditionsProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "AssignScalarFieldToConditionsProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/assign_scalar_variable_to_conditions_process.h
+++ b/kratos/processes/assign_scalar_variable_to_conditions_process.h
@@ -96,7 +96,7 @@ public:
 
 
     /// Destructor.
-    virtual ~AssignScalarVariableToConditionsProcess() {}
+    ~AssignScalarVariableToConditionsProcess() override {}
 
 
     ///@}
@@ -116,7 +116,7 @@ public:
 
 
     /// Execute method is used to execute the AssignScalarVariableToConditionsProcess algorithms.
-    virtual void Execute() override
+    void Execute() override
     {
 
         KRATOS_TRY;
@@ -146,7 +146,7 @@ public:
 
     }
 
-    virtual void ExecuteInitializeSolutionStep() override
+    void ExecuteInitializeSolutionStep() override
     {
         Execute();
     }
@@ -168,19 +168,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "AssignScalarVariableToConditionsProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "AssignScalarVariableToConditionsProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
@@ -58,7 +58,7 @@ namespace Kratos
 	  CalculateDiscontinuousDistanceToSkinProcess(ModelPart& rVolumePart, ModelPart& rSkinPart);
 
 	  /// Destructor.
-      virtual ~CalculateDiscontinuousDistanceToSkinProcess();
+      ~CalculateDiscontinuousDistanceToSkinProcess() override;
 
 
       ///@}
@@ -93,7 +93,7 @@ namespace Kratos
 
       virtual void Clear();
 
-	  virtual void Execute() override;
+	  void Execute() override;
 
       ///@}
       ///@name Access
@@ -106,13 +106,13 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override;
+      void PrintInfo(std::ostream& rOStream) const override;
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override;
+      void PrintData(std::ostream& rOStream) const override;
 
       ///@}
 

--- a/kratos/processes/calculate_distance_to_skin_process.h
+++ b/kratos/processes/calculate_distance_to_skin_process.h
@@ -60,7 +60,7 @@ namespace Kratos
 	  CalculateDistanceToSkinProcess(ModelPart& rVolumePart, ModelPart& rSkinPart);
 
 	  /// Destructor.
-      virtual ~CalculateDistanceToSkinProcess();
+      ~CalculateDistanceToSkinProcess() override;
 
 	  ///@}
 	  ///@name Deleted
@@ -78,9 +78,9 @@ namespace Kratos
 	  ///@}
       ///@name Operations
       ///@{
-      virtual void Initialize() override;
+      void Initialize() override;
 
-      virtual void CalculateDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects) override;
+      void CalculateDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects) override;
 
       virtual void InitializeNodalDistances();
 
@@ -100,20 +100,20 @@ namespace Kratos
 
       virtual int IntersectionTriangleSegment(Element::GeometryType& rGeometry, double* RayPoint1, double* RayPoint2, double* IntersectionPoint); //TODO: This method has been adapted from the previous implementation. It is still pending to update it.
 
-	  virtual void Execute() override;
+	  void Execute() override;
 
       ///@}
       ///@name Input and output
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override;
+      void PrintInfo(std::ostream& rOStream) const override;
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override;
+      void PrintData(std::ostream& rOStream) const override;
 
       ///@}
 

--- a/kratos/processes/calculate_embedded_signed_distance_to_3d_skin_process.h
+++ b/kratos/processes/calculate_embedded_signed_distance_to_3d_skin_process.h
@@ -75,7 +75,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~CalculateEmbeddedSignedDistanceTo3DSkinProcess()
+    ~CalculateEmbeddedSignedDistanceTo3DSkinProcess() override
     {
     }
 
@@ -92,7 +92,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         // Create a pointer to the discontinuous or continuos distance calculation process
         CalculateDiscontinuousDistanceToSkinProcess::Pointer pdistance_calculator;
@@ -141,19 +141,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
+    std::string Info() const override
     {
         return "CalculateEmbeddedSignedDistanceTo3DSkinProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "CalculateEmbeddedSignedDistanceTo3DSkinProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/calculate_nodal_area_process.h
+++ b/kratos/processes/calculate_nodal_area_process.h
@@ -119,7 +119,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~CalculateNodalAreaProcess()
+    ~CalculateNodalAreaProcess() override
     {
     }
 
@@ -138,7 +138,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY
 
@@ -211,19 +211,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "CalculateNodalAreaProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "CalculateNodalAreaProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/calculate_signed_distance_to_3d_condition_skin_process.h
+++ b/kratos/processes/calculate_signed_distance_to_3d_condition_skin_process.h
@@ -331,7 +331,7 @@ private:
 	}
 
       /// Destructor.
-      virtual ~CalculateSignedDistanceTo3DConditionSkinProcess()
+      ~CalculateSignedDistanceTo3DConditionSkinProcess() override
 	{
 	}
       
@@ -353,7 +353,7 @@ private:
       ///******************************************************************************************************************
       ///******************************************************************************************************************
 
-      virtual void Execute() override
+      void Execute() override
       {
           KRATOS_TRY
 	/*
@@ -1993,19 +1993,19 @@ private:
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override
+      std::string Info() const override
 	{
 	  return "CalculateSignedDistanceTo3DConditionSkinProcess";
 	}
       
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override
+      void PrintInfo(std::ostream& rOStream) const override
 	{
 	  rOStream << "CalculateSignedDistanceTo3DConditionSkinProcess";
 	}
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override
+      void PrintData(std::ostream& rOStream) const override
 	{
 	}
       

--- a/kratos/processes/calculate_signed_distance_to_3d_skin_process.h
+++ b/kratos/processes/calculate_signed_distance_to_3d_skin_process.h
@@ -298,7 +298,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~CalculateSignedDistanceTo3DSkinProcess()
+    ~CalculateSignedDistanceTo3DSkinProcess() override
     {
     }
 
@@ -320,7 +320,7 @@ public:
     ///******************************************************************************************************************
     ///******************************************************************************************************************
 
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
 
@@ -2472,19 +2472,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "CalculateSignedDistanceTo3DSkinProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "CalculateSignedDistanceTo3DSkinProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/check_skin_process.h
+++ b/kratos/processes/check_skin_process.h
@@ -112,7 +112,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~CheckSkinProcess() {}
+    ~CheckSkinProcess() override {}
 
 
     ///@}
@@ -132,7 +132,7 @@ public:
 
 
     /// Check elements to make sure that their jacobian is positive and conditions to ensure that their face normals point outwards
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
 
@@ -209,19 +209,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "CheckSkinProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "CheckSkinProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         this->PrintInfo(rOStream);
     }

--- a/kratos/processes/compute_bdfcoefficients_process.h
+++ b/kratos/processes/compute_bdfcoefficients_process.h
@@ -121,7 +121,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~ComputeBDFCoefficientsProcess()
+    ~ComputeBDFCoefficientsProcess() override
     {
     }
 
@@ -141,7 +141,7 @@ public:
     ///@{
     ///this function fills the vector BDF_COEFFICIENTS with the correct values
     ///depending on the time_order chosen
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY
         
@@ -208,19 +208,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "ComputeBDFCoefficientsProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "ComputeBDFCoefficientsProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/compute_nodal_gradient_process.h
+++ b/kratos/processes/compute_nodal_gradient_process.h
@@ -81,7 +81,7 @@ public:
         , Variable<double>& r_area_variable);
 
     /// Destructor.
-    virtual ~ComputeNodalGradientProcess()
+    ~ComputeNodalGradientProcess() override
     {
     }
 
@@ -100,7 +100,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
         
@@ -176,19 +176,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "ComputeNodalGradientProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "ComputeNodalGradientProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/condition_erase_process.h
+++ b/kratos/processes/condition_erase_process.h
@@ -83,7 +83,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~ConditionEraseProcess()
+    ~ConditionEraseProcess() override
     {
     }
 
@@ -102,7 +102,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
         
@@ -127,19 +127,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "ConditionEraseProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "ConditionEraseProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/element_erase_process.h
+++ b/kratos/processes/element_erase_process.h
@@ -82,7 +82,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~ElementEraseProcess()
+    ~ElementEraseProcess() override
     {
     }
 
@@ -101,7 +101,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
 
@@ -126,19 +126,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "ElementEraseProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "ElementEraseProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/eliminate_isolated_nodes_process.h
+++ b/kratos/processes/eliminate_isolated_nodes_process.h
@@ -120,7 +120,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~EliminateIsolatedNodesProcess()
+    ~EliminateIsolatedNodesProcess() override
     {
     }
 
@@ -139,7 +139,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
 
@@ -173,19 +173,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "EliminateIsolatedNodesProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "EliminateIsolatedNodesProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/fast_transfer_between_model_parts_process.h
+++ b/kratos/processes/fast_transfer_between_model_parts_process.h
@@ -79,7 +79,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~FastTransferBetweenModelPartsProcess() {}
+    ~FastTransferBetweenModelPartsProcess() override {}
 
     ///@}
     ///@name Operators
@@ -98,7 +98,7 @@ public:
 
 
     /// Execute method is used to execute the FastTransferBetweenModelPartsProcess algorithms.
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
         
@@ -141,19 +141,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "FastTransferBetweenModelPartsProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "FastTransferBetweenModelPartsProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/find_conditions_neighbours_process.h
+++ b/kratos/processes/find_conditions_neighbours_process.h
@@ -121,7 +121,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~FindConditionsNeighboursProcess()
+    ~FindConditionsNeighboursProcess() override
     {
     }
 
@@ -140,7 +140,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         NodesContainerType& rNodes = mr_model_part.Nodes();
         ConditionsContainerType& rConds = mr_model_part.Conditions();
@@ -227,19 +227,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "FindConditionsNeighboursProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "FindConditionsNeighboursProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/find_elements_neighbours_process.h
+++ b/kratos/processes/find_elements_neighbours_process.h
@@ -121,7 +121,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~FindElementalNeighboursProcess()
+    ~FindElementalNeighboursProcess() override
     {
     }
 
@@ -140,7 +140,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         NodesContainerType& rNodes = mr_model_part.Nodes();
         ElementsContainerType& rElems = mr_model_part.Elements();
@@ -252,19 +252,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "FindElementalNeighboursProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "FindElementalNeighboursProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/find_intersected_geometrical_objects_process.h
+++ b/kratos/processes/find_intersected_geometrical_objects_process.h
@@ -248,7 +248,7 @@ namespace Kratos
 
 
 	  /// Destructor.
-	  virtual ~FindIntersectedGeometricalObjectsProcess() {}
+	  ~FindIntersectedGeometricalObjectsProcess() override {}
 
 	  ///@name Member Variables
 	  ///@{
@@ -273,20 +273,20 @@ namespace Kratos
 
 	  virtual void Clear();
 
-	  virtual void Execute() override;
+	  void Execute() override;
 
       ///@}
       ///@name Input and output
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override;
+      void PrintInfo(std::ostream& rOStream) const override;
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override;
+      void PrintData(std::ostream& rOStream) const override;
 
       ///@}
 

--- a/kratos/processes/find_nodal_h_process.h
+++ b/kratos/processes/find_nodal_h_process.h
@@ -77,7 +77,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~FindNodalHProcess()
+    ~FindNodalHProcess() override
     {
     }
 
@@ -96,7 +96,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY
         
@@ -154,19 +154,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "FindNodalHProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "FindNodalHProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/find_nodal_neighbours_process.h
+++ b/kratos/processes/find_nodal_neighbours_process.h
@@ -120,7 +120,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~FindNodalNeighboursProcess()
+    ~FindNodalNeighboursProcess() override
     {
     }
 
@@ -139,7 +139,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         NodesContainerType& rNodes = mr_model_part.Nodes();
         ElementsContainerType& rElems = mr_model_part.Elements();
@@ -217,19 +217,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "FindNodalNeighboursProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "FindNodalNeighboursProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -172,7 +172,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~LevelSetConvectionProcess()
+    ~LevelSetConvectionProcess() override
     {
     }
 
@@ -191,7 +191,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
 
@@ -299,19 +299,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "LevelSetConvectionProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "LevelSetConvectionProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/measure_mesh_quality_process.h
+++ b/kratos/processes/measure_mesh_quality_process.h
@@ -58,7 +58,7 @@ namespace Kratos
       MeasureMeshQualityProcess(ModelPart& rModelPart, std::size_t Dimension);
 
       /// Destructor.
-      virtual ~MeasureMeshQualityProcess();
+      ~MeasureMeshQualityProcess() override;
 
 
       ///@}
@@ -70,7 +70,7 @@ namespace Kratos
       ///@name Operations
       ///@{
 
-	  virtual void Execute() override;
+	  void Execute() override;
 
       ///@}
       ///@name Access
@@ -87,13 +87,13 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override;
+      void PrintInfo(std::ostream& rOStream) const override;
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override;
+      void PrintData(std::ostream& rOStream) const override;
 
 
       ///@}

--- a/kratos/processes/mesh_coarsening_process.h
+++ b/kratos/processes/mesh_coarsening_process.h
@@ -69,7 +69,7 @@ namespace Kratos
 	  MeshCoarseningProcess(ModelPart& rModelPart);
 
       /// Destructor.
-      virtual ~MeshCoarseningProcess();
+      ~MeshCoarseningProcess() override;
 
 
       ///@}
@@ -102,13 +102,13 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override;
+      void PrintInfo(std::ostream& rOStream) const override;
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override;
+      void PrintData(std::ostream& rOStream) const override;
 
 
       ///@}

--- a/kratos/processes/mesh_local_smoothing_process.h
+++ b/kratos/processes/mesh_local_smoothing_process.h
@@ -71,7 +71,7 @@ namespace Kratos
 	  MeshLocalSmoothingProcess(ModelPart& rModelPart, double AptQuality = 0.5, std::size_t MaxIterationsNumber = 10);
 
       /// Destructor.
-      virtual ~MeshLocalSmoothingProcess();
+      ~MeshLocalSmoothingProcess() override;
       
 
       ///@}
@@ -83,7 +83,7 @@ namespace Kratos
       ///@name Operations
       ///@{
       
-	  virtual void Execute() override;
+	  void Execute() override;
       
       ///@}
       ///@name Access
@@ -100,13 +100,13 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
       
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override;
+      void PrintInfo(std::ostream& rOStream) const override;
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override;
+      void PrintData(std::ostream& rOStream) const override;
       
             
       ///@}      

--- a/kratos/processes/mesh_node_collapsing_process.h
+++ b/kratos/processes/mesh_node_collapsing_process.h
@@ -69,7 +69,7 @@ namespace Kratos
 	  MeshNodeCollapsingProcess(MeshNodeCollapsingProcess const& rOther) = delete;
 
 	  /// Destructor.
-      virtual ~MeshNodeCollapsingProcess();
+      ~MeshNodeCollapsingProcess() override;
 
 
       ///@}
@@ -101,13 +101,13 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override;
+      void PrintInfo(std::ostream& rOStream) const override;
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override;
+      void PrintData(std::ostream& rOStream) const override;
 
 
       ///@}

--- a/kratos/processes/node_erase_process.h
+++ b/kratos/processes/node_erase_process.h
@@ -84,7 +84,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~NodeEraseProcess()
+    ~NodeEraseProcess() override
     {
     }
 
@@ -103,7 +103,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
 
@@ -128,19 +128,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "NodeEraseProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "NodeEraseProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/process.h
+++ b/kratos/processes/process.h
@@ -76,7 +76,7 @@ public:
     Process(Flags options) : Flags( options ) {}
 
     /// Destructor.
-    virtual ~Process() {}
+    ~Process() override {}
 
 
     ///@}
@@ -156,19 +156,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "Process";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "Process";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/reorder_and_optimize_modelpart_process.h
+++ b/kratos/processes/reorder_and_optimize_modelpart_process.h
@@ -65,7 +65,7 @@ public:
     ReorderAndOptimizeModelPartProcess(ReorderAndOptimizeModelPartProcess const& rOther) = delete;
 
     /// Destructor.
-	virtual ~ReorderAndOptimizeModelPartProcess() {};
+	~ReorderAndOptimizeModelPartProcess() override {};
 
     ///@}
     ///@name Operators
@@ -96,13 +96,13 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override;
+    std::string Info() const override;
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override;
+    void PrintInfo(std::ostream& rOStream) const override;
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override;
+    void PrintData(std::ostream& rOStream) const override;
 
 
     ///@}

--- a/kratos/processes/replace_elements_and_condition_process.h
+++ b/kratos/processes/replace_elements_and_condition_process.h
@@ -87,7 +87,7 @@ public:
 
     
     /// Destructor.
-    virtual ~ReplaceElementsAndConditionsProcess() {}
+    ~ReplaceElementsAndConditionsProcess() override {}
 
 
     ///@}
@@ -107,7 +107,7 @@ public:
 
 
     /// Execute method is used to execute the ReplaceElementsAndConditionsProcess algorithms.
-    virtual void Execute()  override
+    void Execute()  override
     {
         ModelPart& r_root_model_part = ObtainRootModelPart( mr_model_part );
         
@@ -162,19 +162,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "ReplaceElementsAndConditionsProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "ReplaceElementsAndConditionsProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/processes/rotation_operation.h
+++ b/kratos/processes/rotation_operation.h
@@ -101,7 +101,7 @@ public:
      }
 
     /// Destructor.
-    virtual ~RotationOperation() {}
+    ~RotationOperation() override {}
 
 
     ///@}
@@ -142,7 +142,7 @@ public:
 */
 
     /// this function will be executed at every time step BEFORE performing the solve phase
-    virtual void ExecuteInitializeSolutionStep() override
+    void ExecuteInitializeSolutionStep() override
     {
 				KRATOS_TRY
 		if ((mr_model_part.NumberOfTables())==0)

--- a/kratos/processes/structured_mesh_generator_process.h
+++ b/kratos/processes/structured_mesh_generator_process.h
@@ -65,7 +65,7 @@ namespace Kratos
 	  StructuredMeshGeneratorProcess(StructuredMeshGeneratorProcess const& rOther) = delete;
 
       /// Destructor.
-      virtual ~StructuredMeshGeneratorProcess() ;
+      ~StructuredMeshGeneratorProcess() override ;
 
       ///@}
       ///@name Operators
@@ -96,13 +96,13 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override;
+      void PrintInfo(std::ostream& rOStream) const override;
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override;
+      void PrintData(std::ostream& rOStream) const override;
 
 
       ///@}

--- a/kratos/processes/tetrahedra_mesh_edge_swapping_process.h
+++ b/kratos/processes/tetrahedra_mesh_edge_swapping_process.h
@@ -61,7 +61,7 @@ namespace Kratos
       TetrahedraMeshEdgeSwappingProcess(ModelPart & rModelPart);
 
       /// Destructor.
-      virtual ~TetrahedraMeshEdgeSwappingProcess();
+      ~TetrahedraMeshEdgeSwappingProcess() override;
 
 
       ///@}
@@ -91,13 +91,13 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
       /// Print information about this object.
-      virtual void PrintInfo(std::ostream& rOStream) const override;
+      void PrintInfo(std::ostream& rOStream) const override;
 
       /// Print object's data.
-      virtual void PrintData(std::ostream& rOStream) const override;
+      void PrintData(std::ostream& rOStream) const override;
 
 
       ///@}

--- a/kratos/processes/tetrahedra_mesh_quality_weighted_smoothing_process.h
+++ b/kratos/processes/tetrahedra_mesh_quality_weighted_smoothing_process.h
@@ -69,7 +69,7 @@ namespace Kratos
       TetrahedraMeshQualityWeightedSmoothingProcess(ModelPart& rModelPart, double AptQuality = 0.75, std::size_t IterationsNumber=1);
 
       /// Destructor.
-      virtual ~TetrahedraMeshQualityWeightedSmoothingProcess();
+      ~TetrahedraMeshQualityWeightedSmoothingProcess() override;
 
 
       ///@}
@@ -96,7 +96,7 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
 
       ///@}

--- a/kratos/processes/tetrahedra_mesh_worst_element_smoothing_process.h
+++ b/kratos/processes/tetrahedra_mesh_worst_element_smoothing_process.h
@@ -69,7 +69,7 @@ namespace Kratos
       TetrahedraMeshWorstElementSmoothingProcess(ModelPart& rModelPart, double AptQuality = 0.5, std::size_t IterationsNumber=10);
 
       /// Destructor.
-      virtual ~TetrahedraMeshWorstElementSmoothingProcess();
+      ~TetrahedraMeshWorstElementSmoothingProcess() override;
 
 
       ///@}
@@ -96,7 +96,7 @@ namespace Kratos
       ///@{
 
       /// Turn back information as a string.
-      virtual std::string Info() const override;
+      std::string Info() const override;
 
 
       ///@}

--- a/kratos/processes/tetrahedral_mesh_orientation_check.h
+++ b/kratos/processes/tetrahedral_mesh_orientation_check.h
@@ -107,7 +107,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~TetrahedralMeshOrientationCheck() {}
+    ~TetrahedralMeshOrientationCheck() override {}
 
 
     ///@}
@@ -127,7 +127,7 @@ public:
 
 
     /// Check elements to make sure that their jacobian is positive and conditions to ensure that their face normals point outwards
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
         
@@ -379,19 +379,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "TetrahedralMeshOrientationCheck";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "TetrahedralMeshOrientationCheck";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
         this->PrintInfo(rOStream);
     }

--- a/kratos/processes/translation_operation.h
+++ b/kratos/processes/translation_operation.h
@@ -101,7 +101,7 @@ public:
      }
 
     /// Destructor.
-    virtual ~TranslationOperation() {}
+    ~TranslationOperation() override {}
 
 
     ///@}
@@ -142,7 +142,7 @@ public:
 */
 
     /// this function will be executed at every time step BEFORE performing the solve phase
-    virtual void ExecuteInitializeSolutionStep() override
+    void ExecuteInitializeSolutionStep() override
     {
 	KRATOS_TRY
 	if ((mr_model_part.NumberOfTables())==0)

--- a/kratos/processes/variational_distance_calculation_process.h
+++ b/kratos/processes/variational_distance_calculation_process.h
@@ -201,7 +201,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~VariationalDistanceCalculationProcess()
+    ~VariationalDistanceCalculationProcess() override
     {
     }
 
@@ -220,7 +220,7 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Execute() override
+    void Execute() override
     {
         KRATOS_TRY;
 
@@ -271,19 +271,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "VariationalDistanceCalculationProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "VariationalDistanceCalculationProcess";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 

--- a/kratos/python/bounded_vector_python_interface.h
+++ b/kratos/python/bounded_vector_python_interface.h
@@ -95,7 +95,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~BoundedVectorPythonInterface() {}
+    ~BoundedVectorPythonInterface() override {}
 
 
     ///@}

--- a/kratos/python/matrix_python_interface.h
+++ b/kratos/python/matrix_python_interface.h
@@ -93,7 +93,7 @@ public:
     ///@{
 
     /// Destructor.
-    virtual ~MatrixPythonInterface() {}
+    ~MatrixPythonInterface() override {}
 
 
     ///@}

--- a/kratos/python/vector_python_interface.h
+++ b/kratos/python/vector_python_interface.h
@@ -94,7 +94,7 @@ public:
     }
 
     /// Destructor.
-    virtual ~VectorPythonInterface() {}
+    ~VectorPythonInterface() override {}
 
 
     ///@}

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -176,7 +176,7 @@ public:
 
     /** Destructor.
      */
-    virtual ~ResidualBasedBlockBuilderAndSolver()
+    ~ResidualBasedBlockBuilderAndSolver() override
     {
     }
 
@@ -957,7 +957,7 @@ public:
      * @param r_model_part
      * @return 0 all ok
      */
-    virtual int Check(ModelPart& r_mUSE_GOOGLE_HASHodel_part) override
+    int Check(ModelPart& r_mUSE_GOOGLE_HASHodel_part) override
     {
         KRATOS_TRY
 

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
@@ -177,7 +177,7 @@ public:
 
     /** Destructor.
      */
-    virtual ~ResidualBasedEliminationBuilderAndSolver()
+    ~ResidualBasedEliminationBuilderAndSolver() override
     {
     }
 
@@ -971,7 +971,7 @@ public:
      * @param r_model_part
      * @return 0 all ok
      */
-    virtual int Check(ModelPart& r_model_part) override
+    int Check(ModelPart& r_model_part) override
     {
         KRATOS_TRY
 

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
@@ -149,7 +149,7 @@ public:
 
     /** Destructor.
     */
-    virtual ~ResidualBasedEliminationBuilderAndSolverComponentwise() {}
+    ~ResidualBasedEliminationBuilderAndSolverComponentwise() override {}
 
 
     /*@} */

--- a/kratos/solving_strategies/convergencecriterias/and_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/and_criteria.h
@@ -124,7 +124,7 @@ public:
 
     /** Destructor.
     */
-    virtual ~And_Criteria () {}
+    ~And_Criteria () override {}
 
     ///@}
     ///@name Operators

--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -117,7 +117,7 @@ public:
 
     /** Destructor.
     */
-    virtual ~DisplacementCriteria() {}
+    ~DisplacementCriteria() override {}
 
 
     ///@}

--- a/kratos/solving_strategies/convergencecriterias/or_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/or_criteria.h
@@ -127,7 +127,7 @@ public:
 
     /** Destructor.
     */
-    virtual ~Or_Criteria () {}
+    ~Or_Criteria () override {}
 
 
     ///@}

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -126,7 +126,7 @@ public:
 
     //* Destructor.
     
-    virtual ~ResidualCriteria() {}
+    ~ResidualCriteria() override {}
 
 
     ///@} 

--- a/kratos/solving_strategies/schemes/residual_based_bossak_displacement_scheme.hpp
+++ b/kratos/solving_strategies/schemes/residual_based_bossak_displacement_scheme.hpp
@@ -126,15 +126,15 @@ public:
     /**
      * Clone
      */
-    virtual BaseTypePointer Clone() override
+    BaseTypePointer Clone() override
     {
         return BaseTypePointer( new ResidualBasedBossakDisplacementScheme(*this) );
     }
 
     /** Destructor.
      */
-    virtual ~ResidualBasedBossakDisplacementScheme
-    () {}
+    ~ResidualBasedBossakDisplacementScheme
+    () override {}
 
     ///@}
     ///@name Operators
@@ -788,7 +788,7 @@ public:
      * @return Zero means  all ok
      */
 
-    virtual int Check(ModelPart& rModelPart) override
+    int Check(ModelPart& rModelPart) override
     {
         KRATOS_TRY;
 

--- a/kratos/solving_strategies/schemes/residual_based_newmark_displacement_scheme.hpp
+++ b/kratos/solving_strategies/schemes/residual_based_newmark_displacement_scheme.hpp
@@ -100,15 +100,15 @@ public:
     /**
      * Clone 
      */
-    virtual BaseTypePointer Clone() override
+    BaseTypePointer Clone() override
     {
       return BaseTypePointer( new ResidualBasedNewmarkDisplacementScheme(*this) );
     }
     
     /** Destructor.
      */
-    virtual ~ResidualBasedNewmarkDisplacementScheme
-    () {}
+    ~ResidualBasedNewmarkDisplacementScheme
+    () override {}
 
     ///@}
     ///@name Operators

--- a/kratos/solving_strategies/schemes/residualbased_incremental_aitken_static_scheme.h
+++ b/kratos/solving_strategies/schemes/residualbased_incremental_aitken_static_scheme.h
@@ -92,7 +92,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~ResidualBasedIncrementalAitkenStaticScheme() {}
+    ~ResidualBasedIncrementalAitkenStaticScheme() override {}
 
 
     ///@}
@@ -111,10 +111,10 @@ public:
       * @param Dx Solution vector (containing the increment of the unknowns obtained in the present iteration)
       * @param b Right hand side vector
       */
-    virtual void InitializeSolutionStep(ModelPart &r_model_part,
+    void InitializeSolutionStep(ModelPart &r_model_part,
                                         TSystemMatrixType &A,
                                         TSystemVectorType &Dx,
-                                        TSystemVectorType &b)
+                                        TSystemVectorType &b) override
     {
         BaseType::InitializeSolutionStep(r_model_part,A,Dx,b);
         mPreviousDx = ZeroVector(Dx.size());
@@ -128,10 +128,10 @@ public:
       * @param Dx Solution vector (containing the increment of the unknowns obtained in the present iteration)
       * @param b Right hand side vector
       */
-    virtual void InitializeNonLinIteration(ModelPart &r_model_part,
+    void InitializeNonLinIteration(ModelPart &r_model_part,
                                            TSystemMatrixType &A,
                                            TSystemVectorType &Dx,
-                                           TSystemVectorType &b)
+                                           TSystemVectorType &b) override
     {
         BaseType::InitializeNonLinIteration(r_model_part,A,Dx,b);
     }
@@ -144,11 +144,11 @@ public:
       * @param Dx Solution vector (containing the increment of the unknowns obtained in the present iteration)
       * @param b Right hand side vector
       */
-    virtual void Update(ModelPart &r_model_part,
+    void Update(ModelPart &r_model_part,
                         DofsArrayType &rDofSet,
                         TSystemMatrixType &A,
                         TSystemVectorType &Dx,
-                        TSystemVectorType &b)
+                        TSystemVectorType &b) override
     {
         mIterationCounter++;
 

--- a/kratos/solving_strategies/schemes/residualbased_incrementalupdate_static_scheme.h
+++ b/kratos/solving_strategies/schemes/residualbased_incrementalupdate_static_scheme.h
@@ -126,7 +126,7 @@ public:
 
     /** Destructor.
     */
-    virtual ~ResidualBasedIncrementalUpdateStaticScheme() {}
+    ~ResidualBasedIncrementalUpdateStaticScheme() override {}
 
 
     /*@} */
@@ -138,7 +138,7 @@ public:
     Performing the update of the solution.
     */
     //***************************************************************************
-    virtual void Update(
+    void Update(
         ModelPart& r_model_part,
         DofsArrayType& rDofSet,
         TSystemMatrixType& A,
@@ -164,7 +164,7 @@ public:
     Performing the update of the solution.
     */
     //***************************************************************************
-    virtual void Predict(
+    void Predict(
         ModelPart& r_model_part,
         DofsArrayType& rDofSet,
         TSystemMatrixType& A,
@@ -274,7 +274,7 @@ public:
     this function calculates at the same time the contribution to the LHS and to the RHS
     of the system
     */
-    virtual void CalculateSystemContributions(
+    void CalculateSystemContributions(
         Element::Pointer rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
@@ -294,7 +294,7 @@ public:
 
     //***************************************************************************
     //***************************************************************************
-    virtual void Calculate_RHS_Contribution(
+    void Calculate_RHS_Contribution(
         Element::Pointer rCurrentElement,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
@@ -311,7 +311,7 @@ public:
 
     //***************************************************************************
     //***************************************************************************
-    virtual void Calculate_LHS_Contribution(
+    void Calculate_LHS_Contribution(
         Element::Pointer rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         Element::EquationIdVectorType& EquationId,
@@ -330,7 +330,7 @@ public:
     /** functions totally analogous to the precedent but applied to
     the "condition" objects
     */
-    virtual void Condition_CalculateSystemContributions(
+    void Condition_CalculateSystemContributions(
         Condition::Pointer rCurrentCondition,
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
@@ -346,7 +346,7 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void Condition_Calculate_RHS_Contribution(
+    void Condition_Calculate_RHS_Contribution(
         Condition::Pointer rCurrentCondition,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,

--- a/kratos/solving_strategies/schemes/residualbased_incrementalupdate_static_scheme_slip.h
+++ b/kratos/solving_strategies/schemes/residualbased_incrementalupdate_static_scheme_slip.h
@@ -104,7 +104,7 @@ public:
     {}
 
     /// Destructor.
-    virtual ~ResidualBasedIncrementalUpdateStaticSchemeSlip(){}
+    ~ResidualBasedIncrementalUpdateStaticSchemeSlip() override{}
 
     ///@}
     ///@name Operators
@@ -116,7 +116,7 @@ public:
     ///@{
 
     /// Update the degrees of freedom after a solution iteration.
-    virtual void Update(ModelPart& r_model_part,
+    void Update(ModelPart& r_model_part,
                         DofsArrayType& rDofSet,
                         TSystemMatrixType& A,
                         TSystemVectorType& Dx,
@@ -135,7 +135,7 @@ public:
 
 
     /// Obtain an element's local contribution to the system and apply slip conditions if needed.
-    virtual void CalculateSystemContributions(Element::Pointer rCurrentElement,
+    void CalculateSystemContributions(Element::Pointer rCurrentElement,
                                               LocalSystemMatrixType& LHS_Contribution,
                                               LocalSystemVectorType& RHS_Contribution,
                                               Element::EquationIdVectorType& EquationId,
@@ -152,7 +152,7 @@ public:
     }
 
     /// Obtain an element's local contribution to the RHS and apply slip conditions if needed.
-    virtual void Calculate_RHS_Contribution(Element::Pointer rCurrentElement,
+    void Calculate_RHS_Contribution(Element::Pointer rCurrentElement,
                                             LocalSystemVectorType& RHS_Contribution,
                                             Element::EquationIdVectorType& EquationId,
                                             ProcessInfo& CurrentProcessInfo) override
@@ -168,7 +168,7 @@ public:
     }
 
     /// Obtain an element's local contribution to the system matrix and apply slip conditions if needed.
-    virtual void Calculate_LHS_Contribution(Element::Pointer rCurrentElement,
+    void Calculate_LHS_Contribution(Element::Pointer rCurrentElement,
                                             LocalSystemMatrixType& LHS_Contribution,
                                             Element::EquationIdVectorType& EquationId,
                                             ProcessInfo& CurrentProcessInfo) override
@@ -186,7 +186,7 @@ public:
 
 
     /// Obtain a condition's local contribution to the system and apply slip conditions if needed.
-    virtual void Condition_CalculateSystemContributions(Condition::Pointer rCurrentCondition,
+    void Condition_CalculateSystemContributions(Condition::Pointer rCurrentCondition,
                                                         LocalSystemMatrixType& LHS_Contribution,
                                                         LocalSystemVectorType& RHS_Contribution,
                                                         Element::EquationIdVectorType& EquationId,
@@ -203,7 +203,7 @@ public:
     }
 
     /// Obtain a condition's local contribution to the RHS and apply slip conditions if needed.
-    virtual void Condition_Calculate_RHS_Contribution(Condition::Pointer rCurrentCondition,
+    void Condition_Calculate_RHS_Contribution(Condition::Pointer rCurrentCondition,
                                                       LocalSystemVectorType& RHS_Contribution,
                                                       Element::EquationIdVectorType& EquationId,
                                                       ProcessInfo& CurrentProcessInfo) override

--- a/kratos/solving_strategies/strategies/adaptive_residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/adaptive_residualbased_newton_raphson_strategy.h
@@ -300,7 +300,7 @@ public:
 
     /** Destructor.
     */
-    virtual ~AdaptiveResidualBasedNewtonRaphsonStrategy() {}
+    ~AdaptiveResidualBasedNewtonRaphsonStrategy() override {}
 
     /** Destructor.
     */

--- a/kratos/solving_strategies/strategies/explicit_strategy.h
+++ b/kratos/solving_strategies/strategies/explicit_strategy.h
@@ -157,7 +157,7 @@ namespace Kratos
        
 	      }
 
-	  virtual ~ExplicitStrategy () {}
+	  ~ExplicitStrategy () override {}
 	           
 
 

--- a/kratos/solving_strategies/strategies/line_search_strategy.h
+++ b/kratos/solving_strategies/strategies/line_search_strategy.h
@@ -153,7 +153,7 @@ public:
      * Destructor.
      */
 
-    virtual ~LineSearchStrategy()
+    ~LineSearchStrategy() override
     {
     }
 
@@ -243,7 +243,7 @@ protected:
      * Here the database is updated
      */
 
-    virtual void UpdateDatabase(
+    void UpdateDatabase(
         TSystemMatrixType& A,
         TSystemVectorType& Dx,
         TSystemVectorType& b,

--- a/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
@@ -230,7 +230,7 @@ public:
 
     /** Destructor.
      */
-    virtual ~ResidualBasedLinearStrategy()
+    ~ResidualBasedLinearStrategy() override
     {
       // in trilinos third party library, the linear solver's
       // preconditioner should be freed before the system matrix.

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -258,7 +258,7 @@ public:
      * Destructor.
      */
      
-    virtual ~ResidualBasedNewtonRaphsonStrategy()
+    ~ResidualBasedNewtonRaphsonStrategy() override
     {
         Clear();
     }
@@ -339,7 +339,7 @@ public:
     // 3 -> Print of debug informations:
     //		Echo of stiffness matrix, Dx, b...
 
-    virtual void SetEchoLevel(int Level) override
+    void SetEchoLevel(int Level) override
     {
         BaseType::mEchoLevel = Level;
         GetBuilderAndSolver()->SetEchoLevel(Level);
@@ -353,7 +353,7 @@ public:
      * values of the solution step of interest are assumed equal to the old values 
      */
      
-    virtual void Predict() override
+    void Predict() override
     {
         KRATOS_TRY
         //OPERATIONS THAT SHOULD BE DONE ONCE - internal check to avoid repetitions
@@ -389,7 +389,7 @@ public:
      * Initialization of member variables and prior operations
      */
      
-    virtual void Initialize() override
+    void Initialize() override
     {
         KRATOS_TRY;
 
@@ -436,7 +436,7 @@ public:
      * All those functions can otherwise be called separately.
      */
      
-    virtual double Solve() override
+    double Solve() override
     {
         Initialize();
         InitializeSolutionStep();
@@ -450,7 +450,7 @@ public:
      * Clears the internal storage
      */
      
-    virtual void Clear() override
+    void Clear() override
     {
         KRATOS_TRY;
 
@@ -486,7 +486,7 @@ public:
      * analysis - the convergence criteria used is the one used inside the "solve" step
      */
      
-    virtual bool IsConverged() override
+    bool IsConverged() override
     {
         KRATOS_TRY;
 
@@ -513,7 +513,7 @@ public:
      * negligible cost
      */
      
-    virtual void CalculateOutputData() override
+    void CalculateOutputData() override
     {
         TSystemMatrixType& A = *mpA;
         TSystemVectorType& Dx = *mpDx;
@@ -528,7 +528,7 @@ public:
      * A member variable should be used as a flag to make sure this function is called only once per step.
      */
     
-    virtual void InitializeSolutionStep() override
+    void InitializeSolutionStep() override
     {
         KRATOS_TRY;
 
@@ -604,7 +604,7 @@ public:
      * A member variable should be used as a flag to make sure this function is called only once per step.
      */
     
-    virtual void FinalizeSolutionStep() override
+    void FinalizeSolutionStep() override
     {
         KRATOS_TRY;
 
@@ -645,7 +645,7 @@ public:
      * Solves the current step. This function returns true if a solution has been found, false otherwise.
      */
     
-    virtual bool SolveSolutionStep() override
+    bool SolveSolutionStep() override
     {
         // Pointers needed in the solution
         typename TSchemeType::Pointer pScheme = GetScheme();
@@ -1024,7 +1024,7 @@ protected:
      * It is designed to be called ONCE to verify that the input is correct.
      */
      
-    virtual int Check() override
+    int Check() override
     {
         KRATOS_TRY
 

--- a/kratos/spatial_containers/bins_static.h
+++ b/kratos/spatial_containers/bins_static.h
@@ -124,7 +124,7 @@ public:
     //************************************************************************
 
     // destructor
-    virtual ~Bins() { }
+    ~Bins() override { }
 
     //************************************************************************
 
@@ -786,7 +786,7 @@ public:
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream, std::string const& Perfix = std::string()) const override
+    void PrintData(std::ostream& rOStream, std::string const& Perfix = std::string()) const override
     {
         rOStream << Perfix << "Bin[" << SearchUtils::PointerDistance(mPointBegin, mPointEnd) << "] : " << std::endl;
         for(IteratorConstIterator i_cell = mIndexCell.begin() ; i_cell != mIndexCell.end()-1 ; i_cell++)

--- a/kratos/spatial_containers/bounding_volume_tree.h
+++ b/kratos/spatial_containers/bounding_volume_tree.h
@@ -273,12 +273,12 @@ public:
     typedef kDOP::Array2DType Array2DType;
     KRATOS_CLASS_POINTER_DEFINITION(_6DOP);
     _6DOP() : kDOP() {this->Initialize();}
-    virtual ~_6DOP() {}
-    virtual std::size_t NumberOfDirections() const override {return 3;}
+    ~_6DOP() override {}
+    std::size_t NumberOfDirections() const override {return 3;}
 
 private:
     static ArrayType msDirection[];
-    virtual Array2DType Direction() const override;
+    Array2DType Direction() const override;
 };
 
 class _8DOP : public kDOP
@@ -288,11 +288,11 @@ public:
     typedef kDOP::Array2DType Array2DType;
     KRATOS_CLASS_POINTER_DEFINITION(_8DOP);
     _8DOP() : kDOP() {this->Initialize();}
-    virtual ~_8DOP() {}
-    virtual std::size_t NumberOfDirections() const override {return 4;}
+    ~_8DOP() override {}
+    std::size_t NumberOfDirections() const override {return 4;}
 private:
     static ArrayType msDirection[];
-    virtual Array2DType Direction() const override;
+    Array2DType Direction() const override;
 };
 
 class _12DOP : public kDOP
@@ -302,11 +302,11 @@ public:
     typedef kDOP::Array2DType Array2DType;
     KRATOS_CLASS_POINTER_DEFINITION(_12DOP);
     _12DOP() : kDOP() {this->Initialize();}
-    virtual ~_12DOP() {}
-    virtual std::size_t NumberOfDirections() const override {return 6;}
+    ~_12DOP() override {}
+    std::size_t NumberOfDirections() const override {return 6;}
 private:
     static ArrayType msDirection[];
-    virtual Array2DType Direction() const override;
+    Array2DType Direction() const override;
 };
 
 class _14DOP : public kDOP
@@ -316,11 +316,11 @@ public:
     typedef kDOP::Array2DType Array2DType;
     KRATOS_CLASS_POINTER_DEFINITION(_14DOP);
     _14DOP() : kDOP() {this->Initialize();}
-    virtual ~_14DOP() {}
-    virtual std::size_t NumberOfDirections() const override {return 7;}
+    ~_14DOP() override {}
+    std::size_t NumberOfDirections() const override {return 7;}
 private:
     static ArrayType msDirection[];
-    virtual Array2DType Direction() const override;
+    Array2DType Direction() const override;
 };
 
 class _18DOP : public kDOP
@@ -330,11 +330,11 @@ public:
     typedef kDOP::Array2DType Array2DType;
     KRATOS_CLASS_POINTER_DEFINITION(_18DOP);
     _18DOP() : kDOP() {this->Initialize();}
-    virtual ~_18DOP() {}
-    virtual std::size_t NumberOfDirections() const override {return 9;}
+    ~_18DOP() override {}
+    std::size_t NumberOfDirections() const override {return 9;}
 private:
     static ArrayType msDirection[];
-    virtual Array2DType Direction() const override;
+    Array2DType Direction() const override;
 };
 
 class _20DOP : public kDOP
@@ -344,11 +344,11 @@ public:
     typedef kDOP::Array2DType Array2DType;
     KRATOS_CLASS_POINTER_DEFINITION(_20DOP);
     _20DOP() : kDOP() {this->Initialize();}
-    virtual ~_20DOP() {}
-    virtual std::size_t NumberOfDirections() const override {return 10;}
+    ~_20DOP() override {}
+    std::size_t NumberOfDirections() const override {return 10;}
 private:
     static ArrayType msDirection[];
-    virtual Array2DType Direction() const override;
+    Array2DType Direction() const override;
 };
 
 class _26DOP : public kDOP
@@ -358,11 +358,11 @@ public:
     typedef kDOP::Array2DType Array2DType;
     KRATOS_CLASS_POINTER_DEFINITION(_26DOP);
     _26DOP() : kDOP() {this->Initialize();}
-    virtual ~_26DOP() {}
-    virtual std::size_t NumberOfDirections() const override {return 13;}
+    ~_26DOP() override {}
+    std::size_t NumberOfDirections() const override {return 13;}
 private:
     static ArrayType msDirection[];
-    virtual Array2DType Direction() const override;
+    Array2DType Direction() const override;
 };
 
 
@@ -421,7 +421,7 @@ public:
     SimpleBoundingVolumePartitioner() {}
     ~SimpleBoundingVolumePartitioner() {}
 
-    virtual void Partition(ConditionsContainerType& rAllConditions,
+    void Partition(ConditionsContainerType& rAllConditions,
                            const kDOP& rBoundingVolume,
                            ConditionsContainerType& rOutputSet1,
                            ConditionsContainerType& rOutputSet2) override;
@@ -435,7 +435,7 @@ public:
     LineRegressionVolumePartitioner() {}
     ~LineRegressionVolumePartitioner() {}
 
-    virtual void Partition(ConditionsContainerType& rAllConditions,
+    void Partition(ConditionsContainerType& rAllConditions,
                            const kDOP& rBoundingVolume,
                            ConditionsContainerType& rOutputSet1,
                            ConditionsContainerType& rOutputSet2) override;


### PR DESCRIPTION
hello everyone,

this branch adds the overrides everywhere employing the clang-tidy, following the procedure described by @loumalouomega.

The commit is pretty big, however
i subdivided the big push in quite a lot of different commits (by subdirectory) which can eventually be reverted independently. 

My idea is that as a very minimum it would be important to keep this for the applications (@jcotela, @msandre there is a commit for the fluidDynamics and another one for the AdjointFluid)

as well as for the strategies, geometries and linear_solvers. 

My proposal is that if someone is working in one of the changed subdirectory and fears problems at the moment of merging, then it should be easy to revert the specific commit that refers to the directory in question. We can repeat the same procedure later on and add the missing overrides. 
