### PR TITLE
Removing duplicate calls to AddVariables in python interface.

### DIFF
--- a/kratos/python/add_containers_to_python.cpp
+++ b/kratos/python/add_containers_to_python.cpp
@@ -367,8 +367,6 @@ void  AddContainersToPython()
     AddCFDVariablesToPython(); ///@TODO: move variables to CFD application
     AddALEVariablesToPython(); ///@TODO: move variables to ALE application
     AddFSIVariablesToPython(); ///@TODO: move variables to FSI application
-    AddMATVariablesToPython(); ///@TODO: move variables to CFD application
-    AddALEVariablesToPython(); ///@TODO: move variables to ALE application
     AddMappingVariablesToPython(); ///@TODO: move variables to Mapping application
     AddMATVariablesToPython(); ///@TODO: move variables to CL application
     AddLegacyStructuralAppVarsToPython();


### PR DESCRIPTION
There were duplicate calls to functions registering ALE and MAT application variables to python. I think they were harmless, but I'm removing them just in case. 