### PR TITLE
Replaced boost::shared_ptr by Kratos::shared_ptr in Poro and Dam Apps

### DIFF
--- a/applications/DamApplication/custom_strategies/schemes/trilinos_dam_UP_scheme.hpp
+++ b/applications/DamApplication/custom_strategies/schemes/trilinos_dam_UP_scheme.hpp
@@ -174,7 +174,7 @@ protected:
         Epetra_Map dof_update_map(-1,index_array.size(), &(*(index_array.begin())),0,Dx.Comm() );
 
         // Defining the importer class
-        boost::shared_ptr<Epetra_Import> pDofImporter( new Epetra_Import(dof_update_map,Dx.Map()) );
+        Kratos::shared_ptr<Epetra_Import> pDofImporter( new Epetra_Import(dof_update_map,Dx.Map()) );
         mpDofImporter.swap(pDofImporter);
 
         mImporterIsInitialized = true;
@@ -182,7 +182,7 @@ protected:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    boost::shared_ptr<Epetra_Import> pGetImporter()
+    Kratos::shared_ptr<Epetra_Import> pGetImporter()
     {
         return mpDofImporter;
     }
@@ -194,7 +194,7 @@ private:
     /// Member Variables
     
     bool mImporterIsInitialized;
-    boost::shared_ptr<Epetra_Import> mpDofImporter;
+    Kratos::shared_ptr<Epetra_Import> mpDofImporter;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/trilinos_newmark_dynamic_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/trilinos_newmark_dynamic_U_Pw_scheme.hpp
@@ -174,7 +174,7 @@ protected:
         Epetra_Map dof_update_map(-1,index_array.size(), &(*(index_array.begin())),0,Dx.Comm() );
 
         // Defining the importer class
-        boost::shared_ptr<Epetra_Import> pDofImporter( new Epetra_Import(dof_update_map,Dx.Map()) );
+        Kratos::shared_ptr<Epetra_Import> pDofImporter( new Epetra_Import(dof_update_map,Dx.Map()) );
         mpDofImporter.swap(pDofImporter);
 
         mImporterIsInitialized = true;
@@ -182,7 +182,7 @@ protected:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    boost::shared_ptr<Epetra_Import> pGetImporter()
+    Kratos::shared_ptr<Epetra_Import> pGetImporter()
     {
         return mpDofImporter;
     }
@@ -194,7 +194,7 @@ private:
     /// Member Variables
     
     bool mImporterIsInitialized;
-    boost::shared_ptr<Epetra_Import> mpDofImporter;
+    Kratos::shared_ptr<Epetra_Import> mpDofImporter;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/trilinos_newmark_quasistatic_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/trilinos_newmark_quasistatic_U_Pw_scheme.hpp
@@ -174,7 +174,7 @@ protected:
         Epetra_Map dof_update_map(-1,index_array.size(), &(*(index_array.begin())),0,Dx.Comm() );
 
         // Defining the importer class
-        boost::shared_ptr<Epetra_Import> pDofImporter( new Epetra_Import(dof_update_map,Dx.Map()) );
+        Kratos::shared_ptr<Epetra_Import> pDofImporter( new Epetra_Import(dof_update_map,Dx.Map()) );
         mpDofImporter.swap(pDofImporter);
 
         mImporterIsInitialized = true;
@@ -182,7 +182,7 @@ protected:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    boost::shared_ptr<Epetra_Import> pGetImporter()
+    Kratos::shared_ptr<Epetra_Import> pGetImporter()
     {
         return mpDofImporter;
     }
@@ -194,7 +194,7 @@ private:
     /// Member Variables
     
     bool mImporterIsInitialized;
-    boost::shared_ptr<Epetra_Import> mpDofImporter;
+    Kratos::shared_ptr<Epetra_Import> mpDofImporter;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/trilinos_newmark_quasistatic_damped_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/trilinos_newmark_quasistatic_damped_U_Pw_scheme.hpp
@@ -174,7 +174,7 @@ protected:
         Epetra_Map dof_update_map(-1,index_array.size(), &(*(index_array.begin())),0,Dx.Comm() );
 
         // Defining the importer class
-        boost::shared_ptr<Epetra_Import> pDofImporter( new Epetra_Import(dof_update_map,Dx.Map()) );
+        Kratos::shared_ptr<Epetra_Import> pDofImporter( new Epetra_Import(dof_update_map,Dx.Map()) );
         mpDofImporter.swap(pDofImporter);
 
         mImporterIsInitialized = true;
@@ -182,7 +182,7 @@ protected:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    boost::shared_ptr<Epetra_Import> pGetImporter()
+    Kratos::shared_ptr<Epetra_Import> pGetImporter()
     {
         return mpDofImporter;
     }
@@ -194,7 +194,7 @@ private:
     /// Member Variables
     
     bool mImporterIsInitialized;
-    boost::shared_ptr<Epetra_Import> mpDofImporter;
+    Kratos::shared_ptr<Epetra_Import> mpDofImporter;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
I replaced boost::shared_ptr by Kratos::shared_ptr in the PoromechanicsApplication and the DamApplication as requested in #1328 