### PR TITLE
Renaming core conditions processes

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hertz_simple_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hertz_simple_test_parameters.json
@@ -55,11 +55,11 @@
         }
     }],
     "loads_process_list"       : [{
-        "python_module"   : "assign_scalar_to_conditions_process",
+        "python_module"   : "assign_scalar_variable_to_conditions_process",
         "kratos_module" : "KratosMultiphysics",
         "help"                  : "This process sets a vector variable value over a condition",
         "check"                 : "DirectorVectorNonZero direction",
-        "process_name"          : "AssignScalarToConditionsProcess",
+        "process_name"          : "AssignScalarVariableToConditionsProcess",
         "Parameters"            : {
             "mesh_id"         : 0,
             "model_part_name" : "LineLoad2D_bc_pressure",

--- a/applications/ShapeOptimizationApplication/test_examples/01_Strain_Energy_Minimization_3D_Hook/ProjectParameters.json
+++ b/applications/ShapeOptimizationApplication/test_examples/01_Strain_Energy_Minimization_3D_Hook/ProjectParameters.json
@@ -66,7 +66,7 @@
         }
     }],
     "loads_process_list"       : [{
-        "python_module"   : "assign_scalar_to_conditions_process",
+        "python_module"   : "assign_scalar_variable_to_conditions_process",
         "kratos_module" : "KratosMultiphysics",
         "help"                  : "This process sets a scalar variable value over a condition",
         "process_name"          : "ApplyScalarOnConditionsProcess",

--- a/applications/ShapeOptimizationApplication/test_examples/01_Strain_Energy_Minimization_3D_Hook/ProjectParameters_with_mass_constraint.json
+++ b/applications/ShapeOptimizationApplication/test_examples/01_Strain_Energy_Minimization_3D_Hook/ProjectParameters_with_mass_constraint.json
@@ -66,7 +66,7 @@
         }
     }],
     "loads_process_list"       : [{
-        "python_module"   : "assign_scalar_to_conditions_process",
+        "python_module"   : "assign_scalar_variable_to_conditions_process",
         "kratos_module" : "KratosMultiphysics",
         "help"                  : "This process sets a scalar variable value over a condition",
         "process_name"          : "ApplyScalarOnConditionsProcess",

--- a/kratos/python_scripts/assign_scalar_variable_to_conditions_process.py
+++ b/kratos/python_scripts/assign_scalar_variable_to_conditions_process.py
@@ -5,9 +5,10 @@ from math import *
 def Factory(settings, Model):
     if(type(settings) != KratosMultiphysics.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
-    return AssignScalarToConditionsProcess(Model, settings["Parameters"])
+    return AssignScalarVariableToConditionsProcess(Model, settings["Parameters"])
 
-class AssignScalarToConditionsProcess(KratosMultiphysics.Process):
+## all the processes python processes should be derived from "python_process"
+class AssignScalarVariableToConditionsProcess(KratosMultiphysics.Process):
     def __init__(self, Model, settings ):
         KratosMultiphysics.Process.__init__(self)
 
@@ -23,10 +24,10 @@ class AssignScalarToConditionsProcess(KratosMultiphysics.Process):
             """
             )
 
-        #assign this here since it will change the "interval" prior to validation
+        # assign this here since it will change the "interval" prior to validation
         self.interval = KratosMultiphysics.IntervalUtility(settings)
 
-        #here i do a trick, since i want to allow "value" to be a string or a double value
+        # here i do a trick, since i want to allow "value" to be a string or a double value
         if(settings.Has("value")):
             if(settings["value"].IsString()):
                 default_settings["value"].SetString("0.0")
@@ -52,7 +53,7 @@ class AssignScalarToConditionsProcess(KratosMultiphysics.Process):
             params.AddValue("local_axes", settings["local_axes"])
             self.AssignValueProcess = KratosMultiphysics.AssignScalarFieldToConditionsProcess(self.model_part, params)
                 
-        #construct a variable_utils object to speedup fixing
+        # construct a variable_utils object to speedup fixing
         self.step_is_active = False
 
     def ExecuteInitializeSolutionStep(self):

--- a/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
+++ b/kratos/python_scripts/assign_vector_by_direction_to_condition_process.py
@@ -117,14 +117,12 @@ class AssignVectorByDirectionToConditionProcess(KratosMultiphysics.Process):
             z_params.AddEmptyValue("value").SetString("("+str(unit_direction[2])+")*("+modulus+")")
 
         # Construct a AssignScalarToNodesProcess for each component
-        import assign_scalar_to_conditions_process
+        import assign_scalar_variable_to_conditions_process
 
         self.aux_processes = []
-        self.aux_processes.append( assign_scalar_to_conditions_process.AssignScalarToConditionsProcess(Model, x_params) )
-        self.aux_processes.append( assign_scalar_to_conditions_process.AssignScalarToConditionsProcess(Model, y_params) )
-        self.aux_processes.append( assign_scalar_to_conditions_process.AssignScalarToConditionsProcess(Model, z_params) )
-
-        # print("Finished construction of AssignVectorByDirectionToConditionProcess")
+        self.aux_processes.append( assign_scalar_variable_to_conditions_process.AssignScalarVariableToConditionsProcess(Model, x_params) )
+        self.aux_processes.append( assign_scalar_variable_to_conditions_process.AssignScalarVariableToConditionsProcess(Model, y_params) )
+        self.aux_processes.append( assign_scalar_variable_to_conditions_process.AssignScalarVariableToConditionsProcess(Model, z_params) )
 
     def ExecuteInitializeSolutionStep(self):
         for process in self.aux_processes:

--- a/kratos/python_scripts/assign_vector_variable_to_conditions_process.py
+++ b/kratos/python_scripts/assign_vector_variable_to_conditions_process.py
@@ -4,10 +4,10 @@ from math import *
 def Factory(settings, Model):
     if(type(settings) != KratosMultiphysics.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
-    return AssignVectorToConditionProcess(Model, settings["Parameters"])
+    return AssignVectorVariableToConditionProcess(Model, settings["Parameters"])
 
-##all the processes python processes should be derived from "python_process"
-class AssignVectorToConditionProcess(KratosMultiphysics.Process):
+## all the processes python processes should be derived from "python_process"
+class AssignVectorVariableToConditionProcess(KratosMultiphysics.Process):
     def __init__(self, Model, settings ):
         KratosMultiphysics.Process.__init__(self)
 
@@ -22,17 +22,14 @@ class AssignVectorToConditionProcess(KratosMultiphysics.Process):
             }
             """
             )
-        #example of admissible values for "value" : [10.0, "3*t", "x+y"]
 
-        #detect "End" as a tag and replace it by a large number
+        # detect "End" as a tag and replace it by a large number
         if(settings.Has("interval")):
             if(settings["interval"][1].IsString() ):
                 if(settings["interval"][1].GetString() == "End"):
                     settings["interval"][1].SetDouble(1e30) # = default_settings["interval"][1]
                 else:
                     raise Exception("the second value of interval can be \"End\" or a number, interval currently:"+settings["interval"].PrettyPrintJsonString())
-
-        #print(settings.PrettyPrintJsonString())
 
         settings.ValidateAndAssignDefaults(default_settings)
         
@@ -45,9 +42,9 @@ class AssignVectorToConditionProcess(KratosMultiphysics.Process):
 
         self.aux_processes = []
 
-        import assign_scalar_to_conditions_process
+        import assign_scalar_variable_to_conditions_process
 
-        #component X
+        # component X
         if(not settings["value"][0].IsNull()):
             x_params = KratosMultiphysics.Parameters("{}")
             x_params.AddValue("model_part_name",settings["model_part_name"])
@@ -56,9 +53,9 @@ class AssignVectorToConditionProcess(KratosMultiphysics.Process):
             x_params.AddValue("value",settings["value"][0])
             x_params.AddEmptyValue("variable_name").SetString(settings["variable_name"].GetString() + "_X")
             x_params.AddValue("local_axes",settings["local_axes"])
-            self.aux_processes.append( assign_scalar_to_conditions_process.AssignScalarToConditionsProcess(Model, x_params) )
+            self.aux_processes.append( assign_scalar_variable_to_conditions_process.AssignScalarVariableToConditionsProcess(Model, x_params) )
 
-        #component Y
+        # component Y
         if(not settings["value"][1].IsNull()):
             y_params = KratosMultiphysics.Parameters("{}")
             y_params.AddValue("model_part_name",settings["model_part_name"])
@@ -67,9 +64,9 @@ class AssignVectorToConditionProcess(KratosMultiphysics.Process):
             y_params.AddValue("value",settings["value"][1])
             y_params.AddEmptyValue("variable_name").SetString(settings["variable_name"].GetString() + "_Y")
             y_params.AddValue("local_axes",settings["local_axes"])
-            self.aux_processes.append( assign_scalar_to_conditions_process.AssignScalarToConditionsProcess(Model, y_params) )
+            self.aux_processes.append( assign_scalar_variable_to_conditions_process.AssignScalarVariableToConditionsProcess(Model, y_params) )
 
-        #component Z
+        # component Z
         if(not settings["value"][2].IsNull()):
             z_params = KratosMultiphysics.Parameters("{}")
             z_params.AddValue("model_part_name",settings["model_part_name"])
@@ -78,16 +75,12 @@ class AssignVectorToConditionProcess(KratosMultiphysics.Process):
             z_params.AddValue("value",settings["value"][2])
             z_params.AddEmptyValue("variable_name").SetString(settings["variable_name"].GetString() + "_Z")
             z_params.AddValue("local_axes",settings["local_axes"])
-            self.aux_processes.append( assign_scalar_to_conditions_process.AssignScalarToConditionsProcess(Model, z_params) )
-
-        # print("Finished construction of AssignVectorProcess Process")
+            self.aux_processes.append( assign_scalar_variable_to_conditions_process.AssignScalarVariableToConditionsProcess(Model, z_params) )
 
     def ExecuteInitializeSolutionStep(self):
         for process in self.aux_processes:
             process.ExecuteInitializeSolutionStep()
 
     def ExecuteFinalizeSolutionStep(self):
-        #print("---")
         for process in self.aux_processes:
-            #print("current_time = ", self.model_part.ProcessInfo[KratosMultiphysics.TIME], " interval = ", process.interval)
             process.ExecuteFinalizeSolutionStep()

--- a/kratos/tests/test_processes.py
+++ b/kratos/tests/test_processes.py
@@ -501,7 +501,7 @@ class TestProcesses(KratosUnittest.TestCase):
             {
                 "process_list" : [
                     {
-                        "python_module"   : "assign_scalar_to_conditions_process",
+                        "python_module"   : "assign_scalar_variable_to_conditions_process",
                         "kratos_module" : "KratosMultiphysics",
                         "process_name"          : "AssignScalarVariableToConditionsProcess",
                         "Parameters"            : {
@@ -511,7 +511,7 @@ class TestProcesses(KratosUnittest.TestCase):
                         }
                     },
                     {
-                        "python_module"   : "assign_scalar_to_conditions_process",
+                        "python_module"   : "assign_scalar_variable_to_conditions_process",
                         "kratos_module" : "KratosMultiphysics",
                         "process_name"          : "AssignScalarVariableToConditionsProcess",
                         "Parameters"            : {
@@ -548,9 +548,9 @@ class TestProcesses(KratosUnittest.TestCase):
             {
                 "process_list" : [
                     {
-                        "python_module"   : "assign_scalar_to_conditions_process",
+                        "python_module"   : "assign_scalar_variable_to_conditions_process",
                         "kratos_module" : "KratosMultiphysics",
-                        "process_name"          : "AssignScalarToConditionsProcess",
+                        "process_name"          : "AssignScalarVariableToConditionsProcess",
                         "Parameters"            : {
                             "model_part_name":"Main",
                             "variable_name": "INITIAL_STRAIN",
@@ -591,9 +591,9 @@ class TestProcesses(KratosUnittest.TestCase):
             {
                 "process_list" : [
                     {
-                        "python_module"   : "assign_scalar_to_conditions_process",
+                        "python_module"   : "assign_scalar_variable_to_conditions_process",
                         "kratos_module" : "KratosMultiphysics",
-                        "process_name"          : "AssignScalarToConditionsProcess",
+                        "process_name"          : "AssignScalarVariableToConditionsProcess",
                         "Parameters"            : {
                             "model_part_name":"Main",
                             "variable_name": "DISPLACEMENT_X",


### PR DESCRIPTION
The core condition processes have been renamed from:
- assign_scalar_to_conditions_proces.py
- assign_vector_to_conditions_process.py
to:
- assign_scalar_variable_to_conditions_process.py
- assign_vector_variable_to_conditions_process.py