### PR TITLE
Feature improve material reading process

### DIFF
--- a/kratos/python_scripts/read_materials_process.py
+++ b/kratos/python_scripts/read_materials_process.py
@@ -37,8 +37,8 @@ class ReadMaterialsProcess(KratosMultiphysics.Process):
         settings.ValidateAndAssignDefaults(default_settings)
         self.Model = Model
 
-        parameter_file = open(settings["materials_filename"].GetString(), 'r')
-        materials = KratosMultiphysics.Parameters(parameter_file.read())
+        with open(settings["materials_filename"].GetString(), 'r') as parameter_file:
+            materials = KratosMultiphysics.Parameters(parameter_file.read())
         
         for i in range(materials["properties"].size()):
             self._AssignPropertyBlock(materials["properties"][i])

--- a/kratos/python_scripts/read_materials_process.py
+++ b/kratos/python_scripts/read_materials_process.py
@@ -1,13 +1,13 @@
-from KratosMultiphysics import * 
+import KratosMultiphysics  
 import importlib
         
 def Factory(settings, Model):
-    if(type(settings) != Parameters):
+    if(type(settings) != KratosMultiphysics.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
     return ReadMaterialsProcess(Model, settings["Parameters"])
 
 
-class ReadMaterialsProcess(Process):
+class ReadMaterialsProcess(KratosMultiphysics.Process):
     def __init__(self, Model, settings):
         """Read constitutive law and material properties from a json file and assign them to elements and conditions.
 
@@ -26,30 +26,49 @@ class ReadMaterialsProcess(Process):
 
         See _AssignPropertyBlock for detail on how properties are imported.
         """
-        Process.__init__(self) 
-        default_settings = Parameters("""
+        KratosMultiphysics.Process.__init__(self) 
+        default_settings = KratosMultiphysics.Parameters("""
             {
             "materials_filename" : "please specify the file to be opened"
             }
             """
-            )
+        )
             
         settings.ValidateAndAssignDefaults(default_settings)
         self.Model = Model
 
         parameter_file = open(settings["materials_filename"].GetString(), 'r')
-        materials = Parameters(parameter_file.read())
+        materials = KratosMultiphysics.Parameters(parameter_file.read())
         
         for i in range(materials["properties"].size()):
             self._AssignPropertyBlock(materials["properties"][i])
         
         print("finished reading materials")
         
-    def _GetItemFromModule(self,my_string):
-        """Return the python object named by the string argument.
+    def _GetVariable(self,my_string):
+        """Return the python object of a Variable named by the string argument.
+
+        Examples:
+        variable = self._GetVariable("VELOCITY")
+        variable = self._GetVariable("KratosMultiphysics.VELOCITY")
+        variable = self._GetVariable("SUBSCALE_PRESSURE")
+        variable = self._GetVariable("FluidDynamicsApplication.SUBSCALE_PRESSURE")
+        variable = self._GetVariable("KratosMultiphysics.FluidDynamicsApplication.SUBSCALE_PRESSURE")
+        """
+        splitted = my_string.split(".")
+
+        if len(splitted) == 0:
+            raise Exception("Something wrong. Trying to split the string " + my_string)
+        if len(splitted) > 3:
+            raise Exception("Something wrong. String " + my_string + " has too many arguments")
+
+        return KratosMultiphysics.KratosGlobals.GetVariable(splitted[-1]) # This also checks if the application has been imported
+
+    def _GetConstitutiveLaw(self,my_string):
+        """Return the python object of a Constitutive Law named by the string argument.
 
         Example:
-        constitutive_law = self._GetItemFromModule('KratosMultiphysics.StructuralMechanicsApplication.LinearElastic3DLaw')
+        constitutive_law = self._GetConstitutiveLaw('KratosMultiphysics.StructuralMechanicsApplication.LinearElastic3DLaw')
         model_part.GetProperties(prop_id).SetValue(CONSTITUTIVE_LAW, constitutive_law)
         """
         splitted = my_string.split(".")
@@ -58,15 +77,37 @@ class ReadMaterialsProcess(Process):
         if(len(splitted) == 1):
             return eval(my_string)
         else:
+            variable_name = splitted[-1]
             module_name = ""
             for i in range(len(splitted)-1):
                 module_name += splitted[i] 
                 if i != len(splitted)-2:
                     module_name += "."
 
+            # Philipp check if the app is imported, not if it is registered (or maybe after?) 
+            # Anyway, have a look at the "application_importer.py"
+            # if module_name not in sys.modules:
+            #     raise ImportError(module_name + " is not imported!")
             module = importlib.import_module(module_name)
             return getattr(module,splitted[-1]) 
+            # return getattr(globals()[module_name], splitted[-1])
              
+
+        # # print(sys.modules)
+
+        # theapp = sys.modules["KratosMultiphysics.FluidDynamicsApplication"]
+
+        # # print(theapp)
+
+        # thesecondapp = KratosGlobals.RequestedApplications["KratosFluidDynamicsApplication"]
+
+        # if theapp is thesecondapp:
+        #     print("TRUE")
+        # else:
+        #     print("False :(")
+
+
+
     def _AssignPropertyBlock(self, data):
         """Set constitutive law and material properties and assign to elements and conditions.
 
@@ -108,15 +149,15 @@ class ReadMaterialsProcess(Process):
 
         # Set the CONSTITUTIVE_LAW for the current properties.
         if "Variables" in mat["constitutive_law"].keys(): #pass the list of variables when constructing the constitutive law
-           constitutive_law = self._GetItemFromModule( mat["constitutive_law"]["name"].GetString())(mat["constitutive_law"]["Variables"])
+           constitutive_law = self._GetConstitutiveLaw( mat["constitutive_law"]["name"].GetString())(mat["constitutive_law"]["Variables"])
         else:
-           constitutive_law = self._GetItemFromModule( mat["constitutive_law"]["name"].GetString())()
+           constitutive_law = self._GetConstitutiveLaw( mat["constitutive_law"]["name"].GetString())()
            
-        prop.SetValue(CONSTITUTIVE_LAW, constitutive_law)
+        prop.SetValue(KratosMultiphysics.CONSTITUTIVE_LAW, constitutive_law)
         
         # Add / override the values of material parameters in the properties
         for key, value in mat["Variables"].items():
-            var = self._GetItemFromModule(key)
+            var = self._GetVariable(key)
             if value.IsDouble():
                 prop.SetValue( var, value.GetDouble() )
             elif value.IsInt():
@@ -136,10 +177,10 @@ class ReadMaterialsProcess(Process):
         for key, table in mat["Tables"].items():
             table_name = key
 
-            input_var = self._GetItemFromModule(table["input_variable"].GetString())
-            output_var = self._GetItemFromModule(table["output_variable"].GetString())
+            input_var = self._GetVariable(table["input_variable"].GetString())
+            output_var = self._GetVariable(table["output_variable"].GetString())
 
-            new_table = PiecewiseLinearTable()
+            new_table = KratosMultiphysics.PiecewiseLinearTable()
 
             for i in range(table["data"].size()):
                 new_table.AddRow(table["data"][i][0].GetDouble(), table["data"][i][1].GetDouble())

--- a/kratos/tests/materials.json
+++ b/kratos/tests/materials.json
@@ -11,11 +11,12 @@
 				"KratosMultiphysics.YOUNG_MODULUS": 200.0,
 				"POISSON_RATIO": 0.3,
 				"YIELD_STRESS": 400.0,
-				"KratosMultiphysics.FluidDynamicsApplication.SUBSCALE_PRESSURE" : 0.1
+				"KratosMultiphysics.FluidDynamicsApplication.SUBSCALE_PRESSURE" : 0.1,
+				"FluidDynamicsApplication.VORTICITY_MAGNITUDE" : -5.888
 				},
 			"Tables": {
 				"Table1": {
-					"input_variable": "TEMPERATURE",
+					"input_variable": "KratosMultiphysics.TEMPERATURE",
 					"output_variable": "YOUNG_MODULUS",
 					"data": [
 						[0.0, 100.0],

--- a/kratos/tests/materials.json
+++ b/kratos/tests/materials.json
@@ -5,7 +5,7 @@
 		"Material": {
 			"name": "steel",
 			"constitutive_law": {
-				"name": "KratosMultiphysics.SolidMechanicsApplication.LinearElastic3DLaw"
+				"name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElastic3DLaw"
 			},
 			"Variables": {
 				"KratosMultiphysics.YOUNG_MODULUS": 200.0,
@@ -30,7 +30,7 @@
 		"Material": {
 			"name": "steel",
 			"constitutive_law": {
-				"name": "ConstitutiveLaw"
+				"name": "KratosMultiphysics.ConstitutiveLaw"
 			},
 			"Variables": {
 				"YOUNG_MODULUS": 100.0,

--- a/kratos/tests/test_materials_input.py
+++ b/kratos/tests/test_materials_input.py
@@ -11,7 +11,7 @@ class TestMaterialsInput(KratosUnittest.TestCase):
 
     def test_input(self):
         try:
-            import KratosMultiphysics.FluidDynamicsApplication
+            import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
         except:
             self.skipTest("KratosMultiphysics.FluidDynamicsApplication is not available")
             
@@ -63,6 +63,8 @@ class TestMaterialsInput(KratosUnittest.TestCase):
         self.assertTrue(model_part.Properties[1].GetValue(KratosMultiphysics.YOUNG_MODULUS) == 200.0)
         self.assertTrue(model_part.Properties[1].GetValue(KratosMultiphysics.POISSON_RATIO) == 0.3)
         self.assertTrue(model_part.Properties[1].GetValue(KratosMultiphysics.YIELD_STRESS) == 400.0)
+        self.assertTrue(model_part.Properties[1].GetValue(KratosFluid.SUBSCALE_PRESSURE) == 0.1)
+        self.assertTrue(model_part.Properties[1].GetValue(KratosFluid.VORTICITY_MAGNITUDE) == -5.888)
 
         self.assertTrue(model_part.Properties[2].GetValue(KratosMultiphysics.YOUNG_MODULUS) == 100.0)
         self.assertTrue(model_part.Properties[2].GetValue(KratosMultiphysics.POISSON_RATIO) == 0.1)

--- a/kratos/tests/test_materials_input.py
+++ b/kratos/tests/test_materials_input.py
@@ -1,23 +1,29 @@
 ﻿from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-from KratosMultiphysics import *
+import KratosMultiphysics
+from  os.path import dirname, realpath
 
 def GetFilePath(fileName):
-    return os.path.dirname(os.path.realpath(__file__)) + "/" + fileName
+    return dirname(realpath(__file__)) + "/" + fileName
 
 class TestMaterialsInput(KratosUnittest.TestCase):
 
     def test_input(self):
         try:
-            import KratosMultiphysics.SolidMechanicsApplication
+            import KratosMultiphysics.FluidDynamicsApplication
         except:
-            self.skipTest("KratosMultiphysics.SolidMechanicsApplication is not available")
+            self.skipTest("KratosMultiphysics.FluidDynamicsApplication is not available")
+            
+        try:
+            import KratosMultiphysics.StructuralMechanicsApplication
+        except:
+            self.skipTest("KratosMultiphysics.StructuralMechanicsApplication is not available")
         
-        model_part = ModelPart("Main")
-        model_part.AddNodalSolutionStepVariable(DISPLACEMENT)
-        model_part.AddNodalSolutionStepVariable(VISCOSITY)
-        model_part_io = ModelPartIO(GetFilePath("test_model_part_io_read")) #reusing the file that is already in the directory
+        model_part = KratosMultiphysics.ModelPart("Main")
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VISCOSITY)
+        model_part_io = KratosMultiphysics.ModelPartIO(GetFilePath("test_model_part_io_read")) #reusing the file that is already in the directory
         model_part_io.ReadModelPart(model_part)
     
         #define a Model TODO: replace to use the real Model once available
@@ -29,7 +35,7 @@ class TestMaterialsInput(KratosUnittest.TestCase):
             "Outlet" : model_part.GetSubModelPart("Outlet")
             }
         
-        test_settings = Parameters("""
+        test_settings = KratosMultiphysics.Parameters("""
             {
                     "Parameters": {
                             "materials_filename": "materials.json"
@@ -54,30 +60,30 @@ class TestMaterialsInput(KratosUnittest.TestCase):
             self.assertTrue(cond.Properties.Id == 2)   
                     
         #test that the properties are read correctly
-        self.assertTrue(model_part.Properties[1].GetValue(YOUNG_MODULUS) == 200.0)
-        self.assertTrue(model_part.Properties[1].GetValue(POISSON_RATIO) == 0.3)
-        self.assertTrue(model_part.Properties[1].GetValue(YIELD_STRESS) == 400.0)
+        self.assertTrue(model_part.Properties[1].GetValue(KratosMultiphysics.YOUNG_MODULUS) == 200.0)
+        self.assertTrue(model_part.Properties[1].GetValue(KratosMultiphysics.POISSON_RATIO) == 0.3)
+        self.assertTrue(model_part.Properties[1].GetValue(KratosMultiphysics.YIELD_STRESS) == 400.0)
 
-        self.assertTrue(model_part.Properties[2].GetValue(YOUNG_MODULUS) == 100.0)
-        self.assertTrue(model_part.Properties[2].GetValue(POISSON_RATIO) == 0.1)
-        self.assertTrue(model_part.Properties[2].GetValue(YIELD_STRESS) == 800.0)
-        self.assertTrue(model_part.Properties[2].GetValue(HTC) == 0.3)
-        self.assertTrue(model_part.Properties[2].GetValue(TIME_STEPS) == 159) # int
-        self.assertTrue(model_part.Properties[2].GetValue(UPDATE_SENSITIVITIES) == True) # bool
-        self.assertTrue(model_part.Properties[2].GetValue(IDENTIFIER) == "MyTestString") # std::string
+        self.assertTrue(model_part.Properties[2].GetValue(KratosMultiphysics.YOUNG_MODULUS) == 100.0)
+        self.assertTrue(model_part.Properties[2].GetValue(KratosMultiphysics.POISSON_RATIO) == 0.1)
+        self.assertTrue(model_part.Properties[2].GetValue(KratosMultiphysics.YIELD_STRESS) == 800.0)
+        self.assertTrue(model_part.Properties[2].GetValue(KratosMultiphysics.HTC) == 0.3)
+        self.assertTrue(model_part.Properties[2].GetValue(KratosMultiphysics.TIME_STEPS) == 159) # int
+        self.assertTrue(model_part.Properties[2].GetValue(KratosMultiphysics.UPDATE_SENSITIVITIES) == True) # bool
+        self.assertTrue(model_part.Properties[2].GetValue(KratosMultiphysics.IDENTIFIER) == "MyTestString") # std::string
 
-        mat_vector = model_part.Properties[2].GetValue(CAUCHY_STRESS_VECTOR)
+        mat_vector = model_part.Properties[2].GetValue(KratosMultiphysics.CAUCHY_STRESS_VECTOR)
         self.assertAlmostEqual(mat_vector[0],1.5)
         self.assertAlmostEqual(mat_vector[1],0.3)
         self.assertAlmostEqual(mat_vector[2],-2.58)
 
-        mat_matrix = model_part.Properties[2].GetValue(LOCAL_INERTIA_TENSOR)
+        mat_matrix = model_part.Properties[2].GetValue(KratosMultiphysics.LOCAL_INERTIA_TENSOR)
         self.assertAlmostEqual(mat_matrix[0,0],1.27)
         self.assertAlmostEqual(mat_matrix[0,1],-22.5)
         self.assertAlmostEqual(mat_matrix[1,0],2.01)
         self.assertAlmostEqual(mat_matrix[1,1],0.257)
 
-        table = model_part.Properties[2].GetTable(TEMPERATURE, YOUNG_MODULUS)
+        table = model_part.Properties[2].GetTable(KratosMultiphysics.TEMPERATURE, KratosMultiphysics.YOUNG_MODULUS)
         self.assertAlmostEqual(table.GetValue(1.5),11.0)
         self.assertAlmostEqual(table.GetNearestValue(1.1),10.0)
         self.assertAlmostEqual(table.GetDerivative(1.2),2.0)


### PR DESCRIPTION
I wanted to do some improvements to the reading of the materials.
I found @RiccardoRossi branch `feature-improving-reading-of-materials`, which I used as a basis (I couldn't use it bcs it was too old)

Improvements:
- Now this process does **not** import any applications any more, errors are thrown accordingly
- Variable Names do not have to be proceeded by e.g. `KratosMultiphysics` or `KratosMultiphysics.FluidDynamicsApplication` any more. This solves also issues with the GiD interface (FYI @jginternational )
- Module handling is done in a cleaner way (constitutive laws)

There is one thing that I am not sure abt:
I get the following warning:
```
/home/philippb/software/Kratos_aux/kratos/python_scripts/read_materials_process.py:7: ResourceWarning: unclosed file <_io.TextIOWrapper name='/home/philippb/software/Kratos_aux/kratos/tests/materials.json' mode='r' encoding='UTF-8'>
  return ReadMaterialsProcess(Model, settings["Parameters"])
```
This only appears when I run the test, running a real case works fine. @KratosMultiphysics/technical-committee do you have an idea why this happens? I couldn't figure it out