### PR TITLE
Trying to detect system zlib before adding it to compilation paths.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -311,6 +311,17 @@ if(${MPI_NEEDED} MATCHES ON )
   # find_package(Boost COMPONENTS mpi_python REQUIRED)
 endif(${MPI_NEEDED} MATCHES ON )
 
+# Find zlib (for gidpost)
+find_package(ZLIB)
+
+if( ZLIB_FOUND )
+  include_directories( ${ZLIB_INCLUDE_DIRS} )
+else( ZLIB_FOUND )
+  # Compile our own
+  add_subdirectory(external_libraries/zlib)
+  set( ZLIB_LIBRARIES zlib )
+endif( ZLIB_FOUND )
+  
 
 ##echo user options
 message( " ")
@@ -321,10 +332,6 @@ message( " ")
 ######################################################################################
 #include internal dependencies
 include_directories( ${CMAKE_SOURCE_DIR}/external_libraries )
-include_directories( ${CMAKE_SOURCE_DIR}/external_libraries/zlib )
-# we have to add this for zconf
-include_directories( ${CMAKE_BINARY_DIR}/external_libraries/zlib )
-# include_directories( ${CMAKE_SOURCE_DIR}/external_libraries/gidpost )
 
 # defines needed
 add_definitions( -DKRATOS_PYTHON )
@@ -334,7 +341,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
 # include subdirectories
-add_subdirectory(external_libraries/zlib)
 add_subdirectory(external_libraries/gidpost)
 add_subdirectory(kratos)
 add_subdirectory(applications)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,6 +317,7 @@ find_package(ZLIB)
 if( ZLIB_FOUND )
   include_directories( ${ZLIB_INCLUDE_DIRS} )
 else( ZLIB_FOUND )
+  message( "-- Preparing local ZLIB compilation.")
   # Compile our own
   add_subdirectory(external_libraries/zlib)
   include_directories( ${CMAKE_SOURCE_DIR}/external_libraries/zlib )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,6 +319,9 @@ if( ZLIB_FOUND )
 else( ZLIB_FOUND )
   # Compile our own
   add_subdirectory(external_libraries/zlib)
+  include_directories( ${CMAKE_SOURCE_DIR}/external_libraries/zlib )
+  # we have to add this for zconf
+  include_directories( ${CMAKE_BINARY_DIR}/external_libraries/zlib )
   set( ZLIB_LIBRARIES zlib )
 endif( ZLIB_FOUND )
   

--- a/external_libraries/gidpost/CMakeLists.txt
+++ b/external_libraries/gidpost/CMakeLists.txt
@@ -30,7 +30,7 @@ if (HDF5)
   target_link_libraries(gidpost ${HDF5_LIBRARIES})
 endif (HDF5)
 
-target_link_libraries(gidpost zlib)
+target_link_libraries(gidpost ${ZLIB_LIBRARIES})
 
 find_package( Threads )
 if ( Threads_FOUND )


### PR DESCRIPTION
Currently, kratos compiles and installs its own zlib as part of the installation process, since it is required by gidpost and it is not usually found in windows. However, Linux systems tend to have their own versions of zlib, which makes it unnecessary. Moreover, some libraries (notably the HDF5 libraries) used by kratos also need zlib, which causes incompatibilities: hdf5 links against the system zlib, which may be shadowed by the kratos-compiled version, causing CMake to complain and path mismatches (for example, I have had cases where command-line commands failed because they tried to use the kratos zlib instead of the system one).

I'd like to modify the CMake code a bit so that zlib is only compiled if it cannot be found in the system. Does anyone see potential problems with this?

To reviewers: please do not merge this yet, since I haven't tested it in windows.