### PR TITLE
changing boost::shared_ptr to Kratos::shared_ptr or Kratos::make_shared

### DIFF
--- a/kratos/containers/buffer.h
+++ b/kratos/containers/buffer.h
@@ -245,7 +245,7 @@ public:
       is in charge of storing pointers correctly.
     */
     template<class TDataType>
-    void push_back(boost::shared_ptr<TDataType> const& rValue)
+    void push_back(Kratos::shared_ptr<TDataType> const& rValue)
     {
         KRATOS_THROW_ERROR(std::logic_error, "You cannot store a pointer in the buffer try the Serializer instead", "" );
     }

--- a/kratos/containers/pointer_hash_map_set.h
+++ b/kratos/containers/pointer_hash_map_set.h
@@ -64,7 +64,7 @@ namespace Kratos
 template<class TDataType,
          class THashType = boost::hash<TDataType>,
          class TGetKeyType = SetIdentityFunction<TDataType>,
-         class TPointerType = boost::shared_ptr<TDataType> >
+         class TPointerType = Kratos::shared_ptr<TDataType> >
 class PointerHashMapSet
 {
 

--- a/kratos/containers/pointer_vector.h
+++ b/kratos/containers/pointer_vector.h
@@ -66,7 +66,7 @@ namespace Kratos
     deleting.
  */
 template<class TDataType,
-         class TPointerType = boost::shared_ptr<TDataType>,
+         class TPointerType = Kratos::shared_ptr<TDataType>,
          class TContainerType = std::vector<TPointerType> >
 class PointerVector
 {

--- a/kratos/containers/pointer_vector_map.h
+++ b/kratos/containers/pointer_vector_map.h
@@ -65,7 +65,7 @@ namespace Kratos
 template<class TKeyType,class TDataType,
 
          class TCompareType = std::less<TKeyType>,
-         class TPointerType = boost::shared_ptr<TDataType>,
+         class TPointerType = Kratos::shared_ptr<TDataType>,
          class TContainerType = std::vector<std::pair<TKeyType, TPointerType> > >
 class PointerVectorMap
 {

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -70,7 +70,7 @@ template<class TDataType,
          class TGetKeyType = SetIdentityFunction<TDataType>,
          class TCompareType = std::less<typename TGetKeyType::result_type>,
          class TEqualType = std::equal_to<typename TGetKeyType::result_type>,
-         class TPointerType = boost::shared_ptr<TDataType>,
+         class TPointerType = Kratos::shared_ptr<TDataType>,
          class TContainerType = std::vector<TPointerType> >
 class PointerVectorSet
 {

--- a/kratos/containers/weak_pointer_vector.h
+++ b/kratos/containers/weak_pointer_vector.h
@@ -64,7 +64,7 @@ namespace Kratos
     deleting.
  */
 template<class TDataType,
-         class TPointerType = boost::weak_ptr<TDataType>,
+         class TPointerType = Kratos::weak_ptr<TDataType>,
          class TContainerType = std::vector<TPointerType> >
 class WeakPointerVector
 {

--- a/kratos/containers/weak_pointer_vector_iterator.h
+++ b/kratos/containers/weak_pointer_vector_iterator.h
@@ -141,7 +141,7 @@ private:
 
     typename BaseType::reference dereference() const
     {
-        return *(boost::shared_ptr<TDataType>(*(this->base())));
+        return *(Kratos::shared_ptr<TDataType>(*(this->base())));
     }
 
     ///@}

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -397,7 +397,7 @@ public:
 
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //         NewPoints.push_back(boost::make_shared< Point >((*this)[i]));
+    //         NewPoints.push_back(Kratos::make_shared< Point >((*this)[i]));
     //     }
 
     //     //NewPoints[i] = typename Point::Pointer(new Point(*mPoints[i]));

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -389,7 +389,7 @@ public:
             *i = typename PointType::Pointer( new PointType( **i ) );
     }
 
-    // virtual boost::shared_ptr< Geometry< Point > > Clone() const
+    // virtual Kratos::shared_ptr< Geometry< Point > > Clone() const
     // {
     //     Geometry< Point >::PointsArrayType NewPoints;
 

--- a/kratos/geometries/hexahedra_3d_20.h
+++ b/kratos/geometries/hexahedra_3d_20.h
@@ -349,7 +349,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //         NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+    //         NewPoints.push_back(Kratos::make_shared< Point<3> >((*this)[i]));
     //     }
 
 

--- a/kratos/geometries/hexahedra_3d_27.h
+++ b/kratos/geometries/hexahedra_3d_27.h
@@ -369,7 +369,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //         NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+    //         NewPoints.push_back(Kratos::make_shared< Point<3> >((*this)[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/hexahedra_3d_8.h
+++ b/kratos/geometries/hexahedra_3d_8.h
@@ -311,7 +311,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //         NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+    //         NewPoints.push_back(Kratos::make_shared< Point<3> >((*this)[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/hexahedra_interface_3d_8.h
+++ b/kratos/geometries/hexahedra_interface_3d_8.h
@@ -486,7 +486,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //         NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+    //         NewPoints.push_back(Kratos::make_shared< Point<3> >((*this)[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/line_2d.h
+++ b/kratos/geometries/line_2d.h
@@ -267,7 +267,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -273,7 +273,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //         NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+    //         NewPoints.push_back(Kratos::make_shared< Point<3> >((*this)[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -266,7 +266,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //         NewPoints.push_back(boost::make_shared< Point<3> >((*this)[i]));
+    //         NewPoints.push_back(Kratos::make_shared< Point<3> >((*this)[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -272,7 +272,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -266,7 +266,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/line_gauss_lobatto_3d_2.h
+++ b/kratos/geometries/line_gauss_lobatto_3d_2.h
@@ -270,7 +270,7 @@ public:
         //making a copy of the nodes TO POINTS (not Nodes!!!)
 
         for ( IndexType i = 0 ; i < BaseType::Points().size() ; i++ )
-            NewPoints.push_back(boost::make_shared< Point >((*this)[i]));
+            NewPoints.push_back(Kratos::make_shared< Point >((*this)[i]));
 
         //creating a geometry with the new points
        Geometry< Point >::Pointer p_clone( new LineGaussLobatto3D2< Point >( NewPoints ) );

--- a/kratos/geometries/point_2d.h
+++ b/kratos/geometries/point_2d.h
@@ -263,7 +263,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/point_3d.h
+++ b/kratos/geometries/point_3d.h
@@ -264,7 +264,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/prism_3d_15.h
+++ b/kratos/geometries/prism_3d_15.h
@@ -332,7 +332,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/prism_3d_6.h
+++ b/kratos/geometries/prism_3d_6.h
@@ -303,7 +303,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/prism_interface_3d_6.h
+++ b/kratos/geometries/prism_interface_3d_6.h
@@ -328,7 +328,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/quadrilateral_2d_4.h
+++ b/kratos/geometries/quadrilateral_2d_4.h
@@ -326,7 +326,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }   
         
     //     //creating a geometry with the new points
@@ -505,10 +505,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_2d_8.h
+++ b/kratos/geometries/quadrilateral_2d_8.h
@@ -323,7 +323,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points
@@ -930,10 +930,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_2d_9.h
+++ b/kratos/geometries/quadrilateral_2d_9.h
@@ -325,7 +325,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points
@@ -486,10 +486,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -325,7 +325,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //         NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //         NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/quadrilateral_3d_8.h
+++ b/kratos/geometries/quadrilateral_3d_8.h
@@ -316,7 +316,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points
@@ -995,10 +995,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -325,7 +325,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points
@@ -988,10 +988,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 4 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 5 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 6 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 7 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_interface_2d_4.h
+++ b/kratos/geometries/quadrilateral_interface_2d_4.h
@@ -354,7 +354,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points
@@ -859,10 +859,10 @@ public:
     GeometriesArrayType Edges( void ) override
     {
         GeometriesArrayType edges = GeometriesArrayType();
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 3 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 3 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 3 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/quadrilateral_interface_3d_4.h
+++ b/kratos/geometries/quadrilateral_interface_3d_4.h
@@ -362,7 +362,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/sphere_3d_1.h
+++ b/kratos/geometries/sphere_3d_1.h
@@ -268,7 +268,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -317,7 +317,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -292,7 +292,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points

--- a/kratos/geometries/triangle_2d_3.h
+++ b/kratos/geometries/triangle_2d_3.h
@@ -323,7 +323,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points
@@ -782,9 +782,9 @@ public:
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/triangle_2d_6.h
+++ b/kratos/geometries/triangle_2d_6.h
@@ -335,7 +335,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points
@@ -618,9 +618,9 @@ public:
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 3 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 4 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 5 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 3 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 4 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 5 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -322,7 +322,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //             NewPoints.push_back(boost::make_shared< Point<3> >(( *this )[i]));
+    //             NewPoints.push_back(Kratos::make_shared< Point<3> >(( *this )[i]));
     //     }
 
     //     //creating a geometry with the new points
@@ -1268,9 +1268,9 @@ public:
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -315,7 +315,7 @@ public:
     }
 
 
-    // boost::shared_ptr< Geometry< Point<3> > > Clone() const override
+    // Kratos::shared_ptr< Geometry< Point<3> > > Clone() const override
     // {
     //     Geometry< Point<3> >::PointsArrayType NewPoints;
 

--- a/kratos/geometries/triangle_3d_6.h
+++ b/kratos/geometries/triangle_3d_6.h
@@ -335,7 +335,7 @@ public:
     //     //making a copy of the nodes TO POINTS (not Nodes!!!)
     //     for ( IndexType i = 0 ; i < this->size() ; i++ )
     //     {
-    //         Point<3>::Pointer pnew_point = boost::make_shared< Point<3> >(( *this )[i]);
+    //         Point<3>::Pointer pnew_point = Kratos::make_shared< Point<3> >(( *this )[i]);
     //         NewPoints.push_back(pnew_point);
     //     }
 
@@ -1131,9 +1131,9 @@ public:
     {
         GeometriesArrayType edges = GeometriesArrayType();
 
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 3 ), this->pGetPoint( 1 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 4 ), this->pGetPoint( 2 ) ) );
-        edges.push_back( boost::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 5 ), this->pGetPoint( 0 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 0 ), this->pGetPoint( 3 ), this->pGetPoint( 1 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 1 ), this->pGetPoint( 4 ), this->pGetPoint( 2 ) ) );
+        edges.push_back( Kratos::make_shared<EdgeType>( this->pGetPoint( 2 ), this->pGetPoint( 5 ), this->pGetPoint( 0 ) ) );
         return edges;
     }
 

--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -177,9 +177,9 @@ public:
         mpInterfaceMesh(MeshType::Pointer(new MeshType))
     {
         MeshType mesh;
-        mLocalMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
-        mGhostMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
-        mInterfaceMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
+        mLocalMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+        mGhostMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+        mInterfaceMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
     }
 
     /// Copy constructor.
@@ -267,9 +267,9 @@ public:
 
         for (IndexType i = 0; i < mNumberOfColors; i++)
         {
-            mLocalMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
-            mGhostMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
-            mInterfaceMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
+            mLocalMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+            mGhostMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+            mInterfaceMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
         }
     }
 

--- a/kratos/includes/io.h
+++ b/kratos/includes/io.h
@@ -232,7 +232,7 @@ public:
         KRATOS_ERROR <<  "Calling base class member. Please check the definition of derived class" << std::endl;
     }
 
-    virtual void DivideInputToPartitions(boost::shared_ptr<std::iostream> * Streams,
+    virtual void DivideInputToPartitions(Kratos::shared_ptr<std::iostream> * Streams,
                                          SizeType NumberOfPartitions, GraphType const& DomainsColoredGraph,
                                          PartitionIndicesType const& NodesPartitions,
                                          PartitionIndicesType const& ElementsPartitions,

--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -65,7 +65,7 @@ private:
 
   public:
     iterator_adaptor(value_iterator it,
-                     boost::shared_ptr<rapidjson::Document> pdoc)
+                     Kratos::shared_ptr<rapidjson::Document> pdoc)
         : mValueIterator(it), mpParameters(new Parameters(&it->value, pdoc)) {}
     iterator_adaptor(const iterator_adaptor &it)
         : mValueIterator(it.mValueIterator),
@@ -106,7 +106,7 @@ private:
 
   public:
     const_iterator_adaptor(value_iterator it,
-                           boost::shared_ptr<rapidjson::Document> pdoc)
+                           Kratos::shared_ptr<rapidjson::Document> pdoc)
         : mValueIterator(it),
           mpParameters(new Parameters(
               const_cast<rapidjson::Value *>(&it->value), pdoc)) {}
@@ -153,7 +153,7 @@ public:
 
   Parameters(const std::string json_string) {
 
-    mpdoc = boost::shared_ptr<rapidjson::Document>(new rapidjson::Document());
+    mpdoc = Kratos::make_shared<rapidjson::Document>();
     rapidjson::ParseResult ok = mpdoc->Parse<0>(json_string.c_str());
 
     if (!ok) {
@@ -191,8 +191,8 @@ public:
 
   // generates a clone of the current document
   Parameters Clone() {
-    boost::shared_ptr<rapidjson::Document> pnew_cloned_doc =
-        boost::shared_ptr<rapidjson::Document>(new rapidjson::Document());
+    auto pnew_cloned_doc =
+        Kratos::make_shared<rapidjson::Document>();
     rapidjson::ParseResult ok =
         pnew_cloned_doc->Parse<0>(this->WriteJsonString().c_str());
     if (!ok) {
@@ -945,11 +945,11 @@ private:
   // ATTENTION: please DO NOT use this constructor. It assumes rapidjson and
   // hence it should be considered as an implementation detail
   Parameters(rapidjson::Value *pvalue,
-             boost::shared_ptr<rapidjson::Document> pdoc)
+             Kratos::shared_ptr<rapidjson::Document> pdoc)
       : mpvalue(pvalue), mpdoc(pdoc) {}
 
   rapidjson::Value *mpvalue;
-  boost::shared_ptr<rapidjson::Document> mpdoc;
+  Kratos::shared_ptr<rapidjson::Document> mpdoc;
 
   // ATTENTION: please DO NOT use this method. It is a low level accessor, and
   // may change in the future

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -593,7 +593,7 @@ public:
             }
             else
             {
-                PropertiesType::Pointer pnew_property = boost::make_shared<PropertiesType>(PropertiesId);
+                PropertiesType::Pointer pnew_property = Kratos::make_shared<PropertiesType>(PropertiesId);
                 GetMesh(ThisIndex).AddProperties(pnew_property);
                 return pnew_property;
             }
@@ -618,7 +618,7 @@ public:
             }
             else
             {
-                PropertiesType::Pointer pnew_property = boost::make_shared<PropertiesType>(PropertiesId);
+                PropertiesType::Pointer pnew_property = Kratos::make_shared<PropertiesType>(PropertiesId);
                 GetMesh(ThisIndex).AddProperties(pnew_property);
                 return *pnew_property;
             }

--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -86,7 +86,7 @@ public:
     ModelPartIO(std::string const& Filename, const Flags Options = IO::READ|IO::NOT_IGNORE_VARIABLES_ERROR);
 
     /// Constructor with stream.
-    ModelPartIO(boost::shared_ptr<std::iostream> Stream);
+    ModelPartIO(Kratos::shared_ptr<std::iostream> Stream);
 
 
     /// Constructor with filenames.
@@ -174,7 +174,7 @@ public:
                                          PartitionIndicesContainerType const& ElementsAllPartitions,
                                          PartitionIndicesContainerType const& ConditionsAllPartitions) override;
 
-    void DivideInputToPartitions(boost::shared_ptr<std::iostream> * Streams,
+    void DivideInputToPartitions(Kratos::shared_ptr<std::iostream> * Streams,
                                          SizeType NumberOfPartitions, GraphType const& DomainsColoredGraph,
                                          PartitionIndicesType const& NodesPartitions,
                                          PartitionIndicesType const& ElementsPartitions,
@@ -183,7 +183,7 @@ public:
                                          PartitionIndicesContainerType const& ElementsAllPartitions,
                                          PartitionIndicesContainerType const& ConditionsAllPartitions) override;
 
-    void SwapStreamSource(boost::shared_ptr<std::iostream> newStream);
+    void SwapStreamSource(Kratos::shared_ptr<std::iostream> newStream);
 
 
     ///@}
@@ -281,7 +281,7 @@ protected:
     std::string mFilename;
     Flags mOptions;
 
-    boost::shared_ptr<std::iostream> mpStream;
+    Kratos::shared_ptr<std::iostream> mpStream;
 
 
     ///@}

--- a/kratos/includes/neighbours.h
+++ b/kratos/includes/neighbours.h
@@ -70,9 +70,9 @@ public:
 
     typedef std::size_t IndexType;
 
-    typedef boost::weak_ptr<TNodeType> NodeWeakPointer;
+    typedef Kratos::weak_ptr<TNodeType> NodeWeakPointer;
 
-    typedef boost::weak_ptr<TElementType> ElementWeakPointer;
+    typedef Kratos::weak_ptr<TElementType> ElementWeakPointer;
 
     /** An array of pointers to elements. */
     typedef WeakPointerVector<TElementType> NeighbourElementsArrayType;

--- a/kratos/includes/node.h
+++ b/kratos/includes/node.h
@@ -335,7 +335,7 @@ public:
 
     typename Node<TDimension>::Pointer Clone()
     {
-        Node<3>::Pointer p_new_node = boost::make_shared<Node<3> >( this->Id(), (*this)[0], (*this)[1], (*this)[2]);
+        Node<3>::Pointer p_new_node = Kratos::make_shared<Node<3> >( this->Id(), (*this)[0], (*this)[1], (*this)[2]);
         p_new_node->mSolutionStepsNodalData = this->mSolutionStepsNodalData;
 
         Node<3>::DofsContainerType& my_dofs = (this)->GetDofs();
@@ -1021,7 +1021,7 @@ public:
             return *(it_dof.base());
         }
 
-        typename DofType::Pointer p_new_dof =  boost::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable);
+        typename DofType::Pointer p_new_dof =  Kratos::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable);
         mDofs.insert(mDofs.begin(), p_new_dof);
 
 //         if(!mDofs.IsSorted())
@@ -1049,7 +1049,7 @@ public:
             return *(it_dof.base());
         }
 
-        typename DofType::Pointer p_new_dof =  boost::make_shared<DofType>(SourceDof);
+        typename DofType::Pointer p_new_dof =  Kratos::make_shared<DofType>(SourceDof);
         mDofs.insert(mDofs.begin(), p_new_dof);
 
         p_new_dof->SetId(Id());
@@ -1087,7 +1087,7 @@ public:
             return *(it_dof.base());
         }
 
-        typename DofType::Pointer p_new_dof =  boost::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable, rDofReaction);
+        typename DofType::Pointer p_new_dof =  Kratos::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable, rDofReaction);
         mDofs.insert(mDofs.begin(), p_new_dof);
 
 //         if(!mDofs.IsSorted())
@@ -1118,7 +1118,7 @@ public:
             return *it_dof;
         }
             
-        typename DofType::Pointer p_new_dof =  boost::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable);
+        typename DofType::Pointer p_new_dof =  Kratos::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable);
         mDofs.insert(mDofs.begin(), p_new_dof);
 
 //         if(!mDofs.IsSorted())
@@ -1154,7 +1154,7 @@ public:
             return *it_dof;
         }
 
-        typename DofType::Pointer p_new_dof =  boost::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable, rDofReaction);
+        typename DofType::Pointer p_new_dof =  Kratos::make_shared<DofType>(Id(), &mSolutionStepsNodalData, rDofVariable, rDofReaction);
         mDofs.insert(mDofs.begin(), p_new_dof);
 
 //         if(!mDofs.IsSorted())

--- a/kratos/includes/serializer.h
+++ b/kratos/includes/serializer.h
@@ -279,7 +279,7 @@ public:
     }
 
     template<class TDataType>
-    void load(std::string const & rTag, boost::weak_ptr<TDataType>& pValue)
+    void load(std::string const & rTag, Kratos::weak_ptr<TDataType>& pValue)
     {
         // This is for testing. I have to change it. Pooyan.
         //KRATOS_THROW_ERROR(std::logic_error, "The serialization for weak_ptrs is not implemented yet", "")
@@ -476,7 +476,7 @@ public:
     }
 
     template<class TDataType>
-    void save(std::string const & rTag, boost::weak_ptr<TDataType> pValue)
+    void save(std::string const & rTag, Kratos::weak_ptr<TDataType> pValue)
     {
         // This is for testing. I have to implement it. Pooyan.
         //KRATOS_THROW_ERROR(std::logic_error, "The serialization for weak_ptrs is not implemented yet", "")

--- a/kratos/includes/serializer.h
+++ b/kratos/includes/serializer.h
@@ -194,7 +194,7 @@ public:
     }
 
     template<class TDataType>
-    void load(std::string const & rTag, boost::shared_ptr<TDataType>& pValue)
+    void load(std::string const & rTag, Kratos::shared_ptr<TDataType>& pValue)
     {
         PointerType pointer_type = SP_INVALID_POINTER;
         void* p_pointer;
@@ -209,7 +209,7 @@ public:
                 if(pointer_type == SP_BASE_CLASS_POINTER)
                 {
                     if(!pValue)
-                        pValue = boost::shared_ptr<TDataType>(new TDataType);
+                        pValue = Kratos::make_shared<TDataType>();
 
                     load(rTag, *pValue);
                 }
@@ -223,7 +223,7 @@ public:
                         KRATOS_THROW_ERROR(std::runtime_error, "There is no object registered in Kratos with name : ", object_name)
 
                         if(!pValue)
-                            pValue = boost::shared_ptr<TDataType>(static_cast<TDataType*>((i_prototype->second)()));
+                            pValue = Kratos::shared_ptr<TDataType>(static_cast<TDataType*>((i_prototype->second)()));
 
                     load(rTag, *pValue);
 
@@ -231,7 +231,7 @@ public:
                 mLoadedPointers[p_pointer]=&pValue;
             }
             else
-                pValue = *static_cast<boost::shared_ptr<TDataType>*>((i_pointer->second));
+                pValue = *static_cast<Kratos::shared_ptr<TDataType>*>((i_pointer->second));
         }
     }
 
@@ -416,7 +416,7 @@ public:
 
 
     template<class TDataType>
-    void save(std::string const & rTag, boost::shared_ptr<TDataType> pValue)
+    void save(std::string const & rTag, Kratos::shared_ptr<TDataType> pValue)
     {
         save(rTag, pValue.get());
     }
@@ -493,7 +493,7 @@ public:
     }
 
     template<class TDataType>
-    void save(std::string const & rTag, boost::shared_ptr<const TDataType> pValue)
+    void save(std::string const & rTag, Kratos::shared_ptr<const TDataType> pValue)
     {
         // This is for testing. I have to change it. Pooyan.
 //          save_trace_point(rTag);

--- a/kratos/includes/serializer.h
+++ b/kratos/includes/serializer.h
@@ -209,8 +209,7 @@ public:
                 if(pointer_type == SP_BASE_CLASS_POINTER)
                 {
                     if(!pValue)
-                        pValue = Kratos::make_shared<TDataType>();
-
+                        pValue = Kratos::shared_ptr<TDataType>(new TDataType);
                     load(rTag, *pValue);
                 }
                 else if(pointer_type == SP_DERIVED_CLASS_POINTER)

--- a/kratos/linear_solvers/bicgstab_solver.h
+++ b/kratos/linear_solvers/bicgstab_solver.h
@@ -85,7 +85,7 @@ public:
     BICGSTABSolver(double NewMaxTolerance, unsigned int NewMaxIterationsNumber, typename TPreconditionerType::Pointer pNewPreconditioner) :
         BaseType(NewMaxTolerance, NewMaxIterationsNumber, pNewPreconditioner) {}
         
-    BICGSTABSolver(Parameters settings, typename TPreconditionerType::Pointer pNewPreconditioner = boost::make_shared<TPreconditionerType>()):
+    BICGSTABSolver(Parameters settings, typename TPreconditionerType::Pointer pNewPreconditioner = Kratos::make_shared<TPreconditionerType>()):
         BaseType(settings, pNewPreconditioner) {}
         
     /// Copy constructor.

--- a/kratos/linear_solvers/cg_solver.h
+++ b/kratos/linear_solvers/cg_solver.h
@@ -90,7 +90,7 @@ public:
     CGSolver(double NewMaxTolerance, unsigned int NewMaxIterationsNumber, typename TPreconditionerType::Pointer pNewPreconditioner) :
         BaseType(NewMaxTolerance, NewMaxIterationsNumber, pNewPreconditioner) {}
         
-    CGSolver(Parameters settings, typename TPreconditionerType::Pointer pNewPreconditioner = boost::make_shared<TPreconditionerType>()):
+    CGSolver(Parameters settings, typename TPreconditionerType::Pointer pNewPreconditioner = Kratos::make_shared<TPreconditionerType>()):
         BaseType(settings, pNewPreconditioner) {}
 
 

--- a/kratos/linear_solvers/deflated_cg_solver.h
+++ b/kratos/linear_solvers/deflated_cg_solver.h
@@ -113,7 +113,7 @@ public:
     }
     
     DeflatedCGSolver(Parameters settings,
-                    typename TPreconditionerType::Pointer pNewPreconditioner = boost::make_shared<TPreconditionerType>()
+                    typename TPreconditionerType::Pointer pNewPreconditioner = Kratos::make_shared<TPreconditionerType>()
                    ): BaseType ()
 
     {

--- a/kratos/linear_solvers/iterative_solver.h
+++ b/kratos/linear_solvers/iterative_solver.h
@@ -128,7 +128,7 @@ public:
         mMaxIterationsNumber(NewMaxIterationsNumber) {}
 
     IterativeSolver(Parameters settings,
-                    typename TPreconditionerType::Pointer pNewPreconditioner = boost::make_shared<TPreconditionerType>()
+                    typename TPreconditionerType::Pointer pNewPreconditioner = Kratos::make_shared<TPreconditionerType>()
                    ):
         mResidualNorm(0),
         mIterationsNumber(0),

--- a/kratos/linear_solvers/mixedup_linear_solver.h
+++ b/kratos/linear_solvers/mixedup_linear_solver.h
@@ -1013,7 +1013,7 @@ private:
             #pragma omp parallel
             if ( OpenMPUtils::ThisThread() == k)
             {
-//                 boost::shared_ptr< IndexVector > pNext( new IndexVector(rL.size1() ) );
+//                 Kratos::shared_ptr< IndexVector > pNext( new IndexVector(rL.size1() ) );
 //                 IndexVector& Next = *pNext; // Keeps track of which columns were filled
                 IndexVector Next(rL.size1());
                 for (unsigned int m = 0; m < rL.size1(); m++) Next[m] = -1;

--- a/kratos/linear_solvers/skyline_lu_custom_scalar_solver.h
+++ b/kratos/linear_solvers/skyline_lu_custom_scalar_solver.h
@@ -117,9 +117,9 @@ public:
 
 private:
 
-    boost::shared_ptr<BuiltinMatrixType> pBuiltinMatrix;
+    Kratos::shared_ptr<BuiltinMatrixType> pBuiltinMatrix;
 
-    boost::shared_ptr<SolverType> pSolver;
+    Kratos::shared_ptr<SolverType> pSolver;
 };
 
 ///@}

--- a/kratos/linear_solvers/skyline_lu_custom_scalar_solver.h
+++ b/kratos/linear_solvers/skyline_lu_custom_scalar_solver.h
@@ -82,7 +82,7 @@ public:
                 rA.index2_data().begin(),
                 rA.value_data().begin());
 
-        pSolver = boost::make_shared<SolverType>(*pBuiltinMatrix);
+        pSolver = Kratos::make_shared<SolverType>(*pBuiltinMatrix);
     }
 
     bool Solve(SparseMatrixType& rA, VectorType& rX, VectorType& rB) override

--- a/kratos/modeler/mesh_suite_modeler.h
+++ b/kratos/modeler/mesh_suite_modeler.h
@@ -519,7 +519,7 @@ public:
             for(int j = 0; j<numb_of_neighb; j++)
             {
                 int ii = nn[i][j]+1;
-                //neighbours.push_back(boost::weak_ptr< Node<3> >( r_model_nodes(ii) ) );
+                //neighbours.push_back(Kratos::weak_ptr< Node<3> >( r_model_nodes(ii) ) );
                 neighbours.push_back( r_model_nodes(ii)  );
             }
         }

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_ausas_modified_shape_functions.cpp
@@ -24,7 +24,7 @@ namespace Kratos
 /// Default constructor
 Tetrahedra3D4AusasModifiedShapeFunctions::Tetrahedra3D4AusasModifiedShapeFunctions(const GeometryPointerType pInputGeometry, const Vector& rNodalDistances) :
     AusasModifiedShapeFunctions(pInputGeometry, rNodalDistances),
-    mpTetrahedraSplitter(boost::make_shared<DivideTetrahedra3D4>(*pInputGeometry, rNodalDistances)) {
+    mpTetrahedraSplitter(Kratos::make_shared<DivideTetrahedra3D4>(*pInputGeometry, rNodalDistances)) {
 
     // Perform the element splitting
     mpTetrahedraSplitter->GenerateDivision();

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.cpp
@@ -24,7 +24,7 @@ namespace Kratos
 /// Default constructor
 Tetrahedra3D4ModifiedShapeFunctions::Tetrahedra3D4ModifiedShapeFunctions(const GeometryPointerType pInputGeometry, const Vector& rNodalDistances) :
     ModifiedShapeFunctions(pInputGeometry, rNodalDistances),
-    mpTetrahedraSplitter(boost::make_shared<DivideTetrahedra3D4>(*pInputGeometry, rNodalDistances)) {
+    mpTetrahedraSplitter(Kratos::make_shared<DivideTetrahedra3D4>(*pInputGeometry, rNodalDistances)) {
 
     // Perform the element splitting
     mpTetrahedraSplitter->GenerateDivision();

--- a/kratos/modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.cpp
@@ -24,7 +24,7 @@ namespace Kratos
 /// Default constructor
 Triangle2D3AusasModifiedShapeFunctions::Triangle2D3AusasModifiedShapeFunctions(const GeometryPointerType pInputGeometry, const Vector& rNodalDistances) :
     AusasModifiedShapeFunctions(pInputGeometry, rNodalDistances),
-    mpTriangleSplitter(boost::make_shared<DivideTriangle2D3>(*pInputGeometry, rNodalDistances)) {
+    mpTriangleSplitter(Kratos::make_shared<DivideTriangle2D3>(*pInputGeometry, rNodalDistances)) {
 
     // Perform the element splitting
     mpTriangleSplitter->GenerateDivision();

--- a/kratos/modified_shape_functions/triangle_2d_3_modified_shape_functions.cpp
+++ b/kratos/modified_shape_functions/triangle_2d_3_modified_shape_functions.cpp
@@ -24,7 +24,7 @@ namespace Kratos
 /// Default constructor
 Triangle2D3ModifiedShapeFunctions::Triangle2D3ModifiedShapeFunctions(const GeometryPointerType pInputGeometry, const Vector& rNodalDistances) :
     ModifiedShapeFunctions(pInputGeometry, rNodalDistances),
-    mpTriangleSplitter(boost::make_shared<DivideTriangle2D3>(*pInputGeometry, rNodalDistances)) {
+    mpTriangleSplitter(Kratos::make_shared<DivideTriangle2D3>(*pInputGeometry, rNodalDistances)) {
 
     // Perform the element splitting
     mpTriangleSplitter->GenerateDivision();

--- a/kratos/processes/calculate_signed_distance_to_3d_skin_process.h
+++ b/kratos/processes/calculate_signed_distance_to_3d_skin_process.h
@@ -1682,7 +1682,7 @@ public:
     {
         Timer::Start("Generating Octree");
         //std::cout << "Generating the Octree..." << std::endl;
-        boost::shared_ptr<OctreeType> temp_octree =  boost::shared_ptr<OctreeType>( new OctreeType() );
+        auto temp_octree =  Kratos::make_shared<OctreeType>();
         //OctreeType::Pointer temp_octree = OctreeType::Pointer(new OctreeType() );
         mpOctree.swap(temp_octree);
         
@@ -2601,7 +2601,7 @@ private:
 
     DistanceSpatialContainersConfigure::data_type mOctreeNodes;
 
-    boost::shared_ptr<OctreeType> mpOctree;
+    Kratos::shared_ptr<OctreeType> mpOctree;
 
     static const double epsilon;
 

--- a/kratos/processes/simple_mortar_mapper_process.cpp
+++ b/kratos/processes/simple_mortar_mapper_process.cpp
@@ -155,7 +155,7 @@ void SimpleMortarMapperProcess<TDim, TNumNodes, TVarType, THist>::AssemblyMortar
         for (unsigned int i_node = 0; i_node < TDim; ++i_node) {
             PointType global_point;
             SlaveGeometry.GlobalCoordinates(global_point, ConditionsPointSlave[i_geom][i_node]);
-            points_array[i_node] = boost::make_shared<PointType>( global_point );
+            points_array[i_node] = Kratos::make_shared<PointType>( global_point );
         }
 
         DecompType decomp_geom( points_array );
@@ -225,7 +225,7 @@ inline bounded_matrix<double, TNumNodes, TNumNodes> SimpleMortarMapperProcess<TD
         for (unsigned int i_node = 0; i_node < TDim; ++i_node) {
             PointType global_point;
             SlaveGeometry.GlobalCoordinates(global_point, ConditionsPointsSlave[i_geom][i_node]);
-            points_array[i_node] = boost::make_shared<PointType>( global_point );
+            points_array[i_node] = Kratos::make_shared<PointType>( global_point );
         }
 
         DecompType decomp_geom( points_array );

--- a/kratos/python/add_logger_to_python.cpp
+++ b/kratos/python/add_logger_to_python.cpp
@@ -16,7 +16,9 @@
 #include <boost/python/raw_function.hpp>
 
 // Project includes
+#include "includes/define.h"
 #include "input_output/logger.h"
+
 using namespace boost::python;
 
 namespace Kratos

--- a/kratos/python/add_logger_to_python.cpp
+++ b/kratos/python/add_logger_to_python.cpp
@@ -63,7 +63,7 @@ object print(boost::python::tuple args, boost::python::dict kwargs) {
 void  AddLoggerToPython() {
 	using namespace boost::python;
 
-  class_<Logger, boost::shared_ptr<Logger>, boost::noncopyable>("Logger", no_init)
+  class_<Logger, Kratos::shared_ptr<Logger>, boost::noncopyable>("Logger", no_init)
   .def("Print", raw_function(print,1))
   .staticmethod("Print");
 }

--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -69,7 +69,7 @@ ModelPart::MeshType::Pointer ModelPartGetMesh2(ModelPart& rModelPart, ModelPart:
     // adding necessary meshes to the model part.
     ModelPart::MeshType empty_mesh;
     for(ModelPart::IndexType i = number_of_meshes ; i < MeshIndex + 1 ; i++)
-        rModelPart.GetMeshes().push_back(boost::make_shared<ModelPart::MeshType>(empty_mesh.Clone()));
+        rModelPart.GetMeshes().push_back(Kratos::make_shared<ModelPart::MeshType>(empty_mesh.Clone()));
 
     return rModelPart.pGetMesh(MeshIndex);
 }

--- a/kratos/python/add_strategies_to_python.cpp
+++ b/kratos/python/add_strategies_to_python.cpp
@@ -173,24 +173,24 @@ namespace Kratos
             return dummy.CreateEmptyVectorPointer();
         }
 
-        // 	boost::shared_ptr< CompressedMatrix > CreateEmptyMatrixPointer()
+        // 	Kratos::shared_ptr< CompressedMatrix > CreateEmptyMatrixPointer()
         // 	{
-        // 		boost::shared_ptr<CompressedMatrix> pNewMat = boost::shared_ptr<CompressedMatrix>(new CompressedMatrix() );
+        // 		Kratos::shared_ptr<CompressedMatrix> pNewMat = Kratos::shared_ptr<CompressedMatrix>(new CompressedMatrix() );
         // 		return pNewMat;
         // 	}
         //
-        // 	boost::shared_ptr< Vector > CreateEmptyVectorPointer()
+        // 	Kratos::shared_ptr< Vector > CreateEmptyVectorPointer()
         // 	{
-        // 		boost::shared_ptr<Vector > pNewVec = boost::shared_ptr<Vector >(new Vector() );
+        // 		Kratos::shared_ptr<Vector > pNewVec = Kratos::shared_ptr<Vector >(new Vector() );
         // 		return pNewVec;
         // 	}
 
-        CompressedMatrix& GetMatRef(boost::shared_ptr<CompressedMatrix>& dummy)
+        CompressedMatrix& GetMatRef(Kratos::shared_ptr<CompressedMatrix>& dummy)
         {
             return *dummy;
         }
 
-        Vector& GetVecRef(boost::shared_ptr<Vector>& dummy)
+        Vector& GetVecRef(Kratos::shared_ptr<Vector>& dummy)
         {
             return *dummy;
         }
@@ -203,7 +203,7 @@ namespace Kratos
             // 			def("CreateEmptyMatrixPointer",CreateEmptyMatrixPointer);
             // 			def("CreateEmptyVectorPointer",CreateEmptyVectorPointer);
 
-            class_< boost::shared_ptr<CompressedMatrix> >("CompressedMatrixPointer", init<boost::shared_ptr<CompressedMatrix> >())
+            class_< Kratos::shared_ptr<CompressedMatrix> >("CompressedMatrixPointer", init<Kratos::shared_ptr<CompressedMatrix> >())
                     .def("GetReference", GetMatRef, return_value_policy<reference_existing_object > ())
                     //    				.def("GetReference", GetRef, return_internal_reference<1>() )
                     ;
@@ -211,7 +211,7 @@ namespace Kratos
             // // // 			class_< CompressedMatrix , boost::noncopyable >("CompressedMatrix", init< >() );
 
 
-            class_< boost::shared_ptr<Vector> >("VectorPointer", init< boost::shared_ptr<Vector> >())
+            class_< Kratos::shared_ptr<Vector> >("VectorPointer", init< Kratos::shared_ptr<Vector> >())
                     .def("GetReference", GetVecRef, return_value_policy<reference_existing_object > ())
                     ;
             // // // 			class_< Vector , boost::noncopyable >("Vector", init< >() );

--- a/kratos/python/add_testing_to_python.cpp
+++ b/kratos/python/add_testing_to_python.cpp
@@ -15,6 +15,7 @@
 #include <boost/python.hpp>
 
 // Project includes
+#include "includes/define.h"
 #include "testing/testing.h"
 
 

--- a/kratos/python/add_testing_to_python.cpp
+++ b/kratos/python/add_testing_to_python.cpp
@@ -31,7 +31,7 @@ void ListOfAllTestCases() {
 void  AddTestingToPython() {
 	using namespace boost::python;
 
-  scope tester_scope = class_<Testing::Tester, boost::shared_ptr<Testing::Tester>, boost::noncopyable>("Tester", no_init)
+  scope tester_scope = class_<Testing::Tester, Kratos::shared_ptr<Testing::Tester>, boost::noncopyable>("Tester", no_init)
 
   // Properties
   .def("SetVerbosity",&Testing::Tester::SetVerbosity)

--- a/kratos/python/matrix_python_interface.h
+++ b/kratos/python/matrix_python_interface.h
@@ -193,7 +193,7 @@ public:
         fill_row(ThisMatrix, i, Value, TFunctorType());
     }
 
-// 			static class_<TMatrixType, boost::shared_ptr<TMatrixType> > CreateInterface(std::string const& Name)
+// 			static class_<TMatrixType, Kratos::shared_ptr<TMatrixType> > CreateInterface(std::string const& Name)
     static class_<TMatrixType > CreateInterface(std::string const& Name)
     {
 // 				boost::python::converter::registry::push_back(
@@ -201,7 +201,7 @@ public:
 // 					&construct1,
 // 					boost::python::type_id<TMatrixType>());
 
-//  				return class_<TMatrixType, boost::shared_ptr<TMatrixType> >(Name.c_str())
+//  				return class_<TMatrixType, Kratos::shared_ptr<TMatrixType> >(Name.c_str())
         return class_<TMatrixType >(Name.c_str())
                .def(init<TMatrixType>())
                /* 					.def("Resize", &BaseType::resize1) */

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -16,7 +16,7 @@
 #include "input_output/logger.h"
 
 namespace Kratos {
-Kernel::Kernel() : mpKratosCoreApplication(boost::make_shared<KratosApplication>(
+Kernel::Kernel() : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(
                 std::string("KratosMultiphysics"))) {
     std::cout << " |  /           |             " << std::endl;
     std::cout << " ' /   __| _` | __|  _ \\   __|" << std::endl;

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -42,7 +42,7 @@ ModelPart::ModelPart()
 {
     mName = "Default";
     MeshType mesh;
-    mMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
+    mMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
     mpCommunicator->SetLocalMesh(pGetMesh());  // assigning the current mesh to the local mesh of communicator for openmp cases
 }
 
@@ -60,7 +60,7 @@ ModelPart::ModelPart(std::string const& NewName)
 {
     mName = NewName;
     MeshType mesh;
-    mMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
+    mMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
     mpCommunicator->SetLocalMesh(pGetMesh());  // assigning the current mesh to the local mesh of communicator for openmp cases
 }
 
@@ -78,7 +78,7 @@ ModelPart::ModelPart(std::string const& NewName, IndexType NewBufferSize)
 {
     mName = NewName;
     MeshType mesh;
-    mMeshes.push_back(boost::make_shared<MeshType>(mesh.Clone()));
+    mMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
     mpCommunicator->SetLocalMesh(pGetMesh());  // assigning the current mesh to the local mesh of communicator for openmp cases
 }
 
@@ -333,7 +333,7 @@ ModelPart::NodeType::Pointer ModelPart::CreateNewNode(int Id, double x, double y
     }
 
     //create a new node
-    NodeType::Pointer p_new_node = boost::make_shared< NodeType >( Id, x, y, z );
+    NodeType::Pointer p_new_node = Kratos::make_shared< NodeType >( Id, x, y, z );
 
     // Giving model part's variables list to the node
     p_new_node->SetSolutionStepVariablesList(pNewVariablesList);
@@ -379,7 +379,7 @@ ModelPart::NodeType::Pointer ModelPart::CreateNewNode(ModelPart::IndexType Id, d
     }
 
     //create a new node
-    NodeType::Pointer p_new_node = boost::make_shared< NodeType >( Id, x, y, z, mpVariablesList, pThisData, mBufferSize);
+    NodeType::Pointer p_new_node = Kratos::make_shared< NodeType >( Id, x, y, z, mpVariablesList, pThisData, mBufferSize);
     //add the new node to the list of nodes
     GetMesh(ThisIndex).AddNode(p_new_node);
 

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -26,7 +26,7 @@ namespace Kratos
       , mFilename(Filename + ".mdpa")
       , mOptions(Options)
     {
-        boost::shared_ptr<std::fstream> pFile = boost::make_shared<std::fstream>();
+        Kratos::shared_ptr<std::fstream> pFile = boost::make_shared<std::fstream>();
         std::fstream::openmode OpenMode;
 
         // Set the mode
@@ -63,7 +63,7 @@ namespace Kratos
     }
 
     /// Constructor with stream
-    ModelPartIO::ModelPartIO(boost::shared_ptr<std::iostream> Stream)
+    ModelPartIO::ModelPartIO(Kratos::shared_ptr<std::iostream> Stream)
       : mNumberOfLines(1)
     {
         // nullptr test can be confusing with boost::shared_ptr. Commented until we move to std::shared_ptr
@@ -71,7 +71,7 @@ namespace Kratos
         //    KRATOS_THROW_ERROR(std::invalid_argument, "Error: ModelPartIO Stream is invalid ", "");
 
         // Check if the pointer was .reset() or never initialized and if its a NULL pointer)
-        // if (Stream == NULL || Stream == boost::shared_ptr<std::iostream>(NULL))
+        // if (Stream == NULL || Stream == Kratos::shared_ptr<std::iostream>(NULL))
         //    KRATOS_THROW_ERROR(std::invalid_argument, "Error: ModelPartIO Stream is invalid ", "");
 
         mpStream = Stream;
@@ -678,7 +678,7 @@ namespace Kratos
     }
 
     void ModelPartIO::DivideInputToPartitions(
-        boost::shared_ptr<std::iostream> * Streams,
+        Kratos::shared_ptr<std::iostream> * Streams,
         SizeType NumberOfPartitions, GraphType const& DomainsColoredGraph,
         PartitionIndicesType const& NodesPartitions,
         PartitionIndicesType const& ElementsPartitions,
@@ -4642,7 +4642,7 @@ namespace Kratos
         mNumberOfLines = 1;
     }
 
-    void ModelPartIO::SwapStreamSource(boost::shared_ptr<std::iostream> newStream)
+    void ModelPartIO::SwapStreamSource(Kratos::shared_ptr<std::iostream> newStream)
     {
         mpStream.swap(newStream);
     }

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -26,7 +26,7 @@ namespace Kratos
       , mFilename(Filename + ".mdpa")
       , mOptions(Options)
     {
-        Kratos::shared_ptr<std::fstream> pFile = boost::make_shared<std::fstream>();
+        Kratos::shared_ptr<std::fstream> pFile = Kratos::make_shared<std::fstream>();
         std::fstream::openmode OpenMode;
 
         // Set the mode
@@ -1096,7 +1096,7 @@ namespace Kratos
             ExtractValue(word, y);
             ReadWord(word);
             ExtractValue(word, z);
-            NodeType::Pointer temp_node = boost::make_shared< NodeType >( ReorderedNodeId(temp_id), x, y, z);
+            NodeType::Pointer temp_node = Kratos::make_shared< NodeType >( ReorderedNodeId(temp_id), x, y, z);
             temp_node->X0() = temp_node->X();
             temp_node->Y0() = temp_node->Y();
             temp_node->Z0() = temp_node->Z();
@@ -1282,7 +1282,7 @@ namespace Kratos
     {
         KRATOS_TRY
 
-        Properties::Pointer props = boost::make_shared<Properties>();
+        Properties::Pointer props = Kratos::make_shared<Properties>();
         Properties& temp_properties = *props;
         //Properties temp_properties;
 
@@ -2657,7 +2657,7 @@ namespace Kratos
         // adding necessary meshes to the model part.
         MeshType empty_mesh;
         for(SizeType i = number_of_meshes ; i < mesh_id + 1 ; i++)
-            rModelPart.GetMeshes().push_back(boost::make_shared<MeshType>(empty_mesh.Clone()));
+            rModelPart.GetMeshes().push_back(Kratos::make_shared<MeshType>(empty_mesh.Clone()));
 
         MeshType& mesh = rModelPart.GetMesh(mesh_id);
 
@@ -2863,7 +2863,7 @@ namespace Kratos
     {
         KRATOS_TRY
 
-        Properties::Pointer props = boost::make_shared<Properties>();
+        Properties::Pointer props = Kratos::make_shared<Properties>();
         Properties& temp_properties = *props;
 //         Properties temp_properties;
 

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -126,8 +126,8 @@ public:
 
     typedef std::size_t SizeType;
 
-    typedef typename boost::shared_ptr< TMatrixType > MatrixPointerType;
-    typedef typename boost::shared_ptr< TVectorType > VectorPointerType;
+    typedef typename Kratos::shared_ptr< TMatrixType > MatrixPointerType;
+    typedef typename Kratos::shared_ptr< TVectorType > VectorPointerType;
 
     ///@}
     ///@name Life Cycle

--- a/kratos/templates/geometry_template
+++ b/kratos/templates/geometry_template
@@ -229,7 +229,7 @@ namespace Kratos
       ///@name Operations
       ///@{
       
-      virtual boost::shared_ptr< Geometry< Point > > Clone() const
+      virtual Kratos::shared_ptr< Geometry< Point > > Clone() const
 	{
 	  Geometry< Point >::PointsArrayType NewPoints;
 
@@ -238,7 +238,7 @@ namespace Kratos
 	    NewPoints.push_back(mPoints[i]);
 
 	  //creating a geometry with the new points
-	  boost::shared_ptr< Geometry< Point > > p_clone(new ClassName< Point >(NewPoints));
+	  Kratos::shared_ptr< Geometry< Point > > p_clone(new ClassName< Point >(NewPoints));
 	  p_clone->ClonePoints();
 
 	  return p_clone;

--- a/kratos/tests/processes/test_calculate_distance_to_skin_process.cpp
+++ b/kratos/tests/processes/test_calculate_distance_to_skin_process.cpp
@@ -26,14 +26,14 @@ namespace Kratos {
 	  {
 
 		  // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
-          Node<3>::Pointer p_point1 = boost::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
-          Node<3>::Pointer p_point2 = boost::make_shared<Node<3>>(2, 10.00, 0.00, 0.00);
-          Node<3>::Pointer p_point3 = boost::make_shared<Node<3>>(3, 10.00, 10.00, 0.00);
-          Node<3>::Pointer p_point4 = boost::make_shared<Node<3>>(4, 0.00, 10.00, 0.00);
-          Node<3>::Pointer p_point5 = boost::make_shared<Node<3>>(5, 0.00, 0.00, 10.00);
-          Node<3>::Pointer p_point6 = boost::make_shared<Node<3>>(6, 10.00, 0.00, 10.00);
-          Node<3>::Pointer p_point7 = boost::make_shared<Node<3>>(7, 10.00, 10.00, 10.00);
-          Node<3>::Pointer p_point8 = boost::make_shared<Node<3>>(8, 0.00, 10.00, 10.00);
+          Node<3>::Pointer p_point1 = Kratos::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
+          Node<3>::Pointer p_point2 = Kratos::make_shared<Node<3>>(2, 10.00, 0.00, 0.00);
+          Node<3>::Pointer p_point3 = Kratos::make_shared<Node<3>>(3, 10.00, 10.00, 0.00);
+          Node<3>::Pointer p_point4 = Kratos::make_shared<Node<3>>(4, 0.00, 10.00, 0.00);
+          Node<3>::Pointer p_point5 = Kratos::make_shared<Node<3>>(5, 0.00, 0.00, 10.00);
+          Node<3>::Pointer p_point6 = Kratos::make_shared<Node<3>>(6, 10.00, 0.00, 10.00);
+          Node<3>::Pointer p_point7 = Kratos::make_shared<Node<3>>(7, 10.00, 10.00, 10.00);
+          Node<3>::Pointer p_point8 = Kratos::make_shared<Node<3>>(8, 0.00, 10.00, 10.00);
 
           Hexahedra3D8<Node<3> > geometry(p_point1, p_point2, p_point3, p_point4, p_point5, p_point6, p_point7, p_point8);
 
@@ -74,14 +74,14 @@ namespace Kratos {
 	  {
 
 		  // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
-		  Node<3>::Pointer p_point1 = boost::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
-		  Node<3>::Pointer p_point2 = boost::make_shared<Node<3>>(2, 10.00, 0.00, 0.00);
-		  Node<3>::Pointer p_point3 = boost::make_shared<Node<3>>(3, 10.00, 10.00, 0.00);
-		  Node<3>::Pointer p_point4 = boost::make_shared<Node<3>>(4, 0.00, 10.00, 0.00);
-		  Node<3>::Pointer p_point5 = boost::make_shared<Node<3>>(5, 0.00, 0.00, 10.00);
-		  Node<3>::Pointer p_point6 = boost::make_shared<Node<3>>(6, 10.00, 0.00, 10.00);
-		  Node<3>::Pointer p_point7 = boost::make_shared<Node<3>>(7, 10.00, 10.00, 10.00);
-		  Node<3>::Pointer p_point8 = boost::make_shared<Node<3>>(8, 0.00, 10.00, 10.00);
+		  Node<3>::Pointer p_point1 = Kratos::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
+		  Node<3>::Pointer p_point2 = Kratos::make_shared<Node<3>>(2, 10.00, 0.00, 0.00);
+		  Node<3>::Pointer p_point3 = Kratos::make_shared<Node<3>>(3, 10.00, 10.00, 0.00);
+		  Node<3>::Pointer p_point4 = Kratos::make_shared<Node<3>>(4, 0.00, 10.00, 0.00);
+		  Node<3>::Pointer p_point5 = Kratos::make_shared<Node<3>>(5, 0.00, 0.00, 10.00);
+		  Node<3>::Pointer p_point6 = Kratos::make_shared<Node<3>>(6, 10.00, 0.00, 10.00);
+		  Node<3>::Pointer p_point7 = Kratos::make_shared<Node<3>>(7, 10.00, 10.00, 10.00);
+		  Node<3>::Pointer p_point8 = Kratos::make_shared<Node<3>>(8, 0.00, 10.00, 10.00);
 
 		  Hexahedra3D8<Node<3> > geometry(p_point1, p_point2, p_point3, p_point4, p_point5, p_point6, p_point7, p_point8);
 
@@ -123,14 +123,14 @@ namespace Kratos {
 	  {
 
 		  // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
-		  Node<3>::Pointer p_point1 = boost::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
-		  Node<3>::Pointer p_point2 = boost::make_shared<Node<3>>(2, 10.00, 0.00, 0.00);
-		  Node<3>::Pointer p_point3 = boost::make_shared<Node<3>>(3, 10.00, 10.00, 0.00);
-		  Node<3>::Pointer p_point4 = boost::make_shared<Node<3>>(4, 0.00, 10.00, 0.00);
-		  Node<3>::Pointer p_point5 = boost::make_shared<Node<3>>(5, 0.00, 0.00, 10.00);
-		  Node<3>::Pointer p_point6 = boost::make_shared<Node<3>>(6, 10.00, 0.00, 10.00);
-		  Node<3>::Pointer p_point7 = boost::make_shared<Node<3>>(7, 10.00, 10.00, 10.00);
-		  Node<3>::Pointer p_point8 = boost::make_shared<Node<3>>(8, 0.00, 10.00, 10.00);
+		  Node<3>::Pointer p_point1 = Kratos::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
+		  Node<3>::Pointer p_point2 = Kratos::make_shared<Node<3>>(2, 10.00, 0.00, 0.00);
+		  Node<3>::Pointer p_point3 = Kratos::make_shared<Node<3>>(3, 10.00, 10.00, 0.00);
+		  Node<3>::Pointer p_point4 = Kratos::make_shared<Node<3>>(4, 0.00, 10.00, 0.00);
+		  Node<3>::Pointer p_point5 = Kratos::make_shared<Node<3>>(5, 0.00, 0.00, 10.00);
+		  Node<3>::Pointer p_point6 = Kratos::make_shared<Node<3>>(6, 10.00, 0.00, 10.00);
+		  Node<3>::Pointer p_point7 = Kratos::make_shared<Node<3>>(7, 10.00, 10.00, 10.00);
+		  Node<3>::Pointer p_point8 = Kratos::make_shared<Node<3>>(8, 0.00, 10.00, 10.00);
 
 		  Hexahedra3D8<Node<3> > geometry(p_point1, p_point2, p_point3, p_point4, p_point5, p_point6, p_point7, p_point8);
 

--- a/kratos/tests/processes/test_mortar_mapper_process.cpp
+++ b/kratos/tests/processes/test_mortar_mapper_process.cpp
@@ -90,7 +90,7 @@ namespace Kratos
             // Adding map
             IndexSet this_set;
             this_set.AddId(2);
-            p_cond_0->SetValue(INDEX_SET, boost::make_shared<IndexSet>(this_set));
+            p_cond_0->SetValue(INDEX_SET, Kratos::make_shared<IndexSet>(this_set));
             
             // Setting flags
             // SLAVE
@@ -183,7 +183,7 @@ namespace Kratos
             // Adding map
             IndexSet this_set;
             this_set.AddId(2);
-            p_cond_0->SetValue(INDEX_SET, boost::make_shared<IndexSet>(this_set));
+            p_cond_0->SetValue(INDEX_SET, Kratos::make_shared<IndexSet>(this_set));
             
             // Setting flags
             // SLAVE
@@ -295,8 +295,8 @@ namespace Kratos
             this_set0.AddId(4);
             this_set1.AddId(3);
             this_set1.AddId(4);
-            p_cond_0->SetValue(INDEX_SET, boost::make_shared<IndexSet>(this_set0));
-            p_cond_1->SetValue(INDEX_SET, boost::make_shared<IndexSet>(this_set1));
+            p_cond_0->SetValue(INDEX_SET, Kratos::make_shared<IndexSet>(this_set0));
+            p_cond_1->SetValue(INDEX_SET, Kratos::make_shared<IndexSet>(this_set1));
             
             // Setting flags
             // SLAVE

--- a/kratos/tests/sources/test_model_part_io.cpp
+++ b/kratos/tests/sources/test_model_part_io.cpp
@@ -26,7 +26,7 @@ namespace Testing {
 
 KRATOS_TEST_CASE_IN_SUITE(
     ModelPartIOSubModelPartsDivision, KratosCoreFastSuite) {
-    boost::shared_ptr<std::iostream> p_input(new std::stringstream(
+    Kratos::shared_ptr<std::iostream> p_input(new std::stringstream(
         R"input(
 				Begin ModelPartData
                                  DENSITY 2700.000000
@@ -98,9 +98,9 @@ KRATOS_TEST_CASE_IN_SUITE(
 
     ModelPartIO model_part_io(p_input);
 
-    boost::shared_ptr<std::stringstream> p_output_0(new std::stringstream);
-    boost::shared_ptr<std::stringstream> p_output_1(new std::stringstream);
-    boost::shared_ptr<std::iostream> streams[2] = {p_output_0, p_output_1};
+    Kratos::shared_ptr<std::stringstream> p_output_0(new std::stringstream);
+    Kratos::shared_ptr<std::stringstream> p_output_1(new std::stringstream);
+    Kratos::shared_ptr<std::iostream> streams[2] = {p_output_0, p_output_1};
 
     std::size_t number_of_partitions = 2;
     std::size_t number_of_colors = 1;

--- a/kratos/tests/utilities/test_geometrical_sensitivity_utility.cpp
+++ b/kratos/tests/utilities/test_geometrical_sensitivity_utility.cpp
@@ -30,10 +30,10 @@ namespace Testing
 Geometry<Point>::Pointer CreateQuadrilateral2D4N()
 {
     Geometry<Point>::PointsArrayType points;
-    points.push_back(boost::make_shared<Point>(0.0, 0.0, 0.0));
-    points.push_back(boost::make_shared<Point>(1.2, 0.1, 0.0));
-    points.push_back(boost::make_shared<Point>(1.3, 1.02, 0.0));
-    points.push_back(boost::make_shared<Point>(0.1, 1.0, 0.0));
+    points.push_back(Kratos::make_shared<Point>(0.0, 0.0, 0.0));
+    points.push_back(Kratos::make_shared<Point>(1.2, 0.1, 0.0));
+    points.push_back(Kratos::make_shared<Point>(1.3, 1.02, 0.0));
+    points.push_back(Kratos::make_shared<Point>(0.1, 1.0, 0.0));
 
     return Geometry<Point>::Pointer(new Quadrilateral2D4<Point>(points));
 }
@@ -41,14 +41,14 @@ Geometry<Point>::Pointer CreateQuadrilateral2D4N()
 Geometry<Point>::Pointer CreateHexahedra3D8N()
 {
     Geometry<Point>::PointsArrayType points;
-    points.push_back(boost::make_shared<Point>(0.0, 0.0, 0.0));
-    points.push_back(boost::make_shared<Point>(1.02, 0.0, 0.0));
-    points.push_back(boost::make_shared<Point>(1.1, 1.03, 0.07));
-    points.push_back(boost::make_shared<Point>(0.01, 1.0, 0.0));
-    points.push_back(boost::make_shared<Point>(0.0, 0.0, 1.05));
-    points.push_back(boost::make_shared<Point>(1.08, 0.01, 1.0));
-    points.push_back(boost::make_shared<Point>(1.03, 1.09, 1.0));
-    points.push_back(boost::make_shared<Point>(0.0, 1.05, 1.04));
+    points.push_back(Kratos::make_shared<Point>(0.0, 0.0, 0.0));
+    points.push_back(Kratos::make_shared<Point>(1.02, 0.0, 0.0));
+    points.push_back(Kratos::make_shared<Point>(1.1, 1.03, 0.07));
+    points.push_back(Kratos::make_shared<Point>(0.01, 1.0, 0.0));
+    points.push_back(Kratos::make_shared<Point>(0.0, 0.0, 1.05));
+    points.push_back(Kratos::make_shared<Point>(1.08, 0.01, 1.0));
+    points.push_back(Kratos::make_shared<Point>(1.03, 1.09, 1.0));
+    points.push_back(Kratos::make_shared<Point>(0.0, 1.05, 1.04));
 
     return Geometry<Point>::Pointer(new Hexahedra3D8<Point>(points));
 }
@@ -56,9 +56,9 @@ Geometry<Point>::Pointer CreateHexahedra3D8N()
 Geometry<Point>::Pointer CreateTriangle2D3N()
 {
     Geometry<Point>::PointsArrayType points;
-    points.push_back(boost::make_shared<Point>(0.04, 0.02, 0.0));
-    points.push_back(boost::make_shared<Point>(1.1, 0.03, 0.0));
-    points.push_back(boost::make_shared<Point>(1.08, 1.0, 0.0));
+    points.push_back(Kratos::make_shared<Point>(0.04, 0.02, 0.0));
+    points.push_back(Kratos::make_shared<Point>(1.1, 0.03, 0.0));
+    points.push_back(Kratos::make_shared<Point>(1.08, 1.0, 0.0));
 
     return Geometry<Point>::Pointer(new Triangle2D3<Point>(points));
 }
@@ -66,10 +66,10 @@ Geometry<Point>::Pointer CreateTriangle2D3N()
 Geometry<Point>::Pointer CreateTetrahedra3D4N()
 {
     Geometry<Point>::PointsArrayType points;
-    points.push_back(boost::make_shared<Point>(0.0, 0.04, 0.0));
-    points.push_back(boost::make_shared<Point>(1.01, 0.0, 0.2));
-    points.push_back(boost::make_shared<Point>(1.05, 1.0, 0.0));
-    points.push_back(boost::make_shared<Point>(0.0, 0.03, 1.09));
+    points.push_back(Kratos::make_shared<Point>(0.0, 0.04, 0.0));
+    points.push_back(Kratos::make_shared<Point>(1.01, 0.0, 0.2));
+    points.push_back(Kratos::make_shared<Point>(1.05, 1.0, 0.0));
+    points.push_back(Kratos::make_shared<Point>(0.0, 0.03, 1.09));
 
     return Geometry<Point>::Pointer(new Tetrahedra3D4<Point>(points));
 }

--- a/kratos/utilities/divide_tetrahedra_3d_4.cpp
+++ b/kratos/utilities/divide_tetrahedra_3d_4.cpp
@@ -71,7 +71,7 @@ namespace Kratos
             // Add the original geometry points
             for (unsigned int i = 0; i < n_nodes; ++i) {
                 const array_1d<double, 3> aux_point_coords = geometry[i].Coordinates();
-                IndexedPointPointerType paux_point = boost::make_shared<IndexedPoint>(aux_point_coords, i);
+                IndexedPointPointerType paux_point = Kratos::make_shared<IndexedPoint>(aux_point_coords, i);
                 mAuxPointsContainer.push_back(paux_point);
             }
 
@@ -99,7 +99,7 @@ namespace Kratos
                     }
 
                     // Add the intersection point to the auxiliar points array
-                    IndexedPointPointerType paux_point = boost::make_shared<IndexedPoint>(aux_point_coords, aux_node_id);
+                    IndexedPointPointerType paux_point = Kratos::make_shared<IndexedPoint>(aux_point_coords, aux_node_id);
                     mAuxPointsContainer.push_back(paux_point);
                 }
 
@@ -122,7 +122,7 @@ namespace Kratos
                 TetrahedraSplit::TetrahedraGetNewConnectivityGID(idivision, t.data(), mSplitEdges.data(), &i0, &i1, &i2, &i3);
 
                 // Generate a pointer to an auxiliar triangular geometry made with the subdivision points
-                IndexedPointGeometryPointerType p_aux_partition = boost::make_shared<IndexedPointTetrahedraType>(mAuxPointsContainer(i0), 
+                IndexedPointGeometryPointerType p_aux_partition = Kratos::make_shared<IndexedPointTetrahedraType>(mAuxPointsContainer(i0), 
                                                                                                                  mAuxPointsContainer(i1), 
                                                                                                                  mAuxPointsContainer(i2),
                                                                                                                  mAuxPointsContainer(i3));
@@ -189,7 +189,7 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes) && (node_k_key >= n_nodes)) {
                         // Generate an indexed point triangle geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_tri = boost::make_shared<IndexedPointTriangleType>(mAuxPointsContainer(node_i_key), 
+                        IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(mAuxPointsContainer(node_i_key), 
                                                                                                                           mAuxPointsContainer(node_j_key),
                                                                                                                           mAuxPointsContainer(node_k_key));
                         mPositiveInterfaces.push_back(p_intersection_tri);
@@ -217,7 +217,7 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes) && (node_k_key >= n_nodes)) {
                         // Generate an indexed point triangle geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_tri = boost::make_shared<IndexedPointTriangleType>(mAuxPointsContainer(node_i_key), 
+                        IndexedPointGeometryPointerType p_intersection_tri = Kratos::make_shared<IndexedPointTriangleType>(mAuxPointsContainer(node_i_key), 
                                                                                                                           mAuxPointsContainer(node_j_key),
                                                                                                                           mAuxPointsContainer(node_k_key));
                         mNegativeInterfaces.push_back(p_intersection_tri);
@@ -303,7 +303,7 @@ namespace Kratos
                         if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_j_key) != faces_edge_nodes.end()) {
                             if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_k_key) != faces_edge_nodes.end()) {
                                 // If both nodes are in the candidate nodes list, the subface is exterior
-                                IndexedPointGeometryPointerType p_subface_triang = boost::make_shared<IndexedPointTriangleType>(
+                                IndexedPointGeometryPointerType p_subface_triang = Kratos::make_shared<IndexedPointTriangleType>(
                                     mAuxPointsContainer(node_i_key),
                                     mAuxPointsContainer(node_j_key),
                                     mAuxPointsContainer(node_k_key));

--- a/kratos/utilities/divide_triangle_2d_3.cpp
+++ b/kratos/utilities/divide_triangle_2d_3.cpp
@@ -76,7 +76,7 @@ namespace Kratos
             // Add the original geometry points
             for (unsigned int i = 0; i < n_nodes; ++i) {
                 const array_1d<double, 3> aux_point_coords = geometry[i].Coordinates();
-                IndexedPointPointerType paux_point = boost::make_shared<IndexedPoint>(aux_point_coords, i);
+                IndexedPointPointerType paux_point = Kratos::make_shared<IndexedPoint>(aux_point_coords, i);
                 mAuxPointsContainer.push_back(paux_point);
             }
 
@@ -104,7 +104,7 @@ namespace Kratos
                     }
 
                     // Add the intersection point to the auxiliar points array
-                    IndexedPointPointerType paux_point = boost::make_shared<IndexedPoint>(aux_point_coords, aux_node_id);
+                    IndexedPointPointerType paux_point = Kratos::make_shared<IndexedPoint>(aux_point_coords, aux_node_id);
                     mAuxPointsContainer.push_back(paux_point);
                 }
 
@@ -127,7 +127,7 @@ namespace Kratos
                 TriangleGetNewConnectivityGID(idivision, t.data(), mSplitEdges.data(), &i0, &i1, &i2);
 
                 // Generate a pointer to an auxiliar triangular geometry made with the subdivision points
-                IndexedPointGeometryPointerType p_aux_partition = boost::make_shared<IndexedPointTriangleType>(mAuxPointsContainer(i0),
+                IndexedPointGeometryPointerType p_aux_partition = Kratos::make_shared<IndexedPointTriangleType>(mAuxPointsContainer(i0),
                                                                                                                mAuxPointsContainer(i1),
                                                                                                                mAuxPointsContainer(i2));
 
@@ -193,7 +193,7 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes)) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_line = boost::make_shared<IndexedPointLineType>(mAuxPointsContainer(node_i_key),
+                        IndexedPointGeometryPointerType p_intersection_line = Kratos::make_shared<IndexedPointLineType>(mAuxPointsContainer(node_i_key),
                                                                                                                        mAuxPointsContainer(node_j_key));
                         mPositiveInterfaces.push_back(p_intersection_line);
                         mPositiveInterfacesParentIds.push_back(i_subdivision);
@@ -219,7 +219,7 @@ namespace Kratos
                     // If the indexed keys is larger or equal to the number of nodes means that they are the auxiliar interface points
                     if ((node_i_key >= n_nodes) && (node_j_key >= n_nodes)) {
                         // Generate an indexed point line geometry pointer with the two interface nodes
-                        IndexedPointGeometryPointerType p_intersection_line = boost::make_shared<IndexedPointLineType>(mAuxPointsContainer(node_i_key),
+                        IndexedPointGeometryPointerType p_intersection_line = Kratos::make_shared<IndexedPointLineType>(mAuxPointsContainer(node_i_key),
                                                                                                                        mAuxPointsContainer(node_j_key));
                         mNegativeInterfaces.push_back(p_intersection_line);
                         mNegativeInterfacesParentIds.push_back(i_subdivision);
@@ -305,7 +305,7 @@ namespace Kratos
                     if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_i_key) != faces_edge_nodes.end()) {
                         if (std::find(faces_edge_nodes.begin(), faces_edge_nodes.end(), node_j_key) != faces_edge_nodes.end()) {
                             // If both nodes are in the candidate nodes list, the subface is exterior
-                            IndexedPointGeometryPointerType p_subface_line = boost::make_shared<IndexedPointLineType>(
+                            IndexedPointGeometryPointerType p_subface_line = Kratos::make_shared<IndexedPointLineType>(
                                 mAuxPointsContainer(node_i_key),
                                 mAuxPointsContainer(node_j_key));
 

--- a/kratos/utilities/exact_mortar_segmentation_utility.cpp
+++ b/kratos/utilities/exact_mortar_segmentation_utility.cpp
@@ -162,11 +162,11 @@ bool ExactMortarIntegrationUtility<3, 3, false>::GetExactIntegration(
 
         aux_point.Coordinates() = OriginalSlaveGeometry[i_node].Coordinates();  // NOTE: We are in a linear triangle, all the nodes belong already to the plane, so, the step one can be avoided, we directly project  the master nodes
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
-        points_array_slave[i_node] = boost::make_shared<PointType>(aux_point);
+        points_array_slave[i_node] = Kratos::make_shared<PointType>(aux_point);
         
         aux_point = MortarUtilities::FastProject( slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
-        points_array_master[i_node] = boost::make_shared<PointType>(aux_point);
+        points_array_master[i_node] = Kratos::make_shared<PointType>(aux_point);
         
         if (distance > mDistanceThreshold) {
             ConditionsPointsSlave.clear();
@@ -244,13 +244,13 @@ bool ExactMortarIntegrationUtility<3, 4, false>::GetExactIntegration(
         double distance_slave, distance_master;
 
         aux_point = MortarUtilities::FastProject(slave_center, OriginalSlaveGeometry[i_node], SlaveNormal, distance_slave);
-        points_array_slave_not_rotated[i_node] = boost::make_shared<PointType>(aux_point);
+        points_array_slave_not_rotated[i_node] = Kratos::make_shared<PointType>(aux_point);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
-        points_array_slave[i_node] = boost::make_shared<PointType>(aux_point);
+        points_array_slave[i_node] = Kratos::make_shared<PointType>(aux_point);
         
         aux_point = MortarUtilities::FastProject( slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance_master);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
-        points_array_master[i_node] = boost::make_shared<PointType>(aux_point);
+        points_array_master[i_node] = Kratos::make_shared<PointType>(aux_point);
         
         if (distance_slave > mDistanceThreshold || distance_master > mDistanceThreshold) {
             ConditionsPointsSlave.clear();
@@ -457,11 +457,11 @@ bool ExactMortarIntegrationUtility<3, 3, true>::GetExactIntegration(
 
         aux_point.Coordinates() = OriginalSlaveGeometry[i_node].Coordinates();  // NOTE: We are in a linear triangle, all the nodes belong already to the plane, so, the step one can be avoided, we directly project  the master nodes
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
-        points_array_slave[i_node] = boost::make_shared<PointType>(aux_point);
+        points_array_slave[i_node] = Kratos::make_shared<PointType>(aux_point);
 
         aux_point = MortarUtilities::FastProject(slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
-        points_array_master[i_node] = boost::make_shared<PointType>(aux_point);
+        points_array_master[i_node] = Kratos::make_shared<PointType>(aux_point);
     }
 
     Triangle3D3<PointType> slave_geometry(points_array_slave);
@@ -534,13 +534,13 @@ bool ExactMortarIntegrationUtility<3, 4, true>::GetExactIntegration(
         double distance_slave, distance_master;
 
         aux_point = MortarUtilities::FastProject(slave_center, OriginalSlaveGeometry[i_node], SlaveNormal, distance_slave);
-        points_array_slave_not_rotated[i_node] = boost::make_shared<PointType>(aux_point);
+        points_array_slave_not_rotated[i_node] = Kratos::make_shared<PointType>(aux_point);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
-        points_array_slave[i_node] = boost::make_shared<PointType>(aux_point);
+        points_array_slave[i_node] = Kratos::make_shared<PointType>(aux_point);
 
         aux_point = MortarUtilities::FastProject(slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance_master);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
-        points_array_master[i_node] = boost::make_shared<PointType>(aux_point);
+        points_array_master[i_node] = Kratos::make_shared<PointType>(aux_point);
         
         if (distance_slave > mDistanceThreshold || distance_master > mDistanceThreshold) {
             ConditionsPointsSlave.clear();
@@ -602,7 +602,7 @@ bool ExactMortarIntegrationUtility<TDim, TNumNodes,
         for (unsigned int i_node = 0; i_node < TDim; ++i_node) {
             PointType global_point;
             OriginalSlaveGeometry.GlobalCoordinates(global_point, conditions_points_slave[i_geom][i_node]);
-            points_array[i_node] = boost::make_shared<PointType>(global_point);
+            points_array[i_node] = Kratos::make_shared<PointType>(global_point);
         }
 
         DecompositionType decomp_geom(points_array);
@@ -660,7 +660,7 @@ void ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong>::GetTotalArea(
         for (unsigned int i_node = 0; i_node < TDim; ++i_node) {
             PointType global_point;
             OriginalSlaveGeometry.GlobalCoordinates(global_point, ConditionsPointsSlave[i_geom][i_node]);
-            points_array[i_node] = boost::make_shared<PointType>(global_point);
+            points_array[i_node] = Kratos::make_shared<PointType>(global_point);
         }
         
         DecompositionType decomp_geom( points_array );

--- a/kratos/utilities/exact_mortar_segmentation_utility.h
+++ b/kratos/utilities/exact_mortar_segmentation_utility.h
@@ -280,7 +280,7 @@ class KRATOS_API(KRATOS_CORE) ExactMortarIntegrationUtility {
                 SlaveGeometry.GlobalCoordinates(
                     global_point, ConditionsPointSlave[i_geom][i_node]);
                 points_array[i_node] =
-                    boost::make_shared<PointType>(global_point);
+                    Kratos::make_shared<PointType>(global_point);
             }
 
             TriangleType decomp_geom(points_array);


### PR DESCRIPTION
This is PR replaces the shared pointers as requested in #1328. The shared pointers involving in new allocations has been changed to make_shared for performance.