### PR TITLE
Update ale_navier_stokes_solver_vmsmonolithic.py

### DIFF
--- a/applications/ALEapplication/python_scripts/ale_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/ALEapplication/python_scripts/ale_navier_stokes_solver_vmsmonolithic.py
@@ -16,6 +16,7 @@ class ALENavierStokesSolverVMSMonolithic(navier_stokes_solver_vmsmonolithic.Navi
         # remove the ale_settings so we can use the navier stokes constructor
         navier_stokes_settings = custom_settings.Clone()
         navier_stokes_settings.RemoveValue("ale_settings")
+        navier_stokes_settings["solver_type"].SetString("Monolithic")
         super(ALENavierStokesSolverVMSMonolithic, self).__init__(model_part, navier_stokes_settings)
         # create ale solver
         ale_solver_type = custom_settings["ale_settings"]["solver_type"].GetString()


### PR DESCRIPTION
navier_stokes_settings["solver_type"].SetString("Monolithic") needs to be added so that it works with the python_solver_wrapper from the FluidDynamics application. I have tested the OpenMP version, Trilinos might need the same fix.