### PR TITLE
[EigenSolversApp] Removing unnecessary include

### DIFF
--- a/applications/EigenSolversApplication/custom_solvers/eigen_direct_solver.h
+++ b/applications/EigenSolversApplication/custom_solvers/eigen_direct_solver.h
@@ -13,8 +13,6 @@
 #define KRATOS_EIGEN_SOLVER_H_INCLUDED
 
 // External includes
-#include "boost/smart_ptr.hpp"
-
 #include <Eigen/Core>
 #include <Eigen/Sparse>
 #if defined EIGEN_USE_MKL_ALL


### PR DESCRIPTION
Removing the inclusion of the boost smart ptr that will be removed at some point
=> use `Kratos::shared_ptr` if you need it