### PR TITLE
Tests StructrualMechanics Cleanup und small fixes

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -25,6 +25,8 @@ from test_patch_test_small_strain import TestPatchTestSmallStrain as TTestPatchT
 from test_patch_test_large_strain import TestPatchTestLargeStrain as TTestPatchTestLargeStrain
 from test_quadratic_elements import TestQuadraticElements as TTestQuadraticElements
 from test_patch_test_shells import TestPatchTestShells as TTestPatchTestShells
+from test_patch_test_truss import TestTruss3D2N as TTestTruss3D2N
+from test_patch_test_cr_beam import TestCrBeam3D2N as TTestCrBeam3D2N
 # Test loading conditions
 from test_loading_conditions import TestLoadingConditions as TestLoadingConditions
 # Basic moving mesh test
@@ -32,8 +34,6 @@ from SmallTests import SimpleMeshMovingTest as TSimpleMeshMovingTest
 # Dynamic basic tests
 from SmallTests import DynamicBossakTests as TDynamicBossakTests
 from SmallTests import DynamicNewmarkTests as TDynamicNewmarkTests
-# Nodal damping test
-from test_nodal_damping import NodalDampingTests as TNodalDampingTests
 # Patch test Small Displacements
 from SmallTests import SDTwoDShearQuaPatchTest as TSDTwoDShearQuaPatchTest
 from SmallTests import SDTwoDShearTriPatchTest as TSDTwoDShearTriPatchTest
@@ -134,6 +134,7 @@ def AssambleTestSuites():
     # Create a test suit with the selected tests (Small tests):
     smallSuite = suites['small']
     # Simple patch tests
+    ## Solids
     smallSuite.addTest(TTestConstitutiveLaw('test_Uniaxial_HyperElastic_3D'))
     smallSuite.addTest(TTestConstitutiveLaw('test_Shear_HyperElastic_3D'))
     smallSuite.addTest(TTestConstitutiveLaw('test_Shear_Plus_Strech_HyperElastic_3D'))
@@ -147,19 +148,29 @@ def AssambleTestSuites():
     smallSuite.addTest(TTestPatchTestLargeStrain('test_UL_2D_quadrilateral'))
     smallSuite.addTest(TTestPatchTestLargeStrain('test_UL_3D_hexa'))
     smallSuite.addTest(TTestQuadraticElements('test_Quad8'))
+    ## Shells
     smallSuite.addTest(TTestPatchTestShells('test_thin_shell_triangle'))
     smallSuite.addTest(TTestPatchTestShells('test_thick_shell_triangle'))
     smallSuite.addTest(TTestPatchTestShells('test_thin_shell_quadrilateral'))
     smallSuite.addTest(TTestPatchTestShells('test_thick_shell_quadrilateral'))
+    ## Trusses
+    smallSuite.addTest(TTestTruss3D2N('test_truss3D2N_linear'))
+    smallSuite.addTest(TTestTruss3D2N('test_truss3D2N_nonlinear'))
+    smallSuite.addTest(TTestTruss3D2N('test_truss3D2N_dynamic'))
+    ## Beams
+    smallSuite.addTest(TTestCrBeam3D2N('test_cr_beam_linear'))
+    smallSuite.addTest(TTestCrBeam3D2N('test_cr_beam_nonlinear'))
+    smallSuite.addTest(TTestCrBeam3D2N('test_cr_beam_dynamic_lumped_mass_matrix'))
+    smallSuite.addTest(TTestCrBeam3D2N('test_cr_beam_dynamic_consistent_mass_matrix'))
     # Test loading conditions
-    smallSuite.addTest(TestLoadingConditions('test_execution'))
+    smallSuite.addTest(TestLoadingConditions('test_LineLoadCondition2D2N'))
+    smallSuite.addTest(TestLoadingConditions('test_LineLoadCondition2D2NAngle'))
+    smallSuite.addTest(TestLoadingConditions('test_SurfaceLoadCondition3D4N'))
     # Basic moving mesh test
     smallSuite.addTest(TSimpleMeshMovingTest('test_execution'))
     # Dynamic basic tests
     smallSuite.addTest(TDynamicBossakTests('test_execution'))
     smallSuite.addTest(TDynamicNewmarkTests('test_execution'))
-    # Nodal damping test
-    smallSuite.addTest(TNodalDampingTests('test_execution'))
     # Patch test Small Displacements
     smallSuite.addTest(TSDTwoDShearQuaPatchTest('test_execution'))
     smallSuite.addTest(TSDTwoDShearTriPatchTest('test_execution'))
@@ -203,7 +214,7 @@ def AssambleTestSuites():
     smallSuite.addTest(T3D2NBeamCrLinearTest('test_execution'))
     smallSuite.addTest(T3D2NBeamCrDynamicTest('test_execution'))
     # Nodal damping test
-    smallSuite.addTest(TNodalDampingTests('test_execution'))
+    smallSuite.addTest(TNodalDampingTests('test_nodal_damping'))
 
     if (missing_external_dependencies == False):
         if (hasattr(KratosMultiphysics.ExternalSolversApplication,
@@ -213,7 +224,10 @@ def AssambleTestSuites():
             smallSuite.addTest(TEigen3D3NThinCircleTests('test_execution'))
             smallSuite.addTest(TEigenTL3D8NCubeTests('test_execution'))
             # Element damping test
-            smallSuite.addTest(TSpringDamperElementTests('test_execution'))
+            smallSuite.addTest(TSpringDamperElementTests('test_undamped_mdof_system_dynamic'))
+            smallSuite.addTest(TSpringDamperElementTests('test_undamped_sdof_system_harmonic'))
+            smallSuite.addTest(TSpringDamperElementTests('test_damped_mdof_system_dynamic'))
+            smallSuite.addTest(TSpringDamperElementTests('test_undamped_mdof_system_eigen'))
         else:
             print(
                 "FEASTSolver solver is not included in the compilation of the External Solvers Application"
@@ -242,7 +256,7 @@ def AssambleTestSuites():
     nightSuite.addTest(TShellQ4ThinLinearDynamicTests('test_execution'))
     nightSuite.addTest(TShellQ4ThinNonLinearDynamicTests('test_execution'))
     # CL tests
-    ##nightSuite.addTest(TIsotropicDamageSimoJuPSTest('test_execution'))
+    ##nightSuite.addTest(TIsotropicDamageSimoJuPSTest('test_execution')) # FIXME: Needs get up to date
 
     # For very long tests that should not be in nighly and you can use to validate 
     validationSuite = suites['validation']
@@ -253,83 +267,8 @@ def AssambleTestSuites():
     
     # Create a test suit that contains all the tests:
     allSuite = suites['all']
-    allSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([
-        TTestConstitutiveLaw,
-        TTestPatchTestSmallStrain,
-        TTestPatchTestLargeStrain,
-        TTestQuadraticElements,
-        TTestPatchTestShells,
-        TestLoadingConditions,
-        TSimpleMeshMovingTest,
-        TDynamicBossakTests,
-        TDynamicNewmarkTests,
-        TNodalDampingTests,
-        TSDTwoDShearQuaPatchTest,
-        TSDTwoDShearTriPatchTest,
-        TSDTwoDTensionQuaPatchTest,
-        TSDTwoDTensionTriPatchTest,
-        TSDThreeDShearHexaPatchTest,
-        TSDThreeDShearTetraPatchTest,
-        TSDThreeDTensionHexaPatchTest,
-        TSDThreeDTensionTetraPatchTest,
-        TTLTwoDShearQuaPatchTest,
-        TTLTwoDShearTriPatchTest,
-        TTLTwoDTensionQuaPatchTest,
-        TTLTwoDTensionTriPatchTest,
-        TTLThreeDShearHexaPatchTest,
-        TTLThreeDShearTetraPatchTest,
-        TTLThreeDTensionHexaPatchTest,
-        TTLThreeDTensionTetraPatchTest,
-        TULTwoDShearQuaPatchTest,
-        TULTwoDShearTriPatchTest,
-        TULTwoDTensionQuaPatchTest,
-        TULTwoDTensionTriPatchTest,
-        TULThreeDShearHexaPatchTest,
-        TULThreeDShearTetraPatchTest,
-        TULThreeDTensionHexaPatchTest,
-        TULThreeDTensionTetraPatchTest,
-        TSprismMembranePatchTests,
-        TSprismBendingPatchTests,
-        TFofi4PointTentnoCableTests,
-        TMembraneQ4PointLoadTests,
-        TShellQ4ThickBendingRollUpTests,
-        # TShellQ4ThickDrillingRollUpTests, # FIXME: Needs get up to date
-        TShellT3ThinBendingRollUpTests,
-        TShellT3ThinDrillingRollUpTests,
-        TShellT3IsotropicScordelisTests,
-        TTestMultipointConstraints,
-        TShellT3ThickLinearStaticTests,
-        TShellT3ThickNonLinearStaticTests,
-        TShellT3ThickLinearDynamicTests,
-        TShellT3ThickNonLinearDynamicTests,
-        TShellQ4ThinLinearStaticTests,
-        TShellQ4ThinNonLinearStaticTests,
-        TShellQ4ThinLinearDynamicTests,
-        TShellQ4ThinNonLinearDynamicTests,
-        T3D2NTrussTest,
-        T3D2NTrussLinearTest,
-        T3D2NTrussDynamicTest,
-        T3D2NBeamCrTest,
-        T3D2NBeamCrLinearTest,
-        T3D2NBeamCrDynamicTest,
-        TPendulusTLTest,
-        TPendulusULTest,
-        ####TIsotropicDamageSimoJuPSTest, # FIXME: Need CL correspondent
-        ####TSprismPanTests # FIXME: Needs get up to date
-    ]))
-
-    if (missing_external_dependencies == False):
-        if (hasattr(KratosMultiphysics.ExternalSolversApplication,
-                    "FEASTSolver")):
-            allSuite.addTests(
-                KratosUnittest.TestLoader().loadTestsFromTestCases([
-                    TSpringDamperElementTests, TEigenQ4Thick2x2PlateTests,
-                    TEigenTL3D8NCubeTests, TEigen3D3NThinCircleTests
-                ]))
-        else:
-            print(
-                "FEASTSolver solver is not included in the compilation of the External Solvers Application"
-            )
+    allSuite.addTests(nightSuite) # already contains the smallSuite
+    allSuite.addTests(validationSuite)
 
     return suites
 

--- a/applications/StructuralMechanicsApplication/tests/test_loading_conditions.py
+++ b/applications/StructuralMechanicsApplication/tests/test_loading_conditions.py
@@ -280,11 +280,5 @@ class TestLoadingConditions(KratosUnittest.TestCase):
         for i in range(len(rhs)):
             self.assertAlmostEqual(rhs[i],reference_res[i])     
         
-    def test_execution(self):
-        self.test_LineLoadCondition2D2N()
-        self.test_LineLoadCondition2D2NAngle()
-        self.test_SurfaceLoadCondition3D4N()
-        #self.test_LineLoadCondition3D2NRotDof()
-        
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/StructuralMechanicsApplication/tests/test_nodal_damping.py
+++ b/applications/StructuralMechanicsApplication/tests/test_nodal_damping.py
@@ -63,7 +63,7 @@ class NodalDampingTests(KratosUnittest.TestCase):
 
         mp.ProcessInfo[KratosMultiphysics.IS_RESTARTED] = False
    
-    def test_execution(self):
+    def test_nodal_damping(self):
         mp = KratosMultiphysics.ModelPart("sdof")
         self._add_variables(mp)
 

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_cr_beam.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_cr_beam.py
@@ -49,40 +49,23 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
         cl = StructuralMechanicsApplication.LinearElastic3DLaw()
         mp.GetProperties()[0].SetValue(KratosMultiphysics.CONSTITUTIVE_LAW,cl)
 
-        
     def _apply_BCs(self,mp,which_dof):
-        
         if (which_dof == 'xyz'):
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_X, True, mp.Nodes)
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Y, True, mp.Nodes)
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Z, True, mp.Nodes)
-            # for node in mp.Nodes:
-            #     node.Fix(KratosMultiphysics.DISPLACEMENT_X)
-            #     node.Fix(KratosMultiphysics.DISPLACEMENT_Y)
-            #     node.Fix(KratosMultiphysics.DISPLACEMENT_Z)
         if (which_dof == 'xz'):            
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_X, True, mp.Nodes)
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Z, True, mp.Nodes)
-            # for node in mp.Nodes:
-            #     node.Fix(KratosMultiphysics.DISPLACEMENT_X)
-            #     node.Fix(KratosMultiphysics.DISPLACEMENT_Z)
         if (which_dof == 'yz'):
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Y, True, mp.Nodes)
-            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Z, True, mp.Nodes)            
-            # for node in mp.Nodes:
-            #     node.Fix(KratosMultiphysics.DISPLACEMENT_Y)
-            #     node.Fix(KratosMultiphysics.DISPLACEMENT_Z)
+            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Z, True, mp.Nodes)       
         if (which_dof == 'rotXYZ'):
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.ROTATION_X, True, mp.Nodes)
             KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.ROTATION_Y, True, mp.Nodes)
-            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.ROTATION_Z, True, mp.Nodes)
-            # for node in mp.Nodes:
-            #     node.Fix(KratosMultiphysics.ROTATION_X)
-            #     node.Fix(KratosMultiphysics.ROTATION_Y)
-            #     node.Fix(KratosMultiphysics.ROTATION_Z)                
+            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.ROTATION_Z, True, mp.Nodes)             
 
     def _apply_Neumann_BCs(self,mp,which_dof,load_size_dir):
-
         if(which_dof == 'y'):
             KratosMultiphysics.VariableUtils().SetScalarVar(StructuralMechanicsApplication.
                 POINT_LOAD_Y, load_size_dir, mp.Nodes)
@@ -96,9 +79,7 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
             #     node.SetSolutionStepValue(StructuralMechanicsApplication.
             #     POINT_LOAD_X,0,load_size_dir)  
 
-        
     def _solve_linear(self,mp):
-        
         linear_solver = KratosMultiphysics.SkylineLUFactorizationSolver()
         builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver)
         scheme = KratosMultiphysics.ResidualBasedIncrementalUpdateStaticScheme()
@@ -144,15 +125,14 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
         
         strategy.Check()
         strategy.Solve()
+
     def _solve_dynamic(self,mp):
-        
         #define a minimal newton raphson solver
         linear_solver = KratosMultiphysics.SkylineLUFactorizationSolver()
         builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver)
         scheme = KratosMultiphysics.ResidualBasedBossakDisplacementScheme(0.00)
         convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-8,1e-8)
         convergence_criterion.SetEchoLevel(0)
-
 
         max_iters = 1000
         compute_reactions = True
@@ -172,10 +152,7 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
         strategy.Check()
         strategy.Solve()
         
-           
-    
     def _check_results_linear(self,mp,endNode):
-        
         #check displacement result
         displacement_cantilever_tip = mp.Nodes[endNode].GetSolutionStepValue(
             KratosMultiphysics.DISPLACEMENT)
@@ -206,16 +183,13 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
             self.assertAlmostEqual(displacement_y, 0.00,5)
 
     def _check_results_dynamic(self,mp,time_i,nr_nodes):
-        
         #check free vibration of cantilever tip
         disp_y_analytical = ((1.541*(10**(-2)))*(1-cos(575.076*time_i)) 
             -(3.193*(10**(-4)))*(1-cos(3603.800*time_i)))*(-1)
         disp_y_simulated = mp.Nodes[nr_nodes].GetSolutionStepValue(
             KratosMultiphysics.DISPLACEMENT_Y)
 
-
         self.assertAlmostEqual(disp_y_analytical, disp_y_simulated,2)
-
 
     def _set_and_fill_buffer(self,mp,buffer_size,delta_time):
         # Set buffer size
@@ -270,11 +244,11 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
         self._apply_BCs(bcs_rot,'rotXYZ')
 
         self._apply_Neumann_BCs(bcs_neumann,'y',Force_Y)
-
         
         #solve + compare
         self._solve_linear(mp)    
         self._check_results_linear(mp,nr_nodes)
+
     def test_cr_beam_nonlinear(self):
         dim = 3
         nr_nodes = 21
@@ -305,7 +279,6 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
         self._apply_BCs(bcs_xyz,'xyz')
         self._apply_BCs(bcs_rot,'rotXYZ')
 
-
         #incrementally increase load -> nonlinear case
         Moment_Z = 25000.00
         time_start = 0.00
@@ -323,6 +296,7 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
             self._solve_nonlinear(mp)
             self._check_results_nonlinear(mp,time_step,Moment_i,nr_nodes)
             time_step += 1
+
     def test_cr_beam_dynamic_lumped_mass_matrix(self):
         dim = 3
         nr_nodes = 11
@@ -331,7 +305,6 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
         self._add_variables(mp)
         self._apply_material_properties(mp,dim)
         mp.GetProperties()[0].SetValue(StructuralMechanicsApplication.LUMPED_MASS_MATRIX,1)
-
 
         #create nodes
         dx = 1.00 / nr_elements
@@ -381,6 +354,7 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
             self._solve_dynamic(mp)  
             self._check_results_dynamic(mp,time_i,nr_nodes)
             time_step += 1        
+
     def test_cr_beam_dynamic_consistent_mass_matrix(self):
         dim = 3
         nr_nodes = 11
@@ -390,7 +364,6 @@ class TestCrBeam3D2N(KratosUnittest.TestCase):
         self._apply_material_properties(mp,dim)
         mp.GetProperties()[0].SetValue(StructuralMechanicsApplication.LUMPED_MASS_MATRIX,0)
 
-        
         #create nodes
         dx = 1.00 / nr_elements
         for i in range(nr_nodes):

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_truss.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_truss.py
@@ -16,7 +16,6 @@ class TestTruss3D2N(KratosUnittest.TestCase):
             node.AddDof(KratosMultiphysics.DISPLACEMENT_Y, KratosMultiphysics.REACTION_Y)
             node.AddDof(KratosMultiphysics.DISPLACEMENT_Z, KratosMultiphysics.REACTION_Z)
             
-    
     def _add_variables(self,mp):
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION)
@@ -24,7 +23,6 @@ class TestTruss3D2N(KratosUnittest.TestCase):
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.VOLUME_ACCELERATION) 
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.ACCELERATION)      
-
         
     def _apply_material_properties(self,mp,dim):
         #define properties
@@ -43,32 +41,30 @@ class TestTruss3D2N(KratosUnittest.TestCase):
 
         
     def _apply_BCs(self,mp,which_dof):
-        
         if (which_dof == 'xyz'):
-            for node in mp.Nodes:
-                node.Fix(KratosMultiphysics.DISPLACEMENT_X)
-                node.Fix(KratosMultiphysics.DISPLACEMENT_Y)
-                node.Fix(KratosMultiphysics.DISPLACEMENT_Z)
-        if (which_dof == 'xz'):
-            for node in mp.Nodes:
-                node.Fix(KratosMultiphysics.DISPLACEMENT_X)
-                node.Fix(KratosMultiphysics.DISPLACEMENT_Z)
+            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_X, True, mp.Nodes)
+            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Y, True, mp.Nodes)
+            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Z, True, mp.Nodes)
+        if (which_dof == 'xz'):            
+            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_X, True, mp.Nodes)
+            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Z, True, mp.Nodes)
         if (which_dof == 'yz'):
-            for node in mp.Nodes:
-                node.Fix(KratosMultiphysics.DISPLACEMENT_Y)
-                node.Fix(KratosMultiphysics.DISPLACEMENT_Z)
+            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Y, True, mp.Nodes)
+            KratosMultiphysics.VariableUtils().ApplyFixity(KratosMultiphysics.DISPLACEMENT_Z, True, mp.Nodes)  
 
     def _apply_Neumann_BCs(self,mp,which_dof,load_size_dir):
-
         if(which_dof == 'y'):
-            for node in mp.Nodes:
-                node.SetSolutionStepValue(StructuralMechanicsApplication.
-                POINT_LOAD_Y,0,load_size_dir)        
+            KratosMultiphysics.VariableUtils().SetScalarVar(StructuralMechanicsApplication.
+                POINT_LOAD_Y, load_size_dir, mp.Nodes)
+            # for node in mp.Nodes:
+            #     node.SetSolutionStepValue(StructuralMechanicsApplication.
+            #     POINT_LOAD_Y,0,load_size_dir)        
         if(which_dof == 'x'):
-            for node in mp.Nodes:
-                node.SetSolutionStepValue(StructuralMechanicsApplication.
-                POINT_LOAD_X,0,load_size_dir)  
-
+            KratosMultiphysics.VariableUtils().SetScalarVar(StructuralMechanicsApplication.
+                POINT_LOAD_X, load_size_dir, mp.Nodes)
+            # for node in mp.Nodes:
+            #     node.SetSolutionStepValue(StructuralMechanicsApplication.
+            #     POINT_LOAD_X,0,load_size_dir)  
         
     def _solve_linear(self,mp):
         linear_solver = KratosMultiphysics.SkylineLUFactorizationSolver()
@@ -116,15 +112,14 @@ class TestTruss3D2N(KratosUnittest.TestCase):
         
         strategy.Check()
         strategy.Solve()
+
     def _solve_dynamic(self,mp):
-        
         #define a minimal newton raphson solver
         linear_solver = KratosMultiphysics.SkylineLUFactorizationSolver()
         builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver)
         scheme = KratosMultiphysics.ResidualBasedBossakDisplacementScheme(0.00)
         convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-8,1e-8)
         convergence_criterion.SetEchoLevel(0)
-
 
         max_iters = 1000
         compute_reactions = True
@@ -144,10 +139,7 @@ class TestTruss3D2N(KratosUnittest.TestCase):
         strategy.Check()
         strategy.Solve()
         
-           
-    
     def _check_results_linear(self,mp):
-        
         #1.) check displacement result
         displacement_nodes = [mp.Nodes[1].GetSolutionStepValue(
             KratosMultiphysics.DISPLACEMENT),mp.Nodes[2].GetSolutionStepValue(
@@ -231,7 +223,6 @@ class TestTruss3D2N(KratosUnittest.TestCase):
         P_i = ((EA/(2*L3))*(disp_temp*disp_temp +2*1*disp_temp)*(disp_temp+1))
         self.assertAlmostEqual(P_i,Force_i,1)
 
-
     def _check_results_dynamic(self,mp,time_i):
         
         #analaytical free-vibration node 3
@@ -255,6 +246,7 @@ class TestTruss3D2N(KratosUnittest.TestCase):
             KratosMultiphysics.DISPLACEMENT_X)  
 
         self.assertAlmostEqual(simulated_disp_temp, test_disp_temp,6)
+
     def _set_and_fill_buffer(self,mp,buffer_size,delta_time):
         # Set buffer size
         mp.SetBufferSize(buffer_size)
@@ -342,7 +334,6 @@ class TestTruss3D2N(KratosUnittest.TestCase):
         #apply constant boundary conditions
         self._apply_BCs(bcs_xyz,'xyz')
         self._apply_BCs(bcs_xz,'xz')
-
 
         #incrementally increase load -> nonlinear case
         Force_y = -37000000

--- a/applications/StructuralMechanicsApplication/tests/test_spring_damper_element.py
+++ b/applications/StructuralMechanicsApplication/tests/test_spring_damper_element.py
@@ -161,7 +161,7 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
         return mp
         
    
-    def _test_undamped_mdof_system_dynamic(self):
+    def test_undamped_mdof_system_dynamic(self):
         mp = self._set_up_mdof_system()
 
         #set parameters
@@ -208,7 +208,7 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
                 + phi22 * (K21*cos(omega_E_2*time) + K22*sin(omega_E_2*time))
             self.assertAlmostEqual(mp.Nodes[2].GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y,0),current_analytical_displacement_y_2,delta=1e-2)
 
-    def _test_undamped_sdof_system_harmonic(self):
+    def test_undamped_sdof_system_harmonic(self):
         mp = self._set_up_sdof_system()
 
         #set parameters
@@ -248,7 +248,7 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
                 current_analytical_displacement_y,delta=5e-3)
             
         
-    def _test_damped_mdof_system_dynamic(self):
+    def test_damped_mdof_system_dynamic(self):
         mp = self._set_up_mdof_system()
 
         #set parameters
@@ -286,11 +286,11 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
             self.assertAlmostEqual(mp.Nodes[2].GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y,0), \
                 current_analytical_displacement_y_2,delta=5e-2)
 
-    def _test_undamped_mdof_system_eigen(self):
+    def test_undamped_mdof_system_eigen(self):
         import KratosMultiphysics.ExternalSolversApplication as ExternalSolversApplication
-        if not hasattr(KratosMultiphysics.ExternalSolversApplication, "FEASTSolver") \
-            or not hasattr(KratosMultiphysics.ExternalSolversApplication, "PastixSolver"):
-            self.skipTest("Pastix or FEAST are not available")
+        # FEAST is available otherwise this test is not being called
+        if not hasattr(KratosMultiphysics.ExternalSolversApplication, "PastixSolver"):
+            self.skipTest("Pastix Solver is not available")
 
         mp = self._set_up_mdof_system()
 
@@ -332,12 +332,6 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
         analytical_eigenvalues = [5,20]
         for ev in range(len(analytical_eigenvalues)):
             self.assertAlmostEqual(current_eigenvalues[ev], analytical_eigenvalues[ev])
-
-    def test_execution(self):
-        self._test_undamped_mdof_system_dynamic()
-        self._test_undamped_sdof_system_harmonic()
-        self._test_damped_mdof_system_dynamic()
-        self._test_undamped_mdof_system_eigen()
 
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
Hi @KratosMultiphysics/structural-mechanics 
I found some small mistakes in the tests and did also some cleanup.

I also used the opportunity to remove the necessity of having to add the tests twice, bcs ofc there were some tests forgotten. Now it is done nice and clean, same as in the FluidDynamicsApp

@KlausBSautter I added the patch tests for the truss and the beam, they were not added

@adityaghantasala the mpc test is failing, but now bcs you add the variables after adding the nodes, which can create bad segfaults, see #492. I coulnd't fix it on the fly, can you please have a look?

Other than that I didn't change anything