### PR TITLE
Deprecating cross products

### DIFF
--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -362,12 +362,12 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
     
     
 #ifdef __GNUC__
-#define DEPRECATED __attribute__((deprecated))
+#define KRATOS_DEPRECATED __attribute__((deprecated))
 #elif defined(_MSC_VER)
-#define DEPRECATED __declspec(deprecated)
+#define KRATOS_DEPRECATED __declspec(deprecated)
 #else
 #pragma message("WARNING: You need to implement DEPRECATED for this compiler")
-#define DEPRECATED
+#define KRATOS_DEPRECATED
 #endif
     
 

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -358,6 +358,18 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
     KRATOS_REGISTER_IN_PYTHON_FLAG_IMPLEMENTATION(flag);   \
     KRATOS_REGISTER_IN_PYTHON_FLAG_IMPLEMENTATION(NOT_##flag)
 
+    
+    
+    
+#ifdef __GNUC__
+#define DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define DEPRECATED __declspec(deprecated)
+#else
+#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+#define DEPRECATED
+#endif
+    
 
 namespace Kratos
 {

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -789,7 +789,10 @@ public:
         return c;
     }
 
-    static inline array_1d<double, 3> UnitCrossProduct(
+    //this function is deprecated since instead of giving back vec x Tuple it gives back Tuple x Vec ( = -Vec x Tuple)
+    //THAT IS -- THIS FUNCTION GIVES BACK THE OPPOSITE SIGN OF THE PRODUCT
+    //please use instead CrossProd(c,a,b) which is also in general more optimal since it never creates tmp on return
+    DEPRECATED static inline array_1d<double, 3> UnitCrossProduct(
         const array_1d<double, 3>& vec, 
         const array_1d<double, 3>& Tuple
         )
@@ -805,7 +808,10 @@ public:
         return cross;
     }
 
-    static inline array_1d<double, 3> CrossProduct(
+    //this function is deprecated since instead of giving back vec x Tuple it gives back Tuple x Vec ( = -Vec x Tuple)
+    //THAT IS -- THIS FUNCTION GIVES BACK THE OPPOSITE SIGN OF THE PRODUCT
+    //please use instead CrossProd(c,a,b) which is also in general more optimal since it never creates tmp on return
+    DEPRECATED static inline array_1d<double, 3> CrossProduct(
         const array_1d<double, 3>& vec, 
         const array_1d<double, 3>& Tuple
         )
@@ -835,6 +841,25 @@ public:
         c[0] = a[1]*b[2] - a[2]*b[1];
         c[1] = a[2]*b[0] - a[0]*b[2];
         c[2] = a[0]*b[1] - a[1]*b[0];
+    }
+    
+    //general version    
+    template< class T1, class T2, class T3 >
+    static inline void CrossProduct(T1& c, const T2& a, const T3& b ){
+        c[0] = a[1]*b[2] - a[2]*b[1];
+        c[1] = a[2]*b[0] - a[0]*b[2];
+        c[2] = a[0]*b[1] - a[1]*b[0];
+    }
+
+    template< class T1, class T2, class T3 >
+    static inline void UnitCrossProduct(T1& c, const T2& a, const T3& b ){
+        CrossProduct(c,a,b);
+        double norm = norm_2(c);
+#ifdef KRATOS_DEBUG
+        if(norm < 1000.0*std::numeric_limits<double>::epsilon())
+            KRATOS_ERROR << "norm is 0 when making the UnitCrossProduct of the vectors " << a << " and " << b << std::endl;
+#endif
+        c/=norm;
     }
     
     /**

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -792,7 +792,7 @@ public:
     //this function is deprecated since instead of giving back vec x Tuple it gives back Tuple x Vec ( = -Vec x Tuple)
     //THAT IS -- THIS FUNCTION GIVES BACK THE OPPOSITE SIGN OF THE PRODUCT
     //please use instead CrossProd(c,a,b) which is also in general more optimal since it never creates tmp on return
-    DEPRECATED static inline array_1d<double, 3> UnitCrossProduct(
+    KRATOS_DEPRECATED static inline array_1d<double, 3> UnitCrossProduct(
         const array_1d<double, 3>& vec, 
         const array_1d<double, 3>& Tuple
         )
@@ -811,7 +811,7 @@ public:
     //this function is deprecated since instead of giving back vec x Tuple it gives back Tuple x Vec ( = -Vec x Tuple)
     //THAT IS -- THIS FUNCTION GIVES BACK THE OPPOSITE SIGN OF THE PRODUCT
     //please use instead CrossProd(c,a,b) which is also in general more optimal since it never creates tmp on return
-    DEPRECATED static inline array_1d<double, 3> CrossProduct(
+    KRATOS_DEPRECATED static inline array_1d<double, 3> CrossProduct(
         const array_1d<double, 3>& vec, 
         const array_1d<double, 3>& Tuple
         )


### PR DESCRIPTION
this adds a DEPRECATED tag to the deprecated cross_product functions, thus triggering compilation warnings

this is an attempt to correct #664