### PR TITLE
Removing deprecated Point::Coordinate() method.

### DIFF
--- a/kratos/geometries/point.h
+++ b/kratos/geometries/point.h
@@ -195,28 +195,6 @@ public:
         return this->operator[](2);
     }
 
-    /** This is an access method to point's coordinate by indices. For example this
-    function return x, y and z coordinate whith 1, 2 and 3 as input
-    respectively.
-    @note: This method is deprecated: use X(), Y(), Z() or the base class' operator[] method instead.
-    */
-    KRATOS_DEPRECATED double Coordinate(IndexType CoordinateIndex) const
-    {
-        KRATOS_DEBUG_ERROR_IF((CoordinateIndex > 3)||(CoordinateIndex == 0)) << "Coordinate index = " << CoordinateIndex << " is out of range [1..3]";
-        return this->operator[](CoordinateIndex - 1);
-    }
-
-    /** This is an access method to get a reference to point's coordinate by
-    indices. For example this function return references to x, y and z coordinate whith 1, 2
-    and 3 as input respectively.
-    @note: This method is deprecated: use X(), Y(), Z() or the base class' operator[] method instead.
-    */
-    KRATOS_DEPRECATED double &Coordinate(IndexType CoordinateIndex)
-    {
-        KRATOS_DEBUG_ERROR_IF((CoordinateIndex > 3)||(CoordinateIndex == 0)) << "Coordinate index = " << CoordinateIndex << " is out of range [1..3]";
-        return this->operator[](CoordinateIndex - 1);
-    }
-
     CoordinatesArrayType const &Coordinates() const
     {
         return *this;


### PR DESCRIPTION
This closes #1152 