### PR TITLE
Feature kirchhoff saint venant constitutive model

### DIFF
--- a/applications/StructuralMechanicsApplication/CMakeLists.txt
+++ b/applications/StructuralMechanicsApplication/CMakeLists.txt
@@ -33,6 +33,9 @@ set( KRATOS_STRUCTURAL_MECHANICS_APPLICATION_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/linear_plane_strain.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/elastic_isotropic_3d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/axisym_elastic_isotropic.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/hyper_elastic_isotropic_neo_hookean_plane_strain_2d.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/linear_elastic_orthotropic_2D_law.cpp

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.cpp
@@ -1,0 +1,421 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Malik Ali Dawi
+//                   Ruben Zorrilla
+//
+
+// System includes
+#include <iostream>
+
+// External includes
+
+// Project includes
+#include "includes/properties.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h"
+
+#include "structural_mechanics_application_variables.h"
+
+namespace Kratos
+{
+//******************************CONSTRUCTOR*******************************************
+//************************************************************************************
+HyperElasticIsotropicKirchhoff3D::HyperElasticIsotropicKirchhoff3D()
+    : ConstitutiveLaw() {
+}
+
+//******************************COPY CONSTRUCTOR**************************************
+//************************************************************************************
+
+HyperElasticIsotropicKirchhoff3D::HyperElasticIsotropicKirchhoff3D(const HyperElasticIsotropicKirchhoff3D& rOther)
+    : ConstitutiveLaw(rOther) {
+}
+
+//********************************CLONE***********************************************
+//************************************************************************************
+
+ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoff3D::Clone() const {
+    HyperElasticIsotropicKirchhoff3D::Pointer p_clone(new HyperElasticIsotropicKirchhoff3D(*this));
+    return p_clone;
+}
+
+//*******************************DESTRUCTOR*******************************************
+//************************************************************************************
+
+HyperElasticIsotropicKirchhoff3D::~HyperElasticIsotropicKirchhoff3D() {
+};
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponsePK1 (Parameters& rValues) {
+
+    CalculateMaterialResponsePK2(rValues);
+
+    Vector& stress_vector                = rValues.GetStressVector();
+    const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
+    const double& determinant_f          = rValues.GetDeterminantF();
+
+    TransformStresses(stress_vector, deformation_gradient_f, determinant_f, StressMeasure_PK2, StressMeasure_PK1);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void  HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) {
+
+    // Get Values to compute the constitutive law:
+    Flags &Options=rValues.GetOptions();
+
+    const Properties& material_properties = rValues.GetMaterialProperties();
+    Vector& strain_vector                 = rValues.GetStrainVector();
+    Vector& stress_vector                 = rValues.GetStressVector();
+
+    // The material properties
+    const double& young_modulus = material_properties[YOUNG_MODULUS];
+    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+
+    if(Options.Is( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
+        CalculateGreenLagrangianStrain(rValues, strain_vector);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
+        Matrix& ConstitutiveMatrix = rValues.GetConstitutiveMatrix();
+        CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
+         if (rValues.IsSetDeformationGradientF() == true) {
+            CalculateGreenLagrangianStrain(rValues, strain_vector);
+        }
+
+        if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
+            Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
+            noalias(stress_vector) = prod(constitutive_matrix, strain_vector);
+        } else {
+            CalculatePK2Stress( strain_vector, stress_vector, young_modulus, poisson_coefficient );
+        }
+    }
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponseKirchhoff (Parameters& rValues) {
+
+    // Get Values to compute the constitutive law:
+    Flags &Options=rValues.GetOptions();
+
+    const Properties& material_properties = rValues.GetMaterialProperties();
+    Vector& strain_vector                 = rValues.GetStrainVector();
+    Vector& stress_vector                 = rValues.GetStressVector();
+
+    // The material properties
+    const double& young_modulus = material_properties[YOUNG_MODULUS];
+    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+
+     // The deformation gradient
+    const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
+
+    if(Options.Is( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
+        CalculateAlmansiStrain(rValues, strain_vector);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
+        Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
+        CalculateConstitutiveMatrixKirchhoff(constitutive_matrix, deformation_gradient_f ,young_modulus, poisson_coefficient);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
+        if (rValues.IsSetDeformationGradientF() == true) {
+               CalculateGreenLagrangianStrain(rValues, strain_vector);
+        }
+
+        CalculateKirchhoffStress(strain_vector, stress_vector, deformation_gradient_f ,young_modulus, poisson_coefficient);
+    }
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponseCauchy (Parameters& rValues) {
+
+    CalculateMaterialResponseKirchhoff(rValues);
+
+    Vector& stress_vector       = rValues.GetStressVector();
+    Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
+    const double& determinant_f = rValues.GetDeterminantF();
+
+    // Set to Cauchy Stress:
+    stress_vector       /= determinant_f;
+    constitutive_matrix /= determinant_f;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponsePK1(Parameters& rValues) {
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponsePK1(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponsePK2(Parameters& rValues) {
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponsePK2(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponseCauchy(Parameters& rValues) {
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponseCauchy(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponseKirchhoff(Parameters& rValues) {
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponseKirchhoff(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+
+double& HyperElasticIsotropicKirchhoff3D::CalculateValue(
+    Parameters& rParameterValues,
+    const Variable<double>& rThisVariable,
+    double& rValue) {
+    
+    const Properties& material_properties  = rParameterValues.GetMaterialProperties();
+    Vector& strain_vector                  = rParameterValues.GetStrainVector();
+
+    // The material properties
+    const double& young_modulus = material_properties[YOUNG_MODULUS];
+    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+
+
+    // The LAME parameters
+    const double lame_lambda = (young_modulus * poisson_coefficient)/((1.0 + poisson_coefficient)*(1.0 - 2.0 * poisson_coefficient));
+    const double lame_mu = young_modulus/(2.0 * (1.0 + poisson_coefficient));
+
+    // We compute the right Cauchy-Green tensor (C):
+
+    if (rThisVariable == STRAIN_ENERGY) {
+
+        CalculateGreenLagrangianStrain(rParameterValues,strain_vector);
+        Matrix E_tensor=MathUtils<double>::StrainVectorToTensor(strain_vector);
+        Matrix E_tensor_sq=prod(E_tensor,E_tensor);
+        double E_trace = 0.0;
+        double E_trace_sq = 0.0;
+        for (unsigned int i = 0; i < E_tensor.size1();i++) {
+            E_trace     += E_tensor (i,i);
+            E_trace_sq  += E_tensor_sq(i,i);
+        }
+
+        rValue = 0.5 * lame_lambda * E_trace * E_trace  + 0.5 *lame_mu *E_trace_sq ;
+    }
+
+    return( rValue );
+}
+
+//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::GetLawFeatures(Features& rFeatures) {
+    //Set the type of law
+    rFeatures.mOptions.Set( THREE_DIMENSIONAL_LAW );
+    rFeatures.mOptions.Set( FINITE_STRAINS );
+    rFeatures.mOptions.Set( ISOTROPIC );
+
+    //Set strain measure required by the consitutive law
+    rFeatures.mStrainMeasures.push_back(StrainMeasure_GreenLagrange);
+    rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
+
+    //Set the strain size
+    rFeatures.mStrainSize = GetStrainSize();
+
+    //Set the spacedimension
+    rFeatures.mSpaceDimension = WorkingSpaceDimension();
+}
+
+//************************************************************************************
+//************************************************************************************
+
+int HyperElasticIsotropicKirchhoff3D::Check(
+    const Properties& rmaterial_properties,
+    const GeometryType& rElementGeometry,
+    const ProcessInfo& rCurrentProcessInfo) {
+
+    if(YOUNG_MODULUS.Key() == 0 || rmaterial_properties[YOUNG_MODULUS] <= 0.0) {
+        KRATOS_ERROR << "YOUNG_MODULUS has Key zero or invalid value " << std::endl;
+    }
+
+    const double& nu = rmaterial_properties[POISSON_RATIO];
+    const bool check = bool( (nu > 0.499 && nu < 0.501 ) || (nu < -0.999 && nu > -1.01 ) );
+
+    if(POISSON_RATIO.Key() == 0 || check==true) {
+        KRATOS_ERROR << "POISSON_RATIO has Key zero invalid value " << std::endl;
+    }
+
+    if(DENSITY.Key() == 0 || rmaterial_properties[DENSITY] < 0.0) {
+        KRATOS_ERROR << "DENSITY has Key zero or invalid value " << std::endl;
+    }
+
+    return 0;
+}
+
+//************************************************************************************
+//************************************************************************************
+//CalculateConstitutiveMatrixPK2( constitutive_matrix, inverse_C_tensor, determinant_f, lame_lambda, lame_mu );
+
+//CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
+void HyperElasticIsotropicKirchhoff3D::CalculateConstitutiveMatrixPK2(
+    Matrix& ConstitutiveMatrix,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+    
+    ConstitutiveMatrix.clear();
+    ConstitutiveMatrix = ZeroMatrix(6,6);
+    const double c1 = YoungModulus / (( 1.00 + PoissonCoefficient ) * ( 1 - 2 * PoissonCoefficient ) );
+    const double c2 = c1 * ( 1 - PoissonCoefficient );
+    const double c3 = c1 * PoissonCoefficient;
+    const double c4 = c1 * 0.5 * ( 1 - 2 * PoissonCoefficient );
+
+    ConstitutiveMatrix( 0, 0 ) = c2;
+    ConstitutiveMatrix( 0, 1 ) = c3;
+    ConstitutiveMatrix( 0, 2 ) = c3;
+    ConstitutiveMatrix( 1, 0 ) = c3;
+    ConstitutiveMatrix( 1, 1 ) = c2;
+    ConstitutiveMatrix( 1, 2 ) = c3;
+    ConstitutiveMatrix( 2, 0 ) = c3;
+    ConstitutiveMatrix( 2, 1 ) = c3;
+    ConstitutiveMatrix( 2, 2 ) = c2;
+    ConstitutiveMatrix( 3, 3 ) = c4;
+    ConstitutiveMatrix( 4, 4 ) = c4;
+    ConstitutiveMatrix( 5, 5 ) = c4;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::CalculateConstitutiveMatrixKirchhoff(
+    Matrix& ConstitutiveMatrix,
+    const Matrix& DeformationGradientF,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+
+    ConstitutiveMatrix.clear();
+
+    CalculateConstitutiveMatrixPK2(ConstitutiveMatrix, YoungModulus, PoissonCoefficient);
+    PushForwardConstitutiveMatrix (ConstitutiveMatrix,DeformationGradientF );
+
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::CalculatePK2Stress(
+    const Vector& rStrainVector,
+    Vector& rStressVector,
+    const double& YoungModulus,
+    const double& PoissonCoefficient ) {
+
+    const double lame_lambda = (YoungModulus * PoissonCoefficient)/((1.0 + PoissonCoefficient)*(1.0 - 2.0 * PoissonCoefficient));
+    const double lame_mu = YoungModulus/(2.0 * (1.0 + PoissonCoefficient));
+    Matrix E_tensor=MathUtils<double>::StrainVectorToTensor(rStrainVector);
+    double E_trace = 0.0;
+    for (unsigned int i = 0; i < E_tensor.size1();i++) {
+      E_trace += E_tensor (i,i);
+    }
+    const SizeType dimension = WorkingSpaceDimension();
+    Matrix stress_matrix = lame_lambda*E_trace*IdentityMatrix(dimension, dimension) + 2.0 * lame_mu * E_tensor;
+    rStressVector = MathUtils<double>::StressTensorToVector( stress_matrix, rStressVector.size() );
+
+    // Other possibility
+    //SizeType SizeSystem = GetStrainSize();
+    //Matrix ConstMatrixPK2(SizeSystem,SizeSystem);
+    //CalculateConstitutiveMatrixPK2(ConstMatrixPK2, YoungModulus, PoissonCoefficient);
+    //rStressVector = prod(ConstMatrixPK2,rStrainVector);
+
+}
+
+
+//************************************************************************************
+//************************************************************************************
+void HyperElasticIsotropicKirchhoff3D::CalculateKirchhoffStress(
+    const Vector& rStrainVector,
+    Vector& rStressVector,
+    const Matrix& DeformationGradientF,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+
+    CalculatePK2Stress( rStrainVector, rStressVector, YoungModulus, PoissonCoefficient );
+    Matrix StressMatrix = MathUtils<double>::StressVectorToTensor( rStressVector );
+    ContraVariantPushForward (StressMatrix,DeformationGradientF); //Kirchhoff
+    rStressVector = MathUtils<double>::StressTensorToVector( StressMatrix, rStressVector.size() );
+
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::CalculateGreenLagrangianStrain(
+    Parameters& rValues,
+    Vector& rStrainVector) {
+
+    //1.-Compute total deformation gradient
+    const Matrix& F = rValues.GetDeformationGradientF();
+
+    // E = 0.5*(inv(C) - I)
+    Matrix C_tensor = prod(trans(F),F);
+
+    rStrainVector[0] = 0.5 * ( C_tensor( 0, 0 ) - 1.00 );
+    rStrainVector[1] = 0.5 * ( C_tensor( 1, 1 ) - 1.00 );
+    rStrainVector[2] = 0.5 * ( C_tensor( 2, 2 ) - 1.00 );
+    rStrainVector[3] = C_tensor( 0, 1 ); // xy
+    rStrainVector[4] = C_tensor( 1, 2 ); // yz
+    rStrainVector[5] = C_tensor( 0, 2 ); // xz
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoff3D::CalculateAlmansiStrain(
+    Parameters& rValues,
+    Vector& rStrainVector ) {
+
+    //1.-Compute total deformation gradient
+    const Matrix& F = rValues.GetDeformationGradientF();
+
+    // e = 0.5*(1-inv(B))
+    Matrix B_tensor = prod(F,trans(F));
+
+    // Calculating the inverse of the jacobian
+    Matrix inverse_B_tensor ( 3, 3 );
+    double aux_det_b = 0;
+    MathUtils<double>::InvertMatrix( B_tensor, inverse_B_tensor, aux_det_b);
+
+    rStrainVector[0] = 0.5 * ( 1.00 - inverse_B_tensor( 0, 0 ) );
+    rStrainVector[1] = 0.5 * ( 1.00 - inverse_B_tensor( 1, 1 ) );
+    rStrainVector[2] = 0.5 * ( 1.00 - inverse_B_tensor( 2, 2 ) );
+    rStrainVector[3] = - inverse_B_tensor( 0, 1 ); // xy
+    rStrainVector[4] = - inverse_B_tensor( 1, 2 ); // yz
+    rStrainVector[5] = - inverse_B_tensor( 0, 2 ); // xz
+}
+
+} // Namespace Kratos

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h
@@ -1,0 +1,329 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Malik Ali Dawi
+//                   Ruben Zorrilla
+//
+
+#if !defined (KRATOS_HYPER_ELASTIC_ISOTROPIC_KIRCHHOFF_SAINT_VENANT_3D_LAW_H_INCLUDED)
+#define  KRATOS_HYPER_ELASTIC_ISOTROPIC_KIRCHHOFF_SAINT_VENANT_3D_LAW_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/constitutive_law.h"
+
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) HyperElasticIsotropicKirchhoff3D : public ConstitutiveLaw
+{
+public:
+
+    ///@name Type Definitions
+    ///@{
+
+    typedef ProcessInfo      ProcessInfoType;
+    typedef ConstitutiveLaw         BaseType;
+    typedef std::size_t             SizeType;
+
+    /**
+     * Counted pointer of HyperElasticIsotropicKirchhoff3D
+     */
+    KRATOS_CLASS_POINTER_DEFINITION( HyperElasticIsotropicKirchhoff3D );
+
+    ///@name Lyfe Cycle
+    ///@{
+
+    /**
+     * Default constructor.
+     */
+    HyperElasticIsotropicKirchhoff3D();
+
+    ConstitutiveLaw::Pointer Clone() const override;
+
+    /**
+     * Copy constructor.
+     */
+    HyperElasticIsotropicKirchhoff3D (const HyperElasticIsotropicKirchhoff3D& rOther);
+
+    /**
+     * Destructor.
+     */
+    ~HyperElasticIsotropicKirchhoff3D() override;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * This function is designed to be called once to check compatibility with element
+     * @param rFeatures: The Features of the law
+     */
+    void GetLawFeatures(Features& rFeatures) override;
+
+    /**
+     * Dimension of the law:
+     */
+    SizeType WorkingSpaceDimension() override {
+        return 3;
+    };
+
+    /**
+     * Voigt tensor size:
+     */
+    SizeType GetStrainSize() override {
+        return 6;
+    };
+
+    /**
+     * Computes the material response:
+     * PK1 stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponsePK1 (Parameters & rValues) override;
+
+    /**
+     * Computes the material response:
+     * PK2 stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponsePK2 (Parameters & rValues) override;
+
+    /**
+     * Computes the material response:
+     * Kirchhoff stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponseKirchhoff (Parameters & rValues) override;
+
+    /**
+     * Computes the material response:
+     * Cauchy stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponseCauchy (Parameters & rValues) override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponsePK1 (Parameters & rValues) override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponsePK2 (Parameters & rValues) override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponseKirchhoff (Parameters & rValues)  override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponseCauchy (Parameters & rValues) override;
+
+    /**
+     * calculates the value of a specified variable
+     * @param rParameterValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @param rValue output: the value of the specified variable
+     */
+    double& CalculateValue(
+        Parameters& rParameterValues, 
+        const Variable<double>& rThisVariable, 
+        double& rValue) override;
+
+    /**
+     * This function provides the place to perform checks on the completeness of the input.
+     * It is designed to be called only once (or anyway, not often) typically at the beginning
+     * of the calculations, so to verify that nothing is missing from the input
+     * or that no common error is found.
+     * @param rMaterialProperties: The properties of the material
+     * @param rElementGeometry: The geometry of the element
+     * @param rCurrentProcessInfo: The current process info instance
+     */
+    int Check(
+        const Properties& rMaterialProperties,
+        const GeometryType& rElementGeometry,
+        const ProcessInfo& rCurrentProcessInfo) override;
+
+protected:
+
+    ///@name Protected static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    ///@}
+
+private:
+
+    ///@name Static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+    /**
+     * It calculates the constitutive matrix C (PK2)
+     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param InverseCTensor: The inverse right Cauchy-Green tensor
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Second Lame parameter
+     */
+    virtual void CalculateConstitutiveMatrixPK2(
+        Matrix& ConstitutiveMatrix,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the constitutive matrix C (Kirchoff)
+     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Second Lame parameter
+     */
+    virtual void CalculateConstitutiveMatrixKirchhoff(
+        Matrix& ConstitutiveMatrix,
+        const Matrix& DeformationGradientF,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the PK2 stress vector
+     * @param InvCTensor: The inverse of the right Cauchy-Green tensor
+     * @param rStressVector: The stress vector in Voigt notation
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Second Lame parameter
+     */
+    virtual void CalculatePK2Stress(
+        const Vector& rStrainVector,
+        Vector& rStressVector,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the Kirchoff stress vector
+     * @param BTensor: The left Cauchy-Green tensor
+     * @param rStressVector: The stress vector in Voigt notation
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    virtual void CalculateKirchhoffStress(
+        const Vector& rStrainVector,
+        Vector& rStressVector,
+        const Matrix& DeformationGradientF,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the strain vector
+     * @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    virtual void CalculateGreenLagrangianStrain(
+        Parameters& rValues,
+        Vector& rStrainVector);
+
+    /**
+     * Calculates the Almansi strains
+     * @param @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    virtual void CalculateAlmansiStrain(
+        Parameters& rValues,
+        Vector& rStrainVector);
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+    ///@}
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+    ///@}
+
+    ///@}
+    ///@name Serialization
+    ///@{
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override
+    {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw )
+    }
+
+    void load(Serializer& rSerializer) override
+    {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw)
+    }
+
+}; // Class HyperElasticIsotropicKirchhoff3D
+}  // namespace Kratos.
+#endif // KRATOS_HYPER_ELASTIC_ISOTROPIC_KIRCHHOFF_SAINT_VENANT_3D_LAW_H_INCLUDED  defined

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
@@ -1,0 +1,396 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Malik Ali Dawi
+//                   Ruben Zorrilla
+//
+
+// System includes
+#include <iostream>
+
+// External includes
+
+// Project includes
+#include "includes/properties.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h"
+
+#include "structural_mechanics_application_variables.h"
+
+namespace Kratos
+{
+//******************************CONSTRUCTOR*******************************************
+//************************************************************************************
+HyperElasticIsotropicKirchhoffPlaneStrain2D::HyperElasticIsotropicKirchhoffPlaneStrain2D()
+    : ConstitutiveLaw() {
+}
+
+//******************************COPY CONSTRUCTOR**************************************
+//************************************************************************************
+
+HyperElasticIsotropicKirchhoffPlaneStrain2D::HyperElasticIsotropicKirchhoffPlaneStrain2D(const HyperElasticIsotropicKirchhoffPlaneStrain2D& rOther)
+    : ConstitutiveLaw(rOther) {
+}
+
+//********************************CLONE***********************************************
+//************************************************************************************
+
+ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoffPlaneStrain2D::Clone() const {
+    HyperElasticIsotropicKirchhoffPlaneStrain2D::Pointer p_clone(new HyperElasticIsotropicKirchhoffPlaneStrain2D(*this));
+    return p_clone;
+}
+
+//*******************************DESTRUCTOR*******************************************
+//************************************************************************************
+
+HyperElasticIsotropicKirchhoffPlaneStrain2D::~HyperElasticIsotropicKirchhoffPlaneStrain2D() {
+};
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateMaterialResponsePK1 (Parameters& rValues) {
+
+    CalculateMaterialResponsePK2(rValues);
+
+    Vector& stress_vector                = rValues.GetStressVector();
+    const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
+    const double& determinant_f          = rValues.GetDeterminantF();
+
+    TransformStresses(stress_vector, deformation_gradient_f, determinant_f, StressMeasure_PK2, StressMeasure_PK1);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void  HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) {
+
+    // Get Values to compute the constitutive law:
+    Flags &Options=rValues.GetOptions();
+
+    const Properties& material_properties  = rValues.GetMaterialProperties();
+    Vector& strain_vector                  = rValues.GetStrainVector();
+    Vector& stress_vector                  = rValues.GetStressVector();
+
+    // The material properties
+    const double& young_modulus = material_properties[YOUNG_MODULUS];
+    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+
+
+    if(Options.Is( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
+        CalculateGreenLagrangianStrain(rValues, strain_vector);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
+        Matrix& ConstitutiveMatrix = rValues.GetConstitutiveMatrix();
+        CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
+        if (rValues.IsSetDeformationGradientF() == true) {
+            CalculateGreenLagrangianStrain(rValues, strain_vector);
+        }
+
+        if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
+            Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
+            noalias(stress_vector) = prod(constitutive_matrix, strain_vector);
+        } else {
+            CalculatePK2Stress( strain_vector, stress_vector, young_modulus, poisson_coefficient );
+        }
+    }
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateMaterialResponseKirchhoff (Parameters& rValues) {
+    
+    // Get Values to compute the constitutive law:
+    Flags &Options=rValues.GetOptions();
+
+    const Properties& material_properties  = rValues.GetMaterialProperties();
+    Vector& strain_vector                  = rValues.GetStrainVector();
+    Vector& stress_vector                  = rValues.GetStressVector();
+
+    // The material properties
+    const double& young_modulus = material_properties[YOUNG_MODULUS];
+    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+
+
+    // The deformation gradient
+    const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
+
+    if(Options.Is( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
+        CalculateAlmansiStrain(rValues, strain_vector);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
+        Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
+        CalculateConstitutiveMatrixKirchhoff(constitutive_matrix, deformation_gradient_f ,young_modulus, poisson_coefficient);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
+        if (rValues.IsSetDeformationGradientF() == true) {
+               CalculateGreenLagrangianStrain(rValues, strain_vector);
+        }
+        CalculateKirchhoffStress(strain_vector, stress_vector, deformation_gradient_f ,young_modulus, poisson_coefficient);
+    }
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateMaterialResponseCauchy (Parameters& rValues) {
+
+    CalculateMaterialResponseKirchhoff(rValues);
+
+    Vector& stress_vector       = rValues.GetStressVector();
+    Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
+    const double& determinant_f = rValues.GetDeterminantF();
+
+    // Set to Cauchy Stress:
+    stress_vector       /= determinant_f;
+    constitutive_matrix /= determinant_f;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::FinalizeMaterialResponsePK1(Parameters& rValues)
+{
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponsePK1(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::FinalizeMaterialResponsePK2(Parameters& rValues)
+{
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponsePK2(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::FinalizeMaterialResponseCauchy(Parameters& rValues)
+{
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponseCauchy(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::FinalizeMaterialResponseKirchhoff(Parameters& rValues)
+{
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponseKirchhoff(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+
+double& HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateValue(
+    Parameters& rParameterValues,
+    const Variable<double>& rThisVariable,
+    double& rValue) {
+
+    const Properties& material_properties  = rParameterValues.GetMaterialProperties();
+    Vector& strain_vector                  = rParameterValues.GetStrainVector();
+
+    // The material properties
+    const double& young_modulus = material_properties[YOUNG_MODULUS];
+    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+
+    // The LAME parameters
+    const double lame_lambda = (young_modulus * poisson_coefficient)/((1.0 + poisson_coefficient)*(1.0 - 2.0 * poisson_coefficient));
+    const double lame_mu = young_modulus/(2.0 * (1.0 + poisson_coefficient));
+
+    // We compute the right Cauchy-Green tensor (C):
+    if (rThisVariable == STRAIN_ENERGY) {
+        CalculateGreenLagrangianStrain(rParameterValues,strain_vector);
+        Matrix E_tensor=MathUtils<double>::StrainVectorToTensor(strain_vector);
+        Matrix E_tensor_sq=prod(E_tensor,E_tensor);
+        double E_trace = 0.0;
+        double E_trace_sq = 0.0;
+        for (unsigned int i = 0; i < E_tensor.size1();i++) {
+            E_trace     += E_tensor (i,i);
+            E_trace_sq  += E_tensor_sq(i,i);
+        }
+
+        rValue = 0.5 * lame_lambda * E_trace * E_trace  + 0.5 *lame_mu *E_trace_sq ;
+    }
+
+    return( rValue );
+}
+
+//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::GetLawFeatures(Features& rFeatures) {
+
+    //Set the type of law
+    rFeatures.mOptions.Set( THREE_DIMENSIONAL_LAW );
+    rFeatures.mOptions.Set( FINITE_STRAINS );
+    rFeatures.mOptions.Set( ISOTROPIC );
+
+    //Set strain measure required by the consitutive law
+    rFeatures.mStrainMeasures.push_back(StrainMeasure_GreenLagrange);
+    rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
+
+    //Set the strain size
+    rFeatures.mStrainSize = GetStrainSize();
+
+    //Set the spacedimension
+    rFeatures.mSpaceDimension = WorkingSpaceDimension();
+}
+
+//************************************************************************************
+//************************************************************************************
+
+int HyperElasticIsotropicKirchhoffPlaneStrain2D::Check(
+    const Properties& rmaterial_properties,
+    const GeometryType& rElementGeometry,
+    const ProcessInfo& rCurrentProcessInfo) {
+
+    if(YOUNG_MODULUS.Key() == 0 || rmaterial_properties[YOUNG_MODULUS] <= 0.0) {
+        KRATOS_ERROR << "YOUNG_MODULUS has Key zero or invalid value " << std::endl;
+    }
+
+    const double& nu = rmaterial_properties[POISSON_RATIO];
+    const bool check = bool( (nu >0.499 && nu<0.501 ) || (nu < -0.999 && nu > -1.01 ) );
+
+    if(POISSON_RATIO.Key() == 0 || check==true) {
+        KRATOS_ERROR << "POISSON_RATIO has Key zero invalid value " << std::endl;
+    }
+
+    if(DENSITY.Key() == 0 || rmaterial_properties[DENSITY] < 0.0) {
+        KRATOS_ERROR << "DENSITY has Key zero or invalid value " << std::endl;
+    }
+
+    return 0;
+}
+
+//************************************************************************************
+//************************************************************************************
+//CalculateConstitutiveMatrixPK2( constitutive_matrix, inverse_C_tensor, determinant_f, lame_lambda, lame_mu );
+
+//CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateConstitutiveMatrixPK2(
+    Matrix& ConstitutiveMatrix,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+
+    ConstitutiveMatrix.clear();
+    ConstitutiveMatrix = ZeroMatrix(3,3);
+    const double c0 = YoungModulus / ((1.00 + PoissonCoefficient)*(1-2*PoissonCoefficient));
+    const double c1 = (1.00 - PoissonCoefficient)*c0;
+    const double c2 = c0 * PoissonCoefficient;
+    const double c3 = (0.5 - PoissonCoefficient)*c0;
+
+    ConstitutiveMatrix(0,0) = c1;
+    ConstitutiveMatrix(0,1) = c2;
+    ConstitutiveMatrix(1,0) = c2;
+    ConstitutiveMatrix(1,1) = c1;
+    ConstitutiveMatrix(2,2) = c3;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateConstitutiveMatrixKirchhoff(
+    Matrix& ConstitutiveMatrix,
+    const Matrix& DeformationGradientF,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+
+    ConstitutiveMatrix.clear();
+
+    CalculateConstitutiveMatrixPK2(ConstitutiveMatrix, YoungModulus, PoissonCoefficient);
+    PushForwardConstitutiveMatrix (ConstitutiveMatrix, DeformationGradientF );
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculatePK2Stress(
+    const Vector& rStrainVector,
+    Vector& rStressVector,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+
+    SizeType SizeSystem = GetStrainSize();
+    Matrix ConstMatrixPK2(SizeSystem,SizeSystem);
+    CalculateConstitutiveMatrixPK2(ConstMatrixPK2, YoungModulus, PoissonCoefficient);
+    rStressVector = prod(ConstMatrixPK2,rStrainVector);
+}
+
+
+//************************************************************************************
+//************************************************************************************
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateKirchhoffStress(
+    const Vector& rStrainVector,
+    Vector& rStressVector,
+    const Matrix& DeformationGradientF,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+
+    CalculatePK2Stress( rStrainVector, rStressVector, YoungModulus, PoissonCoefficient );
+    Matrix StressMatrix = MathUtils<double>::StressVectorToTensor( rStressVector );
+    ContraVariantPushForward (StressMatrix,DeformationGradientF); //Kirchhoff
+    rStressVector = MathUtils<double>::StressTensorToVector( StressMatrix, rStressVector.size() );
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateGreenLagrangianStrain(
+    Parameters& rValues,
+    Vector& rStrainVector) {
+
+    //1.-Compute total deformation gradient
+    const Matrix& F = rValues.GetDeformationGradientF();
+
+    // E = 0.5*(inv(C) - I)
+    Matrix C_tensor = prod(trans(F),F);
+
+    rStrainVector[0] = 0.5 * ( C_tensor( 0, 0 ) - 1.00 );
+    rStrainVector[1] = 0.5 * ( C_tensor( 1, 1 ) - 1.00 );
+    rStrainVector[2] = C_tensor( 0, 1 ); // xy
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateAlmansiStrain(
+    Parameters& rValues,
+    Vector& rStrainVector) {
+        
+    //1.-Compute total deformation gradient
+    const Matrix& F = rValues.GetDeformationGradientF();
+
+    // e = 0.5*(1-inv(B))
+    Matrix B_tensor = prod(F,trans(F));
+
+    //Calculating the inverse of the jacobian
+    Matrix inverse_B_tensor ( 2, 2 );
+    double aux_det_b = 0;
+    MathUtils<double>::InvertMatrix( B_tensor, inverse_B_tensor, aux_det_b);
+
+    rStrainVector[0] = 0.5 * ( 1.00 - inverse_B_tensor( 0, 0 ) );
+    rStrainVector[1] = 0.5 * ( 1.00 - inverse_B_tensor( 1, 1 ) );
+    rStrainVector[2] = - inverse_B_tensor( 0, 1 ); // xy ??? yz
+}
+
+} // Namespace Kratos

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h
@@ -1,0 +1,325 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Malik Ali Dawi
+//                   Ruben Zorrilla
+//
+
+#if !defined (KRATOS_HYPER_ELASTIC_ISOTROPIC_KIRCHHOFF_PLANE_STRAIN_2D_LAW_H_INCLUDED)
+#define  KRATOS_HYPER_ELASTIC_ISOTROPIC_KIRCHHOFF_PLANE_STRAIN_2D_LAW_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/constitutive_law.h"
+
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) HyperElasticIsotropicKirchhoffPlaneStrain2D : public ConstitutiveLaw
+{
+public:
+
+    ///@name Type Definitions
+    ///@{
+
+    typedef ProcessInfo      ProcessInfoType;
+    typedef ConstitutiveLaw         BaseType;
+    typedef std::size_t             SizeType;
+    
+    /**
+     * Counted pointer of HyperElasticIsotropicKirchhoffPlaneStrain2D
+     */
+    KRATOS_CLASS_POINTER_DEFINITION( HyperElasticIsotropicKirchhoffPlaneStrain2D );
+
+    ///@name Lyfe Cycle
+    ///@{
+
+    /**
+     * Default constructor.
+     */
+    HyperElasticIsotropicKirchhoffPlaneStrain2D();
+
+    ConstitutiveLaw::Pointer Clone() const override;
+
+    /**
+     * Copy constructor.
+     */
+    HyperElasticIsotropicKirchhoffPlaneStrain2D (const HyperElasticIsotropicKirchhoffPlaneStrain2D& rOther);
+
+    /**
+     * Destructor.
+     */
+    ~HyperElasticIsotropicKirchhoffPlaneStrain2D() override;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * This function is designed to be called once to check compatibility with element
+     * @param rFeatures: The Features of the law
+     */
+    void GetLawFeatures(Features& rFeatures) override;
+
+    /**
+     * Dimension of the law:
+     */
+    SizeType WorkingSpaceDimension() override {
+        return 2;
+    };
+
+    /**
+     * Voigt tensor size:
+     */
+    SizeType GetStrainSize() override {
+        return 3;
+    };
+
+    /**
+     * Computes the material response:
+     * PK1 stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponsePK1 (Parameters & rValues) override;
+
+    /**
+     * Computes the material response:
+     * PK2 stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponsePK2 (Parameters & rValues) override;
+
+    /**
+     * Computes the material response:
+     * Kirchhoff stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponseKirchhoff (Parameters & rValues) override;
+
+    /**
+     * Computes the material response:
+     * Cauchy stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponseCauchy (Parameters & rValues) override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponsePK1 (Parameters & rValues) override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponsePK2 (Parameters & rValues) override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponseKirchhoff (Parameters & rValues)  override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponseCauchy (Parameters & rValues) override;
+
+    /**
+     * calculates the value of a specified variable
+     * @param rParameterValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @param rValue output: the value of the specified variable
+     */
+    double& CalculateValue(Parameters& rParameterValues, const Variable<double>& rThisVariable, double& rValue) override;
+
+    /**
+     * This function provides the place to perform checks on the completeness of the input.
+     * It is designed to be called only once (or anyway, not often) typically at the beginning
+     * of the calculations, so to verify that nothing is missing from the input
+     * or that no common error is found.
+     * @param rMaterialProperties: The properties of the material
+     * @param rElementGeometry: The geometry of the element
+     * @param rCurrentProcessInfo: The current process info instance
+     */
+    int Check(
+        const Properties& rMaterialProperties,
+        const GeometryType& rElementGeometry,
+        const ProcessInfo& rCurrentProcessInfo) override;
+
+protected:
+
+    ///@name Protected static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    ///@}
+
+private:
+
+    ///@name Static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+    /**
+     * It calculates the constitutive matrix C (PK2)
+     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param InverseCTensor: The inverse right Cauchy-Green tensor
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    virtual void CalculateConstitutiveMatrixPK2(
+        Matrix& ConstitutiveMatrix,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the constitutive matrix C (Kirchoff)
+     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    virtual void CalculateConstitutiveMatrixKirchhoff(
+        Matrix& ConstitutiveMatrix,
+        const Matrix& DeformationGradientF,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the PK2 stress vector
+     * @param InvCTensor: The inverse of the right Cauchy-Green tensor
+     * @param rStressVector: The stress vector in Voigt notation
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    virtual void CalculatePK2Stress(
+        const Vector& rStrainVector,
+        Vector& rStressVector,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the Kirchoff stress vector
+     * @param BTensor: The left Cauchy-Green tensor
+     * @param rStressVector: The stress vector in Voigt notation
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    virtual void CalculateKirchhoffStress(
+        const Vector& rStrainVector,
+        Vector& rStressVector,
+        const Matrix& DeformationGradientF,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the strain vector
+     * @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    virtual void CalculateGreenLagrangianStrain(
+        Parameters& rValues,
+        Vector& rStrainVector);
+
+    /**
+     * Calculates the Almansi strains
+     * @param @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    virtual void CalculateAlmansiStrain(
+        Parameters& rValues,
+        Vector& rStrainVector);
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+    ///@}
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+    ///@}
+
+    ///@}
+    ///@name Serialization
+    ///@{
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw )
+    }
+
+    void load(Serializer& rSerializer) override {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw)
+    }
+
+
+}; // Class HyperElasticIsotropicKirchhoffPlaneStrain2D
+}  // namespace Kratos.
+#endif // KRATOS_HYPER_ELASTIC_ISOTROPIC_KIRCHHOFF_PLANE_STRAIN_2D_LAW_H_INCLUDED  defined

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
@@ -1,0 +1,391 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Malik Ali Dawi
+//                   Ruben Zorrilla
+//
+
+// System includes
+#include <iostream>
+
+// External includes
+
+// Project includes
+#include "includes/properties.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h"
+
+#include "structural_mechanics_application_variables.h"
+
+namespace Kratos
+{
+//******************************CONSTRUCTOR*******************************************
+//************************************************************************************
+HyperElasticIsotropicKirchhoffPlaneStress2D::HyperElasticIsotropicKirchhoffPlaneStress2D()
+    : ConstitutiveLaw() {
+}
+
+//******************************COPY CONSTRUCTOR**************************************
+//************************************************************************************
+
+HyperElasticIsotropicKirchhoffPlaneStress2D::HyperElasticIsotropicKirchhoffPlaneStress2D(const HyperElasticIsotropicKirchhoffPlaneStress2D& rOther)
+    : ConstitutiveLaw(rOther) {
+}
+
+//********************************CLONE***********************************************
+//************************************************************************************
+
+ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoffPlaneStress2D::Clone() const {
+    HyperElasticIsotropicKirchhoffPlaneStress2D::Pointer p_clone(new HyperElasticIsotropicKirchhoffPlaneStress2D(*this));
+    return p_clone;
+}
+
+//*******************************DESTRUCTOR*******************************************
+//************************************************************************************
+
+HyperElasticIsotropicKirchhoffPlaneStress2D::~HyperElasticIsotropicKirchhoffPlaneStress2D() {
+};
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateMaterialResponsePK1 (Parameters& rValues) {
+
+    CalculateMaterialResponsePK2(rValues);
+
+    Vector& stress_vector                = rValues.GetStressVector();
+    const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
+    const double& determinant_f          = rValues.GetDeterminantF();
+
+    TransformStresses(stress_vector, deformation_gradient_f, determinant_f, StressMeasure_PK2, StressMeasure_PK1);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void  HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) {
+
+    // Get Values to compute the constitutive law:
+    Flags &Options=rValues.GetOptions();
+
+    const Properties& material_properties  = rValues.GetMaterialProperties();
+    Vector& strain_vector                  = rValues.GetStrainVector();
+    Vector& stress_vector                  = rValues.GetStressVector();
+
+    // The material properties
+    const double& young_modulus = material_properties[YOUNG_MODULUS];
+    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+
+    if(Options.Is( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
+        CalculateGreenLagrangianStrain(rValues, strain_vector);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
+        Matrix& ConstitutiveMatrix = rValues.GetConstitutiveMatrix();
+        CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
+        if (rValues.IsSetDeformationGradientF() == true) {
+            CalculateGreenLagrangianStrain(rValues, strain_vector);
+        }
+
+        if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) )  {
+            Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
+            noalias(stress_vector) = prod(constitutive_matrix, strain_vector);
+        } else {
+            CalculatePK2Stress( strain_vector, stress_vector, young_modulus, poisson_coefficient );
+        }
+    }
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateMaterialResponseKirchhoff (Parameters& rValues) {
+
+    // Get Values to compute the constitutive law:
+    Flags &Options=rValues.GetOptions();
+
+    const Properties& material_properties  = rValues.GetMaterialProperties();
+    Vector& strain_vector                  = rValues.GetStrainVector();
+    Vector& stress_vector                  = rValues.GetStressVector();
+
+    // The material properties
+    const double& young_modulus = material_properties[YOUNG_MODULUS];
+    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+
+    // The deformation gradient
+    const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
+
+    if(Options.Is( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
+        CalculateAlmansiStrain(rValues, strain_vector);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
+        Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
+        CalculateConstitutiveMatrixKirchhoff(constitutive_matrix, deformation_gradient_f ,young_modulus, poisson_coefficient);
+    }
+
+    if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
+        if (rValues.IsSetDeformationGradientF() == true) {
+               CalculateGreenLagrangianStrain(rValues, strain_vector);
+        }
+        CalculateKirchhoffStress(strain_vector, stress_vector, deformation_gradient_f ,young_modulus, poisson_coefficient);
+    }
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateMaterialResponseCauchy (Parameters& rValues) {
+
+    CalculateMaterialResponseKirchhoff(rValues);
+
+    Vector& stress_vector       = rValues.GetStressVector();
+    Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
+    const double& determinant_f = rValues.GetDeterminantF();
+
+    // Set to Cauchy Stress:
+    stress_vector       /= determinant_f;
+    constitutive_matrix /= determinant_f;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::FinalizeMaterialResponsePK1(Parameters& rValues) {
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponsePK1(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::FinalizeMaterialResponsePK2(Parameters& rValues) {
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponsePK2(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::FinalizeMaterialResponseCauchy(Parameters& rValues) {
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponseCauchy(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::FinalizeMaterialResponseKirchhoff(Parameters& rValues) {
+//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+//     this->CalculateMaterialResponseKirchhoff(rValues);
+//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+
+double& HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateValue(
+    Parameters& rParameterValues,
+    const Variable<double>& rThisVariable,
+    double& rValue) {
+
+    const Properties& material_properties  = rParameterValues.GetMaterialProperties();
+    Vector& strain_vector                  = rParameterValues.GetStrainVector();
+
+    // The material properties
+    const double& young_modulus = material_properties[YOUNG_MODULUS];
+    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+
+    // The LAME parameters
+    const double lame_lambda = (young_modulus * poisson_coefficient)/((1.0 + poisson_coefficient)*(1.0 - 2.0 * poisson_coefficient));
+    const double lame_mu = young_modulus/(2.0 * (1.0 + poisson_coefficient));
+
+    // We compute the right Cauchy-Green tensor (C):
+    if (rThisVariable == STRAIN_ENERGY) {
+        CalculateGreenLagrangianStrain(rParameterValues,strain_vector);
+        Matrix E_tensor=MathUtils<double>::StrainVectorToTensor(strain_vector);
+        Matrix E_tensor_sq=prod(E_tensor,E_tensor);
+        double E_trace = 0.0;
+        double E_trace_sq = 0.0;
+        for (unsigned int i = 0; i < E_tensor.size1();i++) {
+            E_trace     += E_tensor (i,i);
+            E_trace_sq  += E_tensor_sq(i,i);
+        }
+
+        rValue = 0.5 * lame_lambda * E_trace * E_trace  + 0.5 *lame_mu *E_trace_sq ;
+    }
+
+    return( rValue );
+}
+
+//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::GetLawFeatures(Features& rFeatures) {
+
+    //Set the type of law
+    rFeatures.mOptions.Set( THREE_DIMENSIONAL_LAW );
+    rFeatures.mOptions.Set( FINITE_STRAINS );
+    rFeatures.mOptions.Set( ISOTROPIC );
+
+    //Set strain measure required by the consitutive law
+    rFeatures.mStrainMeasures.push_back(StrainMeasure_GreenLagrange);
+    rFeatures.mStrainMeasures.push_back(StrainMeasure_Deformation_Gradient);
+
+    //Set the strain size
+    rFeatures.mStrainSize = GetStrainSize();
+
+    //Set the spacedimension
+    rFeatures.mSpaceDimension = WorkingSpaceDimension();
+}
+
+//************************************************************************************
+//************************************************************************************
+
+int HyperElasticIsotropicKirchhoffPlaneStress2D::Check(
+    const Properties& rmaterial_properties,
+    const GeometryType& rElementGeometry,
+    const ProcessInfo& rCurrentProcessInfo) {
+
+    if(YOUNG_MODULUS.Key() == 0 || rmaterial_properties[YOUNG_MODULUS] <= 0.0) {
+        KRATOS_ERROR << "YOUNG_MODULUS has Key zero or invalid value " << std::endl;
+    }
+
+    const double& nu = rmaterial_properties[POISSON_RATIO];
+    const bool check = bool( (nu >0.499 && nu<0.501 ) || (nu < -0.999 && nu > -1.01 ) );
+
+    if(POISSON_RATIO.Key() == 0 || check==true) {
+        KRATOS_ERROR << "POISSON_RATIO has Key zero invalid value " << std::endl;
+    }
+
+    if(DENSITY.Key() == 0 || rmaterial_properties[DENSITY] < 0.0) {
+        KRATOS_ERROR << "DENSITY has Key zero or invalid value " << std::endl;
+    }
+
+    return 0;
+}
+
+//************************************************************************************
+//************************************************************************************
+//CalculateConstitutiveMatrixPK2( constitutive_matrix, inverse_C_tensor, determinant_f, lame_lambda, lame_mu );
+
+//CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
+void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateConstitutiveMatrixPK2(
+    Matrix& ConstitutiveMatrix,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+
+    ConstitutiveMatrix.clear();
+    ConstitutiveMatrix = ZeroMatrix(3,3);
+
+    double c1 = YoungModulus / (1.00 - PoissonCoefficient*PoissonCoefficient);
+    double c2 = c1 * PoissonCoefficient;
+    double c3 = 0.5*YoungModulus / (1 + PoissonCoefficient);
+
+    ConstitutiveMatrix(0,0) = c1;
+    ConstitutiveMatrix(0,1) = c2;
+    ConstitutiveMatrix(1,0) = c2;
+    ConstitutiveMatrix(1,1) = c1;
+    ConstitutiveMatrix(2,2) = c3;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateConstitutiveMatrixKirchhoff(
+    Matrix& ConstitutiveMatrix,
+    const Matrix& DeformationGradientF,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+        
+    ConstitutiveMatrix.clear();
+
+    CalculateConstitutiveMatrixPK2(ConstitutiveMatrix, YoungModulus, PoissonCoefficient);
+    PushForwardConstitutiveMatrix (ConstitutiveMatrix,DeformationGradientF );
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculatePK2Stress(
+    const Vector& rStrainVector,
+    Vector& rStressVector,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+
+    SizeType SizeSystem = GetStrainSize();
+    Matrix ConstMatrixPK2(SizeSystem,SizeSystem);
+    CalculateConstitutiveMatrixPK2(ConstMatrixPK2, YoungModulus, PoissonCoefficient);
+    rStressVector = prod(ConstMatrixPK2,rStrainVector);
+
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateKirchhoffStress(
+    const Vector& rStrainVector,
+    Vector& rStressVector,
+    const Matrix& DeformationGradientF,
+    const double& YoungModulus,
+    const double& PoissonCoefficient) {
+
+    CalculatePK2Stress( rStrainVector, rStressVector, YoungModulus, PoissonCoefficient );
+    Matrix StressMatrix = MathUtils<double>::StressVectorToTensor( rStressVector );
+    ContraVariantPushForward (StressMatrix,DeformationGradientF); //Kirchhoff
+    rStressVector = MathUtils<double>::StressTensorToVector( StressMatrix, rStressVector.size() );
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateGreenLagrangianStrain(
+    Parameters& rValues,
+    Vector& rStrainVector) {
+
+    //1.-Compute total deformation gradient
+    const Matrix& F = rValues.GetDeformationGradientF();
+
+    // E = 0.5*(inv(C) - I)
+    Matrix C_tensor = prod(trans(F),F);
+
+    rStrainVector[0] = 0.5 * ( C_tensor( 0, 0 ) - 1.00 );
+    rStrainVector[1] = 0.5 * ( C_tensor( 1, 1 ) - 1.00 );
+    rStrainVector[2] = C_tensor( 0, 1 ); // xy
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateAlmansiStrain(
+    Parameters& rValues,
+    Vector& rStrainVector) {
+        
+    //1.-Compute total deformation gradient
+    const Matrix& F = rValues.GetDeformationGradientF();
+
+    // e = 0.5*(1-inv(B))
+    Matrix B_tensor = prod(F,trans(F));
+
+    //Calculating the inverse of the jacobian
+    Matrix inverse_B_tensor ( 2, 2 );
+    double aux_det_b = 0;
+    MathUtils<double>::InvertMatrix( B_tensor, inverse_B_tensor, aux_det_b);
+
+    rStrainVector[0] = 0.5 * ( 1.00 - inverse_B_tensor( 0, 0 ) );
+    rStrainVector[1] = 0.5 * ( 1.00 - inverse_B_tensor( 1, 1 ) );
+    rStrainVector[2] = - inverse_B_tensor( 0, 1 ); // xy ??? yz
+}
+
+} // Namespace Kratos

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h
@@ -1,0 +1,325 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:         BSD License
+//                   license: structural_mechanics_application/license.txt
+//
+//  Main authors:    Malik Ali Dawi
+//                   Ruben Zorrilla
+//
+
+#if !defined (KRATOS_HYPER_ELASTIC_ISOTROPIC_KIRCHHOFF_PLANE_STRESS_2D_LAW_H_INCLUDED)
+#define  KRATOS_HYPER_ELASTIC_ISOTROPIC_KIRCHHOFF_PLANE_STRESS_2D_LAW_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/constitutive_law.h"
+
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) HyperElasticIsotropicKirchhoffPlaneStress2D : public ConstitutiveLaw
+{
+public:
+
+    ///@name Type Definitions
+    ///@{
+
+    typedef ProcessInfo      ProcessInfoType;
+    typedef ConstitutiveLaw         BaseType;
+    typedef std::size_t             SizeType;
+
+    /**
+     * Counted pointer of HyperElasticIsotropicKirchhoffPlaneStress2D
+     */
+    KRATOS_CLASS_POINTER_DEFINITION( HyperElasticIsotropicKirchhoffPlaneStress2D );
+
+    ///@name Lyfe Cycle
+    ///@{
+
+    /**
+     * Default constructor.
+     */
+    HyperElasticIsotropicKirchhoffPlaneStress2D();
+
+    ConstitutiveLaw::Pointer Clone() const override;
+
+    /**
+     * Copy constructor.
+     */
+    HyperElasticIsotropicKirchhoffPlaneStress2D (const HyperElasticIsotropicKirchhoffPlaneStress2D& rOther);
+
+    /**
+     * Destructor.
+     */
+    ~HyperElasticIsotropicKirchhoffPlaneStress2D() override;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * This function is designed to be called once to check compatibility with element
+     * @param rFeatures: The Features of the law
+     */
+    void GetLawFeatures(Features& rFeatures) override;
+
+    /**
+     * Dimension of the law:
+     */
+    SizeType WorkingSpaceDimension() override {
+        return 2;
+    };
+
+    /**
+     * Voigt tensor size:
+     */
+    SizeType GetStrainSize() override {
+        return 3;
+    };
+
+    /**
+     * Computes the material response:
+     * PK1 stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponsePK1 (Parameters & rValues) override;
+
+    /**
+     * Computes the material response:
+     * PK2 stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponsePK2 (Parameters & rValues) override;
+
+    /**
+     * Computes the material response:
+     * Kirchhoff stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponseKirchhoff (Parameters & rValues) override;
+
+    /**
+     * Computes the material response:
+     * Cauchy stresses and algorithmic ConstitutiveMatrix
+     * @param rValues: The Internalvalues of the law
+     * @see   Parameters
+     */
+    void CalculateMaterialResponseCauchy (Parameters & rValues) override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponsePK1 (Parameters & rValues) override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponsePK2 (Parameters & rValues) override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponseKirchhoff (Parameters & rValues)  override;
+
+    /**
+      * Updates the material response:
+      * Cauchy stresses and Internal Variables
+      * @param rValues: The Internalvalues of the law
+      * @see   Parameters
+      */
+    void FinalizeMaterialResponseCauchy (Parameters & rValues) override;
+
+    /**
+     * calculates the value of a specified variable
+     * @param rParameterValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @param rValue output: the value of the specified variable
+     */
+    double& CalculateValue(Parameters& rParameterValues, const Variable<double>& rThisVariable, double& rValue) override;
+
+    /**
+     * This function provides the place to perform checks on the completeness of the input.
+     * It is designed to be called only once (or anyway, not often) typically at the beginning
+     * of the calculations, so to verify that nothing is missing from the input
+     * or that no common error is found.
+     * @param rMaterialProperties: The properties of the material
+     * @param rElementGeometry: The geometry of the element
+     * @param rCurrentProcessInfo: The current process info instance
+     */
+    int Check(
+        const Properties& rMaterialProperties,
+        const GeometryType& rElementGeometry,
+        const ProcessInfo& rCurrentProcessInfo) override;
+
+protected:
+
+    ///@name Protected static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    ///@}
+
+private:
+
+    ///@name Static Member Variables
+    ///@{
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+    /**
+     * It calculates the constitutive matrix C (PK2)
+     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param InverseCTensor: The inverse right Cauchy-Green tensor
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    virtual void CalculateConstitutiveMatrixPK2(
+        Matrix& ConstitutiveMatrix,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the constitutive matrix C (Kirchoff)
+     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    virtual void CalculateConstitutiveMatrixKirchhoff(
+        Matrix& ConstitutiveMatrix,
+        const Matrix& DeformationGradientF,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the PK2 stress vector
+     * @param InvCTensor: The inverse of the right Cauchy-Green tensor
+     * @param rStressVector: The stress vector in Voigt notation
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    virtual void CalculatePK2Stress(
+        const Vector& rStrainVector,
+        Vector& rStressVector,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the Kirchoff stress vector
+     * @param BTensor: The left Cauchy-Green tensor
+     * @param rStressVector: The stress vector in Voigt notation
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    virtual void CalculateKirchhoffStress(
+        const Vector& rStrainVector,
+        Vector& rStressVector,
+        const Matrix& DeformationGradientF,
+        const double& YoungModulus,
+        const double& PoissonCoefficient);
+
+    /**
+     * It calculates the strain vector
+     * @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    virtual void CalculateGreenLagrangianStrain(
+        Parameters& rValues,
+        Vector& rStrainVector);
+
+    /**
+     * Calculates the Almansi strains
+     * @param @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    virtual void CalculateAlmansiStrain(
+        Parameters& rValues,
+        Vector& rStrainVector);
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+    ///@}
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+    ///@}
+
+    ///@}
+    ///@name Serialization
+    ///@{
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw )
+    }
+
+    void load(Serializer& rSerializer) override {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw)
+    }
+
+
+}; // Class HyperElasticIsotropicKirchhoffPlaneStress2D
+}  // namespace Kratos.
+#endif // KRATOS_HYPER_ELASTIC_ISOTROPIC_KIRCHHOFF_PLANE_STRESS_2D_LAW_H_INCLUDED  defined

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.cpp
@@ -155,12 +155,12 @@ void HyperElasticIsotropicNeoHookean3D::CalculateMaterialResponseKirchhoff (Para
     if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) )
     {
         Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
-        CalculateConstitutiveMatrixKirchoff( constitutive_matrix, determinant_f, lame_lambda, lame_mu );
+        CalculateConstitutiveMatrixKirchhoff( constitutive_matrix, determinant_f, lame_lambda, lame_mu );
     }
 
     if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) )
     {
-        CalculateKirchoffStress( B_tensor, stress_vector, determinant_f, lame_lambda, lame_mu );
+        CalculateKirchhoffStress( B_tensor, stress_vector, determinant_f, lame_lambda, lame_mu );
     }
 }
 
@@ -350,7 +350,7 @@ void HyperElasticIsotropicNeoHookean3D::CalculateConstitutiveMatrixPK2(
 //************************************************************************************
 //************************************************************************************
 
-void HyperElasticIsotropicNeoHookean3D::CalculateConstitutiveMatrixKirchoff(
+void HyperElasticIsotropicNeoHookean3D::CalculateConstitutiveMatrixKirchhoff(
     Matrix& ConstitutiveMatrix,
     const double& DeterminantF,
     const double& LameLambda,
@@ -399,7 +399,7 @@ void HyperElasticIsotropicNeoHookean3D::CalculatePK2Stress(
 //************************************************************************************
 //************************************************************************************
 
-void HyperElasticIsotropicNeoHookean3D::CalculateKirchoffStress(
+void HyperElasticIsotropicNeoHookean3D::CalculateKirchhoffStress(
     const Matrix& BTensor,
     Vector& rStressVector,
     const double& DeterminantF,

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.h
@@ -231,7 +231,7 @@ private:
      * @param InverseCTensor: The inverse right Cauchy-Green tensor
      * @param DeterminantF: The determinant of the deformation gradient
      * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
+     * @param LameMu: Second Lame parameter
      */
     virtual void CalculateConstitutiveMatrixPK2(
         Matrix& ConstitutiveMatrix,
@@ -246,9 +246,9 @@ private:
      * @param ConstitutiveMatrix: The constitutive matrix
      * @param DeterminantF: The determinant of the deformation gradient
      * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
+     * @param LameMu: Second Lame parameter
      */
-    virtual void CalculateConstitutiveMatrixKirchoff(
+    virtual void CalculateConstitutiveMatrixKirchhoff(
         Matrix& ConstitutiveMatrix,
         const double& DeterminantF,
         const double& LameLambda,
@@ -261,7 +261,7 @@ private:
      * @param rStressVector: The stress vector in Voigt notation
      * @param DeterminantF: The determinant of the deformation gradient
      * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
+     * @param LameMu: Second Lame parameter
      */
     virtual void CalculatePK2Stress(
         const Matrix& InvCTensor,
@@ -277,9 +277,9 @@ private:
      * @param rStressVector: The stress vector in Voigt notation
      * @param DeterminantF: The determinant of the deformation gradient
      * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
+     * @param LameMu: Second Lame parameter
      */
-    virtual void CalculateKirchoffStress(
+    virtual void CalculateKirchhoffStress(
         const Matrix& BTensor,
         Vector& rStressVector,
         const double& DeterminantF,

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_plane_strain_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_plane_strain_2d.cpp
@@ -107,7 +107,7 @@ void HyperElasticIsotropicNeoHookeanPlaneStrain2D::CalculateConstitutiveMatrixPK
 //************************************************************************************
 //************************************************************************************
 
-void HyperElasticIsotropicNeoHookeanPlaneStrain2D::CalculateConstitutiveMatrixKirchoff(
+void HyperElasticIsotropicNeoHookeanPlaneStrain2D::CalculateConstitutiveMatrixKirchhoff(
     Matrix& ConstitutiveMatrix,
     const double& DeterminantF,
     const double& LameLambda,

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_neo_hookean_plane_strain_2d.h
@@ -144,7 +144,7 @@ private:
      * @param InverseCTensor: The inverse right Cauchy-Green tensor
      * @param DeterminantF: The determinant of the deformation gradient
      * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
+     * @param LameMu: Second Lame parameter
      */
     void CalculateConstitutiveMatrixPK2(
         Matrix& ConstitutiveMatrix,
@@ -159,9 +159,9 @@ private:
      * @param ConstitutiveMatrix: The constitutive matrix
      * @param DeterminantF: The determinant of the deformation gradient
      * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
+     * @param LameMu: Second Lame parameter
      */
-    void CalculateConstitutiveMatrixKirchoff(
+    void CalculateConstitutiveMatrixKirchhoff(
         Matrix& ConstitutiveMatrix,
         const double& DeterminantF,
         const double& LameLambda,

--- a/applications/StructuralMechanicsApplication/custom_python/add_custom_constitutive_laws_to_python.cpp
+++ b/applications/StructuralMechanicsApplication/custom_python/add_custom_constitutive_laws_to_python.cpp
@@ -26,6 +26,9 @@
 #include "custom_constitutive/linear_plane_strain.h"
 #include "custom_constitutive/elastic_isotropic_3d.h"
 #include "custom_constitutive/axisym_elastic_isotropic.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h"
 #include "custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.h"
 #include "custom_constitutive/hyper_elastic_isotropic_neo_hookean_plane_strain_2d.h"
 #include "custom_constitutive/linear_elastic_orthotropic_2D_law.h"
@@ -42,49 +45,52 @@ void  AddCustomConstitutiveLawsToPython()
 {
 
     class_< TrussConstitutiveLaw, bases< ConstitutiveLaw >, boost::noncopyable >
-    ( "TrussConstitutiveLaw",
-      init<>() )
+    ( "TrussConstitutiveLaw", init<>() )
     ;
 
     class_< BeamConstitutiveLaw, bases< ConstitutiveLaw >, boost::noncopyable >
-    ( "BeamConstitutiveLaw",
-      init<>() )
+    ( "BeamConstitutiveLaw", init<>() )
     ;
 
     class_< LinearPlaneStress, bases< ConstitutiveLaw >, boost::noncopyable >
-    ( "LinearElasticPlaneStress2DLaw",
-      init<>() )
+    ( "LinearElasticPlaneStress2DLaw", init<>() )
     ;
     
     class_< LinearPlaneStrain, bases< ConstitutiveLaw >, boost::noncopyable >
-    ( "LinearElasticPlaneStrain2DLaw",
-      init<>() )
+    ( "LinearElasticPlaneStrain2DLaw", init<>() )
     ;
 
     class_< ElasticIsotropic3D, bases< ConstitutiveLaw >, boost::noncopyable >
-    ( "LinearElastic3DLaw",
-      init<>() )
+    ( "LinearElastic3DLaw", init<>() )
     ;
 
     class_< AxisymElasticIsotropic, bases< ConstitutiveLaw >, boost::noncopyable >
-    ( "LinearElasticAxisym2DLaw",
-      init<>() )
+    ( "LinearElasticAxisym2DLaw", init<>() )
+    ;
+
+    class_< HyperElasticIsotropicKirchhoff3D, bases< ConstitutiveLaw >, boost::noncopyable >
+    ( "KirchhoffSaintVenant3DLaw", init<>() )
+    ;
+
+    class_< HyperElasticIsotropicKirchhoffPlaneStress2D, bases< ConstitutiveLaw >, boost::noncopyable >
+    ( "KirchhoffSaintVenantPlaneStress2DLaw", init<>() )
+    ;
+
+    class_< HyperElasticIsotropicKirchhoffPlaneStrain2D, bases< ConstitutiveLaw >, boost::noncopyable >
+    ( "KirchhoffSaintVenantPlaneStrain2DLaw", init<>() )
     ;
 
     class_< HyperElasticIsotropicNeoHookean3D, bases< ConstitutiveLaw >, boost::noncopyable >
-    ( "HyperElastic3DLaw",
-      init<>() )
+    ( "HyperElastic3DLaw", init<>() )
     ;
     
     class_< HyperElasticIsotropicNeoHookeanPlaneStrain2D, bases< ConstitutiveLaw >, boost::noncopyable >
-    ( "HyperElasticPlaneStrain2DLaw",
-      init<>() )
+    ( "HyperElasticPlaneStrain2DLaw", init<>() )
     ;
     
-	class_< LinearElasticOrthotropic2DLaw, bases< ConstitutiveLaw >, boost::noncopyable >
-	("LinearElasticOrthotropic2DLaw",
-		init<>())
-	;
+    class_< LinearElasticOrthotropic2DLaw, bases< ConstitutiveLaw >, boost::noncopyable >
+    ("LinearElasticOrthotropic2DLaw", init<>())
+    ;
 }
 
 }  // namespace Python.

--- a/applications/StructuralMechanicsApplication/structural_mechanics_application.cpp
+++ b/applications/StructuralMechanicsApplication/structural_mechanics_application.cpp
@@ -46,324 +46,125 @@
 #include "geometries/quadrilateral_2d_4.h"
 #include "geometries/quadrilateral_2d_8.h"
 #include "geometries/quadrilateral_2d_9.h"
+
 namespace Kratos {
 KratosStructuralMechanicsApplication::KratosStructuralMechanicsApplication()
     : KratosApplication("StructuralMechanicsApplication"),
       /* ELEMENTS */
       // Adding the truss elements
-      mTrussElement3D2N(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(
-                               Element::GeometryType::PointsArrayType(2))),
-          false),
-      mTrussLinearElement3D2N(0,
-          Element::GeometryType::Pointer(
-              new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2))),
-          true),
+      mTrussElement3D2N(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2))), false),
+      mTrussLinearElement3D2N(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2))), true),
       // Adding the beam element
-      mCrBeamElement3D2N(0,
-          Element::GeometryType::Pointer(
-              new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2))),
-          false),
-      mCrLinearBeamElement3D2N(0,
-          Element::GeometryType::Pointer(
-              new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2))),
-          true),
-      mCrBeamElement2D2N(0,
-          Element::GeometryType::Pointer(
-              new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2))),
-          false),
-      mCrLinearBeamElement2D2N(0,
-          Element::GeometryType::Pointer(
-              new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2))),
-          true),
+      mCrBeamElement3D2N(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2))), false),
+      mCrLinearBeamElement3D2N(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2))), true),
+      mCrBeamElement2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2))), false),
+      mCrLinearBeamElement2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2))), true),
       // Adding the shells elements
-      mIsotropicShellElement3D3N(
-          0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(
-                 Element::GeometryType::PointsArrayType(3)))),
-      mShellThickElement3D4N(0,
-          Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(
-              Element::GeometryType::PointsArrayType(4))),
-          false),
-      mShellThickCorotationalElement3D4N(0,
-          Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(
-              Element::GeometryType::PointsArrayType(4))),
-          true),
-      mShellThinCorotationalElement3D4N(0,
-          Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(
-              Element::GeometryType::PointsArrayType(4))),
-          true),
-      mShellThinElement3D3N(0,
-          Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(
-              Element::GeometryType::PointsArrayType(3))),
-          false),
-      mShellThinCorotationalElement3D3N(0,
-          Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(
-              Element::GeometryType::PointsArrayType(3))),
-          true),
-      mShellThickCorotationalElement3D3N(0,
-          Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(
-              Element::GeometryType::PointsArrayType(3))),
-          true),
+      mIsotropicShellElement3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+      mShellThickElement3D4N(0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(Element::GeometryType::PointsArrayType(4))), false),
+      mShellThickCorotationalElement3D4N(0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(Element::GeometryType::PointsArrayType(4))), true),
+      mShellThinCorotationalElement3D4N(0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(Element::GeometryType::PointsArrayType(4))), true),
+      mShellThinElement3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3))), false),
+      mShellThinCorotationalElement3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3))), true),
+      mShellThickCorotationalElement3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3))), true),
       // Adding the membrane element
-      mMembraneElement3D3N(
-          0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(
-                 Element::GeometryType::PointsArrayType(3)))),
-      mMembraneElement3D4N(
-          0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
-      mPreStressMembraneElement3D3N(
-          0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(
-                 Element::GeometryType::PointsArrayType(3)))),
-      mPreStressMembraneElement3D4N(
-          0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
+      mMembraneElement3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+      mMembraneElement3D4N(0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+      mPreStressMembraneElement3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+      mPreStressMembraneElement3D4N(0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
       // Adding the SPRISM element
-      mSprismElement3D6N(
-          0, Element::GeometryType::Pointer(new Prism3D6<Node<3> >(
-                 Element::GeometryType::PointsArrayType(6)))),
+      mSprismElement3D6N(0, Element::GeometryType::Pointer(new Prism3D6<Node<3> >(Element::GeometryType::PointsArrayType(6)))),
       // Adding the nodal concentrated element
-      mNodalConcentratedElement2D1N(0,
-          Element::GeometryType::Pointer(
-              new Point2D<Node<3> >(Element::GeometryType::PointsArrayType(1))),
-          true),
-      mNodalConcentratedDampedElement2D1N(0,
-          Element::GeometryType::Pointer(
-              new Point2D<Node<3> >(Element::GeometryType::PointsArrayType(1))),
-          false),
-      mNodalConcentratedElement3D1N(0,
-          Element::GeometryType::Pointer(
-              new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1))),
-          true),
-      mNodalConcentratedDampedElement3D1N(0,
-          Element::GeometryType::Pointer(
-              new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1))),
-          false),
+      mNodalConcentratedElement2D1N(0, Element::GeometryType::Pointer(new Point2D<Node<3> >(Element::GeometryType::PointsArrayType(1))), true),
+      mNodalConcentratedDampedElement2D1N(0, Element::GeometryType::Pointer(new Point2D<Node<3> >(Element::GeometryType::PointsArrayType(1))), false),
+      mNodalConcentratedElement3D1N(0, Element::GeometryType::Pointer(new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1))), true),
+      mNodalConcentratedDampedElement3D1N(0, Element::GeometryType::Pointer(new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1))), false),
       // Adding the kinematic linear elements
-      mSmallDisplacement2D3N(
-          0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(
-                 Element::GeometryType::PointsArrayType(3)))),
-      mSmallDisplacement2D4N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
-      mSmallDisplacement2D6N(
-          0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(
-                 Element::GeometryType::PointsArrayType(6)))),
-      mSmallDisplacement2D8N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(
-                 Element::GeometryType::PointsArrayType(8)))),
-      mSmallDisplacement2D9N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(
-                 Element::GeometryType::PointsArrayType(9)))),
-      mSmallDisplacement3D4N(
-          0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
-      mSmallDisplacement3D6N(
-          0, Element::GeometryType::Pointer(new Prism3D6<Node<3> >(
-                 Element::GeometryType::PointsArrayType(6)))),
-      mSmallDisplacement3D8N(
-          0, Element::GeometryType::Pointer(new Hexahedra3D8<Node<3> >(
-                 Element::GeometryType::PointsArrayType(8)))),
-      mSmallDisplacement3D10N(
-          0, Element::GeometryType::Pointer(new Tetrahedra3D10<Node<3> >(
-                 Element::GeometryType::PointsArrayType(10)))),
-      mSmallDisplacement3D15N(
-          0, Element::GeometryType::Pointer(new Prism3D15<Node<3> >(
-                 Element::GeometryType::PointsArrayType(15)))),
-      mSmallDisplacement3D20N(
-          0, Element::GeometryType::Pointer(new Hexahedra3D20<Node<3> >(
-                 Element::GeometryType::PointsArrayType(20)))),
-      mSmallDisplacement3D27N(
-          0, Element::GeometryType::Pointer(new Hexahedra3D27<Node<3> >(
-                 Element::GeometryType::PointsArrayType(27)))),
-      mAxisymSmallDisplacement2D3N(
-          0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(
-                 Element::GeometryType::PointsArrayType(3)))),
-      mAxisymSmallDisplacement2D4N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
-      mAxisymSmallDisplacement2D6N(
-          0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(
-                 Element::GeometryType::PointsArrayType(6)))),
-      mAxisymSmallDisplacement2D8N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(
-                 Element::GeometryType::PointsArrayType(8)))),
-      mAxisymSmallDisplacement2D9N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(
-                 Element::GeometryType::PointsArrayType(9)))),
+      mSmallDisplacement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+      mSmallDisplacement2D4N(0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+      mSmallDisplacement2D6N(0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(Element::GeometryType::PointsArrayType(6)))),
+      mSmallDisplacement2D8N(0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(Element::GeometryType::PointsArrayType(8)))),
+      mSmallDisplacement2D9N(0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(Element::GeometryType::PointsArrayType(9)))),
+      mSmallDisplacement3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+      mSmallDisplacement3D6N(0, Element::GeometryType::Pointer(new Prism3D6<Node<3> >(Element::GeometryType::PointsArrayType(6)))),
+      mSmallDisplacement3D8N(0, Element::GeometryType::Pointer(new Hexahedra3D8<Node<3> >(Element::GeometryType::PointsArrayType(8)))),
+      mSmallDisplacement3D10N(0, Element::GeometryType::Pointer(new Tetrahedra3D10<Node<3> >(Element::GeometryType::PointsArrayType(10)))),
+      mSmallDisplacement3D15N(0, Element::GeometryType::Pointer(new Prism3D15<Node<3> >(Element::GeometryType::PointsArrayType(15)))),
+      mSmallDisplacement3D20N(0, Element::GeometryType::Pointer(new Hexahedra3D20<Node<3> >(Element::GeometryType::PointsArrayType(20)))),
+      mSmallDisplacement3D27N(0, Element::GeometryType::Pointer(new Hexahedra3D27<Node<3> >(Element::GeometryType::PointsArrayType(27)))),
+      mAxisymSmallDisplacement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+      mAxisymSmallDisplacement2D4N(0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+      mAxisymSmallDisplacement2D6N(0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(Element::GeometryType::PointsArrayType(6)))),
+      mAxisymSmallDisplacement2D8N(0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(Element::GeometryType::PointsArrayType(8)))),
+      mAxisymSmallDisplacement2D9N(0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(Element::GeometryType::PointsArrayType(9)))),
       // Adding the Total lagrangian elements
-      mTotalLagrangian2D3N(
-          0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(
-                 Element::GeometryType::PointsArrayType(3)))),
-      mTotalLagrangian2D4N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
-      mTotalLagrangian2D6N(
-          0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(
-                 Element::GeometryType::PointsArrayType(6)))),
-      mTotalLagrangian2D8N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(
-                 Element::GeometryType::PointsArrayType(8)))),
-      mTotalLagrangian2D9N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(
-                 Element::GeometryType::PointsArrayType(9)))),
-      mTotalLagrangian3D4N(
-          0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
-      mTotalLagrangian3D6N(
-          0, Element::GeometryType::Pointer(new Prism3D6<Node<3> >(
-                 Element::GeometryType::PointsArrayType(6)))),
-      mTotalLagrangian3D8N(
-          0, Element::GeometryType::Pointer(new Hexahedra3D8<Node<3> >(
-                 Element::GeometryType::PointsArrayType(8)))),
-      mTotalLagrangian3D10N(
-          0, Element::GeometryType::Pointer(new Tetrahedra3D10<Node<3> >(
-                 Element::GeometryType::PointsArrayType(10)))),
-      mTotalLagrangian3D15N(
-          0, Element::GeometryType::Pointer(new Prism3D15<Node<3> >(
-                 Element::GeometryType::PointsArrayType(15)))),
-      mTotalLagrangian3D20N(
-          0, Element::GeometryType::Pointer(new Hexahedra3D20<Node<3> >(
-                 Element::GeometryType::PointsArrayType(20)))),
-      mTotalLagrangian3D27N(
-          0, Element::GeometryType::Pointer(new Hexahedra3D27<Node<3> >(
-                 Element::GeometryType::PointsArrayType(27)))),
-      mAxisymTotalLagrangian2D3N(
-          0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(
-                 Element::GeometryType::PointsArrayType(3)))),
-      mAxisymTotalLagrangian2D4N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
-      mAxisymTotalLagrangian2D6N(
-          0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(
-                 Element::GeometryType::PointsArrayType(6)))),
-      mAxisymTotalLagrangian2D8N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(
-                 Element::GeometryType::PointsArrayType(8)))),
-      mAxisymTotalLagrangian2D9N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(
-                 Element::GeometryType::PointsArrayType(9)))),
+      mTotalLagrangian2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+      mTotalLagrangian2D4N(0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+      mTotalLagrangian2D6N(0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(Element::GeometryType::PointsArrayType(6)))),
+      mTotalLagrangian2D8N(0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(Element::GeometryType::PointsArrayType(8)))),
+      mTotalLagrangian2D9N(0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(Element::GeometryType::PointsArrayType(9)))),
+      mTotalLagrangian3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+      mTotalLagrangian3D6N(0, Element::GeometryType::Pointer(new Prism3D6<Node<3> >(Element::GeometryType::PointsArrayType(6)))),
+      mTotalLagrangian3D8N(0, Element::GeometryType::Pointer(new Hexahedra3D8<Node<3> >(Element::GeometryType::PointsArrayType(8)))),
+      mTotalLagrangian3D10N(0, Element::GeometryType::Pointer(new Tetrahedra3D10<Node<3> >(Element::GeometryType::PointsArrayType(10)))),
+      mTotalLagrangian3D15N(0, Element::GeometryType::Pointer(new Prism3D15<Node<3> >(Element::GeometryType::PointsArrayType(15)))),
+      mTotalLagrangian3D20N(0, Element::GeometryType::Pointer(new Hexahedra3D20<Node<3> >(Element::GeometryType::PointsArrayType(20)))),
+      mTotalLagrangian3D27N(0, Element::GeometryType::Pointer(new Hexahedra3D27<Node<3> >(Element::GeometryType::PointsArrayType(27)))),
+      mAxisymTotalLagrangian2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+      mAxisymTotalLagrangian2D4N(0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+      mAxisymTotalLagrangian2D6N(0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(Element::GeometryType::PointsArrayType(6)))),
+      mAxisymTotalLagrangian2D8N(0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(Element::GeometryType::PointsArrayType(8)))),
+      mAxisymTotalLagrangian2D9N(0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(Element::GeometryType::PointsArrayType(9)))),
       // Adding the Updated lagrangian elements
-      mUpdatedLagrangian2D3N(
-          0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(
-                 Element::GeometryType::PointsArrayType(3)))),
-      mUpdatedLagrangian2D4N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
-      mUpdatedLagrangian2D6N(
-          0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(
-                 Element::GeometryType::PointsArrayType(6)))),
-      mUpdatedLagrangian2D8N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(
-                 Element::GeometryType::PointsArrayType(8)))),
-      mUpdatedLagrangian2D9N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(
-                 Element::GeometryType::PointsArrayType(9)))),
-      mUpdatedLagrangian3D4N(
-          0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
-      mUpdatedLagrangian3D6N(
-          0, Element::GeometryType::Pointer(new Prism3D6<Node<3> >(
-                 Element::GeometryType::PointsArrayType(6)))),
-      mUpdatedLagrangian3D8N(
-          0, Element::GeometryType::Pointer(new Hexahedra3D8<Node<3> >(
-                 Element::GeometryType::PointsArrayType(8)))),
-      mUpdatedLagrangian3D10N(
-          0, Element::GeometryType::Pointer(new Tetrahedra3D10<Node<3> >(
-                 Element::GeometryType::PointsArrayType(10)))),
-      mUpdatedLagrangian3D15N(
-          0, Element::GeometryType::Pointer(new Prism3D15<Node<3> >(
-                 Element::GeometryType::PointsArrayType(15)))),
-      mUpdatedLagrangian3D20N(
-          0, Element::GeometryType::Pointer(new Hexahedra3D20<Node<3> >(
-                 Element::GeometryType::PointsArrayType(20)))),
-      mUpdatedLagrangian3D27N(
-          0, Element::GeometryType::Pointer(new Hexahedra3D27<Node<3> >(
-                 Element::GeometryType::PointsArrayType(27)))),
-      mAxisymUpdatedLagrangian2D3N(
-          0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(
-                 Element::GeometryType::PointsArrayType(3)))),
-      mAxisymUpdatedLagrangian2D4N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(
-                 Element::GeometryType::PointsArrayType(4)))),
-      mAxisymUpdatedLagrangian2D6N(
-          0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(
-                 Element::GeometryType::PointsArrayType(6)))),
-      mAxisymUpdatedLagrangian2D8N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(
-                 Element::GeometryType::PointsArrayType(8)))),
-      mAxisymUpdatedLagrangian2D9N(
-          0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(
-                 Element::GeometryType::PointsArrayType(9)))),
+      mUpdatedLagrangian2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+      mUpdatedLagrangian2D4N(0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+      mUpdatedLagrangian2D6N(0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(Element::GeometryType::PointsArrayType(6)))),
+      mUpdatedLagrangian2D8N(0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(Element::GeometryType::PointsArrayType(8)))),
+      mUpdatedLagrangian2D9N(0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(Element::GeometryType::PointsArrayType(9)))),
+      mUpdatedLagrangian3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+      mUpdatedLagrangian3D6N(0, Element::GeometryType::Pointer(new Prism3D6<Node<3> >(Element::GeometryType::PointsArrayType(6)))),
+      mUpdatedLagrangian3D8N( 0, Element::GeometryType::Pointer(new Hexahedra3D8<Node<3> >(Element::GeometryType::PointsArrayType(8)))),
+      mUpdatedLagrangian3D10N(0, Element::GeometryType::Pointer(new Tetrahedra3D10<Node<3> >(Element::GeometryType::PointsArrayType(10)))),
+      mUpdatedLagrangian3D15N(0, Element::GeometryType::Pointer(new Prism3D15<Node<3> >(Element::GeometryType::PointsArrayType(15)))),
+      mUpdatedLagrangian3D20N(0, Element::GeometryType::Pointer(new Hexahedra3D20<Node<3> >(Element::GeometryType::PointsArrayType(20)))),
+      mUpdatedLagrangian3D27N(0, Element::GeometryType::Pointer(new Hexahedra3D27<Node<3> >(Element::GeometryType::PointsArrayType(27)))),
+      mAxisymUpdatedLagrangian2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+      mAxisymUpdatedLagrangian2D4N(0, Element::GeometryType::Pointer(new Quadrilateral2D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+      mAxisymUpdatedLagrangian2D6N(0, Element::GeometryType::Pointer(new Triangle2D6<Node<3> >(Element::GeometryType::PointsArrayType(6)))),
+      mAxisymUpdatedLagrangian2D8N(0, Element::GeometryType::Pointer(new Quadrilateral2D8<Node<3> >(Element::GeometryType::PointsArrayType(8)))),
+      mAxisymUpdatedLagrangian2D9N(0, Element::GeometryType::Pointer(new Quadrilateral2D9<Node<3> >(Element::GeometryType::PointsArrayType(9)))),
       // Adding the spring damper element
-      mSpringDamperElement3D2N(
-          0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(
-                 Element::GeometryType::PointsArrayType(2)))),
+      mSpringDamperElement3D2N(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
       /* CONDITIONS */
       // Adding point load conditions
-      mPointLoadCondition2D1N(
-          0, Condition::GeometryType::Pointer(new Point2D<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(1)))),
-      mPointLoadCondition3D1N(
-          0, Condition::GeometryType::Pointer(new Point3D<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(1)))),
-      mPointContactCondition2D1N(
-          0, Condition::GeometryType::Pointer(new Point2D<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(1)))),
-      mPointContactCondition3D1N(
-          0, Condition::GeometryType::Pointer(new Point3D<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(1)))),
-      mAxisymPointLoadCondition2D1N(
-          0, Condition::GeometryType::Pointer(new Point2D<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(1)))),
+      mPointLoadCondition2D1N(0, Condition::GeometryType::Pointer(new Point2D<Node<3> >(Condition::GeometryType::PointsArrayType(1)))),
+      mPointLoadCondition3D1N(0, Condition::GeometryType::Pointer(new Point3D<Node<3> >(Condition::GeometryType::PointsArrayType(1)))),
+      mPointContactCondition2D1N(0, Condition::GeometryType::Pointer(new Point2D<Node<3> >(Condition::GeometryType::PointsArrayType(1)))),
+      mPointContactCondition3D1N(0, Condition::GeometryType::Pointer(new Point3D<Node<3> >(Condition::GeometryType::PointsArrayType(1)))),
+      mAxisymPointLoadCondition2D1N(0, Condition::GeometryType::Pointer(new Point2D<Node<3> >(Condition::GeometryType::PointsArrayType(1)))),
       // Adding line load conditions
-      mLineLoadCondition2D2N(
-          0, Condition::GeometryType::Pointer(new Line2D2<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(2)))),
-      mLineLoadCondition2D3N(
-          0, Condition::GeometryType::Pointer(new Line2D3<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(3)))),
-      mAxisymLineLoadCondition2D2N(
-          0, Condition::GeometryType::Pointer(new Line2D2<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(2)))),
-      mAxisymLineLoadCondition2D3N(
-          0, Condition::GeometryType::Pointer(new Line2D3<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(3)))),
+      mLineLoadCondition2D2N(0, Condition::GeometryType::Pointer(new Line2D2<Node<3> >(Condition::GeometryType::PointsArrayType(2)))),
+      mLineLoadCondition2D3N(0, Condition::GeometryType::Pointer(new Line2D3<Node<3> >(Condition::GeometryType::PointsArrayType(3)))),
+      mAxisymLineLoadCondition2D2N(0, Condition::GeometryType::Pointer(new Line2D2<Node<3> >(Condition::GeometryType::PointsArrayType(2)))),
+      mAxisymLineLoadCondition2D3N(0, Condition::GeometryType::Pointer(new Line2D3<Node<3> >(Condition::GeometryType::PointsArrayType(3)))),
       // Adding surface load conditions
-      mSurfaceLoadCondition3D3N(
-          0, Condition::GeometryType::Pointer(new Triangle3D3<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(3)))),
-      mSurfaceLoadCondition3D4N(
-          0, Condition::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(4)))),
-      mSurfaceLoadCondition3D6N(
-          0, Condition::GeometryType::Pointer(new Triangle3D6<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(6)))),
-      mSurfaceLoadCondition3D8N(
-          0, Condition::GeometryType::Pointer(new Quadrilateral3D8<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(8)))),
-      mSurfaceLoadCondition3D9N(
-          0, Condition::GeometryType::Pointer(new Quadrilateral3D9<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(9)))),
+      mSurfaceLoadCondition3D3N(0, Condition::GeometryType::Pointer(new Triangle3D3<Node<3> >(Condition::GeometryType::PointsArrayType(3)))),
+      mSurfaceLoadCondition3D4N(0, Condition::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >( Condition::GeometryType::PointsArrayType(4)))),
+      mSurfaceLoadCondition3D6N(0, Condition::GeometryType::Pointer(new Triangle3D6<Node<3> >(Condition::GeometryType::PointsArrayType(6)))),
+      mSurfaceLoadCondition3D8N(0, Condition::GeometryType::Pointer(new Quadrilateral3D8<Node<3> >(Condition::GeometryType::PointsArrayType(8)))),
+      mSurfaceLoadCondition3D9N(0, Condition::GeometryType::Pointer(new Quadrilateral3D9<Node<3> >(Condition::GeometryType::PointsArrayType(9)))),
       // Adding point moment conditions
-      mPointMomentCondition3D1N(
-          0, Condition::GeometryType::Pointer(new Point3D<Node<3> >(
-                 Condition::GeometryType::PointsArrayType(1)))) {}
+      mPointMomentCondition3D1N(0, Condition::GeometryType::Pointer(new Point3D<Node<3> >(Condition::GeometryType::PointsArrayType(1)))) {}
 
 void KratosStructuralMechanicsApplication::Register() {
     // calling base class register to register Kratos components
     KratosApplication::Register();
-    std::cout << "     KRATOS   ___|  |                   |                   "
-                 "|               "
-              << std::endl;
-    std::cout << "            \\___ \\  __|  __| |   |  __| __| |   |  __| _` "
-                 "| |               "
-              << std::endl;
-    std::cout << "                  | |   |    |   | (    |   |   | |   (   | "
-                 "|               "
-              << std::endl;
-    std::cout << "            _____/ \\__|_|   \\__,_|\\___|\\__|\\__,_|_|  "
-                 "\\__,_|_| MECHANICS     "
-              << std::endl;
 
+    std::cout << "     KRATOS   ___|  |                   |                   |                     " << std::endl;
+    std::cout << "            \\___ \\  __|  __| |   |  __| __| |   |  __| _` | |                   " << std::endl;
+    std::cout << "                  | |   |    |   | (    |   |   | |   (   | |                     " << std::endl;
+    std::cout << "            _____/ \\__|_|   \\__,_|\\___|\\__|\\__,_|_|  \\__,_|_| MECHANICS     " << std::endl;
+    
     // Generalized eigenvalue problem
     KRATOS_REGISTER_VARIABLE(BUILD_LEVEL)
     KRATOS_REGISTER_VARIABLE(EIGENVALUE_VECTOR)
@@ -500,77 +301,49 @@ void KratosStructuralMechanicsApplication::Register() {
     KRATOS_REGISTER_ELEMENT("CrLinearBeamElement2D2N", mCrLinearBeamElement2D2N)
 
     //Register the shells elements
-    KRATOS_REGISTER_ELEMENT(
-        "IsotropicShellElement3D3N", mIsotropicShellElement3D3N)
+    KRATOS_REGISTER_ELEMENT("IsotropicShellElement3D3N", mIsotropicShellElement3D3N)
     KRATOS_REGISTER_ELEMENT("ShellThickElement3D4N", mShellThickElement3D4N)
-    KRATOS_REGISTER_ELEMENT(
-        "ShellThickElementCorotational3D4N", mShellThickCorotationalElement3D4N)
-    KRATOS_REGISTER_ELEMENT(
-        "ShellThinElementCorotational3D4N", mShellThinCorotationalElement3D4N)
+    KRATOS_REGISTER_ELEMENT("ShellThickElementCorotational3D4N", mShellThickCorotationalElement3D4N)
+    KRATOS_REGISTER_ELEMENT("ShellThinElementCorotational3D4N", mShellThinCorotationalElement3D4N)
     KRATOS_REGISTER_ELEMENT("ShellThinElement3D3N", mShellThinElement3D3N)
-    KRATOS_REGISTER_ELEMENT(
-        "ShellThickElementCorotational3D3N", mShellThickCorotationalElement3D3N)
-    KRATOS_REGISTER_ELEMENT(
-        "ShellThinElementCorotational3D3N", mShellThinCorotationalElement3D3N)
+    KRATOS_REGISTER_ELEMENT("ShellThickElementCorotational3D3N", mShellThickCorotationalElement3D3N)
+    KRATOS_REGISTER_ELEMENT("ShellThinElementCorotational3D3N", mShellThinCorotationalElement3D3N)
 
     // Register the membrane element
     KRATOS_REGISTER_ELEMENT("MembraneElement3D3N", mMembraneElement3D3N)
     KRATOS_REGISTER_ELEMENT("MembraneElement3D4N", mMembraneElement3D4N)
-    KRATOS_REGISTER_ELEMENT(
-        "PreStressMembraneElement3D3N", mPreStressMembraneElement3D3N)
-    KRATOS_REGISTER_ELEMENT(
-        "PreStressMembraneElement3D4N", mPreStressMembraneElement3D4N)
+    KRATOS_REGISTER_ELEMENT("PreStressMembraneElement3D3N", mPreStressMembraneElement3D3N)
+    KRATOS_REGISTER_ELEMENT("PreStressMembraneElement3D4N", mPreStressMembraneElement3D4N)
 
     // Register the SPRISM element
     KRATOS_REGISTER_ELEMENT("SprismElement3D6N", mSprismElement3D6N);
 
     // Register the nodal concentrated element
-    KRATOS_REGISTER_ELEMENT(
-        "NodalConcentratedElement2D1N", mNodalConcentratedElement2D1N);
-    KRATOS_REGISTER_ELEMENT("NodalConcentratedDampedElement2D1N",
-        mNodalConcentratedDampedElement2D1N);
-    KRATOS_REGISTER_ELEMENT(
-        "NodalConcentratedElement3D1N", mNodalConcentratedElement3D1N);
-    KRATOS_REGISTER_ELEMENT("NodalConcentratedDampedElement3D1N",
-        mNodalConcentratedDampedElement3D1N);
+    KRATOS_REGISTER_ELEMENT("NodalConcentratedElement2D1N", mNodalConcentratedElement2D1N);
+    KRATOS_REGISTER_ELEMENT("NodalConcentratedDampedElement2D1N", mNodalConcentratedDampedElement2D1N);
+    KRATOS_REGISTER_ELEMENT("NodalConcentratedElement3D1N", mNodalConcentratedElement3D1N);
+    KRATOS_REGISTER_ELEMENT("NodalConcentratedDampedElement3D1N", mNodalConcentratedDampedElement3D1N);
 
     // SOLID ELEMENTS
     // Small displacement elements
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement2D3N", mSmallDisplacement2D3N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement2D4N", mSmallDisplacement2D4N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement2D6N", mSmallDisplacement2D6N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement2D8N", mSmallDisplacement2D8N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement2D9N", mSmallDisplacement2D9N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement3D4N", mSmallDisplacement3D4N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement3D6N", mSmallDisplacement3D6N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement3D8N", mSmallDisplacement3D8N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement3D10N", mSmallDisplacement3D10N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement3D15N", mSmallDisplacement3D15N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement3D20N", mSmallDisplacement3D20N)
-    KRATOS_REGISTER_ELEMENT(
-        "SmallDisplacementElement3D27N", mSmallDisplacement3D27N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement2D3N", mSmallDisplacement2D3N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement2D4N", mSmallDisplacement2D4N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement2D6N", mSmallDisplacement2D6N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement2D8N", mSmallDisplacement2D8N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement2D9N", mSmallDisplacement2D9N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement3D4N", mSmallDisplacement3D4N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement3D6N", mSmallDisplacement3D6N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement3D8N", mSmallDisplacement3D8N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement3D10N", mSmallDisplacement3D10N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement3D15N", mSmallDisplacement3D15N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement3D20N", mSmallDisplacement3D20N)
+    KRATOS_REGISTER_ELEMENT("SmallDisplacementElement3D27N", mSmallDisplacement3D27N)
 
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymSmallDisplacementElement2D3N", mAxisymSmallDisplacement2D3N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymSmallDisplacementElement2D4N", mAxisymSmallDisplacement2D4N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymSmallDisplacementElement2D6N", mAxisymSmallDisplacement2D6N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymSmallDisplacementElement2D8N", mAxisymSmallDisplacement2D8N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymSmallDisplacementElement2D9N", mAxisymSmallDisplacement2D9N)
+    KRATOS_REGISTER_ELEMENT("AxisymSmallDisplacementElement2D3N", mAxisymSmallDisplacement2D3N)
+    KRATOS_REGISTER_ELEMENT("AxisymSmallDisplacementElement2D4N", mAxisymSmallDisplacement2D4N)
+    KRATOS_REGISTER_ELEMENT("AxisymSmallDisplacementElement2D6N", mAxisymSmallDisplacement2D6N)
+    KRATOS_REGISTER_ELEMENT("AxisymSmallDisplacementElement2D8N", mAxisymSmallDisplacement2D8N)
+    KRATOS_REGISTER_ELEMENT("AxisymSmallDisplacementElement2D9N", mAxisymSmallDisplacement2D9N)
 
     // Total lagrangian elements
     KRATOS_REGISTER_ELEMENT("TotalLagrangianElement2D3N", mTotalLagrangian2D3N)
@@ -581,103 +354,65 @@ void KratosStructuralMechanicsApplication::Register() {
     KRATOS_REGISTER_ELEMENT("TotalLagrangianElement3D4N", mTotalLagrangian3D4N)
     KRATOS_REGISTER_ELEMENT("TotalLagrangianElement3D6N", mTotalLagrangian3D6N)
     KRATOS_REGISTER_ELEMENT("TotalLagrangianElement3D8N", mTotalLagrangian3D8N)
-    KRATOS_REGISTER_ELEMENT(
-        "TotalLagrangianElement3D10N", mTotalLagrangian3D10N)
-    KRATOS_REGISTER_ELEMENT(
-        "TotalLagrangianElement3D15N", mTotalLagrangian3D15N)
-    KRATOS_REGISTER_ELEMENT(
-        "TotalLagrangianElement3D20N", mTotalLagrangian3D20N)
-    KRATOS_REGISTER_ELEMENT(
-        "TotalLagrangianElement3D27N", mTotalLagrangian3D27N)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianElement3D10N", mTotalLagrangian3D10N)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianElement3D15N", mTotalLagrangian3D15N)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianElement3D20N", mTotalLagrangian3D20N)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianElement3D27N", mTotalLagrangian3D27N)
 
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymTotalLagrangianElement2D3N", mAxisymTotalLagrangian2D3N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymTotalLagrangianElement2D4N", mAxisymTotalLagrangian2D4N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymTotalLagrangianElement2D6N", mAxisymTotalLagrangian2D6N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymTotalLagrangianElement2D8N", mAxisymTotalLagrangian2D8N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymTotalLagrangianElement2D9N", mAxisymTotalLagrangian2D9N)
+    KRATOS_REGISTER_ELEMENT("AxisymTotalLagrangianElement2D3N", mAxisymTotalLagrangian2D3N)
+    KRATOS_REGISTER_ELEMENT("AxisymTotalLagrangianElement2D4N", mAxisymTotalLagrangian2D4N)
+    KRATOS_REGISTER_ELEMENT("AxisymTotalLagrangianElement2D6N", mAxisymTotalLagrangian2D6N)
+    KRATOS_REGISTER_ELEMENT("AxisymTotalLagrangianElement2D8N", mAxisymTotalLagrangian2D8N)
+    KRATOS_REGISTER_ELEMENT("AxisymTotalLagrangianElement2D9N", mAxisymTotalLagrangian2D9N)
 
     // Updated lagrangian elements
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement2D3N", mUpdatedLagrangian2D3N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement2D4N", mUpdatedLagrangian2D4N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement2D6N", mUpdatedLagrangian2D6N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement2D8N", mUpdatedLagrangian2D8N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement2D9N", mUpdatedLagrangian2D9N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement3D4N", mUpdatedLagrangian3D4N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement3D6N", mUpdatedLagrangian3D6N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement3D8N", mUpdatedLagrangian3D8N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement3D10N", mUpdatedLagrangian3D10N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement3D15N", mUpdatedLagrangian3D15N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement3D20N", mUpdatedLagrangian3D20N)
-    KRATOS_REGISTER_ELEMENT(
-        "UpdatedLagrangianElement3D27N", mUpdatedLagrangian3D27N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement2D3N", mUpdatedLagrangian2D3N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement2D4N", mUpdatedLagrangian2D4N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement2D6N", mUpdatedLagrangian2D6N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement2D8N", mUpdatedLagrangian2D8N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement2D9N", mUpdatedLagrangian2D9N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement3D4N", mUpdatedLagrangian3D4N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement3D6N", mUpdatedLagrangian3D6N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement3D8N", mUpdatedLagrangian3D8N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement3D10N", mUpdatedLagrangian3D10N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement3D15N", mUpdatedLagrangian3D15N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement3D20N", mUpdatedLagrangian3D20N)
+    KRATOS_REGISTER_ELEMENT("UpdatedLagrangianElement3D27N", mUpdatedLagrangian3D27N)
 
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymUpdatedLagrangianElement2D3N", mAxisymUpdatedLagrangian2D3N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymUpdatedLagrangianElement2D4N", mAxisymUpdatedLagrangian2D4N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymUpdatedLagrangianElement2D6N", mAxisymUpdatedLagrangian2D6N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymUpdatedLagrangianElement2D8N", mAxisymUpdatedLagrangian2D8N)
-    KRATOS_REGISTER_ELEMENT(
-        "AxisymUpdatedLagrangianElement2D9N", mAxisymUpdatedLagrangian2D9N)
+    KRATOS_REGISTER_ELEMENT("AxisymUpdatedLagrangianElement2D3N", mAxisymUpdatedLagrangian2D3N)
+    KRATOS_REGISTER_ELEMENT("AxisymUpdatedLagrangianElement2D4N", mAxisymUpdatedLagrangian2D4N)
+    KRATOS_REGISTER_ELEMENT("AxisymUpdatedLagrangianElement2D6N", mAxisymUpdatedLagrangian2D6N)
+    KRATOS_REGISTER_ELEMENT("AxisymUpdatedLagrangianElement2D8N", mAxisymUpdatedLagrangian2D8N)
+    KRATOS_REGISTER_ELEMENT("AxisymUpdatedLagrangianElement2D9N", mAxisymUpdatedLagrangian2D9N)
 
     // Register the spring damper element
-    KRATOS_REGISTER_ELEMENT(
-        "SpringDamperElement3D2N", mSpringDamperElement3D2N);
+    KRATOS_REGISTER_ELEMENT("SpringDamperElement3D2N", mSpringDamperElement3D2N);
 
     // Register the conditions
     // Point loads
     KRATOS_REGISTER_CONDITION("PointLoadCondition2D1N", mPointLoadCondition2D1N)
     KRATOS_REGISTER_CONDITION("PointLoadCondition3D1N", mPointLoadCondition3D1N)
-    KRATOS_REGISTER_CONDITION(
-        "PointContactCondition2D1N", mPointContactCondition2D1N)
-    KRATOS_REGISTER_CONDITION(
-        "PointContactCondition3D1N", mPointContactCondition3D1N)
+    KRATOS_REGISTER_CONDITION("PointContactCondition2D1N", mPointContactCondition2D1N)
+    KRATOS_REGISTER_CONDITION("PointContactCondition3D1N", mPointContactCondition3D1N)
 
-    KRATOS_REGISTER_CONDITION(
-        "AxisymPointLoadCondition2D1N", mAxisymPointLoadCondition2D1N)
+    KRATOS_REGISTER_CONDITION("AxisymPointLoadCondition2D1N", mAxisymPointLoadCondition2D1N)
 
     // Line loads
     KRATOS_REGISTER_CONDITION("LineLoadCondition2D2N", mLineLoadCondition2D2N)
     KRATOS_REGISTER_CONDITION("LineLoadCondition2D3N", mLineLoadCondition2D3N)
 
-    KRATOS_REGISTER_CONDITION(
-        "AxisymLineLoadCondition2D2N", mAxisymLineLoadCondition2D2N)
-    KRATOS_REGISTER_CONDITION(
-        "AxisymLineLoadCondition2D3N", mAxisymLineLoadCondition2D3N)
+    KRATOS_REGISTER_CONDITION("AxisymLineLoadCondition2D2N", mAxisymLineLoadCondition2D2N)
+    KRATOS_REGISTER_CONDITION("AxisymLineLoadCondition2D3N", mAxisymLineLoadCondition2D3N)
 
     // Surface loads
-    KRATOS_REGISTER_CONDITION(
-        "SurfaceLoadCondition3D3N", mSurfaceLoadCondition3D3N)
-    KRATOS_REGISTER_CONDITION(
-        "SurfaceLoadCondition3D4N", mSurfaceLoadCondition3D4N)
-    KRATOS_REGISTER_CONDITION(
-        "SurfaceLoadCondition3D6N", mSurfaceLoadCondition3D6N)
-    KRATOS_REGISTER_CONDITION(
-        "SurfaceLoadCondition3D8N", mSurfaceLoadCondition3D8N)
-    KRATOS_REGISTER_CONDITION(
-        "SurfaceLoadCondition3D9N", mSurfaceLoadCondition3D9N)
+    KRATOS_REGISTER_CONDITION("SurfaceLoadCondition3D3N", mSurfaceLoadCondition3D3N)
+    KRATOS_REGISTER_CONDITION("SurfaceLoadCondition3D4N", mSurfaceLoadCondition3D4N)
+    KRATOS_REGISTER_CONDITION("SurfaceLoadCondition3D6N", mSurfaceLoadCondition3D6N)
+    KRATOS_REGISTER_CONDITION("SurfaceLoadCondition3D8N", mSurfaceLoadCondition3D8N)
+    KRATOS_REGISTER_CONDITION("SurfaceLoadCondition3D9N", mSurfaceLoadCondition3D9N)
 
     // Point moment
-    KRATOS_REGISTER_CONDITION(
-        "PointMomentCondition3D1N", mPointMomentCondition3D1N);
+    KRATOS_REGISTER_CONDITION("PointMomentCondition3D1N", mPointMomentCondition3D1N);
 
     // For MPC implementations
     KRATOS_REGISTER_VARIABLE(MPC_DATA_CONTAINER)
@@ -688,12 +423,13 @@ void KratosStructuralMechanicsApplication::Register() {
     Serializer::Register("LinearElasticPlaneStrain2DLaw", mLinearPlaneStrain);
     Serializer::Register("LinearElasticPlaneStress2DLaw", mLinearPlaneStress);
     Serializer::Register("LinearElasticAxisym2DLaw", mAxisymElasticIsotropic);
-    Serializer::Register(
-        "HyperElastic3DLaw", mHyperElasticIsotropicNeoHookean3D);
-    Serializer::Register("HyperElasticPlaneStrain2DLaw",
-        mHyperElasticIsotropicNeoHookeanPlaneStrain2D);
-    Serializer::Register(
-        "LinearElasticOrthotropic2DLaw", mLinearElasticOrthotropic2DLaw);
+    Serializer::Register("LinearElasticOrthotropic2DLaw", mLinearElasticOrthotropic2DLaw);
+    // Register hyper elastic laws
+    Serializer::Register("KirchhoffSaintVenant3DLaw", mHyperElasticIsotropicKirchhoff3D);
+    Serializer::Register("KirchhoffSaintVenantPlaneStress2DLaw", mHyperElasticIsotropicKirchhoffPlaneStress2D);
+    Serializer::Register("KirchhoffSaintVenantPlaneStrain2DLaw", mHyperElasticIsotropicKirchhoffPlaneStrain2D);
+    Serializer::Register("HyperElastic3DLaw", mHyperElasticIsotropicNeoHookean3D);
+    Serializer::Register("HyperElasticPlaneStrain2DLaw", mHyperElasticIsotropicNeoHookeanPlaneStrain2D);
 }
 
 }  // namespace Kratos.

--- a/applications/StructuralMechanicsApplication/structural_mechanics_application.h
+++ b/applications/StructuralMechanicsApplication/structural_mechanics_application.h
@@ -34,7 +34,6 @@
 #include "custom_elements/cr_beam_element_3D2N.hpp"
 #include "custom_elements/cr_beam_element_2D2N.hpp"
 
-
 /* Adding shells and membranes elements */
 #include "custom_elements/isotropic_shell_element.hpp"
 #include "custom_elements/membrane_element.hpp"
@@ -76,6 +75,9 @@
 #include "custom_constitutive/axisym_elastic_isotropic.h"
 #include "custom_constitutive/linear_plane_strain.h"
 #include "custom_constitutive/linear_plane_stress.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h"
 #include "custom_constitutive/hyper_elastic_isotropic_neo_hookean_3d.h"
 #include "custom_constitutive/hyper_elastic_isotropic_neo_hookean_plane_strain_2d.h"
 #include "custom_constitutive/linear_elastic_orthotropic_2D_law.h"
@@ -375,6 +377,9 @@ private:
     const AxisymElasticIsotropic mAxisymElasticIsotropic;
     const LinearPlaneStrain  mLinearPlaneStrain;
     const LinearPlaneStress  mLinearPlaneStress;
+    const HyperElasticIsotropicKirchhoff3D  mHyperElasticIsotropicKirchhoff3D;
+    const HyperElasticIsotropicKirchhoffPlaneStress2D  mHyperElasticIsotropicKirchhoffPlaneStress2D;
+    const HyperElasticIsotropicKirchhoffPlaneStrain2D  mHyperElasticIsotropicKirchhoffPlaneStrain2D;
     const HyperElasticIsotropicNeoHookean3D  mHyperElasticIsotropicNeoHookean3D;
     const HyperElasticIsotropicNeoHookeanPlaneStrain2D  mHyperElasticIsotropicNeoHookeanPlaneStrain2D;
     const LinearElasticOrthotropic2DLaw mLinearElasticOrthotropic2DLaw;

--- a/applications/StructuralMechanicsApplication/tests/constitutive_law_test.py
+++ b/applications/StructuralMechanicsApplication/tests/constitutive_law_test.py
@@ -141,8 +141,221 @@ class TestConstitutiveLaw(KratosUnittest.TestCase):
         print("C      = ", cl_params.GetConstitutiveMatrix())
         
         cl.FinalizeMaterialResponseCauchy(cl_params)
-        cl.FinalizeSolutionStep(properties, geom, N, model_part.ProcessInfo)
-    
+        cl.FinalizeSolutionStep(properties, geom, N, model_part.ProcessInfo)    
+
+    def test_Uniaxial_KirchhoffSaintVenant_3D(self):
+        nnodes = 4
+        dim = 3
+
+        # Define a model  and geometry
+        model_part = KratosMultiphysics.ModelPart("test")
+
+        geom = self._create_geometry(model_part, dim, nnodes)
+
+        # Material properties
+        young_modulus = 200e9
+        poisson_ratio = 0.3
+        properties = self._create_properties(model_part, young_modulus, poisson_ratio)
+
+        N = KratosMultiphysics.Vector(nnodes)
+        DN_DX = KratosMultiphysics.Matrix(nnodes, dim)
+
+        # Construct a constitutive law
+        cl = StructuralMechanicsApplication.KirchhoffSaintVenant3DLaw()
+        self._cl_check(cl, properties, geom, model_part, dim)
+
+        # Set the parameters to be employed
+        dict_options = {'USE_ELEMENT_PROVIDED_STRAIN': False,
+                        'COMPUTE_STRESS': True,
+                        'COMPUTE_CONSTITUTIVE_TENSOR': True,
+                        'FINITE_STRAINS': True,
+                        'ISOTROPIC': True,
+                        }
+        cl_options = self._set_cl_options(dict_options)
+
+        # Define deformation gradient
+        F = self._create_F()
+        detF = 1.0
+
+        stress_vector = KratosMultiphysics.Vector(cl.GetStrainSize())
+        strain_vector = KratosMultiphysics.Vector(cl.GetStrainSize())
+        constitutive_matrix = KratosMultiphysics.Matrix(cl.GetStrainSize(),cl.GetStrainSize())
+
+        # Setting the parameters - note that a constitutive law may not need them all!
+        cl_params = self._set_cl_parameters(cl_options, F, detF, strain_vector, stress_vector, constitutive_matrix, N, DN_DX, model_part, properties, geom)
+
+        # Check the results
+        lame_lambda = (young_modulus * poisson_ratio) / ((1.0 + poisson_ratio) * (1.0 - 2.0 * poisson_ratio))
+        lame_mu = young_modulus / (2.0 * (1.0 + poisson_ratio))
+
+        reference_stress = KratosMultiphysics.Vector(cl.GetStrainSize())
+        for i in range(cl.GetStrainSize()):
+            reference_stress[i] = 0.0
+
+        for i in range(100):
+            F[0,0] = 1.0 + 0.05 * i
+            detF = 1.0 + 0.05 * i
+            cl_params.SetDeformationGradientF(F)
+            cl_params.SetDeterminantF(detF)
+
+            # Chauchy
+            cl.CalculateMaterialResponseCauchy(cl_params)
+            cl.FinalizeMaterialResponseCauchy(cl_params)
+            cl.FinalizeSolutionStep(properties, geom, N, model_part.ProcessInfo)
+            reference_stress[0] =( (lame_lambda *  0.5  + lame_mu) * (detF ** 2.0 - 1.0)*(detF ** 2.0) ) / detF
+            reference_stress[1] = 0.5*lame_lambda*(detF ** 2.0 - 1.0) / detF
+            reference_stress[2] = reference_stress[1]
+
+            stress = cl_params.GetStressVector()
+
+            for j in range(cl.GetStrainSize()):
+                self.assertAlmostEqual(reference_stress[j], stress[j], 2)
+
+    def test_Shear_KirchhoffSaintVenant_3D(self):
+        nnodes = 4
+        dim = 3
+
+        # Define a model  and geometry
+        model_part = KratosMultiphysics.ModelPart("test")
+        geom = self._create_geometry(model_part, dim, nnodes)
+
+        # Material properties
+        young_modulus = 200e9
+        poisson_ratio = 0.3
+        properties = self._create_properties(model_part, young_modulus, poisson_ratio)
+
+        N = KratosMultiphysics.Vector(nnodes)
+        DN_DX = KratosMultiphysics.Matrix(nnodes, dim)
+
+        # Construct a constitutive law
+        cl = StructuralMechanicsApplication.KirchhoffSaintVenant3DLaw()
+        self._cl_check(cl, properties, geom, model_part, dim)
+
+        # Set the parameters to be employed
+        dict_options = {'USE_ELEMENT_PROVIDED_STRAIN': False,
+                        'COMPUTE_STRESS': True,
+                        'COMPUTE_CONSTITUTIVE_TENSOR': True,
+                        'FINITE_STRAINS': True,
+                        'ISOTROPIC': True,
+                        }
+        cl_options = self._set_cl_options(dict_options)
+
+        # Define deformation gradient
+        F = self._create_F()
+        detF = 1.0
+
+        stress_vector = KratosMultiphysics.Vector(cl.GetStrainSize())
+        strain_vector = KratosMultiphysics.Vector(cl.GetStrainSize())
+        constitutive_matrix = KratosMultiphysics.Matrix(cl.GetStrainSize(),cl.GetStrainSize())
+
+        # Setting the parameters - note that a constitutive law may not need them all!
+        cl_params = self._set_cl_parameters(cl_options, F, detF, strain_vector, stress_vector, constitutive_matrix, N, DN_DX, model_part, properties, geom)
+
+        # Check the results
+        lame_lambda = (young_modulus * poisson_ratio) / ((1.0 + poisson_ratio) * (1.0 - 2.0 * poisson_ratio))
+        lame_mu = young_modulus / (2.0 * (1.0 + poisson_ratio))
+
+        reference_stress = KratosMultiphysics.Vector(cl.GetStrainSize())
+        for i in range(cl.GetStrainSize()):
+            reference_stress[i] = 0.0
+
+        for i in range(100):
+            F[0,1] = 0.02 * i
+            cl_params.SetDeformationGradientF(F)
+
+            # Cauchy
+            cl.CalculateMaterialResponseCauchy(cl_params)
+            cl.FinalizeMaterialResponseCauchy(cl_params)
+            cl.FinalizeSolutionStep(properties, geom, N, model_part.ProcessInfo)
+
+            reference_stress[0] = (0.5*lame_lambda + 2*lame_mu) * (F[0,1])**2.0 + (0.5*lame_lambda + lame_mu) * (F[0,1])**4.0
+            reference_stress[1] = (0.5*lame_lambda + lame_mu) * (F[0,1])**2.0
+            reference_stress[2] = 0.5*lame_lambda  * (F[0,1])**2.0
+            reference_stress[3] = lame_mu * (F[0,1]) + (0.5*lame_lambda + lame_mu) * (F[0,1])**3.0
+
+            stress = cl_params.GetStressVector()
+
+            for j in range(cl.GetStrainSize()):
+                self.assertAlmostEqual(reference_stress[j], stress[j], 2)
+
+    def test_Shear_Plus_Strech_KirchhoffSaintVenant_3D(self):
+        nnodes = 4
+        dim = 3
+
+        # Define a model  and geometry
+        model_part = KratosMultiphysics.ModelPart("test")
+        geom = self._create_geometry(model_part, dim, nnodes)
+
+        # Material properties
+        young_modulus = 200e9
+        poisson_ratio = 0.3
+        properties = self._create_properties(model_part, young_modulus, poisson_ratio)
+
+        N = KratosMultiphysics.Vector(nnodes)
+        DN_DX = KratosMultiphysics.Matrix(nnodes, dim)
+
+        # Construct a constitutive law
+        cl = StructuralMechanicsApplication.KirchhoffSaintVenant3DLaw()
+        self._cl_check(cl, properties, geom, model_part, dim)
+
+        # Set the parameters to be employed
+        dict_options = {'USE_ELEMENT_PROVIDED_STRAIN': False,
+                        'COMPUTE_STRESS': True,
+                        'COMPUTE_CONSTITUTIVE_TENSOR': True,
+                        'FINITE_STRAINS': True,
+                        'ISOTROPIC': True,
+                        }
+        cl_options = self._set_cl_options(dict_options)
+
+        # Define deformation gradient
+        F = self._create_F()
+        detF = 1.0
+
+        stress_vector = KratosMultiphysics.Vector(cl.GetStrainSize())
+        strain_vector = KratosMultiphysics.Vector(cl.GetStrainSize())
+        constitutive_matrix = KratosMultiphysics.Matrix(cl.GetStrainSize(),cl.GetStrainSize())
+
+        # Setting the parameters - note that a constitutive law may not need them all!
+        cl_params = self._set_cl_parameters(cl_options, F, detF, strain_vector, stress_vector, constitutive_matrix, N, DN_DX, model_part, properties, geom)
+
+        # Check the results
+        lame_lambda = (young_modulus * poisson_ratio) / ((1.0 + poisson_ratio) * (1.0 - 2.0 * poisson_ratio))
+        lame_mu = young_modulus / (2.0 * (1.0 + poisson_ratio))
+
+        reference_stress = KratosMultiphysics.Vector(cl.GetStrainSize())
+        for i in range(cl.GetStrainSize()):
+            reference_stress[i] = 0.0
+
+        x1beta = 1.0
+        x2beta = 1.0
+        x3beta = math.pi/200
+        for i in range(100):
+            F[0,0] =  math.cos(x3beta * i)
+            F[0,1] = -math.sin(x3beta * i)
+            F[1,0] =  math.sin(x3beta * i)
+            F[1,1] =  math.cos(x3beta * i)
+            F[0,2] =  - x1beta * math.sin(x3beta * i) - x2beta * math.cos(x3beta * i)
+            F[1,2] =    x1beta * math.cos(x3beta * i) - x2beta * math.sin(x3beta * i)
+
+            cl_params.SetDeformationGradientF(F)
+
+            # Cauchy
+            cl.CalculateMaterialResponseCauchy(cl_params)
+            cl.FinalizeMaterialResponseCauchy(cl_params)
+            cl.FinalizeSolutionStep(properties, geom, N, model_part.ProcessInfo)
+
+            reference_stress[0]= math.cos(x3beta * i)*(x2beta*lame_mu*(x2beta*math.cos(x3beta * i) + x1beta*math.sin(x3beta * i)) + (lame_lambda*math.cos(x3beta * i)*(x1beta**2 + x2beta**2))/2) + (x2beta*math.cos(x3beta * i) + x1beta*math.sin(x3beta * i))*((lame_lambda/2 + lame_mu)*(x1beta**2 + x2beta**2)*(x2beta*math.cos(x3beta * i) + x1beta*math.sin(x3beta * i)) + x2beta*lame_mu*math.cos(x3beta * i) + x1beta*lame_mu*math.sin(x3beta * i)) + math.sin(x3beta * i)*((lame_lambda*math.sin(x3beta * i)*(x1beta**2 + x2beta**2))/2 + x1beta*lame_mu*(x2beta*math.cos(x3beta * i) + x1beta*math.sin(x3beta * i)))
+            reference_stress[1]= math.cos(x3beta * i)*(x1beta*lame_mu*(x1beta*math.cos(x3beta * i) - x2beta*math.sin(x3beta * i)) + (lame_lambda*math.cos(x3beta * i)*(x1beta**2 + x2beta**2))/2) + (x1beta*math.cos(x3beta * i) - x2beta*math.sin(x3beta * i))*((lame_lambda/2 + lame_mu)*(x1beta**2 + x2beta**2)*(x1beta*math.cos(x3beta * i) - x2beta*math.sin(x3beta * i)) + x1beta*lame_mu*math.cos(x3beta * i) - x2beta*lame_mu*math.sin(x3beta * i)) + math.sin(x3beta * i)*((lame_lambda*math.sin(x3beta * i)*(x1beta**2 + x2beta**2))/2 - x2beta*lame_mu*(x1beta*math.cos(x3beta * i) - x2beta*math.sin(x3beta * i)))
+            reference_stress[2]=(lame_lambda/2 + lame_mu)*(x1beta**2 + x2beta**2)
+            reference_stress[3]= math.sin(x3beta * i)*(x2beta*lame_mu*(x2beta*math.cos(x3beta * i) + x1beta*math.sin(x3beta * i)) + (lame_lambda*math.cos(x3beta * i)*(x1beta**2 + x2beta**2))/2) - math.cos(x3beta * i)*((lame_lambda*math.sin(x3beta * i)*(x1beta**2 + x2beta**2))/2 + x1beta*lame_mu*(x2beta*math.cos(x3beta * i) + x1beta*math.sin(x3beta * i))) - (x1beta*math.cos(x3beta * i) - x2beta*math.sin(x3beta * i))*((lame_lambda/2 + lame_mu)*(x1beta**2 + x2beta**2)*(x2beta*math.cos(x3beta * i) + x1beta*math.sin(x3beta * i)) + x2beta*lame_mu*math.cos(x3beta * i) + x1beta*lame_mu*math.sin(x3beta * i))
+            reference_stress[4]=(lame_lambda/2 + lame_mu)*(x1beta**2 + x2beta**2)*(x1beta*math.cos(x3beta * i) - x2beta*math.sin(x3beta * i)) + x1beta*lame_mu*math.cos(x3beta * i) - x2beta*lame_mu*math.sin(x3beta * i)
+            reference_stress[5]=- (lame_lambda/2 + lame_mu)*(x1beta**2 + x2beta**2)*(x2beta*math.cos(x3beta * i) + x1beta*math.sin(x3beta * i)) - x2beta*lame_mu*math.cos(x3beta * i) - x1beta*lame_mu*math.sin(x3beta * i)
+
+            stress = cl_params.GetStressVector()
+
+            for j in range(cl.GetStrainSize()):
+                self.assertAlmostEqual(reference_stress[j], stress[j], 2)
+
     def test_Uniaxial_HyperElastic_3D(self):
         nnodes = 4
         dim = 3


### PR DESCRIPTION
This PR adds a Kirchhoff Saint-Venant constitutive model to the StructuralMechanicsApplication (@KratosMultiphysics/structural-mechanics ). This new feature has been implemented with the help of Malek Ali Dawi, a student who is starting to work with us in FSI validation. 

By the way, since this implies to modify the structural mechanics application source and headers, I took the chance for cleaning up them again (remember that a few days ago the formatting was messed up). Sorry for the inconveniences that this might cause during the review.