### PR TITLE
Disabling pfem apps until tetgen is implemented

### DIFF
--- a/scripts/build/nightly/configure_clang.sh
+++ b/scripts/build/nightly/configure_clang.sh
@@ -25,10 +25,10 @@ cmake .. \
 -DMESHING_APPLICATION=ON                                                                        \
 -DMULTISCALE_APPLICATION=OFF                                                                    \
 -DPARTICLE_MECHANICS_APPLICATION=ON                                                             \
--DPFEM_APPLICATION=ON                                                                           \
--DCONTACT_MECHANICS_APPLICATION=ON                                                              \
--DPFEM_FLUID_DYNAMICS_APPLICATION=ON                                                            \
--DPFEM_SOLID_MECHANICS_APPLICATION=ON                                                           \
+-DPFEM_APPLICATION=OFF                                                                           \
+-DCONTACT_MECHANICS_APPLICATION=OFF                                                              \
+-DPFEM_FLUID_DYNAMICS_APPLICATION=OFF                                                            \
+-DPFEM_SOLID_MECHANICS_APPLICATION=OFF                                                           \
 -DPOROMECHANICS_APPLICATION=ON                                                                  \
 -DSHAPE_OPTIMIZATION_APPLICATION=ON                                                             \
 -DSOLID_MECHANICS_APPLICATION=ON                                                                \

--- a/scripts/build/nightly/configure_gcc.sh
+++ b/scripts/build/nightly/configure_gcc.sh
@@ -25,10 +25,10 @@ cmake .. \
 -DMESHING_APPLICATION=ON                                                                        \
 -DMULTISCALE_APPLICATION=OFF                                                                    \
 -DPARTICLE_MECHANICS_APPLICATION=ON                                                             \
--DPFEM_APPLICATION=ON                                                                           \
--DCONTACT_MECHANICS_APPLICATION=ON                                                              \
--DPFEM_FLUID_DYNAMICS_APPLICATION=ON                                                            \
--DPFEM_SOLID_MECHANICS_APPLICATION=ON                                                           \
+-DPFEM_APPLICATION=OFF                                                                           \
+-DCONTACT_MECHANICS_APPLICATION=OFF                                                              \
+-DPFEM_FLUID_DYNAMICS_APPLICATION=OFF                                                            \
+-DPFEM_SOLID_MECHANICS_APPLICATION=OFF                                                           \
 -DPOROMECHANICS_APPLICATION=ON                                                                  \
 -DSHAPE_OPTIMIZATION_APPLICATION=ON                                                             \
 -DSOLID_MECHANICS_APPLICATION=ON                                                                \


### PR DESCRIPTION
As I commented, this way we can still compile nightly builds in the meantime. 
I suppose it will be fixed during this weekend / early next week.