### PR TITLE
Used os.path.join in CompareTwoFilesCheckProcess

### DIFF
--- a/kratos/python_scripts/compare_two_files_check_process.py
+++ b/kratos/python_scripts/compare_two_files_check_process.py
@@ -39,8 +39,8 @@ class CompareTwoFilesCheckProcess(KratosMultiphysics.Process, KratosUnittest.Tes
         self.error_assumed = self.params["error_assumed"].GetDouble()
         
     def ExecuteInitialize(self):
-        self.file_name_1 = os.getcwd() + "/" + self.params["file_name_1"].GetString()
-        self.file_name_2 = os.getcwd() + "/" + self.params["file_name_2"].GetString()
+        self.file_name_1 = os.path.join(os.getcwd(), self.params["file_name_1"].GetString())
+        self.file_name_2 = os.path.join(os.getcwd(), self.params["file_name_2"].GetString())
         
     def ExecuteBeforeSolutionLoop(self):
         pass

--- a/kratos/tests/test_gid_io.py
+++ b/kratos/tests/test_gid_io.py
@@ -57,9 +57,29 @@ class TestGidIO(KratosUnittest.TestCase):
         return model_part
 
     def __Check(self,output_file,reference_file):
-        import filecmp
-        self.assertTrue( filecmp.cmp(os.path.dirname(os.path.realpath(__file__)) + "/" 
-            +output_file, os.path.dirname(os.path.realpath(__file__)) + "/" +reference_file))
+        import compare_two_files_check_process
+
+        ## Settings string in json format
+        params = KratosMultiphysics.Parameters("""
+            {
+                "file_name_1"            : "",
+                "file_name_2"            : "",
+                "deterministic"          : true
+            }
+        """)
+
+        params["file_name_1"].SetString(output_file)
+        params["file_name_2"].SetString(reference_file)
+
+        cmp_process = compare_two_files_check_process.CompareTwoFilesCheckProcess(KratosMultiphysics.ModelPart(), params)
+
+        cmp_process.ExecuteInitialize()
+        cmp_process.ExecuteBeforeSolutionLoop()
+        cmp_process.ExecuteInitializeSolutionStep()
+        cmp_process.ExecuteFinalizeSolutionStep()
+        cmp_process.ExecuteBeforeOutputStep()
+        cmp_process.ExecuteAfterOutputStep()
+        cmp_process.ExecuteFinalize()
 
     def test_gid_io_all(self):
         model_part = self.__InitialRead()


### PR DESCRIPTION
I corrected what was mentioned in #1086 abt handling the paths by using os.path.join
@roigcarlo is this ok for you? I changed also the gid_io test to use the file comparison process instead of some custom thing. I hope this is ok bcs it is a little bit of overhead.
If you dont want this then i can revert it

@loumalouomega I checked and I think the meshing-app is the only app using this process. I don't have mmg, could you please check if the tests are still working? Thx.

FYI @KratosMultiphysics/technical-committee 