### PR TITLE
Hotfix GiDIO test

### DIFF
--- a/kratos/tests/test_gid_io.py
+++ b/kratos/tests/test_gid_io.py
@@ -68,8 +68,8 @@ class TestGidIO(KratosUnittest.TestCase):
             }
         """)
 
-        params["file_name_1"].SetString(output_file)
-        params["file_name_2"].SetString(reference_file)
+        params["file_name_1"].SetString(GetFilePath(output_file))
+        params["file_name_2"].SetString(GetFilePath(reference_file))
 
         cmp_process = compare_two_files_check_process.CompareTwoFilesCheckProcess(KratosMultiphysics.ModelPart(), params)
 


### PR DESCRIPTION
I forgot to use the path of the files to compare
Before it only worked if the test was run from the test folder, now it also works if all the test are run (=> nightly tests)