### PR TITLE
Changing override to virtual for base class.

### DIFF
--- a/kratos/includes/table.h
+++ b/kratos/includes/table.h
@@ -373,7 +373,7 @@ private:
 
     friend class Serializer;
 
-    void save(Serializer& rSerializer) const override
+    virtual void save(Serializer& rSerializer) const
     {
         std::size_t  local_size = mData.size();
 
@@ -386,7 +386,7 @@ private:
         }
     }
 
-    void load(Serializer& rSerializer) override
+    virtual void load(Serializer& rSerializer)
     {
         std::size_t local_size;
 


### PR DESCRIPTION
Since Table has no parent class, it does not make sense to mark its functions `override`. This was causing a compilation error when using clang.