### PR TITLE
Fixing KratosComponent Warning

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -3,6 +3,9 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 ## Kratos main source code
 set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/exact_mortar_segmentation_utility.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sources/point.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sources/element.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/sources/condition.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/global_variables.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/deprecated_variables.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/c2c_variables.cpp;
@@ -24,12 +27,10 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/kratos_components.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/model_part_io.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/reorder_consecutive_model_part_io.cpp;
-    # ${CMAKE_CURRENT_SOURCE_DIR}/processes/calculate_signed_distance_to_3d_skin_process.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/simple_mortar_mapper_process.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/io.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/model_part.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/containers/model.cpp;
-    #${CMAKE_CURRENT_SOURCE_DIR}/sources/kratos_exception.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/containers/variable_data.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/mesh_local_smoothing_process.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/tetrahedra_mesh_worst_element_smoothing_process.cpp;

--- a/kratos/geometries/point.h
+++ b/kratos/geometries/point.h
@@ -61,7 +61,7 @@ namespace Kratos
 @see Node
 @see IntegrationPoint
 */
-class Point : public array_1d<double, 3>
+class KRATOS_API(KRATOS_CORE) Point : public array_1d<double, 3>
 {
     static constexpr int mDimension = 3;
 
@@ -77,11 +77,8 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(Point);
 
     typedef array_1d<double, mDimension> BaseType;
-
     typedef BaseType CoordinatesArrayType;
-
     typedef std::size_t SizeType;
-
     typedef std::size_t IndexType;
 
     ///@}
@@ -89,63 +86,38 @@ public:
     ///@{
 
     /// Default constructor.
-    Point() : BaseType(mDimension)
-    {
-        SetAllCoordinates();
-    }
+    Point();
 
     /// 3d constructor.
-    Point(double NewX, double NewY = 0, double NewZ = 0) : BaseType(mDimension)
-    {
-        this->operator()(0) = NewX;
-        this->operator()(1) = NewY;
-        this->operator()(2) = NewZ;
-    }
+    Point(double NewX, double NewY = 0, double NewZ = 0);
 
     /** Copy constructor. Initialize this point with the coordinates
     of given point.*/
-    Point(Point const &rOtherPoint)
-        : BaseType(rOtherPoint) {}
+    Point(Point const &rOtherPoint);
 
     /** Constructor using coordinates stored in given array. Initialize
     this point with the coordinates in the array. */
-    Point(CoordinatesArrayType const &rOtherCoordinates)
-        : BaseType(rOtherCoordinates) {}
+    Point(CoordinatesArrayType const &rOtherCoordinates);
 
     /** Constructor using coordinates stored in given array. Initialize
     this point with the coordinates in the array. */
     template <class TVectorType>
-    Point(vector_expression<TVectorType> const &rOtherCoordinates)
-        : BaseType(rOtherCoordinates) {}
+    Point(vector_expression<TVectorType> const &rOtherCoordinates) : BaseType(rOtherCoordinates) {}
 
     /** Constructor using coordinates stored in given std::vector. Initialize
     this point with the coordinates in the array. */
-    Point(std::vector<double> const &rOtherCoordinates) : BaseType(mDimension)
-    {
-        SizeType size = rOtherCoordinates.size();
-        size = (mDimension < size) ? mDimension : size;
-        for (IndexType i = 0; i < size; i++)
-            this->operator[](i) = rOtherCoordinates[i];
-    }
+    Point(std::vector<double> const &rOtherCoordinates);
 
     /// Destructor.
-    virtual ~Point() {}
+    virtual ~Point();
 
     ///@}
     ///@name Operators
     ///@{
 
     /// Assignment operator.
-    Point &operator=(const Point &rOther)
-    {
-        CoordinatesArrayType::operator=(rOther);
-        return *this;
-    }
-
-    bool operator==(const Point &rOther)
-    {
-        return std::equal(this->begin(), this->end(), rOther.begin());
-    }
+    Point &operator=(const Point &rOther);
+    bool operator==(const Point &rOther);
 
     ///@}
     ///@name Operations
@@ -155,80 +127,41 @@ public:
     ///@name Access
     ///@{
 
-    static constexpr IndexType Dimension()
-    {
-        return 3;
-    }
+    static constexpr IndexType Dimension();
 
     /** Returns X coordinate */
-    double X() const
-    {
-        return this->operator[](0);
-    }
+    double X() const;
 
     /** Returns Y coordinate */
-    double Y() const
-    {
-        return this->operator[](1);
-    }
+    double Y() const;
 
     /** Returns Z coordinate */
-    double Z() const
-    {
-        return this->operator[](2);
-    }
+    double Z() const;
 
-    double &X()
-    {
-        return this->operator[](0);
-    }
+    /** Returns X coordinate */
+    double &X();
 
     /** Returns Y coordinate */
-    double &Y()
-    {
-        return this->operator[](1);
-    }
+    double &Y();
 
     /** Returns Z coordinate */
-    double &Z()
-    {
-        return this->operator[](2);
-    }
+    double &Z();
 
-    CoordinatesArrayType const &Coordinates() const
-    {
-        return *this;
-    }
-
-    CoordinatesArrayType &Coordinates()
-    {
-        return *this;
-    }
+    CoordinatesArrayType const &Coordinates() const;
+    CoordinatesArrayType &Coordinates();
 
     ///@}
     ///@name Input and output
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const
-    {
-        return "Point";
-    }
+    virtual std::string Info() const;
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream &rOStream) const
-    {
-        rOStream << this->Info();
-    }
+    virtual void PrintInfo(std::ostream &rOStream) const;
 
     /// Print object's data.
-    virtual void PrintData(std::ostream &rOStream) const
-    {
-        rOStream << "(" << this->operator[](0)
-                        << this->operator[](1)  
-                        << this->operator[](2) 
-                 << ")";
-    }
+    virtual void PrintData(std::ostream &rOStream) const;
 
     ///@}
 
@@ -236,11 +169,7 @@ public:
     ///@name Private Operations
     ///@{
 
-    void SetAllCoordinates(double const &Value = double())
-    {
-        for (IndexType i = 0; i < mDimension; i++)
-            this->operator()(i) = Value;
-    }
+    void SetAllCoordinates(double const &Value = double());
 
     ///@}
     ///@name Serialization
@@ -248,15 +177,8 @@ public:
 
     friend class Serializer;
 
-    virtual void save(Serializer &rSerializer) const
-    {
-        rSerializer.save_base("BaseClass", *static_cast<const array_1d<double, mDimension> *>(this));
-    }
-
-    virtual void load(Serializer &rSerializer)
-    {
-        rSerializer.load_base("BaseClass", *static_cast<array_1d<double, mDimension> *>(this));
-    }
+    virtual void save(Serializer &rSerializer) const;
+    virtual void load(Serializer &rSerializer);
 
     ///@}
 
@@ -264,7 +186,8 @@ public:
 
 ///@}
 
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Point>;
+// Explicit instantiation declaration
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Point>;
 
 ///@name Type Definitions
 ///@{
@@ -273,21 +196,6 @@ template class KRATOS_API(KRATOS_CORE) KratosComponents<Point>;
 ///@name Input and output
 ///@{
 
-/// input stream function
-inline std::istream &operator>>(std::istream &rIStream,
-                                Point &rThis){
-                                    return rIStream;
-                                }
-
-/// output stream function
-inline std::ostream &operator<<(std::ostream &rOStream,
-                                const Point &rThis)
-{
-    rThis.PrintInfo(rOStream);
-    rThis.PrintData(rOStream);
-
-    return rOStream;
-}
 ///@}
 
 } // namespace Kratos.

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -1189,7 +1189,8 @@ inline std::ostream & operator <<(std::ostream& rOStream,
 }
 ///@}
 
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Condition >;
+// Explicit instantiation declaration
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Condition>;
 
 void KRATOS_API(KRATOS_CORE) AddKratosComponent(std::string const& Name, Condition const& ThisComponent);
 

--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -1368,7 +1368,8 @@ inline std::ostream & operator <<(std::ostream& rOStream,
 ///@}
 ///@} addtogroup block
  
-template class KRATOS_API(KRATOS_CORE) KratosComponents<ConstitutiveLaw >;
+// Explicit instantiation declaration
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<ConstitutiveLaw>;
 
 void KRATOS_API(KRATOS_CORE) AddKratosComponent(std::string const& Name, ConstitutiveLaw const& ThisComponent);
 

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -1237,7 +1237,8 @@ inline std::ostream & operator <<(std::ostream& rOStream,
 }
 ///@}
 
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Element >;
+// Explicit instantiation declaration
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Element>;
 
 void KRATOS_API(KRATOS_CORE) AddKratosComponent(std::string const& Name, Element const& ThisComponent);
 

--- a/kratos/includes/kratos_components.h
+++ b/kratos/includes/kratos_components.h
@@ -454,19 +454,19 @@ private:
 
 }; // Class KratosComponents
 
-
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<bool> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<int> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<unsigned int> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<double> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<array_1d<double, 3> > >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Quaternion<double> > >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Vector> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Matrix> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<std::string> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<VariableComponent<VectorComponentAdaptor<array_1d<double, 3> > > >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Flags> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Flags>;
+// Explicit instantiation declaration
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<bool> >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<int> >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<unsigned int> >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<double> >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<array_1d<double, 3> > >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Quaternion<double> > >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Vector> >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Matrix> >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<std::string> >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<VariableComponent<VectorComponentAdaptor<array_1d<double, 3> > > >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Flags> >;
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<Flags>;
 
 #ifdef KratosCore_EXPORTS
 template<class TComponentType>

--- a/kratos/includes/periodic_condition.h
+++ b/kratos/includes/periodic_condition.h
@@ -372,7 +372,8 @@ private:
 
 ///@}
 
-template class KRATOS_API(KRATOS_CORE) KratosComponents<PeriodicCondition >;
+// Explicit instantiation declaration
+extern template class KRATOS_API(KRATOS_CORE) KratosComponents<PeriodicCondition >;
 
 ///@name Type Definitions
 ///@{

--- a/kratos/sources/condition.cpp
+++ b/kratos/sources/condition.cpp
@@ -3,6 +3,6 @@
 namespace Kratos {
 
 // Explicit instantiation of the component
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Condition>;
+template class KratosComponents<Condition>;
 
 }

--- a/kratos/sources/condition.cpp
+++ b/kratos/sources/condition.cpp
@@ -1,0 +1,8 @@
+#include "includes/condition.h"
+
+namespace Kratos {
+
+// Explicit instantiation of the component
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Condition>;
+
+}

--- a/kratos/sources/constitutive_law.cpp
+++ b/kratos/sources/constitutive_law.cpp
@@ -1667,7 +1667,7 @@ void ConstitutiveLaw::CalculateCauchyStresses(Vector& Cauchy_StressVector,
 }
 
 // Explicit instantiation of the component
-template class KRATOS_API(KRATOS_CORE) KratosComponents<ConstitutiveLaw>;
+template class KratosComponents<ConstitutiveLaw>;
 
 } /* namespace Kratos.*/
 

--- a/kratos/sources/constitutive_law.cpp
+++ b/kratos/sources/constitutive_law.cpp
@@ -1666,8 +1666,8 @@ void ConstitutiveLaw::CalculateCauchyStresses(Vector& Cauchy_StressVector,
 {
 }
 
-
-
+// Explicit instantiation of the component
+template class KRATOS_API(KRATOS_CORE) KratosComponents<ConstitutiveLaw>;
 
 } /* namespace Kratos.*/
 

--- a/kratos/sources/element.cpp
+++ b/kratos/sources/element.cpp
@@ -1,0 +1,8 @@
+#include "includes/element.h"
+
+namespace Kratos {
+
+// Explicit instantiation of the component
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Element>;
+
+}

--- a/kratos/sources/element.cpp
+++ b/kratos/sources/element.cpp
@@ -3,6 +3,6 @@
 namespace Kratos {
 
 // Explicit instantiation of the component
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Element>;
+template class KratosComponents<Element>;
 
 }

--- a/kratos/sources/kratos_components.cpp
+++ b/kratos/sources/kratos_components.cpp
@@ -110,23 +110,18 @@ void AddKratosComponent(std::string const& Name, ConstitutiveLaw const& ThisComp
 KratosComponents<VariableData>::ComponentsContainerType KratosComponents<VariableData>::msComponents;
 
 // Explicit instantiation definition
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<bool> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<int> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<unsigned int> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<double> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<array_1d<double, 3> > >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Quaternion<double> > >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Vector> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Matrix> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<std::string> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<VariableComponent<VectorComponentAdaptor<array_1d<double, 3> > > >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Flags> >;
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Flags>;
-
-// template class KRATOS_API(KRATOS_CORE) KratosComponents<Point>;
-// template class KRATOS_API(KRATOS_CORE) KratosComponents<Element>;
-// template class KRATOS_API(KRATOS_CORE) KratosComponents<Condition>;
-// template class KRATOS_API(KRATOS_CORE) KratosComponents<PeriodicCondition>;
+template class KratosComponents<Variable<bool> >;
+template class KratosComponents<Variable<int> >;
+template class KratosComponents<Variable<unsigned int> >;
+template class KratosComponents<Variable<double> >;
+template class KratosComponents<Variable<array_1d<double, 3> > >;
+template class KratosComponents<Variable<Quaternion<double> > >;
+template class KratosComponents<Variable<Vector> >;
+template class KratosComponents<Variable<Matrix> >;
+template class KratosComponents<Variable<std::string> >;
+template class KratosComponents<VariableComponent<VectorComponentAdaptor<array_1d<double, 3> > > >;
+template class KratosComponents<Variable<Flags> >;
+template class KratosComponents<Flags>;
 
 }  // namespace Kratos.
 

--- a/kratos/sources/kratos_components.cpp
+++ b/kratos/sources/kratos_components.cpp
@@ -109,6 +109,25 @@ void AddKratosComponent(std::string const& Name, ConstitutiveLaw const& ThisComp
 // Specialize array of compenents for VariableData
 KratosComponents<VariableData>::ComponentsContainerType KratosComponents<VariableData>::msComponents;
 
+// Explicit instantiation definition
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<bool> >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<int> >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<unsigned int> >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<double> >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<array_1d<double, 3> > >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Quaternion<double> > >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Vector> >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Matrix> >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<std::string> >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<VariableComponent<VectorComponentAdaptor<array_1d<double, 3> > > >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Variable<Flags> >;
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Flags>;
+
+// template class KRATOS_API(KRATOS_CORE) KratosComponents<Point>;
+// template class KRATOS_API(KRATOS_CORE) KratosComponents<Element>;
+// template class KRATOS_API(KRATOS_CORE) KratosComponents<Condition>;
+// template class KRATOS_API(KRATOS_CORE) KratosComponents<PeriodicCondition>;
+
 }  // namespace Kratos.
 
 

--- a/kratos/sources/periodic_condition.cpp
+++ b/kratos/sources/periodic_condition.cpp
@@ -159,5 +159,8 @@ void PeriodicCondition::load(Serializer& rSerializer)
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
 }
 
+// Explicit instantiation of the component
+template class KRATOS_API(KRATOS_CORE) KratosComponents<PeriodicCondition>;
+
 }
 

--- a/kratos/sources/periodic_condition.cpp
+++ b/kratos/sources/periodic_condition.cpp
@@ -160,7 +160,7 @@ void PeriodicCondition::load(Serializer& rSerializer)
 }
 
 // Explicit instantiation of the component
-template class KRATOS_API(KRATOS_CORE) KratosComponents<PeriodicCondition>;
+template class KratosComponents<PeriodicCondition>;
 
 }
 

--- a/kratos/sources/point.cpp
+++ b/kratos/sources/point.cpp
@@ -1,0 +1,175 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Riccardo Rossi
+//                   Janosch Stascheit
+//                   Felix Nagel
+//  contributors:    Hoang Giang Bui
+//                   Josep Maria Carbonell
+//
+
+// Project includes
+#include "geometries/point.h"
+
+namespace Kratos {
+
+/// Default constructor.
+Point::Point() : BaseType(mDimension)
+{
+    SetAllCoordinates();
+}
+
+/// 3d constructor.
+Point::Point(double NewX, double NewY, double NewZ) : BaseType(mDimension)
+{
+    this->operator()(0) = NewX;
+    this->operator()(1) = NewY;
+    this->operator()(2) = NewZ;
+}
+
+/** Copy constructor. Initialize this point with the coordinates
+of given point.*/
+Point::Point(Point const &rOtherPoint) : BaseType(rOtherPoint) {}
+
+/** Constructor using coordinates stored in given array. Initialize
+this point with the coordinates in the array. */
+Point::Point(CoordinatesArrayType const &rOtherCoordinates) : BaseType(rOtherCoordinates) {}
+
+/** Constructor using coordinates stored in given std::vector. Initialize
+this point with the coordinates in the array. */
+Point::Point(std::vector<double> const &rOtherCoordinates) : BaseType(mDimension)
+{
+    SizeType size = rOtherCoordinates.size();
+    size = (mDimension < size) ? mDimension : size;
+    for (IndexType i = 0; i < size; i++)
+        this->operator[](i) = rOtherCoordinates[i];
+}
+
+/// Destructor.
+Point::~Point() {}
+
+/// Assignment operator.
+Point &Point::operator=(const Point &rOther)
+{
+    CoordinatesArrayType::operator=(rOther);
+    return *this;
+}
+
+bool Point::operator==(const Point &rOther)
+{
+    return std::equal(this->begin(), this->end(), rOther.begin());
+}
+
+constexpr Point::IndexType Point::Dimension()
+{
+    return 3;
+}
+
+/** Returns X coordinate */
+double Point::X() const
+{
+    return this->operator[](0);
+}
+
+/** Returns Y coordinate */
+double Point::Y() const
+{
+    return this->operator[](1);
+}
+
+/** Returns Z coordinate */
+double Point::Z() const
+{
+    return this->operator[](2);
+}
+
+double & Point::X()
+{
+    return this->operator[](0);
+}
+
+/** Returns Y coordinate */
+double & Point::Y()
+{
+    return this->operator[](1);
+}
+
+/** Returns Z coordinate */
+double & Point::Z()
+{
+    return this->operator[](2);
+}
+
+Point::CoordinatesArrayType const & Point::Coordinates() const
+{
+    return *this;
+}
+
+Point::CoordinatesArrayType & Point::Coordinates()
+{
+    return *this;
+}
+
+/// Turn back information as a string.
+std::string Point::Info() const
+{
+    return "Point";
+}
+
+/// Print information about this object.
+void Point::PrintInfo(std::ostream &rOStream) const
+{
+    rOStream << this->Info();
+}
+
+/// Print object's data.
+void Point::PrintData(std::ostream &rOStream) const
+{
+    rOStream << "(" << this->operator[](0)
+                    << this->operator[](1)  
+                    << this->operator[](2) 
+             << ")";
+}
+
+void Point::SetAllCoordinates(double const &Value)
+{
+    for (IndexType i = 0; i < mDimension; i++)
+        this->operator()(i) = Value;
+}
+
+void Point::save(Serializer &rSerializer) const
+{
+    rSerializer.save_base("BaseClass", *static_cast<const array_1d<double, mDimension> *>(this));
+}
+
+void Point::load(Serializer &rSerializer)
+{
+    rSerializer.load_base("BaseClass", *static_cast<array_1d<double, mDimension> *>(this));
+}
+
+// Explicit instantiation of the component
+template class KRATOS_API(KRATOS_CORE) KratosComponents<Point>;
+
+/// input stream function
+inline std::istream &operator>>(std::istream &rIStream,
+                                Point &rThis){
+                                    return rIStream;
+                                }
+
+/// output stream function
+inline std::ostream &operator<<(std::ostream &rOStream,
+                                const Point &rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+} // namespace Kratos.

--- a/kratos/sources/point.cpp
+++ b/kratos/sources/point.cpp
@@ -154,7 +154,7 @@ void Point::load(Serializer &rSerializer)
 }
 
 // Explicit instantiation of the component
-template class KRATOS_API(KRATOS_CORE) KratosComponents<Point>;
+template class KratosComponents<Point>;
 
 /// input stream function
 inline std::istream &operator>>(std::istream &rIStream,


### PR DESCRIPTION
This is not meant to be merged (or maybe it can). Just a discussion.

In order to solve the nasty KratosComponent warning I used the new C++11 explicit instantiation declaration, so the definition is in a CPP and the declaration is a extern class template in the .h.  I think this way the fix is not invasive at all and do not requeire deep changes in the code, as opposite of the one we tested in the other branch.

In order to do so, I had to create element.cpp, point.cpp and condition.cpp, as the others already existed. 

I also moved the whole implementation of point to a cpp, except for the templated constructor to check it works. Maybe it could be a good time to move condition and element as well.

This is the only way I found. There is also the option of forward declaring the Point, Element etc.. in the components cpp, but I found that solution very ugly and I am not completely sure that would run...

I am not expert in template instantiation so maybe a did something barbaric... tell me what you think.