### PR TITLE
Body force initialization

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/apply_outlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_outlet_process.py
@@ -96,6 +96,12 @@ class ApplyOutletProcess(KratosMultiphysics.Process):
 
     # Private methods section
     def _AddOutletHydrostaticComponent(self):
+        # Initialize body force value (avoid segfault in MPI if the local mesh has no outlet nodes)
+        body_force = KratosMultiphysics.Vector(3)
+        body_force[0] = 0.0
+        body_force[1] = 0.0
+        body_force[2] = 0.0
+
         # Get the body force value
         for node in self.outlet_model_part.Nodes:
             body_force = node.GetSolutionStepValue(KratosMultiphysics.BODY_FORCE, 0)


### PR DESCRIPTION
Initialization of the variable body force before getting its value. Otherwise a segfault is throw when the local mesh of the outlet_model_part has no nodes.