### PR TITLE
Make other EigenValueSolvers useable

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
@@ -16,7 +16,6 @@ class EigenSolver(structural_mechanics_solver.MechanicalSolver):
     """The structural mechanics eigen solver.
 
     This class creates the mechanical solvers for eigenvalue analysis.
-    It currently supports the Feast solver.
 
     Public member variables:
     eigensolver_settings -- settings for the eigenvalue solvers.
@@ -24,32 +23,19 @@ class EigenSolver(structural_mechanics_solver.MechanicalSolver):
     See structural_mechanics_solver.py for more information.
     """
     def __init__(self, main_model_part, custom_settings):
-        # Set defaults and validate custom settings.
-        eigensolver_settings = KratosMultiphysics.Parameters("""
-        {
-            "eigensolver_settings" : {
-                "solver_type": "FEAST",
-                "print_feast_output": true,
-                "perform_stochastic_estimate": true,
-                "solve_eigenvalue_problem": true,
-                "lambda_min": 0.0,
-                "lambda_max": 1.0,
-                "search_dimension": 10,
-                "linear_solver_settings": {
-                    "solver_type": "skyline_lu"
-                }
-            }
-        }
-        """)
-        self.validate_and_transfer_matching_settings(custom_settings, eigensolver_settings)
-        self.eigensolver_settings = eigensolver_settings["eigensolver_settings"]
+        # Validation of eigensolver_settings is done in the eigenvalue solvers
+        self.eigensolver_settings = custom_settings["eigensolver_settings"]
+
         # Validate the remaining settings in the base class.
-        if not custom_settings.Has("scheme_type"): # Override defaults in the base class.
-            custom_settings.AddEmptyValue("scheme_type")
-            custom_settings["scheme_type"].SetString("dynamic")
+        structural_settings = custom_settings.Clone()
+        structural_settings.RemoveValue("eigensolver_settings")
+
+        if not structural_settings.Has("scheme_type"): # Override defaults in the base class.
+            structural_settings.AddEmptyValue("scheme_type")
+            structural_settings["scheme_type"].SetString("dynamic")
         
         # Construct the base solver.
-        super(EigenSolver, self).__init__(main_model_part, custom_settings)
+        super(EigenSolver, self).__init__(main_model_part, structural_settings)
         print("::[EigenSolver]:: Construction finished")
 
     #### Private functions ####

--- a/kratos/python_scripts/eigen_solver_factory.py
+++ b/kratos/python_scripts/eigen_solver_factory.py
@@ -17,7 +17,7 @@ def ConstructSolver(settings):
         eigen_solver = KratosMultiphysics.PowerIterationHighestEigenvalueSolver( settings, linear_solver)
     elif(solver_type == "rayleigh_quotient_iteration_eigenvalue_solver"):
         eigen_solver = KratosMultiphysics.RayleighQuotientIterationEigenvalueSolver( settings, linear_solver)
-    elif(solver_type == "FEAST"):
+    elif(solver_type == "FEAST" or solver_type == "feast"):
         import KratosMultiphysics.ExternalSolversApplication
         eigen_solver = KratosMultiphysics.ExternalSolversApplication.FEASTSolver(settings, linear_solver)
     else:


### PR DESCRIPTION
Currently the eigenvalue settings are always being validated against the default settings of FEAST.
Therefore other eigensolvers (which have different parameters) could not be used.

This PR moves the validation of the parameters to the solvers themselves.
Now every solver from the `eigen_solver_factory` can be used