### PR TITLE
Hotfix wrong error in key

### DIFF
--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
@@ -824,31 +824,30 @@ protected:
     {
         ModelPart& rModelPart = BaseType::GetModelPart();
 
-#pragma omp parallel
+        const int num_nodes_in_model_part = rModelPart.NumberOfNodes();
+
+        #pragma omp parallel for
+        for (int i = 0; i < num_nodes_in_model_part; i++)
         {
-            ModelPart::NodeIterator NodeBegin; // = rModelPart.NodesBegin();
-            ModelPart::NodeIterator NodeEnd; // = rModelPart.NodesEnd();
-            OpenMPUtils::PartitionedIterators(rModelPart.Nodes(),NodeBegin,NodeEnd);
-
-            for ( ModelPart::NodeIterator itNode = NodeBegin; itNode != NodeEnd; ++itNode )
+            ModelPart::NodeIterator itNode = rModelPart.NodesBegin() + i;
+            const Node<3>& r_const_node = *itNode;
+            
+            if ( r_const_node.GetValue(rSlipWallFlag) != 0.0 )
             {
-                if ( itNode->GetValue(rSlipWallFlag) != 0.0 )
+                const array_1d<double,3>& rNormal = itNode->FastGetSolutionStepValue(NORMAL);
+                array_1d<double,3>& rDeltaVelocity = itNode->FastGetSolutionStepValue(FRACT_VEL);
+
+                double Proj = rNormal[0] * rDeltaVelocity[0];
+                double Norm = rNormal[0] * rNormal[0];
+
+                for (unsigned int d = 1; d < mDomainSize; ++d)
                 {
-                    const array_1d<double,3>& rNormal = itNode->FastGetSolutionStepValue(NORMAL);
-                    array_1d<double,3>& rDeltaVelocity = itNode->FastGetSolutionStepValue(FRACT_VEL);
-
-                    double Proj = rNormal[0] * rDeltaVelocity[0];
-                    double Norm = rNormal[0] * rNormal[0];
-
-                    for (unsigned int d = 1; d < mDomainSize; ++d)
-                    {
-                        Proj += rNormal[d] * rDeltaVelocity[d];
-                        Norm += rNormal[d] * rNormal[d];
-                    }
-
-                    Proj /= Norm;
-                    rDeltaVelocity -= Proj * rNormal;
+                    Proj += rNormal[d] * rDeltaVelocity[d];
+                    Norm += rNormal[d] * rNormal[d];
                 }
+
+                Proj /= Norm;
+                rDeltaVelocity -= Proj * rNormal;
             }
         }
     }

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_base_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_base_solver.py
@@ -106,6 +106,7 @@ class NavierStokesBaseSolver(object):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ADVPROJ)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DIVPROJ)
         self.main_model_part.AddNodalSolutionStepVariable(KratosCFD.PATCH_INDEX)          # PATCH_INDEX belongs to FluidDynamicsApp.
+        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.EXTERNAL_PRESSURE)
 
         print("Base class fluid solver variables added correctly")
 

--- a/kratos/containers/data_value_container.h
+++ b/kratos/containers/data_value_container.h
@@ -186,6 +186,9 @@ public:
 
     template<class TDataType> TDataType& GetValue(const Variable<TDataType>& rThisVariable)
     {
+#ifdef KRATOS_DEBUG
+        KRATOS_ERROR_IF(rThisVariable.Key() == 0) << "attempting to do a GetValue for: " << rThisVariable << " the variable has key zero" << std::endl;
+#endif
         typename ContainerType::iterator i;
 
         if ((i = std::find_if(mData.begin(), mData.end(), IndexCheck(rThisVariable.Key())))  != mData.end())
@@ -204,6 +207,10 @@ public:
     //TODO: make the variable of the constant version consistent with the one of the "classical" one
     template<class TDataType> const TDataType& GetValue(const Variable<TDataType>& rThisVariable) const
     {
+#ifdef KRATOS_DEBUG
+        KRATOS_ERROR_IF(rThisVariable.Key() == 0) << "attempting to do a GetValue for: " << rThisVariable << " the variable has key zero" << std::endl;
+#endif
+        
         typename ContainerType::const_iterator i;
 
         if ((i = std::find_if(mData.begin(), mData.end(), IndexCheck(rThisVariable.Key())))  != mData.end())
@@ -229,6 +236,9 @@ public:
 
     template<class TDataType> void SetValue(const Variable<TDataType>& rThisVariable, TDataType const& rValue)
     {
+#ifdef KRATOS_DEBUG
+        KRATOS_ERROR_IF(rThisVariable.Key() == 0) << "attempting to do a SetValue for: " << rThisVariable << " the variable has key zero" << std::endl;
+#endif
         typename ContainerType::iterator i;
 
         if ((i = std::find_if(mData.begin(), mData.end(), IndexCheck(rThisVariable.Key())))  != mData.end())

--- a/kratos/containers/fix_data_value_container.h
+++ b/kratos/containers/fix_data_value_container.h
@@ -286,7 +286,9 @@ public:
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
 //             mpVariablesList->Add(rThisVariable);
 
-//  	  KRATOS_WATCH(rThisVariable)
+         if(rThisVariable.Key()==0)
+            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
+
 
         IndexType index = mpVariablesList->Index(rThisVariable);
 
@@ -320,6 +322,9 @@ public:
     {
         IndexType index = mpVariablesList->Index(rThisVariable);
 #ifdef KRATOS_DEBUG
+         if(rThisVariable.Key()==0)
+            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
+        
         //KRATOS_WATCH("attention printing FastGetValue");
         if(!mpVariablesList->Has(rThisVariable))
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
@@ -333,6 +338,9 @@ public:
     {
         IndexType index = mpVariablesList->Index(rThisVariable);
 #ifdef KRATOS_DEBUG
+         if(rThisVariable.Key()==0)
+            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
+
         //KRATOS_WATCH("attention printing FastGetValue");
         if(!mpVariablesList->Has(rThisVariable))
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";

--- a/kratos/containers/fix_data_value_container.h
+++ b/kratos/containers/fix_data_value_container.h
@@ -284,11 +284,6 @@ public:
     {
         if(!mpVariablesList->Has(rThisVariable))
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
-//             mpVariablesList->Add(rThisVariable);
-
-         if(rThisVariable.Key()==0)
-            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
-
 
         IndexType index = mpVariablesList->Index(rThisVariable);
 
@@ -296,7 +291,6 @@ public:
         if((index >= mSize)||(mSize == 0))
             Update();
 
-//  	  KRATOS_WATCH(*(TDataType*)(mpData + index))
         return *(TDataType*)(mpData + index);
     }
 
@@ -304,12 +298,8 @@ public:
     {
         if(!mpVariablesList->Has(rThisVariable))
             return rThisVariable.Zero();
-        //std:: cout << "oh oh" << std::endl;
-        // KRATOS_WATCH(rThisVariable)
-        IndexType index = mpVariablesList->Index(rThisVariable);
+         IndexType index = mpVariablesList->Index(rThisVariable);
 
-//  	  KRATOS_WATCH(index)
-//  	  KRATOS_WATCH(mSize)
         if(index >= mSize)
             return rThisVariable.Zero();
 
@@ -320,30 +310,46 @@ public:
     //by Riccardo: variables are not added
     template<class TDataType> TDataType& FastGetValue(const Variable<TDataType>& rThisVariable)
     {
-        IndexType index = mpVariablesList->Index(rThisVariable);
 #ifdef KRATOS_DEBUG
          if(rThisVariable.Key()==0)
             KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
         
-        //KRATOS_WATCH("attention printing FastGetValue");
         if(!mpVariablesList->Has(rThisVariable))
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
+#endif
+        
+        
+        IndexType index = mpVariablesList->Index(rThisVariable);
+        
+        
+        
+#ifdef KRATOS_DEBUG
         if(index >= mSize)
             KRATOS_ERROR << "variable " << rThisVariable << " an inconsistency of variable_list happend in the fixed_data_value_container";
 #endif
+
+
         return *(TDataType*)(mpData + index);
     }
     
     template<class TDataType> const TDataType& FastGetValue(const Variable<TDataType>& rThisVariable) const
     {
-        IndexType index = mpVariablesList->Index(rThisVariable);
 #ifdef KRATOS_DEBUG
          if(rThisVariable.Key()==0)
             KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
 
-        //KRATOS_WATCH("attention printing FastGetValue");
         if(!mpVariablesList->Has(rThisVariable))
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
+#endif
+        
+        
+        
+        IndexType index = mpVariablesList->Index(rThisVariable);
+
+        
+        
+        
+#ifdef KRATOS_DEBUG
         if(index >= mSize)
             KRATOS_ERROR << "variable " << rThisVariable << " an inconsistency of variable_list happend in the fixed_data_value_container";
 #endif
@@ -481,12 +487,20 @@ public:
 
     template<class TDataType> bool Has(const Variable<TDataType>& rThisVariable) const
     {
+#ifdef KRATOS_DEBUG
+         if(rThisVariable.Key()==0)
+            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " which is not registered!! (key = 0) within the call to function Has " << std::endl;
+#endif
         return mpVariablesList->Has(rThisVariable);
     }
 
     template<class TAdaptorType> bool Has(const VariableComponent<TAdaptorType>& rThisVariable) const
     {
-        return mpVariablesList->Has(rThisVariable.GetSourceVariable());
+#ifdef KRATOS_DEBUG
+         if(rThisVariable.Key()==0)
+            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " which is not registered!! (key = 0) within the call to function Has " << std::endl;
+#endif
+         return mpVariablesList->Has(rThisVariable.GetSourceVariable());
     }
 
     bool IsEmpty()

--- a/kratos/containers/fix_data_value_container.h
+++ b/kratos/containers/fix_data_value_container.h
@@ -282,7 +282,7 @@ public:
 
     template<class TDataType> TDataType& GetValue(const Variable<TDataType>& rThisVariable)
     {
-        KRATOS_ERROR_IF(!mpVariablesList->Has(rThisVariable)) << "variable " << rThisVariable << " not found in the fixed_data_value_container";
+        KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access unregistered (key = 0) variable " << rThisVariable.Name() << " in a call to FixDataValueContainer::GetValue." << std::endl;
 
         IndexType index = mpVariablesList->Index(rThisVariable);
 
@@ -310,17 +310,14 @@ public:
     template<class TDataType> TDataType& FastGetValue(const Variable<TDataType>& rThisVariable)
     {
 #ifdef KRATOS_DEBUG
-        KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
-        KRATOS_ERROR_IF(!mpVariablesList->Has(rThisVariable)) << "variable " << rThisVariable << " not found in the fixed_data_value_container";
+        KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access unregistered (key = 0) variable " << rThisVariable.Name() << " in a call to FixDataValueContainer::FastGetValue." << std::endl;
+        KRATOS_ERROR_IF(!mpVariablesList->Has(rThisVariable)) << "Trying to access " << rThisVariable.Name() << ", which is not added to this FixDataValueContainer." << std::endl;
 #endif
-        
-        
+
         IndexType index = mpVariablesList->Index(rThisVariable);
-        
-        
-        
+
 #ifdef KRATOS_DEBUG
-        KRATOS_ERROR_IF(index >= mSize) << "variable " << rThisVariable << " an inconsistency of variable_list happend in the fixed_data_value_container";
+        KRATOS_ERROR_IF(index >= mSize) << "An inconsistency in variable_list was encountered in a call to FixDataValueContainer::FastGetValue for variable " << rThisVariable << "." << std::endl;
 #endif
 
 
@@ -330,14 +327,14 @@ public:
     template<class TDataType> const TDataType& FastGetValue(const Variable<TDataType>& rThisVariable) const
     {
 #ifdef KRATOS_DEBUG
-        KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
-        KRATOS_ERROR_IF(!mpVariablesList->Has(rThisVariable)) << "variable " << rThisVariable << " not found in the fixed_data_value_container";
+        KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access unregistered (key = 0) variable " << rThisVariable.Name() << " in a call to FixDataValueContainer::FastGetValue." << std::endl;
+        KRATOS_ERROR_IF(!mpVariablesList->Has(rThisVariable)) << "Trying to access " << rThisVariable.Name() << ", which is not added to this FixDataValueContainer." << std::endl;
 #endif
         
         IndexType index = mpVariablesList->Index(rThisVariable);
 
 #ifdef KRATOS_DEBUG
-        KRATOS_ERROR_IF(index >= mSize) << "variable " << rThisVariable << " an inconsistency of variable_list happend in the fixed_data_value_container";
+        KRATOS_ERROR_IF(index >= mSize) << "An inconsistency in variable_list was encountered in a call to FixDataValueContainer::FastGetValue for variable " << rThisVariable << "." << std::endl;
 #endif
         return *(const TDataType*)(mpData + index);
     }
@@ -474,7 +471,7 @@ public:
     template<class TDataType> bool Has(const Variable<TDataType>& rThisVariable) const
     {
 #ifdef KRATOS_DEBUG
-         KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access to the variable " << rThisVariable.Name() << " which is not registered!! (key = 0) within the call to function Has " << std::endl;
+         KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access unregistered (key = 0) variable " << rThisVariable.Name() << " in a call to FixDataValueContainer::Has." << std::endl;
 #endif
         return mpVariablesList->Has(rThisVariable);
     }
@@ -482,7 +479,7 @@ public:
     template<class TAdaptorType> bool Has(const VariableComponent<TAdaptorType>& rThisVariable) const
     {
 #ifdef KRATOS_DEBUG
-         KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access to the variable " << rThisVariable.Name() << " which is not registered!! (key = 0) within the call to function Has " << std::endl;
+         KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access unregistered (key = 0) component variable " << rThisVariable.Name() << " in a call to FixDataValueContainer::Has." << std::endl;
 #endif
          return mpVariablesList->Has(rThisVariable.GetSourceVariable());
     }

--- a/kratos/containers/fix_data_value_container.h
+++ b/kratos/containers/fix_data_value_container.h
@@ -282,8 +282,7 @@ public:
 
     template<class TDataType> TDataType& GetValue(const Variable<TDataType>& rThisVariable)
     {
-        if(!mpVariablesList->Has(rThisVariable))
-            KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
+        KRATOS_ERROR_IF(!mpVariablesList->Has(rThisVariable)) << "variable " << rThisVariable << " not found in the fixed_data_value_container";
 
         IndexType index = mpVariablesList->Index(rThisVariable);
 
@@ -311,11 +310,8 @@ public:
     template<class TDataType> TDataType& FastGetValue(const Variable<TDataType>& rThisVariable)
     {
 #ifdef KRATOS_DEBUG
-         if(rThisVariable.Key()==0)
-            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
-        
-        if(!mpVariablesList->Has(rThisVariable))
-            KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
+        KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
+        KRATOS_ERROR_IF(!mpVariablesList->Has(rThisVariable)) << "variable " << rThisVariable << " not found in the fixed_data_value_container";
 #endif
         
         
@@ -324,8 +320,7 @@ public:
         
         
 #ifdef KRATOS_DEBUG
-        if(index >= mSize)
-            KRATOS_ERROR << "variable " << rThisVariable << " an inconsistency of variable_list happend in the fixed_data_value_container";
+        KRATOS_ERROR_IF(index >= mSize) << "variable " << rThisVariable << " an inconsistency of variable_list happend in the fixed_data_value_container";
 #endif
 
 
@@ -335,23 +330,14 @@ public:
     template<class TDataType> const TDataType& FastGetValue(const Variable<TDataType>& rThisVariable) const
     {
 #ifdef KRATOS_DEBUG
-         if(rThisVariable.Key()==0)
-            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
-
-        if(!mpVariablesList->Has(rThisVariable))
-            KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
+        KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
+        KRATOS_ERROR_IF(!mpVariablesList->Has(rThisVariable)) << "variable " << rThisVariable << " not found in the fixed_data_value_container";
 #endif
-        
-        
         
         IndexType index = mpVariablesList->Index(rThisVariable);
 
-        
-        
-        
 #ifdef KRATOS_DEBUG
-        if(index >= mSize)
-            KRATOS_ERROR << "variable " << rThisVariable << " an inconsistency of variable_list happend in the fixed_data_value_container";
+        KRATOS_ERROR_IF(index >= mSize) << "variable " << rThisVariable << " an inconsistency of variable_list happend in the fixed_data_value_container";
 #endif
         return *(const TDataType*)(mpData + index);
     }
@@ -488,8 +474,7 @@ public:
     template<class TDataType> bool Has(const Variable<TDataType>& rThisVariable) const
     {
 #ifdef KRATOS_DEBUG
-         if(rThisVariable.Key()==0)
-            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " which is not registered!! (key = 0) within the call to function Has " << std::endl;
+         KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access to the variable " << rThisVariable.Name() << " which is not registered!! (key = 0) within the call to function Has " << std::endl;
 #endif
         return mpVariablesList->Has(rThisVariable);
     }
@@ -497,8 +482,7 @@ public:
     template<class TAdaptorType> bool Has(const VariableComponent<TAdaptorType>& rThisVariable) const
     {
 #ifdef KRATOS_DEBUG
-         if(rThisVariable.Key()==0)
-            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " which is not registered!! (key = 0) within the call to function Has " << std::endl;
+         KRATOS_ERROR_IF(rThisVariable.Key()==0) << "Trying to access to the variable " << rThisVariable.Name() << " which is not registered!! (key = 0) within the call to function Has " << std::endl;
 #endif
          return mpVariablesList->Has(rThisVariable.GetSourceVariable());
     }

--- a/kratos/containers/variable_data.h
+++ b/kratos/containers/variable_data.h
@@ -109,11 +109,6 @@ public:
 
     KeyType Key() const
     {
-        #ifdef KRATOS_DEBUG
-        if(mKey==0){
-            KRATOS_ERROR << "The variable " << mName << " is not registered!!" << std::endl;
-        }
-        #endif 
         return mKey;
     }
 

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -251,7 +251,7 @@ public:
     ModelPart(std::string const& NewName, IndexType NewBufferSize);
 
     /// Copy constructor.
-    ModelPart(ModelPart const& rOther);
+    explicit ModelPart(ModelPart const& rOther);
 
 
     /// Destructor.

--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -625,7 +625,7 @@ void AddModelPartToPython()
 
 
 
-	class_<ModelPart, bases<DataValueContainer, Flags> >("ModelPart")
+	class_<ModelPart, bases<DataValueContainer, Flags>, boost::noncopyable >("ModelPart")
 		.def(init<std::string const&>())
 		.def(init<>())
 		.add_property("Name", GetModelPartName, SetModelPartName)


### PR DESCRIPTION
avoiding throwing an error from within the method Key of the variable_data.

putting it in the functions HAs, GetValue, FastGetValue instead

