### PR TITLE
Correct Typo in the Fixing of Dynamic Variables (SolidMechApp)

### DIFF
--- a/applications/SolidMechanicsApplication/python_scripts/assign_scalar_to_nodes_process.py
+++ b/applications/SolidMechanicsApplication/python_scripts/assign_scalar_to_nodes_process.py
@@ -164,14 +164,14 @@ class AssignScalarToNodesProcess(KratosMultiphysics.Process):
         
         self.fix_derivated_variable = False
         for dynamic_variable in self.AngularDynamicVariables:
-            if dynamic_variable in self.variable_name:
+            if dynamic_variable in self.variable_name[:-2]:
                 self.derivated_variable_name = "ROTATION" + self.variable_name[-2:]
                 self.fix_derivated_variable = True
                 break
 
         if( self.fix_derivated_variable == False ):
             for dynamic_variable in self.LinearDynamicVariables:
-                if dynamic_variable == self.variable_name:
+                if dynamic_variable == self.variable_name[:-2]:
                     self.derivated_variable_name = "DISPLACEMENT" + self.variable_name[-2:]
                     self.fix_derivated_variable = True
                     break


### PR DESCRIPTION
The full name of the variable (i.e. VELOCITY) was compared to the name of the component(i.e. VELOCITY_X). 