### PR TITLE
Removing remaining UnitCrossProduct

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -727,7 +727,7 @@ public:
 
         array_1d<double, 3> normal;
         MathUtils<double>::CrossProduct(normal, tangent_xi, tangent_eta);
-        return normal;
+        return normal/norm_2(normal);
     }
     
     /** Calculates the quality of the geometry according to a given criteria.

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -790,7 +790,9 @@ public:
         const array_1d<double, 3> tangent_xi  = this->GetPoint(1) - this->GetPoint(0);
         const array_1d<double, 3> tangent_eta = this->GetPoint(2) - this->GetPoint(0);
         
-        return MathUtils<double>::UnitCrossProduct( tangent_eta, tangent_xi );
+        array_1d<double, 3> normal;
+        MathUtils<double>::CrossProduct(normal, tangent_xi, tangent_eta);
+        return normal/norm_2(normal);
     }
 
     /**


### PR DESCRIPTION
Besides, the unitary normal from geometry.h wasn't unitary