### PR TITLE
Fixed error in mpi_python

### DIFF
--- a/external_libraries/mpi_python/CMakeLists.txt
+++ b/external_libraries/mpi_python/CMakeLists.txt
@@ -10,7 +10,7 @@ add_definitions( -w )
 ###############################################################
 add_library(mpipython SHARED ${MPI_PYTHON_SOURCES})
 
-target_link_libraries(mpipython ${Boost_PYTHON_LIBRARIES} ${PYTHON_LIBRARIES} ${MPI_LIBRARIES})
+target_link_libraries(mpipython ${Boost_LIBRARIES} ${PYTHON_LIBRARIES} ${MPI_LIBRARIES})
 
 set_target_properties(mpipython PROPERTIES PREFIX "")
 


### PR DESCRIPTION
This should be the correct code now since I changed the way boost libraries ( boost-python to be correct ) were detected.

The interesting thing is that this shouldn't be compiling since may and nobody seems to have noticed it....