### PR TITLE
setting some missing important options to the solver

### DIFF
--- a/kratos/linear_solvers/amgcl_ns_solver.h
+++ b/kratos/linear_solvers/amgcl_ns_solver.h
@@ -77,20 +77,20 @@ public:
         Parameters default_parameters( R"(
                                        {
                                        "solver_type" : "AMGCL_NS_Solver",
-                                       "krylov_type" : "gmres",
+                                       "krylov_type" : "fgmres",
                                        "velocity_block_preconditioner" :
                                         {
-                                            "krylov_type" : "bicgstab",
+                                            "krylov_type" : "lgmres",
                                             "tolerance" : 1e-3,
-                                            "preconditioner_type" : "spai0",
-                                            "max_iteration": 50
+                                            "preconditioner_type" : "ilu0",
+                                            "max_iteration": 5
                                         },
                                         "pressure_block_preconditioner" :
                                         {
-                                            "krylov_type" : "cg",
+                                            "krylov_type" : "lgmres",
                                             "tolerance" : 1e-2,
                                             "preconditioner_type" : "spai0",
-                                            "max_iteration": 50
+                                            "max_iteration": 20
                                         },
                                        "tolerance" : 1e-9,
                                        "gmres_krylov_space_dimension": 50,
@@ -133,6 +133,30 @@ public:
 //             KRATOS_THROW_ERROR(std::invalid_argument," coarsening_type is invalid: available possibilities are : ",msg.str());
 //         }
 
+
+//HERE THE setting of AMGCL (not kratos)
+//     "precond" : {
+//         "usolver" : {
+//             "precond" : {
+//                 "type" : "ilu0"
+//             },
+//             "solver" : {
+//                 "tol" : 1e-2
+//             }
+//         },
+//         "psolver" : {
+//             "solver" : {
+//                 "type" : "lgmres",
+//                 "maxiter" : 20,
+//                 "tol" : 1e-1
+//             }
+//         }
+//     },
+//     "solver" : {
+//         "type" : "fgmres"
+//     }
+    
+
         mcoarse_enough = rParameters["coarse_enough"].GetInt();
 
         mTol = rParameters["tolerance"].GetDouble();
@@ -142,17 +166,19 @@ public:
 
         mndof = 1; //this will be computed automatically later on
         
-        if(rParameters["krylov_type"].GetString() == "gmres")
+        if(rParameters["krylov_type"].GetString() == "gmres" || rParameters["krylov_type"].GetString() == "lgmres" || rParameters["krylov_type"].GetString() == "fgmres")
             mprm.put("solver.M",  rParameters["gmres_krylov_space_dimension"].GetInt());
 
         //setting velocity solver options
         mprm.put("precond.usolver.solver.type", rParameters["velocity_block_preconditioner"]["krylov_type"].GetString());
         mprm.put("precond.usolver.solver.tol", rParameters["velocity_block_preconditioner"]["tolerance"].GetDouble());
+        mprm.put("precond.usolver.solver.maxiter", rParameters["velocity_block_preconditioner"]["max_iteration"].GetInt());
         mprm.put("precond.usolver.precond.type", rParameters["velocity_block_preconditioner"]["preconditioner_type"].GetString());
 
         //setting pressure solver options
         mprm.put("precond.psolver.solver.type", rParameters["pressure_block_preconditioner"]["krylov_type"].GetString());
         mprm.put("precond.psolver.solver.tol", rParameters["pressure_block_preconditioner"]["tolerance"].GetDouble());
+        mprm.put("precond.psolver.solver.maxiter", rParameters["pressure_block_preconditioner"]["max_iteration"].GetInt());
         mprm.put("precond.psolver.precond.relax.type", rParameters["pressure_block_preconditioner"]["preconditioner_type"].GetString());
         mprm.put("precond.psolver.precond.coarsening.aggr.eps_strong", 0.0);
         mprm.put("precond.psolver.precond.coarsening.aggr.block_size", 1);


### PR DESCRIPTION
with this pull request the default linear solver is set to fgmres for the outer loop. furthermore iterations are set correctly in the inner loops of pressure and velocity.

inner solvers are set to lgmres for better robustness