### PR TITLE
Cleaning Eigensolverfactory

### DIFF
--- a/kratos/python_scripts/eigen_solver_factory.py
+++ b/kratos/python_scripts/eigen_solver_factory.py
@@ -2,30 +2,33 @@ from __future__ import print_function, absolute_import, division #makes KratosMu
 
 def ConstructSolver(settings):
     import KratosMultiphysics
-    
+
     if(type(settings) != KratosMultiphysics.Parameters):
         raise Exception("Input is expected to be provided as a Kratos Parameters object")
-    
+
     solver_type = settings["solver_type"].GetString()
-    
-    if solver_type == "eigen_eigensystem":
-        import KratosMultiphysics.EigenSolversApplication
-        eigen_solver = KratosMultiphysics.EigenSolversApplication.EigensystemSolver(settings)
-        return eigen_solver
-    
-    import new_linear_solver_factory
-    linear_solver = new_linear_solver_factory.ConstructSolver(settings["linear_solver_settings"])
-        
+
+    if settings.Has("linear_solver_settings"):
+        import new_linear_solver_factory
+        linear_solver = new_linear_solver_factory.ConstructSolver(settings["linear_solver_settings"])
+
+    # Solvers in KratosCore
     if(solver_type == "power_iteration_eigenvalue_solver"):
         eigen_solver = KratosMultiphysics.PowerIterationEigenvalueSolver( settings, linear_solver)
     elif(solver_type == "power_iteration_highest_eigenvalue_solver"):
         eigen_solver = KratosMultiphysics.PowerIterationHighestEigenvalueSolver( settings, linear_solver)
     elif(solver_type == "rayleigh_quotient_iteration_eigenvalue_solver"):
         eigen_solver = KratosMultiphysics.RayleighQuotientIterationEigenvalueSolver( settings, linear_solver)
+    # Solvers in Applications
     elif(solver_type == "FEAST" or solver_type == "feast"):
+        KratosMultiphysics.CheckRegisteredApplications("ExternalSolversApplication")
         import KratosMultiphysics.ExternalSolversApplication
         eigen_solver = KratosMultiphysics.ExternalSolversApplication.FEASTSolver(settings, linear_solver)
+    elif (solver_type == "eigen_eigensystem"):
+        KratosMultiphysics.CheckRegisteredApplications("EigenSolversApplication")
+        import KratosMultiphysics.EigenSolversApplication
+        eigen_solver = KratosMultiphysics.EigenSolversApplication.EigensystemSolver(settings)
     else:
-        raise Exception("Solver type not found. Asking for :" + solver_type)
-    
+        raise Exception("Solver type not found. Asking for : " + solver_type)
+
     return eigen_solver


### PR DESCRIPTION
Hi @loumalouomega 
Some small fixes in the eigensolverfactory, to be more consistent

Also checking if the app has been imported in the main script

@armingeiser and @oberbichler in case you use the eigen-eigenvaluesolver and don't import the EigenSolversApplication in the MainScript it will fail now.
This is however intended, the user has to import all the apps he needs in the main script (previously the factory would import the application, but this is deprecated)