### PR TITLE
Utils/application generator tune up

### DIFF
--- a/kratos/python_scripts/application_generator/applicationGenerator.py
+++ b/kratos/python_scripts/application_generator/applicationGenerator.py
@@ -411,7 +411,6 @@ class ApplicationGenerator(TemplateRule):
 
         # First read the file and parse all the info
         with open(srcFile, 'r') as src:
-            last = None 
             for l in src:
                 # Select the block
                 if 'Import_' in l and 'Application = False' in l:
@@ -432,8 +431,6 @@ class ApplicationGenerator(TemplateRule):
                 # Append the result if its not null
                 if l is not '\n' or currentBlock == 'prepareBlock':
                     fileStruct[currentBlock].append(l)
-
-                last = l
 
         # Prepare some blocks
         prepareBlockContent = [

--- a/kratos/python_scripts/application_generator/applicationGenerator.py
+++ b/kratos/python_scripts/application_generator/applicationGenerator.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import shutil
+import difflib
 
 from classes.elementCreator import ElementCreator
 from classes.conditionCreator import ConditionCreator
@@ -21,6 +22,34 @@ class ApplicationGenerator(TemplateRule):
     def __init__(self, name):
 
         super(ApplicationGenerator, self).__init__()
+
+        appStrPos = name.lower().find('application')
+        maxi = 5
+        while appStrPos != -1 and maxi > 0:
+            oldname = name
+            name = name[0:appStrPos] + name[appStrPos+len('application'):len(name)]
+
+            msg = Formatc([
+                {'color': bcolors.WARNING, 'msg': '[WARNING]'},
+                {'color': bcolors.CYAN, 'msg': ' {}'.format(oldname)},
+                {'color': None, 'msg': ' already contains the substring "'},
+                {'color': bcolors.CYAN, 'msg': '{}'.format('Application')},
+                {'color': None, 'msg': '". Removing... : '+name},
+            ], sys.stderr)
+
+            print(msg, file=sys.stderr)
+            appStrPos = name.lower().find('application')
+            maxi = maxi -1
+
+        if difflib.SequenceMatcher(None, name.lower(), 'application').ratio() > 0.65:
+            msg = Formatc([
+                {'color': bcolors.WARNING, 'msg': '[WARNING]'},
+                {'color': None, 'msg': ' Your application name contains something wrong after automatic fix, please select another name.'},
+            ], sys.stderr)
+
+            print(msg, file=sys.stderr)
+            exit()
+
 
         self._appDir = GetApplicationsDirectory()
 

--- a/kratos/python_scripts/application_generator/createApplication.py
+++ b/kratos/python_scripts/application_generator/createApplication.py
@@ -8,11 +8,17 @@ from classes.variableCreator import VariableCreator
 
 from applicationGenerator import ApplicationGenerator
 
+if len(sys.argv) != 2:
+    print("Error: Invalid usage.\nPlease call this script with your application name (in camelCase) like this: ")
+    print("python createApplication.py MyNewApplication")
+    exit()
+
 # Read the application name and generate Camel, Caps and Low
 appNameCamel = sys.argv[1]
 
 # Fetch the applications directory
 debugApp = ApplicationGenerator(appNameCamel)
+
 
 # Add KratosVariables
 debugApp.AddVariables([


### PR DESCRIPTION
Some details that were still unfinished in the new application generator.
It aims to make something usable towards the wiki update for "how to create an application".

Usage for the new user will be:

`python createApplication [Name]`

and add his app to the configure.

As a reminder this will 
- Create the application skeleton (CMakeLists, cpp's, h's, etc..)
- Create a simple element, condition and a couple of processes
- Populate the classes with some Kratos variables, dofs, etc...

Support for complex things is still very early in development so I will not explicitly explain how to modify it from the script in the wiki.