### PR TITLE
Avoiding warnings due to include a missing directory

### DIFF
--- a/applications/ExternalSolversApplication/CMakeLists.txt
+++ b/applications/ExternalSolversApplication/CMakeLists.txt
@@ -3,7 +3,6 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 message("**** configuring KratosExternalSolversApplication ****")
 
 include_directories( ${CMAKE_SOURCE_DIR}/kratos )
-include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/external_libraries )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/custom_external_libraries/SuperLU_4.3 )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/custom_external_libraries )
 


### PR DESCRIPTION
The external_libraries directory does not exist so it gives some warnings when it try to include during the compilation.