### PR TITLE
Trying to fix compilation error.

### DIFF
--- a/applications/AdjointFluidApplication/custom_processes/input_primal_solution_process.h
+++ b/applications/AdjointFluidApplication/custom_processes/input_primal_solution_process.h
@@ -211,7 +211,7 @@ public:
         int itNode = 0;
         for (const auto& rNode : mrModelPart.Nodes())
         {
-            Delta += std::abs(rNode.Id() - NodeIdBuffer[itNode]);
+            Delta += std::abs(static_cast<int>(rNode.Id()) - static_cast<int>(NodeIdBuffer[itNode]));
             itNode++;
         }
 
@@ -328,7 +328,7 @@ public:
         int itNode = 0;
         for (const auto& rNode : mrModelPart.Nodes())
         {
-            Delta += std::abs(rNode.Id() - NodeIdBuffer[itNode]);
+            Delta += std::abs(static_cast<int>(rNode.Id()) - static_cast<int>(NodeIdBuffer[itNode]));
             itNode++;
         }
 

--- a/applications/AdjointFluidApplication/custom_processes/output_primal_solution_process.h
+++ b/applications/AdjointFluidApplication/custom_processes/output_primal_solution_process.h
@@ -358,7 +358,7 @@ public:
             int itNode = 0;
             for (const auto& rNode : mrModelPart.Nodes())
             {
-                Delta += std::abs(rNode.Id() - NodeIdBuffer[itNode]);
+                Delta += std::abs(static_cast<int>(rNode.Id()) - static_cast<int>(NodeIdBuffer[itNode]));
                 itNode++;
             }
     


### PR DESCRIPTION
I'm altering an operation that did not compile in gcc 7.2.0. Apparently the issue is that std::abs is not defined for unsigned types and should fail if you try to use it (std::abs makes no sense for an unsigned int, "negative numbers" are very large unsigned integers). I've tried to fix the error while respecting the spirit of the original code, but feel free to use a different solution instead.