### PR TITLE
Fixing compilation in win

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -137,7 +137,8 @@ set_target_properties(KratosCore PROPERTIES COMPILE_DEFINITIONS "KRATOS_CORE=IMP
 ## Define library KratosTests if enabled
 if(${KRATOS_BUILD_TESTING} MATCHES ON)
     add_library(KratosTests SHARED ${KRATOS_TEST_SOURCES})
-    target_link_libraries(KratosTests KratosCore)
+	target_link_libraries(KratosTests KratosCore)
+	set_target_properties(KratosTests PROPERTIES COMPILE_DEFINITIONS "KRATOS_TESTS=IMPORT,API")
     set_target_properties(KratosTests PROPERTIES PREFIX "")
     set(KRATOS_TEST_LIBRARIES KratosTests)
 endif(${KRATOS_BUILD_TESTING} MATCHES ON)

--- a/kratos/processes/find_intersected_geometrical_objects_process.h
+++ b/kratos/processes/find_intersected_geometrical_objects_process.h
@@ -219,7 +219,7 @@ namespace Kratos
   It also provides some helper methods for derived classes to check
   individual element or condition interesections.
   */
-  class FindIntersectedGeometricalObjectsProcess : public Process
+  class KRATOS_API(KRATOS_CORE) FindIntersectedGeometricalObjectsProcess : public Process
     {
     public:
       ///@name Type Definitions

--- a/kratos/processes/mesh_coarsening_process.h
+++ b/kratos/processes/mesh_coarsening_process.h
@@ -40,7 +40,7 @@ namespace Kratos
   /// Short class definition.
   /** Detail class definition.
   */
-  class MeshCoarseningProcess : public MeshNodeCollapsingProcess
+  class KRATOS_API(KRATOS_CORE) MeshCoarseningProcess : public MeshNodeCollapsingProcess
     {
     public:
       ///@name Type Definitions

--- a/kratos/processes/tetrahedra_mesh_edge_swapping_process.h
+++ b/kratos/processes/tetrahedra_mesh_edge_swapping_process.h
@@ -40,7 +40,7 @@ namespace Kratos
   /// Short class definition.
   /** Detail class definition.
   */
-  class TetrahedraMeshEdgeSwappingProcess : public Process
+  class KRATOS_API(KRATOS_CORE) TetrahedraMeshEdgeSwappingProcess : public Process
     {
     public:
       ///@name Type Definitions

--- a/kratos/testing/test_suite.h
+++ b/kratos/testing/test_suite.h
@@ -165,7 +165,7 @@ inline std::ostream& operator<<(
             TestName, TestSuiteName)
 
 #define KRATOS_TESTING_TEST_CASE_IN_SUITE_CLASS(TestCaseName, ParentName)      \
-    class KRATOS_TESTING_CREATE_CLASS_NAME(TestCaseName) : public ParentName { \
+    class KRATOS_API(KRATOS_TESTS) KRATOS_TESTING_CREATE_CLASS_NAME(TestCaseName) : public ParentName { \
         KRATOS_TESTING_TEST_CASE_CLASS_BODY(TestCaseName, ParentName)          \
         static const Kratos::Testing::Internals::AddThisTestToTestSuite        \
             mAnotherDummy;                                                     \

--- a/kratos/utilities/geometrical_sensitivity_utility.h
+++ b/kratos/utilities/geometrical_sensitivity_utility.h
@@ -30,7 +30,7 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
-class GeometricalSensitivityUtility
+class KRATOS_API(KRATOS_CORE) GeometricalSensitivityUtility
 {
 public:
     ///@name Type Definitions


### PR DESCRIPTION
This fixes #1219

It had two problems, first I forgot to export some additional symbols needed by the new test library when I separated it from `KratosCore` project. Also, individual tests needed to be exported for VS to be able to generate the `.lib` file and be able to execute them through `Kratos`