### PR TITLE
Using clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 dist: trusty
 language: cpp
-compiler: g++
+compiler: clang
 
 git:
   depth: 3
@@ -15,7 +15,7 @@ env:
     - CCACHE_COMPRESS=true
     - CCACHE_NODISABLE=true
     - CCACHE_MAXSIZE=500M
-    - FC=gfortran-6
+    - FC=gfortran
 
 addons:
   apt:
@@ -23,9 +23,7 @@ addons:
       - sourceline: 'ppa:ubuntu-toolchain-r/test'
       - sourceline: 'ppa:boost-latest/ppa'
     packages:
-      - gcc-6
-      - g++-6
-      - gfortran-6
+      - gfortran
       - libboost1.55-dev
       - libboost-serialization1.55-dev
       - libboost-python1.55-dev

--- a/scripts/build/travis/configure_travis_trusty.sh
+++ b/scripts/build/travis/configure_travis_trusty.sh
@@ -45,8 +45,8 @@ CMAKE_BIN=cmake
 #        C_COMPILER=gcc
 #        CXX_COMPILER=g++
 # --------------------------------------------------------------------------------------------------------------
-C_COMPILER=gcc-6
-CXX_COMPILER=g++-6
+C_COMPILER=clang
+CXX_COMPILER=clang++
 
 # Build type
 #    Indicate the build type. Possible values are "Release", "RelWithDebInfo" or "Debug"
@@ -82,8 +82,8 @@ CXX_WARN_FLAGS="-Wall"
 #        C_CUSTOM_FLAGS="-fmessage-length=20"
 #        CXX_CUSTOM_FLAGS="-fmessage-length=20"
 # --------------------------------------------------------------------------------------------------------------
-C_CUSTOM_FLAGS=""
-CXX_CUSTOM_FLAGS=""
+C_CUSTOM_FLAGS="-flto"
+CXX_CUSTOM_FLAGS="-flto"
 
 CMAKE_LIBS=(
   # Boost


### PR DESCRIPTION
Do not merge.

In my quest to reduce build times I shall try the new clang 5.0 that came with the newest trusty image.