### PR TITLE
Kratos Parameters improve Vector/Matrix related methods

### DIFF
--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -266,7 +266,7 @@ public:
 
         for (unsigned int i=0; i<mpvalue->Size(); ++i)
         {
-            if (!(*mpvalue)[i].IsNumber()) // TODO Check if this is true for Double AND int
+            if (!(*mpvalue)[i].IsNumber()) 
                 return false;
         }
         return true; // All entries are numbers or Vector is empty
@@ -292,7 +292,7 @@ public:
             
             for (unsigned int j=0; j<ncols; ++j) // Check all values in column
             {
-                if (!row_i[j].IsNumber()) // TODO Check if this is true for Double AND int
+                if (!row_i[j].IsNumber()) 
                     return false;
             }
         }

--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -261,65 +261,42 @@ public:
     }
     bool IsVector() const
     {
-        if(mpvalue->IsArray())
-        {
-            if (mpvalue->Size() > 0) // check size first before accessing to avoid segfault
-            {
-                if((*mpvalue)[0].IsArray()) // mpvalue is a matrix
-                {
-                    return false;
-                }
-                else
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                return true;
-            }
-        }
-        else
-        {
+        if(!mpvalue->IsArray())
             return false;
+
+        for (unsigned int i=0; i<mpvalue->Size(); ++i)
+        {
+            if (!(*mpvalue)[i].IsNumber()) // TODO Check if this is true for Double AND int
+                return false;
         }
+        return true; // All entries are numbers or Vector is empty
     }
     bool IsMatrix() const
     {
-        if(mpvalue->IsArray())
-        {
-            unsigned int nrows = mpvalue->Size();
-            if (nrows > 0)
-            {
-                if((*mpvalue)[0].IsArray()) // mpvalue is a matrix
-                {
-                    unsigned int ncols = 0;
-                    if(nrows != 0)
-                        ncols = (*mpvalue)[0].Size();
-            
-                    for (unsigned int i=1; i<nrows; ++i)
-                    {
-                        auto& row_i = (*mpvalue)[i];
-                        if(row_i.IsArray() == false) return false;
-                        if(row_i.Size() != ncols) return false;
-                    }
-            
-                    return true;                    
-                }
-                else
-                {
-                    return false;
-                }
-            }
-            else
-            {
-                return false;
-            }
-        }
-        else
-        {
+        if(!mpvalue->IsArray()) // mpvalue != [ ... ]
             return false;
+
+        unsigned int nrows = mpvalue->Size();
+        if (nrows == 0) // mpvalue is an empty array/vector => "[]"
+            return false; 
+
+        for (unsigned int i=0; i<nrows; ++i)
+        {
+            auto& row_i = (*mpvalue)[i];
+            if (!row_i.IsArray())
+                return false;
+
+            unsigned int ncols = row_i.Size();
+            if (ncols != (*mpvalue)[0].Size()) // compare number of columns to first row
+                return false; // number of columns is not consistent
+            
+            for (unsigned int j=0; j<ncols; ++j) // Check all values in column
+            {
+                if (!row_i[j].IsNumber()) // TODO Check if this is true for Double AND int
+                    return false;
+            }
         }
+        return true; // All entries are numbers or Matrix is empty ([[]] or [[],[],[],...])
     }
     bool IsSubParameter() const
     {
@@ -351,13 +328,12 @@ public:
         KRATOS_ERROR_IF_NOT(mpvalue->IsArray()) << "argument must be a Vector (a json list)" << std::endl;
         
         const unsigned int size = mpvalue->Size();
-        if (size > 0)
-            KRATOS_ERROR_IF((*mpvalue)[0].IsArray()) << "argument must be a Vector (a json list), it might be a matrix" << std::endl;
             
         Vector V(size);
         
         for(unsigned int i=0; i<size; ++i)
         {
+            KRATOS_ERROR_IF_NOT((*mpvalue)[i].IsNumber()) << "Entry " << i << " is not a number!" << std::endl;
             V(i) = (*mpvalue)[i].GetDouble();
         }
         
@@ -368,10 +344,11 @@ public:
         KRATOS_ERROR_IF_NOT(mpvalue->IsArray()) << "argument must be a Matrix (a json list of lists)" << std::endl;
         
         const unsigned int nrows = mpvalue->Size();
+        KRATOS_ERROR_IF(nrows == 0) << "argument must be a Matrix (a json list of lists)" << std::endl;
+
         unsigned int ncols = 0;
-        if(nrows != 0)
-            if((*mpvalue)[0].IsArray())
-                ncols = (*mpvalue)[0].Size();
+        if((*mpvalue)[0].IsArray())
+            ncols = (*mpvalue)[0].Size();
             
         Matrix A(nrows,ncols);
         
@@ -379,9 +356,10 @@ public:
         {
             auto& row_i = (*mpvalue)[i];
             KRATOS_ERROR_IF_NOT(row_i.IsArray()) << "not an array on row " << i << std::endl;
-            KRATOS_ERROR_IF(row_i.Size() != ncols) << "wrong size of row " << i << std::endl;
+            KRATOS_ERROR_IF_NOT(row_i.Size() == ncols) << "wrong size of row " << i << std::endl;
             for(unsigned int j=0; j<ncols; ++j)
             {
+                KRATOS_ERROR_IF_NOT((row_i)[j].IsNumber()) << "Entry (" << i << "," << j << ") is not a number!" << std::endl;
                 A(i,j) = (row_i)[j].GetDouble();
             }
         }

--- a/kratos/tests/test_kratos_parameters.py
+++ b/kratos/tests/test_kratos_parameters.py
@@ -471,7 +471,41 @@ class TestParameters(KratosUnittest.TestCase):
                     tmp[key].GetMatrix()   
         
     def test_vector_interface(self):
-        tmp = Parameters("""{ }""")
+        # Read and check Vectors from a Parameters-Object
+        tmp = Parameters("""{
+            "valid_vectors" : [ []
+            ],
+            "false_vectors" : [ [[2,3],2],
+                                [2,3,[2]],
+                                [2,3,[]],
+                                [{"key":3},2],
+                                [2,3,{"key":3}],
+                                [true,2],
+                                [2,3,true],
+                                [5,"string",2] 
+            ]
+        }""")      
+
+        # Check the IsVector Method
+        for i in range(tmp["valid_vectors"].size()):
+            valid_vector = tmp["valid_vectors"][i]
+            self.assertTrue(valid_vector.IsVector())
+        
+        for i in range(tmp["false_vectors"].size()):
+            false_vector = tmp["false_vectors"][i]
+            self.assertFalse(false_vector.IsVector())
+
+        # Check the GetVector Method also on the valid Matrices
+        for i in range(tmp["valid_vectors"].size()):
+            valid_vector = tmp["valid_vectors"][i]
+            valid_vector.GetVector()
+
+        # Check that the errors of the GetVector method are thrown correctly
+        for i in range(tmp["false_vectors"].size()):
+            false_vector = tmp["false_vectors"][i]
+            with self.assertRaises(RuntimeError):        
+                false_vector.GetVector()
+
         # Manually assign and check a Vector
         vec = Vector(3)
         vec[0] = 1.32
@@ -489,11 +523,42 @@ class TestParameters(KratosUnittest.TestCase):
         self.assertEqual(V2[2],5.5)
 
     def test_matrix_interface(self):
-        # Read and check a Matrix from a Parameters-Object
+        # Read and check Matrices from a Parameters-Object
         tmp = Parameters("""{
-            "false_matrix_value": [[2, 1.5,3.3],[1,2]]
+            "valid_matrices" : [ [[]],
+                                 [[],[]],
+                                 [[-9.81,8, 5.47]]
+            ],
+            "false_matrices" : [ [],
+                                 [[[]]],
+                                 [[3.3] , [1,2]],
+                                 [[2,1.5,3.3] , [3,{"key":3},2]],
+                                 [[2,1.5,3.3] , [5,false,2]],
+                                 [[2,1.5,3.3] , [[2,3],1,2]],
+                                 [[2,1.5,3.3] , ["string",2,9]] 
+            ]
         }""")
         
+        # Check the IsMatrix Method
+        for i in range(tmp["valid_matrices"].size()):
+            valid_matrix = tmp["valid_matrices"][i]
+            self.assertTrue(valid_matrix.IsMatrix())
+            
+        for i in range(tmp["false_matrices"].size()):
+            false_matrix = tmp["false_matrices"][i]
+            self.assertFalse(false_matrix.IsMatrix())
+
+        # Check the GetMatrix Method also on the valid Matrices
+        for i in range(tmp["valid_matrices"].size()):
+            valid_matrix = tmp["valid_matrices"][i]
+            valid_matrix.GetMatrix()
+
+        # Check that the errors of the GetMatrix method are thrown correctly
+        for i in range(tmp["false_matrices"].size()):
+            false_matrix = tmp["false_matrices"][i]
+            with self.assertRaises(RuntimeError):        
+                false_matrix.GetMatrix()
+
         # Manually assign and check a Matrix
         mat = Matrix(3,2)
         mat[0,0] = 1.0
@@ -516,13 +581,6 @@ class TestParameters(KratosUnittest.TestCase):
         self.assertEqual(A2[2,0],5.0)
         self.assertEqual(A2[2,1],6.0)
 
-        # Check the IsMatrix Method
-        self.assertFalse(tmp["false_matrix_value"].IsMatrix()) # Mis-sized Matrix
-
-        # check that the errors of the GetMatrix method are thrown correctly
-        with self.assertRaises(RuntimeError):        
-            tmp["false_matrix_value"].GetMatrix() # Mis-sized Matrix
-        
         
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
This PR improves the `IsVector` and the `IsMatrix` Methods (and small updates to `GetVector` and `GetMatrix`)
The problem was that the subparamters of a vector or matrix defined in json could not be numbers, which was not detected by the `Is...` methods. Then the `Get...` Methods fail because of incompatible data types.
Now every value is checked to ensure that the data types are consistent.

Also the tests were extended