### PR TITLE
Adding the possibility to read vectors or matrices

### DIFF
--- a/kratos/python_scripts/read_materials_process.py
+++ b/kratos/python_scripts/read_materials_process.py
@@ -86,7 +86,9 @@ class ReadMaterialsProcess(Process):
                 },
                 "Variables" : {
                     "YOUNG_MODULUS" : 200e9,
-                    "POISSION_RATIO" : 0.3
+                    "POISSION_RATIO" : 0.3,
+                    "RESIDUAL_VECTOR" : [1.5,0.3,-2.58]
+                    "LOCAL_INERTIA_TENSOR" : [[0.27,0.0],[0.0,0.27]]
                 },
                 "Tables" : {}
             }

--- a/kratos/python_scripts/read_materials_process.py
+++ b/kratos/python_scripts/read_materials_process.py
@@ -86,8 +86,8 @@ class ReadMaterialsProcess(Process):
                 },
                 "Variables" : {
                     "YOUNG_MODULUS" : 200e9,
-                    "POISSION_RATIO" : 0.3,
-                    "RESIDUAL_VECTOR" : [1.5,0.3,-2.58]
+                    "POISSON_RATIO" : 0.3,
+                    "RESIDUAL_VECTOR" : [1.5,0.3,-2.58],
                     "LOCAL_INERTIA_TENSOR" : [[0.27,0.0],[0.0,0.27]]
                 },
                 "Tables" : {}

--- a/kratos/python_scripts/read_materials_process.py
+++ b/kratos/python_scripts/read_materials_process.py
@@ -118,7 +118,22 @@ class ReadMaterialsProcess(Process):
         # Add / override the values of material parameters in the properties
         for key, value in mat["Variables"].items():
             var = self._GetItemFromModule(key)
-            prop.SetValue( var, value)
+            if isinstance(value, (list, tuple)):
+                size_1 = len(value)
+                if isinstance(value[0], (list, tuple)):
+                    size_2 = len(value[0])
+                    matrix = Matrix(size_1,size_2)
+                    for i in range(size_1):
+                        for j in range(size_2):
+                            matrix[i, j] = value[i][j]
+                    prop.SetValue( var, matrix)
+                else:
+                    vector = Vector(size_1)
+                    for i in range(size_1):
+                        vector[i] = value[i]
+                    prop.SetValue( var, vector)
+            else:
+                prop.SetValue( var, value)
 
         # Add / override tables in the properties
         for key, table in mat["Tables"].items():

--- a/kratos/tests/materials.json
+++ b/kratos/tests/materials.json
@@ -36,15 +36,19 @@
 				"YOUNG_MODULUS": 100.0,
 				"POISSON_RATIO": 0.1,
 				"YIELD_STRESS": 800.0,
-				"HTC" : 0.3
+				"HTC" : 0.3,
+                "CAUCHY_STRESS_VECTOR" : [1.5,0.3,-2.58],
+                "KratosMultiphysics.LOCAL_INERTIA_TENSOR" : [[1.27,-22.5],[2.01,0.257]]
 			},
 			"Tables": {
-                                    "Table1" : {
+                "Table1" : {
 					"input_variable": "TEMPERATURE",
 					"output_variable": "YOUNG_MODULUS",
 					"data": [
 						[0.0, 2.0],
-						[1.0, 10.0]
+						[1.0, 10.0],
+						[2.0, 12.0],
+						[3.5, 15.0]
 					]
 				}
 			}

--- a/kratos/tests/test_materials_input.py
+++ b/kratos/tests/test_materials_input.py
@@ -2,11 +2,9 @@
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics import *
-#from KratosMultiphysics.SolidMechanicsApplication import *
 
 def GetFilePath(fileName):
     return os.path.dirname(os.path.realpath(__file__)) + "/" + fileName
-
 
 class TestMaterialsInput(KratosUnittest.TestCase):
 
@@ -15,7 +13,6 @@ class TestMaterialsInput(KratosUnittest.TestCase):
             import KratosMultiphysics.SolidMechanicsApplication
         except:
             self.skipTest("KratosMultiphysics.SolidMechanicsApplication is not available")
-        
         
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(DISPLACEMENT)
@@ -40,7 +37,7 @@ class TestMaterialsInput(KratosUnittest.TestCase):
             }
             """)
         
-        ##assign the real path 
+        #assign the real path 
         test_settings["Parameters"]["materials_filename"].SetString(GetFilePath("materials.json"))
         
         import read_materials_process
@@ -60,13 +57,28 @@ class TestMaterialsInput(KratosUnittest.TestCase):
         self.assertTrue(model_part.Properties[1].GetValue(YOUNG_MODULUS) == 200.0)
         self.assertTrue(model_part.Properties[1].GetValue(POISSON_RATIO) == 0.3)
         self.assertTrue(model_part.Properties[1].GetValue(YIELD_STRESS) == 400.0)
-        
-
 
         self.assertTrue(model_part.Properties[2].GetValue(YOUNG_MODULUS) == 100.0)
         self.assertTrue(model_part.Properties[2].GetValue(POISSON_RATIO) == 0.1)
         self.assertTrue(model_part.Properties[2].GetValue(YIELD_STRESS) == 800.0)
         self.assertTrue(model_part.Properties[2].GetValue(HTC) == 0.3)
+
+        mat_vector = model_part.Properties[2].GetValue(CAUCHY_STRESS_VECTOR)
+        self.assertAlmostEqual(mat_vector[0],1.5)
+        self.assertAlmostEqual(mat_vector[1],0.3)
+        self.assertAlmostEqual(mat_vector[2],-2.58)
+
+        mat_matrix = model_part.Properties[2].GetValue(LOCAL_INERTIA_TENSOR)
+        self.assertAlmostEqual(mat_matrix[0,0],1.27)
+        self.assertAlmostEqual(mat_matrix[0,1],-22.5)
+        self.assertAlmostEqual(mat_matrix[1,0],2.01)
+        self.assertAlmostEqual(mat_matrix[1,1],0.257)
+
+        table = model_part.Properties[2].GetTable(TEMPERATURE, YOUNG_MODULUS)
+        self.assertAlmostEqual(table.GetValue(1.5),11.0)
+        self.assertAlmostEqual(table.GetNearestValue(1.1),10.0)
+        self.assertAlmostEqual(table.GetDerivative(1.2),2.0)
+        
 
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
I wasn't impossible to read any vector or matrix in the current implementation. For example for the LOCAL_INERTIA_TENSOR:

~~~json
            "Variables"        : {
                "THICKNESS"     : 1.0,
                "DENSITY"       : 7850.0,
                "YOUNG_MODULUS" : 206900000000.0,
                "POISSON_RATIO" : 0.29,
                "KratosMultiphysics.StructuralMechanicsApplication.CROSS_AREA"    : 1.0,
                "LOCAL_INERTIA_TENSOR"  : [[0.27,0.0],[0.0,0.27]]
            },
~~~