### PR TITLE
updated clear() to fix some bugs.

### DIFF
--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -448,6 +448,8 @@ public:
     void clear()
     {
         mData.clear();
+        mSortedPartSize = size_type();
+        mMaxBufferSize = 1;
     }
 
     iterator find(const key_type& Key)

--- a/kratos/containers/variables_list.h
+++ b/kratos/containers/variables_list.h
@@ -86,11 +86,9 @@ namespace Kratos
 		///@{
 
 		/// Default constructor. mPosition should have at least on entry.
-		VariablesList() : mDataSize(0), mKeys(1, static_cast<IndexType>(-1)), mPositions(1, static_cast<IndexType>(-1)), mVariables()
-		{
-		}
+        VariablesList() = default;
 
-		template <class TInputIteratorType>
+        template <class TInputIteratorType>
 		VariablesList(TInputIteratorType First, TInputIteratorType Last)
 		{
 			for (; First != Last; First++)
@@ -237,8 +235,8 @@ namespace Kratos
 			mDataSize = 0;
 			mHashFunctionIndex = 0;
 			mVariables.clear();
-			mKeys.clear();
-			mPositions.clear();
+			mKeys = {static_cast<IndexType>(-1)};
+			mPositions = {static_cast<IndexType>(-1)};
 		}
 
 
@@ -339,14 +337,13 @@ namespace Kratos
 	private:
 		///@name Member Variables
 		///@{
+		SizeType mDataSize = 0;
 
-		SizeType mDataSize;
+		SizeType mHashFunctionIndex = 0;
 
-		SizeType mHashFunctionIndex;
+		KeysContainerType mKeys = {static_cast<IndexType>(-1)};
 
-		KeysContainerType mKeys;
-
-		PositionsContainerType mPositions;
+		PositionsContainerType mPositions = {static_cast<IndexType>(-1)};
 
 		VariablesContainerType mVariables;
 


### PR DESCRIPTION
Calling the clear functions on some container types was giving the object an invalid state leading to bad behaviour when subsequent functions are called. I tried to make the clear functions reflect the default constructors.