### PR TITLE
Use non deprecated CrossProduct and UnitCrossProduct

### DIFF
--- a/kratos/geometries/nurbs_2d.h
+++ b/kratos/geometries/nurbs_2d.h
@@ -1606,7 +1606,10 @@ public:
     {
         Vector gXi,gEta;
         BaseVectors(Xi,Eta,gXi,gEta);
-        Vector Normal = MathUtils<double>::UnitCrossProduct(gXi,gEta);
+        Vector Normal;
+
+        MathUtils<double>::UnitCrossProduct(Normal, gEta, gXi);
+        
         return Normal;
     }
 

--- a/kratos/geometries/nurbs_3d.h
+++ b/kratos/geometries/nurbs_3d.h
@@ -1401,7 +1401,10 @@ public:
     {
         Vector gXi,gEta;
         BaseVectors(Xi,Eta,gXi,gEta);
-        Vector Normal = MathUtils<double>::UnitCrossProduct(gXi,gEta);
+        Vector Normal;
+
+        MathUtils<double>::UnitCrossProduct(Normal, gEta, gXi);
+
         return Normal;
     }
 

--- a/kratos/geometries/plane.h
+++ b/kratos/geometries/plane.h
@@ -60,7 +60,9 @@ public:
     {
         array_1d<double, 3> edge1 = p1 - p0;
         array_1d<double, 3> edge2 = p2 - p0;
-        mNormal   =  MathUtils<double>::UnitCrossProduct(edge1,edge2);
+
+        MathUtils<double>::UnitCrossProduct(mNormal, edge2, edge1);
+
         mConstant =  inner_prod(mNormal, p0);
     }
 
@@ -69,7 +71,9 @@ public:
     {
         array_1d<double, 3> edge1 = p1 - p0;
         array_1d<double, 3> edge2 = p2 - p0;
-        mNormal   =  MathUtils<double>::UnitCrossProduct(edge1,edge2);
+
+        MathUtils<double>::UnitCrossProduct(mNormal, edge2, edge1);
+
         mConstant =  inner_prod(mNormal, p0);
     }
 

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -523,10 +523,12 @@ public:
       const CoordinatesArrayType& rP2 = this->Points()[2].Coordinates();
       const CoordinatesArrayType& rP3 = this->Points()[3].Coordinates();
 
-      auto c012 = MathUtils<double>::CrossProduct(rP1-rP0, rP2-rP0);
-      auto c013 = MathUtils<double>::CrossProduct(rP1-rP0, rP3-rP0);
-      auto c023 = MathUtils<double>::CrossProduct(rP2-rP0, rP3-rP0);
-      auto c123 = MathUtils<double>::CrossProduct(rP2-rP1, rP3-rP1);
+      array_1d<double, 3> c012, c013, c023, c123;
+
+      MathUtils<double>::CrossProduct(c012, rP2-rP0, rP1-rP0);
+      MathUtils<double>::CrossProduct(c013, rP3-rP0, rP1-rP0);
+      MathUtils<double>::CrossProduct(c023, rP3-rP0, rP2-rP0);
+      MathUtils<double>::CrossProduct(c123, rP3-rP1, rP2-rP1);
 
       double n012 = std::sqrt(c012[0]*c012[0] + c012[1]*c012[1] + c012[2]*c012[2]);
       double n013 = std::sqrt(c013[0]*c013[0] + c013[1]*c013[1] + c013[2]*c013[2]);
@@ -1313,12 +1315,10 @@ public:
         array_1d<double, 3> edge21 = geom_1[2].Coordinates() - geom_1[1].Coordinates();
         array_1d<double, 3> edge31 = geom_1[3].Coordinates() - geom_1[1].Coordinates();
 
-
-        plane[0].mNormal = MathUtils<double>::UnitCrossProduct(edge20,edge10);  // <v0,v2,v1>
-        plane[1].mNormal = MathUtils<double>::UnitCrossProduct(edge10,edge30);  // <v0,v1,v3>
-        plane[2].mNormal = MathUtils<double>::UnitCrossProduct(edge30,edge20);  // <v0,v3,v2>
-        plane[3].mNormal = MathUtils<double>::UnitCrossProduct(edge21,edge31);  // <v1,v2,v3>
-
+        MathUtils<double>::UnitCrossProduct(plane[0].mNormal, edge10, edge20);  // <v0,v2,v1>
+        MathUtils<double>::UnitCrossProduct(plane[1].mNormal, edge30, edge10);  // <v0,v1,v3>
+        MathUtils<double>::UnitCrossProduct(plane[2].mNormal, edge20, edge30);  // <v0,v3,v2>
+        MathUtils<double>::UnitCrossProduct(plane[3].mNormal, edge31, edge21);  // <v1,v2,v3>
 
         double det = inner_prod(edge10, plane[3].mNormal);
         if (det < 0.00)

--- a/kratos/tests/math_utils/test_math_utils.cpp
+++ b/kratos/tests/math_utils/test_math_utils.cpp
@@ -595,8 +595,10 @@ namespace Kratos
             array_1d<double, 3> b = ZeroVector(3);
             b[0] = 1.0;
 
-            const array_1d<double, 3>  c = MathUtils<double>::CrossProduct(a, b);
-            const array_1d<double, 3>  d = MathUtils<double>::UnitCrossProduct(a, b);
+            array_1d<double, 3>  c, d;
+
+            MathUtils<double>::CrossProduct(c, b, a);
+            MathUtils<double>::UnitCrossProduct(d, b, a);
             
             KRATOS_CHECK_EQUAL(c[2], 2.0);
             KRATOS_CHECK_EQUAL(d[2], 1.0);


### PR DESCRIPTION
@RiccardoRossi As we spoke last Friday, this removes the warnings for the deprecated UnitCrossProd ( and CrossProd) 