### PR TITLE
Initializing properties to nullptr if not provided

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -935,21 +935,33 @@ public:
 
     PropertiesType::Pointer pGetProperties()
     {
+        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
+            << "Tryining to get the properties of " << Info()
+            << ", which are uninitialized." << std::endl;
         return mpProperties;
     }
 
     const PropertiesType::Pointer pGetProperties() const
     {
+        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
+            << "Tryining to get the properties of " << Info()
+            << ", which are uninitialized." << std::endl;
         return mpProperties;
     }
 
     PropertiesType& GetProperties()
     {
+        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
+            << "Tryining to get the properties of " << Info()
+            << ", which are uninitialized." << std::endl;
         return *mpProperties;
     }
 
     PropertiesType const& GetProperties() const
     {
+        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
+            << "Tryining to get the properties of " << Info()
+            << ", which are uninitialized." << std::endl;
         return *mpProperties;
     }
 

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -132,7 +132,7 @@ public:
     Condition(IndexType NewId = 0)
         : BaseType(NewId)
         , Flags()
-        , mpProperties(new PropertiesType)
+        , mpProperties(nullptr)
     {
     }
 
@@ -142,7 +142,7 @@ public:
     Condition(IndexType NewId, const NodesArrayType& ThisNodes)
         : BaseType(NewId,GeometryType::Pointer(new GeometryType(ThisNodes)))
         , Flags()
-        , mpProperties(new PropertiesType)
+        , mpProperties(nullptr)
     {
     }
 
@@ -152,7 +152,7 @@ public:
     Condition(IndexType NewId, GeometryType::Pointer pGeometry)
         : BaseType(NewId,pGeometry)
         , Flags()
-        , mpProperties(new PropertiesType)
+        , mpProperties(nullptr)
     {
     }
 

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -130,7 +130,7 @@ public:
     Element(IndexType NewId = 0)
         : BaseType(NewId)
         , Flags()
-        , mpProperties(new PropertiesType)
+        , mpProperties(nullptr)
     {
     }
 
@@ -140,7 +140,7 @@ public:
     Element(IndexType NewId, const NodesArrayType& ThisNodes)
         : BaseType(NewId,GeometryType::Pointer(new GeometryType(ThisNodes)))
         , Flags()
-        , mpProperties(new PropertiesType)
+        , mpProperties(nullptr)
     {
     }
 
@@ -150,7 +150,7 @@ public:
     Element(IndexType NewId, GeometryType::Pointer pGeometry)
         : BaseType(NewId,pGeometry)
         , Flags()
-        , mpProperties(new PropertiesType)
+        , mpProperties(nullptr)
     {
     }
 

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -983,21 +983,33 @@ public:
 
     PropertiesType::Pointer pGetProperties()
     {
+        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
+            << "Tryining to get the properties of " << Info()
+            << ", which are uninitialized." << std::endl;
         return mpProperties;
     }
 
     const PropertiesType::Pointer pGetProperties() const
     {
+        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
+            << "Tryining to get the properties of " << Info()
+            << ", which are uninitialized." << std::endl;
         return mpProperties;
     }
 
     PropertiesType& GetProperties()
     {
+        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
+            << "Tryining to get the properties of " << Info()
+            << ", which are uninitialized." << std::endl;
         return *mpProperties;
     }
 
     PropertiesType const& GetProperties() const
     {
+        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
+            << "Tryining to get the properties of " << Info()
+            << ", which are uninitialized." << std::endl;
         return *mpProperties;
     }
 


### PR DESCRIPTION
Instead of allocating a new one on the spot.

The old version seems to be related to some weird valgrind errors in the FluidDynamicsApplication (they are gone with this correction).