### PR TITLE
removing unneeded virtual public from convergence criterias

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictional_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictional_mortar_criteria.h
@@ -49,7 +49,8 @@ namespace Kratos
 /** @brief Custom convergence criteria for the mortar condition 
  */
 template<class TSparseSpace, class TDenseSpace>
-class ALMFrictionalMortarConvergenceCriteria : public virtual  BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >
+class ALMFrictionalMortarConvergenceCriteria 
+    : public  BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictionless_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictionless_mortar_criteria.h
@@ -49,7 +49,8 @@ namespace Kratos
 /** @brief Custom convergence criteria for the mortar condition 
  */
 template<class TSparseSpace, class TDenseSpace>
-class ALMFrictionlessMortarConvergenceCriteria : public virtual  BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >
+class ALMFrictionlessMortarConvergenceCriteria 
+    : public  BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/base_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/base_mortar_criteria.h
@@ -49,7 +49,8 @@ namespace Kratos
 /** @brief Custom convergence criteria for the mortar condition 
  */
 template<class TSparseSpace, class TDenseSpace>
-class BaseMortarConvergenceCriteria : public virtual  ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class BaseMortarConvergenceCriteria 
+    : public  ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/mesh_tying_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/mesh_tying_mortar_criteria.h
@@ -48,7 +48,8 @@ namespace Kratos
 /** @brief Custom convergence criteria for the mortar condition 
  */
 template<class TSparseSpace, class TDenseSpace>
-class MeshTyingMortarConvergenceCriteria : public virtual  BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >
+class MeshTyingMortarConvergenceCriteria 
+    : public  BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions

--- a/applications/HDF5Application/custom_io/hdf5_model_part_io.h
+++ b/applications/HDF5Application/custom_io/hdf5_model_part_io.h
@@ -35,7 +35,7 @@ namespace HDF5
 ///@{
 
 /// A class for serial IO of a model part in HDF5.
-class ModelPartIO : public virtual IO, public ModelPartIOBase
+class ModelPartIO : public ModelPartIOBase
 {
 public:
     ///@name Type Definitions

--- a/applications/HDF5Application/custom_io/hdf5_model_part_io_base.h
+++ b/applications/HDF5Application/custom_io/hdf5_model_part_io_base.h
@@ -38,7 +38,7 @@ namespace HDF5
 ///@name Kratos Classes
 ///@{
 
-class ModelPartIOBase : public virtual IO
+class ModelPartIOBase : public IO
 {
 public:
     ///@name Type Definitions

--- a/applications/HDF5Application/custom_io/hdf5_partitioned_model_part_io.h
+++ b/applications/HDF5Application/custom_io/hdf5_partitioned_model_part_io.h
@@ -36,7 +36,7 @@ namespace HDF5
 ///@{
 
 /// A class for partitioned IO of a model part in HDF5.
-class PartitionedModelPartIO : public virtual IO, public ModelPartIOBase
+class PartitionedModelPartIO : public ModelPartIOBase
 {
 public:
     ///@name Type Definitions

--- a/applications/MeshingApplication/custom_strategies/custom_convergencecriterias/error_mesh_criteria.h
+++ b/applications/MeshingApplication/custom_strategies/custom_convergencecriterias/error_mesh_criteria.h
@@ -63,7 +63,7 @@ namespace Kratos
 /** @brief Custom convergence criteria for the mortar condition 
  */
 template<class TSparseSpace, class TDenseSpace>
-class ErrorMeshCriteria : public virtual  ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class ErrorMeshCriteria : public ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions

--- a/applications/MultiScaleApplication/custom_strategies/convergencecriterias/displacement_norm_criteria.h
+++ b/applications/MultiScaleApplication/custom_strategies/convergencecriterias/displacement_norm_criteria.h
@@ -85,7 +85,7 @@ namespace Kratos
 /** Residual Norm Criteria.
 */
 template<class TSparseSpace,class TDenseSpace>
-class DisplacementNormCriteria : public virtual  ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class DisplacementNormCriteria : public  ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     /**@name Type Definitions */

--- a/applications/MultiScaleApplication/custom_strategies/convergencecriterias/energy_norm_criteria.h
+++ b/applications/MultiScaleApplication/custom_strategies/convergencecriterias/energy_norm_criteria.h
@@ -85,7 +85,7 @@ namespace Kratos
 /** Residual Norm Criteria.
 */
 template<class TSparseSpace,class TDenseSpace>
-class EnergyNormCriteria : public virtual  ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class EnergyNormCriteria : public  ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     /**@name Type Definitions */

--- a/applications/MultiScaleApplication/custom_strategies/convergencecriterias/residual_norm_criteria.h
+++ b/applications/MultiScaleApplication/custom_strategies/convergencecriterias/residual_norm_criteria.h
@@ -65,7 +65,7 @@ namespace Kratos
 {
 
 template<class TSparseSpace,class TDenseSpace>
-class ResidualNormCriteria : public virtual  ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class ResidualNormCriteria : public  ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
 

--- a/applications/SolidMechanicsApplication/custom_strategies/convergence_criteria/component_wise_residual_convergence_criterion.hpp
+++ b/applications/SolidMechanicsApplication/custom_strategies/convergence_criteria/component_wise_residual_convergence_criterion.hpp
@@ -54,7 +54,7 @@ namespace Kratos
 template<class TSparseSpace,
          class TDenseSpace
          >
-class ComponentWiseResidualConvergenceCriterion : public virtual  ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class ComponentWiseResidualConvergenceCriterion : public ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     /**@name Type Definitions */

--- a/applications/SolidMechanicsApplication/custom_strategies/convergence_criteria/displacement_convergence_criterion.hpp
+++ b/applications/SolidMechanicsApplication/custom_strategies/convergence_criteria/displacement_convergence_criterion.hpp
@@ -53,7 +53,7 @@ namespace Kratos
 template<class TSparseSpace,
          class TDenseSpace
          >
-class DisplacementConvergenceCriterion : virtual public ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class DisplacementConvergenceCriterion : public ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     /**@name Type Definitions */

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_and_other_dof_criteria.h
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_and_other_dof_criteria.h
@@ -70,7 +70,7 @@ Detail class definition.
 template<class TSparseSpace,
          class TDenseSpace
          >
-class DisplacementAndOtherDoFCriteria : virtual public ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class DisplacementAndOtherDoFCriteria : public ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/residual_displacement_and_other_dof_criteria.h
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/residual_displacement_and_other_dof_criteria.h
@@ -67,7 +67,7 @@ Detail class definition.
 template<class TSparseSpace,
          class TDenseSpace
          >
-class ResidualDisplacementAndOtherDoFCriteria : public virtual  ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class ResidualDisplacementAndOtherDoFCriteria : public ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions 

--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -70,7 +70,7 @@ Detail class definition.
 template<class TSparseSpace,
          class TDenseSpace
          >
-class DisplacementCriteria : virtual public ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class DisplacementCriteria : public ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions
@@ -135,8 +135,6 @@ public:
     {
         if (SparseSpaceType::Size(Dx) != 0) //if we are solving for something
         {
-            //TDataType mFinalCorrectionNorm = sqrt(std::inner_product(Dx.begin(),Dx.end(),Dx.begin(),TDataType()));
-            //TDataType mFinalCorrectionNorm = sqrt(Dot(Dx,Dx));
             TDataType mFinalCorrectionNorm = TSparseSpace::TwoNorm(Dx);
 
             TDataType ratio = 0.00;

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -74,7 +74,7 @@ Detail class definition.
 template<class TSparseSpace,
          class TDenseSpace
          >
-class ResidualCriteria : public virtual  ConvergenceCriteria< TSparseSpace, TDenseSpace >
+class ResidualCriteria : public  ConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions 


### PR DESCRIPTION
this PR takes out "virtual public" and "public virtual" which were wrongly added to some convergence criterias. 

@loumalouomega @msandre @jcotela @roigcarlo can u grep "virtual public" and "public virtual" and see if it is needed? this is a forward looking change...so please take them out if you can