### PR TITLE
Fix spalart allmaras turbulence

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/spalart_allmaras_turbulence_model.h
+++ b/applications/FluidDynamicsApplication/custom_processes/spalart_allmaras_turbulence_model.h
@@ -7,8 +7,8 @@
 //
 
 
-#if !defined(KRATOS_SPALART_ALLMARAS_H_INCLUDED )
-#define  KRATOS_SPALART_ALLMARAS_H_INCLUDED
+#if !defined(KRATOS_SPALART_ALLMARAS_TURBULENCE_H_INCLUDED )
+#define  KRATOS_SPALART_ALLMARAS_TURBULENCE_H_INCLUDED
 
 
 
@@ -640,6 +640,6 @@ inline std::ostream & operator <<(std::ostream& rOStream,
 
 } // namespace Kratos.
 
-#endif // KRATOS_SPALART_ALLMARAS_H_INCLUDED  defined
+#endif // KRATOS_SPALART_ALLMARAS_TURBULENCE_H_INCLUDED  defined
 
 


### PR DESCRIPTION
The ward is the same as in this file: https://github.com/KratosMultiphysics/Kratos/blob/hotfix/correct-header-ward/applications/FluidDynamicsApplication/custom_elements/spalart_allmaras.h#L39

so it does not compile under certain circumstances.