### PR TITLE
Reseting flag in gid_io.h

### DIFF
--- a/kratos/includes/gid_io.h
+++ b/kratos/includes/gid_io.h
@@ -576,7 +576,10 @@ public:
     void  CloseResultFile()
     {
         if ( mResultFileOpen )
+        {
             GiD_fClosePostResultFile( mResultFile );
+            mResultFileOpen = false;
+        }
     }
 
     /**


### PR DESCRIPTION
I discovered that CloseResultFile() does not reset the flag of open file in gid_io.h