### PR TITLE
Fix local point coordinate

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -906,35 +906,24 @@ public:
 
         unsigned int maxiter = 1000;
 
-        if(LocalSpaceDimension() == 2) {
-            for ( unsigned int k = 0; k < maxiter; k++ ) {
-                CurrentGlobalCoords = ZeroVector( 3 );
-                GlobalCoordinates( CurrentGlobalCoords, rResult );
-                noalias( CurrentGlobalCoords ) = rPoint - CurrentGlobalCoords;
-                InverseOfJacobian( J, rResult );
-                DeltaXi[0] = J(0,0) * CurrentGlobalCoords(0) + J(0,1) * CurrentGlobalCoords(1);
-                DeltaXi[1] = J(1,0) * CurrentGlobalCoords(0) + J(1,1) * CurrentGlobalCoords(1);
-                noalias( rResult ) += DeltaXi;
-
-                if ( norm_2( DeltaXi ) > 30 || norm_2( DeltaXi ) < tol ) {
-                    break;
+        for(unsigned int k = 0; k < maxiter; k++) {
+            CurrentGlobalCoords = ZeroVector( 3 );
+            GlobalCoordinates( CurrentGlobalCoords, rResult );
+            noalias( CurrentGlobalCoords ) = rPoint - CurrentGlobalCoords;
+            InverseOfJacobian( J, rResult );
+            DeltaXi.clear();
+            for(unsigned int i=0; i<WorkingSpaceDimension(); ++i) {
+                for(unsigned int j=0; k<WorkingSpaceDimension(); ++j) {
+                    DeltaXi[i] += J(i,j)*CurrentGlobalCoords[j];
                 }
             }
-        } else if(LocalSpaceDimension() == 3) {
-            for ( unsigned int k = 0; k < maxiter; k++ ) {
-                CurrentGlobalCoords = ZeroVector( 3 );
-                GlobalCoordinates( CurrentGlobalCoords, rResult );
-                noalias( CurrentGlobalCoords ) = rPoint - CurrentGlobalCoords;
-                InverseOfJacobian( J, rResult );
-                noalias( DeltaXi ) = prod( J, CurrentGlobalCoords );
-                noalias( rResult ) += DeltaXi;
+            noalias( rResult ) += DeltaXi;
 
-                if ( norm_2( DeltaXi ) > 30 || norm_2( DeltaXi ) < tol ) {
-                    break;
-                }
+            if(norm_2( DeltaXi ) > 30 || norm_2( DeltaXi ) < tol) {
+                break;
             }
         }
-
+        
         return rResult;
     }
 

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -920,9 +920,7 @@ public:
                     break;
                 }
             }
-        }
-
-        if(LocalSpaceDimension() == 3) {
+        } else if(LocalSpaceDimension() == 3) {
             for ( unsigned int k = 0; k < maxiter; k++ ) {
                 CurrentGlobalCoords = ZeroVector( 3 );
                 GlobalCoordinates( CurrentGlobalCoords, rResult );

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -907,13 +907,13 @@ public:
         unsigned int maxiter = 1000;
 
         for(unsigned int k = 0; k < maxiter; k++) {
-            CurrentGlobalCoords = ZeroVector( 3 );
+            CurrentGlobalCoords.clear();
             GlobalCoordinates( CurrentGlobalCoords, rResult );
             noalias( CurrentGlobalCoords ) = rPoint - CurrentGlobalCoords;
             InverseOfJacobian( J, rResult );
             DeltaXi.clear();
-            for(unsigned int i=0; i<WorkingSpaceDimension(); ++i) {
-                for(unsigned int j=0; k<WorkingSpaceDimension(); ++j) {
+            for(unsigned int i = 0; i < WorkingSpaceDimension(); i++) {
+                for(unsigned int j = 0; k < WorkingSpaceDimension(); j++) {
                     DeltaXi[i] += J(i,j)*CurrentGlobalCoords[j];
                 }
             }

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -903,23 +903,25 @@ public:
 
         //Newton iteration:
         const double tol = 1.0e-8;
-
         unsigned int maxiter = 1000;
 
         for(unsigned int k = 0; k < maxiter; k++) {
             CurrentGlobalCoords.clear();
+            DeltaXi.clear();
+
             GlobalCoordinates( CurrentGlobalCoords, rResult );
             noalias( CurrentGlobalCoords ) = rPoint - CurrentGlobalCoords;
             InverseOfJacobian( J, rResult );
-            DeltaXi.clear();
             for(unsigned int i = 0; i < WorkingSpaceDimension(); i++) {
-                for(unsigned int j = 0; k < WorkingSpaceDimension(); j++) {
+                for(unsigned int j = 0; j < WorkingSpaceDimension(); j++) {
                     DeltaXi[i] += J(i,j)*CurrentGlobalCoords[j];
                 }
             }
             noalias( rResult ) += DeltaXi;
 
-            if(norm_2( DeltaXi ) > 30 || norm_2( DeltaXi ) < tol) {
+            auto norm2DXi = norm_2(DeltaXi);
+
+            if(norm2DXi > 30 || norm2DXi < tol) {
                 break;
             }
         }

--- a/kratos/tests/geometries/test_geometry.cpp
+++ b/kratos/tests/geometries/test_geometry.cpp
@@ -22,7 +22,7 @@
 #include "tests/geometries/test_geometry.h"
 
 namespace Kratos {
-	namespace Testing {
+namespace Testing {
 
     /// Auxiliar check functions (from geometry_tester.h)
     /// - All this functions should probably me moved somewhere else.
@@ -370,5 +370,5 @@ namespace Kratos {
       }
     }
 
-	}
-}  // namespace Kratos.
+} // namespace Testing.
+} // namespace Kratos.

--- a/kratos/tests/geometries/test_quadrilateral_2d_4.cpp
+++ b/kratos/tests/geometries/test_quadrilateral_2d_4.cpp
@@ -142,13 +142,15 @@ namespace Testing
         geom->PointLocalCoordinates(TestResultA, TestPointA);
         geom->PointLocalCoordinates(TestResultB, TestPointB);
 
-        KRATOS_CHECK_EQUAL(1.0, TestResultA[0]);
-        KRATOS_CHECK_EQUAL(1.0, TestResultA[1]);
-        KRATOS_CHECK_EQUAL(0.0, TestResultA[2]);
+        // Test transformation in the edge
+        KRATOS_CHECK_NEAR(TestResultA[0], 1.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(TestResultA[1], 1.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(TestResultA[2], 1.0, TOLERANCE);
 
-        KRATOS_CHECK_EQUAL(0.0, TestResultB[0]);
-        KRATOS_CHECK_EQUAL(0.0, TestResultB[1]);
-        KRATOS_CHECK_EQUAL(0.0, TestResultB[2]);
+        // Test transformation in the center
+        KRATOS_CHECK_NEAR(TestResultB[0], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(TestResultB[1], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(TestResultB[2], 0.0, TOLERANCE);
     }
 
 } // namespace Testing

--- a/kratos/tests/geometries/test_quadrilateral_2d_4.cpp
+++ b/kratos/tests/geometries/test_quadrilateral_2d_4.cpp
@@ -60,8 +60,8 @@ namespace Testing
       return typename Quadrilateral2D4<TPointType>::Pointer(new Quadrilateral2D4<TPointType>(
         GeneratePoint<TPointType>( 0.0, 0.0, 0.0),
         GeneratePoint<TPointType>( 1.0, 0.0, 0.0),
-        GeneratePoint<TPointType>( 1.1, 1.1, 0.0),
-        GeneratePoint<TPointType>( 0.0, 1.1, 0.0)
+        GeneratePoint<TPointType>( 1.0, 1.0, 0.0),
+        GeneratePoint<TPointType>( 0.0, 1.0, 0.0)
       ));
     }
 
@@ -133,10 +133,22 @@ namespace Testing
      */
     KRATOS_TEST_CASE_IN_SUITE(Quadrilateral2D4PointLocalCoordinates, KratosCoreGeometriesFastSuite) {
         auto geom = GenerateRightQuadrilateral2D4<Node<3>>();
-        Point TestPoint(1.0, 1.0, 0.0);
-        Point TestResult(0.0, 0.0, 0.0); 
-        geom->PointLocalCoordinates(TestResult, TestPoint);
-        std::cout << TestResult[0] << " " << TestResult[1] << " " << TestResult[2] << std::endl;
+
+        Point TestPointA(1.0, 1.0, 0.0);
+        Point TestPointB(0.5, 0.5, 0.0);
+        Point TestResultA(0.0, 0.0, 0.0);
+        Point TestResultB(0.0, 0.0, 0.0);
+
+        geom->PointLocalCoordinates(TestResultA, TestPointA);
+        geom->PointLocalCoordinates(TestResultB, TestPointB);
+
+        KRATOS_CHECK_EQUAL(1.0, TestResultA[0]);
+        KRATOS_CHECK_EQUAL(1.0, TestResultA[1]);
+        KRATOS_CHECK_EQUAL(0.0, TestResultA[2]);
+
+        KRATOS_CHECK_EQUAL(0.0, TestResultB[0]);
+        KRATOS_CHECK_EQUAL(0.0, TestResultB[1]);
+        KRATOS_CHECK_EQUAL(0.0, TestResultB[2]);
     }
 
 } // namespace Testing

--- a/kratos/tests/geometries/test_quadrilateral_2d_4.cpp
+++ b/kratos/tests/geometries/test_quadrilateral_2d_4.cpp
@@ -145,7 +145,7 @@ namespace Testing
         // Test transformation in the edge
         KRATOS_CHECK_NEAR(TestResultA[0], 1.0, TOLERANCE);
         KRATOS_CHECK_NEAR(TestResultA[1], 1.0, TOLERANCE);
-        KRATOS_CHECK_NEAR(TestResultA[2], 1.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(TestResultA[2], 0.0, TOLERANCE);
 
         // Test transformation in the center
         KRATOS_CHECK_NEAR(TestResultB[0], 0.0, TOLERANCE);

--- a/kratos/tests/geometries/test_quadrilateral_2d_4.cpp
+++ b/kratos/tests/geometries/test_quadrilateral_2d_4.cpp
@@ -128,5 +128,16 @@ namespace Testing
         KRATOS_CHECK_IS_FALSE(geom->HasIntersection(point_1, point_2));
     }
 
+    /** Tests the PointLocalCoordinates for Quadrilateral2D4.
+     * Tests the PointLocalCoordinates for Quadrilateral2D4.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Quadrilateral2D4PointLocalCoordinates, KratosCoreGeometriesFastSuite) {
+        auto geom = GenerateRightQuadrilateral2D4<Node<3>>();
+        Point TestPoint(1.0, 1.0, 0.0);
+        Point TestResult(0.0, 0.0, 0.0); 
+        geom->PointLocalCoordinates(TestResult, TestPoint);
+        std::cout << TestResult[0] << " " << TestResult[1] << " " << TestResult[2] << std::endl;
+    }
+
 } // namespace Testing
 } // namespace Kratos

--- a/kratos/tests/geometries/test_quadrilateral_3d_4.cpp
+++ b/kratos/tests/geometries/test_quadrilateral_3d_4.cpp
@@ -127,13 +127,15 @@ namespace Testing
         geom->PointLocalCoordinates(TestResultA, TestPointA);
         geom->PointLocalCoordinates(TestResultB, TestPointB);
 
-        KRATOS_CHECK_EQUAL(1.0, TestResultA[0]);
-        KRATOS_CHECK_EQUAL(1.0, TestResultA[1]);
-        KRATOS_CHECK_EQUAL(0.0, TestResultA[2]);
+        // Test transformation in the edge
+        KRATOS_CHECK_NEAR(TestResultA[0], 1.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(TestResultA[1], 1.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(TestResultA[2], 0.0, TOLERANCE);
 
-        KRATOS_CHECK_EQUAL(0.0, TestResultB[0]);
-        KRATOS_CHECK_EQUAL(0.0, TestResultB[1]);
-        KRATOS_CHECK_EQUAL(0.0, TestResultB[2]);
+        // Test transformation in the center
+        KRATOS_CHECK_NEAR(TestResultB[0], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(TestResultB[1], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(TestResultB[2], 0.0, TOLERANCE);
     }
 
 //     /** Checks if the volume of the quadrilateral is calculated correctly.

--- a/kratos/tests/geometries/test_quadrilateral_3d_4.cpp
+++ b/kratos/tests/geometries/test_quadrilateral_3d_4.cpp
@@ -64,6 +64,21 @@ namespace Testing
         ));
     }
 
+    /** Generates a sample Quadrilateral3D4.
+    * Generates a right quadrilateral with origin in the origin and leg size 1.
+    * @return  Pointer to a Quadrilateral3D4
+    */
+    template<class TPointType>
+    typename Quadrilateral3D4<TPointType>::Pointer GenerateFlatQuadrilateral3D4() 
+    {
+        return typename Quadrilateral3D4<TPointType>::Pointer(new Quadrilateral3D4<TPointType>(
+        GeneratePoint<TPointType>( 0.0, 0.0, 0.0),
+        GeneratePoint<TPointType>( 1.0, 0.0, 0.0),
+        GeneratePoint<TPointType>( 1.1, 1.1, 0.0),
+        GeneratePoint<TPointType>( 0.0, 1.1, 0.0)
+        ));
+    }
+
     /// Tests
 
     /** Checks if the number of edges is correct.
@@ -96,6 +111,17 @@ namespace Testing
         
         KRATOS_CHECK_NEAR(geom->Area(), 1.06947235, TOLERANCE);
 //         KRATOS_CHECK_NEAR(geom->Area(), 1.08935, TOLERANCE); // NOTE: Solution from Mathematica
+    }
+
+    /** Tests the PointLocalCoordinates for Quadrilateral2D4.
+     * Tests the PointLocalCoordinates for Quadrilateral2D4.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(Quadrilateral3D4PointLocalCoordinates, KratosCoreGeometriesFastSuite) {
+        auto geom = GenerateFlatQuadrilateral3D4<Node<3>>();
+        Point TestPoint(1.0, 1.0, 0.0);
+        Point TestResult(0.0, 0.0, 0.0); 
+        geom->PointLocalCoordinates(TestResult, TestPoint);
+        std::cout << TestResult[0] << " " << TestResult[1] << " " << TestResult[2] << std::endl;
     }
 
 //     /** Checks if the volume of the quadrilateral is calculated correctly.

--- a/kratos/tests/geometries/test_quadrilateral_3d_4.cpp
+++ b/kratos/tests/geometries/test_quadrilateral_3d_4.cpp
@@ -74,8 +74,8 @@ namespace Testing
         return typename Quadrilateral3D4<TPointType>::Pointer(new Quadrilateral3D4<TPointType>(
         GeneratePoint<TPointType>( 0.0, 0.0, 0.0),
         GeneratePoint<TPointType>( 1.0, 0.0, 0.0),
-        GeneratePoint<TPointType>( 1.1, 1.1, 0.0),
-        GeneratePoint<TPointType>( 0.0, 1.1, 0.0)
+        GeneratePoint<TPointType>( 1.0, 1.0, 0.0),
+        GeneratePoint<TPointType>( 0.0, 1.0, 0.0)
         ));
     }
 
@@ -118,10 +118,22 @@ namespace Testing
      */
     KRATOS_TEST_CASE_IN_SUITE(Quadrilateral3D4PointLocalCoordinates, KratosCoreGeometriesFastSuite) {
         auto geom = GenerateFlatQuadrilateral3D4<Node<3>>();
-        Point TestPoint(1.0, 1.0, 0.0);
-        Point TestResult(0.0, 0.0, 0.0); 
-        geom->PointLocalCoordinates(TestResult, TestPoint);
-        std::cout << TestResult[0] << " " << TestResult[1] << " " << TestResult[2] << std::endl;
+
+        Point TestPointA(1.0, 1.0, 0.0);
+        Point TestPointB(0.5, 0.5, 0.0);
+        Point TestResultA(0.0, 0.0, 0.0);
+        Point TestResultB(0.0, 0.0, 0.0);
+
+        geom->PointLocalCoordinates(TestResultA, TestPointA);
+        geom->PointLocalCoordinates(TestResultB, TestPointB);
+
+        KRATOS_CHECK_EQUAL(1.0, TestResultA[0]);
+        KRATOS_CHECK_EQUAL(1.0, TestResultA[1]);
+        KRATOS_CHECK_EQUAL(0.0, TestResultA[2]);
+
+        KRATOS_CHECK_EQUAL(0.0, TestResultB[0]);
+        KRATOS_CHECK_EQUAL(0.0, TestResultB[1]);
+        KRATOS_CHECK_EQUAL(0.0, TestResultB[2]);
     }
 
 //     /** Checks if the volume of the quadrilateral is calculated correctly.

--- a/kratos/tests/geometries/test_triangle_3d_3.cpp
+++ b/kratos/tests/geometries/test_triangle_3d_3.cpp
@@ -110,7 +110,7 @@ namespace Testing
     auto geom = GenerateRightTriangle3D3<Node<3>>();
 
     KRATOS_CHECK_EXCEPTION_IS_THROWN(geom->Volume(), "Calling base class 'Volume' method instead of derived class one.");
-	}
+  }
 
   /** Checks if the minimum edge length is calculated correctly.
    * Checks if the minimum edge length is calculated correctly.


### PR DESCRIPTION
This fixes #987

This is an incomplete PR and needs:
- [ ] Add checks to the tests

In general the code is fixed and it does not break for 2D anymore. Also corrected an error that was making recursive stack trace if the base geometry chrased.

Honestly I don't understand what the code does so I cannot check if the results are correct or not. But I would expect that the quadrilateral defined by the points: `(0,0)(1,0)(0,1)(1,1)` and the global coordinate `(1,1)` would result into `(1,1)` as local coordinates. But the result is `(0.833333 0.818182)`. At least I would expect both coordinates to be the same...

If this is Ok, or someone gives me an example with the expected results I'll finish the missing checks and we can merge.