### PR TITLE
[Core] adding checks (debug) for accessing internal variables in ConstitutiveLaw

### DIFF
--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -1,10 +1,10 @@
-//    |  /           | 
-//    ' /   __| _` | __|  _ \   __| 
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ \.
-//   _|\_\_|  \__,_|\__|\___/ ____/ 
-//                   Multi-Physics  
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
@@ -87,24 +87,24 @@ public:
 
     /**
      * Flags related to the Parameters of the Contitutive Law
-     */   
+     */
     KRATOS_DEFINE_LOCAL_FLAG( USE_ELEMENT_PROVIDED_STRAIN );
     KRATOS_DEFINE_LOCAL_FLAG( COMPUTE_STRESS );
     KRATOS_DEFINE_LOCAL_FLAG( COMPUTE_CONSTITUTIVE_TENSOR );
     KRATOS_DEFINE_LOCAL_FLAG( COMPUTE_STRAIN_ENERGY );
-    
+
     KRATOS_DEFINE_LOCAL_FLAG( ISOCHORIC_TENSOR_ONLY );
     KRATOS_DEFINE_LOCAL_FLAG( VOLUMETRIC_TENSOR_ONLY );
-    
+
     KRATOS_DEFINE_LOCAL_FLAG( MECHANICAL_RESPONSE_ONLY );
     KRATOS_DEFINE_LOCAL_FLAG( THERMAL_RESPONSE_ONLY );
 
     KRATOS_DEFINE_LOCAL_FLAG( INCREMENTAL_STRAIN_MEASURE );
 
-    
+
     ///the next two flags are designed for internal use within the constitutive law.
     ///please DO NOT use them from the API
-    KRATOS_DEFINE_LOCAL_FLAG( INITIALIZE_MATERIAL_RESPONSE );    
+    KRATOS_DEFINE_LOCAL_FLAG( INITIALIZE_MATERIAL_RESPONSE );
     KRATOS_DEFINE_LOCAL_FLAG( FINALIZE_MATERIAL_RESPONSE );
 
 
@@ -130,7 +130,7 @@ public:
     {
 
       KRATOS_CLASS_POINTER_DEFINITION(Features);
-      
+
     /**
      * Structure "Features" to be used by the element to get the the constitutive law characteristics*
      * its variables will be used to check constitutive law and element compatibility
@@ -152,7 +152,7 @@ public:
       Features()
       {
       }
-      
+
       /**
        * Destructor.
        */
@@ -405,19 +405,59 @@ public:
        */
       Flags& GetOptions () {return mOptions;};
 
-      const double& GetDeterminantF              () {return mDeterminantF;};
-      const Vector& GetShapeFunctionsValues      () {return *mpShapeFunctionsValues;};
-      const Matrix& GetShapeFunctionsDerivatives () {return *mpShapeFunctionsDerivatives;};
-      const Matrix& GetDeformationGradientF      () {return *mpDeformationGradientF;};
+      const double& GetDeterminantF()
+      {
+          KRATOS_DEBUG_ERROR_IF_NOT(IsSetDeterminantF()) << "DeterminantF is not set!" << std::endl;
+          return mDeterminantF;
+      }
+      const Vector& GetShapeFunctionsValues()
+      {
+          KRATOS_DEBUG_ERROR_IF_NOT(IsSetShapeFunctionsValues()) << "ShapeFunctionsValues is not set!" << std::endl;
+          return *mpShapeFunctionsValues;
+      }
+      const Matrix& GetShapeFunctionsDerivatives()
+      {
+          KRATOS_DEBUG_ERROR_IF_NOT(IsSetShapeFunctionsDerivatives()) << "ShapeFunctionsDerivatives is not set!" << std::endl;
+          return *mpShapeFunctionsDerivatives;
+      }
+      const Matrix& GetDeformationGradientF()
+      {
+          KRATOS_DEBUG_ERROR_IF_NOT(IsSetDeformationGradientF()) << "DeformationGradientF is not set!" << std::endl;
+          return *mpDeformationGradientF;
+      }
 
-      Vector& GetStrainVector                    () {return *mpStrainVector;};
-      Vector& GetStressVector                    () {return *mpStressVector;};
+      Vector& GetStrainVector()
+      {
+          KRATOS_DEBUG_ERROR_IF_NOT(IsSetStrainVector()) << "StrainVector is not set!" << std::endl;
+          return *mpStrainVector;
+      }
+      Vector& GetStressVector()
+      {
+          KRATOS_DEBUG_ERROR_IF_NOT(IsSetStressVector()) << "StressVector is not set!" << std::endl;
+          return *mpStressVector;
+      }
 
-      Matrix& GetConstitutiveMatrix              () {return *mpConstitutiveMatrix;};
+      Matrix& GetConstitutiveMatrix()
+      {
+          KRATOS_DEBUG_ERROR_IF_NOT(IsSetConstitutiveMatrix()) << "ConstitutiveMatrix is not set!" << std::endl;
+          return *mpConstitutiveMatrix;
+      }
 
-      const ProcessInfo&  GetProcessInfo         () {return *mpCurrentProcessInfo;};
-      const Properties&   GetMaterialProperties  () {return *mpMaterialProperties;};
-      const GeometryType& GetElementGeometry     () {return *mpElementGeometry;};
+      const ProcessInfo& GetProcessInfo()
+      {
+          KRATOS_DEBUG_ERROR_IF_NOT(IsSetProcessInfo()) << "ProcessInfo is not set!" << std::endl;
+          return *mpCurrentProcessInfo;
+      }
+      const Properties& GetMaterialProperties()
+      {
+          KRATOS_DEBUG_ERROR_IF_NOT(IsSetMaterialProperties()) << "MaterialProperties is not set!" << std::endl;
+          return *mpMaterialProperties;
+      }
+      const GeometryType& GetElementGeometry()
+      {
+          KRATOS_DEBUG_ERROR_IF_NOT(IsSetElementGeometry()) << "ElementGeometry is not set!" << std::endl;
+          return *mpElementGeometry;
+      }
 
       /**
        * Returns the reference to the value of a specified variable with not constant access
@@ -432,7 +472,7 @@ public:
       /**
        * Returns if the different components has been set
        */
-       
+
       bool IsSetDeterminantF              () {return (mDeterminantF > 0.0);};
       bool IsSetShapeFunctionsValues      () {return (mpShapeFunctionsValues != NULL);};
       bool IsSetShapeFunctionsDerivatives () {return (mpShapeFunctionsDerivatives != NULL);};
@@ -647,7 +687,7 @@ public:
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
      * @param rValue output: the value of the specified variable
-     */    
+     */
     virtual int& CalculateValue(Parameters& rParameterValues, const Variable<int>& rThisVariable, int& rValue);
 
     /**
@@ -656,7 +696,7 @@ public:
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
      * @param rValue output: the value of the specified variable
-     */    
+     */
     virtual double& CalculateValue(Parameters& rParameterValues, const Variable<double>& rThisVariable, double& rValue);
 
     /**
@@ -665,7 +705,7 @@ public:
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
      * @param rValue output: the value of the specified variable
-     */    
+     */
     virtual Vector& CalculateValue(Parameters& rParameterValues, const Variable<Vector>& rThisVariable, Vector& rValue);
 
     /**
@@ -674,7 +714,7 @@ public:
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
      * @param rValue output: the value of the specified variable
-     */  
+     */
     virtual Matrix& CalculateValue(Parameters& rParameterValues, const Variable<Matrix>& rThisVariable, Matrix& rValue);
 
     /**
@@ -706,7 +746,7 @@ public:
       * no valid implementation is contained here.
       */
     virtual bool ValidateInput(const Properties& rMaterialProperties);
-    
+
 
     /**
      * returns the expected strain measure of this constitutive law (by default linear strains)
@@ -872,7 +912,7 @@ public:
     virtual void InitializeMaterialResponseCauchy (Parameters& rValues);
 
 
-    
+
     /**
      * Finalize the material response,  called by the element in FinalizeSolutionStep.
      * @see Parameters
@@ -1186,12 +1226,12 @@ public:
       rOStream << "ConstitutiveLaw has no data";
     }
 
-    
+
     ///@}
     ///@name Friends
     ///@{
     ///@}
-    
+
 protected:
 
     ///@name Protected static Member Variables
@@ -1266,7 +1306,7 @@ protected:
 				     const unsigned int& a, const unsigned int& b,
 				     const unsigned int& c, const unsigned int& d);
 
- 
+
     ///@}
     ///@name Protected  Access
     ///@{
@@ -1284,13 +1324,13 @@ protected:
 
     ///@}
 
-    
+
 private:
 
     ///@name Static Member Variables
     ///@{
 
-    
+
     ///@}
     ///@name Member Variables
     ///@{
@@ -1328,7 +1368,7 @@ private:
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Flags );
     }
 
- 
+
     ///@}
     ///@name Private Inquiry
     ///@{
@@ -1339,7 +1379,7 @@ private:
     ///@{
 
     ///@}
-    
+
 }; /* Class ConstitutiveLaw */
 
 ///@}
@@ -1364,10 +1404,10 @@ inline std::ostream & operator <<(std::ostream& rOStream,
 
     return rOStream;
 }
- 
+
 ///@}
 ///@} addtogroup block
- 
+
 template class KRATOS_API(KRATOS_CORE) KratosComponents<ConstitutiveLaw >;
 
 void KRATOS_API(KRATOS_CORE) AddKratosComponent(std::string const& Name, ConstitutiveLaw const& ThisComponent);


### PR DESCRIPTION
This PR add checks in DEBUG mode to when internal variables are accessed.
If one of the quantities is not initialized (i.e. nullptr) it would give a segfault.
Now a proper error message is thrown.

Some tests are failing now, but this related to #1545 

closes #1547