### PR TITLE
TrilinosApp remove compiler warning

### DIFF
--- a/applications/trilinos_application/external_includes/amgcl_mpi_schur_complement_solver.h
+++ b/applications/trilinos_application/external_includes/amgcl_mpi_schur_complement_solver.h
@@ -372,7 +372,9 @@ public:
             mPressureMask.resize( rA.NumMyRows(), false );
 
         int counter = 0;
+#ifdef KRATOS_DEBUG
         int npressures = 0;
+#endif
         for (ModelPart::DofsArrayType::iterator it = rDofSet.begin(); it!=rDofSet.end(); it++)
         {
             if( it->GetSolutionStepValue ( PARTITION_INDEX ) == my_pid )


### PR DESCRIPTION
This removes the warning that `npressures` is unused