### PR TITLE
DON'T MERGE: Replacing boost for std pointers (just core, for testing) TESTS CRASH

### DIFF
--- a/kratos/containers/buffer.h
+++ b/kratos/containers/buffer.h
@@ -245,7 +245,7 @@ public:
       is in charge of storing pointers correctly.
     */
     template<class TDataType>
-    void push_back(boost::shared_ptr<TDataType> const& rValue)
+    void push_back(std::shared_ptr<TDataType> const& rValue)
     {
         KRATOS_THROW_ERROR(std::logic_error, "You cannot store a pointer in the buffer try the Serializer instead", "" );
     }

--- a/kratos/containers/pointer_hash_map_set.h
+++ b/kratos/containers/pointer_hash_map_set.h
@@ -64,7 +64,7 @@ namespace Kratos
 template<class TDataType,
          class THashType = boost::hash<TDataType>,
          class TGetKeyType = SetIdentityFunction<TDataType>,
-         class TPointerType = boost::shared_ptr<TDataType> >
+         class TPointerType = std::shared_ptr<TDataType> >
 class PointerHashMapSet
 {
 

--- a/kratos/containers/pointer_vector.h
+++ b/kratos/containers/pointer_vector.h
@@ -66,7 +66,7 @@ namespace Kratos
     deleting.
  */
 template<class TDataType,
-         class TPointerType = boost::shared_ptr<TDataType>,
+         class TPointerType = std::shared_ptr<TDataType>,
          class TContainerType = std::vector<TPointerType> >
 class PointerVector
 {

--- a/kratos/containers/pointer_vector_map.h
+++ b/kratos/containers/pointer_vector_map.h
@@ -65,7 +65,7 @@ namespace Kratos
 template<class TKeyType,class TDataType,
 
          class TCompareType = std::less<TKeyType>,
-         class TPointerType = boost::shared_ptr<TDataType>,
+         class TPointerType = std::shared_ptr<TDataType>,
          class TContainerType = std::vector<std::pair<TKeyType, TPointerType> > >
 class PointerVectorMap
 {

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -70,7 +70,7 @@ template<class TDataType,
          class TGetKeyType = SetIdentityFunction<TDataType>,
          class TCompareType = std::less<typename TGetKeyType::result_type>,
          class TEqualType = std::equal_to<typename TGetKeyType::result_type>,
-         class TPointerType = boost::shared_ptr<TDataType>,
+         class TPointerType = std::shared_ptr<TDataType>,
          class TContainerType = std::vector<TPointerType> >
 class PointerVectorSet
 {

--- a/kratos/containers/weak_pointer_vector.h
+++ b/kratos/containers/weak_pointer_vector.h
@@ -64,7 +64,7 @@ namespace Kratos
     deleting.
  */
 template<class TDataType,
-         class TPointerType = boost::weak_ptr<TDataType>,
+         class TPointerType = std::weak_ptr<TDataType>,
          class TContainerType = std::vector<TPointerType> >
 class WeakPointerVector
 {

--- a/kratos/containers/weak_pointer_vector_iterator.h
+++ b/kratos/containers/weak_pointer_vector_iterator.h
@@ -141,7 +141,7 @@ private:
 
     typename BaseType::reference dereference() const
     {
-        return *(boost::shared_ptr<TDataType>(*(this->base())));
+        return *(std::shared_ptr<TDataType>(*(this->base())));
     }
 
     ///@}

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -390,7 +390,7 @@ public:
             *i = typename PointType::Pointer( new PointType( **i ) );
     }
 
-    virtual boost::shared_ptr< Geometry< Point<3> > > Clone() const
+    virtual std::shared_ptr< Geometry< Point<3> > > Clone() const
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -398,7 +398,7 @@ public:
 
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-            NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+            NewPoints.push_back(std::make_shared< Point<3> >((*this)[i]));
         }
 
         //NewPoints[i] = typename Point<3>::Pointer(new Point<3>(*mPoints[i]));

--- a/kratos/geometries/hexahedra_3d_20.h
+++ b/kratos/geometries/hexahedra_3d_20.h
@@ -349,7 +349,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-            NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+            NewPoints.push_back(std::make_shared< Point<3> >((*this)[i]));
         }
 
 

--- a/kratos/geometries/hexahedra_3d_27.h
+++ b/kratos/geometries/hexahedra_3d_27.h
@@ -369,7 +369,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-            NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+            NewPoints.push_back(std::make_shared< Point<3> >((*this)[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/hexahedra_3d_8.h
+++ b/kratos/geometries/hexahedra_3d_8.h
@@ -311,7 +311,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-            NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+            NewPoints.push_back(std::make_shared< Point<3> >((*this)[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/hexahedra_interface_3d_8.h
+++ b/kratos/geometries/hexahedra_interface_3d_8.h
@@ -486,7 +486,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-            NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+            NewPoints.push_back(std::make_shared< Point<3> >((*this)[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/line_2d.h
+++ b/kratos/geometries/line_2d.h
@@ -267,7 +267,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -273,7 +273,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-            NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+            NewPoints.push_back(std::make_shared< Point<3> >((*this)[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -266,7 +266,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-            NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+            NewPoints.push_back(std::make_shared< Point<3> >((*this)[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -272,7 +272,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -266,7 +266,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/line_gl_3d_2.h
+++ b/kratos/geometries/line_gl_3d_2.h
@@ -270,7 +270,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
 
         for ( IndexType i = 0 ; i < BaseType::Points().size() ; i++ )
-            NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+            NewPoints.push_back(std::make_shared< Point<3> >((*this)[i]));
 
         //creating a geometry with the new points
        Geometry< Point<3> >::Pointer p_clone( new LineGL3D2< Point<3> >( NewPoints ) );

--- a/kratos/geometries/point_2d.h
+++ b/kratos/geometries/point_2d.h
@@ -263,7 +263,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/point_3d.h
+++ b/kratos/geometries/point_3d.h
@@ -264,7 +264,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/prism_3d_15.h
+++ b/kratos/geometries/prism_3d_15.h
@@ -332,7 +332,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/prism_3d_6.h
+++ b/kratos/geometries/prism_3d_6.h
@@ -303,7 +303,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/prism_interface_3d_6.h
+++ b/kratos/geometries/prism_interface_3d_6.h
@@ -328,7 +328,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/quadrilateral_2d_4.h
+++ b/kratos/geometries/quadrilateral_2d_4.h
@@ -325,7 +325,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }   
         
         //creating a geometry with the new points
@@ -504,10 +504,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_2d_8.h
+++ b/kratos/geometries/quadrilateral_2d_8.h
@@ -323,7 +323,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points
@@ -930,10 +930,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_2d_9.h
+++ b/kratos/geometries/quadrilateral_2d_9.h
@@ -325,7 +325,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points
@@ -486,10 +486,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -325,7 +325,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-            NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+            NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/quadrilateral_3d_8.h
+++ b/kratos/geometries/quadrilateral_3d_8.h
@@ -316,7 +316,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points
@@ -995,10 +995,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -325,7 +325,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points
@@ -988,10 +988,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_interface_2d_4.h
+++ b/kratos/geometries/quadrilateral_interface_2d_4.h
@@ -354,7 +354,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points
@@ -859,10 +859,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_interface_3d_4.h
+++ b/kratos/geometries/quadrilateral_interface_3d_4.h
@@ -362,7 +362,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/sphere_3d_1.h
+++ b/kratos/geometries/sphere_3d_1.h
@@ -268,7 +268,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -317,7 +317,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -292,7 +292,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points

--- a/kratos/geometries/triangle_2d_3.h
+++ b/kratos/geometries/triangle_2d_3.h
@@ -323,7 +323,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points
@@ -744,9 +744,9 @@ public:
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/triangle_2d_6.h
+++ b/kratos/geometries/triangle_2d_6.h
@@ -335,7 +335,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points
@@ -618,9 +618,9 @@ public:
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 3 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 4 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 5 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 3 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 4 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 5 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -315,14 +315,14 @@ public:
     }
 
 
-    boost::shared_ptr< Geometry< Point<3> > > Clone() const override
+    std::shared_ptr< Geometry< Point<3> > > Clone() const override
     {
         Geometry< Point<3> >::PointsArrayType NewPoints;
 
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-                NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+                NewPoints.push_back(std::make_shared< Point<3> >(( *this )[i]));
         }
 
         //creating a geometry with the new points
@@ -1239,9 +1239,9 @@ public:
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/triangle_3d_6.h
+++ b/kratos/geometries/triangle_3d_6.h
@@ -335,7 +335,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
         for ( IndexType i = 0 ; i < this->size() ; i++ )
         {
-            Point<3>::Pointer pnew_point = boost::make_shared< Point<3> >(( *this )[i]);
+            Point<3>::Pointer pnew_point = std::make_shared< Point<3> >(( *this )[i]);
             NewPoints.push_back(pnew_point);
         }
 
@@ -1131,9 +1131,9 @@ public:
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 3 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 4 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 5 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 3 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 4 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( std::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 5 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -177,9 +177,9 @@ public:
         mpInterfaceMesh(MeshType::Pointer(new MeshType))
     {
         MeshType mesh;
-        mLocalMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
-        mGhostMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
-        mInterfaceMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
+        mLocalMeshes.push_back(std::make_shared<MeshType>(mesh.Clone()));
+        mGhostMeshes.push_back(std::make_shared<MeshType>(mesh.Clone()));
+        mInterfaceMeshes.push_back(std::make_shared<MeshType>(mesh.Clone()));
     }
 
     /// Copy constructor.
@@ -267,9 +267,9 @@ public:
 
         for (IndexType i = 0; i < mNumberOfColors; i++)
         {
-            mLocalMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
-            mGhostMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
-            mInterfaceMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
+            mLocalMeshes.push_back(std::make_shared<MeshType>(mesh.Clone()));
+            mGhostMeshes.push_back(std::make_shared<MeshType>(mesh.Clone()));
+            mInterfaceMeshes.push_back(std::make_shared<MeshType>(mesh.Clone()));
         }
     }
 

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -31,13 +31,13 @@
 
 
 
-#define KRATOS_CLASS_POINTER_DEFINITION(a) typedef boost::shared_ptr<a > Pointer; \
-typedef boost::shared_ptr<a > SharedPointer; \
-typedef boost::weak_ptr<a > WeakPointer
+#define KRATOS_CLASS_POINTER_DEFINITION(a) typedef std::shared_ptr<a > Pointer; \
+typedef std::shared_ptr<a > SharedPointer; \
+typedef std::weak_ptr<a > WeakPointer
 
-#define KRATOS_CLASS_POINTER_DEFINITION_WITHTYPENAME(a) typedef boost::shared_ptr<a > Pointer; \
-typedef typename boost::shared_ptr<a > SharedPointer; \
-typedef typename boost::weak_ptr<a > WeakPointer
+#define KRATOS_CLASS_POINTER_DEFINITION_WITHTYPENAME(a) typedef std::shared_ptr<a > Pointer; \
+typedef typename std::shared_ptr<a > SharedPointer; \
+typedef typename std::weak_ptr<a > WeakPointer
 
 //-----------------------------------------------------------------
 //

--- a/kratos/includes/io.h
+++ b/kratos/includes/io.h
@@ -217,7 +217,7 @@ public:
         KRATOS_ERROR <<  "Calling base class member. Please check the definition of derived class" << std::endl;
     }
 
-    virtual void DivideInputToPartitions(boost::shared_ptr<std::iostream> * Streams,
+    virtual void DivideInputToPartitions(std::shared_ptr<std::iostream> * Streams,
                                          SizeType NumberOfPartitions, GraphType const& DomainsColoredGraph,
                                          PartitionIndicesType const& NodesPartitions,
                                          PartitionIndicesType const& ElementsPartitions,

--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -66,7 +66,7 @@ private:
 		value_iterator mValueIterator;
     std::unique_ptr<Parameters> mpParameters;
 	public:
-		iterator_adaptor(value_iterator it, boost::shared_ptr<rapidjson::Document> pdoc) :mValueIterator(it), mpParameters(new Parameters(&it->value, pdoc)) {}
+		iterator_adaptor(value_iterator it, std::shared_ptr<rapidjson::Document> pdoc) :mValueIterator(it), mpParameters(new Parameters(&it->value, pdoc)) {}
 		iterator_adaptor(const iterator_adaptor& it) : mValueIterator(it.mValueIterator), mpParameters(new Parameters(*(it.mpParameters))) {}
 		iterator_adaptor& operator++() { mValueIterator++; return *this; }
 		iterator_adaptor operator++(int) { iterator_adaptor tmp(*this); operator++(); return tmp; }
@@ -85,7 +85,7 @@ private:
 		value_iterator mValueIterator;
     std::unique_ptr<Parameters> mpParameters;
 	public:
-		const_iterator_adaptor(value_iterator it, boost::shared_ptr<rapidjson::Document> pdoc) :mValueIterator(it), mpParameters(new Parameters(const_cast<rapidjson::Value*>(&it->value), pdoc)) {}
+		const_iterator_adaptor(value_iterator it, std::shared_ptr<rapidjson::Document> pdoc) :mValueIterator(it), mpParameters(new Parameters(const_cast<rapidjson::Value*>(&it->value), pdoc)) {}
 		const_iterator_adaptor(const const_iterator_adaptor& it) : mValueIterator(it.mValueIterator), mpParameters(new Parameters(*(it.mpParameters))) {}
 		const_iterator_adaptor& operator++() { mValueIterator++; return *this; }
 		const_iterator_adaptor operator++(int) { const_iterator_adaptor tmp(*this); operator++(); return tmp; }
@@ -109,7 +109,7 @@ public:
     Parameters(const std::string json_string)
     {
 
-        mpdoc =  boost::shared_ptr<rapidjson::Document>(new rapidjson::Document() );
+        mpdoc =  std::shared_ptr<rapidjson::Document>(new rapidjson::Document() );
         rapidjson::ParseResult ok = mpdoc->Parse<0>(json_string.c_str());
 
         if( !ok )
@@ -143,7 +143,7 @@ public:
     //generates a clone of the current document
     Parameters Clone()
     {
-        boost::shared_ptr<rapidjson::Document> pnew_cloned_doc =  boost::shared_ptr<rapidjson::Document>(new rapidjson::Document() );
+        std::shared_ptr<rapidjson::Document> pnew_cloned_doc =  std::shared_ptr<rapidjson::Document>(new rapidjson::Document() );
         rapidjson::ParseResult ok = pnew_cloned_doc->Parse<0>(this->WriteJsonString().c_str());
         if( !ok )
         {
@@ -570,12 +570,12 @@ public:
 
 private:
   //ATTENTION: please DO NOT use this constructor. It assumes rapidjson and hence it should be considered as an implementation detail
-  Parameters(rapidjson::Value* pvalue, boost::shared_ptr<rapidjson::Document> pdoc): mpvalue(pvalue),mpdoc(pdoc)
+  Parameters(rapidjson::Value* pvalue, std::shared_ptr<rapidjson::Document> pdoc): mpvalue(pvalue),mpdoc(pdoc)
   {
   }
 
     rapidjson::Value* mpvalue;
-    boost::shared_ptr<rapidjson::Document> mpdoc;
+    std::shared_ptr<rapidjson::Document> mpdoc;
 
     //ATTENTION: please DO NOT use this method. It is a low level accessor, and may change in the future
     rapidjson::Value* GetUnderlyingStorage() const

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -587,7 +587,7 @@ public:
             }
             else
             {
-                PropertiesType::Pointer pnew_property = boost::make_shared<PropertiesType>(PropertiesId);
+                PropertiesType::Pointer pnew_property = std::make_shared<PropertiesType>(PropertiesId);
                 GetMesh(ThisIndex).AddProperties(pnew_property);
                 return pnew_property;
             }
@@ -612,7 +612,7 @@ public:
             }
             else
             {
-                PropertiesType::Pointer pnew_property = boost::make_shared<PropertiesType>(PropertiesId);
+                PropertiesType::Pointer pnew_property = std::make_shared<PropertiesType>(PropertiesId);
                 GetMesh(ThisIndex).AddProperties(pnew_property);
                 return *pnew_property;
             }

--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -86,7 +86,7 @@ public:
     ModelPartIO(std::string const& Filename, const Flags Options = IO::READ|IO::NOT_IGNORE_VARIABLES_ERROR);
 
     /// Constructor with stream.
-    ModelPartIO(boost::shared_ptr<std::iostream> Stream);
+    ModelPartIO(std::shared_ptr<std::iostream> Stream);
 
 
     /// Constructor with filenames.
@@ -174,7 +174,7 @@ public:
                                          PartitionIndicesContainerType const& ElementsAllPartitions,
                                          PartitionIndicesContainerType const& ConditionsAllPartitions) override;
 
-    void DivideInputToPartitions(boost::shared_ptr<std::iostream> * Streams,
+    void DivideInputToPartitions(std::shared_ptr<std::iostream> * Streams,
                                          SizeType NumberOfPartitions, GraphType const& DomainsColoredGraph,
                                          PartitionIndicesType const& NodesPartitions,
                                          PartitionIndicesType const& ElementsPartitions,
@@ -183,7 +183,7 @@ public:
                                          PartitionIndicesContainerType const& ElementsAllPartitions,
                                          PartitionIndicesContainerType const& ConditionsAllPartitions) override;
 
-    void SwapStreamSource(boost::shared_ptr<std::iostream> newStream);
+    void SwapStreamSource(std::shared_ptr<std::iostream> newStream);
 
 
     ///@}
@@ -281,7 +281,7 @@ protected:
     std::string mFilename;
     Flags mOptions;
 
-    boost::shared_ptr<std::iostream> mpStream;
+    std::shared_ptr<std::iostream> mpStream;
 
 
     ///@}

--- a/kratos/includes/neighbours.h
+++ b/kratos/includes/neighbours.h
@@ -70,9 +70,9 @@ public:
 
     typedef std::size_t IndexType;
 
-    typedef boost::weak_ptr<TNodeType> NodeWeakPointer;
+    typedef std::weak_ptr<TNodeType> NodeWeakPointer;
 
-    typedef boost::weak_ptr<TElementType> ElementWeakPointer;
+    typedef std::weak_ptr<TElementType> ElementWeakPointer;
 
     /** An array of pointers to elements. */
     typedef WeakPointerVector<TElementType> NeighbourElementsArrayType;

--- a/kratos/includes/node.h
+++ b/kratos/includes/node.h
@@ -339,7 +339,7 @@ public:
 
     typename Node<TDimension>::Pointer Clone()
     {
-        Node<3>::Pointer p_new_node = boost::make_shared<Node<3> >( this->Id(), (*this)[0], (*this)[1], (*this)[2]);
+        Node<3>::Pointer p_new_node = std::make_shared<Node<3> >( this->Id(), (*this)[0], (*this)[1], (*this)[2]);
         p_new_node->mSolutionStepsNodalData = this->mSolutionStepsNodalData;
 
         Node<3>::DofsContainerType& my_dofs = (this)->GetDofs();
@@ -1025,7 +1025,7 @@ public:
             return *(it_dof.base());
         }
 
-        typename DofType::Pointer p_new_dof =  boost::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable);
+        typename DofType::Pointer p_new_dof =  std::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable);
         mDofs.insert(mDofs.begin(), p_new_dof);
 
 //         if(!mDofs.IsSorted())
@@ -1053,7 +1053,7 @@ public:
             return *(it_dof.base());
         }
 
-        typename DofType::Pointer p_new_dof =  boost::make_shared<DofType>(SourceDof);
+        typename DofType::Pointer p_new_dof =  std::make_shared<DofType>(SourceDof);
         mDofs.insert(mDofs.begin(), p_new_dof);
 
         p_new_dof->SetId(Id());
@@ -1091,7 +1091,7 @@ public:
             return *(it_dof.base());
         }
 
-        typename DofType::Pointer p_new_dof =  boost::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable, rDofReaction);
+        typename DofType::Pointer p_new_dof =  std::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable, rDofReaction);
         mDofs.insert(mDofs.begin(), p_new_dof);
 
 //         if(!mDofs.IsSorted())
@@ -1122,7 +1122,7 @@ public:
             return *it_dof;
         }
             
-        typename DofType::Pointer p_new_dof =  boost::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable);
+        typename DofType::Pointer p_new_dof =  std::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable);
         mDofs.insert(mDofs.begin(), p_new_dof);
 
 //         if(!mDofs.IsSorted())
@@ -1158,7 +1158,7 @@ public:
             return *it_dof;
         }
 
-        typename DofType::Pointer p_new_dof =  boost::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable, rDofReaction);
+        typename DofType::Pointer p_new_dof =  std::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable, rDofReaction);
         mDofs.insert(mDofs.begin(), p_new_dof);
 
 //         if(!mDofs.IsSorted())

--- a/kratos/includes/serializer.h
+++ b/kratos/includes/serializer.h
@@ -194,7 +194,7 @@ public:
     }
 
     template<class TDataType>
-    void load(std::string const & rTag, boost::shared_ptr<TDataType>& pValue)
+    void load(std::string const & rTag, std::shared_ptr<TDataType>& pValue)
     {
         PointerType pointer_type = SP_INVALID_POINTER;
         void* p_pointer;
@@ -209,7 +209,7 @@ public:
                 if(pointer_type == SP_BASE_CLASS_POINTER)
                 {
                     if(!pValue)
-                        pValue = boost::shared_ptr<TDataType>(new TDataType);
+                        pValue = std::shared_ptr<TDataType>(new TDataType);
 
                     load(rTag, *pValue);
                 }
@@ -223,7 +223,7 @@ public:
                         KRATOS_THROW_ERROR(std::runtime_error, "There is no object registered in Kratos with name : ", object_name)
 
                         if(!pValue)
-                            pValue = boost::shared_ptr<TDataType>(static_cast<TDataType*>((i_prototype->second)()));
+                            pValue = std::shared_ptr<TDataType>(static_cast<TDataType*>((i_prototype->second)()));
 
                     load(rTag, *pValue);
 
@@ -231,7 +231,7 @@ public:
                 mLoadedPointers[p_pointer]=&pValue;
             }
             else
-                pValue = *static_cast<boost::shared_ptr<TDataType>*>((i_pointer->second));
+                pValue = *static_cast<std::shared_ptr<TDataType>*>((i_pointer->second));
         }
     }
 
@@ -280,7 +280,7 @@ public:
     }
 
     template<class TDataType>
-    void load(std::string const & rTag, boost::weak_ptr<TDataType>& pValue)
+    void load(std::string const & rTag, std::weak_ptr<TDataType>& pValue)
     {
         // This is for testing. I have to change it. Pooyan.
         //KRATOS_THROW_ERROR(std::logic_error, "The serialization for weak_ptrs is not implemented yet", "")
@@ -416,7 +416,7 @@ public:
 
 
     template<class TDataType>
-    void save(std::string const & rTag, boost::shared_ptr<TDataType> pValue)
+    void save(std::string const & rTag, std::shared_ptr<TDataType> pValue)
     {
         save(rTag, pValue.get());
     }
@@ -477,7 +477,7 @@ public:
     }
 
     template<class TDataType>
-    void save(std::string const & rTag, boost::weak_ptr<TDataType> pValue)
+    void save(std::string const & rTag, std::weak_ptr<TDataType> pValue)
     {
         // This is for testing. I have to implement it. Pooyan.
         //KRATOS_THROW_ERROR(std::logic_error, "The serialization for weak_ptrs is not implemented yet", "")
@@ -493,7 +493,7 @@ public:
     }
 
     template<class TDataType>
-    void save(std::string const & rTag, boost::shared_ptr<const TDataType> pValue)
+    void save(std::string const & rTag, std::shared_ptr<const TDataType> pValue)
     {
         // This is for testing. I have to change it. Pooyan.
 //          save_trace_point(rTag);

--- a/kratos/linear_solvers/bicgstab_solver.h
+++ b/kratos/linear_solvers/bicgstab_solver.h
@@ -85,7 +85,7 @@ public:
     BICGSTABSolver(double NewMaxTolerance, unsigned int NewMaxIterationsNumber, typename TPreconditionerType::Pointer pNewPreconditioner) :
         BaseType(NewMaxTolerance, NewMaxIterationsNumber, pNewPreconditioner) {}
         
-    BICGSTABSolver(Parameters settings, typename TPreconditionerType::Pointer pNewPreconditioner = boost::make_shared<TPreconditionerType>()):
+    BICGSTABSolver(Parameters settings, typename TPreconditionerType::Pointer pNewPreconditioner = std::make_shared<TPreconditionerType>()):
         BaseType(settings, pNewPreconditioner) {}
         
     /// Copy constructor.

--- a/kratos/linear_solvers/cg_solver.h
+++ b/kratos/linear_solvers/cg_solver.h
@@ -90,7 +90,7 @@ public:
     CGSolver(double NewMaxTolerance, unsigned int NewMaxIterationsNumber, typename TPreconditionerType::Pointer pNewPreconditioner) :
         BaseType(NewMaxTolerance, NewMaxIterationsNumber, pNewPreconditioner) {}
         
-    CGSolver(Parameters settings, typename TPreconditionerType::Pointer pNewPreconditioner = boost::make_shared<TPreconditionerType>()):
+    CGSolver(Parameters settings, typename TPreconditionerType::Pointer pNewPreconditioner = std::make_shared<TPreconditionerType>()):
         BaseType(settings, pNewPreconditioner) {}
 
 

--- a/kratos/linear_solvers/deflated_cg_solver.h
+++ b/kratos/linear_solvers/deflated_cg_solver.h
@@ -113,7 +113,7 @@ public:
     }
     
     DeflatedCGSolver(Parameters settings,
-                    typename TPreconditionerType::Pointer pNewPreconditioner = boost::make_shared<TPreconditionerType>()
+                    typename TPreconditionerType::Pointer pNewPreconditioner = std::make_shared<TPreconditionerType>()
                    ): BaseType ()
 
     {

--- a/kratos/linear_solvers/iterative_solver.h
+++ b/kratos/linear_solvers/iterative_solver.h
@@ -128,7 +128,7 @@ public:
         mMaxIterationsNumber(NewMaxIterationsNumber) {}
 
     IterativeSolver(Parameters settings,
-                    typename TPreconditionerType::Pointer pNewPreconditioner = boost::make_shared<TPreconditionerType>()
+                    typename TPreconditionerType::Pointer pNewPreconditioner = std::make_shared<TPreconditionerType>()
                    ):
         mResidualNorm(0),
         mIterationsNumber(0),

--- a/kratos/linear_solvers/mixedup_linear_solver.h
+++ b/kratos/linear_solvers/mixedup_linear_solver.h
@@ -1013,7 +1013,7 @@ private:
             #pragma omp parallel
             if ( OpenMPUtils::ThisThread() == k)
             {
-//                 boost::shared_ptr< IndexVector > pNext( new IndexVector(rL.size1() ) );
+//                 std::shared_ptr< IndexVector > pNext( new IndexVector(rL.size1() ) );
 //                 IndexVector& Next = *pNext; // Keeps track of which columns were filled
                 IndexVector Next(rL.size1());
                 for (unsigned int m = 0; m < rL.size1(); m++) Next[m] = -1;

--- a/kratos/modeler/mesh_suite_modeler.h
+++ b/kratos/modeler/mesh_suite_modeler.h
@@ -519,7 +519,7 @@ public:
             for(int j = 0; j<numb_of_neighb; j++)
             {
                 int ii = nn[i][j]+1;
-                //neighbours.push_back(boost::weak_ptr< Node<3> >( r_model_nodes(ii) ) );
+                //neighbours.push_back(std::weak_ptr< Node<3> >( r_model_nodes(ii) ) );
                 neighbours.push_back( r_model_nodes(ii)  );
             }
         }

--- a/kratos/processes/calculate_signed_distance_to_3d_skin_process.h
+++ b/kratos/processes/calculate_signed_distance_to_3d_skin_process.h
@@ -1680,7 +1680,7 @@ public:
     {
         Timer::Start("Generating Octree");
         //std::cout << "Generating the Octree..." << std::endl;
-        boost::shared_ptr<OctreeType> temp_octree =  boost::shared_ptr<OctreeType>( new OctreeType() );
+        std::shared_ptr<OctreeType> temp_octree =  std::shared_ptr<OctreeType>( new OctreeType() );
         //OctreeType::Pointer temp_octree = OctreeType::Pointer(new OctreeType() );
         mpOctree.swap(temp_octree);
         
@@ -2601,7 +2601,7 @@ private:
 
     DistanceSpatialContainersConfigure::data_type mOctreeNodes;
 
-    boost::shared_ptr<OctreeType> mpOctree;
+    std::shared_ptr<OctreeType> mpOctree;
 
     static const double epsilon;
 

--- a/kratos/python/add_logger_to_python.cpp
+++ b/kratos/python/add_logger_to_python.cpp
@@ -63,7 +63,7 @@ object print(tuple args, dict kwargs) {
 void  AddLoggerToPython() {
 	using namespace boost::python;
 
-  class_<Logger, boost::shared_ptr<Logger>, boost::noncopyable>("Logger", no_init)
+  class_<Logger, std::shared_ptr<Logger>, boost::noncopyable>("Logger", no_init)
   .def("Print", raw_function(print,1))
   .staticmethod("Print");
 }

--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -69,7 +69,7 @@ ModelPart::MeshType::Pointer ModelPartGetMesh2(ModelPart& rModelPart, ModelPart:
     // adding necessary meshes to the model part.
     ModelPart::MeshType empty_mesh;
     for(ModelPart::IndexType i = number_of_meshes ; i < MeshIndex + 1 ; i++)
-        rModelPart.GetMeshes().push_back(boost::make_shared<ModelPart::MeshType>(empty_mesh.Clone()));
+        rModelPart.GetMeshes().push_back(std::make_shared<ModelPart::MeshType>(empty_mesh.Clone()));
 
     return rModelPart.pGetMesh(MeshIndex);
 }

--- a/kratos/python/add_strategies_to_python.cpp
+++ b/kratos/python/add_strategies_to_python.cpp
@@ -173,24 +173,24 @@ namespace Kratos
             return dummy.CreateEmptyVectorPointer();
         }
 
-        // 	boost::shared_ptr< CompressedMatrix > CreateEmptyMatrixPointer()
+        // 	std::shared_ptr< CompressedMatrix > CreateEmptyMatrixPointer()
         // 	{
-        // 		boost::shared_ptr<CompressedMatrix> pNewMat = boost::shared_ptr<CompressedMatrix>(new CompressedMatrix() );
+        // 		std::shared_ptr<CompressedMatrix> pNewMat = std::shared_ptr<CompressedMatrix>(new CompressedMatrix() );
         // 		return pNewMat;
         // 	}
         //
-        // 	boost::shared_ptr< Vector > CreateEmptyVectorPointer()
+        // 	std::shared_ptr< Vector > CreateEmptyVectorPointer()
         // 	{
-        // 		boost::shared_ptr<Vector > pNewVec = boost::shared_ptr<Vector >(new Vector() );
+        // 		std::shared_ptr<Vector > pNewVec = std::shared_ptr<Vector >(new Vector() );
         // 		return pNewVec;
         // 	}
 
-        CompressedMatrix& GetMatRef(boost::shared_ptr<CompressedMatrix>& dummy)
+        CompressedMatrix& GetMatRef(std::shared_ptr<CompressedMatrix>& dummy)
         {
             return *dummy;
         }
 
-        Vector& GetVecRef(boost::shared_ptr<Vector>& dummy)
+        Vector& GetVecRef(std::shared_ptr<Vector>& dummy)
         {
             return *dummy;
         }
@@ -203,7 +203,7 @@ namespace Kratos
             // 			def("CreateEmptyMatrixPointer",CreateEmptyMatrixPointer);
             // 			def("CreateEmptyVectorPointer",CreateEmptyVectorPointer);
 
-            class_< boost::shared_ptr<CompressedMatrix> >("CompressedMatrixPointer", init<boost::shared_ptr<CompressedMatrix> >())
+            class_< std::shared_ptr<CompressedMatrix> >("CompressedMatrixPointer", init<std::shared_ptr<CompressedMatrix> >())
                     .def("GetReference", GetMatRef, return_value_policy<reference_existing_object > ())
                     //    				.def("GetReference", GetRef, return_internal_reference<1>() )
                     ;
@@ -211,7 +211,7 @@ namespace Kratos
             // // // 			class_< CompressedMatrix , boost::noncopyable >("CompressedMatrix", init< >() );
 
 
-            class_< boost::shared_ptr<Vector> >("VectorPointer", init< boost::shared_ptr<Vector> >())
+            class_< std::shared_ptr<Vector> >("VectorPointer", init< std::shared_ptr<Vector> >())
                     .def("GetReference", GetVecRef, return_value_policy<reference_existing_object > ())
                     ;
             // // // 			class_< Vector , boost::noncopyable >("Vector", init< >() );

--- a/kratos/python/add_testing_to_python.cpp
+++ b/kratos/python/add_testing_to_python.cpp
@@ -31,7 +31,7 @@ void ListOfAllTestCases() {
 void  AddTestingToPython() {
 	using namespace boost::python;
 
-  scope tester_scope = class_<Testing::Tester, boost::shared_ptr<Testing::Tester>, boost::noncopyable>("Tester", no_init)
+  scope tester_scope = class_<Testing::Tester, std::shared_ptr<Testing::Tester>, boost::noncopyable>("Tester", no_init)
 
   // Properties
   .def("SetVerbosity",&Testing::Tester::SetVerbosity)

--- a/kratos/python/matrix_python_interface.h
+++ b/kratos/python/matrix_python_interface.h
@@ -193,7 +193,7 @@ public:
         fill_row(ThisMatrix, i, Value, TFunctorType());
     }
 
-// 			static class_<TMatrixType, boost::shared_ptr<TMatrixType> > CreateInterface(std::string const& Name)
+// 			static class_<TMatrixType, std::shared_ptr<TMatrixType> > CreateInterface(std::string const& Name)
     static class_<TMatrixType > CreateInterface(std::string const& Name)
     {
 // 				boost::python::converter::registry::push_back(
@@ -201,7 +201,7 @@ public:
 // 					&construct1,
 // 					boost::python::type_id<TMatrixType>());
 
-//  				return class_<TMatrixType, boost::shared_ptr<TMatrixType> >(Name.c_str())
+//  				return class_<TMatrixType, std::shared_ptr<TMatrixType> >(Name.c_str())
         return class_<TMatrixType >(Name.c_str())
                .def(init<TMatrixType>())
                /* 					.def("Resize", &BaseType::resize1) */

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -42,7 +42,7 @@ ModelPart::ModelPart()
 {
     mName = "Default";
     MeshType mesh;
-    mMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
+    mMeshes.push_back(std::make_shared<MeshType>(mesh.Clone()));
     mpCommunicator->SetLocalMesh(pGetMesh());  // assigning the current mesh to the local mesh of communicator for openmp cases
 }
 
@@ -60,7 +60,7 @@ ModelPart::ModelPart(std::string const& NewName)
 {
     mName = NewName;
     MeshType mesh;
-    mMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
+    mMeshes.push_back(std::make_shared<MeshType>(mesh.Clone()));
     mpCommunicator->SetLocalMesh(pGetMesh());  // assigning the current mesh to the local mesh of communicator for openmp cases
 }
 
@@ -78,7 +78,7 @@ ModelPart::ModelPart(std::string const& NewName, IndexType NewBufferSize)
 {
     mName = NewName;
     MeshType mesh;
-    mMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
+    mMeshes.push_back(std::make_shared<MeshType>(mesh.Clone()));
     mpCommunicator->SetLocalMesh(pGetMesh());  // assigning the current mesh to the local mesh of communicator for openmp cases
 }
 
@@ -336,7 +336,7 @@ ModelPart::NodeType::Pointer ModelPart::CreateNewNode(int Id, double x, double y
     }
 
     //create a new node
-    NodeType::Pointer p_new_node = boost::make_shared< NodeType >( Id, x, y, z );
+    NodeType::Pointer p_new_node = std::make_shared< NodeType >( Id, x, y, z );
 
     // Giving model part's variables list to the node
     p_new_node->SetSolutionStepVariablesList(pNewVariablesList);
@@ -382,7 +382,7 @@ ModelPart::NodeType::Pointer ModelPart::CreateNewNode(ModelPart::IndexType Id, d
     }
 
     //create a new node
-    NodeType::Pointer p_new_node = boost::make_shared< NodeType >( Id, x, y, z, mpVariablesList, pThisData, mBufferSize);
+    NodeType::Pointer p_new_node = std::make_shared< NodeType >( Id, x, y, z, mpVariablesList, pThisData, mBufferSize);
     //add the new node to the list of nodes
     GetMesh(ThisIndex).AddNode(p_new_node);
 

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -26,7 +26,7 @@ namespace Kratos
       , mFilename(Filename + ".mdpa")
       , mOptions(Options)
     {
-        boost::shared_ptr<std::fstream> pFile = boost::make_shared<std::fstream>();
+        std::shared_ptr<std::fstream> pFile = std::make_shared<std::fstream>();
         std::fstream::openmode OpenMode;
 
         // Set the mode
@@ -63,15 +63,15 @@ namespace Kratos
     }
 
     /// Constructor with stream
-    ModelPartIO::ModelPartIO(boost::shared_ptr<std::iostream> Stream)
+    ModelPartIO::ModelPartIO(std::shared_ptr<std::iostream> Stream)
       : mNumberOfLines(1)
     {
-        // nullptr test can be confusing with boost::shared_ptr. Commented until we move to std::shared_ptr
+        // nullptr test can be confusing with std::shared_ptr. Commented until we move to std::shared_ptr
         // if (Stream == nullptr)
         //    KRATOS_THROW_ERROR(std::invalid_argument, "Error: ModelPartIO Stream is invalid ", "");
 
         // Check if the pointer was .reset() or never initialized and if its a NULL pointer)
-        // if (Stream == NULL || Stream == boost::shared_ptr<std::iostream>(NULL))
+        // if (Stream == NULL || Stream == std::shared_ptr<std::iostream>(NULL))
         //    KRATOS_THROW_ERROR(std::invalid_argument, "Error: ModelPartIO Stream is invalid ", "");
 
         mpStream = Stream;
@@ -726,7 +726,7 @@ namespace Kratos
     }
 
     void ModelPartIO::DivideInputToPartitions(
-        boost::shared_ptr<std::iostream> * Streams,
+        std::shared_ptr<std::iostream> * Streams,
         SizeType NumberOfPartitions, GraphType const& DomainsColoredGraph,
         PartitionIndicesType const& NodesPartitions,
         PartitionIndicesType const& ElementsPartitions,
@@ -1144,7 +1144,7 @@ namespace Kratos
             ExtractValue(word, y);
             ReadWord(word);
             ExtractValue(word, z);
-            NodeType::Pointer temp_node = boost::make_shared< NodeType >( ReorderedNodeId(temp_id), x, y, z);
+            NodeType::Pointer temp_node = std::make_shared< NodeType >( ReorderedNodeId(temp_id), x, y, z);
             temp_node->X0() = temp_node->X();
             temp_node->Y0() = temp_node->Y();
             temp_node->Z0() = temp_node->Z();
@@ -1330,7 +1330,7 @@ namespace Kratos
     {
         KRATOS_TRY
 
-        Properties::Pointer props = boost::make_shared<Properties>();
+        Properties::Pointer props = std::make_shared<Properties>();
         Properties& temp_properties = *props;
         //Properties temp_properties;
 
@@ -2710,7 +2710,7 @@ namespace Kratos
         // adding necessary meshes to the model part.
         MeshType empty_mesh;
         for(SizeType i = number_of_meshes ; i < mesh_id + 1 ; i++)
-            rModelPart.GetMeshes().push_back(boost::make_shared<MeshType>(empty_mesh.Clone()));
+            rModelPart.GetMeshes().push_back(std::make_shared<MeshType>(empty_mesh.Clone()));
 
         MeshType& mesh = rModelPart.GetMesh(mesh_id);
 
@@ -2916,7 +2916,7 @@ namespace Kratos
     {
         KRATOS_TRY
 
-        Properties::Pointer props = boost::make_shared<Properties>();
+        Properties::Pointer props = std::make_shared<Properties>();
         Properties& temp_properties = *props;
 //         Properties temp_properties;
 
@@ -4695,7 +4695,7 @@ namespace Kratos
         mNumberOfLines = 1;
     }
 
-    void ModelPartIO::SwapStreamSource(boost::shared_ptr<std::iostream> newStream)
+    void ModelPartIO::SwapStreamSource(std::shared_ptr<std::iostream> newStream)
     {
         mpStream.swap(newStream);
     }

--- a/kratos/spaces/dense_space.h
+++ b/kratos/spaces/dense_space.h
@@ -74,8 +74,8 @@ public:
 
     typedef std::size_t IndexType;
 
-    typedef typename boost::shared_ptr< TMatrixType > MatrixPointerType;
-    typedef typename boost::shared_ptr< TVectorType > VectorPointerType;
+    typedef typename std::shared_ptr< TMatrixType > MatrixPointerType;
+    typedef typename std::shared_ptr< TVectorType > VectorPointerType;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -125,8 +125,8 @@ public:
 
     typedef std::size_t SizeType;
 
-    typedef typename boost::shared_ptr< TMatrixType > MatrixPointerType;
-    typedef typename boost::shared_ptr< TVectorType > VectorPointerType;
+    typedef typename std::shared_ptr< TMatrixType > MatrixPointerType;
+    typedef typename std::shared_ptr< TVectorType > VectorPointerType;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/templates/geometry_template
+++ b/kratos/templates/geometry_template
@@ -229,7 +229,7 @@ namespace Kratos
       ///@name Operations
       ///@{
       
-      virtual boost::shared_ptr< Geometry< Point<3> > > Clone() const
+      virtual std::shared_ptr< Geometry< Point<3> > > Clone() const
 	{
 	  Geometry< Point<3> >::PointsArrayType NewPoints;
 
@@ -238,7 +238,7 @@ namespace Kratos
 	    NewPoints.push_back(mPoints[i]);
 
 	  //creating a geometry with the new points
-	  boost::shared_ptr< Geometry< Point<3> > > p_clone(new ClassName< Point<3> >(NewPoints));
+	  std::shared_ptr< Geometry< Point<3> > > p_clone(new ClassName< Point<3> >(NewPoints));
 	  p_clone->ClonePoints();
 
 	  return p_clone;

--- a/kratos/tests/processes/test_calculate_distance_to_skin_process.cpp
+++ b/kratos/tests/processes/test_calculate_distance_to_skin_process.cpp
@@ -26,14 +26,14 @@ namespace Kratos {
 	  {
 
 		  // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
-		  Point<3>::Pointer p_point1 = boost::make_shared<Point<3>>(0.00, 0.00, 0.00);
-		  Point<3>::Pointer p_point2 = boost::make_shared<Point<3>>(10.00, 0.00, 0.00);
-		  Point<3>::Pointer p_point3 = boost::make_shared<Point<3>>(10.00, 10.00, 0.00);
-		  Point<3>::Pointer p_point4 = boost::make_shared<Point<3>>(0.00, 10.00, 0.00);
-		  Point<3>::Pointer p_point5 = boost::make_shared<Point<3>>(0.00, 0.00, 10.00);
-		  Point<3>::Pointer p_point6 = boost::make_shared<Point<3>>(10.00, 0.00, 10.00);
-		  Point<3>::Pointer p_point7 = boost::make_shared<Point<3>>(10.00, 10.00, 10.00);
-		  Point<3>::Pointer p_point8 = boost::make_shared<Point<3>>(0.00, 10.00, 10.00);
+		  Point<3>::Pointer p_point1 = std::make_shared<Point<3>>(0.00, 0.00, 0.00);
+		  Point<3>::Pointer p_point2 = std::make_shared<Point<3>>(10.00, 0.00, 0.00);
+		  Point<3>::Pointer p_point3 = std::make_shared<Point<3>>(10.00, 10.00, 0.00);
+		  Point<3>::Pointer p_point4 = std::make_shared<Point<3>>(0.00, 10.00, 0.00);
+		  Point<3>::Pointer p_point5 = std::make_shared<Point<3>>(0.00, 0.00, 10.00);
+		  Point<3>::Pointer p_point6 = std::make_shared<Point<3>>(10.00, 0.00, 10.00);
+		  Point<3>::Pointer p_point7 = std::make_shared<Point<3>>(10.00, 10.00, 10.00);
+		  Point<3>::Pointer p_point8 = std::make_shared<Point<3>>(0.00, 10.00, 10.00);
 
 		  Hexahedra3D8<Point<3> > geometry(p_point1, p_point2, p_point3, p_point4, p_point5, p_point6, p_point7, p_point8);
 
@@ -74,14 +74,14 @@ namespace Kratos {
 	  {
 
 		  // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
-		  Point<3>::Pointer p_point1 = boost::make_shared<Point<3>>(0.00, 0.00, 0.00);
-		  Point<3>::Pointer p_point2 = boost::make_shared<Point<3>>(10.00, 0.00, 0.00);
-		  Point<3>::Pointer p_point3 = boost::make_shared<Point<3>>(10.00, 10.00, 0.00);
-		  Point<3>::Pointer p_point4 = boost::make_shared<Point<3>>(0.00, 10.00, 0.00);
-		  Point<3>::Pointer p_point5 = boost::make_shared<Point<3>>(0.00, 0.00, 10.00);
-		  Point<3>::Pointer p_point6 = boost::make_shared<Point<3>>(10.00, 0.00, 10.00);
-		  Point<3>::Pointer p_point7 = boost::make_shared<Point<3>>(10.00, 10.00, 10.00);
-		  Point<3>::Pointer p_point8 = boost::make_shared<Point<3>>(0.00, 10.00, 10.00);
+		  Point<3>::Pointer p_point1 = std::make_shared<Point<3>>(0.00, 0.00, 0.00);
+		  Point<3>::Pointer p_point2 = std::make_shared<Point<3>>(10.00, 0.00, 0.00);
+		  Point<3>::Pointer p_point3 = std::make_shared<Point<3>>(10.00, 10.00, 0.00);
+		  Point<3>::Pointer p_point4 = std::make_shared<Point<3>>(0.00, 10.00, 0.00);
+		  Point<3>::Pointer p_point5 = std::make_shared<Point<3>>(0.00, 0.00, 10.00);
+		  Point<3>::Pointer p_point6 = std::make_shared<Point<3>>(10.00, 0.00, 10.00);
+		  Point<3>::Pointer p_point7 = std::make_shared<Point<3>>(10.00, 10.00, 10.00);
+		  Point<3>::Pointer p_point8 = std::make_shared<Point<3>>(0.00, 10.00, 10.00);
 
 		  Hexahedra3D8<Point<3> > geometry(p_point1, p_point2, p_point3, p_point4, p_point5, p_point6, p_point7, p_point8);
 
@@ -123,14 +123,14 @@ namespace Kratos {
 	  {
 
 		  // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
-		  Point<3>::Pointer p_point1 = boost::make_shared<Point<3>>(0.00, 0.00, 0.00);
-		  Point<3>::Pointer p_point2 = boost::make_shared<Point<3>>(10.00, 0.00, 0.00);
-		  Point<3>::Pointer p_point3 = boost::make_shared<Point<3>>(10.00, 10.00, 0.00);
-		  Point<3>::Pointer p_point4 = boost::make_shared<Point<3>>(0.00, 10.00, 0.00);
-		  Point<3>::Pointer p_point5 = boost::make_shared<Point<3>>(0.00, 0.00, 10.00);
-		  Point<3>::Pointer p_point6 = boost::make_shared<Point<3>>(10.00, 0.00, 10.00);
-		  Point<3>::Pointer p_point7 = boost::make_shared<Point<3>>(10.00, 10.00, 10.00);
-		  Point<3>::Pointer p_point8 = boost::make_shared<Point<3>>(0.00, 10.00, 10.00);
+		  Point<3>::Pointer p_point1 = std::make_shared<Point<3>>(0.00, 0.00, 0.00);
+		  Point<3>::Pointer p_point2 = std::make_shared<Point<3>>(10.00, 0.00, 0.00);
+		  Point<3>::Pointer p_point3 = std::make_shared<Point<3>>(10.00, 10.00, 0.00);
+		  Point<3>::Pointer p_point4 = std::make_shared<Point<3>>(0.00, 10.00, 0.00);
+		  Point<3>::Pointer p_point5 = std::make_shared<Point<3>>(0.00, 0.00, 10.00);
+		  Point<3>::Pointer p_point6 = std::make_shared<Point<3>>(10.00, 0.00, 10.00);
+		  Point<3>::Pointer p_point7 = std::make_shared<Point<3>>(10.00, 10.00, 10.00);
+		  Point<3>::Pointer p_point8 = std::make_shared<Point<3>>(0.00, 10.00, 10.00);
 
 		  Hexahedra3D8<Point<3> > geometry(p_point1, p_point2, p_point3, p_point4, p_point5, p_point6, p_point7, p_point8);
 

--- a/kratos/tests/sources/test_model_part_io.cpp
+++ b/kratos/tests/sources/test_model_part_io.cpp
@@ -29,7 +29,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(ModelPartIOSubModelPartsDivision, KratosCoreFastSuite)
 		{
-			boost::shared_ptr<std::iostream> p_input(new std::stringstream(
+			std::shared_ptr<std::iostream> p_input(new std::stringstream(
 				R"input(
 				Begin ModelPartData
                                  DENSITY 2700.000000
@@ -101,9 +101,9 @@ namespace Kratos {
 
 			ModelPartIO model_part_io(p_input);
 
-			boost::shared_ptr<std::stringstream> p_output_0(new std::stringstream);
-			boost::shared_ptr<std::stringstream> p_output_1(new std::stringstream);
-			boost::shared_ptr<std::iostream> streams[2] = { p_output_0, p_output_1 };
+			std::shared_ptr<std::stringstream> p_output_0(new std::stringstream);
+			std::shared_ptr<std::stringstream> p_output_1(new std::stringstream);
+			std::shared_ptr<std::iostream> streams[2] = { p_output_0, p_output_1 };
 
 			std::size_t number_of_partitions = 2;
 			std::size_t number_of_colors = 1;


### PR DESCRIPTION
Replacing (it compiles):

boost::shared_ptr -> std::shared_ptr
boost::weak_ptr -> std::weak_ptr
boost::make_shared -> std::make_shared

I have been doing some tests and the replace is right now not possible for our dependency of boost::python. The community was working on it, https://github.com/boostorg/python/issues/29 and it was suposed to be solved in Boost 1.63, but I think that that version is not compatible with Kratos, right @roigcarlo?