### PR TITLE
Fix GiDIO test

### DIFF
--- a/kratos/tests/test_gid_io.py
+++ b/kratos/tests/test_gid_io.py
@@ -7,7 +7,7 @@ import os
 
 def GetFilePath(fileName):
 
-    return os.path.dirname(os.path.realpath(__file__)) + "/" + fileName
+    return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
 class TestGidIO(KratosUnittest.TestCase):
 
@@ -68,7 +68,7 @@ class TestGidIO(KratosUnittest.TestCase):
             }
         """)
 
-        params["file_name_1"].SetString(GetFilePath(output_file))
+        params["file_name_1"].SetString(output_file)
         params["file_name_2"].SetString(GetFilePath(reference_file))
 
         cmp_process = compare_two_files_check_process.CompareTwoFilesCheckProcess(KratosMultiphysics.ModelPart(), params)


### PR DESCRIPTION
Hi @roigcarlo ,
I had another look at why the test failed and it was not bcs the *.msh files were not copied to the test machine (in fact the *.msh files are created during the test)
I think what I did now fixes it, at least on my machine it works form both directories now (before it wasn't!)
Therefore I am closing your PR, hope thats ok