### PR TITLE
fix incomplete changes of compiler flag

### DIFF
--- a/applications/EigenSolversApplication/CMakeLists.txt
+++ b/applications/EigenSolversApplication/CMakeLists.txt
@@ -36,7 +36,7 @@ if( USE_EIGEN_MKL MATCHES ON )
 	endif()
 
 	include_directories( $ENV{MKLROOT}/include )
-	add_definitions( -DUSE_EIGEN_MKL -DUSE_EIGEN_MKL_ALL )
+	add_definitions( -DUSE_EIGEN_MKL -DEIGEN_USE_MKL_ALL )
 endif()
 
 ## generate variables with the sources

--- a/applications/EigenSolversApplication/custom_python/add_custom_solvers_to_python.cpp
+++ b/applications/EigenSolversApplication/custom_python/add_custom_solvers_to_python.cpp
@@ -48,7 +48,7 @@ void AddCustomSolversToPython()
 		.def(init<Parameters>())
 	;
 
-	#if defined EIGEN_USE_MKL
+	#if defined USE_EIGEN_MKL
 	using PardisoLLTSolver = EigenDirectSolver<PardisoLLT, SparseSpaceType, LocalSpaceType>;
 	class_<PardisoLLTSolver, bases<DirectSolverType>, boost::noncopyable>
 		("PardisoLLTSolver", init<>())
@@ -66,7 +66,7 @@ void AddCustomSolversToPython()
 		("PardisoLUSolver", init<>())
 		.def(init<Parameters>())
 	;	
-	#endif // defined EIGEN_USE_MKL
+	#endif // defined USE_EIGEN_MKL
 
 	using SparseQRSolver = EigenDirectSolver<SparseQR, SparseSpaceType, LocalSpaceType>;
 	class_<SparseQRSolver, bases<DirectSolverType>, boost::noncopyable>
@@ -76,11 +76,11 @@ void AddCustomSolversToPython()
 
 	// --- eigensystem solver
 
-	#if defined EIGEN_USE_MKL
+	#if defined USE_EIGEN_MKL
 	using EigensystemSolverType = EigensystemSolver<PardisoLDLT, SparseSpaceType, LocalSpaceType>;
-	#else  // defined EIGEN_USE_MKL
+	#else  // defined USE_EIGEN_MKL
 	using EigensystemSolverType = EigensystemSolver<SparseLU, SparseSpaceType, LocalSpaceType>;
-	#endif // defined EIGEN_USE_MKL
+	#endif // defined USE_EIGEN_MKL
 	class_<EigensystemSolverType, EigensystemSolverType::Pointer, bases<LinearSolverType>, boost::noncopyable>
     	("EigensystemSolver", init<Parameters>())
     	.def("Solve", &EigensystemSolverType::Solve)


### PR DESCRIPTION
When changing the compiler flag from ```EIGEN_USE_MKL``` to ```USE_EIGEN_MKL``` in order to avoid the warning because ```EIGEN_USE_MKL``` is defined somewhere inside the Eigen headers, the flags where not changed in the code, only in the CMakeLists...

So the warning was gone, but mkl was not used.
