### PR TITLE
mesh-generation wrapper and other minor changes for compat. with json

### DIFF
--- a/applications/swimming_DEM_application/python_scripts/cellular_flow/ethier_benchmark_algorithm.py
+++ b/applications/swimming_DEM_application/python_scripts/cellular_flow/ethier_benchmark_algorithm.py
@@ -208,9 +208,9 @@ class Algorithm(BaseAlgorithm):
         size_parameter = self.pp.CFD_DEM.size_parameter
         with h5py.File(file_name) as f:
             mat_deriv_grp = f.require_group('material derivative')
-            mat_deriv_mthd_group = mat_deriv_grp.require_group('method = ' + str(self.pp.CFD_DEM.material_acceleration_calculation_type))
+            mat_deriv_mthd_group = mat_deriv_grp.require_group('method = ' + str(self.pp.CFD_DEM["material_acceleration_calculation_type"].GetInt()))
             laplacian_grp = f.require_group('laplacian')
-            laplacian_mthd_group = laplacian_grp.require_group('method = ' + str(self.pp.CFD_DEM.laplacian_calculation_type))
+            laplacian_mthd_group = laplacian_grp.require_group('method = ' + str(self.pp.CFD_DEM["laplacian_calculation_type"].GetInt()))
 
             if num_type(size_parameter) == 'int':
                 mesh_grp_mat_deriv = mat_deriv_mthd_group.require_group('regular mesh')
@@ -232,10 +232,10 @@ class Algorithm(BaseAlgorithm):
             size_parameter_name = '_ndiv_'
         elif num_type(size_parameter) == 'float':
             size_parameter_name = '_h_'
-        with open('../errors_recorded/mat_deriv_errors' + size_parameter_name + str(self.pp.CFD_DEM.size_parameter) + '_type_' + str(self.pp.CFD_DEM.material_acceleration_calculation_type) + '.txt', 'w') as mat_errors_file:
+        with open('../errors_recorded/mat_deriv_errors' + size_parameter_name + str(self.pp.CFD_DEM.size_parameter) + '_type_' + str(self.pp.CFD_DEM["material_acceleration_calculation_type"].GetInt()) + '.txt', 'w') as mat_errors_file:
             for error in self.mat_deriv_errors:
                 mat_errors_file.write(str(error) + '\n')
-        with open('../errors_recorded/laplacian_errors' + size_parameter_name + str(size_parameter) + '_type_' + str(self.pp.CFD_DEM.laplacian_calculation_type) + '.txt', 'w') as laplacian_errors_file:
+        with open('../errors_recorded/laplacian_errors' + size_parameter_name + str(size_parameter) + '_type_' + str(self.pp.CFD_DEM["laplacian_calculation_type"].GetInt()) + '.txt', 'w') as laplacian_errors_file:
             for error in self.laplacian_errors:
                 laplacian_errors_file.write(str(error) + '\n')
         sys.stdout.flush()

--- a/applications/swimming_DEM_application/python_scripts/cellular_flow/make_mesh_ethier_benchmark_algorithm.py
+++ b/applications/swimming_DEM_application/python_scripts/cellular_flow/make_mesh_ethier_benchmark_algorithm.py
@@ -1,10 +1,5 @@
 from KratosMultiphysics import *
-from KratosMultiphysics.SwimmingDEMApplication import *
-from KratosMultiphysics.DEMApplication import *
 import ethier_benchmark_algorithm
-import swimming_DEM_procedures as SDP
-import math
-import numpy as np
 BaseAlgorithm = ethier_benchmark_algorithm.Algorithm
 
 
@@ -22,42 +17,11 @@ class Algorithm(BaseAlgorithm):
         self.pp.CFD_DEM.size_parameter = self.pp.CFD_DEM["size_parameter"].GetInt()
 
     def ReadFluidModelParts(self):
-        os.chdir(self.main_path)
-        if ethier_benchmark_algorithm.num_type(self.pp.CFD_DEM.size_parameter) == 'int':
-            model_part_io_fluid = ModelPartIO(self.pp.problem_name.replace('ethier', 'ethier_ndiv_' + str(self.pp.CFD_DEM.size_parameter) + 'GiD'))
-        elif ethier_benchmark_algorithm.num_type(self.pp.CFD_DEM.size_parameter) == 'float':
-            model_part_io_fluid = ModelPartIO(self.pp.problem_name.replace('ethier', 'ethier_h_' + str(self.pp.CFD_DEM.size_parameter)))
-        # model_part_io_fluid.ReadModelPart(self.fluid_algorithm.fluid_model_part)
-        print(self.fluid_algorithm.fluid_model_part)
-        parameters = Parameters("{}")
-        parameters.AddEmptyValue("element_name").SetString('VMS3D')
-        parameters.AddEmptyValue("condition_name").SetString('WallCondition3D')
-        parameters.AddEmptyValue("create_skin_sub_model_part").SetBool(False)
-        parameters.AddEmptyValue("number_of_divisions").SetInt(self.pp.CFD_DEM.size_parameter)
-        # sample_geometry = Tetrahedra3D4(Node(1, 0.,0.,0.),
-        #                                 Node(2, 1.,0.,0.),
-        #                                 Node(3, 1.,1.,0.),
-        #                                 Node(4, 0.,1.,0.))
-        print(parameters)
-        sample_geometry = Hexahedra3D8(Node(1, 0.1, 0.1, 0.0),
-                                       Node(2, 0.0, 0.1, 0.0),
-                                       Node(3, 0.0, 0.0, 0.0),
-                                       Node(4, 0.1, 0.0, 0.0),
-                                       Node(5, 0.1, 0.1, 0.1),
-                                       Node(6, 0.0, 0.1, 0.1),
-                                       Node(7, 0.0, 0.0, 0.1),
-                                       Node(8, 0.1, 0.0, 0.1))
-        # sample_geometry = Tetrahedra3D4(Point3D(0.,0.,0.),
-        #                                 Point3D(1.,0.,0.),
-        #                                 Point3D(1.,1.,0.),
-        #                                 Point3D(0.,1.,0.))
-        mesh_generator_process = StructuredMeshGeneratorProcess(sample_geometry, self.fluid_algorithm.fluid_model_part, parameters)
-        print(parameters)
-        print(mesh_generator_process)
-        self.fluid_algorithm.fluid_model_part.CreateSubModelPart("Skin")
-        del sample_geometry
-        mesh_generator_process.Execute()
-        area_calculator = CalculateNodalAreaProcess(self.fluid_algorithm.fluid_model_part, 3)
-        area_calculator.Execute()
-        for node in self.fluid_algorithm.fluid_model_part.Nodes:
-            print(node.GetSolutionStepValue(NODAL_AREA))
+        from meshing import meshing_utilities
+        self.mesh_generator = meshing_utilities.ParallelepipedRegularMesher(
+                                                model_part_to_be_filled = self.fluid_algorithm.fluid_model_part,
+                                                lower_corner_coordinates = [0.0, 0.0, 0.0],
+                                                higher_corner_coordinates = [0.1, 0.1, 0.1],
+                                                number_of_divisions_per_dimension = 10)
+
+        self.mesh_generator.FillModelPartWithNewMesh()

--- a/applications/swimming_DEM_application/python_scripts/meshing/meshing_utilities.py
+++ b/applications/swimming_DEM_application/python_scripts/meshing/meshing_utilities.py
@@ -1,0 +1,44 @@
+from KratosMultiphysics import *
+
+class ParallelepipedRegularMesher: # TO-DO_ Generalize to different number of divisions per dimension
+    def __init__(self,
+                 model_part_to_be_filled,
+                 lower_corner_coordinates,
+                 higher_corner_coordinates,
+                 number_of_divisions_per_dimension,
+                 element_name='VMS3D',
+                 condition_name='WallCondition3D'):
+        self.lc = lower_corner_coordinates
+        self.hc = higher_corner_coordinates
+        self.n_divisions = number_of_divisions_per_dimension
+        self.mp = model_part_to_be_filled
+
+        parameters = Parameters("{}")
+        parameters.AddEmptyValue("element_name").SetString(element_name)
+        parameters.AddEmptyValue("condition_name").SetString(condition_name)
+        parameters.AddEmptyValue("create_skin_sub_model_part").SetBool(False)
+        parameters.AddEmptyValue("number_of_divisions").SetInt(self.n_divisions)
+
+        domain_geometry = Hexahedra3D8(Node(1, self.hc[0], self.hc[1], self.lc[2]),
+                                       Node(2, self.lc[0], self.hc[1], self.lc[2]),
+                                       Node(3, self.lc[0], self.lc[1], self.lc[2]),
+                                       Node(4, self.hc[0], self.lc[1], self.lc[2]),
+                                       Node(5, self.hc[0], self.hc[1], self.hc[2]),
+                                       Node(6, self.lc[0], self.hc[1], self.hc[2]),
+                                       Node(7, self.lc[0], self.lc[1], self.hc[2]),
+                                       Node(8, self.hc[0], self.lc[1], self.hc[2]))
+
+        self.mesh_generator_process = StructuredMeshGeneratorProcess(domain_geometry,
+                                                                     self.mp,
+                                                                     parameters)
+    def FillModelPartWithNewMesh(self):
+        n_elements = len(self.mp.Elements)
+        if n_elements > 0:
+            raise Exception('The model_part already contains elements ( '
+                            + str(n_elements)
+                            + ' in total). Regular mesh cannot be generated.)')
+        else:
+            if not self.mp.HasSubModelPart("Skin"):
+                self.mp.CreateSubModelPart("Skin")
+
+            self.mesh_generator_process.Execute()


### PR DESCRIPTION
The wrapper allows to fill a model part with no elements with elements of the required type (tetras by default). The generalization to different number of divisions per dimension (suggested by Miguel Angel) should be implemented next