### PR TITLE
Test/Use gfortran 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - CCACHE_COMPRESS=true
     - CCACHE_NODISABLE=true
     - CCACHE_MAXSIZE=500M
+    - FC=gfortran6
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - CCACHE_COMPRESS=true
     - CCACHE_NODISABLE=true
     - CCACHE_MAXSIZE=500M
-    - FC=gfortran6
+    - FC=gfortran-6
 
 addons:
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
     packages:
       - gcc-6
       - g++-6
-      - gfortran
+      - gfortran-6
       - libboost1.55-dev
       - libboost-serialization1.55-dev
       - libboost-python1.55-dev


### PR DESCRIPTION
@maceligueta Follwing your suggestion I removed gcc 4.8.2 from travis ( was installed with the gofrtran packet)
It looks like we are 1-2,5 min faster.

Thx a lot for pointing it out!