### PR TITLE
Added zero-division warnings

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -385,7 +385,7 @@ public:
                 }
                 KRATOS_ERROR_IF(down < std::numeric_limits<double>::epsilon()) << "No valid effective "
                     << "material damping ratio could be computed. Are all elements to be damped available "
-                    << "in the submodelparts? Are the modal vectors available? " << std::endl;
+                    << "in the submodelparts? Are the modal vectors available?" << std::endl;
                 
                 mMaterialDampingRatios(i) = up / down;
             }
@@ -436,7 +436,8 @@ public:
 
         for( std::size_t i = 0; i < n_modes; ++i )
         {
-
+            KRATOS_ERROR_IF(eigenvalues[i] < std::numeric_limits<double>::epsilon()) << "No valid eigenvalue "
+                    << "for mode " << i << std::endl;
             modal_damping = mSystemDamping + mRayleighAlpha / (2 * eigenvalues[i]) + mRayleighBeta * eigenvalues[i] / 2;
             
             if( mUseMaterialDamping )
@@ -450,6 +451,7 @@ public:
             TDenseSpace::GetColumn(i, r_modal_matrix, modal_vector);
 
             ComplexType factor( eigenvalues[i] - std::pow( excitation_frequency, 2.0 ), 2 * modal_damping * std::sqrt(eigenvalues[i]) * excitation_frequency );
+            KRATOS_ERROR_IF(factor < std::numeric_limits<double>::epsilon()) << "No valid factor" << std::endl;
             mode_weight = inner_prod( modal_vector, f ) / factor;
 
             // compute the modal displacement as a superposition of modal_weight * eigenvector

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -451,7 +451,7 @@ public:
             TDenseSpace::GetColumn(i, r_modal_matrix, modal_vector);
 
             ComplexType factor( eigenvalues[i] - std::pow( excitation_frequency, 2.0 ), 2 * modal_damping * std::sqrt(eigenvalues[i]) * excitation_frequency );
-            KRATOS_ERROR_IF(factor < std::numeric_limits<double>::epsilon()) << "No valid factor" << std::endl;
+            KRATOS_ERROR_IF( std::abs(factor) < std::numeric_limits<double>::epsilon() ) << "No valid modal weight" << std::endl;
             mode_weight = inner_prod( modal_vector, f ) / factor;
 
             // compute the modal displacement as a superposition of modal_weight * eigenvector


### PR DESCRIPTION
Hi @qaumann 
I found that you don't ahve warnings in the case of division-by-zero

I added two checks, but I am not sure of they work, can you please check?
Esp the on with the `ComplexType` I am not sure