### PR TITLE
added because base class method throws.

### DIFF
--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
@@ -227,6 +227,9 @@ public:
     ///@name Operations
     ///@{
 
+    void Initialize() override 
+    {}
+
     int Check() override
     {
         KRATOS_TRY;


### PR DESCRIPTION
This fixes the FS solver now that the base class Initialize() throws and error.