### PR TITLE
Unifying the printing of Vector type results.

### DIFF
--- a/kratos/includes/gid_gauss_point_container.h
+++ b/kratos/includes/gid_gauss_point_container.h
@@ -299,7 +299,8 @@ public:
         {
             //WriteGaussPoints(ResultFile);
             GiD_fBeginResult( ResultFile, (char *)(rVariable.Name()).c_str(), (char *)("Kratos"), SolutionTag,
-                             GiD_Vector, GiD_OnGaussPoints, mGPTitle, NULL, 0, NULL );
+                             GiD_Matrix, GiD_OnGaussPoints, mGPTitle, NULL, 0, NULL );
+
             std::vector<Vector> ValuesOnIntPoint(mSize);
             if( mMeshElements.size() != 0 )
             {
@@ -313,9 +314,12 @@ public:
                         for(unsigned int i=0; i<mIndexContainer.size(); i++)
                         {
                             int index = mIndexContainer[i];
-                            if( ValuesOnIntPoint[0].size() == 3 )
-                                GiD_fWriteVector( ResultFile, it->Id(), ValuesOnIntPoint[index][0],
-                                                 ValuesOnIntPoint[index][1], ValuesOnIntPoint[index][2] );
+                            const auto& values = ValuesOnIntPoint[index];
+                            if (values.size() ==3 )
+                                GiD_fWrite2DMatrix(ResultFile, it->Id(), values[0], values[1], values[2]);
+                            else if (values.size() == 6 )
+                                GiD_fWrite3DMatrix( ResultFile, it->Id(), values[0], values[1], values[2],
+                                    values[3], values[4], values[5] );
                         }
                     }
                 }
@@ -332,9 +336,12 @@ public:
                         for(unsigned int i=0; i<mIndexContainer.size(); i++)
                         {
                             int index = mIndexContainer[i];
-                            if( ValuesOnIntPoint[0].size() == 3 )
-                                GiD_fWriteVector( ResultFile, it->Id(), ValuesOnIntPoint[index][0],
-                                                 ValuesOnIntPoint[index][1], ValuesOnIntPoint[index][2] );
+                            const auto& values = ValuesOnIntPoint[index];
+                            if (values.size() ==3 )
+                                GiD_fWrite2DMatrix(ResultFile, it->Id(), values[0], values[1], values[2]);
+                            else if (values.size() == 6 )
+                                GiD_fWrite3DMatrix( ResultFile, it->Id(), values[0], values[1], values[2],
+                                    values[3], values[4], values[5] );
                         }
                     }                 
                 }

--- a/kratos/includes/gid_io.h
+++ b/kratos/includes/gid_io.h
@@ -815,7 +815,7 @@ public:
             const Vector& temp_vector = it_node->FastGetSolutionStepValue(rVariable,
                                  SolutionStepNumber);
             if (temp_vector.size() ==3 )
-                GiD_fWriteVector(mResultFile, it_node->Id(), temp_vector[0], temp_vector[1], temp_vector[2] );
+                GiD_fWrite2DMatrix(mResultFile, it_node->Id(), temp_vector[0], temp_vector[1], temp_vector[2]);
             else if (temp_vector.size() == 6 )
                 GiD_fWrite3DMatrix( mResultFile, it_node->Id(), temp_vector[0], temp_vector[1], temp_vector[2],
                                     temp_vector[3], temp_vector[4], temp_vector[5] );
@@ -1002,7 +1002,7 @@ public:
         {
             const Vector& temp_vector = it_node->GetValue(rVariable);
             if (temp_vector.size() ==3 )
-                GiD_fWriteVector(mResultFile, it_node->Id(), temp_vector[0], temp_vector[1], temp_vector[2] );
+                GiD_fWrite2DMatrix(mResultFile, it_node->Id(), temp_vector[0], temp_vector[1], temp_vector[2]);
             else if (temp_vector.size() == 6 )
                 GiD_fWrite3DMatrix( mResultFile, it_node->Id(), temp_vector[0], temp_vector[1], temp_vector[2],
                                     temp_vector[3], temp_vector[4], temp_vector[5] );


### PR DESCRIPTION
This fixes #1428 

@loumalouomega I was not able to preserve the behaviour of your implementation (vectors if size 3, matrices if size 6), because it fails in Binary mode. I suspect that this is related to the fact that the result was always being declared as a Matrix when calling `GiD_fBeginResult`. If you can think of a way of generalizing it, I'm open to suggestions.

@KratosMultiphysics/technical-committee: I did not implement the plane strain/stress case. Is there a well-defined order for the Voigt vector in that case? (is the z component the 3rd or the last number?)