### PR TITLE
Structural Mechanics update tests after #1053

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/Kratos_Execute_Structural_Test.py
+++ b/applications/StructuralMechanicsApplication/tests/Kratos_Execute_Structural_Test.py
@@ -15,8 +15,6 @@ class Kratos_Execute_Test:
         self.main_model_part = KratosMultiphysics.ModelPart(self.ProjectParameters["problem_data"]["model_part_name"].GetString())
         self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, self.ProjectParameters["problem_data"]["domain_size"].GetInt())
 
-        self.Model = {self.ProjectParameters["problem_data"]["model_part_name"].GetString(): self.main_model_part}
-
         # Construct the solver (main setting methods are located in the solver_module)
         import python_solvers_wrapper_structural
         self.solver = python_solvers_wrapper_structural.CreateSolver(self.main_model_part, self.ProjectParameters)
@@ -32,11 +30,8 @@ class Kratos_Execute_Test:
         # If we integrate it in the model part we cannot use combined solvers
         self.solver.AddDofs()
 
-        # Build sub_model_parts or submeshes (rearrange parts for the application of custom processes)
-        # #Get the list of the submodel part in the object Model
-        for i in range(self.ProjectParameters["solver_settings"]["processes_sub_model_part_list"].size()):
-            part_name = self.ProjectParameters["solver_settings"]["processes_sub_model_part_list"][i].GetString()
-            self.Model.update({part_name: self.main_model_part.GetSubModelPart(part_name)})
+        self.Model = KratosMultiphysics.Model()
+        self.Model.AddModelPart(self.main_model_part)
 
         # Obtain the list of the processes to be applied
         self.list_of_processes = process_factory.KratosProcessFactory(self.Model).ConstructListOfProcesses(self.ProjectParameters["constraints_process_list"])

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -137,37 +137,18 @@ def AssambleTestSuites():
     smallSuite = suites['small']
     # Simple patch tests
     ## Solids
-    smallSuite.addTest(TTestConstitutiveLaw('test_Uniaxial_HyperElastic_3D'))
-    smallSuite.addTest(TTestConstitutiveLaw('test_Shear_HyperElastic_3D'))
-    smallSuite.addTest(TTestConstitutiveLaw('test_Shear_Plus_Strech_HyperElastic_3D'))
-    smallSuite.addTest(TTestPatchTestSmallStrain('test_SmallDisplacementElement_2D_triangle'))
-    smallSuite.addTest(TTestPatchTestSmallStrain('test_SmallDisplacementElement_2D_quadrilateral'))
-    smallSuite.addTest(TTestPatchTestSmallStrain('test_SmallDisplacementElement_3D_hexa'))
-    smallSuite.addTest(TTestPatchTestLargeStrain('test_TL_2D_triangle'))
-    smallSuite.addTest(TTestPatchTestLargeStrain('test_TL_2D_quadrilateral'))
-    smallSuite.addTest(TTestPatchTestLargeStrain('test_TL_3D_hexa'))
-    smallSuite.addTest(TTestPatchTestLargeStrain('test_UL_2D_triangle'))
-    smallSuite.addTest(TTestPatchTestLargeStrain('test_UL_2D_quadrilateral'))
-    smallSuite.addTest(TTestPatchTestLargeStrain('test_UL_3D_hexa'))
-    smallSuite.addTest(TTestQuadraticElements('test_Quad8'))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestConstitutiveLaw]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestPatchTestSmallStrain]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestPatchTestLargeStrain]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestQuadraticElements]))
     ## Shells
-    smallSuite.addTest(TTestPatchTestShells('test_thin_shell_triangle'))
-    smallSuite.addTest(TTestPatchTestShells('test_thick_shell_triangle'))
-    smallSuite.addTest(TTestPatchTestShells('test_thin_shell_quadrilateral'))
-    smallSuite.addTest(TTestPatchTestShells('test_thick_shell_quadrilateral'))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestPatchTestShells]))
     ## Trusses
-    smallSuite.addTest(TTestTruss3D2N('test_truss3D2N_linear'))
-    smallSuite.addTest(TTestTruss3D2N('test_truss3D2N_nonlinear'))
-    smallSuite.addTest(TTestTruss3D2N('test_truss3D2N_dynamic'))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestTruss3D2N]))
     ## Beams
-    smallSuite.addTest(TTestCrBeam3D2N('test_cr_beam_linear'))
-    smallSuite.addTest(TTestCrBeam3D2N('test_cr_beam_nonlinear'))
-    smallSuite.addTest(TTestCrBeam3D2N('test_cr_beam_dynamic_lumped_mass_matrix'))
-    smallSuite.addTest(TTestCrBeam3D2N('test_cr_beam_dynamic_consistent_mass_matrix'))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestCrBeam3D2N]))
     # Test loading conditions
-    smallSuite.addTest(TestLoadingConditions('test_LineLoadCondition2D2N'))
-    smallSuite.addTest(TestLoadingConditions('test_LineLoadCondition2D2NAngle'))
-    smallSuite.addTest(TestLoadingConditions('test_SurfaceLoadCondition3D4N'))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestLoadingConditions]))
     # Basic moving mesh test
     smallSuite.addTest(TSimpleMeshMovingTest('test_execution'))
     # Dynamic basic tests
@@ -216,7 +197,7 @@ def AssambleTestSuites():
     smallSuite.addTest(T3D2NBeamCrLinearTest('test_execution'))
     smallSuite.addTest(T3D2NBeamCrDynamicTest('test_execution'))
     # Nodal damping test
-    smallSuite.addTest(TNodalDampingTests('test_nodal_damping'))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TNodalDampingTests]))
 
     if (missing_external_dependencies == False):
         if (hasattr(KratosMultiphysics.ExternalSolversApplication,
@@ -226,10 +207,7 @@ def AssambleTestSuites():
             smallSuite.addTest(TEigen3D3NThinCircleTests('test_execution'))
             smallSuite.addTest(TEigenTL3D8NCubeTests('test_execution'))
             # Element damping test
-            smallSuite.addTest(TSpringDamperElementTests('test_undamped_mdof_system_dynamic'))
-            smallSuite.addTest(TSpringDamperElementTests('test_undamped_sdof_system_harmonic'))
-            smallSuite.addTest(TSpringDamperElementTests('test_damped_mdof_system_dynamic'))
-            smallSuite.addTest(TSpringDamperElementTests('test_undamped_mdof_system_eigen'))
+            smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TSpringDamperElementTests]))
             # Harmonic analysis test
             smallSuite.addTest(THarmonicAnalysisTests('test_execution'))
         else:


### PR DESCRIPTION
Updated the main test script to accommodate the recent changes of `Kratos::Model`from #1053 

Also how the tests are loaded is slightly changed to detect test cases in the test classes automatically => making it more bullet proof (2 tests were still missing!)