### PR TITLE
Fix  2D discontinuous shape functions utilities

### DIFF
--- a/applications/FluidDynamicsApplication/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/CMakeLists.txt
@@ -23,6 +23,7 @@ set( KRATOS_FLUID_DYNAMICS_APPLICATION_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/stokes_3D.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/stokes_3D_twofluid.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/navier_stokes.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/embedded_ausas_navier_stokes.cpp
 
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/wall_condition.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/fs_werner_wengle_wall_condition.cpp
@@ -32,6 +33,7 @@ set( KRATOS_FLUID_DYNAMICS_APPLICATION_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/stokes_wall_condition.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/fs_periodic_condition.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/navier_stokes_wall_condition.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/embedded_ausas_navier_stokes_wall_condition.cpp
 
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/bingham_3d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_2d_law.cpp

--- a/applications/FluidDynamicsApplication/custom_conditions/embedded_ausas_navier_stokes_wall_condition.cpp
+++ b/applications/FluidDynamicsApplication/custom_conditions/embedded_ausas_navier_stokes_wall_condition.cpp
@@ -120,7 +120,7 @@ void EmbeddedAusasNavierStokesWallCondition<TDim,TNumNodes>::ComputeGaussPointLH
                                                                                               const ConditionDataStruct& rData)
 {
     const unsigned int LocalSize = TDim+1;
-    noalias(lhs_gauss) = ZeroMatrix(TNumNodes*LocalSize,TNumNodes*LocalSize);
+    noalias(lhs_gauss) = ZeroMatrix(TNumNodes*LocalSize, TNumNodes*LocalSize);
 
     // LHS boundary term coming from the integration by parts of the mass conservation equation
     for (unsigned int i=0; i<TNumNodes; ++i)
@@ -170,7 +170,7 @@ void EmbeddedAusasNavierStokesWallCondition<TDim,TNumNodes>::ComputeGaussPointRH
         {
             for (unsigned int dim=0; dim<TDim; ++dim)
             {
-                rhs_gauss[row] += rData.wGauss * rData.N[i] * rData.N[j] * rData.Normal[dim] * rData.v(j,dim);
+                rhs_gauss[row] -= rData.wGauss * rData.N[i] * rData.N[j] * rData.Normal[dim] * rData.v(j,dim);
             }
         }
     }

--- a/applications/FluidDynamicsApplication/custom_conditions/embedded_ausas_navier_stokes_wall_condition.cpp
+++ b/applications/FluidDynamicsApplication/custom_conditions/embedded_ausas_navier_stokes_wall_condition.cpp
@@ -1,0 +1,290 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#include "embedded_ausas_navier_stokes_wall_condition.h"
+
+namespace Kratos
+{
+
+///@name Specialized implementation of VMS for functions that depend on TDim
+///@{
+
+/**
+ * @see EmbeddedAusasNavierStokesWallCondition::EquationIdVector
+ */
+template <>
+void EmbeddedAusasNavierStokesWallCondition<2,2>::EquationIdVector(EquationIdVectorType& rResult,
+                                                                   ProcessInfo& rCurrentProcessInfo)
+{
+    const unsigned int NumNodes = 2;
+    const unsigned int LocalSize = 6;
+    unsigned int LocalIndex = 0;
+
+    if (rResult.size() != LocalSize)
+        rResult.resize(LocalSize, false);
+
+    for (unsigned int iNode = 0; iNode < NumNodes; ++iNode)
+    {
+        rResult[LocalIndex++] = this->GetGeometry()[iNode].GetDof(VELOCITY_X).EquationId();
+        rResult[LocalIndex++] = this->GetGeometry()[iNode].GetDof(VELOCITY_Y).EquationId();
+        rResult[LocalIndex++] = this->GetGeometry()[iNode].GetDof(PRESSURE).EquationId();
+    }
+}
+
+/**
+ * @see EmbeddedAusasNavierStokesWallCondition::EquationIdVector
+ */
+template <>
+void EmbeddedAusasNavierStokesWallCondition<3,3>::EquationIdVector(EquationIdVectorType& rResult,
+                                                                   ProcessInfo& rCurrentProcessInfo)
+{
+    const SizeType NumNodes = 3;
+    const SizeType LocalSize = 12;
+    unsigned int LocalIndex = 0;
+
+    if (rResult.size() != LocalSize)
+        rResult.resize(LocalSize, false);
+
+    for (unsigned int iNode = 0; iNode < NumNodes; ++iNode)
+    {
+        rResult[LocalIndex++] = this->GetGeometry()[iNode].GetDof(VELOCITY_X).EquationId();
+        rResult[LocalIndex++] = this->GetGeometry()[iNode].GetDof(VELOCITY_Y).EquationId();
+        rResult[LocalIndex++] = this->GetGeometry()[iNode].GetDof(VELOCITY_Z).EquationId();
+        rResult[LocalIndex++] = this->GetGeometry()[iNode].GetDof(PRESSURE).EquationId();
+    }
+}
+
+/**
+ * @see EmbeddedAusasNavierStokesWallCondition::GetDofList
+ */
+template <>
+void EmbeddedAusasNavierStokesWallCondition<2,2>::GetDofList(DofsVectorType& rElementalDofList,
+                                                             ProcessInfo& rCurrentProcessInfo)
+{
+    const SizeType NumNodes = 2;
+    const SizeType LocalSize = 6;
+
+    if (rElementalDofList.size() != LocalSize)
+        rElementalDofList.resize(LocalSize);
+
+    unsigned int LocalIndex = 0;
+
+    for (unsigned int iNode = 0; iNode < NumNodes; ++iNode)
+    {
+        rElementalDofList[LocalIndex++] = this->GetGeometry()[iNode].pGetDof(VELOCITY_X);
+        rElementalDofList[LocalIndex++] = this->GetGeometry()[iNode].pGetDof(VELOCITY_Y);
+        rElementalDofList[LocalIndex++] = this->GetGeometry()[iNode].pGetDof(PRESSURE);
+    }
+}
+
+/**
+ * @see EmbeddedAusasNavierStokesWallCondition::GetDofList
+ */
+template <>
+void EmbeddedAusasNavierStokesWallCondition<3,3>::GetDofList(DofsVectorType& rElementalDofList,
+                                                             ProcessInfo& rCurrentProcessInfo)
+{
+    const SizeType NumNodes = 3;
+    const SizeType LocalSize = 12;
+
+    if (rElementalDofList.size() != LocalSize)
+        rElementalDofList.resize(LocalSize);
+
+    unsigned int LocalIndex = 0;
+
+    for (unsigned int iNode = 0; iNode < NumNodes; ++iNode)
+    {
+        rElementalDofList[LocalIndex++] = this->GetGeometry()[iNode].pGetDof(VELOCITY_X);
+        rElementalDofList[LocalIndex++] = this->GetGeometry()[iNode].pGetDof(VELOCITY_Y);
+        rElementalDofList[LocalIndex++] = this->GetGeometry()[iNode].pGetDof(VELOCITY_Z);
+        rElementalDofList[LocalIndex++] = this->GetGeometry()[iNode].pGetDof(PRESSURE);
+    }
+}
+
+/// Computes the Gauss pt. LHS contribution
+/**
+* @param lhs_gauss reference to the local LHS matrix
+* @param data Gauss pt. data structure
+*/
+template<unsigned int TDim, unsigned int TNumNodes>
+void EmbeddedAusasNavierStokesWallCondition<TDim,TNumNodes>::ComputeGaussPointLHSContribution(bounded_matrix<double, TNumNodes*(TDim+1), TNumNodes*(TDim+1)>& lhs_gauss,
+                                                                                              const ConditionDataStruct& rData)
+{
+    const unsigned int LocalSize = TDim+1;
+    noalias(lhs_gauss) = ZeroMatrix(TNumNodes*LocalSize,TNumNodes*LocalSize);
+
+    // LHS boundary term coming from the integration by parts of the mass conservation equation
+    for (unsigned int i=0; i<TNumNodes; ++i)
+    {
+        const unsigned int row = i*LocalSize + TDim;
+
+        for (unsigned int j=0; j<TNumNodes; ++j)
+        {
+            for (unsigned int dim=0; dim<TDim; ++dim)
+            {
+                const unsigned int col = j*LocalSize + dim;
+                lhs_gauss(row, col) = rData.wGauss * rData.N[i] * rData.N[j] * rData.Normal[dim];
+            }
+        }
+    }
+
+}
+
+/// Computes the Gauss pt. RHS contribution
+/**
+* @param rhs_gauss reference to the local RHS vector
+* @param data Gauss pt. data structure
+*/
+template<unsigned int TDim, unsigned int TNumNodes>
+void EmbeddedAusasNavierStokesWallCondition<TDim,TNumNodes>::ComputeGaussPointRHSContribution(array_1d<double, TNumNodes*(TDim+1)>& rhs_gauss,
+                                                                                              const ConditionDataStruct& rData)
+{
+    // Initialize the local RHS
+    const unsigned int LocalSize = TDim+1;
+    noalias(rhs_gauss) = ZeroVector(TNumNodes*LocalSize);
+
+    // Gauss pt. Neumann BC contribution
+    this->ComputeRHSNeumannContribution(rhs_gauss, rData);
+
+    // Gauss pt. outlet inflow prevention contribution
+    // if (this->Is(OUTLET))
+    // {
+    //     this->ComputeRHSOutletInflowContribution(rhs_gauss, data);
+    // }
+
+    // RHS boundary term coming from the integration by parts of the mass conservation equation
+    for (unsigned int i=0; i<TNumNodes; ++i)
+    {
+        const unsigned int row = i*LocalSize + TDim;
+
+        for (unsigned int j=0; j<TNumNodes; ++j)
+        {
+            for (unsigned int dim=0; dim<TDim; ++dim)
+            {
+                rhs_gauss[row] += rData.wGauss * rData.N[i] * rData.N[j] * rData.Normal[dim] * rData.v(j,dim);
+            }
+        }
+    }
+}
+
+/// Computes the condition RHS Neumann BC contribution
+/**
+* @param rhs_gauss reference to the local RHS vector
+* @param data Gauss pt. data structure
+*/
+template<unsigned int TDim, unsigned int TNumNodes>
+void EmbeddedAusasNavierStokesWallCondition<TDim,TNumNodes>::ComputeRHSNeumannContribution(array_1d<double, TNumNodes*(TDim+1)>& rhs_gauss,
+                                                                                           const ConditionDataStruct& rData)
+{
+    const unsigned int LocalSize = TDim+1;
+    const GeometryType& rGeom = this->GetGeometry();
+
+    // Add Neumann BC contribution
+    for (unsigned int i=0; i<TNumNodes; ++i)
+    {
+        const double pext = rGeom[i].FastGetSolutionStepValue(EXTERNAL_PRESSURE);
+
+        for (unsigned int j=0; j<TNumNodes; ++j)
+        {
+            unsigned int row = j*LocalSize;
+            for (unsigned int d=0; d<TDim; ++d)
+            {
+                rhs_gauss[row + d] -= rData.wGauss * rData.N[j] * rData.N[i] * pext * rData.Normal[d];
+            }
+        }
+    }
+}
+
+/// Computes the condition RHS outlet inflow prevention contribution
+/**
+* @param rhs_gauss reference to the local RHS vector
+* @param data Gauss pt. data structure
+*/
+// template<unsigned int TDim, unsigned int TNumNodes>
+// void EmbeddedAusasNavierStokesWallCondition<TDim,TNumNodes>::ComputeRHSOutletInflowContribution(array_1d<double,
+//                                                                                                 TNumNodes*(TDim+1)>& rhs_gauss,
+//                                                                                                 const ConditionDataStruct& data)
+// {
+//     const unsigned int LocalSize = TDim+1;
+//     const GeometryType& rGeom = this->GetGeometry();
+
+//     // Compute Gauss pt. density, velocity norm and velocity projection
+//     double rhoGauss = 0.0;
+//     array_1d<double, 3> vGauss = ZeroVector(3);
+//     for (unsigned int i=0; i<TNumNodes; ++i)
+//     {
+//         const double& rRho = rGeom[i].FastGetSolutionStepValue(DENSITY);
+//         const array_1d<double, 3>& rVelNode = rGeom[i].FastGetSolutionStepValue(VELOCITY);
+//         rhoGauss += data.N[i]*rRho;
+//         vGauss += data.N[i]*rVelNode;
+//     }
+
+//     const double vGaussProj = inner_prod(vGauss, data.Normal);
+//     const double vGaussSquaredNorm = std::pow(vGauss[0],2) + std::pow(vGauss[1],2) + std::pow(vGauss[2],2);
+
+//     // Add outlet inflow prevention contribution
+//     const double delta = data.delta;
+//     const double U_0 = data.charVel;
+//     const double S_0 = 0.5*(1-tanh(vGaussProj/(U_0*delta)));
+
+//     for (unsigned int i=0; i<TNumNodes; ++i)
+//     {
+//         unsigned int row = i*LocalSize;
+//         for (unsigned int d=0; d<TDim; ++d)
+//         {
+//             rhs_gauss[row+d] += data.wGauss*data.N[i]*0.5*rhoGauss*vGaussSquaredNorm*S_0*data.Normal[d];
+//         }
+//     }
+// }
+
+/// Computes the 2D condition normal
+/**
+* @param An reference to condition normal vector
+*/
+template <>
+void EmbeddedAusasNavierStokesWallCondition<2,2>::CalculateNormal(array_1d<double,3>& An)
+{
+    Geometry<Node<3> >& pGeometry = this->GetGeometry();
+
+    An[0] =   pGeometry[1].Y() - pGeometry[0].Y();
+    An[1] = - (pGeometry[1].X() - pGeometry[0].X());
+    An[2] =    0.00;
+
+}
+
+/// Computes the 3D condition normal
+/**
+* @param An reference to condition normal vector
+*/
+template <>
+void EmbeddedAusasNavierStokesWallCondition<3,3>::CalculateNormal(array_1d<double,3>& An )
+{
+    Geometry<Node<3> >& pGeometry = this->GetGeometry();
+
+    array_1d<double,3> v1,v2;
+    v1[0] = pGeometry[1].X() - pGeometry[0].X();
+    v1[1] = pGeometry[1].Y() - pGeometry[0].Y();
+    v1[2] = pGeometry[1].Z() - pGeometry[0].Z();
+
+    v2[0] = pGeometry[2].X() - pGeometry[0].X();
+    v2[1] = pGeometry[2].Y() - pGeometry[0].Y();
+    v2[2] = pGeometry[2].Z() - pGeometry[0].Z();
+
+    MathUtils<double>::CrossProduct(An,v1,v2);
+    An *= 0.5;
+}
+
+
+template class EmbeddedAusasNavierStokesWallCondition<2,2>;
+template class EmbeddedAusasNavierStokesWallCondition<3,3>;
+
+} // namespace Kratos

--- a/applications/FluidDynamicsApplication/custom_conditions/embedded_ausas_navier_stokes_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/embedded_ausas_navier_stokes_wall_condition.h
@@ -1,0 +1,651 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#ifndef KRATOS_EMBEDDED_AUSAS_NAVIER_STOKES_WALL_CONDITION_H
+#define KRATOS_EMBEDDED_AUSAS_NAVIER_STOKES_WALL_CONDITION_H
+
+// System includes
+#include <string>
+#include <iostream>
+
+
+// External includes
+
+
+// Project includes
+#include "includes/define.h"
+#include "includes/condition.h"
+#include "includes/model_part.h"
+#include "includes/serializer.h"
+#include "includes/process_info.h"
+
+// Application includes
+#include "fluid_dynamics_application_variables.h"
+#include "includes/deprecated_variables.h"
+#include "includes/cfd_variables.h"
+
+namespace Kratos
+{
+///@addtogroup FluidDynamicsApplication
+///@{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/// Implements a wall condition for the Navier-Stokes monolithic formulation.
+/**
+  It is intended to be used in combination with ASGS Navier-Stokes symbolic elements or their
+  derived classes and the ResidualBasedIncrementalUpdateStaticSchemeSlip time scheme, which supports
+  slip conditions.
+  @see NavierStokes,EmbeddedNavierStokes,ResidualBasedIncrementalUpdateStaticSchemeSlip
+ */
+template <unsigned int TDim, unsigned int TNumNodes = TDim>
+class KRATOS_API(FLUID_DYNAMICS_APPLICATION) EmbeddedAusasNavierStokesWallCondition : public Condition
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of EmbeddedAusasNavierStokesWallCondition
+    KRATOS_CLASS_POINTER_DEFINITION(EmbeddedAusasNavierStokesWallCondition);
+
+    struct ConditionDataStruct
+    {
+        double wGauss;                 // Gauss point weight
+        // double charVel;                // Problem characteristic velocity (used in the outlet inflow prevention)
+        // double delta;                  // Non-dimensional positive sufficiently small constant (used in the outlet inflow prevention)
+        array_1d<double, 3> Normal;    // Condition normal
+        array_1d<double, TNumNodes> N; // Gauss point shape functions values
+
+        bounded_matrix<double, TNumNodes, TDim> v; // Current step velocity
+    };
+
+    typedef Node < 3 > NodeType;
+
+    typedef Properties PropertiesType;
+
+    typedef Geometry<NodeType> GeometryType;
+
+    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
+
+    typedef Vector VectorType;
+
+    typedef Matrix MatrixType;
+
+    typedef std::size_t IndexType;
+
+    typedef std::vector<std::size_t> EquationIdVectorType;
+
+    typedef std::vector< Dof<double>::Pointer > DofsVectorType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    /** Admits an Id as a parameter.
+      @param NewId Index for the new         // Struct to pass around the data
+        ConditionDataStruct data;
+        this->FillElementData(data, rCurrentProcessInfo);condition
+      */
+    EmbeddedAusasNavierStokesWallCondition(IndexType NewId = 0):Condition(NewId)
+    {
+    }
+
+    /// Constructor using an array of nodes
+    /**
+     @param NewId Index of the new condition
+     @param ThisNodes An array containing the nodes of the new condition
+     */
+    EmbeddedAusasNavierStokesWallCondition(IndexType NewId, const NodesArrayType& ThisNodes):
+        Condition(NewId,ThisNodes)
+    {
+    }
+
+    /// Constructor using Geometry
+    /**
+     @param NewId Index of the new condition
+     @param pGeometry Pointer to a geometry object
+     */
+    EmbeddedAusasNavierStokesWallCondition(IndexType NewId, GeometryType::Pointer pGeometry):
+        Condition(NewId,pGeometry)
+    {
+    }
+
+    /// Constructor using Properties
+    /**
+     @param NewId Index of the new element
+     @param pGeometry Pointer to a geometry object
+     @param pProperties Pointer to the element's properties
+     */
+    EmbeddedAusasNavierStokesWallCondition(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties):
+        Condition(NewId,pGeometry,pProperties)
+    {
+    }
+
+    /// Copy constructor.
+    EmbeddedAusasNavierStokesWallCondition(EmbeddedAusasNavierStokesWallCondition const& rOther):
+        Condition(rOther)
+    {
+    }
+
+    /// Destructor.
+    ~EmbeddedAusasNavierStokesWallCondition() override {}
+
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Assignment operator
+    EmbeddedAusasNavierStokesWallCondition & operator=(EmbeddedAusasNavierStokesWallCondition const& rOther)
+    {
+        Condition::operator=(rOther);
+        return *this;
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /// Create a new EmbeddedAusasNavierStokesWallCondition object.
+    /**
+      @param NewId Index of the new condition
+      @param ThisNodes An array containing the nodes of the new condition
+      @param pProperties Pointer to the element's properties
+      */
+    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
+    {
+        return Condition::Pointer(new EmbeddedAusasNavierStokesWallCondition(NewId, GetGeometry().Create(ThisNodes), pProperties));
+    }
+
+    /// Create a new EmbeddedAusasNavierStokesWallCondition object.
+    /**
+      @param NewId Index of the new condition
+      @param pGeom A pointer to the condition's geometry
+      @param pProperties Pointer to the element's properties
+      */
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override
+    {
+        return boost::make_shared< EmbeddedAusasNavierStokesWallCondition >(NewId, pGeom, pProperties);
+    }
+
+    /**
+     * Clones the selected element variables, creating a new one
+     * @param NewId: the ID of the new element
+     * @param ThisNodes: the nodes of the new element
+     * @return a Pointer to the new element
+     */
+    Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override
+    {
+        Condition::Pointer pNewCondition = Create(NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
+
+        pNewCondition->SetData(this->GetData());
+        pNewCondition->SetFlags(this->GetFlags());
+
+        return pNewCondition;
+    }
+
+    /// Calculates the LHS and RHS condition contributions
+    /**
+     * Clones the selected element variables, creating a new one
+     * @param rLeftHandSideMatrix: reference to the LHS matrix
+     * @param rRightHandSideVector: reference to the RHS matrix
+     * @param rCurrentProcessInfo: reference to the ProcessInfo (unused)
+     */
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+                              VectorType& rRightHandSideVector,
+                              ProcessInfo& rCurrentProcessInfo) override
+    {
+        KRATOS_TRY
+
+        constexpr unsigned int MatrixSize = TNumNodes*(TDim+1);
+
+        if (rLeftHandSideMatrix.size1() != MatrixSize)
+            rLeftHandSideMatrix.resize(MatrixSize, MatrixSize, false); //false says not to preserve existing storage!!
+
+        if (rRightHandSideVector.size() != MatrixSize)
+            rRightHandSideVector.resize(MatrixSize, false); //false says not to preserve existing storage!!
+
+        // Struct to pass around the data
+        ConditionDataStruct data;
+        this->FillElementData(data);
+
+        // Allocate memory needed
+        array_1d<double, MatrixSize> rhs_gauss;
+        bounded_matrix<double,MatrixSize, MatrixSize> lhs_gauss;
+
+        // LHS and RHS contributions initialization
+        noalias(rLeftHandSideMatrix) = ZeroMatrix(MatrixSize,MatrixSize);
+        noalias(rRightHandSideVector) = ZeroVector(MatrixSize);
+
+        // Store the outlet inflow prevention constants in the data structure
+        // data.delta = 1e-2; // TODO: Decide if this constant should be fixed or not
+        // const ProcessInfo& rProcessInfo = rCurrentProcessInfo; // const to avoid race conditions on data_value_container access/initialization
+        // data.charVel = rProcessInfo[CHARACTERISTIC_VELOCITY];
+
+        // Gauss point information
+        GeometryType& rGeom = this->GetGeometry();
+        const GeometryType::IntegrationPointsArrayType& IntegrationPoints = rGeom.IntegrationPoints(GeometryData::GI_GAUSS_2);
+        const unsigned int NumGauss = IntegrationPoints.size();
+        Vector GaussPtsJDet = ZeroVector(NumGauss);
+        rGeom.DeterminantOfJacobian(GaussPtsJDet, GeometryData::GI_GAUSS_2);
+        const MatrixType Ncontainer = rGeom.ShapeFunctionsValues(GeometryData::GI_GAUSS_2);
+
+        // Loop on gauss points
+        for(unsigned int igauss = 0; igauss<NumGauss; igauss++)
+        {
+            data.N = row(Ncontainer, igauss);
+            const double J = GaussPtsJDet[igauss];
+            data.wGauss = J * IntegrationPoints[igauss].Weight();
+
+            ComputeGaussPointRHSContribution(rhs_gauss, data);
+            ComputeGaussPointLHSContribution(lhs_gauss, data);
+
+            noalias(rLeftHandSideMatrix) += lhs_gauss;
+            noalias(rRightHandSideVector) += rhs_gauss;
+        }
+
+        KRATOS_CATCH("")
+    }
+
+    /// Calculates the RHS condition contributions
+    /**
+     * Clones the selected element variables, creating a new one
+     * @param rLeftHandSideMatrix: reference to the LHS matrix
+     * @param rCurrentProcessInfo: reference to the ProcessInfo (unused)
+     */
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                               ProcessInfo& rCurrentProcessInfo) override
+    {
+        KRATOS_TRY
+
+        constexpr unsigned int MatrixSize = TNumNodes*(TDim+1);
+
+        if (rLeftHandSideMatrix.size1() != MatrixSize)
+            rLeftHandSideMatrix.resize(MatrixSize, MatrixSize, false); //false says not to preserve existing storage!!
+
+        // Struct to pass around the data
+        ConditionDataStruct data;
+        this->FillElementData(data);
+
+        // Allocate memory needed
+        bounded_matrix<double, MatrixSize, MatrixSize> lhs_gauss;
+
+        // LHS contributions initialization
+        noalias(rLeftHandSideMatrix) = ZeroMatrix(MatrixSize, MatrixSize);
+
+        // Gauss point information
+        GeometryType &rGeom = this->GetGeometry();
+        const GeometryType::IntegrationPointsArrayType &IntegrationPoints = rGeom.IntegrationPoints(GeometryData::GI_GAUSS_2);
+        const unsigned int NumGauss = IntegrationPoints.size();
+        Vector GaussPtsJDet = ZeroVector(NumGauss);
+        rGeom.DeterminantOfJacobian(GaussPtsJDet, GeometryData::GI_GAUSS_2);
+        const MatrixType Ncontainer = rGeom.ShapeFunctionsValues(GeometryData::GI_GAUSS_2);
+
+        // Loop on gauss points
+        for (unsigned int igauss = 0; igauss < NumGauss; igauss++)
+        {
+            data.N = row(Ncontainer, igauss);
+            const double J = GaussPtsJDet[igauss];
+            data.wGauss = J * IntegrationPoints[igauss].Weight();
+
+            ComputeGaussPointLHSContribution(lhs_gauss, data);
+
+            noalias(rLeftHandSideMatrix) += lhs_gauss;
+        }
+
+        KRATOS_CATCH("")
+    }
+
+    /// Calculates the RHS condition contributions
+    /**
+     * Clones the selected element variables, creating a new one
+     * @param rRightHandSideVector: reference to the RHS matrix
+     * @param rCurrentProcessInfo: reference to the ProcessInfo (unused)
+     */
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                        ProcessInfo& rCurrentProcessInfo) override
+    {
+        KRATOS_TRY
+
+        constexpr unsigned int MatrixSize = TNumNodes*(TDim+1);
+
+        if (rRightHandSideVector.size() != MatrixSize)
+            rRightHandSideVector.resize(MatrixSize, false); //false says not to preserve existing storage!!
+
+        // Struct to pass around the data
+        ConditionDataStruct data;
+        this->FillElementData(data);
+
+        // Allocate memory needed
+        array_1d<double,MatrixSize> rhs_gauss;
+
+        // RHS contributions initialization
+        noalias(rRightHandSideVector) = ZeroVector(MatrixSize);
+
+        // Store the outlet inflow prevention constants in the data structure
+        // data.delta = 1e-2; // TODO: Decide if this constant should be fixed or not
+        // const ProcessInfo& rProcessInfo = rCurrentProcessInfo; // const to avoid race conditions on data_value_container access/initialization
+        // data.charVel = rProcessInfo[CHARACTERISTIC_VELOCITY];
+
+        // Gauss point information
+        GeometryType& rGeom = this->GetGeometry();
+        const GeometryType::IntegrationPointsArrayType& IntegrationPoints = rGeom.IntegrationPoints(GeometryData::GI_GAUSS_2);
+        const unsigned int NumGauss = IntegrationPoints.size();
+        Vector GaussPtsJDet = ZeroVector(NumGauss);
+        rGeom.DeterminantOfJacobian(GaussPtsJDet, GeometryData::GI_GAUSS_2);
+        const MatrixType Ncontainer = rGeom.ShapeFunctionsValues(GeometryData::GI_GAUSS_2);
+
+        for(unsigned int igauss = 0; igauss<NumGauss; igauss++)
+        {
+            data.N = row(Ncontainer, igauss);
+            const double J = GaussPtsJDet[igauss];
+            data.wGauss = J * IntegrationPoints[igauss].Weight();
+
+            ComputeGaussPointRHSContribution(rhs_gauss, data);
+
+            noalias(rRightHandSideVector) += rhs_gauss;
+        }
+
+        KRATOS_CATCH("")
+    }
+
+
+    /// Condition check
+    /**
+     * @param rCurrentProcessInfo: reference to the ProcessInfo
+     */
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
+    {
+        KRATOS_TRY;
+
+        const GeometryType& rGeom = this->GetGeometry();
+
+        int Check = Condition::Check(rCurrentProcessInfo); // Checks id > 0 and area > 0
+
+        if (Check != 0)
+        {
+            return Check;
+        }
+        else
+        {
+            // Check that all required variables have been registered
+            if(VELOCITY.Key() == 0)
+                KRATOS_ERROR << "VELOCITY Key is 0. Check if the application was correctly registered.";
+            if(MESH_VELOCITY.Key() == 0)
+                KRATOS_ERROR << "MESH_VELOCITY Key is 0. Check if the application was correctly registered.";
+            if(ACCELERATION.Key() == 0)
+                KRATOS_ERROR << "ACCELERATION Key is 0. Check if the application was correctly registered.";
+            if(PRESSURE.Key() == 0)
+                KRATOS_ERROR << "PRESSURE Key is 0. Check if the application was correctly registered.";
+            if(DENSITY.Key() == 0)
+                KRATOS_ERROR << "DENSITY Key is 0. Check if the application was correctly registered.";
+            if(DYNAMIC_VISCOSITY.Key() == 0)
+                KRATOS_ERROR << "DYNAMIC_VISCOSITY Key is 0. Check if the application was correctly registered.";
+            if(EXTERNAL_PRESSURE.Key() == 0)
+                KRATOS_ERROR << "EXTERNAL_PRESSURE Key is 0. Check if the application was correctly registered.";
+
+            // Checks on nodes
+            // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom
+            for(unsigned int i=0; i<rGeom.size(); ++i)
+            {
+                if(rGeom[i].SolutionStepsDataHas(VELOCITY) == false)
+                    KRATOS_ERROR << "Missing VELOCITY variable on solution step data for node " << rGeom[i].Id();
+                if(rGeom[i].SolutionStepsDataHas(PRESSURE) == false)
+                    KRATOS_ERROR << "Missing PRESSURE variable on solution step data for node " << rGeom[i].Id();
+                if(rGeom[i].SolutionStepsDataHas(MESH_VELOCITY) == false)
+                    KRATOS_ERROR << "Missing MESH_VELOCITY variable on solution step data for node " << rGeom[i].Id();
+                if(rGeom[i].SolutionStepsDataHas(ACCELERATION) == false)
+                    KRATOS_ERROR << "Missing ACCELERATION variable on solution step data for node " << rGeom[i].Id();
+                if(rGeom[i].SolutionStepsDataHas(EXTERNAL_PRESSURE) == false)
+                    KRATOS_ERROR << "Missing EXTERNAL_PRESSURE variable on solution step data for node " << rGeom[i].Id();
+                if(rGeom[i].HasDofFor(VELOCITY_X) == false || rGeom[i].HasDofFor(VELOCITY_Y) == false || rGeom[i].HasDofFor(VELOCITY_Z) == false)
+                    KRATOS_ERROR << "Missing VELOCITY component degree of freedom on node " << rGeom[i].Id();
+                if(rGeom[i].HasDofFor(PRESSURE) == false)
+                    KRATOS_ERROR << "Missing PRESSURE component degree of freedom on node " << rGeom[i].Id();
+            }
+
+            return Check;
+        }
+
+        KRATOS_CATCH("");
+    }
+
+    /// Provides the global indices for each one of this element's local rows.
+    /** This determines the elemental equation ID vector for all elemental DOFs
+     * @param rResult A vector containing the global Id of each row
+     * @param rCurrentProcessInfo the current process info object (unused)
+     */
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+
+    /// Returns a list of the element's Dofs
+    /**
+     * @param ElementalDofList the list of DOFs
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void GetDofList(DofsVectorType& ConditionDofList, ProcessInfo& CurrentProcessInfo) override;
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        std::stringstream buffer;
+        buffer << "EmbeddedAusasNavierStokesWallCondition" << TDim << "D";
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << "EmbeddedAusasNavierStokesWallCondition";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override {}
+
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    void CalculateNormal(array_1d<double,3>& An);
+
+    void ComputeGaussPointLHSContribution(bounded_matrix<double,TNumNodes*(TDim+1),TNumNodes*(TDim+1)>& lhs, const ConditionDataStruct& data);
+    void ComputeGaussPointRHSContribution(array_1d<double,TNumNodes*(TDim+1)>& rhs, const ConditionDataStruct& data);
+    
+    void ComputeRHSNeumannContribution(array_1d<double,TNumNodes*(TDim+1)>& rhs, const ConditionDataStruct& data);
+    // void ComputeRHSOutletInflowContribution(array_1d<double,TNumNodes*(TDim+1)>& rhs, const ConditionDataStruct& data);
+
+    // Auxiliar function to fill the element data structure
+    void FillElementData(ConditionDataStruct &rData)
+    {
+        const GeometryType& rGeom = this->GetGeometry();
+
+        // Compute condition normal
+        this->CalculateNormal(rData.Normal);    // This already contains the area
+        const double A = norm_2(rData.Normal);  // Compute the element area
+        rData.Normal /= A;                      // Divide by the area to get the unit normal vector
+
+        // Fill the nodal velocity array
+        for (unsigned int i = 0; i < TNumNodes; i++)
+        {
+            const array_1d<double, 3> &vel = rGeom[i].FastGetSolutionStepValue(VELOCITY);
+
+            for (unsigned int k = 0; k < TDim; k++)
+            {
+                rData.v(i, k) = vel[k];
+            }
+        }
+    }
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Serialization
+    ///@{
+
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override
+    {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition );
+    }
+
+    void load(Serializer& rSerializer) override
+    {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
+    }
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+
+    ///@}
+
+}; // Class EmbeddedAusasNavierStokesWallCondition
+
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+
+/// input stream function
+template< unsigned int TDim, unsigned int TNumNodes >
+inline std::istream& operator >> (std::istream& rIStream, EmbeddedAusasNavierStokesWallCondition<TDim,TNumNodes>& rThis)
+{
+    return rIStream;
+}
+
+/// output stream function
+template< unsigned int TDim, unsigned int TNumNodes >
+inline std::ostream& operator << (std::ostream& rOStream, const EmbeddedAusasNavierStokesWallCondition<TDim,TNumNodes>& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+
+///@} addtogroup block
+
+
+}  // namespace Kratos.
+
+#endif // KRATOS_EMBEDDED_AUSAS_NAVIER_STOKES_WALL_CONDITION_H

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.cpp
@@ -1,0 +1,1231 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#include "custom_elements/embedded_ausas_navier_stokes.h"
+
+namespace Kratos {
+
+template<>
+void EmbeddedAusasNavierStokes<3>::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    unsigned int Dim = 3;
+    unsigned int NumNodes = 4;
+    unsigned int DofSize  = NumNodes*(Dim+1);
+
+    if (rResult.size() != DofSize)
+        rResult.resize(DofSize, false);
+
+    for(unsigned int i=0; i<NumNodes; i++)
+    {
+        rResult[i*(Dim+1)  ]  =  this->GetGeometry()[i].GetDof(VELOCITY_X).EquationId();
+        rResult[i*(Dim+1)+1]  =  this->GetGeometry()[i].GetDof(VELOCITY_Y).EquationId();
+        rResult[i*(Dim+1)+2]  =  this->GetGeometry()[i].GetDof(VELOCITY_Z).EquationId();
+        rResult[i*(Dim+1)+3]  =  this->GetGeometry()[i].GetDof(PRESSURE).EquationId();
+    }
+
+    KRATOS_CATCH("")
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<2>::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    unsigned int Dim = 2;
+    unsigned int NumNodes = 3;
+    unsigned int DofSize  = NumNodes*(Dim+1);
+
+    if (rResult.size() != DofSize)
+        rResult.resize(DofSize, false);
+
+    for(unsigned int i=0; i<NumNodes; i++)
+    {
+        rResult[i*(Dim+1)  ]  =  this->GetGeometry()[i].GetDof(VELOCITY_X).EquationId();
+        rResult[i*(Dim+1)+1]  =  this->GetGeometry()[i].GetDof(VELOCITY_Y).EquationId();
+        rResult[i*(Dim+1)+2]  =  this->GetGeometry()[i].GetDof(PRESSURE).EquationId();
+    }
+
+    KRATOS_CATCH("")
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<3>::GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    unsigned int Dim = 3;
+    unsigned int NumNodes = 4;
+    unsigned int DofSize  = NumNodes*(Dim+1);
+
+    if (ElementalDofList.size() != DofSize)
+        ElementalDofList.resize(DofSize);
+
+    for(unsigned int i=0; i<NumNodes; i++)
+    {
+        ElementalDofList[i*(Dim+1)  ]  =  this->GetGeometry()[i].pGetDof(VELOCITY_X);
+        ElementalDofList[i*(Dim+1)+1]  =  this->GetGeometry()[i].pGetDof(VELOCITY_Y);
+        ElementalDofList[i*(Dim+1)+2]  =  this->GetGeometry()[i].pGetDof(VELOCITY_Z);
+        ElementalDofList[i*(Dim+1)+3]  =  this->GetGeometry()[i].pGetDof(PRESSURE);
+    }
+
+    KRATOS_CATCH("");
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<2>::GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    unsigned int Dim = 2;
+    unsigned int NumNodes = 3;
+    unsigned int DofSize  = NumNodes*(Dim+1);
+
+    if (ElementalDofList.size() != DofSize)
+        ElementalDofList.resize(DofSize);
+
+    for(unsigned int i=0; i<NumNodes; i++)
+    {
+        ElementalDofList[i*(Dim+1)  ]  =  this->GetGeometry()[i].pGetDof(VELOCITY_X);
+        ElementalDofList[i*(Dim+1)+1]  =  this->GetGeometry()[i].pGetDof(VELOCITY_Y);
+        ElementalDofList[i*(Dim+1)+2]  =  this->GetGeometry()[i].pGetDof(PRESSURE);
+    }
+
+    KRATOS_CATCH("");
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<3>::ComputeGaussPointLHSContribution(bounded_matrix<double,16,16>& lhs, const ElementDataStruct& data)
+{
+    const int nnodes = 4;
+    const int dim = 3;
+    //~ const int strain_size = 6;
+
+    const double rho = inner_prod(data.N, data.rho);        // Density
+    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double h = data.h;                                // Characteristic element size
+    const double c = data.c;                                // Wave velocity
+
+    const double& dt = data.dt;
+    const double& bdf0 = data.bdf0;
+    // const double& bdf1 = data.bdf1;
+    // const double& bdf2 = data.bdf2;
+    const double& dyn_tau = data.dyn_tau;
+
+    const bounded_matrix<double,nnodes,dim>& v = data.v;
+    // const bounded_matrix<double,nnodes,dim>& vn = data.vn;
+    // const bounded_matrix<double,nnodes,dim>& vnn = data.vnn;
+    const bounded_matrix<double,nnodes,dim>& vmesh = data.vmesh;
+    const bounded_matrix<double,nnodes,dim>& vconv = v - vmesh;
+    // const bounded_matrix<double,nnodes,dim>& f = data.f;
+    // const array_1d<double,nnodes>& p = data.p;
+    // const array_1d<double,nnodes>& pn = data.pn;
+    // const array_1d<double,nnodes>& pnn = data.pnn;
+    //~ const array_1d<double,strain_size>& stress = data.stress;
+
+    // Get constitutive matrix
+    const Matrix& C = data.C;
+
+    // Get shape function values
+    const array_1d<double,nnodes>& N = data.N;
+    const bounded_matrix<double,nnodes,dim>& DN = data.DN_DX;
+
+    // const array_1d<double,dim> vconv_gauss = prod(trans(vconv), N);
+
+    // const double vconv_norm = norm_2(vconv_gauss);
+
+    // Stabilization parameters
+    const double stab_c1 = 4.0;
+    const double stab_c2 = 2.0;
+    // const double tau1 = 1.0/((rho*dyn_tau_coeff)/delta_t + (c2*rho*vconv_norm)/h + (c1*mu)/(h*h));
+    // const double tau2 = (h*h)/(c1*tau1);
+
+    const double clhs0 =             C(0,0)*DN(0,0) + C(0,3)*DN(0,1) + C(0,5)*DN(0,2);
+const double clhs1 =             C(0,3)*DN(0,0);
+const double clhs2 =             C(3,3)*DN(0,1) + C(3,5)*DN(0,2) + clhs1;
+const double clhs3 =             C(0,5)*DN(0,0);
+const double clhs4 =             C(3,5)*DN(0,1) + C(5,5)*DN(0,2) + clhs3;
+const double clhs5 =             pow(DN(0,0), 2);
+const double clhs6 =             N[0]*vconv(0,0) + N[1]*vconv(1,0) + N[2]*vconv(2,0) + N[3]*vconv(3,0);
+const double clhs7 =             N[0]*vconv(0,1) + N[1]*vconv(1,1) + N[2]*vconv(2,1) + N[3]*vconv(3,1);
+const double clhs8 =             N[0]*vconv(0,2) + N[1]*vconv(1,2) + N[2]*vconv(2,2) + N[3]*vconv(3,2);
+const double clhs9 =             stab_c2*sqrt(pow(clhs6, 2) + pow(clhs7, 2) + pow(clhs8, 2));
+const double clhs10 =             clhs9*h/stab_c1 + mu;
+const double clhs11 =             pow(N[0], 2);
+const double clhs12 =             bdf0*rho;
+const double clhs13 =             N[0]*rho;
+const double clhs14 =             DN(0,0)*clhs6 + DN(0,1)*clhs7 + DN(0,2)*clhs8;
+const double clhs15 =             N[0]*bdf0 + clhs14;
+const double clhs16 =             pow(rho, 2);
+const double clhs17 =             DN(0,0)*vconv(0,0) + DN(0,1)*vconv(0,1) + DN(0,2)*vconv(0,2) + DN(1,0)*vconv(1,0) + DN(1,1)*vconv(1,1) + DN(1,2)*vconv(1,2) + DN(2,0)*vconv(2,0) + DN(2,1)*vconv(2,1) + DN(2,2)*vconv(2,2) + DN(3,0)*vconv(3,0) + DN(3,1)*vconv(3,1) + DN(3,2)*vconv(3,2);
+const double clhs18 =             1.0/(clhs9*rho/h + mu*stab_c1/pow(h, 2) + dyn_tau*rho/dt);
+const double clhs19 =             1.0*N[0]*clhs16*clhs17*clhs18;
+const double clhs20 =             1.0*clhs14*clhs16*clhs18;
+const double clhs21 =             clhs11*clhs12 + clhs13*clhs14 + clhs15*clhs19 + clhs15*clhs20;
+const double clhs22 =             C(0,1)*DN(0,1) + C(0,4)*DN(0,2) + clhs1;
+const double clhs23 =             C(1,3)*DN(0,1);
+const double clhs24 =             C(3,3)*DN(0,0) + C(3,4)*DN(0,2) + clhs23;
+const double clhs25 =             C(3,5)*DN(0,0);
+const double clhs26 =             C(4,5)*DN(0,2);
+const double clhs27 =             C(1,5)*DN(0,1) + clhs25 + clhs26;
+const double clhs28 =             DN(0,0)*clhs10;
+const double clhs29 =             DN(0,1)*clhs28;
+const double clhs30 =             C(0,2)*DN(0,2) + C(0,4)*DN(0,1) + clhs3;
+const double clhs31 =             C(3,4)*DN(0,1);
+const double clhs32 =             C(2,3)*DN(0,2) + clhs25 + clhs31;
+const double clhs33 =             C(2,5)*DN(0,2);
+const double clhs34 =             C(4,5)*DN(0,1) + C(5,5)*DN(0,0) + clhs33;
+const double clhs35 =             DN(0,2)*clhs28;
+const double clhs36 =             -N[0];
+const double clhs37 =             pow(c, -2);
+const double clhs38 =             1.0/rho;
+const double clhs39 =             N[0]*bdf0*clhs37*clhs38;
+const double clhs40 =             1.0*clhs17*clhs18;
+const double clhs41 =             1.0*clhs18*rho;
+const double clhs42 =             clhs14*clhs41;
+const double clhs43 =             clhs10*clhs39 + clhs13*clhs40 + clhs36 + clhs42;
+const double clhs44 =             C(0,0)*DN(1,0) + C(0,3)*DN(1,1) + C(0,5)*DN(1,2);
+const double clhs45 =             C(0,3)*DN(1,0);
+const double clhs46 =             C(3,3)*DN(1,1) + C(3,5)*DN(1,2) + clhs45;
+const double clhs47 =             C(0,5)*DN(1,0);
+const double clhs48 =             C(3,5)*DN(1,1) + C(5,5)*DN(1,2) + clhs47;
+const double clhs49 =             DN(1,0)*clhs28;
+const double clhs50 =             N[0]*bdf0*rho;
+const double clhs51 =             N[1]*clhs50;
+const double clhs52 =             DN(1,0)*clhs6 + DN(1,1)*clhs7 + DN(1,2)*clhs8;
+const double clhs53 =             N[1]*bdf0 + clhs52;
+const double clhs54 =             clhs13*clhs52 + clhs19*clhs53 + clhs20*clhs53 + clhs51;
+const double clhs55 =             C(0,1)*DN(1,1) + C(0,4)*DN(1,2) + clhs45;
+const double clhs56 =             C(1,3)*DN(1,1);
+const double clhs57 =             C(3,3)*DN(1,0) + C(3,4)*DN(1,2) + clhs56;
+const double clhs58 =             C(3,5)*DN(1,0);
+const double clhs59 =             C(4,5)*DN(1,2);
+const double clhs60 =             C(1,5)*DN(1,1) + clhs58 + clhs59;
+const double clhs61 =             DN(1,1)*clhs28;
+const double clhs62 =             C(0,2)*DN(1,2) + C(0,4)*DN(1,1) + clhs47;
+const double clhs63 =             C(3,4)*DN(1,1);
+const double clhs64 =             C(2,3)*DN(1,2) + clhs58 + clhs63;
+const double clhs65 =             C(2,5)*DN(1,2);
+const double clhs66 =             C(4,5)*DN(1,1) + C(5,5)*DN(1,0) + clhs65;
+const double clhs67 =             DN(1,2)*clhs28;
+const double clhs68 =             DN(0,0)*N[1];
+const double clhs69 =             bdf0*clhs10*clhs37*clhs38;
+const double clhs70 =             DN(1,0)*N[0];
+const double clhs71 =             1.0*clhs17*clhs18*rho;
+const double clhs72 =             1.0*DN(1,0)*clhs18*rho;
+const double clhs73 =             C(0,0)*DN(2,0) + C(0,3)*DN(2,1) + C(0,5)*DN(2,2);
+const double clhs74 =             C(0,3)*DN(2,0);
+const double clhs75 =             C(3,3)*DN(2,1) + C(3,5)*DN(2,2) + clhs74;
+const double clhs76 =             C(0,5)*DN(2,0);
+const double clhs77 =             C(3,5)*DN(2,1) + C(5,5)*DN(2,2) + clhs76;
+const double clhs78 =             DN(2,0)*clhs28;
+const double clhs79 =             N[2]*clhs50;
+const double clhs80 =             DN(2,0)*clhs6 + DN(2,1)*clhs7 + DN(2,2)*clhs8;
+const double clhs81 =             N[2]*bdf0;
+const double clhs82 =             clhs80 + clhs81;
+const double clhs83 =             clhs13*clhs80 + clhs19*clhs82 + clhs20*clhs82 + clhs79;
+const double clhs84 =             C(0,1)*DN(2,1) + C(0,4)*DN(2,2) + clhs74;
+const double clhs85 =             C(1,3)*DN(2,1);
+const double clhs86 =             C(3,3)*DN(2,0) + C(3,4)*DN(2,2) + clhs85;
+const double clhs87 =             C(3,5)*DN(2,0);
+const double clhs88 =             C(4,5)*DN(2,2);
+const double clhs89 =             C(1,5)*DN(2,1) + clhs87 + clhs88;
+const double clhs90 =             DN(2,1)*clhs28;
+const double clhs91 =             C(0,2)*DN(2,2) + C(0,4)*DN(2,1) + clhs76;
+const double clhs92 =             C(3,4)*DN(2,1);
+const double clhs93 =             C(2,3)*DN(2,2) + clhs87 + clhs92;
+const double clhs94 =             C(2,5)*DN(2,2);
+const double clhs95 =             C(4,5)*DN(2,1) + C(5,5)*DN(2,0) + clhs94;
+const double clhs96 =             DN(2,2)*clhs28;
+const double clhs97 =             DN(0,0)*N[2];
+const double clhs98 =             DN(2,0)*N[0];
+const double clhs99 =             1.0*DN(2,0)*clhs18*rho;
+const double clhs100 =             C(0,0)*DN(3,0) + C(0,3)*DN(3,1) + C(0,5)*DN(3,2);
+const double clhs101 =             C(0,3)*DN(3,0);
+const double clhs102 =             C(3,3)*DN(3,1) + C(3,5)*DN(3,2) + clhs101;
+const double clhs103 =             C(0,5)*DN(3,0);
+const double clhs104 =             C(3,5)*DN(3,1) + C(5,5)*DN(3,2) + clhs103;
+const double clhs105 =             DN(3,0)*clhs28;
+const double clhs106 =             N[3]*clhs50;
+const double clhs107 =             DN(3,0)*clhs6 + DN(3,1)*clhs7 + DN(3,2)*clhs8;
+const double clhs108 =             N[3]*bdf0;
+const double clhs109 =             clhs107 + clhs108;
+const double clhs110 =             clhs106 + clhs107*clhs13 + clhs109*clhs19 + clhs109*clhs20;
+const double clhs111 =             C(0,1)*DN(3,1) + C(0,4)*DN(3,2) + clhs101;
+const double clhs112 =             C(1,3)*DN(3,1);
+const double clhs113 =             C(3,3)*DN(3,0) + C(3,4)*DN(3,2) + clhs112;
+const double clhs114 =             C(3,5)*DN(3,0);
+const double clhs115 =             C(4,5)*DN(3,2);
+const double clhs116 =             C(1,5)*DN(3,1) + clhs114 + clhs115;
+const double clhs117 =             DN(3,1)*clhs28;
+const double clhs118 =             C(0,2)*DN(3,2) + C(0,4)*DN(3,1) + clhs103;
+const double clhs119 =             C(3,4)*DN(3,1);
+const double clhs120 =             C(2,3)*DN(3,2) + clhs114 + clhs119;
+const double clhs121 =             C(2,5)*DN(3,2);
+const double clhs122 =             C(4,5)*DN(3,1) + C(5,5)*DN(3,0) + clhs121;
+const double clhs123 =             DN(3,2)*clhs28;
+const double clhs124 =             DN(0,0)*N[3];
+const double clhs125 =             DN(3,0)*N[0];
+const double clhs126 =             C(0,1)*DN(0,0) + C(1,5)*DN(0,2) + clhs23;
+const double clhs127 =             C(0,4)*DN(0,0) + clhs26 + clhs31;
+const double clhs128 =             C(1,1)*DN(0,1) + C(1,3)*DN(0,0) + C(1,4)*DN(0,2);
+const double clhs129 =             C(1,4)*DN(0,1);
+const double clhs130 =             C(3,4)*DN(0,0) + C(4,4)*DN(0,2) + clhs129;
+const double clhs131 =             pow(DN(0,1), 2);
+const double clhs132 =             C(1,2)*DN(0,2) + C(1,5)*DN(0,0) + clhs129;
+const double clhs133 =             C(2,4)*DN(0,2);
+const double clhs134 =             C(4,4)*DN(0,1) + C(4,5)*DN(0,0) + clhs133;
+const double clhs135 =             DN(0,1)*clhs10;
+const double clhs136 =             DN(0,2)*clhs135;
+const double clhs137 =             C(0,1)*DN(1,0) + C(1,5)*DN(1,2) + clhs56;
+const double clhs138 =             C(0,4)*DN(1,0) + clhs59 + clhs63;
+const double clhs139 =             DN(1,0)*clhs135;
+const double clhs140 =             C(1,1)*DN(1,1) + C(1,3)*DN(1,0) + C(1,4)*DN(1,2);
+const double clhs141 =             C(1,4)*DN(1,1);
+const double clhs142 =             C(3,4)*DN(1,0) + C(4,4)*DN(1,2) + clhs141;
+const double clhs143 =             DN(1,1)*clhs135;
+const double clhs144 =             C(1,2)*DN(1,2) + C(1,5)*DN(1,0) + clhs141;
+const double clhs145 =             C(2,4)*DN(1,2);
+const double clhs146 =             C(4,4)*DN(1,1) + C(4,5)*DN(1,0) + clhs145;
+const double clhs147 =             DN(1,2)*clhs135;
+const double clhs148 =             DN(0,1)*N[1];
+const double clhs149 =             DN(1,1)*N[0];
+const double clhs150 =             1.0*DN(1,1)*clhs18*rho;
+const double clhs151 =             C(0,1)*DN(2,0) + C(1,5)*DN(2,2) + clhs85;
+const double clhs152 =             C(0,4)*DN(2,0) + clhs88 + clhs92;
+const double clhs153 =             DN(2,0)*clhs135;
+const double clhs154 =             C(1,1)*DN(2,1) + C(1,3)*DN(2,0) + C(1,4)*DN(2,2);
+const double clhs155 =             C(1,4)*DN(2,1);
+const double clhs156 =             C(3,4)*DN(2,0) + C(4,4)*DN(2,2) + clhs155;
+const double clhs157 =             DN(2,1)*clhs135;
+const double clhs158 =             C(1,2)*DN(2,2) + C(1,5)*DN(2,0) + clhs155;
+const double clhs159 =             C(2,4)*DN(2,2);
+const double clhs160 =             C(4,4)*DN(2,1) + C(4,5)*DN(2,0) + clhs159;
+const double clhs161 =             DN(2,2)*clhs135;
+const double clhs162 =             DN(0,1)*N[2];
+const double clhs163 =             DN(2,1)*N[0];
+const double clhs164 =             1.0*DN(2,1)*clhs18*rho;
+const double clhs165 =             C(0,1)*DN(3,0) + C(1,5)*DN(3,2) + clhs112;
+const double clhs166 =             C(0,4)*DN(3,0) + clhs115 + clhs119;
+const double clhs167 =             DN(3,0)*clhs135;
+const double clhs168 =             C(1,1)*DN(3,1) + C(1,3)*DN(3,0) + C(1,4)*DN(3,2);
+const double clhs169 =             C(1,4)*DN(3,1);
+const double clhs170 =             C(3,4)*DN(3,0) + C(4,4)*DN(3,2) + clhs169;
+const double clhs171 =             DN(3,1)*clhs135;
+const double clhs172 =             C(1,2)*DN(3,2) + C(1,5)*DN(3,0) + clhs169;
+const double clhs173 =             C(2,4)*DN(3,2);
+const double clhs174 =             C(4,4)*DN(3,1) + C(4,5)*DN(3,0) + clhs173;
+const double clhs175 =             DN(3,2)*clhs135;
+const double clhs176 =             DN(0,1)*N[3];
+const double clhs177 =             DN(3,1)*N[0];
+const double clhs178 =             C(0,2)*DN(0,0) + C(2,3)*DN(0,1) + clhs33;
+const double clhs179 =             C(1,2)*DN(0,1) + C(2,3)*DN(0,0) + clhs133;
+const double clhs180 =             C(2,2)*DN(0,2) + C(2,4)*DN(0,1) + C(2,5)*DN(0,0);
+const double clhs181 =             pow(DN(0,2), 2);
+const double clhs182 =             C(0,2)*DN(1,0) + C(2,3)*DN(1,1) + clhs65;
+const double clhs183 =             DN(0,2)*clhs10;
+const double clhs184 =             DN(1,0)*clhs183;
+const double clhs185 =             C(1,2)*DN(1,1) + C(2,3)*DN(1,0) + clhs145;
+const double clhs186 =             DN(1,1)*clhs183;
+const double clhs187 =             C(2,2)*DN(1,2) + C(2,4)*DN(1,1) + C(2,5)*DN(1,0);
+const double clhs188 =             DN(1,2)*clhs183;
+const double clhs189 =             DN(0,2)*N[1];
+const double clhs190 =             DN(1,2)*N[0];
+const double clhs191 =             1.0*DN(1,2)*clhs18*rho;
+const double clhs192 =             C(0,2)*DN(2,0) + C(2,3)*DN(2,1) + clhs94;
+const double clhs193 =             DN(2,0)*clhs183;
+const double clhs194 =             C(1,2)*DN(2,1) + C(2,3)*DN(2,0) + clhs159;
+const double clhs195 =             DN(2,1)*clhs183;
+const double clhs196 =             C(2,2)*DN(2,2) + C(2,4)*DN(2,1) + C(2,5)*DN(2,0);
+const double clhs197 =             DN(2,2)*clhs183;
+const double clhs198 =             DN(0,2)*N[2];
+const double clhs199 =             DN(2,2)*N[0];
+const double clhs200 =             1.0*DN(2,2)*clhs18*rho;
+const double clhs201 =             C(0,2)*DN(3,0) + C(2,3)*DN(3,1) + clhs121;
+const double clhs202 =             DN(3,0)*clhs183;
+const double clhs203 =             C(1,2)*DN(3,1) + C(2,3)*DN(3,0) + clhs173;
+const double clhs204 =             DN(3,1)*clhs183;
+const double clhs205 =             C(2,2)*DN(3,2) + C(2,4)*DN(3,1) + C(2,5)*DN(3,0);
+const double clhs206 =             DN(3,2)*clhs183;
+const double clhs207 =             DN(0,2)*N[3];
+const double clhs208 =             DN(3,2)*N[0];
+const double clhs209 =             clhs15*clhs41 + clhs36;
+const double clhs210 =             bdf0*clhs37*clhs38;
+const double clhs211 =             1.0*clhs18;
+const double clhs212 =             -N[1];
+const double clhs213 =             clhs212 + clhs41*clhs53;
+const double clhs214 =             1.0*DN(0,0)*clhs18;
+const double clhs215 =             1.0*DN(0,1)*clhs18;
+const double clhs216 =             1.0*DN(0,2)*clhs18;
+const double clhs217 =             DN(1,0)*clhs214 + DN(1,1)*clhs215 + DN(1,2)*clhs216 + N[1]*clhs39;
+const double clhs218 =             -N[2];
+const double clhs219 =             clhs218 + clhs41*clhs82;
+const double clhs220 =             DN(2,0)*clhs214 + DN(2,1)*clhs215 + DN(2,2)*clhs216 + N[2]*clhs39;
+const double clhs221 =             -N[3];
+const double clhs222 =             clhs109*clhs41 + clhs221;
+const double clhs223 =             DN(3,0)*clhs214 + DN(3,1)*clhs215 + DN(3,2)*clhs216 + N[3]*clhs39;
+const double clhs224 =             N[1]*rho;
+const double clhs225 =             1.0*N[1]*clhs16*clhs17*clhs18;
+const double clhs226 =             1.0*clhs16*clhs18*clhs52;
+const double clhs227 =             clhs14*clhs224 + clhs15*clhs225 + clhs15*clhs226 + clhs51;
+const double clhs228 =             1.0*DN(0,0)*clhs18*rho;
+const double clhs229 =             pow(DN(1,0), 2);
+const double clhs230 =             pow(N[1], 2);
+const double clhs231 =             clhs12*clhs230 + clhs224*clhs52 + clhs225*clhs53 + clhs226*clhs53;
+const double clhs232 =             DN(1,0)*clhs10;
+const double clhs233 =             DN(1,1)*clhs232;
+const double clhs234 =             DN(1,2)*clhs232;
+const double clhs235 =             N[1]*bdf0*clhs37*clhs38;
+const double clhs236 =             clhs41*clhs52;
+const double clhs237 =             clhs10*clhs235 + clhs212 + clhs224*clhs40 + clhs236;
+const double clhs238 =             DN(2,0)*clhs232;
+const double clhs239 =             N[1]*bdf0*rho;
+const double clhs240 =             N[2]*clhs239;
+const double clhs241 =             clhs224*clhs80 + clhs225*clhs82 + clhs226*clhs82 + clhs240;
+const double clhs242 =             DN(2,1)*clhs232;
+const double clhs243 =             DN(2,2)*clhs232;
+const double clhs244 =             DN(1,0)*N[2];
+const double clhs245 =             DN(2,0)*N[1];
+const double clhs246 =             DN(3,0)*clhs232;
+const double clhs247 =             N[3]*clhs239;
+const double clhs248 =             clhs107*clhs224 + clhs109*clhs225 + clhs109*clhs226 + clhs247;
+const double clhs249 =             DN(3,1)*clhs232;
+const double clhs250 =             DN(3,2)*clhs232;
+const double clhs251 =             DN(1,0)*N[3];
+const double clhs252 =             DN(3,0)*N[1];
+const double clhs253 =             1.0*DN(0,1)*clhs18*rho;
+const double clhs254 =             pow(DN(1,1), 2);
+const double clhs255 =             DN(1,1)*clhs10;
+const double clhs256 =             DN(1,2)*clhs255;
+const double clhs257 =             DN(2,0)*clhs255;
+const double clhs258 =             DN(2,1)*clhs255;
+const double clhs259 =             DN(2,2)*clhs255;
+const double clhs260 =             DN(1,1)*N[2];
+const double clhs261 =             DN(2,1)*N[1];
+const double clhs262 =             DN(3,0)*clhs255;
+const double clhs263 =             DN(3,1)*clhs255;
+const double clhs264 =             DN(3,2)*clhs255;
+const double clhs265 =             DN(1,1)*N[3];
+const double clhs266 =             DN(3,1)*N[1];
+const double clhs267 =             1.0*DN(0,2)*clhs18*rho;
+const double clhs268 =             pow(DN(1,2), 2);
+const double clhs269 =             DN(1,2)*clhs10;
+const double clhs270 =             DN(2,0)*clhs269;
+const double clhs271 =             DN(2,1)*clhs269;
+const double clhs272 =             DN(2,2)*clhs269;
+const double clhs273 =             DN(1,2)*N[2];
+const double clhs274 =             DN(2,2)*N[1];
+const double clhs275 =             DN(3,0)*clhs269;
+const double clhs276 =             DN(3,1)*clhs269;
+const double clhs277 =             DN(3,2)*clhs269;
+const double clhs278 =             DN(1,2)*N[3];
+const double clhs279 =             DN(3,2)*N[1];
+const double clhs280 =             1.0*DN(1,0)*clhs18;
+const double clhs281 =             1.0*DN(1,1)*clhs18;
+const double clhs282 =             1.0*DN(1,2)*clhs18;
+const double clhs283 =             DN(2,0)*clhs280 + DN(2,1)*clhs281 + DN(2,2)*clhs282 + N[2]*clhs235;
+const double clhs284 =             DN(3,0)*clhs280 + DN(3,1)*clhs281 + DN(3,2)*clhs282 + N[3]*clhs235;
+const double clhs285 =             N[2]*rho;
+const double clhs286 =             1.0*N[2]*clhs16*clhs17*clhs18;
+const double clhs287 =             1.0*clhs16*clhs18*clhs80;
+const double clhs288 =             clhs14*clhs285 + clhs15*clhs286 + clhs15*clhs287 + clhs79;
+const double clhs289 =             clhs240 + clhs285*clhs52 + clhs286*clhs53 + clhs287*clhs53;
+const double clhs290 =             pow(DN(2,0), 2);
+const double clhs291 =             pow(N[2], 2);
+const double clhs292 =             clhs12*clhs291 + clhs285*clhs80 + clhs286*clhs82 + clhs287*clhs82;
+const double clhs293 =             DN(2,0)*clhs10;
+const double clhs294 =             DN(2,1)*clhs293;
+const double clhs295 =             DN(2,2)*clhs293;
+const double clhs296 =             clhs10*clhs37*clhs38;
+const double clhs297 =             clhs41*clhs80;
+const double clhs298 =             clhs218 + clhs285*clhs40 + clhs296*clhs81 + clhs297;
+const double clhs299 =             DN(3,0)*clhs293;
+const double clhs300 =             N[2]*N[3]*bdf0;
+const double clhs301 =             clhs300*rho;
+const double clhs302 =             clhs107*clhs285 + clhs109*clhs286 + clhs109*clhs287 + clhs301;
+const double clhs303 =             DN(3,1)*clhs293;
+const double clhs304 =             DN(3,2)*clhs293;
+const double clhs305 =             DN(2,0)*N[3];
+const double clhs306 =             DN(3,0)*N[2];
+const double clhs307 =             pow(DN(2,1), 2);
+const double clhs308 =             DN(2,1)*clhs10;
+const double clhs309 =             DN(2,2)*clhs308;
+const double clhs310 =             DN(3,0)*clhs308;
+const double clhs311 =             DN(3,1)*clhs308;
+const double clhs312 =             DN(3,2)*clhs308;
+const double clhs313 =             DN(2,1)*N[3];
+const double clhs314 =             DN(3,1)*N[2];
+const double clhs315 =             pow(DN(2,2), 2);
+const double clhs316 =             DN(2,2)*clhs10;
+const double clhs317 =             DN(3,0)*clhs316;
+const double clhs318 =             DN(3,1)*clhs316;
+const double clhs319 =             DN(3,2)*clhs316;
+const double clhs320 =             DN(2,2)*N[3];
+const double clhs321 =             DN(3,2)*N[2];
+const double clhs322 =             1.0*DN(2,0)*DN(3,0)*clhs18 + 1.0*DN(2,1)*DN(3,1)*clhs18 + 1.0*DN(2,2)*DN(3,2)*clhs18 + clhs300*clhs37*clhs38;
+const double clhs323 =             N[3]*rho;
+const double clhs324 =             1.0*N[3]*clhs16*clhs17*clhs18;
+const double clhs325 =             1.0*clhs107*clhs16*clhs18;
+const double clhs326 =             clhs106 + clhs14*clhs323 + clhs15*clhs324 + clhs15*clhs325;
+const double clhs327 =             clhs247 + clhs323*clhs52 + clhs324*clhs53 + clhs325*clhs53;
+const double clhs328 =             clhs301 + clhs323*clhs80 + clhs324*clhs82 + clhs325*clhs82;
+const double clhs329 =             pow(DN(3,0), 2);
+const double clhs330 =             pow(N[3], 2);
+const double clhs331 =             clhs107*clhs323 + clhs109*clhs324 + clhs109*clhs325 + clhs12*clhs330;
+const double clhs332 =             DN(3,0)*clhs10;
+const double clhs333 =             DN(3,1)*clhs332;
+const double clhs334 =             DN(3,2)*clhs332;
+const double clhs335 =             clhs107*clhs41 + clhs108*clhs296 + clhs221 + clhs323*clhs40;
+const double clhs336 =             pow(DN(3,1), 2);
+const double clhs337 =             DN(3,1)*DN(3,2)*clhs10;
+const double clhs338 =             pow(DN(3,2), 2);
+            lhs(0,0)=DN(0,0)*clhs0 + DN(0,1)*clhs2 + DN(0,2)*clhs4 + clhs10*clhs5 + clhs21;
+            lhs(0,1)=DN(0,0)*clhs22 + DN(0,1)*clhs24 + DN(0,2)*clhs27 + clhs29;
+            lhs(0,2)=DN(0,0)*clhs30 + DN(0,1)*clhs32 + DN(0,2)*clhs34 + clhs35;
+            lhs(0,3)=DN(0,0)*clhs43;
+            lhs(0,4)=DN(0,0)*clhs44 + DN(0,1)*clhs46 + DN(0,2)*clhs48 + clhs49 + clhs54;
+            lhs(0,5)=DN(0,0)*clhs55 + DN(0,1)*clhs57 + DN(0,2)*clhs60 + clhs61;
+            lhs(0,6)=DN(0,0)*clhs62 + DN(0,1)*clhs64 + DN(0,2)*clhs66 + clhs67;
+            lhs(0,7)=clhs14*clhs72 + clhs68*clhs69 - clhs68 + clhs70*clhs71;
+            lhs(0,8)=DN(0,0)*clhs73 + DN(0,1)*clhs75 + DN(0,2)*clhs77 + clhs78 + clhs83;
+            lhs(0,9)=DN(0,0)*clhs84 + DN(0,1)*clhs86 + DN(0,2)*clhs89 + clhs90;
+            lhs(0,10)=DN(0,0)*clhs91 + DN(0,1)*clhs93 + DN(0,2)*clhs95 + clhs96;
+            lhs(0,11)=clhs14*clhs99 + clhs69*clhs97 + clhs71*clhs98 - clhs97;
+            lhs(0,12)=DN(0,0)*clhs100 + DN(0,1)*clhs102 + DN(0,2)*clhs104 + clhs105 + clhs110;
+            lhs(0,13)=DN(0,0)*clhs111 + DN(0,1)*clhs113 + DN(0,2)*clhs116 + clhs117;
+            lhs(0,14)=DN(0,0)*clhs118 + DN(0,1)*clhs120 + DN(0,2)*clhs122 + clhs123;
+            lhs(0,15)=DN(3,0)*clhs42 + clhs124*clhs69 - clhs124 + clhs125*clhs71;
+            lhs(1,0)=DN(0,0)*clhs2 + DN(0,1)*clhs126 + DN(0,2)*clhs127 + clhs29;
+            lhs(1,1)=DN(0,0)*clhs24 + DN(0,1)*clhs128 + DN(0,2)*clhs130 + clhs10*clhs131 + clhs21;
+            lhs(1,2)=DN(0,0)*clhs32 + DN(0,1)*clhs132 + DN(0,2)*clhs134 + clhs136;
+            lhs(1,3)=DN(0,1)*clhs43;
+            lhs(1,4)=DN(0,0)*clhs46 + DN(0,1)*clhs137 + DN(0,2)*clhs138 + clhs139;
+            lhs(1,5)=DN(0,0)*clhs57 + DN(0,1)*clhs140 + DN(0,2)*clhs142 + clhs143 + clhs54;
+            lhs(1,6)=DN(0,0)*clhs64 + DN(0,1)*clhs144 + DN(0,2)*clhs146 + clhs147;
+            lhs(1,7)=clhs14*clhs150 + clhs148*clhs69 - clhs148 + clhs149*clhs71;
+            lhs(1,8)=DN(0,0)*clhs75 + DN(0,1)*clhs151 + DN(0,2)*clhs152 + clhs153;
+            lhs(1,9)=DN(0,0)*clhs86 + DN(0,1)*clhs154 + DN(0,2)*clhs156 + clhs157 + clhs83;
+            lhs(1,10)=DN(0,0)*clhs93 + DN(0,1)*clhs158 + DN(0,2)*clhs160 + clhs161;
+            lhs(1,11)=clhs14*clhs164 + clhs162*clhs69 - clhs162 + clhs163*clhs71;
+            lhs(1,12)=DN(0,0)*clhs102 + DN(0,1)*clhs165 + DN(0,2)*clhs166 + clhs167;
+            lhs(1,13)=DN(0,0)*clhs113 + DN(0,1)*clhs168 + DN(0,2)*clhs170 + clhs110 + clhs171;
+            lhs(1,14)=DN(0,0)*clhs120 + DN(0,1)*clhs172 + DN(0,2)*clhs174 + clhs175;
+            lhs(1,15)=DN(3,1)*clhs42 + clhs176*clhs69 - clhs176 + clhs177*clhs71;
+            lhs(2,0)=DN(0,0)*clhs4 + DN(0,1)*clhs127 + DN(0,2)*clhs178 + clhs35;
+            lhs(2,1)=DN(0,0)*clhs27 + DN(0,1)*clhs130 + DN(0,2)*clhs179 + clhs136;
+            lhs(2,2)=DN(0,0)*clhs34 + DN(0,1)*clhs134 + DN(0,2)*clhs180 + clhs10*clhs181 + clhs21;
+            lhs(2,3)=DN(0,2)*clhs43;
+            lhs(2,4)=DN(0,0)*clhs48 + DN(0,1)*clhs138 + DN(0,2)*clhs182 + clhs184;
+            lhs(2,5)=DN(0,0)*clhs60 + DN(0,1)*clhs142 + DN(0,2)*clhs185 + clhs186;
+            lhs(2,6)=DN(0,0)*clhs66 + DN(0,1)*clhs146 + DN(0,2)*clhs187 + clhs188 + clhs54;
+            lhs(2,7)=clhs14*clhs191 + clhs189*clhs69 - clhs189 + clhs190*clhs71;
+            lhs(2,8)=DN(0,0)*clhs77 + DN(0,1)*clhs152 + DN(0,2)*clhs192 + clhs193;
+            lhs(2,9)=DN(0,0)*clhs89 + DN(0,1)*clhs156 + DN(0,2)*clhs194 + clhs195;
+            lhs(2,10)=DN(0,0)*clhs95 + DN(0,1)*clhs160 + DN(0,2)*clhs196 + clhs197 + clhs83;
+            lhs(2,11)=clhs14*clhs200 + clhs198*clhs69 - clhs198 + clhs199*clhs71;
+            lhs(2,12)=DN(0,0)*clhs104 + DN(0,1)*clhs166 + DN(0,2)*clhs201 + clhs202;
+            lhs(2,13)=DN(0,0)*clhs116 + DN(0,1)*clhs170 + DN(0,2)*clhs203 + clhs204;
+            lhs(2,14)=DN(0,0)*clhs122 + DN(0,1)*clhs174 + DN(0,2)*clhs205 + clhs110 + clhs206;
+            lhs(2,15)=DN(3,2)*clhs42 + clhs207*clhs69 - clhs207 + clhs208*clhs71;
+            lhs(3,0)=DN(0,0)*clhs209;
+            lhs(3,1)=DN(0,1)*clhs209;
+            lhs(3,2)=DN(0,2)*clhs209;
+            lhs(3,3)=clhs11*clhs210 + clhs131*clhs211 + clhs181*clhs211 + clhs211*clhs5;
+            lhs(3,4)=DN(0,0)*clhs213;
+            lhs(3,5)=DN(0,1)*clhs213;
+            lhs(3,6)=DN(0,2)*clhs213;
+            lhs(3,7)=clhs217;
+            lhs(3,8)=DN(0,0)*clhs219;
+            lhs(3,9)=DN(0,1)*clhs219;
+            lhs(3,10)=DN(0,2)*clhs219;
+            lhs(3,11)=clhs220;
+            lhs(3,12)=DN(0,0)*clhs222;
+            lhs(3,13)=DN(0,1)*clhs222;
+            lhs(3,14)=DN(0,2)*clhs222;
+            lhs(3,15)=clhs223;
+            lhs(4,0)=DN(1,0)*clhs0 + DN(1,1)*clhs2 + DN(1,2)*clhs4 + clhs227 + clhs49;
+            lhs(4,1)=DN(1,0)*clhs22 + DN(1,1)*clhs24 + DN(1,2)*clhs27 + clhs139;
+            lhs(4,2)=DN(1,0)*clhs30 + DN(1,1)*clhs32 + DN(1,2)*clhs34 + clhs184;
+            lhs(4,3)=clhs228*clhs52 + clhs68*clhs71 + clhs69*clhs70 - clhs70;
+            lhs(4,4)=DN(1,0)*clhs44 + DN(1,1)*clhs46 + DN(1,2)*clhs48 + clhs10*clhs229 + clhs231;
+            lhs(4,5)=DN(1,0)*clhs55 + DN(1,1)*clhs57 + DN(1,2)*clhs60 + clhs233;
+            lhs(4,6)=DN(1,0)*clhs62 + DN(1,1)*clhs64 + DN(1,2)*clhs66 + clhs234;
+            lhs(4,7)=DN(1,0)*clhs237;
+            lhs(4,8)=DN(1,0)*clhs73 + DN(1,1)*clhs75 + DN(1,2)*clhs77 + clhs238 + clhs241;
+            lhs(4,9)=DN(1,0)*clhs84 + DN(1,1)*clhs86 + DN(1,2)*clhs89 + clhs242;
+            lhs(4,10)=DN(1,0)*clhs91 + DN(1,1)*clhs93 + DN(1,2)*clhs95 + clhs243;
+            lhs(4,11)=clhs244*clhs69 - clhs244 + clhs245*clhs71 + clhs52*clhs99;
+            lhs(4,12)=DN(1,0)*clhs100 + DN(1,1)*clhs102 + DN(1,2)*clhs104 + clhs246 + clhs248;
+            lhs(4,13)=DN(1,0)*clhs111 + DN(1,1)*clhs113 + DN(1,2)*clhs116 + clhs249;
+            lhs(4,14)=DN(1,0)*clhs118 + DN(1,1)*clhs120 + DN(1,2)*clhs122 + clhs250;
+            lhs(4,15)=DN(3,0)*clhs236 + clhs251*clhs69 - clhs251 + clhs252*clhs71;
+            lhs(5,0)=DN(1,0)*clhs2 + DN(1,1)*clhs126 + DN(1,2)*clhs127 + clhs61;
+            lhs(5,1)=DN(1,0)*clhs24 + DN(1,1)*clhs128 + DN(1,2)*clhs130 + clhs143 + clhs227;
+            lhs(5,2)=DN(1,0)*clhs32 + DN(1,1)*clhs132 + DN(1,2)*clhs134 + clhs186;
+            lhs(5,3)=clhs148*clhs71 + clhs149*clhs69 - clhs149 + clhs253*clhs52;
+            lhs(5,4)=DN(1,0)*clhs46 + DN(1,1)*clhs137 + DN(1,2)*clhs138 + clhs233;
+            lhs(5,5)=DN(1,0)*clhs57 + DN(1,1)*clhs140 + DN(1,2)*clhs142 + clhs10*clhs254 + clhs231;
+            lhs(5,6)=DN(1,0)*clhs64 + DN(1,1)*clhs144 + DN(1,2)*clhs146 + clhs256;
+            lhs(5,7)=DN(1,1)*clhs237;
+            lhs(5,8)=DN(1,0)*clhs75 + DN(1,1)*clhs151 + DN(1,2)*clhs152 + clhs257;
+            lhs(5,9)=DN(1,0)*clhs86 + DN(1,1)*clhs154 + DN(1,2)*clhs156 + clhs241 + clhs258;
+            lhs(5,10)=DN(1,0)*clhs93 + DN(1,1)*clhs158 + DN(1,2)*clhs160 + clhs259;
+            lhs(5,11)=clhs164*clhs52 + clhs260*clhs69 - clhs260 + clhs261*clhs71;
+            lhs(5,12)=DN(1,0)*clhs102 + DN(1,1)*clhs165 + DN(1,2)*clhs166 + clhs262;
+            lhs(5,13)=DN(1,0)*clhs113 + DN(1,1)*clhs168 + DN(1,2)*clhs170 + clhs248 + clhs263;
+            lhs(5,14)=DN(1,0)*clhs120 + DN(1,1)*clhs172 + DN(1,2)*clhs174 + clhs264;
+            lhs(5,15)=DN(3,1)*clhs236 + clhs265*clhs69 - clhs265 + clhs266*clhs71;
+            lhs(6,0)=DN(1,0)*clhs4 + DN(1,1)*clhs127 + DN(1,2)*clhs178 + clhs67;
+            lhs(6,1)=DN(1,0)*clhs27 + DN(1,1)*clhs130 + DN(1,2)*clhs179 + clhs147;
+            lhs(6,2)=DN(1,0)*clhs34 + DN(1,1)*clhs134 + DN(1,2)*clhs180 + clhs188 + clhs227;
+            lhs(6,3)=clhs189*clhs71 + clhs190*clhs69 - clhs190 + clhs267*clhs52;
+            lhs(6,4)=DN(1,0)*clhs48 + DN(1,1)*clhs138 + DN(1,2)*clhs182 + clhs234;
+            lhs(6,5)=DN(1,0)*clhs60 + DN(1,1)*clhs142 + DN(1,2)*clhs185 + clhs256;
+            lhs(6,6)=DN(1,0)*clhs66 + DN(1,1)*clhs146 + DN(1,2)*clhs187 + clhs10*clhs268 + clhs231;
+            lhs(6,7)=DN(1,2)*clhs237;
+            lhs(6,8)=DN(1,0)*clhs77 + DN(1,1)*clhs152 + DN(1,2)*clhs192 + clhs270;
+            lhs(6,9)=DN(1,0)*clhs89 + DN(1,1)*clhs156 + DN(1,2)*clhs194 + clhs271;
+            lhs(6,10)=DN(1,0)*clhs95 + DN(1,1)*clhs160 + DN(1,2)*clhs196 + clhs241 + clhs272;
+            lhs(6,11)=clhs200*clhs52 + clhs273*clhs69 - clhs273 + clhs274*clhs71;
+            lhs(6,12)=DN(1,0)*clhs104 + DN(1,1)*clhs166 + DN(1,2)*clhs201 + clhs275;
+            lhs(6,13)=DN(1,0)*clhs116 + DN(1,1)*clhs170 + DN(1,2)*clhs203 + clhs276;
+            lhs(6,14)=DN(1,0)*clhs122 + DN(1,1)*clhs174 + DN(1,2)*clhs205 + clhs248 + clhs277;
+            lhs(6,15)=DN(3,2)*clhs236 + clhs278*clhs69 - clhs278 + clhs279*clhs71;
+            lhs(7,0)=DN(1,0)*clhs209;
+            lhs(7,1)=DN(1,1)*clhs209;
+            lhs(7,2)=DN(1,2)*clhs209;
+            lhs(7,3)=clhs217;
+            lhs(7,4)=DN(1,0)*clhs213;
+            lhs(7,5)=DN(1,1)*clhs213;
+            lhs(7,6)=DN(1,2)*clhs213;
+            lhs(7,7)=clhs210*clhs230 + clhs211*clhs229 + clhs211*clhs254 + clhs211*clhs268;
+            lhs(7,8)=DN(1,0)*clhs219;
+            lhs(7,9)=DN(1,1)*clhs219;
+            lhs(7,10)=DN(1,2)*clhs219;
+            lhs(7,11)=clhs283;
+            lhs(7,12)=DN(1,0)*clhs222;
+            lhs(7,13)=DN(1,1)*clhs222;
+            lhs(7,14)=DN(1,2)*clhs222;
+            lhs(7,15)=clhs284;
+            lhs(8,0)=DN(2,0)*clhs0 + DN(2,1)*clhs2 + DN(2,2)*clhs4 + clhs288 + clhs78;
+            lhs(8,1)=DN(2,0)*clhs22 + DN(2,1)*clhs24 + DN(2,2)*clhs27 + clhs153;
+            lhs(8,2)=DN(2,0)*clhs30 + DN(2,1)*clhs32 + DN(2,2)*clhs34 + clhs193;
+            lhs(8,3)=clhs228*clhs80 + clhs69*clhs98 + clhs71*clhs97 - clhs98;
+            lhs(8,4)=DN(2,0)*clhs44 + DN(2,1)*clhs46 + DN(2,2)*clhs48 + clhs238 + clhs289;
+            lhs(8,5)=DN(2,0)*clhs55 + DN(2,1)*clhs57 + DN(2,2)*clhs60 + clhs257;
+            lhs(8,6)=DN(2,0)*clhs62 + DN(2,1)*clhs64 + DN(2,2)*clhs66 + clhs270;
+            lhs(8,7)=clhs244*clhs71 + clhs245*clhs69 - clhs245 + clhs72*clhs80;
+            lhs(8,8)=DN(2,0)*clhs73 + DN(2,1)*clhs75 + DN(2,2)*clhs77 + clhs10*clhs290 + clhs292;
+            lhs(8,9)=DN(2,0)*clhs84 + DN(2,1)*clhs86 + DN(2,2)*clhs89 + clhs294;
+            lhs(8,10)=DN(2,0)*clhs91 + DN(2,1)*clhs93 + DN(2,2)*clhs95 + clhs295;
+            lhs(8,11)=DN(2,0)*clhs298;
+            lhs(8,12)=DN(2,0)*clhs100 + DN(2,1)*clhs102 + DN(2,2)*clhs104 + clhs299 + clhs302;
+            lhs(8,13)=DN(2,0)*clhs111 + DN(2,1)*clhs113 + DN(2,2)*clhs116 + clhs303;
+            lhs(8,14)=DN(2,0)*clhs118 + DN(2,1)*clhs120 + DN(2,2)*clhs122 + clhs304;
+            lhs(8,15)=DN(3,0)*clhs297 + clhs305*clhs69 - clhs305 + clhs306*clhs71;
+            lhs(9,0)=DN(2,0)*clhs2 + DN(2,1)*clhs126 + DN(2,2)*clhs127 + clhs90;
+            lhs(9,1)=DN(2,0)*clhs24 + DN(2,1)*clhs128 + DN(2,2)*clhs130 + clhs157 + clhs288;
+            lhs(9,2)=DN(2,0)*clhs32 + DN(2,1)*clhs132 + DN(2,2)*clhs134 + clhs195;
+            lhs(9,3)=clhs162*clhs71 + clhs163*clhs69 - clhs163 + clhs253*clhs80;
+            lhs(9,4)=DN(2,0)*clhs46 + DN(2,1)*clhs137 + DN(2,2)*clhs138 + clhs242;
+            lhs(9,5)=DN(2,0)*clhs57 + DN(2,1)*clhs140 + DN(2,2)*clhs142 + clhs258 + clhs289;
+            lhs(9,6)=DN(2,0)*clhs64 + DN(2,1)*clhs144 + DN(2,2)*clhs146 + clhs271;
+            lhs(9,7)=clhs150*clhs80 + clhs260*clhs71 + clhs261*clhs69 - clhs261;
+            lhs(9,8)=DN(2,0)*clhs75 + DN(2,1)*clhs151 + DN(2,2)*clhs152 + clhs294;
+            lhs(9,9)=DN(2,0)*clhs86 + DN(2,1)*clhs154 + DN(2,2)*clhs156 + clhs10*clhs307 + clhs292;
+            lhs(9,10)=DN(2,0)*clhs93 + DN(2,1)*clhs158 + DN(2,2)*clhs160 + clhs309;
+            lhs(9,11)=DN(2,1)*clhs298;
+            lhs(9,12)=DN(2,0)*clhs102 + DN(2,1)*clhs165 + DN(2,2)*clhs166 + clhs310;
+            lhs(9,13)=DN(2,0)*clhs113 + DN(2,1)*clhs168 + DN(2,2)*clhs170 + clhs302 + clhs311;
+            lhs(9,14)=DN(2,0)*clhs120 + DN(2,1)*clhs172 + DN(2,2)*clhs174 + clhs312;
+            lhs(9,15)=DN(3,1)*clhs297 + clhs313*clhs69 - clhs313 + clhs314*clhs71;
+            lhs(10,0)=DN(2,0)*clhs4 + DN(2,1)*clhs127 + DN(2,2)*clhs178 + clhs96;
+            lhs(10,1)=DN(2,0)*clhs27 + DN(2,1)*clhs130 + DN(2,2)*clhs179 + clhs161;
+            lhs(10,2)=DN(2,0)*clhs34 + DN(2,1)*clhs134 + DN(2,2)*clhs180 + clhs197 + clhs288;
+            lhs(10,3)=clhs198*clhs71 + clhs199*clhs69 - clhs199 + clhs267*clhs80;
+            lhs(10,4)=DN(2,0)*clhs48 + DN(2,1)*clhs138 + DN(2,2)*clhs182 + clhs243;
+            lhs(10,5)=DN(2,0)*clhs60 + DN(2,1)*clhs142 + DN(2,2)*clhs185 + clhs259;
+            lhs(10,6)=DN(2,0)*clhs66 + DN(2,1)*clhs146 + DN(2,2)*clhs187 + clhs272 + clhs289;
+            lhs(10,7)=clhs191*clhs80 + clhs273*clhs71 + clhs274*clhs69 - clhs274;
+            lhs(10,8)=DN(2,0)*clhs77 + DN(2,1)*clhs152 + DN(2,2)*clhs192 + clhs295;
+            lhs(10,9)=DN(2,0)*clhs89 + DN(2,1)*clhs156 + DN(2,2)*clhs194 + clhs309;
+            lhs(10,10)=DN(2,0)*clhs95 + DN(2,1)*clhs160 + DN(2,2)*clhs196 + clhs10*clhs315 + clhs292;
+            lhs(10,11)=DN(2,2)*clhs298;
+            lhs(10,12)=DN(2,0)*clhs104 + DN(2,1)*clhs166 + DN(2,2)*clhs201 + clhs317;
+            lhs(10,13)=DN(2,0)*clhs116 + DN(2,1)*clhs170 + DN(2,2)*clhs203 + clhs318;
+            lhs(10,14)=DN(2,0)*clhs122 + DN(2,1)*clhs174 + DN(2,2)*clhs205 + clhs302 + clhs319;
+            lhs(10,15)=DN(3,2)*clhs297 + clhs320*clhs69 - clhs320 + clhs321*clhs71;
+            lhs(11,0)=DN(2,0)*clhs209;
+            lhs(11,1)=DN(2,1)*clhs209;
+            lhs(11,2)=DN(2,2)*clhs209;
+            lhs(11,3)=clhs220;
+            lhs(11,4)=DN(2,0)*clhs213;
+            lhs(11,5)=DN(2,1)*clhs213;
+            lhs(11,6)=DN(2,2)*clhs213;
+            lhs(11,7)=clhs283;
+            lhs(11,8)=DN(2,0)*clhs219;
+            lhs(11,9)=DN(2,1)*clhs219;
+            lhs(11,10)=DN(2,2)*clhs219;
+            lhs(11,11)=clhs210*clhs291 + clhs211*clhs290 + clhs211*clhs307 + clhs211*clhs315;
+            lhs(11,12)=DN(2,0)*clhs222;
+            lhs(11,13)=DN(2,1)*clhs222;
+            lhs(11,14)=DN(2,2)*clhs222;
+            lhs(11,15)=clhs322;
+            lhs(12,0)=DN(3,0)*clhs0 + DN(3,1)*clhs2 + DN(3,2)*clhs4 + clhs105 + clhs326;
+            lhs(12,1)=DN(3,0)*clhs22 + DN(3,1)*clhs24 + DN(3,2)*clhs27 + clhs167;
+            lhs(12,2)=DN(3,0)*clhs30 + DN(3,1)*clhs32 + DN(3,2)*clhs34 + clhs202;
+            lhs(12,3)=clhs107*clhs228 + clhs124*clhs71 + clhs125*clhs69 - clhs125;
+            lhs(12,4)=DN(3,0)*clhs44 + DN(3,1)*clhs46 + DN(3,2)*clhs48 + clhs246 + clhs327;
+            lhs(12,5)=DN(3,0)*clhs55 + DN(3,1)*clhs57 + DN(3,2)*clhs60 + clhs262;
+            lhs(12,6)=DN(3,0)*clhs62 + DN(3,1)*clhs64 + DN(3,2)*clhs66 + clhs275;
+            lhs(12,7)=clhs107*clhs72 + clhs251*clhs71 + clhs252*clhs69 - clhs252;
+            lhs(12,8)=DN(3,0)*clhs73 + DN(3,1)*clhs75 + DN(3,2)*clhs77 + clhs299 + clhs328;
+            lhs(12,9)=DN(3,0)*clhs84 + DN(3,1)*clhs86 + DN(3,2)*clhs89 + clhs310;
+            lhs(12,10)=DN(3,0)*clhs91 + DN(3,1)*clhs93 + DN(3,2)*clhs95 + clhs317;
+            lhs(12,11)=clhs107*clhs99 + clhs305*clhs71 + clhs306*clhs69 - clhs306;
+            lhs(12,12)=DN(3,0)*clhs100 + DN(3,1)*clhs102 + DN(3,2)*clhs104 + clhs10*clhs329 + clhs331;
+            lhs(12,13)=DN(3,0)*clhs111 + DN(3,1)*clhs113 + DN(3,2)*clhs116 + clhs333;
+            lhs(12,14)=DN(3,0)*clhs118 + DN(3,1)*clhs120 + DN(3,2)*clhs122 + clhs334;
+            lhs(12,15)=DN(3,0)*clhs335;
+            lhs(13,0)=DN(3,0)*clhs2 + DN(3,1)*clhs126 + DN(3,2)*clhs127 + clhs117;
+            lhs(13,1)=DN(3,0)*clhs24 + DN(3,1)*clhs128 + DN(3,2)*clhs130 + clhs171 + clhs326;
+            lhs(13,2)=DN(3,0)*clhs32 + DN(3,1)*clhs132 + DN(3,2)*clhs134 + clhs204;
+            lhs(13,3)=clhs107*clhs253 + clhs176*clhs71 + clhs177*clhs69 - clhs177;
+            lhs(13,4)=DN(3,0)*clhs46 + DN(3,1)*clhs137 + DN(3,2)*clhs138 + clhs249;
+            lhs(13,5)=DN(3,0)*clhs57 + DN(3,1)*clhs140 + DN(3,2)*clhs142 + clhs263 + clhs327;
+            lhs(13,6)=DN(3,0)*clhs64 + DN(3,1)*clhs144 + DN(3,2)*clhs146 + clhs276;
+            lhs(13,7)=clhs107*clhs150 + clhs265*clhs71 + clhs266*clhs69 - clhs266;
+            lhs(13,8)=DN(3,0)*clhs75 + DN(3,1)*clhs151 + DN(3,2)*clhs152 + clhs303;
+            lhs(13,9)=DN(3,0)*clhs86 + DN(3,1)*clhs154 + DN(3,2)*clhs156 + clhs311 + clhs328;
+            lhs(13,10)=DN(3,0)*clhs93 + DN(3,1)*clhs158 + DN(3,2)*clhs160 + clhs318;
+            lhs(13,11)=clhs107*clhs164 + clhs313*clhs71 + clhs314*clhs69 - clhs314;
+            lhs(13,12)=DN(3,0)*clhs102 + DN(3,1)*clhs165 + DN(3,2)*clhs166 + clhs333;
+            lhs(13,13)=DN(3,0)*clhs113 + DN(3,1)*clhs168 + DN(3,2)*clhs170 + clhs10*clhs336 + clhs331;
+            lhs(13,14)=DN(3,0)*clhs120 + DN(3,1)*clhs172 + DN(3,2)*clhs174 + clhs337;
+            lhs(13,15)=DN(3,1)*clhs335;
+            lhs(14,0)=DN(3,0)*clhs4 + DN(3,1)*clhs127 + DN(3,2)*clhs178 + clhs123;
+            lhs(14,1)=DN(3,0)*clhs27 + DN(3,1)*clhs130 + DN(3,2)*clhs179 + clhs175;
+            lhs(14,2)=DN(3,0)*clhs34 + DN(3,1)*clhs134 + DN(3,2)*clhs180 + clhs206 + clhs326;
+            lhs(14,3)=clhs107*clhs267 + clhs207*clhs71 + clhs208*clhs69 - clhs208;
+            lhs(14,4)=DN(3,0)*clhs48 + DN(3,1)*clhs138 + DN(3,2)*clhs182 + clhs250;
+            lhs(14,5)=DN(3,0)*clhs60 + DN(3,1)*clhs142 + DN(3,2)*clhs185 + clhs264;
+            lhs(14,6)=DN(3,0)*clhs66 + DN(3,1)*clhs146 + DN(3,2)*clhs187 + clhs277 + clhs327;
+            lhs(14,7)=clhs107*clhs191 + clhs278*clhs71 + clhs279*clhs69 - clhs279;
+            lhs(14,8)=DN(3,0)*clhs77 + DN(3,1)*clhs152 + DN(3,2)*clhs192 + clhs304;
+            lhs(14,9)=DN(3,0)*clhs89 + DN(3,1)*clhs156 + DN(3,2)*clhs194 + clhs312;
+            lhs(14,10)=DN(3,0)*clhs95 + DN(3,1)*clhs160 + DN(3,2)*clhs196 + clhs319 + clhs328;
+            lhs(14,11)=clhs107*clhs200 + clhs320*clhs71 + clhs321*clhs69 - clhs321;
+            lhs(14,12)=DN(3,0)*clhs104 + DN(3,1)*clhs166 + DN(3,2)*clhs201 + clhs334;
+            lhs(14,13)=DN(3,0)*clhs116 + DN(3,1)*clhs170 + DN(3,2)*clhs203 + clhs337;
+            lhs(14,14)=DN(3,0)*clhs122 + DN(3,1)*clhs174 + DN(3,2)*clhs205 + clhs10*clhs338 + clhs331;
+            lhs(14,15)=DN(3,2)*clhs335;
+            lhs(15,0)=DN(3,0)*clhs209;
+            lhs(15,1)=DN(3,1)*clhs209;
+            lhs(15,2)=DN(3,2)*clhs209;
+            lhs(15,3)=clhs223;
+            lhs(15,4)=DN(3,0)*clhs213;
+            lhs(15,5)=DN(3,1)*clhs213;
+            lhs(15,6)=DN(3,2)*clhs213;
+            lhs(15,7)=clhs284;
+            lhs(15,8)=DN(3,0)*clhs219;
+            lhs(15,9)=DN(3,1)*clhs219;
+            lhs(15,10)=DN(3,2)*clhs219;
+            lhs(15,11)=clhs322;
+            lhs(15,12)=DN(3,0)*clhs222;
+            lhs(15,13)=DN(3,1)*clhs222;
+            lhs(15,14)=DN(3,2)*clhs222;
+            lhs(15,15)=clhs210*clhs330 + clhs211*clhs329 + clhs211*clhs336 + clhs211*clhs338;
+
+
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<2>::ComputeGaussPointLHSContribution(bounded_matrix<double,9,9>& lhs, const ElementDataStruct& data)
+{
+    const int nnodes = 3;
+    const int dim = 2;
+    //~ const int strain_size = 3;
+
+    const double rho = inner_prod(data.N, data.rho);        // Density
+    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double h = data.h;                                // Characteristic element size
+    const double c = data.c;                                // Wave velocity
+
+    const double& dt = data.dt;
+    const double& bdf0 = data.bdf0;
+    // const double& bdf1 = data.bdf1;
+    // const double& bdf2 = data.bdf2;
+    const double& dyn_tau = data.dyn_tau;
+
+    const bounded_matrix<double,nnodes,dim>& v = data.v;
+    // const bounded_matrix<double,nnodes,dim>& vn = data.vn;
+    // const bounded_matrix<double,nnodes,dim>& vnn = data.vnn;
+    const bounded_matrix<double,nnodes,dim>& vmesh = data.vmesh;
+    const bounded_matrix<double,nnodes,dim>& vconv = v - vmesh;
+    // const bounded_matrix<double,nnodes,dim>& f = data.f;
+    // const array_1d<double,nnodes>& p = data.p;
+    // const array_1d<double,nnodes>& pn = data.pn;
+    // const array_1d<double,nnodes>& pnn = data.pnn;
+    //~ const array_1d<double,strain_size>& stress = data.stress;
+
+    // Get constitutive matrix
+    const Matrix& C = data.C;
+
+    // Get shape function values
+    const array_1d<double,nnodes>& N = data.N;
+    const bounded_matrix<double,nnodes,dim>& DN = data.DN_DX;
+
+    // const array_1d<double,dim> vconv_gauss = prod(trans(vconv), N);
+
+    // const double vconv_norm = norm_2(vconv_gauss);
+
+    // Stabilization parameters
+    const double stab_c1 = 4.0;
+    const double stab_c2 = 2.0;
+    // const double tau1 = 1.0/((rho*dyn_tau_coeff)/delta_t + (c2*rho*vconv_norm)/h + (c1*mu)/(h*h));
+    // const double tau2 = (h*h)/(c1*tau1);
+
+    const double clhs0 =             C(0,0)*DN(0,0) + C(0,2)*DN(0,1);
+const double clhs1 =             C(0,2)*DN(0,0);
+const double clhs2 =             C(2,2)*DN(0,1) + clhs1;
+const double clhs3 =             pow(DN(0,0), 2);
+const double clhs4 =             N[0]*vconv(0,0) + N[1]*vconv(1,0) + N[2]*vconv(2,0);
+const double clhs5 =             N[0]*vconv(0,1) + N[1]*vconv(1,1) + N[2]*vconv(2,1);
+const double clhs6 =             stab_c2*sqrt(pow(clhs4, 2) + pow(clhs5, 2));
+const double clhs7 =             clhs6*h/stab_c1 + mu;
+const double clhs8 =             pow(N[0], 2);
+const double clhs9 =             bdf0*rho;
+const double clhs10 =             N[0]*rho;
+const double clhs11 =             DN(0,0)*clhs4 + DN(0,1)*clhs5;
+const double clhs12 =             N[0]*bdf0 + clhs11;
+const double clhs13 =             pow(rho, 2);
+const double clhs14 =             DN(0,0)*vconv(0,0) + DN(0,1)*vconv(0,1) + DN(1,0)*vconv(1,0) + DN(1,1)*vconv(1,1) + DN(2,0)*vconv(2,0) + DN(2,1)*vconv(2,1);
+const double clhs15 =             1.0/(clhs6*rho/h + mu*stab_c1/pow(h, 2) + dyn_tau*rho/dt);
+const double clhs16 =             1.0*N[0]*clhs13*clhs14*clhs15;
+const double clhs17 =             1.0*clhs11*clhs13*clhs15;
+const double clhs18 =             clhs10*clhs11 + clhs12*clhs16 + clhs12*clhs17 + clhs8*clhs9;
+const double clhs19 =             C(0,1)*DN(0,1) + clhs1;
+const double clhs20 =             C(1,2)*DN(0,1);
+const double clhs21 =             C(2,2)*DN(0,0) + clhs20;
+const double clhs22 =             DN(0,0)*clhs7;
+const double clhs23 =             DN(0,1)*clhs22;
+const double clhs24 =             -N[0];
+const double clhs25 =             pow(c, -2);
+const double clhs26 =             1.0/rho;
+const double clhs27 =             N[0]*bdf0*clhs25*clhs26;
+const double clhs28 =             1.0*clhs14*clhs15;
+const double clhs29 =             1.0*clhs15*rho;
+const double clhs30 =             clhs11*clhs29;
+const double clhs31 =             clhs10*clhs28 + clhs24 + clhs27*clhs7 + clhs30;
+const double clhs32 =             C(0,0)*DN(1,0) + C(0,2)*DN(1,1);
+const double clhs33 =             C(0,2)*DN(1,0);
+const double clhs34 =             C(2,2)*DN(1,1) + clhs33;
+const double clhs35 =             DN(1,0)*clhs22;
+const double clhs36 =             N[0]*bdf0*rho;
+const double clhs37 =             N[1]*clhs36;
+const double clhs38 =             DN(1,0)*clhs4 + DN(1,1)*clhs5;
+const double clhs39 =             N[1]*bdf0;
+const double clhs40 =             clhs38 + clhs39;
+const double clhs41 =             clhs10*clhs38 + clhs16*clhs40 + clhs17*clhs40 + clhs37;
+const double clhs42 =             C(0,1)*DN(1,1) + clhs33;
+const double clhs43 =             C(1,2)*DN(1,1);
+const double clhs44 =             C(2,2)*DN(1,0) + clhs43;
+const double clhs45 =             DN(1,1)*clhs22;
+const double clhs46 =             DN(0,0)*N[1];
+const double clhs47 =             bdf0*clhs25*clhs26*clhs7;
+const double clhs48 =             DN(1,0)*N[0];
+const double clhs49 =             1.0*clhs14*clhs15*rho;
+const double clhs50 =             1.0*DN(1,0)*clhs15*rho;
+const double clhs51 =             C(0,0)*DN(2,0) + C(0,2)*DN(2,1);
+const double clhs52 =             C(0,2)*DN(2,0);
+const double clhs53 =             C(2,2)*DN(2,1) + clhs52;
+const double clhs54 =             DN(2,0)*clhs22;
+const double clhs55 =             N[2]*clhs36;
+const double clhs56 =             DN(2,0)*clhs4 + DN(2,1)*clhs5;
+const double clhs57 =             N[2]*bdf0;
+const double clhs58 =             clhs56 + clhs57;
+const double clhs59 =             clhs10*clhs56 + clhs16*clhs58 + clhs17*clhs58 + clhs55;
+const double clhs60 =             C(0,1)*DN(2,1) + clhs52;
+const double clhs61 =             C(1,2)*DN(2,1);
+const double clhs62 =             C(2,2)*DN(2,0) + clhs61;
+const double clhs63 =             DN(2,1)*clhs22;
+const double clhs64 =             DN(0,0)*N[2];
+const double clhs65 =             DN(2,0)*N[0];
+const double clhs66 =             C(0,1)*DN(0,0) + clhs20;
+const double clhs67 =             C(1,1)*DN(0,1) + C(1,2)*DN(0,0);
+const double clhs68 =             pow(DN(0,1), 2);
+const double clhs69 =             C(0,1)*DN(1,0) + clhs43;
+const double clhs70 =             DN(0,1)*clhs7;
+const double clhs71 =             DN(1,0)*clhs70;
+const double clhs72 =             C(1,1)*DN(1,1) + C(1,2)*DN(1,0);
+const double clhs73 =             DN(1,1)*clhs70;
+const double clhs74 =             DN(0,1)*N[1];
+const double clhs75 =             DN(1,1)*N[0];
+const double clhs76 =             1.0*DN(1,1)*clhs15*rho;
+const double clhs77 =             C(0,1)*DN(2,0) + clhs61;
+const double clhs78 =             DN(2,0)*clhs70;
+const double clhs79 =             C(1,1)*DN(2,1) + C(1,2)*DN(2,0);
+const double clhs80 =             DN(2,1)*clhs70;
+const double clhs81 =             DN(0,1)*N[2];
+const double clhs82 =             DN(2,1)*N[0];
+const double clhs83 =             clhs12*clhs29 + clhs24;
+const double clhs84 =             bdf0*clhs25*clhs26;
+const double clhs85 =             1.0*clhs15;
+const double clhs86 =             -N[1];
+const double clhs87 =             clhs29*clhs40 + clhs86;
+const double clhs88 =             1.0*DN(0,0)*clhs15;
+const double clhs89 =             1.0*DN(0,1)*clhs15;
+const double clhs90 =             DN(1,0)*clhs88 + DN(1,1)*clhs89 + N[1]*clhs27;
+const double clhs91 =             -N[2];
+const double clhs92 =             clhs29*clhs58 + clhs91;
+const double clhs93 =             DN(2,0)*clhs88 + DN(2,1)*clhs89 + N[2]*clhs27;
+const double clhs94 =             N[1]*rho;
+const double clhs95 =             1.0*N[1]*clhs13*clhs14*clhs15;
+const double clhs96 =             1.0*clhs13*clhs15*clhs38;
+const double clhs97 =             clhs11*clhs94 + clhs12*clhs95 + clhs12*clhs96 + clhs37;
+const double clhs98 =             1.0*DN(0,0)*clhs15*rho;
+const double clhs99 =             pow(DN(1,0), 2);
+const double clhs100 =             pow(N[1], 2);
+const double clhs101 =             clhs100*clhs9 + clhs38*clhs94 + clhs40*clhs95 + clhs40*clhs96;
+const double clhs102 =             DN(1,0)*clhs7;
+const double clhs103 =             DN(1,1)*clhs102;
+const double clhs104 =             clhs25*clhs26*clhs7;
+const double clhs105 =             clhs29*clhs38;
+const double clhs106 =             clhs104*clhs39 + clhs105 + clhs28*clhs94 + clhs86;
+const double clhs107 =             DN(2,0)*clhs102;
+const double clhs108 =             N[1]*N[2]*bdf0;
+const double clhs109 =             clhs108*rho;
+const double clhs110 =             clhs109 + clhs56*clhs94 + clhs58*clhs95 + clhs58*clhs96;
+const double clhs111 =             DN(2,1)*clhs102;
+const double clhs112 =             DN(1,0)*N[2];
+const double clhs113 =             DN(2,0)*N[1];
+const double clhs114 =             1.0*DN(0,1)*clhs15*rho;
+const double clhs115 =             pow(DN(1,1), 2);
+const double clhs116 =             DN(1,1)*clhs7;
+const double clhs117 =             DN(2,0)*clhs116;
+const double clhs118 =             DN(2,1)*clhs116;
+const double clhs119 =             DN(1,1)*N[2];
+const double clhs120 =             DN(2,1)*N[1];
+const double clhs121 =             1.0*DN(1,0)*DN(2,0)*clhs15 + 1.0*DN(1,1)*DN(2,1)*clhs15 + clhs108*clhs25*clhs26;
+const double clhs122 =             N[2]*rho;
+const double clhs123 =             1.0*N[2]*clhs13*clhs14*clhs15;
+const double clhs124 =             1.0*clhs13*clhs15*clhs56;
+const double clhs125 =             clhs11*clhs122 + clhs12*clhs123 + clhs12*clhs124 + clhs55;
+const double clhs126 =             clhs109 + clhs122*clhs38 + clhs123*clhs40 + clhs124*clhs40;
+const double clhs127 =             pow(DN(2,0), 2);
+const double clhs128 =             pow(N[2], 2);
+const double clhs129 =             clhs122*clhs56 + clhs123*clhs58 + clhs124*clhs58 + clhs128*clhs9;
+const double clhs130 =             DN(2,0)*DN(2,1)*clhs7;
+const double clhs131 =             clhs104*clhs57 + clhs122*clhs28 + clhs29*clhs56 + clhs91;
+const double clhs132 =             pow(DN(2,1), 2);
+            lhs(0,0)=DN(0,0)*clhs0 + DN(0,1)*clhs2 + clhs18 + clhs3*clhs7;
+            lhs(0,1)=DN(0,0)*clhs19 + DN(0,1)*clhs21 + clhs23;
+            lhs(0,2)=DN(0,0)*clhs31;
+            lhs(0,3)=DN(0,0)*clhs32 + DN(0,1)*clhs34 + clhs35 + clhs41;
+            lhs(0,4)=DN(0,0)*clhs42 + DN(0,1)*clhs44 + clhs45;
+            lhs(0,5)=clhs11*clhs50 + clhs46*clhs47 - clhs46 + clhs48*clhs49;
+            lhs(0,6)=DN(0,0)*clhs51 + DN(0,1)*clhs53 + clhs54 + clhs59;
+            lhs(0,7)=DN(0,0)*clhs60 + DN(0,1)*clhs62 + clhs63;
+            lhs(0,8)=DN(2,0)*clhs30 + clhs47*clhs64 + clhs49*clhs65 - clhs64;
+            lhs(1,0)=DN(0,0)*clhs2 + DN(0,1)*clhs66 + clhs23;
+            lhs(1,1)=DN(0,0)*clhs21 + DN(0,1)*clhs67 + clhs18 + clhs68*clhs7;
+            lhs(1,2)=DN(0,1)*clhs31;
+            lhs(1,3)=DN(0,0)*clhs34 + DN(0,1)*clhs69 + clhs71;
+            lhs(1,4)=DN(0,0)*clhs44 + DN(0,1)*clhs72 + clhs41 + clhs73;
+            lhs(1,5)=clhs11*clhs76 + clhs47*clhs74 + clhs49*clhs75 - clhs74;
+            lhs(1,6)=DN(0,0)*clhs53 + DN(0,1)*clhs77 + clhs78;
+            lhs(1,7)=DN(0,0)*clhs62 + DN(0,1)*clhs79 + clhs59 + clhs80;
+            lhs(1,8)=DN(2,1)*clhs30 + clhs47*clhs81 + clhs49*clhs82 - clhs81;
+            lhs(2,0)=DN(0,0)*clhs83;
+            lhs(2,1)=DN(0,1)*clhs83;
+            lhs(2,2)=clhs3*clhs85 + clhs68*clhs85 + clhs8*clhs84;
+            lhs(2,3)=DN(0,0)*clhs87;
+            lhs(2,4)=DN(0,1)*clhs87;
+            lhs(2,5)=clhs90;
+            lhs(2,6)=DN(0,0)*clhs92;
+            lhs(2,7)=DN(0,1)*clhs92;
+            lhs(2,8)=clhs93;
+            lhs(3,0)=DN(1,0)*clhs0 + DN(1,1)*clhs2 + clhs35 + clhs97;
+            lhs(3,1)=DN(1,0)*clhs19 + DN(1,1)*clhs21 + clhs71;
+            lhs(3,2)=clhs38*clhs98 + clhs46*clhs49 + clhs47*clhs48 - clhs48;
+            lhs(3,3)=DN(1,0)*clhs32 + DN(1,1)*clhs34 + clhs101 + clhs7*clhs99;
+            lhs(3,4)=DN(1,0)*clhs42 + DN(1,1)*clhs44 + clhs103;
+            lhs(3,5)=DN(1,0)*clhs106;
+            lhs(3,6)=DN(1,0)*clhs51 + DN(1,1)*clhs53 + clhs107 + clhs110;
+            lhs(3,7)=DN(1,0)*clhs60 + DN(1,1)*clhs62 + clhs111;
+            lhs(3,8)=DN(2,0)*clhs105 + clhs112*clhs47 - clhs112 + clhs113*clhs49;
+            lhs(4,0)=DN(1,0)*clhs2 + DN(1,1)*clhs66 + clhs45;
+            lhs(4,1)=DN(1,0)*clhs21 + DN(1,1)*clhs67 + clhs73 + clhs97;
+            lhs(4,2)=clhs114*clhs38 + clhs47*clhs75 + clhs49*clhs74 - clhs75;
+            lhs(4,3)=DN(1,0)*clhs34 + DN(1,1)*clhs69 + clhs103;
+            lhs(4,4)=DN(1,0)*clhs44 + DN(1,1)*clhs72 + clhs101 + clhs115*clhs7;
+            lhs(4,5)=DN(1,1)*clhs106;
+            lhs(4,6)=DN(1,0)*clhs53 + DN(1,1)*clhs77 + clhs117;
+            lhs(4,7)=DN(1,0)*clhs62 + DN(1,1)*clhs79 + clhs110 + clhs118;
+            lhs(4,8)=DN(2,1)*clhs105 + clhs119*clhs47 - clhs119 + clhs120*clhs49;
+            lhs(5,0)=DN(1,0)*clhs83;
+            lhs(5,1)=DN(1,1)*clhs83;
+            lhs(5,2)=clhs90;
+            lhs(5,3)=DN(1,0)*clhs87;
+            lhs(5,4)=DN(1,1)*clhs87;
+            lhs(5,5)=clhs100*clhs84 + clhs115*clhs85 + clhs85*clhs99;
+            lhs(5,6)=DN(1,0)*clhs92;
+            lhs(5,7)=DN(1,1)*clhs92;
+            lhs(5,8)=clhs121;
+            lhs(6,0)=DN(2,0)*clhs0 + DN(2,1)*clhs2 + clhs125 + clhs54;
+            lhs(6,1)=DN(2,0)*clhs19 + DN(2,1)*clhs21 + clhs78;
+            lhs(6,2)=clhs47*clhs65 + clhs49*clhs64 + clhs56*clhs98 - clhs65;
+            lhs(6,3)=DN(2,0)*clhs32 + DN(2,1)*clhs34 + clhs107 + clhs126;
+            lhs(6,4)=DN(2,0)*clhs42 + DN(2,1)*clhs44 + clhs117;
+            lhs(6,5)=clhs112*clhs49 + clhs113*clhs47 - clhs113 + clhs50*clhs56;
+            lhs(6,6)=DN(2,0)*clhs51 + DN(2,1)*clhs53 + clhs127*clhs7 + clhs129;
+            lhs(6,7)=DN(2,0)*clhs60 + DN(2,1)*clhs62 + clhs130;
+            lhs(6,8)=DN(2,0)*clhs131;
+            lhs(7,0)=DN(2,0)*clhs2 + DN(2,1)*clhs66 + clhs63;
+            lhs(7,1)=DN(2,0)*clhs21 + DN(2,1)*clhs67 + clhs125 + clhs80;
+            lhs(7,2)=clhs114*clhs56 + clhs47*clhs82 + clhs49*clhs81 - clhs82;
+            lhs(7,3)=DN(2,0)*clhs34 + DN(2,1)*clhs69 + clhs111;
+            lhs(7,4)=DN(2,0)*clhs44 + DN(2,1)*clhs72 + clhs118 + clhs126;
+            lhs(7,5)=clhs119*clhs49 + clhs120*clhs47 - clhs120 + clhs56*clhs76;
+            lhs(7,6)=DN(2,0)*clhs53 + DN(2,1)*clhs77 + clhs130;
+            lhs(7,7)=DN(2,0)*clhs62 + DN(2,1)*clhs79 + clhs129 + clhs132*clhs7;
+            lhs(7,8)=DN(2,1)*clhs131;
+            lhs(8,0)=DN(2,0)*clhs83;
+            lhs(8,1)=DN(2,1)*clhs83;
+            lhs(8,2)=clhs93;
+            lhs(8,3)=DN(2,0)*clhs87;
+            lhs(8,4)=DN(2,1)*clhs87;
+            lhs(8,5)=clhs121;
+            lhs(8,6)=DN(2,0)*clhs92;
+            lhs(8,7)=DN(2,1)*clhs92;
+            lhs(8,8)=clhs127*clhs85 + clhs128*clhs84 + clhs132*clhs85;
+
+
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<3>::ComputeGaussPointRHSContribution(array_1d<double,16>& rhs, const ElementDataStruct& data)
+{
+    const int nnodes = 4;
+    const int dim = 3;
+    const int strain_size = 6;
+
+    const double rho = inner_prod(data.N, data.rho);        // Density
+    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double h = data.h;                                // Characteristic element size
+    const double c = data.c;                                // Wave velocity
+
+    const double& dt = data.dt;
+    const double& bdf0 = data.bdf0;
+    const double& bdf1 = data.bdf1;
+    const double& bdf2 = data.bdf2;
+    const double& dyn_tau = data.dyn_tau;
+
+    const bounded_matrix<double,nnodes,dim>& v = data.v;
+    const bounded_matrix<double,nnodes,dim>& vn = data.vn;
+    const bounded_matrix<double,nnodes,dim>& vnn = data.vnn;
+    const bounded_matrix<double,nnodes,dim>& vmesh = data.vmesh;
+    const bounded_matrix<double,nnodes,dim>& vconv = v - vmesh;
+    const bounded_matrix<double,nnodes,dim>& f = data.f;
+    const array_1d<double,nnodes>& p = data.p;
+    const array_1d<double,nnodes>& pn = data.pn;
+    const array_1d<double,nnodes>& pnn = data.pnn;
+    const array_1d<double,strain_size>& stress = data.stress;
+
+    // Get constitutive matrix
+    // const Matrix& C = data.C;
+
+    // Get shape function values
+    const array_1d<double,nnodes>& N = data.N;
+    const bounded_matrix<double,nnodes,dim>& DN = data.DN_DX;
+
+    // Auxiliary variables used in the calculation of the RHS
+    const array_1d<double,dim> f_gauss = prod(trans(f), N);
+    const array_1d<double,dim> grad_p = prod(trans(DN), p);
+    // const array_1d<double,dim> vconv_gauss = prod(trans(vconv), N);
+    //~ const double p_gauss = inner_prod(N,p);
+
+    // const double vconv_norm = norm_2(vconv_gauss);
+
+    //~ array_1d<double,dim> accel_gauss = bdf0*v_gauss;
+    //~ noalias(accel_gauss) += bdf1*prod(trans(vn), N);
+    //~ noalias(accel_gauss) += bdf2*prod(trans(vnn), N);
+
+    // Stabilization parameters
+    const double stab_c1 = 4.0;
+    const double stab_c2 = 2.0;
+    // const double tau1 = 1.0/((rho*dyn_tau_coeff)/delta_t + (c2*rho*vconv_norm)/h + (c1*mu)/(h*h));
+    // const double tau2 = (h*h)/(c1*tau1);
+
+    const double crhs0 =             N[0]*p[0] + N[1]*p[1] + N[2]*p[2] + N[3]*p[3];
+const double crhs1 =             rho*(N[0]*f(0,0) + N[1]*f(1,0) + N[2]*f(2,0) + N[3]*f(3,0));
+const double crhs2 =             rho*(N[0]*(bdf0*v(0,0) + bdf1*vn(0,0) + bdf2*vnn(0,0)) + N[1]*(bdf0*v(1,0) + bdf1*vn(1,0) + bdf2*vnn(1,0)) + N[2]*(bdf0*v(2,0) + bdf1*vn(2,0) + bdf2*vnn(2,0)) + N[3]*(bdf0*v(3,0) + bdf1*vn(3,0) + bdf2*vnn(3,0)));
+const double crhs3 =             DN(0,0)*v(0,0);
+const double crhs4 =             DN(1,0)*v(1,0);
+const double crhs5 =             DN(2,0)*v(2,0);
+const double crhs6 =             DN(3,0)*v(3,0);
+const double crhs7 =             N[0]*vconv(0,0) + N[1]*vconv(1,0) + N[2]*vconv(2,0) + N[3]*vconv(3,0);
+const double crhs8 =             N[0]*vconv(0,1) + N[1]*vconv(1,1) + N[2]*vconv(2,1) + N[3]*vconv(3,1);
+const double crhs9 =             N[0]*vconv(0,2) + N[1]*vconv(1,2) + N[2]*vconv(2,2) + N[3]*vconv(3,2);
+const double crhs10 =             rho*(crhs7*(crhs3 + crhs4 + crhs5 + crhs6) + crhs8*(DN(0,1)*v(0,0) + DN(1,1)*v(1,0) + DN(2,1)*v(2,0) + DN(3,1)*v(3,0)) + crhs9*(DN(0,2)*v(0,0) + DN(1,2)*v(1,0) + DN(2,2)*v(2,0) + DN(3,2)*v(3,0)));
+const double crhs11 =             stab_c2*sqrt(pow(crhs7, 2) + pow(crhs8, 2) + pow(crhs9, 2));
+const double crhs12 =             DN(0,2)*v(0,2) + DN(1,2)*v(1,2) + DN(2,2)*v(2,2) + DN(3,2)*v(3,2);
+const double crhs13 =             DN(0,1)*v(0,1);
+const double crhs14 =             DN(1,1)*v(1,1);
+const double crhs15 =             DN(2,1)*v(2,1);
+const double crhs16 =             DN(3,1)*v(3,1);
+const double crhs17 =             (N[0]*(bdf0*p[0] + bdf1*pn[0] + bdf2*pnn[0]) + N[1]*(bdf0*p[1] + bdf1*pn[1] + bdf2*pnn[1]) + N[2]*(bdf0*p[2] + bdf1*pn[2] + bdf2*pnn[2]) + N[3]*(bdf0*p[3] + bdf1*pn[3] + bdf2*pnn[3]))/(pow(c, 2)*rho);
+const double crhs18 =             (crhs11*h/stab_c1 + mu)*(crhs12 + crhs13 + crhs14 + crhs15 + crhs16 + crhs17 + crhs3 + crhs4 + crhs5 + crhs6);
+const double crhs19 =             DN(0,0)*vconv(0,0) + DN(0,1)*vconv(0,1) + DN(0,2)*vconv(0,2) + DN(1,0)*vconv(1,0) + DN(1,1)*vconv(1,1) + DN(1,2)*vconv(1,2) + DN(2,0)*vconv(2,0) + DN(2,1)*vconv(2,1) + DN(2,2)*vconv(2,2) + DN(3,0)*vconv(3,0) + DN(3,1)*vconv(3,1) + DN(3,2)*vconv(3,2);
+const double crhs20 =             N[0]*crhs19*rho;
+const double crhs21 =             1.0/(crhs11*rho/h + mu*stab_c1/pow(h, 2) + dyn_tau*rho/dt);
+const double crhs22 =             1.0*crhs21*(DN(0,0)*p[0] + DN(1,0)*p[1] + DN(2,0)*p[2] + DN(3,0)*p[3] - crhs1 + crhs10 + crhs2);
+const double crhs23 =             rho*(DN(0,0)*crhs7 + DN(0,1)*crhs8 + DN(0,2)*crhs9);
+const double crhs24 =             rho*(N[0]*f(0,1) + N[1]*f(1,1) + N[2]*f(2,1) + N[3]*f(3,1));
+const double crhs25 =             rho*(N[0]*(bdf0*v(0,1) + bdf1*vn(0,1) + bdf2*vnn(0,1)) + N[1]*(bdf0*v(1,1) + bdf1*vn(1,1) + bdf2*vnn(1,1)) + N[2]*(bdf0*v(2,1) + bdf1*vn(2,1) + bdf2*vnn(2,1)) + N[3]*(bdf0*v(3,1) + bdf1*vn(3,1) + bdf2*vnn(3,1)));
+const double crhs26 =             rho*(crhs7*(DN(0,0)*v(0,1) + DN(1,0)*v(1,1) + DN(2,0)*v(2,1) + DN(3,0)*v(3,1)) + crhs8*(crhs13 + crhs14 + crhs15 + crhs16) + crhs9*(DN(0,2)*v(0,1) + DN(1,2)*v(1,1) + DN(2,2)*v(2,1) + DN(3,2)*v(3,1)));
+const double crhs27 =             1.0*crhs21*(DN(0,1)*p[0] + DN(1,1)*p[1] + DN(2,1)*p[2] + DN(3,1)*p[3] - crhs24 + crhs25 + crhs26);
+const double crhs28 =             rho*(N[0]*f(0,2) + N[1]*f(1,2) + N[2]*f(2,2) + N[3]*f(3,2));
+const double crhs29 =             rho*(N[0]*(bdf0*v(0,2) + bdf1*vn(0,2) + bdf2*vnn(0,2)) + N[1]*(bdf0*v(1,2) + bdf1*vn(1,2) + bdf2*vnn(1,2)) + N[2]*(bdf0*v(2,2) + bdf1*vn(2,2) + bdf2*vnn(2,2)) + N[3]*(bdf0*v(3,2) + bdf1*vn(3,2) + bdf2*vnn(3,2)));
+const double crhs30 =             rho*(crhs12*crhs9 + crhs7*(DN(0,0)*v(0,2) + DN(1,0)*v(1,2) + DN(2,0)*v(2,2) + DN(3,0)*v(3,2)) + crhs8*(DN(0,1)*v(0,2) + DN(1,1)*v(1,2) + DN(2,1)*v(2,2) + DN(3,1)*v(3,2)));
+const double crhs31 =             1.0*crhs21*(DN(0,2)*p[0] + DN(1,2)*p[1] + DN(2,2)*p[2] + DN(3,2)*p[3] - crhs28 + crhs29 + crhs30);
+const double crhs32 =             N[0]*v(0,0) + N[1]*v(1,0) + N[2]*v(2,0) + N[3]*v(3,0);
+const double crhs33 =             N[0]*v(0,1) + N[1]*v(1,1) + N[2]*v(2,1) + N[3]*v(3,1);
+const double crhs34 =             N[0]*v(0,2) + N[1]*v(1,2) + N[2]*v(2,2) + N[3]*v(3,2);
+const double crhs35 =             N[1]*crhs19*rho;
+const double crhs36 =             rho*(DN(1,0)*crhs7 + DN(1,1)*crhs8 + DN(1,2)*crhs9);
+const double crhs37 =             N[2]*crhs19*rho;
+const double crhs38 =             rho*(DN(2,0)*crhs7 + DN(2,1)*crhs8 + DN(2,2)*crhs9);
+const double crhs39 =             N[3]*crhs19*rho;
+const double crhs40 =             rho*(DN(3,0)*crhs7 + DN(3,1)*crhs8 + DN(3,2)*crhs9);
+            rhs[0]=DN(0,0)*crhs0 - DN(0,0)*crhs18 - DN(0,0)*stress[0] - DN(0,1)*stress[3] - DN(0,2)*stress[5] + N[0]*crhs1 - N[0]*crhs10 - N[0]*crhs2 - crhs20*crhs22 - crhs22*crhs23;
+            rhs[1]=-DN(0,0)*stress[3] + DN(0,1)*crhs0 - DN(0,1)*crhs18 - DN(0,1)*stress[1] - DN(0,2)*stress[4] + N[0]*crhs24 - N[0]*crhs25 - N[0]*crhs26 - crhs20*crhs27 - crhs23*crhs27;
+            rhs[2]=-DN(0,0)*stress[5] - DN(0,1)*stress[4] + DN(0,2)*crhs0 - DN(0,2)*crhs18 - DN(0,2)*stress[2] + N[0]*crhs28 - N[0]*crhs29 - N[0]*crhs30 - crhs20*crhs31 - crhs23*crhs31;
+            rhs[3]=-DN(0,0)*crhs22 + DN(0,0)*crhs32 - DN(0,1)*crhs27 + DN(0,1)*crhs33 - DN(0,2)*crhs31 + DN(0,2)*crhs34 - N[0]*crhs17;
+            rhs[4]=DN(1,0)*crhs0 - DN(1,0)*crhs18 - DN(1,0)*stress[0] - DN(1,1)*stress[3] - DN(1,2)*stress[5] + N[1]*crhs1 - N[1]*crhs10 - N[1]*crhs2 - crhs22*crhs35 - crhs22*crhs36;
+            rhs[5]=-DN(1,0)*stress[3] + DN(1,1)*crhs0 - DN(1,1)*crhs18 - DN(1,1)*stress[1] - DN(1,2)*stress[4] + N[1]*crhs24 - N[1]*crhs25 - N[1]*crhs26 - crhs27*crhs35 - crhs27*crhs36;
+            rhs[6]=-DN(1,0)*stress[5] - DN(1,1)*stress[4] + DN(1,2)*crhs0 - DN(1,2)*crhs18 - DN(1,2)*stress[2] + N[1]*crhs28 - N[1]*crhs29 - N[1]*crhs30 - crhs31*crhs35 - crhs31*crhs36;
+            rhs[7]=-DN(1,0)*crhs22 + DN(1,0)*crhs32 - DN(1,1)*crhs27 + DN(1,1)*crhs33 - DN(1,2)*crhs31 + DN(1,2)*crhs34 - N[1]*crhs17;
+            rhs[8]=DN(2,0)*crhs0 - DN(2,0)*crhs18 - DN(2,0)*stress[0] - DN(2,1)*stress[3] - DN(2,2)*stress[5] + N[2]*crhs1 - N[2]*crhs10 - N[2]*crhs2 - crhs22*crhs37 - crhs22*crhs38;
+            rhs[9]=-DN(2,0)*stress[3] + DN(2,1)*crhs0 - DN(2,1)*crhs18 - DN(2,1)*stress[1] - DN(2,2)*stress[4] + N[2]*crhs24 - N[2]*crhs25 - N[2]*crhs26 - crhs27*crhs37 - crhs27*crhs38;
+            rhs[10]=-DN(2,0)*stress[5] - DN(2,1)*stress[4] + DN(2,2)*crhs0 - DN(2,2)*crhs18 - DN(2,2)*stress[2] + N[2]*crhs28 - N[2]*crhs29 - N[2]*crhs30 - crhs31*crhs37 - crhs31*crhs38;
+            rhs[11]=-DN(2,0)*crhs22 + DN(2,0)*crhs32 - DN(2,1)*crhs27 + DN(2,1)*crhs33 - DN(2,2)*crhs31 + DN(2,2)*crhs34 - N[2]*crhs17;
+            rhs[12]=DN(3,0)*crhs0 - DN(3,0)*crhs18 - DN(3,0)*stress[0] - DN(3,1)*stress[3] - DN(3,2)*stress[5] + N[3]*crhs1 - N[3]*crhs10 - N[3]*crhs2 - crhs22*crhs39 - crhs22*crhs40;
+            rhs[13]=-DN(3,0)*stress[3] + DN(3,1)*crhs0 - DN(3,1)*crhs18 - DN(3,1)*stress[1] - DN(3,2)*stress[4] + N[3]*crhs24 - N[3]*crhs25 - N[3]*crhs26 - crhs27*crhs39 - crhs27*crhs40;
+            rhs[14]=-DN(3,0)*stress[5] - DN(3,1)*stress[4] + DN(3,2)*crhs0 - DN(3,2)*crhs18 - DN(3,2)*stress[2] + N[3]*crhs28 - N[3]*crhs29 - N[3]*crhs30 - crhs31*crhs39 - crhs31*crhs40;
+            rhs[15]=-DN(3,0)*crhs22 + DN(3,0)*crhs32 - DN(3,1)*crhs27 + DN(3,1)*crhs33 - DN(3,2)*crhs31 + DN(3,2)*crhs34 - N[3]*crhs17;
+
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<2>::ComputeGaussPointRHSContribution(array_1d<double,9>& rhs, const ElementDataStruct& data)
+{
+    const int nnodes = 3;
+    const int dim = 2;
+    const int strain_size = 3;
+
+    const double rho = inner_prod(data.N, data.rho);        // Density
+    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double h = data.h;                                // Characteristic element size
+    const double c = data.c;                                // Wave velocity
+
+    const double& dt = data.dt;
+    const double& bdf0 = data.bdf0;
+    const double& bdf1 = data.bdf1;
+    const double& bdf2 = data.bdf2;
+    const double& dyn_tau = data.dyn_tau;
+
+    const bounded_matrix<double,nnodes,dim>& v = data.v;
+    const bounded_matrix<double,nnodes,dim>& vn = data.vn;
+    const bounded_matrix<double,nnodes,dim>& vnn = data.vnn;
+    const bounded_matrix<double,nnodes,dim>& vmesh = data.vmesh;
+    const bounded_matrix<double,nnodes,dim>& vconv = v - vmesh;
+    const bounded_matrix<double,nnodes,dim>& f = data.f;
+    const array_1d<double,nnodes>& p = data.p;
+    const array_1d<double,nnodes>& pn = data.pn;
+    const array_1d<double,nnodes>& pnn = data.pnn;
+    const array_1d<double,strain_size>& stress = data.stress;
+
+    // Get constitutive matrix
+    // const Matrix& C = data.C;
+
+    // Get shape function values
+    const array_1d<double,nnodes>& N = data.N;
+    const bounded_matrix<double,nnodes,dim>& DN = data.DN_DX;
+
+    // Auxiliary variables used in the calculation of the RHS
+    const array_1d<double,dim> f_gauss = prod(trans(f), N);
+    const array_1d<double,dim> grad_p = prod(trans(DN), p);
+    // const array_1d<double,dim> vconv_gauss = prod(trans(vconv), N);
+    //~ const double p_gauss = inner_prod(N,p);
+
+    // const double vconv_norm = norm_2(vconv_gauss);
+
+    //~ array_1d<double,dim> accel_gauss = bdf0*v_gauss;
+    //~ noalias(accel_gauss) += bdf1*prod(trans(vn), N);
+    //~ noalias(accel_gauss) += bdf2*prod(trans(vnn), N);
+
+    // Stabilization parameters
+    const double stab_c1 = 4.0;
+    const double stab_c2 = 2.0;
+    // const double tau1 = 1.0/((rho*dyn_tau_coeff)/delta_t + (c2*rho*vconv_norm)/h + (c1*mu)/(h*h));
+    // const double tau2 = (h*h)/(c1*tau1);
+
+    const double crhs0 =             N[0]*p[0] + N[1]*p[1] + N[2]*p[2];
+const double crhs1 =             rho*(N[0]*f(0,0) + N[1]*f(1,0) + N[2]*f(2,0));
+const double crhs2 =             rho*(N[0]*(bdf0*v(0,0) + bdf1*vn(0,0) + bdf2*vnn(0,0)) + N[1]*(bdf0*v(1,0) + bdf1*vn(1,0) + bdf2*vnn(1,0)) + N[2]*(bdf0*v(2,0) + bdf1*vn(2,0) + bdf2*vnn(2,0)));
+const double crhs3 =             DN(0,0)*v(0,0);
+const double crhs4 =             DN(1,0)*v(1,0);
+const double crhs5 =             DN(2,0)*v(2,0);
+const double crhs6 =             N[0]*vconv(0,0) + N[1]*vconv(1,0) + N[2]*vconv(2,0);
+const double crhs7 =             N[0]*vconv(0,1) + N[1]*vconv(1,1) + N[2]*vconv(2,1);
+const double crhs8 =             rho*(crhs6*(crhs3 + crhs4 + crhs5) + crhs7*(DN(0,1)*v(0,0) + DN(1,1)*v(1,0) + DN(2,1)*v(2,0)));
+const double crhs9 =             stab_c2*sqrt(pow(crhs6, 2) + pow(crhs7, 2));
+const double crhs10 =             DN(0,1)*v(0,1) + DN(1,1)*v(1,1) + DN(2,1)*v(2,1);
+const double crhs11 =             (N[0]*(bdf0*p[0] + bdf1*pn[0] + bdf2*pnn[0]) + N[1]*(bdf0*p[1] + bdf1*pn[1] + bdf2*pnn[1]) + N[2]*(bdf0*p[2] + bdf1*pn[2] + bdf2*pnn[2]))/(pow(c, 2)*rho);
+const double crhs12 =             (crhs9*h/stab_c1 + mu)*(crhs10 + crhs11 + crhs3 + crhs4 + crhs5);
+const double crhs13 =             DN(0,0)*vconv(0,0) + DN(0,1)*vconv(0,1) + DN(1,0)*vconv(1,0) + DN(1,1)*vconv(1,1) + DN(2,0)*vconv(2,0) + DN(2,1)*vconv(2,1);
+const double crhs14 =             N[0]*crhs13*rho;
+const double crhs15 =             1.0/(crhs9*rho/h + mu*stab_c1/pow(h, 2) + dyn_tau*rho/dt);
+const double crhs16 =             1.0*crhs15*(DN(0,0)*p[0] + DN(1,0)*p[1] + DN(2,0)*p[2] - crhs1 + crhs2 + crhs8);
+const double crhs17 =             rho*(DN(0,0)*crhs6 + DN(0,1)*crhs7);
+const double crhs18 =             rho*(N[0]*f(0,1) + N[1]*f(1,1) + N[2]*f(2,1));
+const double crhs19 =             rho*(N[0]*(bdf0*v(0,1) + bdf1*vn(0,1) + bdf2*vnn(0,1)) + N[1]*(bdf0*v(1,1) + bdf1*vn(1,1) + bdf2*vnn(1,1)) + N[2]*(bdf0*v(2,1) + bdf1*vn(2,1) + bdf2*vnn(2,1)));
+const double crhs20 =             rho*(crhs10*crhs7 + crhs6*(DN(0,0)*v(0,1) + DN(1,0)*v(1,1) + DN(2,0)*v(2,1)));
+const double crhs21 =             1.0*crhs15*(DN(0,1)*p[0] + DN(1,1)*p[1] + DN(2,1)*p[2] - crhs18 + crhs19 + crhs20);
+const double crhs22 =             N[0]*v(0,0) + N[1]*v(1,0) + N[2]*v(2,0);
+const double crhs23 =             N[0]*v(0,1) + N[1]*v(1,1) + N[2]*v(2,1);
+const double crhs24 =             N[1]*crhs13*rho;
+const double crhs25 =             rho*(DN(1,0)*crhs6 + DN(1,1)*crhs7);
+const double crhs26 =             N[2]*crhs13*rho;
+const double crhs27 =             rho*(DN(2,0)*crhs6 + DN(2,1)*crhs7);
+            rhs[0]=DN(0,0)*crhs0 - DN(0,0)*crhs12 - DN(0,0)*stress[0] - DN(0,1)*stress[2] + N[0]*crhs1 - N[0]*crhs2 - N[0]*crhs8 - crhs14*crhs16 - crhs16*crhs17;
+            rhs[1]=-DN(0,0)*stress[2] + DN(0,1)*crhs0 - DN(0,1)*crhs12 - DN(0,1)*stress[1] + N[0]*crhs18 - N[0]*crhs19 - N[0]*crhs20 - crhs14*crhs21 - crhs17*crhs21;
+            rhs[2]=-DN(0,0)*crhs16 + DN(0,0)*crhs22 - DN(0,1)*crhs21 + DN(0,1)*crhs23 - N[0]*crhs11;
+            rhs[3]=DN(1,0)*crhs0 - DN(1,0)*crhs12 - DN(1,0)*stress[0] - DN(1,1)*stress[2] + N[1]*crhs1 - N[1]*crhs2 - N[1]*crhs8 - crhs16*crhs24 - crhs16*crhs25;
+            rhs[4]=-DN(1,0)*stress[2] + DN(1,1)*crhs0 - DN(1,1)*crhs12 - DN(1,1)*stress[1] + N[1]*crhs18 - N[1]*crhs19 - N[1]*crhs20 - crhs21*crhs24 - crhs21*crhs25;
+            rhs[5]=-DN(1,0)*crhs16 + DN(1,0)*crhs22 - DN(1,1)*crhs21 + DN(1,1)*crhs23 - N[1]*crhs11;
+            rhs[6]=DN(2,0)*crhs0 - DN(2,0)*crhs12 - DN(2,0)*stress[0] - DN(2,1)*stress[2] + N[2]*crhs1 - N[2]*crhs2 - N[2]*crhs8 - crhs16*crhs26 - crhs16*crhs27;
+            rhs[7]=-DN(2,0)*stress[2] + DN(2,1)*crhs0 - DN(2,1)*crhs12 - DN(2,1)*stress[1] + N[2]*crhs18 - N[2]*crhs19 - N[2]*crhs20 - crhs21*crhs26 - crhs21*crhs27;
+            rhs[8]=-DN(2,0)*crhs16 + DN(2,0)*crhs22 - DN(2,1)*crhs21 + DN(2,1)*crhs23 - N[2]*crhs11;
+
+}
+
+}

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
@@ -1,0 +1,632 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#if !defined(KRATOS_EMBEDDED_AUSAS_NAVIER_STOKES)
+#define  KRATOS_EMBEDDED_AUSAS_NAVIER_STOKES
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+#include "includes/element.h"
+#include "includes/ublas_interface.h"
+#include "includes/variables.h"
+#include "includes/serializer.h"
+#include "utilities/geometry_utilities.h"
+#include "includes/cfd_variables.h"
+
+// Application includes
+#include "fluid_dynamics_application_variables.h"
+
+namespace Kratos
+{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+// TODO: UPDATE THIS INFORMATION
+/**this element is a 3D stokes element, stabilized by employing an ASGS stabilization
+* formulation is described in the file:
+*    https://drive.google.com/file/d/0B_gRLnSH5vCwZ2Zxd09YUmlPZ28/view?usp=sharing
+* symbolic implementation is defined in the file:
+*    https://drive.google.com/file/d/0B_gRLnSH5vCwaXRKRUpDbmx4VXM/view?usp=sharing
+*/
+template< unsigned int TDim, unsigned int TNumNodes = TDim + 1 >
+class EmbeddedAusasNavierStokes : public Element
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Counted pointer of
+    KRATOS_CLASS_POINTER_DEFINITION(EmbeddedAusasNavierStokes);
+
+    struct ElementDataStruct
+    {
+        bounded_matrix<double, TNumNodes, TDim> v, vn, vnn, vmesh, f;
+        array_1d<double,TNumNodes> p, pn, pnn, rho, mu;
+
+        bounded_matrix<double, TNumNodes, TDim > DN_DX;
+        array_1d<double, TNumNodes > N;
+
+        Matrix C;
+        Vector stress;
+        Vector strain;
+
+        double bdf0;
+        double bdf1;
+        double bdf2;
+        double c;             // Wave velocity (needed if artificial compressibility is considered)
+        double h;             // Element size
+        double volume;        // In 2D: element area. In 3D: element volume
+        double dt;            // Time increment
+        double dyn_tau;       // Dynamic tau considered in ASGS stabilization coefficients
+    };
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+
+    EmbeddedAusasNavierStokes(IndexType NewId, GeometryType::Pointer pGeometry)
+    : Element(NewId, pGeometry)
+    {}
+
+    EmbeddedAusasNavierStokes(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties)
+    : Element(NewId, pGeometry, pProperties)
+    {}
+
+    /// Destructor.
+    ~EmbeddedAusasNavierStokes() override {};
+
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& rThisNodes, PropertiesType::Pointer pProperties) const override
+    {
+        KRATOS_TRY
+        return boost::make_shared< EmbeddedAusasNavierStokes < TDim, TNumNodes > >(NewId, this->GetGeometry().Create(rThisNodes), pProperties);
+        KRATOS_CATCH("");
+    }
+
+    Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override
+    {
+        KRATOS_TRY
+        return boost::make_shared< EmbeddedAusasNavierStokes < TDim, TNumNodes > >(NewId, pGeom, pProperties);
+        KRATOS_CATCH("");
+    }
+
+
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+                              VectorType& rRightHandSideVector,
+                              ProcessInfo& rCurrentProcessInfo) override
+    {
+        KRATOS_TRY
+
+        constexpr unsigned int MatrixSize = TNumNodes*(TDim+1);
+
+        if (rLeftHandSideMatrix.size1() != MatrixSize)
+            rLeftHandSideMatrix.resize(MatrixSize, MatrixSize, false); //false says not to preserve existing storage!!
+
+        if (rRightHandSideVector.size() != MatrixSize)
+            rRightHandSideVector.resize(MatrixSize, false); //false says not to preserve existing storage!!
+
+        // Struct to pass around the data
+        ElementDataStruct data;
+        this->FillElementData(data, rCurrentProcessInfo);
+
+        // Allocate memory needed
+        bounded_matrix<double,MatrixSize, MatrixSize> lhs_local;
+        array_1d<double,MatrixSize> rhs_local;
+
+        // Loop on gauss points
+        noalias(rLeftHandSideMatrix) = ZeroMatrix(MatrixSize,MatrixSize);
+        noalias(rRightHandSideVector) = ZeroVector(MatrixSize);
+
+        // Gauss point position
+        bounded_matrix<double,TNumNodes, TNumNodes> Ncontainer;
+        GetShapeFunctionsOnGauss(Ncontainer);
+
+        for(unsigned int igauss = 0; igauss<Ncontainer.size2(); ++igauss)
+        {
+            noalias(data.N) = row(Ncontainer, igauss);
+
+            ComputeConstitutiveResponse(data, rCurrentProcessInfo);
+
+            ComputeGaussPointRHSContribution(rhs_local, data);
+            ComputeGaussPointLHSContribution(lhs_local, data);
+
+            // here we assume that all the weights of the gauss points are the same so we multiply at the end by Volume/n_nodes
+            noalias(rLeftHandSideMatrix) += lhs_local;
+            noalias(rRightHandSideVector) += rhs_local;
+        }
+
+        rLeftHandSideMatrix  *= data.volume/static_cast<double>(TNumNodes);
+        rRightHandSideVector *= data.volume/static_cast<double>(TNumNodes);
+
+        KRATOS_CATCH("Error in embedded Ausas Navier-Stokes element!")
+    }
+
+
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                ProcessInfo& rCurrentProcessInfo) override
+    {
+        KRATOS_TRY
+
+        constexpr unsigned int MatrixSize = TNumNodes*(TDim+1);
+
+        if (rRightHandSideVector.size() != MatrixSize)
+            rRightHandSideVector.resize(MatrixSize, false); //false says not to preserve existing storage!!
+
+        // Struct to pass around the data
+        ElementDataStruct data;
+        this->FillElementData(data, rCurrentProcessInfo);
+
+        // Allocate memory needed
+        array_1d<double,MatrixSize> rhs_local;
+
+        // Gauss point position
+        bounded_matrix<double,TNumNodes, TNumNodes> Ncontainer;
+        GetShapeFunctionsOnGauss(Ncontainer);
+
+        // Loop on gauss point
+        noalias(rRightHandSideVector) = ZeroVector(MatrixSize);
+        for(unsigned int igauss = 0; igauss<Ncontainer.size2(); igauss++)
+        {
+            noalias(data.N) = row(Ncontainer, igauss);
+
+            ComputeConstitutiveResponse(data, rCurrentProcessInfo);
+
+            ComputeGaussPointRHSContribution(rhs_local, data);
+
+            //here we assume that all the weights of the gauss points are the same so we multiply at the end by Volume/n_nodes
+            noalias(rRightHandSideVector) += rhs_local;
+        }
+
+        // rRightHandSideVector *= Volume/static_cast<double>(TNumNodes);
+        rRightHandSideVector *= data.volume/static_cast<double>(TNumNodes);
+
+        KRATOS_CATCH("")
+    }
+
+    /// Checks the input and that all required Kratos variables have been registered.
+    /**
+     * This function provides the place to perform checks on the completeness of the input.
+     * It is designed to be called only once (or anyway, not often) typically at the beginning
+     * of the calculations, so to verify that nothing is missing from the input
+     * or that no common error is found.
+     * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
+     * @return 0 if no errors were found.
+     */
+    int Check(const ProcessInfo& rCurrentProcessInfo) override
+    {
+        KRATOS_TRY
+
+        // Perform basic element checks
+        int ErrorCode = Kratos::Element::Check(rCurrentProcessInfo);
+        if(ErrorCode != 0) return ErrorCode;
+
+        // Check that all required variables have been registered
+        if(VELOCITY.Key() == 0)
+            KRATOS_THROW_ERROR(std::invalid_argument,"VELOCITY Key is 0. Check if the application was correctly registered.","");
+        if(PRESSURE.Key() == 0)
+            KRATOS_THROW_ERROR(std::invalid_argument,"PRESSURE Key is 0. Check if the application was correctly registered.","");
+        if(DENSITY.Key() == 0)
+            KRATOS_THROW_ERROR(std::invalid_argument,"DENSITY Key is 0. Check if the application was correctly registered.","");
+        if(DYNAMIC_TAU.Key() == 0)
+            KRATOS_THROW_ERROR(std::invalid_argument,"DYNAMIC_TAU Key is 0. Check if the application was correctly registered.","");
+        if(DELTA_TIME.Key() == 0)
+            KRATOS_THROW_ERROR(std::invalid_argument,"DELTA_TIME Key is 0. Check if the application was correctly registered.","");
+        if(SOUND_VELOCITY.Key() == 0)
+            KRATOS_THROW_ERROR(std::invalid_argument,"SOUND_VELOCITY Key is 0. Check if the application was correctly registered.","");
+
+        // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom
+        for(unsigned int i=0; i<this->GetGeometry().size(); ++i)
+        {
+            if(this->GetGeometry()[i].SolutionStepsDataHas(VELOCITY) == false)
+                KRATOS_THROW_ERROR(std::invalid_argument,"Missing VELOCITY variable on solution step data for node ",this->GetGeometry()[i].Id());
+            if(this->GetGeometry()[i].SolutionStepsDataHas(PRESSURE) == false)
+                KRATOS_THROW_ERROR(std::invalid_argument,"Missing PRESSURE variable on solution step data for node ",this->GetGeometry()[i].Id());
+
+            if(this->GetGeometry()[i].HasDofFor(VELOCITY_X) == false ||
+               this->GetGeometry()[i].HasDofFor(VELOCITY_Y) == false ||
+               this->GetGeometry()[i].HasDofFor(VELOCITY_Z) == false)
+                KRATOS_THROW_ERROR(std::invalid_argument,"Missing VELOCITY component degree of freedom on node ",this->GetGeometry()[i].Id());
+            if(this->GetGeometry()[i].HasDofFor(PRESSURE) == false)
+                KRATOS_THROW_ERROR(std::invalid_argument,"Missing PRESSURE component degree of freedom on node ",this->GetGeometry()[i].Id());
+        }
+
+        // Check constitutive law
+        if(mpConstitutiveLaw == nullptr)
+            KRATOS_ERROR << "The constitutive law was not set. Cannot proceed. Call the navier_stokes.h Initialize() method needs to be called.";
+
+        mpConstitutiveLaw->Check(GetProperties(), this->GetGeometry(), rCurrentProcessInfo);
+
+        return 0;
+
+        KRATOS_CATCH("");
+    }
+
+
+    void Calculate(const Variable<double>& rVariable,
+                   double& rOutput,
+                   const ProcessInfo& rCurrentProcessInfo) override
+    {
+        KRATOS_TRY
+
+        KRATOS_CATCH("")
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "EmbeddedAusasNavierStokes #";
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << Info() << Id();
+    }
+
+    /// Print object's data.
+    // virtual void PrintData(std::ostream& rOStream) const override
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+protected:
+    ///@name Protected static member variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+    // Constitutive law pointer
+    ConstitutiveLaw::Pointer mpConstitutiveLaw = nullptr;
+
+    // Symbolic function implementing the element
+    void GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+
+    void ComputeGaussPointLHSContribution(bounded_matrix<double,TNumNodes*(TDim+1),TNumNodes*(TDim+1)>& lhs, const ElementDataStruct& data);
+    void ComputeGaussPointRHSContribution(array_1d<double,TNumNodes*(TDim+1)>& rhs, const ElementDataStruct& data);
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+    EmbeddedAusasNavierStokes() : Element()
+    {
+    }
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    // Element initialization (constitutive law)
+    void Initialize() override
+    {
+        KRATOS_TRY
+
+        mpConstitutiveLaw = GetProperties()[CONSTITUTIVE_LAW]->Clone();
+        mpConstitutiveLaw->InitializeMaterial( GetProperties(), this->GetGeometry(), row( this->GetGeometry().ShapeFunctionsValues(), 0 ) );
+
+        KRATOS_CATCH( "" )
+    }
+
+    // Auxiliar function to fill the element data structure
+    void FillElementData(ElementDataStruct& rData, const ProcessInfo& rCurrentProcessInfo)
+    {
+        // Getting data for the given geometry
+        GeometryUtils::CalculateGeometryData(this->GetGeometry(), rData.DN_DX, rData.N, rData.volume);
+
+        // Compute element size
+        rData.h = ComputeH(rData.DN_DX);
+
+        // Database access to all of the variables needed
+        const Vector& BDFVector = rCurrentProcessInfo[BDF_COEFFICIENTS];
+        rData.bdf0 = BDFVector[0];
+        rData.bdf1 = BDFVector[1];
+        rData.bdf2 = BDFVector[2];
+
+        rData.dyn_tau = rCurrentProcessInfo[DYNAMIC_TAU];   // Only, needed if the temporal dependent term is considered in the subscales
+        rData.dt = rCurrentProcessInfo[DELTA_TIME];         // Only, needed if the temporal dependent term is considered in the subscales
+
+        rData.c = rCurrentProcessInfo[SOUND_VELOCITY];      // Wave velocity
+
+        for (unsigned int i = 0; i < TNumNodes; i++)
+        {
+
+            const array_1d<double,3>& body_force = this->GetGeometry()[i].FastGetSolutionStepValue(BODY_FORCE);
+            const array_1d<double,3>& vel = this->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY);
+            const array_1d<double,3>& vel_n = this->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY,1);
+            const array_1d<double,3>& vel_nn = this->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY,2);
+            const array_1d<double,3>& vel_mesh = this->GetGeometry()[i].FastGetSolutionStepValue(MESH_VELOCITY);
+
+            for(unsigned int k=0; k<TDim; k++)
+            {
+                rData.v(i,k)   = vel[k];
+                rData.vn(i,k)  = vel_n[k];
+                rData.vnn(i,k) = vel_nn[k];
+                rData.vmesh(i,k) = vel_mesh[k];
+                rData.f(i,k)   = body_force[k];
+            }
+
+            rData.p[i] = this->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE);
+            rData.pn[i] = this->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE,1);
+            rData.pnn[i] = this->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE,2);
+            rData.rho[i] = this->GetGeometry()[i].FastGetSolutionStepValue(DENSITY);
+            rData.mu[i] = this->GetGeometry()[i].FastGetSolutionStepValue(DYNAMIC_VISCOSITY);
+        }
+
+    }
+
+    // Auxiliar function to compute the element size
+    double ComputeH(boost::numeric::ublas::bounded_matrix<double,TNumNodes, TDim>& DN_DX)
+    {
+        double h=0.0;
+        for(unsigned int i=0; i<TNumNodes; i++)
+        {
+            double h_inv = 0.0;
+            for(unsigned int k=0; k<TDim; k++)
+            {
+                h_inv += DN_DX(i,k)*DN_DX(i,k);
+            }
+            h += 1.0/h_inv;
+        }
+        h = sqrt(h)/static_cast<double>(TNumNodes);
+        return h;
+    }
+
+    // 3D tetrahedra shape functions values at Gauss points
+    void GetShapeFunctionsOnGauss(boost::numeric::ublas::bounded_matrix<double,4,4>& Ncontainer)
+    {
+        Ncontainer(0,0) = 0.58541020; Ncontainer(0,1) = 0.13819660; Ncontainer(0,2) = 0.13819660; Ncontainer(0,3) = 0.13819660;
+        Ncontainer(1,0) = 0.13819660; Ncontainer(1,1) = 0.58541020; Ncontainer(1,2) = 0.13819660; Ncontainer(1,3) = 0.13819660;
+        Ncontainer(2,0) = 0.13819660; Ncontainer(2,1) = 0.13819660; Ncontainer(2,2) = 0.58541020; Ncontainer(2,3) = 0.13819660;
+        Ncontainer(3,0) = 0.13819660; Ncontainer(3,1) = 0.13819660; Ncontainer(3,2) = 0.13819660; Ncontainer(3,3) = 0.58541020;
+    }
+
+    // 2D triangle shape functions values at Gauss points
+    void GetShapeFunctionsOnGauss(boost::numeric::ublas::bounded_matrix<double,3,3>& Ncontainer)
+    {
+        const double one_sixt = 1.0/6.0;
+        const double two_third = 2.0/3.0;
+        Ncontainer(0,0) = one_sixt; Ncontainer(0,1) = one_sixt; Ncontainer(0,2) = two_third;
+        Ncontainer(1,0) = one_sixt; Ncontainer(1,1) = two_third; Ncontainer(1,2) = one_sixt;
+        Ncontainer(2,0) = two_third; Ncontainer(2,1) = one_sixt; Ncontainer(2,2) = one_sixt;
+    }
+
+    // 3D tetrahedra shape functions values at centered Gauss point
+    void GetShapeFunctionsOnUniqueGauss(boost::numeric::ublas::bounded_matrix<double,1,4>& Ncontainer)
+    {
+        Ncontainer(0,0) = 0.25; Ncontainer(0,1) = 0.25; Ncontainer(0,2) = 0.25; Ncontainer(0,3) = 0.25;
+    }
+
+    // 2D triangle shape functions values at centered Gauss point
+    void GetShapeFunctionsOnUniqueGauss(boost::numeric::ublas::bounded_matrix<double,1,3>& Ncontainer)
+    {
+        Ncontainer(0,0) = 1.0/3.0; Ncontainer(0,1) = 1.0/3.0; Ncontainer(0,2) = 1.0/3.0;
+    }
+
+    // Computes the strain rate in Voigt notation
+    void ComputeStrain(ElementDataStruct& rData, const unsigned int& strain_size)
+    {
+        const bounded_matrix<double, TNumNodes, TDim>& v = rData.v;
+        const bounded_matrix<double, TNumNodes, TDim>& DN = rData.DN_DX;
+
+        // Compute strain (B*v)
+        // 3D strain computation
+        if (strain_size == 6)
+        {
+            rData.strain[0] = DN(0,0)*v(0,0) + DN(1,0)*v(1,0) + DN(2,0)*v(2,0) + DN(3,0)*v(3,0);
+            rData.strain[1] = DN(0,1)*v(0,1) + DN(1,1)*v(1,1) + DN(2,1)*v(2,1) + DN(3,1)*v(3,1);
+            rData.strain[2] = DN(0,2)*v(0,2) + DN(1,2)*v(1,2) + DN(2,2)*v(2,2) + DN(3,2)*v(3,2);
+            rData.strain[3] = DN(0,0)*v(0,1) + DN(0,1)*v(0,0) + DN(1,0)*v(1,1) + DN(1,1)*v(1,0) + DN(2,0)*v(2,1) + DN(2,1)*v(2,0) + DN(3,0)*v(3,1) + DN(3,1)*v(3,0);
+            rData.strain[4] = DN(0,1)*v(0,2) + DN(0,2)*v(0,1) + DN(1,1)*v(1,2) + DN(1,2)*v(1,1) + DN(2,1)*v(2,2) + DN(2,2)*v(2,1) + DN(3,1)*v(3,2) + DN(3,2)*v(3,1);
+            rData.strain[5] = DN(0,0)*v(0,2) + DN(0,2)*v(0,0) + DN(1,0)*v(1,2) + DN(1,2)*v(1,0) + DN(2,0)*v(2,2) + DN(2,2)*v(2,0) + DN(3,0)*v(3,2) + DN(3,2)*v(3,0);
+        }
+        // 2D strain computation
+        else if (strain_size == 3)
+        {
+            rData.strain[0] = DN(0,0)*v(0,0) + DN(1,0)*v(1,0) + DN(2,0)*v(2,0);
+            rData.strain[1] = DN(0,1)*v(0,1) + DN(1,1)*v(1,1) + DN(2,1)*v(2,1);
+            rData.strain[2] = DN(0,1)*v(0,0) + DN(1,1)*v(1,0) + DN(2,1)*v(2,0) + DN(0,0)*v(0,1) + DN(1,0)*v(1,1) + DN(2,0)*v(2,1);
+        }
+    }
+
+    // Call the constitutive law to get the stress value
+    virtual void ComputeConstitutiveResponse(ElementDataStruct& rData, const ProcessInfo& rCurrentProcessInfo)
+    {
+        const unsigned int strain_size = (TDim*3)-3;
+
+        if(rData.C.size1() != strain_size)
+            rData.C.resize(strain_size,strain_size,false);
+        if(rData.stress.size() != strain_size)
+            rData.stress.resize(strain_size,false);
+        if(rData.strain.size() != strain_size)
+            rData.strain.resize(strain_size,false);
+
+        ComputeStrain(rData, strain_size);
+
+        // Create constitutive law parameters:
+        ConstitutiveLaw::Parameters Values(this->GetGeometry(), GetProperties(), rCurrentProcessInfo);
+
+        const Vector Nvec(rData.N);
+        Values.SetShapeFunctionsValues(Nvec);
+
+        // Set constitutive law flags:
+        Flags& ConstitutiveLawOptions=Values.GetOptions();
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS);
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR);
+
+        Values.SetStrainVector(rData.strain);       //this is the input parameter
+        Values.SetStressVector(rData.stress);       //this is an ouput parameter
+        Values.SetConstitutiveMatrix(rData.C);      //this is an ouput parameter
+
+        //ATTENTION: here we assume that only one constitutive law is employed for all of the gauss points in the element.
+        //this is ok under the hypothesis that no history dependent behaviour is employed
+        mpConstitutiveLaw->CalculateMaterialResponseCauchy(Values);
+
+    }
+
+    virtual double ComputeEffectiveViscosity(const ElementDataStruct& rData)
+    {
+        // Computes the effective viscosity as the average of the lower diagonal constitutive tensor
+        double mu_eff = 0.0;
+        const unsigned int strain_size = (TDim-1)*3;
+        for (unsigned int i=TDim; i<strain_size; ++i){mu_eff += rData.C(i,i);}
+        mu_eff /= (strain_size - TDim);
+
+        return mu_eff;
+    }
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+private:
+    ///@name Static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    ///@}
+    ///@name Serialization
+    ///@{
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override
+    {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
+    }
+
+    void load(Serializer& rSerializer) override
+    {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
+    }
+
+    ///@}
+
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    ///@}
+
+};
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+
+/// input stream function
+/*  inline std::istream& operator >> (std::istream& rIStream,
+                                    Fluid2DASGS& rThis);
+ */
+/// output stream function
+/*  inline std::ostream& operator << (std::ostream& rOStream,
+                                    const Fluid2DASGS& rThis)
+    {
+      rThis.PrintInfo(rOStream);
+      rOStream << std::endl;
+      rThis.PrintData(rOStream);
+
+      return rOStream;
+    }*/
+///@}
+
+} // namespace Kratos.
+
+#endif // KRATOS_EMBEDDED_AUSAS_NAVIER_STOKES_ELEMENT_INCLUDED  defined

--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
@@ -79,7 +79,13 @@ KratosFluidDynamicsApplication::KratosFluidDynamicsApplication():
     mNavierStokesWallCondition3D(0, Element::GeometryType::Pointer( new Triangle3D3<Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) ),
     // Embedded Navier-Stokes symbolic elements
     mEmbeddedNavierStokes2D(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-    mEmbeddedNavierStokes3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4))))
+    mEmbeddedNavierStokes3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+    // Embedded Navier-Stokes symbolic element with Ausas discontinuous shape functions
+    mEmbeddedAusasNavierStokes2D(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+    mEmbeddedAusasNavierStokes3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+    mEmbeddedAusasNavierStokesWallCondition2D(0, Element::GeometryType::Pointer( new Line2D2<Node<3> >( Element::GeometryType::PointsArrayType( 2 ) ) ) ),
+    mEmbeddedAusasNavierStokesWallCondition3D(0, Element::GeometryType::Pointer( new Triangle3D3<Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) )
+    
 {}
 
 void KratosFluidDynamicsApplication::Register()
@@ -159,6 +165,8 @@ void KratosFluidDynamicsApplication::Register()
     KRATOS_REGISTER_ELEMENT("NavierStokes3D4N",mNavierStokes3D);
     KRATOS_REGISTER_ELEMENT("EmbeddedNavierStokes2D3N",mEmbeddedNavierStokes2D);
     KRATOS_REGISTER_ELEMENT("EmbeddedNavierStokes3D4N",mEmbeddedNavierStokes3D);
+    KRATOS_REGISTER_ELEMENT("EmbeddedAusasNavierStokes2D3N",mEmbeddedAusasNavierStokes2D);
+    KRATOS_REGISTER_ELEMENT("EmbeddedAusasNavierStokes3D4N",mEmbeddedAusasNavierStokes3D);
 
     // Register Conditions
     KRATOS_REGISTER_CONDITION("WallCondition2D2N",mWallCondition2D); //this is the name the element should have according to the naming convention
@@ -173,8 +181,10 @@ void KratosFluidDynamicsApplication::Register()
     KRATOS_REGISTER_CONDITION("WallConditionDiscontinuous3D",mWallConditionDiscontinuous3D);
     KRATOS_REGISTER_CONDITION("MonolithicWallCondition2D",mMonolithicWallCondition2D);
     KRATOS_REGISTER_CONDITION("MonolithicWallCondition3D",mMonolithicWallCondition3D);
-    KRATOS_REGISTER_CONDITION("NavierStokesWallCondition2D",mNavierStokesWallCondition2D);
-    KRATOS_REGISTER_CONDITION("NavierStokesWallCondition3D",mNavierStokesWallCondition3D);
+    KRATOS_REGISTER_CONDITION("NavierStokesWallCondition2D2N",mNavierStokesWallCondition2D);
+    KRATOS_REGISTER_CONDITION("NavierStokesWallCondition3D3N",mNavierStokesWallCondition3D);
+    KRATOS_REGISTER_CONDITION("EmbeddedAusasNavierStokesWallCondition2D2N",mEmbeddedAusasNavierStokesWallCondition2D);
+    KRATOS_REGISTER_CONDITION("EmbeddedAusasNavierStokesWallCondition3D3N",mEmbeddedAusasNavierStokesWallCondition3D);
     KRATOS_REGISTER_CONDITION("StokesWallCondition3D",mStokesWallCondition3D);
     KRATOS_REGISTER_CONDITION("FSPeriodicCondition2D",mFSPeriodicCondition2D);
     KRATOS_REGISTER_CONDITION("FSPeriodicCondition3D",mFSPeriodicCondition3D);

--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.h
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.h
@@ -51,16 +51,18 @@
 #include "custom_conditions/monolithic_wall_condition.h"
 #include "custom_conditions/stokes_wall_condition.h"
 #include "custom_conditions/fs_periodic_condition.h"
-#include "custom_elements/dpg_vms.h"
+#include "custom_conditions/navier_stokes_wall_condition.h"
+#include "custom_conditions/embedded_ausas_navier_stokes_wall_condition.h"
 
+#include "custom_elements/dpg_vms.h"
 #include "custom_elements/bingham_fluid.h"
 #include "custom_elements/herschel_bulkley_fluid.h"
 #include "custom_elements/stokes_3D.h"
 #include "custom_elements/stokes_3D_twofluid.h"
-
 #include "custom_elements/navier_stokes.h"
-#include "custom_conditions/navier_stokes_wall_condition.h"
 #include "custom_elements/embedded_navier_stokes.h"
+#include "custom_elements/embedded_ausas_navier_stokes.h"
+
 
 
 namespace Kratos
@@ -244,9 +246,9 @@ private:
     const SpalartAllmaras mSpalartAllmaras3D;
 
     /// Exact 2D slip condition using rotated coordinates (fractional step version)
-    const  WallCondition<2,2> mWallCondition2D;
+    const WallCondition<2,2> mWallCondition2D;
     /// Exact 3D slip condition using rotated coordinates (fractional step version)
-    const  WallCondition<3,3> mWallCondition3D;
+    const WallCondition<3,3> mWallCondition3D;
 
     /// Wall model using Werner-Wengle power law (fractional step version)
     const FSWernerWengleWallCondition<2,2> mFSWernerWengleWallCondition2D;
@@ -257,16 +259,16 @@ private:
     const FSGeneralizedWallCondition<3,3> mFSGeneralizedWallCondition3D;
 
     /// Exact 2D slip condition using rotated coordinates (fractional step version) - suitable for continuity equation integrated by parts
-    const  WallConditionDiscontinuous<2,2> mWallConditionDiscontinuous2D;
+    const WallConditionDiscontinuous<2,2> mWallConditionDiscontinuous2D;
     /// Exact 3D slip condition using rotated coordinates (fractional step version) - suitable for continuity equation integrated by parts
-    const  WallConditionDiscontinuous<3,3> mWallConditionDiscontinuous3D;
+    const WallConditionDiscontinuous<3,3> mWallConditionDiscontinuous3D;
 
     /// Exact 2D slip condition using rotated coordinates (monolithic version)
-    const  MonolithicWallCondition<2,2> mMonolithicWallCondition2D;
+    const MonolithicWallCondition<2,2> mMonolithicWallCondition2D;
     /// Exact 3D slip condition using rotated coordinates (monolithic version)
-    const  MonolithicWallCondition<3,3> mMonolithicWallCondition3D;
+    const MonolithicWallCondition<3,3> mMonolithicWallCondition3D;
     /// stokes condition(monolithic version)
-    const  StokesWallCondition<3,3> mStokesWallCondition3D;
+    const StokesWallCondition<3,3> mStokesWallCondition3D;
 
     /// Periodic Condition
     const FSPeriodicCondition<2> mFSPeriodicCondition2D;
@@ -299,8 +301,6 @@ private:
     const HerschelBulkleyFluid< VMS<2> > mHerschelBulkleyVMS2D;
     const HerschelBulkleyFluid< VMS<3> > mHerschelBulkleyVMS3D;
 
-//     const NavierStokesSymbolic2D mNavierStokesSymbolic2D;
-//     const StokesSymbolic2D mStokesSymbolic2D;
     const Stokes3D mStokes3D;
     const Stokes3DTwoFluid mStokes3DTwoFluid;
 
@@ -313,6 +313,12 @@ private:
     /// Embedded Navier-Stokes symbolic element
     const EmbeddedNavierStokes<2> mEmbeddedNavierStokes2D;
     const EmbeddedNavierStokes<3> mEmbeddedNavierStokes3D;
+
+    /// Embedded Navier-Stokes symbolic element with Ausas discontinuous shape functions
+    const EmbeddedAusasNavierStokes<2> mEmbeddedAusasNavierStokes2D;
+    const EmbeddedAusasNavierStokes<3> mEmbeddedAusasNavierStokes3D;
+    const EmbeddedAusasNavierStokesWallCondition<2> mEmbeddedAusasNavierStokesWallCondition2D;
+    const EmbeddedAusasNavierStokesWallCondition<3> mEmbeddedAusasNavierStokesWallCondition3D;
 
     ///@}
     ///@name Private Operators

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -90,13 +90,14 @@ class NavierStokesEmbeddedMonolithicSolver(navier_stokes_base_solver.NavierStoke
         ## Add base class variables
         super(NavierStokesEmbeddedMonolithicSolver, self).AddVariables()
         ## Add specific variables needed for the embedded solver
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)          # Distance function nodal values
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE_GRADIENT) # Distance gradient nodal values
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.SOUND_VELOCITY)    # Speed of sound velocity
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.EXTERNAL_PRESSURE) # Nodal external pressure
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DYNAMIC_VISCOSITY) # At the moment, the EmbeddedNavierStokes element works with the DYNAMIC_VISCOSITY
-        self.main_model_part.AddNodalSolutionStepVariable(KratosFluid.EMBEDDED_WET_PRESSURE)    # Post-process variable (stores the fluid nodes pressure and is set to 0 in the structure ones)
-        self.main_model_part.AddNodalSolutionStepVariable(KratosFluid.EMBEDDED_WET_VELOCITY)    # Post-process variable (stores the fluid nodes velocity and is set to 0 in the structure ones)
+        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)              # Distance function nodal values
+        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE_GRADIENT)     # Distance gradient nodal values
+        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ELEMENTAL_DISTANCES)   # Store the element nodal distance values
+        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.SOUND_VELOCITY)        # Speed of sound velocity
+        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.EXTERNAL_PRESSURE)     # Nodal external pressure
+        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DYNAMIC_VISCOSITY)     # At the moment, the EmbeddedNavierStokes element works with the DYNAMIC_VISCOSITY
+        self.main_model_part.AddNodalSolutionStepVariable(KratosFluid.EMBEDDED_WET_PRESSURE)        # Post-process variable (stores the fluid nodes pressure and is set to 0 in the structure ones)
+        self.main_model_part.AddNodalSolutionStepVariable(KratosFluid.EMBEDDED_WET_VELOCITY)        # Post-process variable (stores the fluid nodes velocity and is set to 0 in the structure ones)
 
         print("Monolithic embedded fluid solver variables added correctly")
 

--- a/applications/FluidDynamicsApplication/python_scripts/python_solvers_wrapper_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/python_solvers_wrapper_fluid.py
@@ -21,7 +21,7 @@ def CreateSolver(main_model_part, custom_settings):
         elif (solver_type == "FractionalStep"):
             solver_module_name = "navier_stokes_solver_fractionalstep"
 
-        elif (solver_type == "Embedded"):
+        elif ((solver_type == "Embedded") or (solver_type == "EmbeddedAusas")):
             solver_module_name = "navier_stokes_embedded_solver"
 
         else:
@@ -35,7 +35,7 @@ def CreateSolver(main_model_part, custom_settings):
         elif (solver_type == "FractionalStep"):
             solver_module_name = "trilinos_navier_stokes_solver_fractionalstep"
 
-        elif (solver_type == "Embedded"):
+        elif ((solver_type == "Embedded") or (solver_type == "EmbeddedAusas")):
             solver_module_name = "trilinos_navier_stokes_embedded_solver"
 
         else:

--- a/applications/FluidDynamicsApplication/symbolic_generation/embedded_ausas_navier_stokes/README.md
+++ b/applications/FluidDynamicsApplication/symbolic_generation/embedded_ausas_navier_stokes/README.md
@@ -1,0 +1,17 @@
+# Navier Stokes Element
+
+## ELEMENT DESCRIPTION:
+Current directory contains the documentation for the symbolic derivation of the _"navier_stokes"_ element. This element includes a formulation of a quasi-incompressible _Navier-Stokes_ element for both **2D** and **3D** cases.
+
+## SYMBOLIC GENERATOR SETTINGS:
+* Dimension to compute: This symbolic generator is valid for both **2D** and **3D** cases. Since the element has been programed with a dimension template in Kratos, it is advised to set the _dim_to_compute_ flag as "_Both_". In this case the _generated .cpp_ file will contain both **2D** and **3D** implementations.
+* Linearisation settings: _FullNR_ considers the convective velocity as _"v-vmesh"_, hence _v_ is taken into account in the derivation of the **LHS** and **RHS**. Picard (_a.k.a. QuasiNR_) considers the convective velocity as "a", thus it is considered as a constant in the derivation of the **LHS** and **RHS**.
+* Artificial compressiblity: If set to true, the time derivative of the density is introduced in the mass conservation equation together with the state equation $dp/d\rho=c^2$ (being c the sound velocity). These assumptions add some extra terms to the usual **Navier-Stokes** equations that are intended to act  as a soft artificial compressibility, which is controlled by the value of "_c_", meaning that if this value is large enough the artificial  compressibility terms vanish.
+
+## INSTRUCTIONS
+Run:
+~~~py
+python generate_navier_stokes_element.py
+~~~
+Then  file "_navier_stokes.cpp_" is generated automatically. Such file should be copied within the "_custom_elements_" folder of the
+**FluidDynamicsApplication**. The corresponding header file "navier_stokes.h", which implements the element is already stored in the custom_elements folder.

--- a/applications/FluidDynamicsApplication/symbolic_generation/embedded_ausas_navier_stokes/embedded_ausas_navier_stokes_cpp_template.cpp
+++ b/applications/FluidDynamicsApplication/symbolic_generation/embedded_ausas_navier_stokes/embedded_ausas_navier_stokes_cpp_template.cpp
@@ -1,0 +1,328 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#include "custom_elements/embedded_ausas_navier_stokes.h"
+
+namespace Kratos {
+
+template<>
+void EmbeddedAusasNavierStokes<3>::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    unsigned int Dim = 3;
+    unsigned int NumNodes = 4;
+    unsigned int DofSize  = NumNodes*(Dim+1);
+
+    if (rResult.size() != DofSize)
+        rResult.resize(DofSize, false);
+
+    for(unsigned int i=0; i<NumNodes; i++)
+    {
+        rResult[i*(Dim+1)  ]  =  this->GetGeometry()[i].GetDof(VELOCITY_X).EquationId();
+        rResult[i*(Dim+1)+1]  =  this->GetGeometry()[i].GetDof(VELOCITY_Y).EquationId();
+        rResult[i*(Dim+1)+2]  =  this->GetGeometry()[i].GetDof(VELOCITY_Z).EquationId();
+        rResult[i*(Dim+1)+3]  =  this->GetGeometry()[i].GetDof(PRESSURE).EquationId();
+    }
+
+    KRATOS_CATCH("")
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<2>::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    unsigned int Dim = 2;
+    unsigned int NumNodes = 3;
+    unsigned int DofSize  = NumNodes*(Dim+1);
+
+    if (rResult.size() != DofSize)
+        rResult.resize(DofSize, false);
+
+    for(unsigned int i=0; i<NumNodes; i++)
+    {
+        rResult[i*(Dim+1)  ]  =  this->GetGeometry()[i].GetDof(VELOCITY_X).EquationId();
+        rResult[i*(Dim+1)+1]  =  this->GetGeometry()[i].GetDof(VELOCITY_Y).EquationId();
+        rResult[i*(Dim+1)+2]  =  this->GetGeometry()[i].GetDof(PRESSURE).EquationId();
+    }
+
+    KRATOS_CATCH("")
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<3>::GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    unsigned int Dim = 3;
+    unsigned int NumNodes = 4;
+    unsigned int DofSize  = NumNodes*(Dim+1);
+
+    if (ElementalDofList.size() != DofSize)
+        ElementalDofList.resize(DofSize);
+
+    for(unsigned int i=0; i<NumNodes; i++)
+    {
+        ElementalDofList[i*(Dim+1)  ]  =  this->GetGeometry()[i].pGetDof(VELOCITY_X);
+        ElementalDofList[i*(Dim+1)+1]  =  this->GetGeometry()[i].pGetDof(VELOCITY_Y);
+        ElementalDofList[i*(Dim+1)+2]  =  this->GetGeometry()[i].pGetDof(VELOCITY_Z);
+        ElementalDofList[i*(Dim+1)+3]  =  this->GetGeometry()[i].pGetDof(PRESSURE);
+    }
+
+    KRATOS_CATCH("");
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<2>::GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    unsigned int Dim = 2;
+    unsigned int NumNodes = 3;
+    unsigned int DofSize  = NumNodes*(Dim+1);
+
+    if (ElementalDofList.size() != DofSize)
+        ElementalDofList.resize(DofSize);
+
+    for(unsigned int i=0; i<NumNodes; i++)
+    {
+        ElementalDofList[i*(Dim+1)  ]  =  this->GetGeometry()[i].pGetDof(VELOCITY_X);
+        ElementalDofList[i*(Dim+1)+1]  =  this->GetGeometry()[i].pGetDof(VELOCITY_Y);
+        ElementalDofList[i*(Dim+1)+2]  =  this->GetGeometry()[i].pGetDof(PRESSURE);
+    }
+
+    KRATOS_CATCH("");
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<3>::ComputeGaussPointLHSContribution(bounded_matrix<double,16,16>& lhs, const ElementDataStruct& data)
+{
+    const int nnodes = 4;
+    const int dim = 3;
+    //~ const int strain_size = 6;
+
+    const double rho = inner_prod(data.N, data.rho);        // Density
+    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double h = data.h;                                // Characteristic element size
+    const double c = data.c;                                // Wave velocity
+
+    const double& dt = data.dt;
+    const double& bdf0 = data.bdf0;
+    // const double& bdf1 = data.bdf1;
+    // const double& bdf2 = data.bdf2;
+    const double& dyn_tau = data.dyn_tau;
+
+    const bounded_matrix<double,nnodes,dim>& v = data.v;
+    // const bounded_matrix<double,nnodes,dim>& vn = data.vn;
+    // const bounded_matrix<double,nnodes,dim>& vnn = data.vnn;
+    const bounded_matrix<double,nnodes,dim>& vmesh = data.vmesh;
+    const bounded_matrix<double,nnodes,dim>& vconv = v - vmesh;
+    // const bounded_matrix<double,nnodes,dim>& f = data.f;
+    // const array_1d<double,nnodes>& p = data.p;
+    // const array_1d<double,nnodes>& pn = data.pn;
+    // const array_1d<double,nnodes>& pnn = data.pnn;
+    //~ const array_1d<double,strain_size>& stress = data.stress;
+
+    // Get constitutive matrix
+    const Matrix& C = data.C;
+
+    // Get shape function values
+    const array_1d<double,nnodes>& N = data.N;
+    const bounded_matrix<double,nnodes,dim>& DN = data.DN_DX;
+
+    // const array_1d<double,dim> vconv_gauss = prod(trans(vconv), N);
+
+    // const double vconv_norm = norm_2(vconv_gauss);
+
+    // Stabilization parameters
+    const double stab_c1 = 4.0;
+    const double stab_c2 = 2.0;
+    // const double tau1 = 1.0/((rho*dyn_tau_coeff)/delta_t + (c2*rho*vconv_norm)/h + (c1*mu)/(h*h));
+    // const double tau2 = (h*h)/(c1*tau1);
+
+    //substitute_lhs_3D
+
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<2>::ComputeGaussPointLHSContribution(bounded_matrix<double,9,9>& lhs, const ElementDataStruct& data)
+{
+    const int nnodes = 3;
+    const int dim = 2;
+    //~ const int strain_size = 3;
+
+    const double rho = inner_prod(data.N, data.rho);        // Density
+    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double h = data.h;                                // Characteristic element size
+    const double c = data.c;                                // Wave velocity
+
+    const double& dt = data.dt;
+    const double& bdf0 = data.bdf0;
+    // const double& bdf1 = data.bdf1;
+    // const double& bdf2 = data.bdf2;
+    const double& dyn_tau = data.dyn_tau;
+
+    const bounded_matrix<double,nnodes,dim>& v = data.v;
+    // const bounded_matrix<double,nnodes,dim>& vn = data.vn;
+    // const bounded_matrix<double,nnodes,dim>& vnn = data.vnn;
+    const bounded_matrix<double,nnodes,dim>& vmesh = data.vmesh;
+    const bounded_matrix<double,nnodes,dim>& vconv = v - vmesh;
+    // const bounded_matrix<double,nnodes,dim>& f = data.f;
+    // const array_1d<double,nnodes>& p = data.p;
+    // const array_1d<double,nnodes>& pn = data.pn;
+    // const array_1d<double,nnodes>& pnn = data.pnn;
+    //~ const array_1d<double,strain_size>& stress = data.stress;
+
+    // Get constitutive matrix
+    const Matrix& C = data.C;
+
+    // Get shape function values
+    const array_1d<double,nnodes>& N = data.N;
+    const bounded_matrix<double,nnodes,dim>& DN = data.DN_DX;
+
+    // const array_1d<double,dim> vconv_gauss = prod(trans(vconv), N);
+
+    // const double vconv_norm = norm_2(vconv_gauss);
+
+    // Stabilization parameters
+    const double stab_c1 = 4.0;
+    const double stab_c2 = 2.0;
+    // const double tau1 = 1.0/((rho*dyn_tau_coeff)/delta_t + (c2*rho*vconv_norm)/h + (c1*mu)/(h*h));
+    // const double tau2 = (h*h)/(c1*tau1);
+
+    //substitute_lhs_2D
+
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<3>::ComputeGaussPointRHSContribution(array_1d<double,16>& rhs, const ElementDataStruct& data)
+{
+    const int nnodes = 4;
+    const int dim = 3;
+    const int strain_size = 6;
+
+    const double rho = inner_prod(data.N, data.rho);        // Density
+    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double h = data.h;                                // Characteristic element size
+    const double c = data.c;                                // Wave velocity
+
+    const double& dt = data.dt;
+    const double& bdf0 = data.bdf0;
+    const double& bdf1 = data.bdf1;
+    const double& bdf2 = data.bdf2;
+    const double& dyn_tau = data.dyn_tau;
+
+    const bounded_matrix<double,nnodes,dim>& v = data.v;
+    const bounded_matrix<double,nnodes,dim>& vn = data.vn;
+    const bounded_matrix<double,nnodes,dim>& vnn = data.vnn;
+    const bounded_matrix<double,nnodes,dim>& vmesh = data.vmesh;
+    const bounded_matrix<double,nnodes,dim>& vconv = v - vmesh;
+    const bounded_matrix<double,nnodes,dim>& f = data.f;
+    const array_1d<double,nnodes>& p = data.p;
+    const array_1d<double,nnodes>& pn = data.pn;
+    const array_1d<double,nnodes>& pnn = data.pnn;
+    const array_1d<double,strain_size>& stress = data.stress;
+
+    // Get constitutive matrix
+    // const Matrix& C = data.C;
+
+    // Get shape function values
+    const array_1d<double,nnodes>& N = data.N;
+    const bounded_matrix<double,nnodes,dim>& DN = data.DN_DX;
+
+    // Auxiliary variables used in the calculation of the RHS
+    const array_1d<double,dim> f_gauss = prod(trans(f), N);
+    const array_1d<double,dim> grad_p = prod(trans(DN), p);
+    // const array_1d<double,dim> vconv_gauss = prod(trans(vconv), N);
+    //~ const double p_gauss = inner_prod(N,p);
+
+    // const double vconv_norm = norm_2(vconv_gauss);
+
+    //~ array_1d<double,dim> accel_gauss = bdf0*v_gauss;
+    //~ noalias(accel_gauss) += bdf1*prod(trans(vn), N);
+    //~ noalias(accel_gauss) += bdf2*prod(trans(vnn), N);
+
+    // Stabilization parameters
+    const double stab_c1 = 4.0;
+    const double stab_c2 = 2.0;
+    // const double tau1 = 1.0/((rho*dyn_tau_coeff)/delta_t + (c2*rho*vconv_norm)/h + (c1*mu)/(h*h));
+    // const double tau2 = (h*h)/(c1*tau1);
+
+    //substitute_rhs_3D
+}
+
+
+template<>
+void EmbeddedAusasNavierStokes<2>::ComputeGaussPointRHSContribution(array_1d<double,9>& rhs, const ElementDataStruct& data)
+{
+    const int nnodes = 3;
+    const int dim = 2;
+    const int strain_size = 3;
+
+    const double rho = inner_prod(data.N, data.rho);        // Density
+    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double h = data.h;                                // Characteristic element size
+    const double c = data.c;                                // Wave velocity
+
+    const double& dt = data.dt;
+    const double& bdf0 = data.bdf0;
+    const double& bdf1 = data.bdf1;
+    const double& bdf2 = data.bdf2;
+    const double& dyn_tau = data.dyn_tau;
+
+    const bounded_matrix<double,nnodes,dim>& v = data.v;
+    const bounded_matrix<double,nnodes,dim>& vn = data.vn;
+    const bounded_matrix<double,nnodes,dim>& vnn = data.vnn;
+    const bounded_matrix<double,nnodes,dim>& vmesh = data.vmesh;
+    const bounded_matrix<double,nnodes,dim>& vconv = v - vmesh;
+    const bounded_matrix<double,nnodes,dim>& f = data.f;
+    const array_1d<double,nnodes>& p = data.p;
+    const array_1d<double,nnodes>& pn = data.pn;
+    const array_1d<double,nnodes>& pnn = data.pnn;
+    const array_1d<double,strain_size>& stress = data.stress;
+
+    // Get constitutive matrix
+    // const Matrix& C = data.C;
+
+    // Get shape function values
+    const array_1d<double,nnodes>& N = data.N;
+    const bounded_matrix<double,nnodes,dim>& DN = data.DN_DX;
+
+    // Auxiliary variables used in the calculation of the RHS
+    const array_1d<double,dim> f_gauss = prod(trans(f), N);
+    const array_1d<double,dim> grad_p = prod(trans(DN), p);
+    // const array_1d<double,dim> vconv_gauss = prod(trans(vconv), N);
+    //~ const double p_gauss = inner_prod(N,p);
+
+    // const double vconv_norm = norm_2(vconv_gauss);
+
+    //~ array_1d<double,dim> accel_gauss = bdf0*v_gauss;
+    //~ noalias(accel_gauss) += bdf1*prod(trans(vn), N);
+    //~ noalias(accel_gauss) += bdf2*prod(trans(vnn), N);
+
+    // Stabilization parameters
+    const double stab_c1 = 4.0;
+    const double stab_c2 = 2.0;
+    // const double tau1 = 1.0/((rho*dyn_tau_coeff)/delta_t + (c2*rho*vconv_norm)/h + (c1*mu)/(h*h));
+    // const double tau2 = (h*h)/(c1*tau1);
+
+    //substitute_rhs_2D
+}
+
+}

--- a/applications/FluidDynamicsApplication/symbolic_generation/embedded_ausas_navier_stokes/embedded_ausas_navier_stokes_element.lyx
+++ b/applications/FluidDynamicsApplication/symbolic_generation/embedded_ausas_navier_stokes/embedded_ausas_navier_stokes_element.lyx
@@ -1,0 +1,1190 @@
+#LyX 2.2 created this file. For more info see http://www.lyx.org/
+\lyxformat 508
+\begin_document
+\begin_header
+\save_transient_properties true
+\origin unavailable
+\textclass article
+\begin_preamble
+\usepackage[affil-it]{authblk}
+\usepackage{graphicx}
+\usepackage[space]{grffile}
+\usepackage{latexsym}
+\usepackage{amsfonts}
+\usepackage{url}
+
+\usepackage{textcomp}
+\usepackage{longtable}
+\usepackage{multirow}
+\usepackage{booktabs}
+\end_preamble
+\use_default_options false
+\maintain_unincluded_children false
+\language english
+\language_package none
+\inputencoding utf8
+\fontencoding default
+\font_roman "default" "default"
+\font_sans "default" "default"
+\font_typewriter "default" "default"
+\font_math "auto" "auto"
+\font_default_family default
+\use_non_tex_fonts false
+\font_sc false
+\font_osf false
+\font_sf_scale 100 100
+\font_tt_scale 100 100
+\graphics default
+\default_output_format default
+\output_sync 0
+\bibtex_command default
+\index_command default
+\paperfontsize default
+\spacing single
+\use_hyperref true
+\pdf_bookmarks false
+\pdf_bookmarksnumbered false
+\pdf_bookmarksopen false
+\pdf_bookmarksopenlevel 1
+\pdf_breaklinks false
+\pdf_pdfborder true
+\pdf_colorlinks false
+\pdf_backref section
+\pdf_pdfusetitle false
+\papersize default
+\use_geometry false
+\use_package amsmath 2
+\use_package amssymb 2
+\use_package cancel 1
+\use_package esint 1
+\use_package mathdots 0
+\use_package mathtools 1
+\use_package mhchem 0
+\use_package stackrel 1
+\use_package stmaryrd 1
+\use_package undertilde 1
+\cite_engine basic
+\cite_engine_type default
+\biblio_style plain
+\use_bibtopic false
+\use_indices false
+\paperorientation portrait
+\suppress_date false
+\justification true
+\use_refstyle 0
+\index Index
+\shortcut idx
+\color #008000
+\end_index
+\secnumdepth 3
+\tocdepth 3
+\paragraph_separation indent
+\paragraph_indentation default
+\quotes_language english
+\papercolumns 1
+\papersides 1
+\paperpagestyle default
+\tracking_changes false
+\output_changes false
+\html_math_output 0
+\html_css_as_file 0
+\html_be_strict false
+\end_header
+
+\begin_body
+
+\begin_layout Title
+Pseudo-compressible Navier-Stokes element symbolic implementation
+\end_layout
+
+\begin_layout Author
+Riccardo and Rubén
+\end_layout
+
+\begin_layout Standard
+\begin_inset ERT
+status collapsed
+
+\begin_layout Plain Layout
+
+
+\backslash
+affil
+\end_layout
+
+\end_inset
+
+
+\begin_inset ERT
+status collapsed
+
+\begin_layout Plain Layout
+
+{
+\end_layout
+
+\end_inset
+
+UPC BarcelonaTech, CIMNE
+\begin_inset ERT
+status collapsed
+
+\begin_layout Plain Layout
+
+}
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+
+\backslash
+section
+\end_layout
+
+\end_inset
+
+
+\begin_inset ERT
+status collapsed
+
+\begin_layout Plain Layout
+
+{
+\end_layout
+
+\end_inset
+
+Pseudo-compressible Navier-Stokes formulation
+\begin_inset ERT
+status collapsed
+
+\begin_layout Plain Layout
+
+}
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+The Navier-Stokes equations are conformed by the linear momentum conservation
+ equation
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\frac{\partial\rho\mathbf{u}}{\partial t}-\nabla\cdot\mathbf{\boldsymbol{\sigma}}+\rho\mathbf{a}\cdot\nabla\mathbf{u}=\rho\mathbf{f}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+and the mass conservation equation
+\begin_inset Formula 
+\[
+\frac{D\rho}{Dt}+\nabla\cdot\left(\rho\mathbf{\mathbf{u}}\right)=0
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Developing the material time derivative of the mass conservation equation
+ one has
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\frac{\partial\rho}{\partial t}+\mathbf{u\cdot\nabla\rho}+\nabla\cdot\left(\rho\mathbf{\mathbf{u}}\right)=0
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Let us assume small space variations of the density field, yielding
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\frac{\partial\rho}{\partial t}+\rho\nabla\cdot\mathbf{u}=0
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+The density local time derivative can be obtained as
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\frac{\partial p}{\partial t}=\frac{\partial p}{\partial\rho}\frac{\partial\rho}{\partial t}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\frac{\partial\rho}{\partial t}=\left(\frac{\partial p}{\partial\rho}\right)^{-1}\frac{\partial p}{\partial t}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Considering the state equation
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\frac{\partial p}{\partial\rho}=c^{2}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+the mass conservation equation can be rewritten as
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\frac{1}{c^{2}}\frac{\partial p}{\partial t}+\rho\nabla\cdot\mathbf{u}=0
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+where c is the sound velocity in the considered fluid.
+ Once arrived to this point, one can divide the previous equation by 
+\begin_inset Formula $\rho$
+\end_inset
+
+ for the sake of having a better conditioned matrix (specially in those
+ cases in where 
+\begin_inset Formula $\rho\gg1$
+\end_inset
+
+).
+ This has been implemented as an user-defined option in the symbolic element
+ generation script.
+ Note that this will also affect the stabilization terms.
+\end_layout
+
+\begin_layout Standard
+On the other hand, the density is considered to be time independent in the
+ momentum conservation equation, thus
+\begin_inset Formula 
+\[
+\rho\frac{\partial\mathbf{u}}{\partial t}-\nabla\cdot\mathbf{\boldsymbol{\sigma}}+\rho\mathbf{a}\cdot\nabla\mathbf{u}=\rho\mathbf{f}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+In addition, the stress tensor 
+\begin_inset Formula $\boldsymbol{\sigma}$
+\end_inset
+
+ is defined as 
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\boldsymbol{\sigma}=-p\mathbf{I}+\rho(\nabla\cdot\mathbf{u})\mathbf{I}+\boldsymbol{\tau}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Taking into account that no volumetric deformation is considered in the
+ momentum conservation equation, the stress tensor 
+\begin_inset Formula $\boldsymbol{\sigma}$
+\end_inset
+
+ to be considered turns to be
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\boldsymbol{\sigma}=-p\mathbf{I}+\boldsymbol{\tau}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+where 
+\begin_inset Formula $p$
+\end_inset
+
+ is the pressure and 
+\begin_inset Formula $\boldsymbol{\tau}$
+\end_inset
+
+ the shear stress tensor, which value and computation depends on the constitutiv
+e tensor employed as 
+\begin_inset Formula $\boldsymbol{\tau}=\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u}$
+\end_inset
+
+, being 
+\begin_inset Formula $\text{\nabla}^{s}$
+\end_inset
+
+ the symmetric gradient operator.
+ Substituting the stress tensor above, the linear momentum equation reads
+ as follows
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\rho\frac{\partial\mathbf{u}}{\partial t}-\nabla\cdot\left(-p\mathbf{I}+\boldsymbol{\tau}\right)+\rho\mathbf{a}\cdot\nabla\mathbf{u}=\rho\mathbf{f}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Once arrived to this point, one can define the linear momentum and mass
+ conservation residuals as
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\mathbf{R}^{M}(\mathbf{u},p)=\rho\mathbf{f}-\rho\frac{\partial\mathbf{u}}{\partial t}+\nabla\cdot\left(-p\mathbf{I}+\boldsymbol{\tau}\right)-\rho\mathbf{a}\cdot\nabla\mathbf{u}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\mathbf{R}^{C}(\mathbf{u},p)=-\frac{1}{c^{2}}\frac{\partial p}{\partial t}-\rho\nabla\cdot\mathbf{u}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset ERT
+status open
+
+\begin_layout Plain Layout
+
+
+\backslash
+section
+\end_layout
+
+\end_inset
+
+
+\begin_inset ERT
+status collapsed
+
+\begin_layout Plain Layout
+
+{
+\end_layout
+
+\end_inset
+
+Galerkin weak form and ASGS stabilization
+\begin_inset ERT
+status collapsed
+
+\begin_layout Plain Layout
+
+}
+\end_layout
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Considering the velocity test function 
+\begin_inset Formula $\mathbf{w}$
+\end_inset
+
+ and pressure test function 
+\begin_inset Formula $q$
+\end_inset
+
+, the Galerkin weak form of the problem can be obtained as
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\left(\mathbf{w},\mathbf{R}^{M}(\mathbf{u},p)\right)_{\Omega}+\left(q,\mathbf{R}^{C}(\mathbf{u},p)\right)_{\Omega}=0
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\left(\mathbf{w},\rho\mathbf{f}-\rho\frac{\partial\mathbf{u}}{\partial t}+\nabla\cdot\left(-p\mathbf{I}+\boldsymbol{\tau}\right)-\rho\mathbf{a}\cdot\nabla\mathbf{u}\right)_{\Omega}+\left(q,-\frac{1}{c^{2}}\frac{\partial p}{\partial t}-\rho\nabla\cdot\mathbf{u}\right)_{\Omega}=0
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+On top of that, the following multiscale decomposition is considered
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\begin{eqnarray*}
+\mathbf{u} & = & \mathbf{u_{h}}+\mathbf{u_{s}}\\
+p & = & p_{h}+p_{s}
+\end{eqnarray*}
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+where 
+\family roman
+\series medium
+\shape up
+\size normal
+\emph off
+\bar no
+\strikeout off
+\uuline off
+\uwave off
+\noun off
+\color none
+
+\begin_inset Formula $\mathbf{u_{\mathbf{h}}}$
+\end_inset
+
+ and 
+\begin_inset Formula $p_{h}$
+\end_inset
+
+ belong to the finite element space while
+\family default
+\series default
+\shape default
+\size default
+\emph default
+\bar default
+\strikeout default
+\uuline default
+\uwave default
+\noun default
+\color inherit
+ 
+\family roman
+\series medium
+\shape up
+\size normal
+\emph off
+\bar no
+\strikeout off
+\uuline off
+\uwave off
+\noun off
+\color none
+
+\begin_inset Formula $\mathbf{u_{s}}$
+\end_inset
+
+ and 
+\begin_inset Formula $p_{s}$
+\end_inset
+
+ are the so called unresolvable subscales.
+
+\family default
+\series default
+\shape default
+\size default
+\emph default
+\bar default
+\strikeout default
+\uuline default
+\uwave default
+\noun default
+\color inherit
+ Substituting the proposed decomposition in the Galerkin residual weak form
+ above yields
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\left(\mathbf{w},\rho\mathbf{f}-\rho\frac{\partial(\mathbf{u_{h}}+\mathbf{u_{s}})}{\partial t}+\nabla\cdot\left(-(p_{h}+p_{s})\mathbf{I}+\mathbb{\mathbb{C}}\text{\nabla}^{s}(\mathbf{u_{h}}+\mathbf{u_{s}})\right)-\rho\mathbf{a}\cdot\nabla(\mathbf{u_{h}}+\mathbf{u_{s}})\right)_{\Omega}+\left(q,-\frac{1}{c^{2}}\frac{\partial(p_{h}+p_{s})}{\partial t}-\rho\nabla\cdot(\mathbf{u_{h}}+\mathbf{u_{s}})\right)_{\Omega}=0
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Once arrived to this point it is important to clearly state the assumptions
+ that are to be taken from now on
+\end_layout
+
+\begin_layout Itemize
+Quasi-static subscales: 
+\begin_inset Formula $\frac{\partial\mathbf{u_{s}}}{\partial t}=\frac{\partial p_{s}}{\partial t}\approx0$
+\end_inset
+
+
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{u_{s}}\approx p_{s}\approx0$
+\end_inset
+
+ on 
+\begin_inset Formula $\Gamma$
+\end_inset
+
+
+\end_layout
+
+\begin_layout Itemize
+Linear order finite elements (higher order derivatives are equal to 0)
+\end_layout
+
+\begin_layout Standard
+Developing terms in the decomposed Galerkin residual weak form considering
+ the quasi-static nature of the subscales one obtains
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\begin{align*}
+\left(\mathbf{w},\rho\mathbf{f}\right)_{\Omega}-\left(\mathbf{w},\rho\frac{\partial\mathbf{u_{h}}}{\partial t}\right)_{\Omega}-\left(\mathbf{w},\nabla p_{h}\right)_{\Omega}-\left(\mathbf{w},\nabla p_{s}\right)_{\Omega}+\left(\mathbf{w},\nabla\cdot\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u_{h}}\right)_{\Omega}+\left(\mathbf{w},\nabla\cdot\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u_{s}}\right)_{\Omega}-\left(\mathbf{w},\rho\mathbf{a}\cdot\nabla\mathbf{u_{h}}\right)_{\Omega}-\left(\mathbf{w},\rho\mathbf{a}\cdot\nabla\mathbf{u_{s}}\right)_{\Omega}-\left(q,\frac{1}{c^{2}}\frac{\partial p_{h}}{\partial t}\right)_{\Omega}-\left(q,\rho\nabla\cdot\mathbf{u_{h}}\right)_{\Omega}-\left(q,\rho\nabla\cdot\mathbf{u_{s}}\right)_{\Omega} & =0
+\end{align*}
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Integrating by parts the shear stress terms
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\begin{eqnarray*}
+\left(\mathbf{w},\nabla\cdot\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u_{h}}\right)_{\Omega} & = & -\left(\mathbf{\nabla w},\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u_{h}}\right)_{\Omega}+\int_{\Gamma}\mathbf{w}\cdot\left(\mathbb{C}\text{\nabla}^{s}\mathbf{u}_{h}\right)\mathbf{\cdot n}\\
+\left(\mathbf{w},\nabla\cdot\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u_{s}}\right)_{\Omega} & = & -\left(\mathbf{\nabla w},\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u_{s}}\right)_{\Omega}+\int_{\Gamma}\mathbf{w}\cdot\left(\mathbb{C}\text{\nabla}^{s}\mathbf{u}_{h}\right)\mathbf{\cdot n}\approx-\left(\mathbf{\nabla w},\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u_{s}}\right)_{\Omega}
+\end{eqnarray*}
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Doing the same for the pressure terms
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\begin{eqnarray*}
+\left(\mathbf{w},\nabla p_{h}\right)_{\Omega} & = & -\left(\mathbf{\nabla\cdot w},p_{h}\right)_{\Omega}+\int_{\Gamma}\left(p_{h}\mathbf{w}\right)\mathbf{\cdot n}\\
+\left(\mathbf{w},\nabla p_{s}\right)_{\Omega} & = & -\left(\mathbf{\nabla\cdot w},p_{s}\right)_{\Omega}+\int_{\Gamma}\left(p_{h}\mathbf{w}\right)\mathbf{\cdot n\approx}-\left(\mathbf{\nabla\cdot w},p_{s}\right)_{\Omega}
+\end{eqnarray*}
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Complementary, the subscales mass conservation term is also integrated by
+ parts as
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\left(q,\rho\nabla\cdot\mathbf{u_{s}}\right)_{\Omega}=-\left(\nabla q,\rho\mathbf{u_{s}}\right)_{\Omega}+\int_{\Gamma}\left(\rho q\mathbf{n}\right)\mathbf{\cdot u_{s}\approx}-\left(\nabla q,\rho\mathbf{u_{s}}\right)_{\Omega}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+as well as the subscales convective term
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\left(\mathbf{w},\rho\mathbf{a}\cdot\nabla\mathbf{u_{s}}\right)_{\Omega}=-\left((\rho(\nabla\cdot\mathbf{a})\mathbf{w}+\rho\mathbf{a}\cdot\nabla\mathbf{w}),\mathbf{u_{s}}\right)_{\Omega}+\int_{\Gamma}(\mathbf{n}\cdot(\mathbf{a}\otimes\mathbf{w}))\mathbf{\cdot u_{s}\approx}-\left((\rho(\nabla\cdot\mathbf{a})\mathbf{w}+\rho\mathbf{a}\cdot\nabla\mathbf{w}),\mathbf{u_{s}}\right)_{\Omega}
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+We now need to introduce a model for the subscales (Algebraic SubGrid Scales,
+ ASGS):
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\begin{eqnarray*}
+\mathbf{u_{s}} & = & \tau_{1}\mathbf{R}^{M}(\mathbf{u_{h}},p_{h})\\
+p_{s} & = & \tau_{2}\mathbf{R}^{C}(\mathbf{u_{h}},p_{h})
+\end{eqnarray*}
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+being 
+\begin_inset Formula $\tau_{1}$
+\end_inset
+
+and 
+\begin_inset Formula $\tau_{2}$
+\end_inset
+
+the stabilization coefficients
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\begin{eqnarray*}
+\tau_{1} & = & \left(\frac{c_{1}\mu}{h^{2}}+\frac{c_{2}\rho||\mathbf{a}||}{h}\right)^{-1}\\
+\tau_{2} & = & \frac{h\text{²}}{c_{1}\tau_{1}}=\mu+\frac{c_{2}h||\mathbf{a}||}{c_{1}}
+\end{eqnarray*}
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+where 
+\begin_inset Formula $c_{1}=4$
+\end_inset
+
+, 
+\begin_inset Formula $c_{2}=2$
+\end_inset
+
+ and 
+\begin_inset Formula $h$
+\end_inset
+
+ is the characteristic element size.
+ Note that the selected subscales model contains higher order derivatives
+ that vanish when using linear finite elements.
+ Thus, the final Galerkin residual weak form reads
+\end_layout
+
+\begin_layout Standard
+\begin_inset Formula 
+\[
+\left(\mathbf{w},\rho\mathbf{f}\right)_{\Omega}-\left(\mathbf{w},\rho\frac{\partial\mathbf{u_{h}}}{\partial t}\right)_{\Omega}-\left(\nabla\cdot\mathbf{w},p_{h}\right)_{\Omega}-\left(\nabla\cdot\mathbf{w},p_{s}\right)_{\Omega}-\left(\nabla\mathbf{w},\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u_{h}}\right)_{\Omega}-\left(\nabla\mathbf{w},\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u_{s}}\right)_{\Omega}+\int_{\Gamma}\mathbf{w}\cdot\left(\mathbb{C}\text{\nabla}^{s}\mathbf{u}_{h}-p_{h}\mathbf{I}\right)\mathbf{\cdot n}-\left(\mathbf{w},\rho\mathbf{a}\cdot\nabla\mathbf{u_{h}}\right)_{\Omega}+\left(\rho(\nabla\cdot\mathbf{a})\mathbf{w},\mathbf{u_{s}}\right)_{\Omega}+\left(\rho\mathbf{a}\cdot\nabla\mathbf{w},\mathbf{u_{s}}\right)_{\Omega}-\left(q,\frac{1}{c^{2}}\frac{\partial p_{h}}{\partial t}\right)_{\Omega}-\left(q,\rho\nabla\cdot\mathbf{u_{h}}\right)_{\Omega}+\left(\nabla q,\rho\mathbf{u_{s}}\right)_{\Omega}=0
+\]
+
+\end_inset
+
+
+\end_layout
+
+\begin_layout Standard
+Note that the term 
+\begin_inset Formula $\left(\nabla\mathbf{w},\mathbb{\mathbb{C}}\text{\nabla}^{s}\mathbf{u_{s}}\right)_{\Omega}$
+\end_inset
+
+vanishes if linear elements are used in the subscale approximation.
+ 
+\end_layout
+
+\begin_layout Section*
+SYMBOLS TO BE EMPLOYED
+\end_layout
+
+\begin_layout Standard
+Shape functions 
+\begin_inset Formula $N_{I}$
+\end_inset
+
+ and derivatives 
+\begin_inset Formula $\nabla N_{I}$
+\end_inset
+
+stored respectively in a vector 
+\begin_inset Formula $\mathbf{N}$
+\end_inset
+
+ and a matrix 
+\begin_inset Formula $\mathbf{DN}$
+\end_inset
+
+.
+ Besides the following arrays are defined:
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{p}$
+\end_inset
+
+ such that 
+\begin_inset Formula $p_{I}$
+\end_inset
+
+ is the current step pressure of node I
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{p_{n}}$
+\end_inset
+
+ such that 
+\begin_inset Formula $p_{n,I}$
+\end_inset
+
+ is the previous step pressure of node I
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{p_{nn}}$
+\end_inset
+
+ such that 
+\begin_inset Formula $p_{nn,I}$
+\end_inset
+
+ is the two previous step pressure of node I
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{v}$
+\end_inset
+
+ such that 
+\begin_inset Formula $\mathbf{v_{IK}}$
+\end_inset
+
+ is the current step velocity of node I, component K
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{v_{n}}$
+\end_inset
+
+ such that 
+\begin_inset Formula $\mathbf{v_{n,IK}}$
+\end_inset
+
+ is the previous step velocity of node I, component K
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{v_{nn}}$
+\end_inset
+
+ such that 
+\begin_inset Formula $\mathbf{v_{nn,IK}}$
+\end_inset
+
+ is the two previous steps velocity of node I, component K
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{w}$
+\end_inset
+
+ such that 
+\begin_inset Formula $\mathbf{w_{I}}$
+\end_inset
+
+ is the linear momentum conservation test function value I at the considered
+ Gauss point
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{q}$
+\end_inset
+
+ such that 
+\begin_inset Formula $\mathbf{q_{I}}$
+\end_inset
+
+ is the mass conservation test function value I at the considered Gauss
+ point
+\end_layout
+
+\begin_layout Standard
+Values on the gauss points are expressed in terms of such variables as
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{v\_gauss}:=\mathbf{v}^{T}\mathbf{N}$
+\end_inset
+
+ a 3x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{p\_gauss}:=\mathbf{p}^{T}\mathbf{N}$
+\end_inset
+
+ a 1x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{f\_gauss}:=\mathbf{f}^{T}\mathbf{N}$
+\end_inset
+
+ a 3x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{w\_gauss}:=\mathbf{w}^{T}\mathbf{N}$
+\end_inset
+
+ a 3x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{q\_gauss}:=\mathbf{q}^{T}\mathbf{N}$
+\end_inset
+
+ a 1x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{accel\_gauss}:=\left(BDF_{0}\mathbf{V}+BDF_{1}\mathbf{V}_{n}+BDF_{2}\mathbf{V}_{nn}\right)^{T}\mathbf{N}$
+\end_inset
+
+ a 3x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{pder\_gauss}:=\left(BDF_{0}p+BDF_{1}p_{n}+BDF_{2}p_{nn}\right)\mathbf{N}$
+\end_inset
+
+ a 1x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{v_{h}:=v^{T}N}$
+\end_inset
+
+ a 3x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{w_{h}:=w^{T}N}$
+\end_inset
+
+ a 3x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $p_{h}:=\mathbf{p^{T}N}$
+\end_inset
+
+ a 1x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $q_{h}:=\mathbf{q^{T}N}$
+\end_inset
+
+ a 1x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{div\_p}:=\mathbf{\nabla\cdot p}$
+\end_inset
+
+ a 1x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{div\_v}:=\mathbf{\nabla\cdot v}$
+\end_inset
+
+ a 1x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{div\_vconv}:=\mathbf{\nabla\cdot vconv}$
+\end_inset
+
+ a 1x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{grad\_p}:=\mathbf{DN^{T}\cdot p}$
+\end_inset
+
+ a 3x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{grad\_v}:=\mathbf{DN^{T}\cdot v}$
+\end_inset
+
+ a 3x3 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{grad\_vconv}:=\mathbf{DN^{T}\cdot vconv}$
+\end_inset
+
+ a 3x3 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{grad\_q}:=\mathbf{DN^{T}\cdot q}$
+\end_inset
+
+ a 3x1 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{grad\_w}:=\mathbf{DN^{T}\cdot w}$
+\end_inset
+
+ a 3x3 matrix
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{grad\_sym\_v}:=$
+\end_inset
+
+a 3x3 matrix (symmetric gradient in Voigt form)
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{grad\_sym\_w}:=$
+\end_inset
+
+a 3x3 matrix (symmetric gradient of the test function in Voigt form)
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{convective\_term}:=\mathbf{\left(a_{h}\cdot grad\_vh\right)^{T}}$
+\end_inset
+
+ a 3x1 vector in where 
+\begin_inset Formula $\mathbf{a_{h}}$
+\end_inset
+
+is the convective velocity.
+ If the option 
+\begin_inset Quotes eld
+\end_inset
+
+Picard
+\begin_inset Quotes erd
+\end_inset
+
+ linearisation is set, the convective velocity is defined as a symbol 
+\begin_inset Formula $\mathbf{v_{conv}}$
+\end_inset
+
+ meaning that it is treated as a constant in the automatic differenctiation.
+ On the contrary, if the option 
+\begin_inset Quotes eld
+\end_inset
+
+FullNR
+\begin_inset Quotes erd
+\end_inset
+
+ linearisation is set, the convective velocity is defined as 
+\begin_inset Formula $(\mathbf{v_{h}}-\mathbf{v_{mesh}})$
+\end_inset
+
+ implying that 
+\begin_inset Formula $\mathbf{v_{h}}$
+\end_inset
+
+ is considered in the automatic differenctiation.
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{stress}:$
+\end_inset
+
+ 6x1 shear stress vector computed by constitutive law using the previous
+ iteration database.
+ This stress vector is considered in the computation of the RHS, which is
+ the residual of the previous iteration solution.
+ When computing the LHS (RHS derivative w.r.t.
+ the DOFs), the 
+\begin_inset Formula $\mathbf{stress}$
+\end_inset
+
+ is substituted by 
+\begin_inset Formula $\mathbf{C*grad\_sym\_v}$
+\end_inset
+
+ to consider the stress in the automatic differenctiation.
+\end_layout
+
+\begin_layout Section*
+IMPLEMENTATION
+\end_layout
+
+\begin_layout Standard
+The residual functional implementation is splitted in two pieces
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{rv\_galerkin}$
+\end_inset
+
+: functional corresponding to the standard incompressible Navier-Stokes
+ equations.
+ If 
+\begin_inset Quotes eld
+\end_inset
+
+artificial_compressibility
+\begin_inset Quotes erd
+\end_inset
+
+ is set as True, the artificial compressibility terms are also added to
+ the functional.
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{rv\_stab}$
+\end_inset
+
+: functional corresponding to the standard incompressible Navier-Stokes
+ ASGS stabilization.
+ If 
+\begin_inset Quotes eld
+\end_inset
+
+artificial_compressibility
+\begin_inset Quotes erd
+\end_inset
+
+ is set as True, the artificial compressibility stabilization terms are
+ also added to the stabilization functional.
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{rv}=\mathbf{rv\_galerkin}+\mathbf{rv\_stab}$
+\end_inset
+
+: summation of functionals.
+ This is the functional used to compute the LHS and RHS elemental matrices.
+\end_layout
+
+\begin_layout Standard
+For the definition of the subscales, the residuals are splitted in
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{vel\_residual}$
+\end_inset
+
+: linear momentum conservation equation residual.
+ 
+\end_layout
+
+\begin_layout Itemize
+\begin_inset Formula $\mathbf{mas\_residual}$
+\end_inset
+
+: mass conservation equation residual.
+ If 
+\begin_inset Quotes eld
+\end_inset
+
+artificial_compressibility
+\begin_inset Quotes erd
+\end_inset
+
+ is set as True, the artificial compressibility terms are also added to
+ the residual.
+\end_layout
+
+\end_body
+\end_document

--- a/applications/FluidDynamicsApplication/symbolic_generation/embedded_ausas_navier_stokes/generate_embedded_ausas_navier_stokes_element.py
+++ b/applications/FluidDynamicsApplication/symbolic_generation/embedded_ausas_navier_stokes/generate_embedded_ausas_navier_stokes_element.py
@@ -1,0 +1,231 @@
+from sympy import *
+from KratosMultiphysics import *
+from sympy_fe_utilities import *
+
+## Settings explanation
+# DIMENSION TO COMPUTE:
+# This symbolic generator is valid for both 2D and 3D cases. Since the element has been programed with a dimension template in Kratos,
+# it is advised to set the dim_to_compute flag as "Both". In this case the generated .cpp file will contain both 2D and 3D implementations.
+# LINEARISATION SETTINGS:
+# FullNR considers the convective velocity as "v-vmesh", hence v is taken into account in the derivation of the LHS and RHS.
+# Picard (a.k.a. QuasiNR) considers the convective velocity as "a", thus it is considered as a constant in the derivation of the LHS and RHS.
+# DIVIDE BY RHO:
+# If set to true, divides the mass conservation equation by rho in order to have a better conditioned matrix. Otherwise the original form is kept.
+# ARTIFICIAL COMPRESSIBILITY:
+# If set to true, the time derivative of the density is introduced in the mass conservation equation together with the state equation
+# dp/drho=c^2 (being c the sound velocity). Besides, the velocity divergence is not considered to be 0. These assumptions add some extra terms
+# to the usual Navier-Stokes equations that are intended to act as a soft artificial compressibility, which is controlled by the value of "c".
+# In the derivation of the residual equations the space variations of the density are considered to be close to 0.
+
+## Symbolic generation settings
+do_simplifications = False
+dim_to_compute = "Both"             # Spatial dimensions to compute. Options:  "2D","3D","Both"
+linearisation = "Picard"            # Iteration type. Options: "Picard", "FullNR"
+divide_by_rho = True                # Divide by density in mass conservation equation
+artificial_compressibility = True   # Consider an artificial compressibility
+asgs_stabilization = True           # Consider ASGS stabilization terms
+mode = "c"                          # Output mode to a c++ file
+
+if (dim_to_compute == "2D"):
+    dim_vector = [2]
+elif (dim_to_compute == "3D"):
+    dim_vector = [3]
+elif (dim_to_compute == "Both"):
+    dim_vector = [2,3]
+
+## Read the template file
+templatefile = open("embedded_ausas_navier_stokes_cpp_template.cpp")
+outstring = templatefile.read()
+
+for dim in dim_vector:
+
+    if(dim == 2):
+        nnodes = 3
+        strain_size = 3
+    elif(dim == 3):
+        nnodes = 4
+        strain_size = 6
+
+    impose_partion_of_unity = False
+    N,DN = DefineShapeFunctions(nnodes, dim, impose_partion_of_unity)
+
+    ## Unknown fields definition
+    v = DefineMatrix('v',nnodes,dim)            # Current step velocity (v(i,j) refers to velocity of node i component j)
+    vn = DefineMatrix('vn',nnodes,dim)          # Previous step velocity
+    vnn = DefineMatrix('vnn',nnodes,dim)        # 2 previous step velocity
+    p = DefineVector('p',nnodes)                # Pressure
+    pn = DefineVector('pn',nnodes)              # Previous step pressure
+    pnn = DefineVector('pnn',nnodes)            # 2 previous step pressure
+
+    ## Test functions definition
+    w = DefineMatrix('w',nnodes,dim)            # Velocity field test function
+    q = DefineVector('q',nnodes)                # Pressure field test function
+
+    ## Other data definitions
+    f = DefineMatrix('f',nnodes,dim)            # Forcing term
+
+    ## Constitutive matrix definition
+    C = DefineSymmetricMatrix('C',strain_size,strain_size)
+
+    ## Stress vector definition
+    stress = DefineVector('stress',strain_size)
+
+    ## Other simbols definition
+    c   = Symbol('c',positive= True)            # Wave length number
+    dt  = Symbol('dt', positive = True)         # Time increment
+    rho = Symbol('rho', positive = True)        # Density
+    nu  = Symbol('nu', positive = True)         # Kinematic viscosity (mu/rho)
+    mu  = Symbol('mu', positive = True)         # Dynamic viscosity
+    h = Symbol('h', positive = True)
+    dyn_tau = Symbol('dyn_tau', positive = True)
+    stab_c1 = Symbol('stab_c1', positive = True)
+    stab_c2 = Symbol('stab_c2', positive = True)
+
+    ## Backward differences coefficients
+    bdf0 = Symbol('bdf0')
+    bdf1 = Symbol('bdf1')
+    bdf2 = Symbol('bdf2')
+
+    ## Data interpolation to the Gauss points
+    f_gauss = f.transpose()*N
+    v_gauss = v.transpose()*N
+
+    ## Convective velocity definition
+    if (linearisation == "Picard"):
+        vconv = DefineMatrix('vconv',nnodes,dim)    # Convective velocity defined a symbol
+    elif (linearisation == "FullNR"):
+        vmesh = DefineMatrix('vmesh',nnodes,dim)    # Mesh velocity
+        vconv = v - vmesh                           # Convective velocity defined as a velocity dependent variable
+
+    vconv_gauss = vconv.transpose()*N
+
+    ## Compute the stabilization parameters
+    vconv_gauss_norm = 0.0
+    for i in range(0, dim):
+        vconv_gauss_norm += vconv_gauss[i]**2
+    vconv_gauss_norm = sqrt(vconv_gauss_norm)
+
+    tau1 = 1.0/((rho*dyn_tau)/dt + (stab_c2*rho*vconv_gauss_norm)/h + (stab_c1*mu)/(h*h))   # Stabilization parameter 1
+    tau2 = mu + (stab_c2*vconv_gauss_norm*h)/stab_c1                                        # Stabilization parameter 2
+
+    ## Compute the rest of magnitudes at the Gauss points
+    accel_gauss = (bdf0*v + bdf1*vn + bdf2*vnn).transpose()*N
+
+    p_gauss = p.transpose()*N
+    pder_gauss = (bdf0*p + bdf1*pn + bdf2*pnn).transpose()*N
+
+    w_gauss = w.transpose()*N
+    q_gauss = q.transpose()*N
+
+    ## Gradients computation (fluid dynamics gradient)
+    grad_w = DfjDxi(DN,w)
+    grad_q = DfjDxi(DN,q)
+    grad_p = DfjDxi(DN,p)
+    grad_v = DfjDxi(DN,v)
+    grad_vconv = DfjDxi(DN,vconv)
+
+    div_w = div(DN,w)
+    div_v = div(DN,v)
+    div_vconv = div(DN,vconv)
+
+    grad_sym_v = grad_sym_voigtform(DN,v)       # Symmetric gradient of v in Voigt notation
+    grad_w_voigt = grad_sym_voigtform(DN,w)     # Symmetric gradient of w in Voigt notation
+    # Recall that the grad(w):sigma contraction equals grad_sym(w)*sigma in Voigt notation since sigma is a symmetric tensor.
+
+    # Convective term definition
+    convective_term = (vconv_gauss.transpose()*grad_v)
+
+    ## Compute galerkin functional
+    # Navier-Stokes functional
+    if (divide_by_rho):
+        rv_galerkin = rho*w_gauss.transpose()*f_gauss - rho*w_gauss.transpose()*accel_gauss - rho*w_gauss.transpose()*convective_term.transpose() - grad_w_voigt.transpose()*stress + div_w*p_gauss  + grad_q.transpose()*v_gauss
+        if (artificial_compressibility):
+            rv_galerkin -= (1/(rho*c*c))*q_gauss*pder_gauss
+    else:
+        rv_galerkin = rho*w_gauss.transpose()*f_gauss - rho*w_gauss.transpose()*accel_gauss - rho*w_gauss.transpose()*convective_term.transpose() - grad_w_voigt.transpose()*stress + div_w*p_gauss - rho*grad_q.transpose()*v_gauss
+        if (artificial_compressibility):
+            rv_galerkin -= (1/(c*c))*q_gauss*pder_gauss
+
+    ##  Stabilization functional terms
+    # Momentum conservation residual
+    # Note that the viscous stress term is dropped since linear elements are used
+    vel_residual = rho*f_gauss - rho*accel_gauss -rho*convective_term.transpose() - grad_p
+
+    # Mass conservation residual
+    if (divide_by_rho):
+        mas_residual = -div_v
+        if (artificial_compressibility):
+            mas_residual -= (1/(rho*c*c))*pder_gauss
+    else:
+        mas_residual = -rho*div_v
+        if (artificial_compressibility):
+            mas_residual -= (1/(c*c))*pder_gauss
+
+    vel_subscale = tau1*vel_residual
+    mas_subscale = tau2*mas_residual
+
+    # Compute the ASGS stabilization terms using the momentum and mass conservation residuals above
+    if (divide_by_rho):
+        rv_stab = grad_q.transpose()*vel_subscale
+    else:
+        rv_stab = rho*grad_q.transpose()*vel_subscale
+    rv_stab += rho*vconv_gauss.transpose()*grad_w*vel_subscale
+    rv_stab += rho*div_vconv*w_gauss.transpose()*vel_subscale
+    rv_stab += div_w*mas_subscale
+
+    ## Add the stabilization terms to the original residual terms
+    if (asgs_stabilization):
+        rv = rv_galerkin + rv_stab
+    else:
+        rv = rv_galerkin
+
+    ## Define DOFs and test function vectors
+    dofs = Matrix( zeros(nnodes*(dim+1), 1) )
+    testfunc = Matrix( zeros(nnodes*(dim+1), 1) )
+
+    for i in range(0,nnodes):
+
+        # Velocity DOFs and test functions
+        for k in range(0,dim):
+            dofs[i*(dim+1)+k] = v[i,k]
+            testfunc[i*(dim+1)+k] = w[i,k]
+
+        # Pressure DOFs and test functions
+        dofs[i*(dim+1)+dim] = p[i,0]
+        testfunc[i*(dim+1)+dim] = q[i,0]
+
+    ## Compute LHS and RHS
+    # For the RHS computation one wants the residual of the previous iteration (residual based formulation). By this reason the stress is
+    # included as a symbolic variable, which is assumed to be passed as an argument from the previous iteration database.
+    rhs = Compute_RHS(rv.copy(), testfunc, do_simplifications)
+    rhs_out = OutputVector_CollectingFactors(rhs, "rhs", mode)
+
+    # Compute LHS (RHS(residual) differenctiation w.r.t. the DOFs)
+    # Note that the 'stress' (symbolic variable) is substituted by 'C*grad_sym_v' for the LHS differenctiation. Otherwise the velocity terms
+    # within the velocity symmetryc gradient would not be considered in the differenctiation, meaning that the stress would be considered as
+    # a velocity independent constant in the LHS.
+    SubstituteMatrixValue(rhs, stress, C*grad_sym_v)
+    lhs = Compute_LHS(rhs, testfunc, dofs, do_simplifications) # Compute the LHS (considering stress as C*(B*v) to derive w.r.t. v)
+    lhs_out = OutputMatrix_CollectingFactors(lhs, "lhs", mode)
+
+
+    if(dim == 2):
+        outstring = outstring.replace("//substitute_lhs_2D", lhs_out)
+        outstring = outstring.replace("//substitute_rhs_2D", rhs_out)
+    elif(dim == 3):
+        outstring = outstring.replace("//substitute_lhs_3D", lhs_out)
+        outstring = outstring.replace("//substitute_rhs_3D", rhs_out)
+
+    ## Compute velocity subscale Gauss point value
+    v_s_gauss = tau1*rho*(f_gauss - accel_gauss - convective_term.transpose()) - tau1*grad_p
+    v_s_gauss_out = OutputVector_CollectingFactors(v_s_gauss, "v_s_gauss", mode)
+
+    if(dim == 2):
+        outstring = outstring.replace("//substitute_gausspt_subscale_2D", v_s_gauss_out)
+    elif(dim == 3):
+        outstring = outstring.replace("//substitute_gausspt_subscale_3D", v_s_gauss_out)
+
+## Write the modified template
+out = open("embedded_ausas_navier_stokes.cpp",'w')
+out.write(outstring)
+out.close()

--- a/applications/FluidDynamicsApplication/symbolic_generation/embedded_ausas_navier_stokes/generate_embedded_ausas_navier_stokes_element.py
+++ b/applications/FluidDynamicsApplication/symbolic_generation/embedded_ausas_navier_stokes/generate_embedded_ausas_navier_stokes_element.py
@@ -138,11 +138,11 @@ for dim in dim_vector:
     ## Compute galerkin functional
     # Navier-Stokes functional
     if (divide_by_rho):
-        rv_galerkin = rho*w_gauss.transpose()*f_gauss - rho*w_gauss.transpose()*accel_gauss - rho*w_gauss.transpose()*convective_term.transpose() - grad_w_voigt.transpose()*stress + div_w*p_gauss  + grad_q.transpose()*v_gauss
+        rv_galerkin = rho*w_gauss.transpose()*f_gauss - rho*w_gauss.transpose()*accel_gauss - rho*w_gauss.transpose()*convective_term.transpose() - grad_w_voigt.transpose()*stress + div_w*p_gauss + grad_q.transpose()*v_gauss
         if (artificial_compressibility):
             rv_galerkin -= (1/(rho*c*c))*q_gauss*pder_gauss
     else:
-        rv_galerkin = rho*w_gauss.transpose()*f_gauss - rho*w_gauss.transpose()*accel_gauss - rho*w_gauss.transpose()*convective_term.transpose() - grad_w_voigt.transpose()*stress + div_w*p_gauss - rho*grad_q.transpose()*v_gauss
+        rv_galerkin = rho*w_gauss.transpose()*f_gauss - rho*w_gauss.transpose()*accel_gauss - rho*w_gauss.transpose()*convective_term.transpose() - grad_w_voigt.transpose()*stress + div_w*p_gauss + rho*grad_q.transpose()*v_gauss
         if (artificial_compressibility):
             rv_galerkin -= (1/(c*c))*q_gauss*pder_gauss
 
@@ -216,14 +216,14 @@ for dim in dim_vector:
         outstring = outstring.replace("//substitute_lhs_3D", lhs_out)
         outstring = outstring.replace("//substitute_rhs_3D", rhs_out)
 
-    ## Compute velocity subscale Gauss point value
-    v_s_gauss = tau1*rho*(f_gauss - accel_gauss - convective_term.transpose()) - tau1*grad_p
-    v_s_gauss_out = OutputVector_CollectingFactors(v_s_gauss, "v_s_gauss", mode)
+    # ## Compute velocity subscale Gauss point value
+    # v_s_gauss = tau1*rho*(f_gauss - accel_gauss - convective_term.transpose()) - tau1*grad_p
+    # v_s_gauss_out = OutputVector_CollectingFactors(v_s_gauss, "v_s_gauss", mode)
 
-    if(dim == 2):
-        outstring = outstring.replace("//substitute_gausspt_subscale_2D", v_s_gauss_out)
-    elif(dim == 3):
-        outstring = outstring.replace("//substitute_gausspt_subscale_3D", v_s_gauss_out)
+    # if(dim == 2):
+    #     outstring = outstring.replace("//substitute_gausspt_subscale_2D", v_s_gauss_out)
+    # elif(dim == 3):
+    #     outstring = outstring.replace("//substitute_gausspt_subscale_3D", v_s_gauss_out)
 
 ## Write the modified template
 out = open("embedded_ausas_navier_stokes.cpp",'w')


### PR DESCRIPTION
A minor bug (the edge area was not computed) has been fix in the 2D discontinuous shape functions utilities. It has been fixed. Besides, the method that computes such 2D discontinuous shape functions has been cleaned up.

Three simple tests for the modified function have been created as well.