### PR TITLE
StructuralMechanics using skiptest

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
+++ b/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
@@ -53,6 +53,8 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
                 "search_dimension": 7
         }
         """)
+        if not (hasattr(KratosMultiphysics.ExternalSolversApplication,"PastixComplexSolver")):
+            self.skipTest('"PastixComplexSolver" not available')
 
         feast_system_solver = ExternalSolversApplication.PastixComplexSolver(feast_system_solver_settings)
         eigen_solver = ExternalSolversApplication.FEASTSolver(eigensolver_settings, feast_system_solver)


### PR DESCRIPTION
In case `PastixComplexSolver` is not available the test is skipped (otherwise it fails bcs it does not find the solver)