### PR TITLE
Fix _DEBUG casuistic

### DIFF
--- a/embedded_python/krun_main.cpp
+++ b/embedded_python/krun_main.cpp
@@ -1,10 +1,17 @@
 #ifdef KRATOS_DEBUG
-#include <Python.h>
+  #include <Python.h>
 #else
-#undef _DEBUG
-#include <Python.h>
-#define _DEBUG
+  #ifdef _DEBUG
+    #define _DEBUG_DEFINED
+    #undef _DEBUG
+  #endif
+  #include <Python.h>
+  #ifdef _DEBUG_DEFINED
+    #undef _DEBUG_DEFINED
+    #define _DEBUG
+  #endif
 #endif
+
 #include <iostream>
 
 #if PY_MAJOR_VERSION >= 3


### PR DESCRIPTION
@mbreitenberger Please could you check that you could still debug correctly with the new code?

I had to made that change as the code right now asumes that if `KRATOS_DEBUG` is not defined, then `_DEBUG`  is, and so it defines it at the end. This is not always true and it also colides with a MSVC variable `_DEBUG` with the same name which makes the compiler link agains MSVCR140D.dll instead of  MSVCR140.dll even if release is selected.
For more info: https://msdn.microsoft.com/en-us/library/0b98s6w8.aspx

After we merge this we should merge it as well in the release branch!!