### PR TITLE
Important change! Changing variable key to an automatically generated hash value

### DIFF
--- a/kratos/containers/data_value_container.h
+++ b/kratos/containers/data_value_container.h
@@ -392,7 +392,7 @@ private:
     {
         std::size_t mI;
     public:
-        IndexCheck(int I) : mI(I) {}
+        IndexCheck(std::size_t I) : mI(I) {}
         bool operator()(const ValueType& I)
         {
             return I.first->Key() == mI;

--- a/kratos/containers/variable_component.h
+++ b/kratos/containers/variable_component.h
@@ -91,9 +91,10 @@ public:
     ///@name Life Cycle
     ///@{
 
-    VariableComponent(const std::string& NewName, const AdaptorType& NewAdaptor)
-        : BaseType(NewName, sizeof(DataType), true), mAdaptor(NewAdaptor)
+    VariableComponent(const std::string& ComponentName, const std::string& SourceName, int ComponentIndex, const AdaptorType& NewAdaptor)
+        : BaseType(ComponentName, sizeof(DataType), true, NewAdaptor.GetComponentIndex()), mAdaptor(NewAdaptor)
     {
+        SetKey(GenerateKey(SourceName, sizeof(DataType), true,  ComponentIndex));
     }
 
     /// Copy constructor.
@@ -275,7 +276,7 @@ private:
 ///@}
 
 template<class TAdaptorType>
-const VariableComponent<TAdaptorType> VariableComponent<TAdaptorType>::msStaticObject("NONE", TAdaptorType::StaticObject());
+const VariableComponent<TAdaptorType> VariableComponent<TAdaptorType>::msStaticObject("NONE", "NONE", 0, TAdaptorType::StaticObject());
 
 ///@name Type Definitions
 ///@{

--- a/kratos/containers/variable_data.cpp
+++ b/kratos/containers/variable_data.cpp
@@ -22,42 +22,33 @@
 #include "includes/define.h"
 #include "containers/variable_data.h"
 #include "input_output/logger.h"
+#include "includes/fnv_1a_hash.h"
 
 
 namespace Kratos
 {
 
     /// Constructor.
-	VariableData::VariableData(const std::string& NewName, std::size_t NewSize, bool Iscomponent) : mName(NewName), mKey(0), mSize(NewSize), mIsComponent(Iscomponent) {}
+	VariableData::VariableData(const std::string& NewName, std::size_t NewSize, bool Iscomponent, char ComponentIndex) : mName(NewName), mKey(0), mSize(NewSize), mIsComponent(Iscomponent) {
+        mKey = GenerateKey(mName, mSize, Iscomponent, ComponentIndex);
+    }
 
 	/// Copy constructor
     VariableData::VariableData(const VariableData& rOtherVariable)
         : mName(rOtherVariable.mName), mKey(rOtherVariable.mKey), mSize(rOtherVariable.mSize), mIsComponent(rOtherVariable.mIsComponent) {}
 
-	VariableData::KeyType VariableData::GenerateKey(const std::string& Name, std::size_t Size, std::size_t ComponentIndex)
+	VariableData::KeyType VariableData::GenerateKey(const std::string& Name, std::size_t Size, bool IsComponent, char ComponentIndex)
 	{
-		// For generation of 32bit hash key I use the 
-		// Jenkins's one-at-a-time hash taken from wikipedia 
-		// I could have used better hash functions like murmur or lookup3
-		// But finally choose this for simplicity. Pooyan.
-		// https://en.wikipedia.org/wiki/Jenkins_hash_function
+        std::uint64_t key = Size;
+        key <<= 32;
+        key += FNV1a32Hash::CalculateHash(Name.c_str());
 
-		unsigned int hash, i;
-		for(hash = i = 0; i < Name.size(); ++i)
-		{
-			hash += Name[i];
-			hash += (hash << 10);
-			hash ^= (hash >> 6);
-		}
-		hash += (hash << 3);
-		hash ^= (hash >> 11);
-		hash += (hash << 15);
+        key <<= 1;
+        key += IsComponent;
+        key <<= 7;
+        key += ComponentIndex;
 
-		//if(Size > 127) // to be store in a char
-		//	KRATOS_ERROR << "A variable of Kratos cannot be larger than 127 bytes and variable " << Name << " has sizeof " << Size;
-//		KeyType key = hash;
-//		key << 2; // This is for adding the 
-		return hash;
+		return key;
 
 	}
 

--- a/kratos/containers/variable_data.h
+++ b/kratos/containers/variable_data.h
@@ -230,7 +230,7 @@ public:
     64           size         32-bit hash                comp. index 0
         |-----------|----|---------------------------------------------|-|
     */
-    static KeyType GenerateKey(const std::string& Name, std::size_t Size, std::size_t ComponentIndex);
+    static KeyType GenerateKey(const std::string& Name, std::size_t Size, bool IsComponent, char ComponentIndex);
 
     ///@}
     ///@name Friends
@@ -267,7 +267,7 @@ protected:
     ///@{
 
     /// Constructor.
-    VariableData(const std::string& NewName, std::size_t NewSize, bool Iscomponent = false);
+    VariableData(const std::string& NewName, std::size_t NewSize, bool Iscomponent = false, char ComponentIndex = 0);
 
 
     /** default constructor is to be used only with serialization due to the fact that

--- a/kratos/containers/variable_data.h
+++ b/kratos/containers/variable_data.h
@@ -186,12 +186,12 @@ public:
         return mSize;
     }
 
-    bool IsComponent()
+    bool IsComponent() const
     {
         return mIsComponent;
     }
 
-    bool IsNotComponent()
+    bool IsNotComponent() const
     {
         return !mIsComponent;
     }

--- a/kratos/containers/vector_component_adaptor.h
+++ b/kratos/containers/vector_component_adaptor.h
@@ -124,6 +124,10 @@ public:
         return *mpSourceVariable;
     }
 
+    const int GetComponentIndex() const {
+        return mComponentIndex;
+    }
+
     ///@}
     ///@name Inquiry
     ///@{

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -231,13 +231,13 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
     /*const*/ Kratos::Variable<Kratos::array_1d<double, 3> > name(#name, Kratos::zero_vector<double>(3)); \
 \
     /*const*/ Kratos::VariableComponent<Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> > > \
-                  component1(#component1, Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> >(name, 0)); \
+                  component1(#component1, #name, 0, Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> >(name, 0)); \
 \
     /*const*/ Kratos::VariableComponent<Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> > > \
-                  component2(#component2, Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> >(name, 1)); \
+                  component2(#component2, #name, 1, Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> >(name, 1)); \
 \
     /*const*/ Kratos::VariableComponent<Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> > > \
-                  component3(#component3, Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> >(name, 2));
+                  component3(#component3, #name, 2, Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> >(name, 2));
 
 #ifdef KRATOS_CREATE_3D_VARIABLE_WITH_COMPONENTS
 #undef KRATOS_CREATE_3D_VARIABLE_WITH_COMPONENTS

--- a/kratos/includes/fnv_1a_hash.h
+++ b/kratos/includes/fnv_1a_hash.h
@@ -1,0 +1,89 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license:
+// kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+//
+
+#if !defined(KRATOS_FNV_1A_HASH_H_INCLUDED)
+#define KRATOS_FNV_1A_HASH_H_INCLUDED
+
+namespace Kratos {
+///@addtogroup Kratos Core
+///@{
+///@name Kratos Classes
+///@{
+
+/// A constexpr version of FNV hash function.
+/** The algorithm is the FNV-1a version of Fowler–Noll–Vo (FNV) hash function as
+ *  described in Wikipedia.
+ *  https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+*/
+class FNV1a32Hash {
+
+public:
+  ///@name Type Definitions
+  ///@{
+
+  ///@}
+  ///@name Life Cycle
+  ///@{
+
+  /// The class is unconstructable.
+  FNV1a32Hash() = delete;
+
+  /// Destructor.
+  virtual ~FNV1a32Hash() = delete;
+
+  /// Assignment operator.
+  FNV1a32Hash &operator=(FNV1a32Hash const &rOther) = delete;
+
+  /// Copy constructor.
+  FNV1a32Hash(FNV1a32Hash const &rOther) = delete;
+
+  ///@}
+  ///@name Operations
+  ///@{
+
+  static constexpr std::uint32_t CalculateHash(const char *const TheString) {
+    return CalculateHash(mFNV32OfsetBasis, TheString);
+  }
+
+  ///@}
+
+private:
+  ///@name Static Member Variables
+  ///@{
+
+  static constexpr std::uint32_t mFNV32OfsetBasis = 0x811c9dc5;
+  static constexpr std::uint32_t mFNV32Prime = 0x1000193;
+
+  ///@}
+  ///@name Private Operations
+  ///@{
+  static constexpr std::uint32_t CalculateHash(const std::uint32_t Value,
+                                               const char *const TheString) {
+    return (TheString[0] == '\0')
+               ? Value
+               : CalculateHash((Value ^ TheString[0]) * mFNV32Prime,
+                               TheString + 1);
+  }
+
+  ///@}
+
+}; // Class FNV1a32Hash
+
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos.
+
+#endif // KRATOS_FNV_1A_HASH_H_INCLUDED  defined

--- a/kratos/includes/fnv_1a_hash.h
+++ b/kratos/includes/fnv_1a_hash.h
@@ -72,7 +72,7 @@ private:
                                                const char *const TheString) {
     return (TheString[0] == '\0')
                ? Value
-               : CalculateHash((Value ^ TheString[0]) * mFNV32Prime,
+               : CalculateHash((Value ^ static_cast<std::uint32_t>(TheString[0])) * mFNV32Prime,
                                TheString + 1);
   }
 

--- a/kratos/includes/kernel.h
+++ b/kratos/includes/kernel.h
@@ -96,20 +96,10 @@ class KRATOS_API(KRATOS_CORE) Kernel {
     */
     void ImportApplication(KratosApplication::Pointer pNewApplication);
 
-    /// Assign sequential key to the registered variables.
-    /** This method assigns a sequential key to all registerd variables in kratos and all added applications.
-        It is very important to call this function after adding ALL necessary applications using ImportApplication
-        methods before calling this function. Otherwise it leads to uninitialized variables with key 0!
-        @see ImportApplication
-        @see InitializeApplication
+    /// To be deprecated becuase variables have their own hash key.
+    /** The keys of Variables are not sequencial anymore, so this method will be deprecated
     */
-    void Initialize() {
-        unsigned int j = 0;
-        for (KratosComponents<VariableData>::ComponentsContainerType::iterator
-                 i = KratosComponents<VariableData>::GetComponents().begin();
-             i != KratosComponents<VariableData>::GetComponents().end(); i++)
-            i->second->SetKey(++j);
-    }
+    void Initialize() { }
 
     /// Initializes and synchronizes the list of variables, elements and conditions in each application.
     /** This method gives the application the list of all variables, elements and condition which is registered

--- a/kratos/tests/containers/test_data_value_container.cpp
+++ b/kratos/tests/containers/test_data_value_container.cpp
@@ -1,0 +1,42 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license:
+// kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+//
+
+// System includes
+#include <unordered_set>
+
+// External includes
+
+// Project includes
+#include "containers/data_value_container.h"
+#include "includes/variables.h"
+#include "testing/testing.h"
+
+namespace Kratos {
+namespace Testing {
+
+KRATOS_TEST_CASE_IN_SUITE(DataValueContainer, KratosCoreFastSuite) {
+  DataValueContainer container;
+  Vector original_distances(4);
+  original_distances[0] = 0.00;
+  original_distances[1] = 0.10;
+  original_distances[2] = 0.20;
+  original_distances[3] = 0.30;
+  container.SetValue(ELEMENTAL_DISTANCES, original_distances);
+  auto& distances = container.GetValue(ELEMENTAL_DISTANCES);
+
+  for (std::size_t i = 0; i < distances.size(); i++)
+    KRATOS_CHECK_EQUAL(distances[i], original_distances[i]);
+}
+}
+} // namespace Kratos.

--- a/kratos/tests/containers/test_variables.cpp
+++ b/kratos/tests/containers/test_variables.cpp
@@ -39,11 +39,24 @@ KRATOS_TEST_CASE_IN_SUITE(VariablesKeyUniqueness, KratosCoreFastSuite) {
 }
 
 KRATOS_TEST_CASE_IN_SUITE(VariablesKeyOrder, KratosCoreFastSuite) {
-    KRATOS_CHECK_EQUAL(VELOCITY_X.Key() + 1, VELOCITY_Y.Key()) << VELOCITY_X << " , " << VELOCITY_Y;
-    KRATOS_CHECK_EQUAL(VELOCITY_Y.Key() + 1, VELOCITY_Z.Key()); 
+    for(auto const& key_variable_pair : KratosComponents<VariableData>::GetComponents()){
+        auto variable = key_variable_pair.second;
+        if(variable->IsNotComponent()){
+            if(KratosComponents<VariableData>::Has(variable->Name() + "_X") && 
+               KratosComponents<VariableData>::Has(variable->Name() + "_Y") && 
+               KratosComponents<VariableData>::Has(variable->Name() + "_Z")){
+                   
+                auto const& variable_x = KratosComponents<VariableData>::Get(variable->Name() + "_X");
+                auto const& variable_y = KratosComponents<VariableData>::Get(variable->Name() + "_Y");
+                auto const& variable_z = KratosComponents<VariableData>::Get(variable->Name() + "_Z");
+                if(variable_x.IsComponent() && variable_y.IsComponent() && variable_z.IsComponent()){
+                    KRATOS_CHECK_EQUAL(variable_x.Key() + 1, variable_y.Key()) << " for " << variable_x << " and " << variable_y << std::endl;
+                    KRATOS_CHECK_EQUAL(variable_y.Key() + 1, variable_z.Key()) << " for " << variable_y << " and " << variable_z << std::endl;
+                }          
+           }
+        }
+    }
 
-    KRATOS_CHECK_EQUAL(DISPLACEMENT_X.Key() + 1, DISPLACEMENT_Y.Key());
-    KRATOS_CHECK_EQUAL(DISPLACEMENT_Y.Key() + 1, DISPLACEMENT_Z.Key()); 
 }
 
 

--- a/kratos/tests/containers/test_variables.cpp
+++ b/kratos/tests/containers/test_variables.cpp
@@ -1,0 +1,51 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license:
+//kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+//
+
+// System includes
+#include <unordered_set>
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "includes/variables.h"
+
+namespace Kratos {
+namespace Testing {
+
+// This test is to check the hash function used in variable key, if it fails 
+// means that we should change the hash function. Pooyan.
+KRATOS_TEST_CASE_IN_SUITE(VariablesKeyUniqueness, KratosCoreFastSuite) {
+  std::unordered_set<VariableData::KeyType> registered_keys;
+  for (auto &i : KratosComponents<VariableData>::GetComponents()) {
+    auto hash = i.second->Key();
+    if (registered_keys.find(hash) == registered_keys.end()) {
+      registered_keys.insert(hash);
+    } else {
+      KRATOS_ERROR << "Duplicated variables key founded for variable" << *(i.second) << std::endl;
+    }
+  }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(VariablesKeyOrder, KratosCoreFastSuite) {
+    KRATOS_CHECK_EQUAL(VELOCITY_X.Key() + 1, VELOCITY_Y.Key()) << VELOCITY_X << " , " << VELOCITY_Y;
+    KRATOS_CHECK_EQUAL(VELOCITY_Y.Key() + 1, VELOCITY_Z.Key()); 
+
+    KRATOS_CHECK_EQUAL(DISPLACEMENT_X.Key() + 1, DISPLACEMENT_Y.Key());
+    KRATOS_CHECK_EQUAL(DISPLACEMENT_Y.Key() + 1, DISPLACEMENT_Z.Key()); 
+}
+
+
+}
+} // namespace Kratos.


### PR DESCRIPTION
This is a deep change in parts of the Kratos core that were unchanged for 10 years! Now the variables are created independently from the Kernel and there is no need to be initialized by Kernel. This results in following improvements:
- Variables can be duplicated in different applications and they won't generate conflicts anymore
- `Kernel.Initialize` is empty and can be removed. This implies that the applications are not needed to be initialized in `Kernel`
- Opens the way to unify the `Variable` and `VariableComponent` and as a consequence to remove the all methods accepting the `VariablesComponent`. It also simplifies considerably the `Dof`. 

The tests are running under windows and linux but as this part is the base of many operations I would suggest @KratosMultiphysics/team-maintainers  to check this branch with their applications and leave a feedback here. (I should add that meanwhile I found a [possible] bug that was there from 2003!)