### PR TITLE
Updating embedded deactivation process

### DIFF
--- a/applications/FluidDynamicsApplication/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/CMakeLists.txt
@@ -43,6 +43,7 @@ set( KRATOS_FLUID_DYNAMICS_APPLICATION_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/herschel_bulkey_3d_law.cpp
 
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/boussinesq_force_process.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/distance_modification_process.cpp
 
 )
 

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -1,0 +1,79 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+//
+
+// System includes
+//#include <string>
+//#include <iostream>
+
+// External includes
+
+// Project includes
+// #include "includes/define.h"
+#include "distance_modification_process.h"
+
+// #include "processes/process.h"
+// #include "includes/cfd_variables.h"
+// #include "processes/find_nodal_h_process.h"
+// #include "utilities/openmp_utils.h"
+// #include "includes/kratos_parameters.h"
+
+// Application includes
+
+
+namespace Kratos
+{
+
+/* Public functions *******************************************************/
+DistanceModificationProcess::DistanceModificationProcess(
+    ModelPart& rModelPart, 
+    const bool CheckAtEachStep, 
+    const bool NegElemDeactivation,
+    const bool RecoverOriginalDistance)
+    : Process(), mrModelPart(rModelPart) {
+
+    mFactorCoeff = 2.0;
+    mCheckAtEachStep = CheckAtEachStep;
+    mNegElemDeactivation = NegElemDeactivation;
+    mRecoverOriginalDistance = RecoverOriginalDistance;
+}
+
+DistanceModificationProcess::DistanceModificationProcess(
+    ModelPart& rModelPart,
+    Parameters& rParameters)
+    : Process(), mrModelPart(rModelPart) {
+
+    Parameters default_parameters( R"(
+    {
+        "mesh_id"                                : 0,
+        "model_part_name"                        : "default_model_part_name",
+        "distance_factor"                        : 2.0,
+        "check_at_each_time_step"                : false,
+        "deactivate_full_negative_elements"      : true,
+        "recover_original_distance_at_each_step" : false
+    }  )" );
+
+    rParameters.ValidateAndAssignDefaults(default_parameters);
+
+    mFactorCoeff = rParameters["distance_factor"].GetDouble();
+    mCheckAtEachStep = rParameters["check_at_each_time_step"].GetBool();
+    mNegElemDeactivation = rParameters["deactivate_full_negative_elements"].GetBool();
+    mRecoverOriginalDistance = rParameters["recover_original_distance_at_each_step"].GetBool();
+}
+
+/* Protected functions ****************************************************/
+
+
+/* Private functions ****************************************************/
+
+};  // namespace Kratos.
+

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -50,7 +50,6 @@ DistanceModificationProcess::DistanceModificationProcess(
 
     Parameters default_parameters( R"(
     {
-        "mesh_id"                                : 0,
         "model_part_name"                        : "default_model_part_name",
         "distance_factor"                        : 2.0,
         "distance_threshold"                     : 0.01,

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -16,6 +16,7 @@
 // External includes
 
 // Project includes
+#include "includes/checks.h"
 #include "utilities/openmp_utils.h"
 #include "processes/find_nodal_h_process.h"
 
@@ -31,7 +32,7 @@ DistanceModificationProcess::DistanceModificationProcess(
     ModelPart& rModelPart,
     const double FactorCoeff,
     const double DistanceThreshold,
-    const bool CheckAtEachStep, 
+    const bool CheckAtEachStep,
     const bool NegElemDeactivation,
     const bool RecoverOriginalDistance)
     : Process(), mrModelPart(rModelPart) {
@@ -71,11 +72,10 @@ void DistanceModificationProcess::ExecuteInitialize() {
 
     KRATOS_TRY;
 
-    // Variables check
-    if( mrModelPart.NodesBegin()->SolutionStepsDataHas( DISTANCE ) == false )
-        KRATOS_ERROR << "Nodes do not have DISTANCE variable!";
-    if( mrModelPart.NodesBegin()->SolutionStepsDataHas( NODAL_H ) == false )
-        KRATOS_ERROR << "Nodes do not have NODAL_H variable!";
+    // Required variables check
+    const auto& r_node = *mrModelPart.NodesBegin();
+    KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(NODAL_H, r_node);
+    KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISTANCE, r_node);
 
     // Obtain NODAL_H values
     FindNodalHProcess NodalHCalculator(mrModelPart);
@@ -306,4 +306,3 @@ void DistanceModificationProcess::DeactivateFullNegativeElements() {
 /* Private functions ****************************************************/
 
 };  // namespace Kratos.
-

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -12,22 +12,15 @@
 //
 
 // System includes
-//#include <string>
-//#include <iostream>
 
 // External includes
 
 // Project includes
-// #include "includes/define.h"
-#include "distance_modification_process.h"
-
-// #include "processes/process.h"
-// #include "includes/cfd_variables.h"
-// #include "processes/find_nodal_h_process.h"
-// #include "utilities/openmp_utils.h"
-// #include "includes/kratos_parameters.h"
+#include "utilities/openmp_utils.h"
+#include "processes/find_nodal_h_process.h"
 
 // Application includes
+#include "distance_modification_process.h"
 
 
 namespace Kratos
@@ -35,13 +28,16 @@ namespace Kratos
 
 /* Public functions *******************************************************/
 DistanceModificationProcess::DistanceModificationProcess(
-    ModelPart& rModelPart, 
+    ModelPart& rModelPart,
+    const double FactorCoeff,
+    const double DistanceThreshold,
     const bool CheckAtEachStep, 
     const bool NegElemDeactivation,
     const bool RecoverOriginalDistance)
     : Process(), mrModelPart(rModelPart) {
 
-    mFactorCoeff = 2.0;
+    mFactorCoeff = FactorCoeff;
+    mDistanceThreshold = DistanceThreshold;
     mCheckAtEachStep = CheckAtEachStep;
     mNegElemDeactivation = NegElemDeactivation;
     mRecoverOriginalDistance = RecoverOriginalDistance;
@@ -57,6 +53,7 @@ DistanceModificationProcess::DistanceModificationProcess(
         "mesh_id"                                : 0,
         "model_part_name"                        : "default_model_part_name",
         "distance_factor"                        : 2.0,
+        "distance_threshold"                     : 0.01,
         "check_at_each_time_step"                : false,
         "deactivate_full_negative_elements"      : true,
         "recover_original_distance_at_each_step" : false
@@ -65,13 +62,247 @@ DistanceModificationProcess::DistanceModificationProcess(
     rParameters.ValidateAndAssignDefaults(default_parameters);
 
     mFactorCoeff = rParameters["distance_factor"].GetDouble();
+    mDistanceThreshold = rParameters["distance_threshold"].GetDouble();
     mCheckAtEachStep = rParameters["check_at_each_time_step"].GetBool();
     mNegElemDeactivation = rParameters["deactivate_full_negative_elements"].GetBool();
     mRecoverOriginalDistance = rParameters["recover_original_distance_at_each_step"].GetBool();
 }
 
+void DistanceModificationProcess::ExecuteInitialize() {
+
+    KRATOS_TRY;
+
+    // Variables check
+    if( mrModelPart.NodesBegin()->SolutionStepsDataHas( DISTANCE ) == false )
+        KRATOS_ERROR << "Nodes do not have DISTANCE variable!";
+    if( mrModelPart.NodesBegin()->SolutionStepsDataHas( NODAL_H ) == false )
+        KRATOS_ERROR << "Nodes do not have NODAL_H variable!";
+
+    // Obtain NODAL_H values
+    FindNodalHProcess NodalHCalculator(mrModelPart);
+    NodalHCalculator.Execute();
+
+    KRATOS_CATCH("");
+}
+
+void DistanceModificationProcess::ExecuteBeforeSolutionLoop() {
+
+    KRATOS_TRY;
+
+    unsigned int counter = 1;
+    unsigned int bad_cuts = 1;
+
+    // Modify the nodal distance values until there is no bad intersections
+    while (bad_cuts > 0) {
+        bad_cuts = this->ModifyDistance();
+        mDistanceThreshold /= mFactorCoeff;
+        counter++;
+    }
+
+    // If proceeds (depending on the formulation), perform the deactivation
+    // Deactivates the full negative elements and sets values in the full negative elements
+    if (mNegElemDeactivation) {
+        this->DeactivateFullNegativeElements();
+    }
+
+    KRATOS_CATCH("");
+}
+
+void DistanceModificationProcess::ExecuteInitializeSolutionStep() {
+
+    if(mCheckAtEachStep == true) {
+        DistanceModificationProcess::ExecuteBeforeSolutionLoop();
+    }
+}
+
+void DistanceModificationProcess::ExecuteFinalizeSolutionStep() {
+
+    if(mRecoverOriginalDistance == true) {
+        RecoverOriginalDistance();
+    }
+}
+
 /* Protected functions ****************************************************/
 
+unsigned int DistanceModificationProcess::ModifyDistance() {
+
+    ModelPart::NodesContainerType& rNodes = mrModelPart.Nodes();
+    ModelPart::ElementsContainerType& rElements = mrModelPart.Elements();
+
+    // Distance modification
+    // Case in where the original distance does not need to be preserved (e.g. CFD)
+    if (mRecoverOriginalDistance == false) {
+        #pragma omp parallel for
+        for (int k = 0; k < static_cast<int>(rNodes.size()); ++k) {
+            ModelPart::NodesContainerType::iterator itNode = rNodes.begin() + k;
+            const double h = itNode->FastGetSolutionStepValue(NODAL_H);
+            const double tol_d = mDistanceThreshold*h;
+            double& d = itNode->FastGetSolutionStepValue(DISTANCE);
+
+            // Modify the distance to avoid almost empty fluid elements
+            if((d >= 0.0) && (d < tol_d))
+                d = -0.001*tol_d;
+        }
+    }
+    // Case in where the original distance needs to be kept to track the interface (e.g. FSI)
+    else {
+        const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
+        std::vector<std::vector<unsigned int>> AuxModifiedDistancesIDs(NumThreads);
+        std::vector<std::vector<double>> AuxModifiedDistancesValues(NumThreads);
+
+        #pragma omp parallel shared(AuxModifiedDistancesIDs, AuxModifiedDistancesValues)
+        {
+            const int ThreadId = OpenMPUtils::ThisThread();             // Get the thread id
+            std::vector<unsigned int>   LocalModifiedDistancesIDs;      // Local modified distances nodes id vector
+            std::vector<double>      LocalModifiedDistancesValues;      // Local modified distances original values vector
+
+            #pragma omp for
+            for (int k = 0; k < static_cast<int>(rNodes.size()); ++k) {
+                ModelPart::NodesContainerType::iterator itNode = rNodes.begin() + k;
+                const double h = itNode->FastGetSolutionStepValue(NODAL_H);
+                const double tol_d = mDistanceThreshold*h;
+                double& d = itNode->FastGetSolutionStepValue(DISTANCE);
+
+                if((d >= 0.0) && (d < tol_d)) {
+
+                    // Store the original distance to be recovered at the end of the step
+                    LocalModifiedDistancesIDs.push_back(d);
+                    LocalModifiedDistancesValues.push_back(itNode->Id());
+
+                    // Modify the distance to avoid almost empty fluid elements
+                    d = -0.001*tol_d;
+                }
+            }
+
+            AuxModifiedDistancesIDs[ThreadId] = LocalModifiedDistancesIDs;
+            AuxModifiedDistancesValues[ThreadId] = LocalModifiedDistancesValues;
+        }
+
+        mModifiedDistancesIDs = AuxModifiedDistancesIDs;
+        mModifiedDistancesValues = AuxModifiedDistancesValues;
+    }
+
+    // Syncronize data between partitions (the modified distance has always a lower value)
+    mrModelPart.GetCommunicator().SynchronizeCurrentDataToMin(DISTANCE);
+
+    // Check if there still exist bad cuts
+    unsigned int num_bad_cuts = 0;
+    /* Note: I'm defining a temporary variable because 'num_bad_cuts'
+    *  instead of writing directly into input argument 'bad_cuts'
+    *  because using a reference variable in a reduction pragma does
+    *  not compile in MSVC 2015 nor in clang-3.8 (Is it even allowed by omp?)
+    */
+    #pragma omp parallel for reduction(+ : num_bad_cuts)
+    for (int k = 0; k < static_cast<int>(rElements.size()); ++k) {
+        unsigned int npos = 0;
+        unsigned int nneg = 0;
+
+        ModelPart::ElementsContainerType::iterator itElement = rElements.begin() + k;
+        GeometryType& rGeometry = itElement->GetGeometry();
+
+        for (unsigned int iNode=0; iNode<rGeometry.size(); iNode++) {
+            const double d = rGeometry[iNode].FastGetSolutionStepValue(DISTANCE);
+            (d > 0.0) ? npos++ : nneg++;
+        }
+
+        // The element is cut
+        if((nneg > 0) && (npos > 0)) {
+            for(unsigned int iNode=0; iNode<rGeometry.size(); iNode++) {
+                const Node<3> &rConstNode = rGeometry[iNode];
+                const double h = rConstNode.GetValue(NODAL_H);
+                const double tol_d = (mDistanceThreshold*mFactorCoeff)*h;
+                const double d = rConstNode.FastGetSolutionStepValue(DISTANCE);
+
+                if((d >= 0.0) && (d < tol_d)) {
+                    num_bad_cuts++;
+                    break;
+                }
+            }
+        }
+    }
+
+    return num_bad_cuts;
+}
+
+void DistanceModificationProcess::RecoverOriginalDistance() {
+    #pragma omp parallel
+    {
+        const int ThreadId = OpenMPUtils::ThisThread();
+        const std::vector<unsigned int> LocalModifiedDistancesIDs = mModifiedDistancesIDs[ThreadId];
+        const std::vector<double> LocalModifiedDistancesValues = mModifiedDistancesValues[ThreadId];
+
+        for(unsigned int i=0; i<LocalModifiedDistancesIDs.size(); ++i) {
+            const unsigned int nodeId = LocalModifiedDistancesIDs[i];
+            mrModelPart.GetNode(nodeId).FastGetSolutionStepValue(DISTANCE) = LocalModifiedDistancesValues[i];
+        }
+    }
+
+    // Syncronize data between partitions (the modified distance has always a lower value)
+    mrModelPart.GetCommunicator().SynchronizeCurrentDataToMin(DISTANCE);
+
+    // Empty the modified distance vectors
+    mModifiedDistancesIDs.resize(0);
+    mModifiedDistancesValues.resize(0);
+    mModifiedDistancesIDs.shrink_to_fit();
+    mModifiedDistancesValues.shrink_to_fit();
+}
+
+void DistanceModificationProcess::DeactivateFullNegativeElements() {
+
+    ModelPart::NodesContainerType& rNodes = mrModelPart.Nodes();
+    ModelPart::ElementsContainerType& rElements = mrModelPart.Elements();
+
+    // Initialize the ACTIVE flag to false
+    #pragma omp parallel for
+    for (int i_node = 0; i_node < static_cast<int>(rNodes.size()); ++i_node) {
+        ModelPart::NodesContainerType::iterator it_node = rNodes.begin() + i_node;
+        it_node->Set(ACTIVE, false);
+    }
+
+    // Deactivate those elements whose fixed nodes and negative distance nodes summation is equal (or larger) to their number of nodes
+    #pragma omp parallel for
+    for (int k = 0; k < static_cast<int>(rElements.size()); ++k) {
+        unsigned int fixed = 0;
+        unsigned int inside = 0;
+        ModelPart::ElementsContainerType::iterator itElement = rElements.begin() + k;
+        GeometryType& rGeometry = itElement->GetGeometry();
+
+        // Check the distance function sign at the element nodes
+        for (unsigned int i_node=0; i_node<rGeometry.size(); i_node++) {
+            if (rGeometry[i_node].FastGetSolutionStepValue(DISTANCE) < 0.0)
+                inside++;
+            if (rGeometry[i_node].IsFixed(VELOCITY_X) && rGeometry[i_node].IsFixed(VELOCITY_Y) && rGeometry[i_node].IsFixed(VELOCITY_Z))
+                fixed++;
+        }
+
+        (inside+fixed >= rGeometry.size()) ? itElement->Set(ACTIVE, false) : itElement->Set(ACTIVE, true);
+
+        // If the element is ACTIVE, all its nodes are active as well
+        if (itElement->Is(ACTIVE)) {
+            for (unsigned int i_node = 0; i_node < rGeometry.size(); ++i_node) {
+                rGeometry[i_node].Set(ACTIVE, true);
+            }
+        }
+    }
+
+    // Set to zero and fix the DOFs in the remaining INACTIVE nodes
+    #pragma omp parallel for
+    for (int i_node = 0; i_node < static_cast<int>(rNodes.size()); ++i_node) {
+
+        ModelPart::NodesContainerType::iterator it_node = rNodes.begin() + i_node;
+
+        if (it_node->IsNot(ACTIVE)) {
+            // Fix the nodal DOFs
+            it_node->Fix(PRESSURE);
+            it_node->Fix(VELOCITY_X);
+            it_node->Fix(VELOCITY_Y);
+            it_node->Fix(VELOCITY_Z);
+            // Set to zero the nodal DOFs
+            it_node->FastGetSolutionStepValue(PRESSURE) = 0.0;
+            it_node->FastGetSolutionStepValue(VELOCITY) = ZeroVector(3);
+        }
+    }
+}
 
 /* Private functions ****************************************************/
 

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -21,7 +21,7 @@
 // External includes
 
 // Project includes
-// #include "includes/define.h"
+#include "includes/define.h"
 #include "processes/process.h"
 #include "includes/cfd_variables.h"
 #include "processes/find_nodal_h_process.h"
@@ -78,40 +78,15 @@ public:
         ModelPart& rModelPart, 
         const bool CheckAtEachStep, 
         const bool NegElemDeactivation,
-        const bool RecoverOriginalDistance)
-        : Process(), mrModelPart(rModelPart) {
+        const bool RecoverOriginalDistance);
 
-        mFactorCoeff = 2.0;
-        mCheckAtEachStep = CheckAtEachStep;
-        mNegElemDeactivation = NegElemDeactivation;
-        mRecoverOriginalDistance = RecoverOriginalDistance;
-    }
-
+    /// Constructor with Kratos parameters.
     DistanceModificationProcess(
         ModelPart& rModelPart,
-        Parameters& rParameters)
-        : Process(), mrModelPart(rModelPart) {
-
-        Parameters default_parameters( R"(
-        {
-            "mesh_id"                                : 0,
-            "model_part_name"                        : "default_model_part_name",
-            "distance_factor"                        : 2.0,
-            "check_at_each_time_step"                : false,
-            "deactivate_full_negative_elements"      : true,
-            "recover_original_distance_at_each_step" : false
-        }  )" );
-
-        rParameters.ValidateAndAssignDefaults(default_parameters);
-
-        mFactorCoeff = rParameters["distance_factor"].GetDouble();
-        mCheckAtEachStep = rParameters["check_at_each_time_step"].GetBool();
-        mNegElemDeactivation = rParameters["deactivate_full_negative_elements"].GetBool();
-        mRecoverOriginalDistance = rParameters["recover_original_distance_at_each_step"].GetBool();
-    }
+        Parameters& rParameters);
 
     /// Destructor.
-    ~DistanceModificationProcess() override{}
+    ~DistanceModificationProcess() override {}
 
     ///@}
     ///@name Operators

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -23,9 +23,6 @@
 // Project includes
 #include "includes/define.h"
 #include "processes/process.h"
-#include "includes/cfd_variables.h"
-#include "processes/find_nodal_h_process.h"
-#include "utilities/openmp_utils.h"
 #include "includes/kratos_parameters.h"
 
 // Application includes
@@ -76,6 +73,8 @@ public:
     /// Constructor.
     DistanceModificationProcess(
         ModelPart& rModelPart, 
+        const double FactorCoeff,
+        const double DistanceThreshold,
         const bool CheckAtEachStep, 
         const bool NegElemDeactivation,
         const bool RecoverOriginalDistance);
@@ -100,58 +99,16 @@ public:
     ///@name Access
     ///@{
 
-    void ExecuteInitialize() override
-    {
-        KRATOS_TRY;
-
-        // Obtain NODAL_H values
-        FindNodalHProcess NodalHCalculator(mrModelPart);
-        NodalHCalculator.Execute();
-
-        KRATOS_CATCH("");
-    }
+    void ExecuteInitialize() override;
 
 
-    void ExecuteBeforeSolutionLoop() override
-    {
-        KRATOS_TRY;
-
-        unsigned int counter = 1;
-        unsigned int bad_cuts = 1;
-        double factor = 0.01;
-
-        // Modify the nodal distance values until there is no bad intersections
-        while (bad_cuts > 0)
-        {
-            this->ModifyDistance(factor, bad_cuts);
-            factor /= mFactorCoeff;
-            counter++;
-        }
-
-        if (mNegElemDeactivation) {
-            this->DeactivateFullNegativeElements();
-        }
-
-        KRATOS_CATCH("");
-    }
+    void ExecuteBeforeSolutionLoop() override;
 
 
-    void ExecuteInitializeSolutionStep() override
-    {
-        if(mCheckAtEachStep == true)
-        {
-            ExecuteBeforeSolutionLoop();
-        }
-    }
+    void ExecuteInitializeSolutionStep() override;
 
 
-    void ExecuteFinalizeSolutionStep() override
-    {
-        if(mRecoverOriginalDistance == true)
-        {
-            RecoverOriginalDistance();
-        }
-    }
+    void ExecuteFinalizeSolutionStep() override;
 
     ///@}
     ///@name Inquiry
@@ -175,253 +132,9 @@ public:
     /// Print object's data.
     void PrintData(std::ostream& rOStream) const override {}
 
-
     ///@}
     ///@name Friends
     ///@{
-
-
-    ///@}
-
-protected:
-    ///@name Protected static Member Variables
-    ///@{
-
-    ///@}
-    ///@name Protected member Variables
-    ///@{
-
-    ModelPart&                                              mrModelPart;
-    double                                                 mFactorCoeff;
-    bool                                               mCheckAtEachStep;
-    bool                                           mNegElemDeactivation;
-    bool                                       mRecoverOriginalDistance;
-    std::vector<std::vector<unsigned int>>        mModifiedDistancesIDs;
-    std::vector<std::vector<double>>           mModifiedDistancesValues;
-
-    ///@}
-    ///@name Protected Operators
-    ///@{
-
-    void ModifyDistance(const double& factor,
-                        unsigned int& bad_cuts)
-    {
-        ModelPart::NodesContainerType& rNodes = mrModelPart.Nodes();
-        ModelPart::ElementsContainerType& rElements = mrModelPart.Elements();
-
-        // Simple check
-        if( mrModelPart.NodesBegin()->SolutionStepsDataHas( DISTANCE ) == false )
-            KRATOS_ERROR << "Nodes do not have DISTANCE variable!";
-        if( mrModelPart.NodesBegin()->SolutionStepsDataHas( NODAL_H ) == false )
-            KRATOS_ERROR << "Nodes do not have NODAL_H variable!";
-
-        // Distance modification
-        if (mRecoverOriginalDistance == false) // Case in where the original distance does not need to be preserved (e.g. CFD)
-        {
-            #pragma omp parallel for
-            for (int k = 0; k < static_cast<int>(rNodes.size()); ++k)
-            {
-                ModelPart::NodesContainerType::iterator itNode = rNodes.begin() + k;
-                const double h = itNode->FastGetSolutionStepValue(NODAL_H);
-                const double tol_d = factor*h;
-                double& d = itNode->FastGetSolutionStepValue(DISTANCE);
-
-                // Modify the distance to avoid almost empty fluid elements
-                if((d >= 0.0) && (d < tol_d))
-                    d = -0.001*tol_d;
-            }
-        }
-        else // Case in where the original distance needs to be kept to track the interface (e.g. FSI)
-        {
-            const unsigned int NumThreads = OpenMPUtils::GetNumThreads();
-            std::vector<std::vector<unsigned int>> AuxModifiedDistancesIDs(NumThreads);
-            std::vector<std::vector<double>> AuxModifiedDistancesValues(NumThreads);
-
-            #pragma omp parallel shared(AuxModifiedDistancesIDs, AuxModifiedDistancesValues)
-            {
-                const int ThreadId = OpenMPUtils::ThisThread();             // Get the thread id
-                std::vector<unsigned int>   LocalModifiedDistancesIDs;      // Local modified distances nodes id vector
-                std::vector<double>      LocalModifiedDistancesValues;      // Local modified distances original values vector
-
-                #pragma omp for
-                for (int k = 0; k < static_cast<int>(rNodes.size()); ++k)
-                {
-                    ModelPart::NodesContainerType::iterator itNode = rNodes.begin() + k;
-                    const double h = itNode->FastGetSolutionStepValue(NODAL_H);
-                    const double tol_d = factor*h;
-                    double& d = itNode->FastGetSolutionStepValue(DISTANCE);
-
-                    if((d >= 0.0) && (d < tol_d))
-                    {
-                        // Store the original distance to be recovered at the end of the step
-                        LocalModifiedDistancesIDs.push_back(d);
-                        LocalModifiedDistancesValues.push_back(itNode->Id());
-
-                        // Modify the distance to avoid almost empty fluid elements
-                        d = -0.001*tol_d;
-                    }
-                }
-
-                AuxModifiedDistancesIDs[ThreadId] = LocalModifiedDistancesIDs;
-                AuxModifiedDistancesValues[ThreadId] = LocalModifiedDistancesValues;
-            }
-
-            mModifiedDistancesIDs = AuxModifiedDistancesIDs;
-            mModifiedDistancesValues = AuxModifiedDistancesValues;
-        }
-
-        // Syncronize data between partitions (the modified distance has always a lower value)
-        mrModelPart.GetCommunicator().SynchronizeCurrentDataToMin(DISTANCE);
-
-        // Check if there still exist bad cuts
-        unsigned int num_bad_cuts = 0;
-        /* Note: I'm defining a temporary variable because 'num_bad_cuts'
-        *  instead of writing directly into input argument 'bad_cuts'
-        *  because using a reference variable in a reduction pragma does
-        *  not compile in MSVC 2015 nor in clang-3.8 (Is it even allowed by omp?)
-        */
-        #pragma omp parallel for reduction(+ : num_bad_cuts)
-        for (int k = 0; k < static_cast<int>(rElements.size()); ++k)
-        {
-            unsigned int npos = 0;
-            unsigned int nneg = 0;
-
-            ModelPart::ElementsContainerType::iterator itElement = rElements.begin() + k;
-            GeometryType& rGeometry = itElement->GetGeometry();
-
-            for (unsigned int iNode=0; iNode<rGeometry.size(); iNode++)
-            {
-                const double d = rGeometry[iNode].FastGetSolutionStepValue(DISTANCE);
-                (d > 0.0) ? npos++ : nneg++;
-            }
-
-            if((nneg > 0) && (npos > 0)) // The element is cut
-            {
-                for(unsigned int iNode=0; iNode<rGeometry.size(); iNode++)
-                {
-                    const Node<3> &rConstNode = rGeometry[iNode];
-                    const double h = rConstNode.GetValue(NODAL_H);
-                    const double tol_d = (factor*mFactorCoeff)*h;
-                    const double d = rConstNode.FastGetSolutionStepValue(DISTANCE);
-
-                    if((d >= 0.0) && (d < tol_d))
-                    {
-                        num_bad_cuts++;
-                        break;
-                    }
-                }
-            }
-        }
-
-        bad_cuts = num_bad_cuts;
-    }
-
-
-    void RecoverOriginalDistance()
-    {
-        #pragma omp parallel
-        {
-            const int ThreadId = OpenMPUtils::ThisThread();
-            const std::vector<unsigned int> LocalModifiedDistancesIDs = mModifiedDistancesIDs[ThreadId];
-            const std::vector<double> LocalModifiedDistancesValues = mModifiedDistancesValues[ThreadId];
-
-            for(unsigned int i=0; i<LocalModifiedDistancesIDs.size(); ++i)
-            {
-                const unsigned int nodeId = LocalModifiedDistancesIDs[i];
-                mrModelPart.GetNode(nodeId).FastGetSolutionStepValue(DISTANCE) = LocalModifiedDistancesValues[i];
-            }
-        }
-
-        // Syncronize data between partitions (the modified distance has always a lower value)
-        mrModelPart.GetCommunicator().SynchronizeCurrentDataToMin(DISTANCE);
-
-        // Empty the modified distance vectors
-        mModifiedDistancesIDs.resize(0);
-        mModifiedDistancesValues.resize(0);
-        mModifiedDistancesIDs.shrink_to_fit();
-        mModifiedDistancesValues.shrink_to_fit();
-
-    }
-
-
-    void DeactivateFullNegativeElements()
-    {
-        ModelPart::NodesContainerType& rNodes = mrModelPart.Nodes();
-        ModelPart::ElementsContainerType& rElements = mrModelPart.Elements();
-
-        // Initialize the ACTIVE flag to false
-        #pragma omp parallel for
-        for (int i_node = 0; i_node < static_cast<int>(rNodes.size()); ++i_node) {
-            ModelPart::NodesContainerType::iterator it_node = rNodes.begin() + i_node;
-            it_node->Set(ACTIVE, false);
-        }
-
-        // Deactivate those elements whose fixed nodes and negative distance nodes summation is equal (or larger) to their number of nodes
-        #pragma omp parallel for
-        for (int k = 0; k < static_cast<int>(rElements.size()); ++k)
-        {
-            unsigned int fixed = 0;
-            unsigned int inside = 0;
-            ModelPart::ElementsContainerType::iterator itElement = rElements.begin() + k;
-            GeometryType& rGeometry = itElement->GetGeometry();
-
-            // Check the distance function sign at the element nodes
-            for (unsigned int i_node=0; i_node<rGeometry.size(); i_node++)
-            {
-                if (rGeometry[i_node].FastGetSolutionStepValue(DISTANCE) < 0.0)
-                    inside++;
-                if (rGeometry[i_node].IsFixed(VELOCITY_X) && rGeometry[i_node].IsFixed(VELOCITY_Y) && rGeometry[i_node].IsFixed(VELOCITY_Z))
-                    fixed++;
-            }
-
-            (inside+fixed >= rGeometry.size()) ? itElement->Set(ACTIVE, false) : itElement->Set(ACTIVE, true);
-
-            // If the element is ACTIVE, all its nodes are active as well
-            if (itElement->Is(ACTIVE)) {
-                for (unsigned int i_node = 0; i_node < rGeometry.size(); ++i_node) {
-                    rGeometry[i_node].Set(ACTIVE, true);
-                }
-            }
-        }
-
-        // Set to zero and fix the DOFs in the remaining INACTIVE nodes
-        #pragma omp parallel for
-        for (int i_node = 0; i_node < static_cast<int>(rNodes.size()); ++i_node) {
-
-            ModelPart::NodesContainerType::iterator it_node = rNodes.begin() + i_node;
-
-            if (it_node->IsNot(ACTIVE)) {
-                // Fix the nodal DOFs
-                it_node->Fix(PRESSURE);
-                it_node->Fix(VELOCITY_X);
-                it_node->Fix(VELOCITY_Y);
-                it_node->Fix(VELOCITY_Z);
-                // Set to zero the nodal DOFs
-                it_node->FastGetSolutionStepValue(PRESSURE) = 0.0;
-                it_node->FastGetSolutionStepValue(VELOCITY) = ZeroVector(3);
-            }
-        }
-    }
-
-    ///@}
-    ///@name Protected Operations
-    ///@{
-
-
-    ///@}
-    ///@name Protected  Access
-    ///@{
-
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-
 
     ///@}
 
@@ -434,16 +147,28 @@ private:
     ///@name Member Variables
     ///@{
 
+    ModelPart&                                              mrModelPart;
+    double                                                 mFactorCoeff;
+    double                                           mDistanceThreshold;
+    bool                                               mCheckAtEachStep;
+    bool                                           mNegElemDeactivation;
+    bool                                       mRecoverOriginalDistance;
+    std::vector<std::vector<unsigned int>>        mModifiedDistancesIDs;
+    std::vector<std::vector<double>>           mModifiedDistancesValues;
 
     ///@}
-    ///@name Private Operators
+    ///@name Protected Operators
     ///@{
-
 
     ///@}
     ///@name Private Operations
     ///@{
 
+    unsigned int ModifyDistance();
+
+    void RecoverOriginalDistance();
+
+    void DeactivateFullNegativeElements();
 
     ///@}
     ///@name Private  Access
@@ -467,7 +192,6 @@ private:
 
     /// Copy constructor.
     DistanceModificationProcess(DistanceModificationProcess const& rOther) = delete;
-
 
     ///@}
 

--- a/applications/FluidDynamicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/FluidDynamicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -73,7 +73,7 @@ void AddCustomProcessesToPython()
     ;
 
     class_< DistanceModificationProcess, bases<Process>, boost::noncopyable >
-    ("DistanceModificationProcess",init < ModelPart&, const bool, const bool, const bool >())
+    ("DistanceModificationProcess",init < ModelPart&, const double, const double, const bool, const bool, const bool >())
     .def(init< ModelPart&, Parameters& >())
     ;
 

--- a/applications/FluidDynamicsApplication/python_scripts/apply_distance_modification_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_distance_modification_process.py
@@ -15,7 +15,6 @@ class ApplyDistanceModificationProcess(KratosMultiphysics.Process):
 
         default_parameters = KratosMultiphysics.Parameters( """
         {
-            "mesh_id"                                : 0,
             "model_part_name"                        : "CHOOSE_FLUID_MODELPART_NAME",
             "distance_factor"                        : 2.0,
             "distance_threshold"                     : 0.01,

--- a/applications/FluidDynamicsApplication/python_scripts/apply_distance_modification_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_distance_modification_process.py
@@ -15,11 +15,13 @@ class ApplyDistanceModificationProcess(KratosMultiphysics.Process):
 
         default_parameters = KratosMultiphysics.Parameters( """
         {
-            "mesh_id"                                   : 0,
-            "model_part_name"                           : "CHOOSE_FLUID_MODELPART_NAME",
-            "check_at_each_time_step"                   : false,
-            "deactivate_full_negative_elements"         : true,
-            "recover_original_distance_at_each_step"    : false
+            "mesh_id"                                : 0,
+            "model_part_name"                        : "CHOOSE_FLUID_MODELPART_NAME",
+            "distance_factor"                        : 2.0,
+            "distance_threshold"                     : 0.01,
+            "check_at_each_time_step"                : false,
+            "deactivate_full_negative_elements"      : true,
+            "recover_original_distance_at_each_step" : false
         }  """ )
 
         settings.ValidateAndAssignDefaults(default_parameters);

--- a/applications/FluidDynamicsApplication/tests/EmbeddedAusasCouette3DTest/EmbeddedAusasCouette3DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedAusasCouette3DTest/EmbeddedAusasCouette3DTestParameters.json
@@ -111,7 +111,6 @@
         "kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
         "process_name"  : "ApplyDistanceModificationProcess",
         "Parameters"    : {
-            "mesh_id"                           : 0,
             "model_part_name"                   : "Parts_Fluid",
             "check_at_each_time_step"           : false,
             "deactivate_full_negative_elements" : false


### PR DESCRIPTION
Now the "full" negative nodes (those that do not belong to a split element) are deactivated and their velocity and pressure values are set to zero.

I took the change to separate the process in a header and a source file. Besides I add the possibility of setting the distance "bad cut" settings in the ProjectParameters.json.