### PR TITLE
New Dam Utility for summing stresses due to selfweight

### DIFF
--- a/applications/DamApplication/custom_processes/dam_t_sol_air_heat_flux_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_t_sol_air_heat_flux_process.hpp
@@ -56,7 +56,7 @@ public:
                 "table_ambient_temperature"       : 0,
                 "emisivity"                       : 0.0,
                 "delta_R"                         : 0.0,
-                "absortion_index"                 : 0.0,
+                "absorption_index"                 : 0.0,
                 "total_insolation"                : 0.0               
             }  )" );
         
@@ -64,7 +64,7 @@ public:
         // So that an error is thrown if they don't exist
         rParameters["h_0"];
         rParameters["delta_R"];
-        rParameters["absortion_index"];
+        rParameters["absorption_index"];
 
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
@@ -75,7 +75,7 @@ public:
         mAmbientTemperature = rParameters["ambient_temperature"].GetDouble();
         mEmisivity = rParameters["emisivity"].GetDouble();
         mDeltaR = rParameters["delta_R"].GetDouble();
-        mAbsortion_index = rParameters["absortion_index"].GetDouble();
+        mAbsorption_index = rParameters["absorption_index"].GetDouble();
         mTotalInsolation = rParameters["total_insolation"].GetDouble();
         
         mTimeUnitConverter = mrModelPart.GetProcessInfo()[TIME_UNIT_CONVERTER];
@@ -143,7 +143,7 @@ void ExecuteInitialize()
         }
 
         // Computing the t_soil_air according to t_sol_air criteria
-        double t_sol_air = mAmbientTemperature + (mAbsortion_index*mTotalInsolation/mH0) - (mEmisivity*mDeltaR/mH0);
+        double t_sol_air = mAmbientTemperature + (mAbsorption_index*mTotalInsolation/mH0) - (mEmisivity*mDeltaR/mH0);
 
         if(nnodes != 0)
         {
@@ -195,7 +195,7 @@ protected:
     double mAmbientTemperature;
     double mEmisivity;
     double mDeltaR;
-    double mAbsortion_index;    
+    double mAbsorption_index;    
     double mTotalInsolation;
     double mTimeUnitConverter;    
     TableType::Pointer mpTable;

--- a/applications/DamApplication/custom_processes/dam_t_sol_air_heat_flux_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_t_sol_air_heat_flux_process.hpp
@@ -103,7 +103,7 @@ void ExecuteInitialize()
     Variable<double> var = KratosComponents< Variable<double> >::Get(mVariableName);
     
     // Computing the t_soil_air according to t_sol_air criteria
-    double t_sol_air = mAmbientTemperature + (mAbsortion_index*mTotalInsolation/mH0) - (mEmisivity*mDeltaR/mH0);
+    double t_sol_air = mAmbientTemperature + (mAbsorption_index*mTotalInsolation/mH0) - (mEmisivity*mDeltaR/mH0);
 
     if(nnodes != 0)
     {

--- a/applications/DamApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/DamApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -23,6 +23,7 @@
 
 #include "custom_utilities/streamlines_output_3D_utilities.hpp"
 #include "custom_utilities/global_joint_stress_utility.hpp"
+#include "custom_utilities/transfer_selfweight_stress_utility.hpp"
 
 namespace Kratos
 {
@@ -40,6 +41,10 @@ void  AddCustomUtilitiesToPython()
   
     class_< GlobalJointStressUtility > ("GlobalJointStressUtility", init<ModelPart&, Parameters>())
     .def("ComputingGlobalStress",&GlobalJointStressUtility::ComputingGlobalStress)
+    ;
+
+    class_< TransferSelfweightStressUtility > ("TransferSelfweightStressUtility", init<>())
+    .def("Transfer",&TransferSelfweightStressUtility::Transfer)
     ;
     
 }

--- a/applications/DamApplication/custom_utilities/transfer_selfweight_stress_utility.hpp
+++ b/applications/DamApplication/custom_utilities/transfer_selfweight_stress_utility.hpp
@@ -1,0 +1,98 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Lorenzo Gracia
+//
+//
+
+#if !defined(KRATOS_TRANSFER_SELFWEIGHT_STRESS_UTILITIES )
+#define  KRATOS_TRANSFER_SELFWEIGHT_STRESS_UTILITIES
+
+#include <cmath>
+
+// Project includes
+#include "includes/kratos_flags.h"
+#include "includes/kratos_parameters.h"
+#include "processes/process.h"
+#include "utilities/openmp_utils.h"
+#include "utilities/math_utils.h"
+#include "includes/element.h"
+
+// Application includes
+#include "dam_application_variables.h"
+
+namespace Kratos
+{
+    
+class TransferSelfweightStressUtility
+{
+
+public:
+    
+//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+    /// Constructor
+    TransferSelfweightStressUtility() {}
+
+    ///------------------------------------------------------------------------------------
+    
+    /// Destructor
+    ~TransferSelfweightStressUtility() {}
+
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+// Transforming local stress vector in global coordinates 
+    void Transfer( ModelPart& selfweight_model_part, ModelPart& r_model_part, const int TDim)
+    {
+                
+        KRATOS_TRY;      
+        
+        const int NNodes = static_cast<int>(r_model_part.Nodes().size());
+        ModelPart::NodesContainerType::iterator node_begin = r_model_part.NodesBegin();
+        ModelPart::NodesContainerType::iterator node_begin_selfweight = selfweight_model_part.NodesBegin();             
+            
+        Matrix SumMatrix = ZeroMatrix(TDim,TDim);
+        
+        #pragma omp parallel for 
+        for(int i = 0; i < NNodes; i++)
+        {
+            ModelPart::NodesContainerType::iterator itNode = node_begin + i;
+            ModelPart::NodesContainerType::iterator itNodeSelf = node_begin_selfweight + i;
+            
+            const Matrix& NodalStressSelfweight = itNodeSelf->FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR);
+            Matrix& NodalStress = itNode->FastGetSolutionStepValue(NODAL_CAUCHY_STRESS_TENSOR);
+            
+            for(int j=0; j<TDim; j++)
+            {
+                for (int k=0; k<TDim; k++)
+                {
+                    SumMatrix(j,k) =  NodalStress(j,k) + NodalStressSelfweight(j,k);
+                }
+            }
+            noalias(NodalStress) = SumMatrix;          
+        }
+                
+                           
+         KRATOS_CATCH("");
+
+    }
+
+///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+protected:
+
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+};//Class
+
+} /* namespace Kratos.*/
+
+#endif /* KRATOS_TRANSFER_SELFWEIGHT_STRESS_UTILITIES defined */

--- a/applications/DamApplication/custom_utilities/transfer_selfweight_stress_utility.hpp
+++ b/applications/DamApplication/custom_utilities/transfer_selfweight_stress_utility.hpp
@@ -58,8 +58,6 @@ public:
         ModelPart::NodesContainerType::iterator node_begin = r_model_part.NodesBegin();
         ModelPart::NodesContainerType::iterator node_begin_selfweight = selfweight_model_part.NodesBegin();             
             
-        Matrix SumMatrix = ZeroMatrix(TDim,TDim);
-        
         #pragma omp parallel for 
         for(int i = 0; i < NNodes; i++)
         {
@@ -73,10 +71,9 @@ public:
             {
                 for (int k=0; k<TDim; k++)
                 {
-                    SumMatrix(j,k) =  NodalStress(j,k) + NodalStressSelfweight(j,k);
+                    NodalStress(j,k) += NodalStressSelfweight(j,k);
                 }
-            }
-            noalias(NodalStress) = SumMatrix;          
+            }         
         }
                 
                            

--- a/applications/DamApplication/python_scripts/transfer_selfweight_stress_utility.py
+++ b/applications/DamApplication/python_scripts/transfer_selfweight_stress_utility.py
@@ -1,0 +1,16 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
+#importing the Kratos Library
+from KratosMultiphysics import *
+from KratosMultiphysics.SolidMechanicsApplication import *
+from KratosMultiphysics.ExternalSolversApplication import *
+from KratosMultiphysics.DamApplication import *
+
+class TransferSelfweightStressToMainModelPartUtility:
+
+    def __init__(self):
+               
+        self.TransferUtility = TransferSelfweightStressUtility()
+
+    def Transfer(self,selfweight_model_part,model_part,domain_size):
+
+        self.TransferUtility.Transfer(selfweight_model_part, model_part, domain_size)


### PR DESCRIPTION
This utility sums the nodal stresses due to selfweight. The idea is consider the stresses due to selfweight but not the displacements. So, in case of consideration, the mainscript generates automatically a new model part with selfweight solicitations which is solved, and after, the normal problem is solved and the previous stresses are added.