### PR TITLE
Moving hash to a common class

### DIFF
--- a/applications/MeshingApplication/custom_processes/mmg_process.h
+++ b/applications/MeshingApplication/custom_processes/mmg_process.h
@@ -22,6 +22,7 @@
 
 // Project includes
 #include "processes/process.h"
+#include "includes/key_hash.h"
 #include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
 #include "containers/variables_list.h"
@@ -81,78 +82,6 @@ namespace Kratos
     typedef MeshType::NodeConstantIterator                 NodeConstantIterator;
     typedef MeshType::ConditionConstantIterator       ConditionConstantIterator;
     typedef MeshType::ElementConstantIterator           ElementConstantIterator;
-    
-    #if !defined(HASH_COMBINE)
-    #define HASH_COMBINE
-    template <class TClassType>
-    inline void HashCombine(std::size_t& Seed, const TClassType& Value)
-    {
-        std::hash<TClassType> hasher;
-        Seed ^= hasher(Value) + 0x9e3779b9 + (Seed<<6) + (Seed>>2);
-    }
-    #endif
-    
-    #if !defined(HASH_RANGE)
-    #define HASH_RANGE
-    template <class TClassType>
-    inline std::size_t HashRange(TClassType First, TClassType Last)
-    {
-        std::size_t seed = 0;
-
-        while (First!=Last)
-        {
-            HashCombine(seed, *First);
-            ++First;
-        }
-        
-        return seed;
-    }
-    #endif
-    
-    #if !defined(KEY_COMPAROR_RANGE)
-    #define KEY_COMPAROR_RANGE
-    template<class TClassType>
-    struct KeyComparorRange
-    {
-        bool operator()(const TClassType& lhs, const TClassType& rhs) const
-        {
-            if(lhs.size() != rhs.size())
-            {
-                return false;
-            }
-
-            auto it_lhs = lhs.begin();
-            auto it_rhs = rhs.begin();
-
-            while(it_lhs != lhs.end()) // NOTE: We already checked that are same size
-            {
-                if(*it_lhs != *it_rhs) 
-                {
-                    return false;
-                }
-                if(it_lhs != lhs.end())
-                {
-                    ++it_lhs;
-                    ++it_rhs;
-                }
-            }
-
-            return true;
-        }
-    };
-    #endif
-    
-    #if !defined(KEY_HASHER_RANGE)
-    #define KEY_HASHER_RANGE
-    template<class TClassType>
-    struct KeyHasherRange
-    {
-        std::size_t operator()(const TClassType& rRange) const
-        {
-            return HashRange(rRange.begin(), rRange.end());
-        }
-    };
-    #endif
 
 ///@}
 ///@name  Enum's

--- a/kratos/includes/key_hash.h
+++ b/kratos/includes/key_hash.h
@@ -1,0 +1,180 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+#ifndef KRATOS_KEY_HASH_H_INCLUDED
+#define KRATOS_KEY_HASH_H_INCLUDED
+
+namespace Kratos 
+{
+///@addtogroup Kratos Core
+///@{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+    /**
+     * This method creates an "unique" hash for the input value
+     * @param TClassType The type of class to be hashed
+     * @param Seed This is the seed used to create the hash
+     * @param Value This is the value to be hashed
+     */
+    template <class TClassType>
+    inline void HashCombine(
+        std::size_t& Seed, 
+        const TClassType& Value
+        )
+    {
+        std::hash<TClassType> hasher;
+        Seed ^= hasher(Value) + 0x9e3779b9 + (Seed<<6) + (Seed>>2);
+    }
+    
+    /**
+     * This method combines hash until it reaches the last class in order to obtain a corresponding seed
+     * @param TClassType The type of class to be hashed
+     * @param First The first class to be compared
+     * @param Last The last class to be compared
+     * @return The resulting seed
+     */
+    template <class TClassType>
+    inline std::size_t HashRange(
+        TClassType First, 
+        TClassType Last
+        )
+    {
+        std::size_t seed = 0;
+
+        while (First!=Last)
+        {
+            HashCombine(seed, *First);
+            ++First;
+        }
+        
+        return seed;
+    }
+    
+    /**
+     * \brief This is a key comparer of general pourpose between two classes 
+     * @param TClassType The type of class to be hashed
+     */
+    template<class TClassType>
+    struct KeyComparorRange
+    {
+        /**
+         * This is the () operator
+         * @param first The first class to be compared
+         * @param second The second class to be compared
+         */
+        bool operator()(
+            const TClassType& first, 
+            const TClassType& second
+            ) const
+        {
+            if(first.size() != second.size())
+            {
+                return false;
+            }
+
+            auto it_first = first.begin();
+            auto it_second = second.begin();
+
+            while(it_first != first.end()) // NOTE: We already checked that are same size
+            {
+                if(*it_first != *it_second) 
+                {
+                    return false;
+                }
+                if(it_first != first.end())
+                {
+                    ++it_first;
+                    ++it_second;
+                }
+            }
+
+            return true;
+        }
+    };
+    
+    /**
+     * \brief This is a hasher of general pourpose 
+     * @param TClassType The type of class to be hashed
+     */
+    template<class TClassType>
+    struct KeyHasherRange
+    {
+        /**
+         * This is the () operator
+         * @param pPointer The shared pointer to be hashed
+         * @return The corresponding hash
+         */
+        std::size_t operator()(const TClassType& rRange) const
+        {
+            return HashRange(rRange.begin(), rRange.end());
+        }
+    };
+    
+    /**
+     * \brief This is a hasher for shared pointers 
+     * @param TSharedPointer The type of shared pointer to be hashed
+     */
+    template<class TSharedPointer>
+    struct SharedPointerHasher
+    {
+        /**
+         * This is the () operator
+         * @param pPointer The shared pointer to be hashed
+         * @return The corresponding hash
+         */
+        std::size_t operator()(const TSharedPointer& pPointer) const
+        {
+            return reinterpret_cast<std::size_t>(pPointer.get());
+        }
+    };
+    
+    /**
+     * \brief This is a key comparer between two shared pointers 
+     * @param TClassType The type of shared pointer to be compared
+     */
+    template<class TSharedPointer>
+    struct SharedPointerComparator
+    {
+        /**
+         * This is the () operator
+         * @param first The first class to be compared
+         * @param second The second class to be compared
+         */
+        bool operator()(
+            const TSharedPointer& first, 
+            const TSharedPointer& second
+            ) const
+        {
+            return first.get() == second.get();
+        }
+    };
+    
+///@}
+///@name Kratos Classes
+///@{
+
+} // namespace Kratos.
+#endif

--- a/kratos/includes/mapping_variables.h
+++ b/kratos/includes/mapping_variables.h
@@ -21,6 +21,7 @@
 // Project includes
 #include "includes/condition.h"
 #include "includes/define.h"
+#include "includes/key_hash.h"
 #include "containers/variable.h"
 #include "containers/variable_component.h"
 #include "containers/vector_component_adaptor.h"
@@ -45,30 +46,6 @@ namespace Kratos
 ///@}
 ///@name  Functions
 ///@{
-    
-#if !defined(SHARED_POINTER_HASHER)
-#define SHARED_POINTER_HASHER
-    template<class TSharedPointer>
-    struct SharedPointerHasher
-    {
-        size_t operator()(const TSharedPointer& pCond) const
-        {
-            return reinterpret_cast<size_t>(pCond.get());
-        }
-    };
-#endif
-    
-#if !defined(SHARED_POINTER_COMPARATOR)
-#define SHARED_POINTER_COMPARATOR
-    template<class TSharedPointer>
-    struct SharedPointerComparator
-    {
-        bool operator()(const TSharedPointer& first, const TSharedPointer& second) const
-        {
-            return first.get() == second.get();
-        }
-    };
-#endif
     
 ///@}
 ///@name Kratos Classes
@@ -275,8 +252,8 @@ namespace Kratos
         ///@}
     }; // Class ConditionMap 
     
-    KRATOS_DEFINE_VARIABLE( boost::shared_ptr<ConditionMap>, MAPPING_PAIRS ) // An unordened map of which contains the structure
-    KRATOS_DEFINE_VARIABLE( double, TANGENT_FACTOR )                         // The factor between the tangent and normal behaviour
+    KRATOS_DEFINE_VARIABLE( ConditionMap::Pointer, MAPPING_PAIRS ) // An unordened map of which contains the structure
+    KRATOS_DEFINE_VARIABLE( double, TANGENT_FACTOR )               // The factor between the tangent and normal behaviour
 
 } // namespace Kratos
 


### PR DESCRIPTION
To be able of replace easily the existing  boost unordered_maps/maps/unordered_set/set with the corresponding  std equivalents