### PR TITLE
Fix for GiD GP Container

### DIFF
--- a/kratos/includes/gid_gauss_point_container.h
+++ b/kratos/includes/gid_gauss_point_container.h
@@ -115,6 +115,8 @@ public:
                         GiD_fWriteScalar( ResultFile, it->Id(), ValuesOnIntPoint[index] );
                     }                    
                 }
+				// Set first entry to NaN for test below
+				ValuesOnIntPoint[0] = std::numeric_limits<double>::quiet_NaN();
             }
             if( mMeshConditions.size() != 0 )
             {
@@ -123,6 +125,13 @@ public:
                 {
                     it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                      r_model_part.GetProcessInfo() );
+
+					if (std::isnan(ValuesOnIntPoint[0]))
+					{
+						// we aren't getting any new results, break
+						break;
+					}
+
                     for(unsigned int i=0; i<mIndexContainer.size(); i++)
                     {
                         int index = mIndexContainer[i];


### PR DESCRIPTION
Hi,
A student of mine found a bug in the `gid_gauss_point_container.h`
The problem is the following:
If no new results are retrieved from the conditions, all results were overwritten with the last result from the elements
This is there to prevent this from happening, but there is probably a nicer way

I discussed it already with @pooyan-dadvand in #842 , but now that I looked at it again after a while I really do not like it any more

Maybe one of you knows a better solution