### PR TITLE
Hotfix/Particle Mechanichs omp loops in windows

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_strategies/schemes/MPM_residual_based_bossak_scheme.hpp
+++ b/applications/ParticleMechanicsApplication/custom_strategies/schemes/MPM_residual_based_bossak_scheme.hpp
@@ -226,8 +226,7 @@ public:
 
 
 		#pragma omp parallel for
-		
-		for(unsigned int iter = 0; iter < r_model_part.Nodes().size(); ++iter)
+		for(int iter = 0; iter < static_cast<int>(r_model_part.Nodes().size()); ++iter)
 		{
 			
 			auto i = r_model_part.NodesBegin() + iter;
@@ -275,8 +274,7 @@ public:
         //array_1d<double, 3 > DeltaDisplacement;
 
 		#pragma omp parallel for
-		
-		for(unsigned int iter = 0; iter < r_model_part.Nodes().size(); ++iter)
+		for(int iter = 0; iter < static_cast<int>(r_model_part.Nodes().size()); ++iter)
 		{
 			
 			auto i = r_model_part.NodesBegin() + iter;
@@ -449,8 +447,7 @@ public:
 
 
 		#pragma omp parallel for
-		
-		for(unsigned int iter = 0; iter < mr_grid_model_part.Nodes().size(); ++iter)
+		for(int iter = 0; iter < static_cast<int>(mr_grid_model_part.Nodes().size()); ++iter)
 		{
 			
 			auto i = mr_grid_model_part.NodesBegin() + iter;
@@ -537,8 +534,7 @@ public:
             
             
             #pragma omp parallel for
-		
-			for(unsigned int iter = 0; iter < mr_grid_model_part.Nodes().size(); ++iter)
+			for( int iter = 0; iter < static_cast<int>(mr_grid_model_part.Nodes().size()); ++iter)
 			{
 			
 			auto i = mr_grid_model_part.NodesBegin() + iter;
@@ -578,8 +574,7 @@ public:
 
 
 			#pragma omp parallel for
-		
-			for(unsigned int iter = 0; iter < mr_grid_model_part.Nodes().size(); ++iter)
+			for(int iter = 0; iter < static_cast<int>(mr_grid_model_part.Nodes().size()); ++iter)
 			{
 			
 			auto i = mr_grid_model_part.NodesBegin() + iter;

--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
@@ -795,7 +795,7 @@ public:
 
         
         #pragma omp parallel for
-        for(unsigned int i = 0; i < grid_model_part.Elements().size(); ++i){
+        for(int i = 0; i < static_cast<int>(grid_model_part.Elements().size()); ++i){
 			
 			auto elemItr = grid_model_part.Elements().begin() + i;
 			elemItr -> Reset(ACTIVE);
@@ -831,7 +831,7 @@ public:
 
 
 			#pragma omp for
-            for(unsigned int i = 0; i < mpm_model_part.Elements().size(); ++i){
+            for(int i = 0; i < static_cast<int>(mpm_model_part.Elements().size()); ++i){
 
 				auto elemItr = mpm_model_part.Elements().begin() + i;
 				
@@ -896,7 +896,7 @@ public:
 
             //loop over the material points
             #pragma omp for
-            for(unsigned int i = 0; i < mpm_model_part.Elements().size(); ++i){
+            for(int i = 0; i < static_cast<int>(mpm_model_part.Elements().size()); ++i){
 
 		auto elemItr = mpm_model_part.Elements().begin() + i;
                 


### PR DESCRIPTION
This Pr fixes some problems with the OpenMP loops in win. In general if you want them to compile in windows they can't be `unsigned`.