### PR TITLE
Feature dam reservoir dry part

### DIFF
--- a/applications/DamApplication/custom_processes/dam_bofang_condition_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_bofang_condition_temperature_process.hpp
@@ -59,8 +59,6 @@ class DamBofangConditionTemperatureProcess : public Process
                 "Day_Ambient_Temp"                                 : 1,
                 "Water_level"                                      : 0.0,
                 "Water_level_Table"                                : 0,
-                "Outer_temp"                                       : 0.0,
-                "Outer_temp_Table"                                 : 0,
                 "Month"                                            : 1.0,
                 "Month_Table"                                      : 0
             }  )");
@@ -85,13 +83,11 @@ class DamBofangConditionTemperatureProcess : public Process
         mAmplitude = rParameters["Temperature_Amplitude"].GetDouble();
         mDay = rParameters["Day_Ambient_Temp"].GetInt();
         mWaterLevel = rParameters["Water_level"].GetDouble();
-        mOuterTemp = rParameters["Outer_temp"].GetDouble();
         mMonth = rParameters["Month"].GetDouble();
         mFreq = 0.52323;
 
         mTimeUnitConverter = mrModelPart.GetProcessInfo()[TIME_UNIT_CONVERTER];
         mTableIdWater = rParameters["Water_level_Table"].GetInt();
-        mTableIdOuter = rParameters["Outer_temp_Table"].GetInt();
         mTableIdMonth = rParameters["Month_Table"].GetInt();
 
         if (mTableIdWater != 0)

--- a/applications/DamApplication/custom_processes/dam_bofang_condition_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_bofang_condition_temperature_process.hpp
@@ -138,21 +138,18 @@ class DamBofangConditionTemperatureProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                if (mIsFixed)
-                {
-                    it->Fix(var);
-                }
-
                 double aux = (mReferenceCoordinate + mWaterLevel) - it->Coordinates()[direction];
                 if (aux >= 0.0)
                 {
+                    if (mIsFixed)
+                    {
+                        it->Fix(var);        
+                    }
                     double aux1 = ((mBottomTemp - (mSurfaceTemp * exp(-0.04 * mHeight))) / (1 - (exp(-0.04 * mHeight))));
                     double Temperature = (aux1 + ((mSurfaceTemp - aux1) * (exp(-0.04 * aux))) + (mAmplitude * (exp(-0.018 * aux)) * (cos(mFreq * (mMonth - (mDay / 30.0) - 2.15 + (1.30 * exp(-0.085 * aux)))))));
 
                     it->FastGetSolutionStepValue(var) = Temperature;
                 }
-                else
-                    it->FastGetSolutionStepValue(var) = mOuterTemp;
             }
         }
 
@@ -209,21 +206,18 @@ class DamBofangConditionTemperatureProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                if (mIsFixed)
-                {
-                    it->Fix(var);
-                }
-
                 double aux = (mReferenceCoordinate + mWaterLevel) - it->Coordinates()[direction];
                 if (aux >= 0.0)
                 {
+                    if (mIsFixed)
+                    {
+                        it->Fix(var);        
+                    }
                     double aux1 = ((mBottomTemp - (mSurfaceTemp * exp(-0.04 * mHeight))) / (1 - (exp(-0.04 * mHeight))));
                     double Temperature = (aux1 + ((mSurfaceTemp - aux1) * (exp(-0.04 * aux))) + (mAmplitude * (exp(-0.018 * aux)) * (cos(mFreq * (mMonth - (mDay / 30.0) - 2.15 + (1.30 * exp(-0.085 * aux)))))));
 
                     it->FastGetSolutionStepValue(var) = Temperature;
                 }
-                else
-                    it->FastGetSolutionStepValue(var) = mOuterTemp;
             }
         }
 

--- a/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
@@ -56,8 +56,6 @@ class DamReservoirConstantTemperatureProcess : public Process
                 "Water_temp_Table"                                 : 0,                
                 "Water_level"                                      : 0.0,
                 "Water_level_Table"                                : 0,
-                "Outer_temp"                                       : 0.0,
-                "Outer_temp_Table"                                 : 0
             }  )");
 
         // Some values need to be mandatorily prescribed since no meaningful default value exist. For this reason try accessing to them
@@ -76,12 +74,10 @@ class DamReservoirConstantTemperatureProcess : public Process
         mReferenceCoordinate = rParameters["Reservoir_Bottom_Coordinate_in_Gravity_Direction"].GetDouble();
         mWaterTemp = rParameters["Water_temp"].GetDouble();
         mWaterLevel = rParameters["Water_level"].GetDouble();
-        mOuterTemp = rParameters["Outer_temp"].GetDouble();
 
         mTimeUnitConverter = mrModelPart.GetProcessInfo()[TIME_UNIT_CONVERTER];
         mTableIdWaterTemp = rParameters["Water_temp_Table"].GetInt();
         mTableIdWater = rParameters["Water_level_Table"].GetInt();
-        mTableIdOuter = rParameters["Outer_temp_Table"].GetInt();
 
         if (mTableIdWaterTemp != 0)
             mpTableWaterTemp = mrModelPart.pGetTable(mTableIdWaterTemp);

--- a/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
@@ -127,18 +127,15 @@ class DamReservoirConstantTemperatureProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                if (mIsFixed)
-                {
-                    it->Fix(var);
-                }
-
                 double aux = (mReferenceCoordinate + mWaterLevel) - it->Coordinates()[direction];
                 if (aux >= 0.0)
                 {
+                    if (mIsFixed)
+                    {
+                        it->Fix(var);
+                    }
                     it->FastGetSolutionStepValue(var) = mWaterTemp;
                 }
-                else
-                    it->FastGetSolutionStepValue(var) = mOuterTemp;
             }
         }
 
@@ -196,18 +193,15 @@ class DamReservoirConstantTemperatureProcess : public Process
             {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
 
-                if (mIsFixed)
-                {
-                    it->Fix(var);
-                }
-
                 double aux = (mReferenceCoordinate + mWaterLevel) - it->Coordinates()[direction];
                 if (aux >= 0.0)
                 {
+                    if (mIsFixed)
+                    {
+                        it->Fix(var);
+                    }
                     it->FastGetSolutionStepValue(var) = mWaterTemp;
                 }
-                else
-                    it->FastGetSolutionStepValue(var) = mOuterTemp;
             }
         }
 


### PR DESCRIPTION
Some changes have been added related to the assignment of temperature conditions in the upstream face of the dam.
In the older version, in the dry part of the upstream face of the dam (when the reservoir is not completely full), it was assigned an imposed temperature based on an 'Outer temperature parameter'. With these changes, at the upstream face of the dam remains the condition imposed previously introduced for the whole dam (upstream and downstream). Thus, for all the dry parts of the model they will be coherent all the conditions whether they are imposed temperatures or imposed fluxed.
With these changes, the parameter 'Outer_temp' is unnecessary. Thus, it has been removed from the code. It also will be deleted from the DamInterface repo. 