### PR TITLE
Hotfix geometries area normal

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -685,7 +685,7 @@ public:
 
         return result;
     }
-    
+
     /**
      * It computes the unit normal of the geometry, if possible
      * @return The normal of the geometry
@@ -694,19 +694,19 @@ public:
     {
         const unsigned int local_space_dimension = this->LocalSpaceDimension();
         const unsigned int dimension = this->WorkingSpaceDimension();
-        
+
         if (dimension == local_space_dimension)
         {
             KRATOS_ERROR << "Remember the normal can be computed just in geometries with a local dimension: "<< this->LocalSpaceDimension() << "smaller than the spatial dimension: " << this->WorkingSpaceDimension() << std::endl;
         }
-        
+
         // We define the normal and tangents
         array_1d<double,3> tangent_xi(3, 0.0);
         array_1d<double,3> tangent_eta(3, 0.0);
-        
-        Matrix j_node = ZeroMatrix( dimension, local_space_dimension ); 
+
+        Matrix j_node = ZeroMatrix( dimension, local_space_dimension );
         this->Jacobian( j_node, rPointLocalCoordinates);
-        
+
         // Using the Jacobian tangent directions
         if (dimension == 2)
         {
@@ -714,7 +714,7 @@ public:
             for (unsigned int i_dim = 0; i_dim < dimension; i_dim++)
             {
                 tangent_xi[i_dim]  = j_node(i_dim, 0);
-            } 
+            }
         }
         else
         {
@@ -722,23 +722,29 @@ public:
             {
                 tangent_xi[i_dim]  = j_node(i_dim, 0);
                 tangent_eta[i_dim] = j_node(i_dim, 1);
-            } 
+            }
         }
 
         array_1d<double, 3> normal;
         MathUtils<double>::CrossProduct(normal, tangent_xi, tangent_eta);
         return normal;
     }
-    
+
+    /**
+     * It computes the unit normal of the geometry
+     * @param rPointLocalCoordinates Refernce to the local coordinates of the
+     * point in where the unit normal is to be computed
+     * @return The unit normal in the given point
+     */
     virtual array_1d<double, 3> UnitNormal(const CoordinatesArrayType& rPointLocalCoordinates) const
     {
         array_1d<double, 3> normal = AreaNormal(rPointLocalCoordinates);
-	const double norm_normal = norm_2(normal);
-	if (norm_normal > std::numeric_limits<double>::epsilon()) normal /= norm_normal;
-	else KRATOS_ERROR << "ERROR: The normal norm is zero or almost zero. Norm. normal: " << norm_normal << std::endl;
+        const double norm_normal = norm_2(normal);
+        if (norm_normal > std::numeric_limits<double>::epsilon()) normal /= norm_normal;
+        else KRATOS_ERROR << "ERROR: The normal norm is zero or almost zero. Norm. normal: " << norm_normal << std::endl;
         return normal;
     }
-    
+
     /** Calculates the quality of the geometry according to a given criteria.
      *
      * Calculates the quality of the geometry according to a given criteria. In General
@@ -877,9 +883,9 @@ public:
      * @param rPoint: The point in global coordinates
      * @return The vector containing the local coordinates of the point
      */
-    virtual CoordinatesArrayType& PointLocalCoordinates( 
+    virtual CoordinatesArrayType& PointLocalCoordinates(
             CoordinatesArrayType& rResult,
-            const CoordinatesArrayType& rPoint 
+            const CoordinatesArrayType& rPoint
             )
     {
         Matrix J = ZeroMatrix( LocalSpaceDimension(), LocalSpaceDimension() );
@@ -921,23 +927,23 @@ public:
     }
 
     /**
-     * Returns whether given arbitrary point is inside the Geometry and the respective 
+     * Returns whether given arbitrary point is inside the Geometry and the respective
      * local point for the given global point
      * @param rPoint: The point to be checked if is inside o note in global coordinates
      * @param rResult: The local coordinates of the point
      * @param Tolerance: The  tolerance that will be considered to check if the point is inside or not
      * @return True if the point is inside, false otherwise
      */
-    virtual bool IsInside( 
-        const CoordinatesArrayType& rPoint, 
-        CoordinatesArrayType& rResult, 
+    virtual bool IsInside(
+        const CoordinatesArrayType& rPoint,
+        CoordinatesArrayType& rResult,
         const double Tolerance = std::numeric_limits<double>::epsilon()
         )
     {
         KRATOS_ERROR << "Calling base class IsInside method instead of derived class one. Please check the definition of derived class. " << *this << std::endl;
         return false;
     }
-    
+
     ///@}
     ///@name Inquiry
     ///@{
@@ -1034,7 +1040,7 @@ public:
 //       virtual Pointer Edge(const PointsArrayType& EdgePoints)
 //  {
 //    KRATOS_ERROR << "Calling base class Edge method instead of derived class one. Please check the definition of derived class." << *this << std::endl;
-// 
+//
 //  }
 
     /**
@@ -1183,16 +1189,16 @@ public:
     ///@}
     ///@name Jacobian
     ///@{
-    
+
     /** This method provides the global coordinates corresponding to the local coordinates provided
      * @param rResult The array containing the global coordinates corresponding to the local coordinates provided
      * @param LocalCoordinates The local coordinates provided
      * @return An array containing the global coordinates corresponding to the local coordinates provides
      * @see PointLocalCoordinates
      */
-    virtual CoordinatesArrayType& GlobalCoordinates( 
-        CoordinatesArrayType& rResult, 
-        CoordinatesArrayType const& LocalCoordinates 
+    virtual CoordinatesArrayType& GlobalCoordinates(
+        CoordinatesArrayType& rResult,
+        CoordinatesArrayType const& LocalCoordinates
         ) const
     {
         if (rResult.size() != 3)
@@ -1207,7 +1213,7 @@ public:
 
         return rResult;
     }
-    
+
     /** This method provides the global coordinates corresponding to the local coordinates provided, considering additionally a certain increment in the coordinates
      * @param rResult The array containing the global coordinates corresponding to the local coordinates provided
      * @param LocalCoordinates The local coordinates provided
@@ -1215,10 +1221,10 @@ public:
      * @return An array containing the global coordinates corresponding to the local coordinates provides
      * @see PointLocalCoordinates
      */
-    virtual CoordinatesArrayType& GlobalCoordinates( 
-        CoordinatesArrayType& rResult, 
+    virtual CoordinatesArrayType& GlobalCoordinates(
+        CoordinatesArrayType& rResult,
         CoordinatesArrayType const& LocalCoordinates,
-        Matrix& DeltaPosition 
+        Matrix& DeltaPosition
         ) const
     {
         if (rResult.size() != 3)
@@ -1444,13 +1450,13 @@ public:
 
         return rResult;
     }
-    
+
     /** Jacobian in given point. This method calculate jacobian
     matrix in given point.
 
     @param rCoordinates point which jacobians has to
     be calculated in it.
-    
+
     @param DeltaPosition Matrix with the nodes position increment which describes
     the configuration where the jacobian has to be calculated.
 
@@ -1459,7 +1465,7 @@ public:
     @see DeterminantOfJacobian
     @see InverseOfJacobian
     */
-    
+
     virtual Matrix& Jacobian( Matrix& rResult, const CoordinatesArrayType& rCoordinates, Matrix& DeltaPosition ) const
     {
         if(rResult.size1() != this->WorkingSpaceDimension() || rResult.size2() != this->LocalSpaceDimension())

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -265,7 +265,7 @@ public:
     {
         return typename BaseType::Pointer( new Line2D2( ThisPoints ) );
     }
-    
+
     // Geometry< Point<3> >::Pointer Clone() const override
     // {
     //     Geometry< Point<3> >::PointsArrayType NewPoints;
@@ -792,28 +792,25 @@ public:
     }
 
     /**
-     * It computes the unit normal of the geometry, if possible
-     * @return The normal of the geometry
+     * It computes the area normal of the geometry
+     * @param rPointLocalCoordinates Refernce to the local coordinates of the
+     * point in where the unit normal is to be computed
+     * @return The area normal in the given point
      */
     array_1d<double, 3> AreaNormal(const CoordinatesArrayType& rPointLocalCoordinates) const override
     {
         // We define the normal
         array_1d<double,3> normal;
-        
+
         // We get the local points
         const TPointType& first_point  = BaseType::GetPoint(0);
         const TPointType& second_point = BaseType::GetPoint(1);
-        
+
         // We compute the normal
         normal[0] = second_point[1] -  first_point[1];
         normal[1] =  first_point[0] - second_point[0];
         normal[2] = 0.0;
-        
-        // We normalize
-        const double norm_normal = std::sqrt(normal[0] * normal[0] + normal[1] * normal[1]);
-        if (norm_normal > std::numeric_limits<double>::epsilon()) normal /= norm_normal;
-	    else KRATOS_ERROR << "ERROR: The normal norm is zero or almost zero. Norm. normal: " << norm_normal << std::endl;
-        
+
         return normal;
     }
 
@@ -856,17 +853,17 @@ public:
     }
 
     /**
-     * Returns whether given arbitrary point is inside the Geometry and the respective 
+     * Returns whether given arbitrary point is inside the Geometry and the respective
      * local point for the given global point
      * @param rPoint: The point to be checked if is inside o note in global coordinates
      * @param rResult: The local coordinates of the point
      * @param Tolerance: The  tolerance that will be considered to check if the point is inside or not
      * @return True if the point is inside, false otherwise
      */
-    virtual bool IsInside( 
-        const CoordinatesArrayType& rPoint, 
-        CoordinatesArrayType& rResult, 
-        const double Tolerance = std::numeric_limits<double>::epsilon() 
+    virtual bool IsInside(
+        const CoordinatesArrayType& rPoint,
+        CoordinatesArrayType& rResult,
+        const double Tolerance = std::numeric_limits<double>::epsilon()
         ) override
     {
         PointLocalCoordinates( rResult, rPoint );
@@ -875,10 +872,10 @@ public:
         {
             return true;
         }
-        
+
         return false;
     }
-    
+
     /**
      * Returns the local coordinates of a given arbitrary point
      * @param rResult: The vector containing the local coordinates of the point
@@ -887,7 +884,7 @@ public:
      */
     virtual CoordinatesArrayType& PointLocalCoordinates(
             CoordinatesArrayType& rResult,
-            const CoordinatesArrayType& rPoint 
+            const CoordinatesArrayType& rPoint
             ) override
     {
         rResult.clear();
@@ -926,7 +923,7 @@ public:
 
         return( rResult );
     }
-    
+
     ///@}
     ///@name Friends
     ///@{

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -400,7 +400,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    double Area() const override 
+    double Area() const override
     {
         const double a = MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1));
         const double b = MathUtils<double>::Norm3(this->GetPoint(1)-this->GetPoint(2));
@@ -425,7 +425,7 @@ public:
      * :TODO: could be replaced by something more suitable
      * (comment by janosch)
      */
-    double DomainSize() const override 
+    double DomainSize() const override
     {
         return Area();
     }
@@ -440,7 +440,7 @@ public:
      * @see MaxEdgeLength()
      * @see AverageEdgeLength()
      */
-    double MinEdgeLength() const override 
+    double MinEdgeLength() const override
     {
         const array_1d<double, 3> a = this->GetPoint(0) - this->GetPoint(1);
         const array_1d<double, 3> b = this->GetPoint(1) - this->GetPoint(2);
@@ -461,7 +461,7 @@ public:
      * @see MinEdgeLength()
      * @see AverageEdgeLength()
      */
-    double MaxEdgeLength() const override 
+    double MaxEdgeLength() const override
     {
         const array_1d<double, 3> a = this->GetPoint(0) - this->GetPoint(1);
         const array_1d<double, 3> b = this->GetPoint(1) - this->GetPoint(2);
@@ -482,7 +482,7 @@ public:
      * @see MinEdgeLength()
      * @see MaxEdgeLength()
      */
-    double AverageEdgeLength() const override 
+    double AverageEdgeLength() const override
     {
         return CalculateAvgEdgeLength(
         MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1)),
@@ -498,7 +498,7 @@ public:
      *
      * @see Inradius()
      */
-    double Circumradius() const override 
+    double Circumradius() const override
     {
         return CalculateCircumradius(
         MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1)),
@@ -514,7 +514,7 @@ public:
      *
      * @see Circumradius()
      */
-    double Inradius() const override 
+    double Inradius() const override
     {
         return CalculateInradius(
         MathUtils<double>::Norm3(this->GetPoint(0)-this->GetPoint(1)),
@@ -524,10 +524,10 @@ public:
     }
 
 
-	bool AllSameSide(array_1d<double, 3> const& Distances) 
+	bool AllSameSide(array_1d<double, 3> const& Distances)
     {
         constexpr double epsilon = std::numeric_limits<double>::epsilon();
-        
+
         // put U0,U1,U2 into plane equation 1 to compute signed distances to the plane//
         double du0 = Distances[0];
         double du1 = Distances[1];
@@ -548,13 +548,13 @@ public:
 
 	}
 
-	int GetMajorAxis(array_1d<double, 3> const& V) 
+	int GetMajorAxis(array_1d<double, 3> const& V)
     {
         int index = static_cast<int>(std::abs(V[0]) < std::abs(V[1]));
         return (std::abs(V[index]) > std::abs(V[2])) ? index : 2;
 	}
 
-	bool HasIntersection(const GeometryType& ThisGeometry) override 
+	bool HasIntersection(const GeometryType& ThisGeometry) override
 	{
         // Based on code develop by Moller: http://fileadmin.cs.lth.se/cs/Personal/Tomas_Akenine-Moller/code/opttritri.txt
         // and the article "A Fast Triangle-Triangle Intersection Test", Journal of Graphics Tools, 2(2), 1997:
@@ -630,11 +630,11 @@ public:
 
     /**
      * Check if an axis-aliged bounding box (AABB) intersects a triangle
-     * 
+     *
      * Based on code develop by Moller: http://fileadmin.cs.lth.se/cs/personal/tomas_akenine-moller/code/tribox3.txt
      * and the article "A Fast Triangle-Triangle Intersection Test", SIGGRAPH '05 ACM, Art.8, 2005:
      * http://fileadmin.cs.lth.se/cs/personal/tomas_akenine-moller/code/tribox_tam.pdf
-     * 
+     *
      * @return bool if the triangle overlaps a box
      * @param rLowPoint first corner of the box
      * @param rHighPoint second corner of the box
@@ -667,7 +667,7 @@ public:
      *
      * @return The inradius to circumradius quality metric.
      */
-    double InradiusToCircumradiusQuality() const override 
+    double InradiusToCircumradiusQuality() const override
     {
         constexpr double normFactor = 1.0;
 
@@ -688,7 +688,7 @@ public:
      *
      * @return The inradius to longest edge quality metric.
      */
-    double InradiusToLongestEdgeQuality() const override 
+    double InradiusToLongestEdgeQuality() const override
     {
         constexpr double normFactor = 1.0; // TODO: This normalization coeficient is not correct.
 
@@ -714,7 +714,7 @@ public:
      *
      * @return The Inradius to Circumradius Quality metric.
      */
-    double AreaToEdgeLengthRatio() const override 
+    double AreaToEdgeLengthRatio() const override
     {
         constexpr double normFactor = 1.0;
 
@@ -789,7 +789,7 @@ public:
      *
      * @return The shortest altitude to edge length quality metric.
      */
-    virtual double ShortestAltitudeToLongestEdge() const 
+    virtual double ShortestAltitudeToLongestEdge() const
     {
         constexpr double normFactor = 1.0;
 
@@ -808,33 +808,33 @@ public:
     }
 
     /**
-     * It computes the unit normal of the geometry, if possible
-     * @return The normal of the geometry
+     * It computes the area normal of the geometry
+     * @param rPointLocalCoordinates Local coordinates of the point
+     * in where the area normal is to be computed
+     * @return The area normal in the given point
      */
     array_1d<double, 3> AreaNormal(const CoordinatesArrayType& rPointLocalCoordinates) const override
     {
         const array_1d<double, 3> tangent_xi  = this->GetPoint(1) - this->GetPoint(0);
         const array_1d<double, 3> tangent_eta = this->GetPoint(2) - this->GetPoint(0);
-        
+
         array_1d<double, 3> normal;
         MathUtils<double>::CrossProduct(normal, tangent_xi, tangent_eta);
-	const double norm_normal = norm_2(normal);
-	if (norm_normal > std::numeric_limits<double>::epsilon()) normal /= norm_normal;
-	else KRATOS_ERROR << "ERROR: The normal norm is zero or almost zero. Norm. normal: " << norm_normal << std::endl;
+
         return normal;
     }
 
     /**
-     * Returns whether given arbitrary point is inside the Geometry and the respective 
+     * Returns whether given arbitrary point is inside the Geometry and the respective
      * local point for the given global point
      * @param rPoint: The point to be checked if is inside o note in global coordinates
      * @param rResult: The local coordinates of the point
      * @param Tolerance: The  tolerance that will be considered to check if the point is inside or not
      * @return True if the point is inside, false otherwise
      */
-    bool IsInside( 
-        const CoordinatesArrayType& rPoint, 
-        CoordinatesArrayType& rResult, 
+    bool IsInside(
+        const CoordinatesArrayType& rPoint,
+        CoordinatesArrayType& rResult,
         const double Tolerance = std::numeric_limits<double>::epsilon()
         ) override
     {
@@ -853,16 +853,16 @@ public:
 
         return false;
     }
-    
+
     /**
      * Returns the local coordinates of a given arbitrary point
      * @param rResult: The vector containing the local coordinates of the point
      * @param rPoint: The point in global coordinates
      * @return The vector containing the local coordinates of the point
      */
-    CoordinatesArrayType& PointLocalCoordinates( 
+    CoordinatesArrayType& PointLocalCoordinates(
         CoordinatesArrayType& rResult,
-        const CoordinatesArrayType& rPoint 
+        const CoordinatesArrayType& rPoint
         ) override
     {
         boost::numeric::ublas::bounded_matrix<double,3,3> X;
@@ -2135,7 +2135,7 @@ private:
 //*************************************************************************************
 //*************************************************************************************
 
-    /** 
+    /**
      * @see HasIntersection
      * use separating axis theorem to test overlap between triangle and box
      * need to test for overlap in these directions:
@@ -2207,19 +2207,19 @@ private:
         MathUtils<double>::CrossProduct(normal, edge0, edge1);
         distance = -inner_prod(normal, vert0);
         if(!PlaneBoxOverlap(normal, distance, rBoxHalfSize)) return false;
-        
+
         return true;  // box and triangle overlaps
     }
 
     /**
      * Check if a plane intersects a box
      * @see TriBoxOverlap
-     * 
+     *
      * @return bool intersection flagg
      * @param rNormal the plane normal
      * @param rDist   distance to origin
      * @param rMaxBox box corner from the origin
-     * 
+     *
      * plane equation: rNormal*x+rDist=0
      */
     bool PlaneBoxOverlap(const array_1d<double,3>& rNormal, const double& rDist, const array_1d<double,3>& rMaxBox)
@@ -2240,13 +2240,13 @@ private:
         }
         if(inner_prod(rNormal, vmin) + rDist >  0.00) return false;
         if(inner_prod(rNormal, vmax) + rDist >= 0.00) return true;
-        
+
         return false;
     }
 
     /** AxisTestX
      * This method return true if there is a separating axis
-     * 
+     *
      * @param rEdgeY, rEdgeZ: i-edge corrdinates
      * @param rAbsEdgeY, rAbsEdgeZ: i-edge abs coordinates
      * @param rVertA: i   vertex
@@ -2273,7 +2273,7 @@ private:
 
     /** AxisTestY
      * This method return true if there is a separating axis
-     * 
+     *
      * @param rEdgeX, rEdgeZ: i-edge corrdinates
      * @param rAbsEdgeX, rAbsEdgeZ: i-edge fabs coordinates
      * @param rVertA: i   vertex
@@ -2300,7 +2300,7 @@ private:
 
     /** AxisTestZ
      * This method return true if there is a separating axis
-     * 
+     *
      * @param rEdgeX, rEdgeY: i-edge corrdinates
      * @param rAbsEdgeX, rAbsEdgeY: i-edge fabs coordinates
      * @param rVertA: i   vertex
@@ -2308,10 +2308,10 @@ private:
      * @param rVertC: i+2 vertex
      * @param rBoxHalfSize
      */
-    bool AxisTestZ(double& rEdgeX, double& rEdgeY, 
+    bool AxisTestZ(double& rEdgeX, double& rEdgeY,
                    double& rAbsEdgeX, double& rAbsEdgeY,
-                   array_1d<double,3>& rVertA, 
-                   array_1d<double,3>& rVertC, 
+                   array_1d<double,3>& rVertA,
+                   array_1d<double,3>& rVertC,
                    Point& rBoxHalfSize)
     {
         double proj_a, proj_c, rad;

--- a/kratos/tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_modified_shape_functions.cpp
+++ b/kratos/tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_modified_shape_functions.cpp
@@ -228,11 +228,11 @@ namespace Kratos
 			// Check Gauss pts. outwards unit normal values
 			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0),  0.0, tolerance);
 			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -1.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.25, tolerance);
 
 			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.0, tolerance);
 			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  1.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.25, tolerance);
 		}
 
 
@@ -510,19 +510,19 @@ namespace Kratos
             KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](3,2),  0.0, tolerance);
 
 			// Check Gauss pts. outwards unit normal values
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),       0.0, 1e-6);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[1](0), -0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[1](1),       0.0, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[1](2), -0.707107, 1e-6);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.25, 1e-6);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),  0.0, 1e-6);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.25, 1e-6);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[1](0), -0.25, 1e-6);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[1](1),  0.0, 1e-6);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[1](2), -0.25, 1e-6);
 
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),       0.0, 1e-6);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[1](0),  0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[1](1),       0.0, 1e-6);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[1](2),  0.707107, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.25, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.25, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[1](0), 0.25, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[1](1), 0.0, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[1](2), 0.25, 1e-6);
 		}
 
 

--- a/kratos/tests/modified_shape_functions/test_tetrahedra_3d_4_modified_shape_functions.cpp
+++ b/kratos/tests/modified_shape_functions/test_tetrahedra_3d_4_modified_shape_functions.cpp
@@ -222,12 +222,12 @@ namespace Kratos
             KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](3,2),  1.0, tolerance);
 
 			// Check Gauss pts. outwards unit normal values
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  1.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.25, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.25, tolerance);
 		}
 
 
@@ -505,19 +505,19 @@ namespace Kratos
             KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[1](3,2),  1.0, tolerance);
 
 			// Check Gauss pts. outwards unit normal values
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),       0.0, 1e-6);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[1](0), -0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[1](1),       0.0, 1e-6);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[1](2), -0.707107, 1e-6);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.25, 1e-6);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, 1e-6);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), -0.25, 1e-6);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[1](0), -0.25, 1e-6);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[1](1),  0.0, 1e-6);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[1](2), -0.25, 1e-6);
 
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),       0.0, 1e-6);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[1](0),  0.707107, 1e-6);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[1](1),       0.0, 1e-6);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[1](2),  0.707107, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.25, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.25, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[1](0), 0.25, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[1](1), 0.0, 1e-6);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[1](2), 0.25, 1e-6);
 		}
 
 

--- a/kratos/tests/modified_shape_functions/test_triangle_2d_3_ausas_modified_shape_functions.cpp
+++ b/kratos/tests/modified_shape_functions/test_triangle_2d_3_ausas_modified_shape_functions.cpp
@@ -170,13 +170,13 @@ namespace Kratos
 			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  0.0, tolerance);
 
 			// Check Gauss pts. outwards unit normal values
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -1.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -0.5, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
 
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
 		}
 
 
@@ -327,13 +327,13 @@ namespace Kratos
 			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  2.0, tolerance);
 
 			// Check Gauss pts. outwards unit normal values
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),  0.0, tolerance);
-            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, tolerance);
+            KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
 
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
 		}
 	}   // namespace Testing.
 }  // namespace Kratos.

--- a/kratos/tests/modified_shape_functions/test_triangle_2d_3_modified_shape_functions.cpp
+++ b/kratos/tests/modified_shape_functions/test_triangle_2d_3_modified_shape_functions.cpp
@@ -164,12 +164,12 @@ namespace Kratos
 			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
 
 			// Check Gauss pts. outwards unit normal values
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
 		}
 
 
@@ -314,12 +314,12 @@ namespace Kratos
 			KRATOS_CHECK_NEAR(negative_interface_side_sh_func_gradients[0](2,1),  1.0, tolerance);
 
 			// Check Gauss pts. outwards unit normal values
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -1.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0),  1.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1),  0.0, tolerance);
-			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](0), -0.5, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](1), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(positive_side_area_normals[0](2), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](0), 0.5, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](1), 0.0, tolerance);
+			KRATOS_CHECK_NEAR(negative_side_area_normals[0](2), 0.0, tolerance);
 		}
 
 


### PR DESCRIPTION
The method AreaNormal() of the 

- Line2D2N
- Triangle3D3N

used to return the unit normal value. This PR corrects that.