### PR TITLE
Fix fs solver

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/fractional_step.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/fractional_step.cpp
@@ -904,7 +904,7 @@ int FractionalStep<TDim>::Check(const ProcessInfo &rCurrentProcessInfo)
         if(this->GetGeometry()[i].HasDofFor(PRESSURE) == false)
             KRATOS_THROW_ERROR(std::invalid_argument,"missing PRESSURE component degree of freedom on node ",this->GetGeometry()[i].Id());
     }
-    
+
     // If this is a 2D problem, check that nodes are in XY plane
     if (this->GetGeometry().WorkingSpaceDimension() == 2)
     {
@@ -1113,7 +1113,7 @@ void FractionalStep<TDim>::CalculateGeometryData(ShapeFunctionDerivativesArrayTy
     for (unsigned int g = 0; g < rGeom.IntegrationPointsNumber(GeometryData::GI_GAUSS_2); g++)
         rGaussWeights[g] = DetJ[g] * IntegrationPoints[g].Weight();
 
-    
+
     /*
     const GeometryType& rGeom = this->GetGeometry();
     const SizeType NumNodes = rGeom.PointsNumber();
@@ -1195,15 +1195,15 @@ double FractionalStep<TDim>::EffectiveViscosity(double Density,
                                                 double ElemSize,
                                                 const ProcessInfo &rProcessInfo)
 {
-    double Csmag = this->GetValue(C_SMAGORINSKY);
+    const FractionalStep<TDim>* const_this = static_cast<const FractionalStep<TDim>*> (this);
+    const double Csmag = const_this->GetValue(C_SMAGORINSKY);
     double Viscosity = 0.0;
     this->EvaluateInPoint(Viscosity,VISCOSITY,rN);
 
     if (Csmag > 0.0)
     {
-        double StrainRate = this->EquivalentStrainRate(rDN_DX); // (2SijSij)^0.5
-        double LengthScale = Csmag*ElemSize;
-        LengthScale *= LengthScale; // square
+        const double StrainRate = this->EquivalentStrainRate(rDN_DX); // (2SijSij)^0.5
+        const double LengthScale = std::pow(Csmag*ElemSize, 2);
         Viscosity += 2.0*LengthScale*StrainRate;
     }
 
@@ -1450,7 +1450,7 @@ void FractionalStep<TDim>::CalculateProjectionRHS(VectorType& rMomentumRHS,
 		const array_1d<double,3>& vel = this->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY);
         for (SizeType d = 0; d < TDim; ++d)
             Convection[d] += ConvOp[i] * vel[d];
-			
+
 	}
 
     array_1d<double,TDim> PressureGradient(TDim,0.0);
@@ -1494,10 +1494,10 @@ void FractionalStep<TDim>::CalculateProjectionRHS(VectorType& rConvTerm,
 
     array_1d<double,3> Convection(3,0.0);
     for (unsigned int i = 0; i < NumNodes; ++i)
-	{	
+	{
 		const array_1d<double,3>& vel = this->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY);
         for (unsigned int d = 0; d < TDim; ++d)
-            Convection[d] += ConvOp[i] * vel[d];			
+            Convection[d] += ConvOp[i] * vel[d];
 	}
 
     array_1d<double,TDim> PressureGradient(TDim,0.0);
@@ -1585,7 +1585,7 @@ void FractionalStep<TDim>::ModulatedGradientDiffusion(MatrixType& rDampMatrix,
 
         // C_epsilon
         const double Ce = 1.0;
-        
+
         // ksgs
         double ksgs = -4*AvgDeltaSq*GijSij/(Ce*Ce*Gkk);
 

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
@@ -821,31 +821,30 @@ protected:
     {
         ModelPart& rModelPart = BaseType::GetModelPart();
 
-#pragma omp parallel
+        const int num_nodes_in_model_part = rModelPart.NumberOfNodes();
+
+        #pragma omp parallel for
+        for (int i = 0; i < num_nodes_in_model_part; i++)
         {
-            ModelPart::NodeIterator NodeBegin; // = rModelPart.NodesBegin();
-            ModelPart::NodeIterator NodeEnd; // = rModelPart.NodesEnd();
-            OpenMPUtils::PartitionedIterators(rModelPart.Nodes(),NodeBegin,NodeEnd);
-
-            for ( ModelPart::NodeIterator itNode = NodeBegin; itNode != NodeEnd; ++itNode )
+            ModelPart::NodeIterator itNode = rModelPart.NodesBegin() + i;
+            const Node<3>& r_const_node = *itNode;
+            
+            if ( r_const_node.GetValue(rSlipWallFlag) != 0.0 )
             {
-                if ( itNode->GetValue(rSlipWallFlag) != 0.0 )
+                const array_1d<double,3>& rNormal = itNode->FastGetSolutionStepValue(NORMAL);
+                array_1d<double,3>& rDeltaVelocity = itNode->FastGetSolutionStepValue(FRACT_VEL);
+
+                double Proj = rNormal[0] * rDeltaVelocity[0];
+                double Norm = rNormal[0] * rNormal[0];
+
+                for (unsigned int d = 1; d < mDomainSize; ++d)
                 {
-                    const array_1d<double,3>& rNormal = itNode->FastGetSolutionStepValue(NORMAL);
-                    array_1d<double,3>& rDeltaVelocity = itNode->FastGetSolutionStepValue(FRACT_VEL);
-
-                    double Proj = rNormal[0] * rDeltaVelocity[0];
-                    double Norm = rNormal[0] * rNormal[0];
-
-                    for (unsigned int d = 1; d < mDomainSize; ++d)
-                    {
-                        Proj += rNormal[d] * rDeltaVelocity[d];
-                        Norm += rNormal[d] * rNormal[d];
-                    }
-
-                    Proj /= Norm;
-                    rDeltaVelocity -= Proj * rNormal;
+                    Proj += rNormal[d] * rDeltaVelocity[d];
+                    Norm += rNormal[d] * rNormal[d];
                 }
+
+                Proj /= Norm;
+                rDeltaVelocity -= Proj * rNormal;
             }
         }
     }

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_base_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_base_solver.py
@@ -106,6 +106,7 @@ class NavierStokesBaseSolver(object):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ADVPROJ)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DIVPROJ)
         self.main_model_part.AddNodalSolutionStepVariable(KratosCFD.PATCH_INDEX)          # PATCH_INDEX belongs to FluidDynamicsApp.
+        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.EXTERNAL_PRESSURE)
 
         print("Base class fluid solver variables added correctly")
 

--- a/kratos/containers/fix_data_value_container.h
+++ b/kratos/containers/fix_data_value_container.h
@@ -286,7 +286,9 @@ public:
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
 //             mpVariablesList->Add(rThisVariable);
 
-//  	  KRATOS_WATCH(rThisVariable)
+         if(rThisVariable.Key()==0)
+            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
+
 
         IndexType index = mpVariablesList->Index(rThisVariable);
 
@@ -320,6 +322,9 @@ public:
     {
         IndexType index = mpVariablesList->Index(rThisVariable);
 #ifdef KRATOS_DEBUG
+         if(rThisVariable.Key()==0)
+            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
+        
         //KRATOS_WATCH("attention printing FastGetValue");
         if(!mpVariablesList->Has(rThisVariable))
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
@@ -333,6 +338,9 @@ public:
     {
         IndexType index = mpVariablesList->Index(rThisVariable);
 #ifdef KRATOS_DEBUG
+         if(rThisVariable.Key()==0)
+            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
+
         //KRATOS_WATCH("attention printing FastGetValue");
         if(!mpVariablesList->Has(rThisVariable))
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";

--- a/kratos/containers/fix_data_value_container.h
+++ b/kratos/containers/fix_data_value_container.h
@@ -284,11 +284,6 @@ public:
     {
         if(!mpVariablesList->Has(rThisVariable))
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
-//             mpVariablesList->Add(rThisVariable);
-
-         if(rThisVariable.Key()==0)
-            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
-
 
         IndexType index = mpVariablesList->Index(rThisVariable);
 
@@ -296,7 +291,6 @@ public:
         if((index >= mSize)||(mSize == 0))
             Update();
 
-//  	  KRATOS_WATCH(*(TDataType*)(mpData + index))
         return *(TDataType*)(mpData + index);
     }
 
@@ -304,12 +298,8 @@ public:
     {
         if(!mpVariablesList->Has(rThisVariable))
             return rThisVariable.Zero();
-        //std:: cout << "oh oh" << std::endl;
-        // KRATOS_WATCH(rThisVariable)
-        IndexType index = mpVariablesList->Index(rThisVariable);
+         IndexType index = mpVariablesList->Index(rThisVariable);
 
-//  	  KRATOS_WATCH(index)
-//  	  KRATOS_WATCH(mSize)
         if(index >= mSize)
             return rThisVariable.Zero();
 
@@ -320,30 +310,46 @@ public:
     //by Riccardo: variables are not added
     template<class TDataType> TDataType& FastGetValue(const Variable<TDataType>& rThisVariable)
     {
-        IndexType index = mpVariablesList->Index(rThisVariable);
 #ifdef KRATOS_DEBUG
          if(rThisVariable.Key()==0)
             KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
         
-        //KRATOS_WATCH("attention printing FastGetValue");
         if(!mpVariablesList->Has(rThisVariable))
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
+#endif
+        
+        
+        IndexType index = mpVariablesList->Index(rThisVariable);
+        
+        
+        
+#ifdef KRATOS_DEBUG
         if(index >= mSize)
             KRATOS_ERROR << "variable " << rThisVariable << " an inconsistency of variable_list happend in the fixed_data_value_container";
 #endif
+
+
         return *(TDataType*)(mpData + index);
     }
     
     template<class TDataType> const TDataType& FastGetValue(const Variable<TDataType>& rThisVariable) const
     {
-        IndexType index = mpVariablesList->Index(rThisVariable);
 #ifdef KRATOS_DEBUG
          if(rThisVariable.Key()==0)
             KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " is not registered!! (key = 0) within the call FastGetValue " << std::endl;
 
-        //KRATOS_WATCH("attention printing FastGetValue");
         if(!mpVariablesList->Has(rThisVariable))
             KRATOS_ERROR << "variable " << rThisVariable << " not found in the fixed_data_value_container";
+#endif
+        
+        
+        
+        IndexType index = mpVariablesList->Index(rThisVariable);
+
+        
+        
+        
+#ifdef KRATOS_DEBUG
         if(index >= mSize)
             KRATOS_ERROR << "variable " << rThisVariable << " an inconsistency of variable_list happend in the fixed_data_value_container";
 #endif
@@ -481,12 +487,20 @@ public:
 
     template<class TDataType> bool Has(const Variable<TDataType>& rThisVariable) const
     {
+#ifdef KRATOS_DEBUG
+         if(rThisVariable.Key()==0)
+            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " which is not registered!! (key = 0) within the call to function Has " << std::endl;
+#endif
         return mpVariablesList->Has(rThisVariable);
     }
 
     template<class TAdaptorType> bool Has(const VariableComponent<TAdaptorType>& rThisVariable) const
     {
-        return mpVariablesList->Has(rThisVariable.GetSourceVariable());
+#ifdef KRATOS_DEBUG
+         if(rThisVariable.Key()==0)
+            KRATOS_ERROR << "Trying to access to the variable " << rThisVariable.Name() << " which is not registered!! (key = 0) within the call to function Has " << std::endl;
+#endif
+         return mpVariablesList->Has(rThisVariable.GetSourceVariable());
     }
 
     bool IsEmpty()

--- a/kratos/containers/variable_data.h
+++ b/kratos/containers/variable_data.h
@@ -109,11 +109,6 @@ public:
 
     KeyType Key() const
     {
-        #ifdef KRATOS_DEBUG
-        if(mKey==0){
-            KRATOS_ERROR << "The variable " << mName << " is not registered!!" << std::endl;
-        }
-        #endif 
         return mKey;
     }
 

--- a/kratos/solving_strategies/strategies/solving_strategy.h
+++ b/kratos/solving_strategies/strategies/solving_strategy.h
@@ -2,13 +2,13 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
-//                    
+//
 //
 
 #if !defined(KRATOS_SOLVING_STRATEGY )
@@ -77,50 +77,50 @@ class SolvingStrategy
 public:
     ///@name Type Definitions
     ///@{
-    
+
 //     typedef std::set<Dof::Pointer,ComparePDof>                                    DofSetType;
 
     typedef typename TSparseSpace::DataType                                        TDataType;
-    
+
     typedef typename TSparseSpace::MatrixType                              TSystemMatrixType;
-    
+
     typedef typename TSparseSpace::VectorType                              TSystemVectorType;
 
     typedef typename TSparseSpace::MatrixPointerType                TSystemMatrixPointerType;
-    
+
     typedef typename TSparseSpace::VectorPointerType                TSystemVectorPointerType;
 
     typedef typename TDenseSpace::MatrixType                           LocalSystemMatrixType;
-    
+
     typedef typename TDenseSpace::VectorType                           LocalSystemVectorType;
 
     typedef Scheme<TSparseSpace, TDenseSpace>                                    TSchemeType;
-    
+
     typedef BuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver> TBuilderAndSolverType;
 
     typedef typename ModelPart::DofType                                             TDofType;
-    
+
     typedef typename ModelPart::DofsArrayType                                  DofsArrayType;
-    
+
 //     typedef Dof<TDataType>                                                          TDofType;
-    
+
 //     typedef PointerVectorSet<TDofType, IdentityFunction<TDofType> >            DofsArrayType;
-    
+
 //     typedef PointerVectorSet<TDofType, IndexedObject>                          DofsArrayType;
-    
+
     typedef typename DofsArrayType::iterator                                 DofIteratorType;
-    
+
     typedef typename DofsArrayType::const_iterator                   DofConstantIteratorType;
-    
+
     typedef ModelPart::NodesContainerType                                     NodesArrayType;
-    
+
     typedef ModelPart::ElementsContainerType                               ElementsArrayType;
-    
+
     typedef ModelPart::ConditionsContainerType                           ConditionsArrayType;
-    
+
     /** Counted pointer of ClassName */
     KRATOS_CLASS_POINTER_DEFINITION(SolvingStrategy);
-    
+
     ///@}
     ///@name Life Cycle
     ///@{
@@ -131,14 +131,14 @@ public:
      */
 
     SolvingStrategy(
-        ModelPart& rModelPart, 
+        ModelPart& rModelPart,
         bool MoveMeshFlag = false
     )
         : mrModelPart(rModelPart)
     {
         SetMoveMeshFlag(MoveMeshFlag);
     }
-    
+
     ///@}
 
     /** Destructor.
@@ -146,11 +146,11 @@ public:
 
     ///@{
     virtual ~SolvingStrategy(){}
-    
+
     ///@}
 
     /**OPERATIONS ACCESSIBLE FROM THE INPUT:*/
-    
+
     ///@{
 
     /**
@@ -166,7 +166,6 @@ public:
      */
     virtual void Initialize()
     {
-        KRATOS_ERROR << "You are calling to the base class method Initialize, please define in you derived class the method" << std::endl;
     }
 
     /**
@@ -181,9 +180,9 @@ public:
         Predict();
         SolveSolutionStep();
         FinalizeSolutionStep();
-        
-        return 0.0; 
-        
+
+        return 0.0;
+
     }
 
     /**
@@ -191,7 +190,6 @@ public:
      */
     virtual void Clear()
     {
-        KRATOS_ERROR << "You are calling to the base class method Clear, please define in you derived class the method" << std::endl;
     }
 
     /**
@@ -316,20 +314,20 @@ public:
         if (GetModelPart().NodesBegin()->SolutionStepsDataHas(DISPLACEMENT_X) == false)
         {
             KRATOS_ERROR << "It is impossible to move the mesh since the DISPLACEMENT var is not in the Model Part. Either use SetMoveMeshFlag(False) or add DISPLACEMENT to the list of variables" << std::endl;
-        }   
+        }
 
         NodesArrayType& NodesArray = GetModelPart().Nodes();
         const int numNodes = static_cast<int>(NodesArray.size());
 
         #pragma omp parallel for
-        for(int i = 0; i < numNodes; i++)  
+        for(int i = 0; i < numNodes; i++)
         {
             auto itNode = NodesArray.begin() + i;
 
             noalias(itNode->Coordinates()) = itNode->GetInitialPosition().Coordinates();
             noalias(itNode->Coordinates()) += itNode->FastGetSolutionStepValue(DISPLACEMENT);
         }
-        
+
         if (this->GetEchoLevel() != 0 && GetModelPart().GetCommunicator().MyPID() == 0 )
         {
             std::cout<<" MESH MOVED "<<std::endl;
@@ -390,9 +388,9 @@ public:
         {
             itCond->Check(GetModelPart().GetProcessInfo());
         }
-        
+
         return 0;
-        
+
         KRATOS_CATCH("")
     }
 
@@ -496,4 +494,3 @@ private:
 } /* namespace Kratos.*/
 
 #endif /* KRATOS_SOLVING_STRATEGY  defined */
-


### PR DESCRIPTION
With the included changes, I'm able to finish cleanly the test example that @rubenzorrilla sent me. (I've tested a few times and I have not encountered memory errors so far). I'm creating a PR so that you can test it tomorrow. My modifications since we spoke:
- Modified a non-threadsafe access to Node::GetValue which was causing memory errors in my runs. (Check the code: it was a read of SlipFlag... We need to move to  real Kratos flags for this)
- Added an extra variable to the Navier-Stokes base solver, which is used by the outlet definition process but was not added to the nodal variables list (`EXTERNAL_PRESSURE`)

Please *do not delete* the branch after merge, since we also want to merge this to master.