### PR TITLE
Using Coordinates() method instead of Coordinate(i)

### DIFF
--- a/applications/PoromechanicsApplication/custom_problemtype/Poromechanics_Application.gid/ProjectParametersAuxProcs.tcl
+++ b/applications/PoromechanicsApplication/custom_problemtype/Poromechanics_Application.gid/ProjectParametersAuxProcs.tcl
@@ -101,11 +101,11 @@ proc WritePressureConstraintProcess {FileVar GroupNum Groups EntityType VarName 
             }
             puts $MyFileVar "            \"hydrostatic\":          $PutStrings,"
             if {[lindex [lindex $Groups $i] 5] eq "Y"} {
-                set PutStrings 2
-            } elseif {[lindex [lindex $Groups $i] 5] eq "Z"} {
-                set PutStrings 3
-            } else {
                 set PutStrings 1
+            } elseif {[lindex [lindex $Groups $i] 5] eq "Z"} {
+                set PutStrings 2
+            } else {
+                set PutStrings 0
             }
             puts $MyFileVar "            \"gravity_direction\":    $PutStrings,"
             puts $MyFileVar "            \"reference_coordinate\": [lindex [lindex $Groups $i] 6],"
@@ -180,11 +180,11 @@ proc WriteNormalLoadProcess {FileVar GroupNum Groups VarName TableDict NumGroups
         }
         puts $MyFileVar "            \"hydrostatic\":          $PutStrings,"
         if {[lindex [lindex $Groups $i] 6] eq "Y"} {
-            set PutStrings 2
-        } elseif {[lindex [lindex $Groups $i] 6] eq "Z"} {
-            set PutStrings 3
-        } else {
             set PutStrings 1
+        } elseif {[lindex [lindex $Groups $i] 6] eq "Z"} {
+            set PutStrings 2
+        } else {
+            set PutStrings 0
         }
         puts $MyFileVar "            \"gravity_direction\":    $PutStrings,"
         puts $MyFileVar "            \"reference_coordinate\": [lindex [lindex $Groups $i] 7],"

--- a/applications/PoromechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.hpp
+++ b/applications/PoromechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.hpp
@@ -105,7 +105,7 @@ public:
                 
                 noalias(Coordinates) = it->Coordinates();
 
-                double pressure = mspecific_weight*( mreference_coordinate - Coordinates[mgravity_direction] );
+                const double pressure = mspecific_weight*( mreference_coordinate - Coordinates[mgravity_direction] );
                 
                 if(pressure > 0.0) 
                 {

--- a/applications/PoromechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.hpp
+++ b/applications/PoromechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.hpp
@@ -40,7 +40,7 @@ public:
                 "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed": false,
-                "gravity_direction" : 3,
+                "gravity_direction" : 2,
                 "reference_coordinate" : 0.0,
                 "specific_weight" : 10000.0,
                 "table" : 1
@@ -86,12 +86,14 @@ public:
         Variable<double> var = KratosComponents< Variable<double> >::Get(mvariable_name);
         
         const int nnodes = mr_model_part.GetMesh(mmesh_id).Nodes().size();
-
+        
         if(nnodes != 0)
         {
             ModelPart::NodesContainerType::iterator it_begin = mr_model_part.GetMesh(mmesh_id).NodesBegin();
+            
+            array_1d<double,3> Coordinates;
 
-            #pragma omp parallel for
+            #pragma omp parallel for private(Coordinates)
             for(int i = 0; i<nnodes; i++)
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
@@ -101,7 +103,9 @@ public:
                     it->Fix(var);
                 }
                 
-                double pressure = mspecific_weight*( mreference_coordinate - (it->Coordinate(mgravity_direction)) );
+                noalias(Coordinates) = it->Coordinates();
+
+                double pressure = mspecific_weight*( mreference_coordinate - Coordinates[mgravity_direction] );
                 
                 if(pressure > 0.0) 
                 {

--- a/applications/PoromechanicsApplication/custom_processes/apply_hydrostatic_pressure_table_process.hpp
+++ b/applications/PoromechanicsApplication/custom_processes/apply_hydrostatic_pressure_table_process.hpp
@@ -70,12 +70,16 @@ public:
         {
             ModelPart::NodesContainerType::iterator it_begin = mr_model_part.GetMesh(mmesh_id).NodesBegin();
 
-            #pragma omp parallel for
+            array_1d<double,3> Coordinates;
+
+            #pragma omp parallel for private(Coordinates)
             for(int i = 0; i<nnodes; i++)
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
                 
-                double pressure = mspecific_weight*( reference_coordinate - (it->Coordinate(mgravity_direction)) );
+                noalias(Coordinates) = it->Coordinates();
+
+                double pressure = mspecific_weight*( reference_coordinate - Coordinates[mgravity_direction] );
                 
                 if(pressure > 0.0) 
                 {

--- a/applications/PoromechanicsApplication/custom_processes/apply_hydrostatic_pressure_table_process.hpp
+++ b/applications/PoromechanicsApplication/custom_processes/apply_hydrostatic_pressure_table_process.hpp
@@ -79,7 +79,7 @@ public:
                 
                 noalias(Coordinates) = it->Coordinates();
 
-                double pressure = mspecific_weight*( reference_coordinate - Coordinates[mgravity_direction] );
+                const double pressure = mspecific_weight*( reference_coordinate - Coordinates[mgravity_direction] );
                 
                 if(pressure > 0.0) 
                 {


### PR DESCRIPTION
I just substituted the Coordinate(i) call for the Coordinates() one and every component is accessed through [ ] operator. (related to Issue #1152)