### PR TITLE
Adding param to ModifyProperties

### DIFF
--- a/applications/DEM_application/tests/test_particle_creator_destructor.py
+++ b/applications/DEM_application/tests/test_particle_creator_destructor.py
@@ -24,10 +24,12 @@ class TestParticleCreatorDestructor(KratosUnittest.TestCase):
         
         self.creator_destructor = ParticleCreatorDestructor()
         
-    def ModifyProperties(self, properties):
-        DiscontinuumConstitutiveLawString = properties[DEM_DISCONTINUUM_CONSTITUTIVE_LAW_NAME]
-        DiscontinuumConstitutiveLaw = globals().get(DiscontinuumConstitutiveLawString)()
-        DiscontinuumConstitutiveLaw.SetConstitutiveLawInProperties(properties, False)
+    def ModifyProperties(self, properties, param = 0):
+        
+        if not param:
+            DiscontinuumConstitutiveLawString = properties[DEM_DISCONTINUUM_CONSTITUTIVE_LAW_NAME]
+            DiscontinuumConstitutiveLaw = globals().get(DiscontinuumConstitutiveLawString)()
+            DiscontinuumConstitutiveLaw.SetConstitutiveLawInProperties(properties, False)
 
         scheme = SymplecticEulerScheme()        
         scheme.SetTranslationalIntegrationSchemeInProperties(properties, False)

--- a/applications/swimming_DEM_application/python_scripts/swimming_sphere_strategy.py
+++ b/applications/swimming_DEM_application/python_scripts/swimming_sphere_strategy.py
@@ -66,9 +66,10 @@ class SwimmingStrategy(BaseStrategy):
          else:
              return globals().get(class_name)(0.5,0.25)
 
-    def ModifyProperties(self, properties):
+    def ModifyProperties(self, properties, param = 0):
         
-        super(SwimmingStrategy,self).ModifyProperties(properties)
+        super(SwimmingStrategy,self).ModifyProperties(properties, param)
         
-        if not properties.Has(PARTICLE_SPHERICITY):
-            properties[PARTICLE_SPHERICITY] = 1.0
+        if not param:
+            if not properties.Has(PARTICLE_SPHERICITY):
+                properties[PARTICLE_SPHERICITY] = 1.0


### PR DESCRIPTION
@GuillermoCasas, I have been checking and, although the benchmark was working well due to the fact that it does not have rigid boundaries, the file swimming_sphere_strategy.py should be changed.
However, when I run the candelier benchmark I obtaining an error and a segmentation fault:
====================================================================
Candelier tests results (~ 0.03 = effect of the history force)
====================================================================
No history force, Daitche: OK
    relative radial error: 6.222656399313275e-05
--------------------------------------------------------------------
All forces, Daitche:       OK
    relative radial error: 5.3851223875989466e-05
--------------------------------------------------------------------
No history force, Daitche (rotating frame): OK
    relative radial error:                  8.801411506650061e-05
--------------------------------------------------------------------
All forces, Daitche (rotating frame): Fail
    relative radial error:            0.006287556807077865
====================================================================
Violación de segmento (`core' generado)

Do you think it is due to my last PR? I do not think so, but I am not sure.
