### PR TITLE
Core/correcting warning

### DIFF
--- a/kratos/includes/fixed_size_memory_pool.h
+++ b/kratos/includes/fixed_size_memory_pool.h
@@ -62,7 +62,6 @@ namespace Kratos
 	  /// The constructor to be called
 	  FixedSizeMemoryPool(std::size_t BlockSizeInBytes, SizeType ChunkSize = DefaultChunkSize)
 		  : LockObject()
-		  , mBlockSizeInBytes(BlockSizeInBytes)
 		  , mChunkSize(ChunkSize)
 	  {
 		  for (int i_thread = 0; i_thread < GetNumberOfThreads(); i_thread++)
@@ -181,7 +180,6 @@ namespace Kratos
       ///@name Member Variables
       ///@{
 
-		std::size_t mBlockSizeInBytes;
 		SizeType mChunkSize;
 		std::vector<ThreadFixedSizeMemoryPool> mThreadsPool;
 

--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -138,7 +138,7 @@ public:
 
     std::size_t  ReadConditionsConnectivities(ConnectivitiesContainerType& rConditionsConnectivities) override;
 
-    virtual void WriteConditions(ConditionsContainerType const& rThisConditions);
+    virtual void WriteConditions(ConditionsContainerType const& rThisConditions) override;
 
     void ReadInitialValues(ModelPart& rThisModelPart) override;
 

--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -78,6 +78,9 @@ public:
     typedef std::vector<std::ostream*>            OutputFilesContainerType;
     typedef std::size_t                           SizeType;
 
+    // Prevents this class from hidding IO::WriteProperties(Properties)
+    using BaseType::WriteProperties;
+
     ///@}
     ///@name Life Cycle
     ///@{

--- a/kratos/includes/thread_fixed_size_memory_pool.h
+++ b/kratos/includes/thread_fixed_size_memory_pool.h
@@ -235,14 +235,15 @@ namespace Kratos
       ///@{
 
 		void AddChunk() {
-			if (mThreadNumber != GetThreadNumber())
-				KRATOS_ERROR;
-			KRATOS_DEBUG_CHECK_EQUAL(mThreadNumber, GetThreadNumber());
+			if (mThreadNumber != static_cast<std::size_t>(GetThreadNumber()))
+                KRATOS_ERROR;
+                
+			KRATOS_DEBUG_CHECK_EQUAL(mThreadNumber, static_cast<std::size_t>(GetThreadNumber()));
 
-				mChunks.emplace_back(mBlockSizeInBytes, mChunkSize);
-				Chunk* p_available_chunk = &(mChunks.back());
-				p_available_chunk->Initialize();
-				mAvailableChunks.push_front(p_available_chunk);
+            mChunks.emplace_back(mBlockSizeInBytes, mChunkSize);
+            Chunk* p_available_chunk = &(mChunks.back());
+            p_available_chunk->Initialize();
+            mAvailableChunks.push_front(p_available_chunk);
 		}
 
 		void DeallocateFromAvailableChunk(void* pPointrerToRelease, ChunkList::iterator iChunk) {

--- a/kratos/sources/prime_numbers.cpp
+++ b/kratos/sources/prime_numbers.cpp
@@ -49,7 +49,7 @@ namespace Kratos
 	}
 
 
-	const std::array<std::size_t, PrimeNumbers::mNumberOfPreCalculatedPrimes> PrimeNumbers::mPrecalculatedPrimes = {
+	const std::array<std::size_t, PrimeNumbers::mNumberOfPreCalculatedPrimes> PrimeNumbers::mPrecalculatedPrimes = {{
 		1		,2		,3		,5		,7		,11		,13		,17
 		,19		,23		,29		,31		,37		,41		,43		,47
 		,53		,59		,61		,67		,71		,73		,79		,83
@@ -12550,7 +12550,7 @@ namespace Kratos
 		,1299343	,1299349	,1299359	,1299367	,1299377	,1299379	,1299437	,1299439
 		,1299449	,1299451	,1299457	,1299491	,1299499	,1299533	,1299541	,1299553
 		,1299583	,1299601	,1299631	,1299637	,1299647	,1299653	,1299673	,1299689
-	};
+	}};
 
   
   

--- a/kratos/testing/tester.cpp
+++ b/kratos/testing/tester.cpp
@@ -236,11 +236,13 @@ namespace Kratos
 				TestCasesNamePattern.begin(), TestCasesNamePattern.end(), replace_star, ".*");
 			for (auto i_test = GetInstance().mTestCases.begin();
 				i_test != GetInstance().mTestCases.end(); i_test++)
-				if (std::regex_match(i_test->second->Name(), std::regex(regex_pattern_string.str())))
-					if (i_test->second->IsEnabled())
+				if (std::regex_match(i_test->second->Name(), std::regex(regex_pattern_string.str()))) {
+					if (i_test->second->IsEnabled()) {
 						i_test->second->Select();
-					else
-						i_test->second->UnSelect();
+                    } else {
+                        i_test->second->UnSelect();
+                    }
+                }
 #endif  
 		}
 

--- a/kratos/tests/sources/test_memory_pool.cpp
+++ b/kratos/tests/sources/test_memory_pool.cpp
@@ -106,7 +106,10 @@ namespace Kratos {
 		//}
 
 		class Block64byte : public PoolObject{
-			double block[8];
+            public:
+                Block64byte() {Block[0] = 0;};
+            private:
+                double Block[8];
 		};
 
 		KRATOS_DISABLED_TEST_CASE_IN_SUITE(PoolObjectParallelNewDelete, KratosCoreFastSuite)


### PR DESCRIPTION
Correcting all core warnings (Clang 5). Now it compiles with -Werror.
Pending on testing it with gcc...

If you have a better suggestion of for [This one](https://github.com/KratosMultiphysics/Kratos/commit/410cf1145aed824425c6d16cba4691342853eed3) I am all ears.