### PR TITLE
Updated version shown in terminal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ project (KratosMultiphysics)
 
 # Set here the version number **** only update upon tagging a release!
 set (KratosMultiphysics_MAJOR_VERSION 5)
-set (KratosMultiphysics_MINOR_VERSION 1)
+set (KratosMultiphysics_MINOR_VERSION 2)
 set (KratosMultiphysics_PATCH_VERSION 0)
 
 # Define custom compiler build types


### PR DESCRIPTION
This fixes a problem reported by Kike (which does not have a github account shame on him) by showing 5.2.0 instead of 5.2.1-ecba6c265 which was the previous beta tag.

Quoting:

> Aparece el string “5.2.1-ecba6c265” y es lo que se muestra en la ventana de cálculo
Puede resultar confuso para el usuario que supone que tiene el problemtype Kratos 5.2.0
> 
> Entiendo que tenéis otro identificador para el ejecutable de cálculo, pero como usuario vería mas normal que en la ventana de cálculo se vea “5.2.0” (y en todo caso adicionalmente si queréis también el del ejecutable)