### PR TITLE
Creating method to set the flags ins structural solids

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -87,9 +87,7 @@ void BaseSolidElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
 
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+    SetConstituveLawFlags(ConstitutiveLawOptions);
 
     Values.SetStrainVector(this_constitutive_variables.StrainVector);
     
@@ -139,6 +137,20 @@ void BaseSolidElement::InitializeMaterial()
 ConstitutiveLaw::StressMeasure BaseSolidElement::GetStressMeasure() const
 {
     return ConstitutiveLaw::StressMeasure_PK2;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void BaseSolidElement::SetConstituveLawFlags(
+    Flags& rConstituveLawFlags,
+    const bool ComputeStress,
+    const bool ComputeConstitutiveTensor
+    )
+{
+    rConstituveLawFlags.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
+    rConstituveLawFlags.Set(ConstitutiveLaw::COMPUTE_STRESS, ComputeStress);
+    rConstituveLawFlags.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, ComputeConstitutiveTensor);
 }
 
 /***********************************************************************************/
@@ -515,9 +527,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
         // Set constitutive law flags:
         Flags& ConstitutiveLawOptions=Values.GetOptions();
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+        SetConstituveLawFlags(ConstitutiveLawOptions);
 
         Values.SetStrainVector(this_constitutive_variables.StrainVector);
         
@@ -625,9 +635,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
         // Set constitutive law flags:
         Flags& ConstitutiveLawOptions=Values.GetOptions();
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+        SetConstituveLawFlags(ConstitutiveLawOptions);
 
         Values.SetStrainVector(this_constitutive_variables.StrainVector);
         
@@ -667,9 +675,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
         
         // Set constitutive law flags:
         Flags &ConstitutiveLawOptions=Values.GetOptions();
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, true);
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, false);
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+        SetConstituveLawFlags(ConstitutiveLawOptions);
         
         Values.SetStrainVector(this_constitutive_variables.StrainVector);
         
@@ -755,9 +761,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
         // Set constitutive law flags:
         Flags& ConstitutiveLawOptions=Values.GetOptions();
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, false);
-        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+        SetConstituveLawFlags(ConstitutiveLawOptions, false, true);
 
         Values.SetConstitutiveMatrix(this_constitutive_variables.D); //this is the output parameter
         
@@ -1033,7 +1037,16 @@ void BaseSolidElement::CalculateConstitutiveVariables(
     const ConstitutiveLaw::StressMeasure ThisStressMeasure
     )
 {
-    KRATOS_ERROR << "You have called to the CalculateConstitutiveVariables from the base class for solid elements" << std::endl;
+    // Here we essentially set the input parameters
+    rValues.SetDeterminantF(rThisKinematicVariables.detF); // Assuming the determinant is computed somewhere else
+    rValues.SetDeformationGradientF(rThisKinematicVariables.F); //F computed somewhere else
+    
+    // Here we set the space on which the results shall be written
+    rValues.SetConstitutiveMatrix(rThisConstitutiveVariables.D); // Assuming the determinant is computed somewhere else
+    rValues.SetStressVector(rThisConstitutiveVariables.StressVector); //F computed somewhere else
+    
+    // Actually do the computations in the ConstitutiveLaw    
+    mConstitutiveLawVector[PointNumber]->CalculateMaterialResponse(rValues, ThisStressMeasure); //here the calculations are actually done 
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -87,7 +87,9 @@ void BaseSolidElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
 
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
-    SetConstituveLawFlags(ConstitutiveLawOptions);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
 
     Values.SetStrainVector(this_constitutive_variables.StrainVector);
     
@@ -142,15 +144,9 @@ ConstitutiveLaw::StressMeasure BaseSolidElement::GetStressMeasure() const
 /***********************************************************************************/
 /***********************************************************************************/
 
-void BaseSolidElement::SetConstituveLawFlags(
-    Flags& rConstituveLawFlags,
-    const bool ComputeStress,
-    const bool ComputeConstitutiveTensor
-    )
+bool BaseSolidElement::UseElementProvidedStrain()
 {
-    rConstituveLawFlags.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
-    rConstituveLawFlags.Set(ConstitutiveLaw::COMPUTE_STRESS, ComputeStress);
-    rConstituveLawFlags.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, ComputeConstitutiveTensor);
+    return false;
 }
 
 /***********************************************************************************/
@@ -527,7 +523,9 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
         // Set constitutive law flags:
         Flags& ConstitutiveLawOptions=Values.GetOptions();
-        SetConstituveLawFlags(ConstitutiveLawOptions);
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
 
         Values.SetStrainVector(this_constitutive_variables.StrainVector);
         
@@ -635,7 +633,9 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
         // Set constitutive law flags:
         Flags& ConstitutiveLawOptions=Values.GetOptions();
-        SetConstituveLawFlags(ConstitutiveLawOptions);
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
 
         Values.SetStrainVector(this_constitutive_variables.StrainVector);
         
@@ -675,7 +675,9 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
         
         // Set constitutive law flags:
         Flags &ConstitutiveLawOptions=Values.GetOptions();
-        SetConstituveLawFlags(ConstitutiveLawOptions);
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, false);
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
         
         Values.SetStrainVector(this_constitutive_variables.StrainVector);
         
@@ -761,7 +763,9 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
         // Set constitutive law flags:
         Flags& ConstitutiveLawOptions=Values.GetOptions();
-        SetConstituveLawFlags(ConstitutiveLawOptions, false, true);
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, false);
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
 
         Values.SetConstitutiveMatrix(this_constitutive_variables.D); //this is the output parameter
         

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -468,16 +468,9 @@ protected:
     virtual ConstitutiveLaw::StressMeasure GetStressMeasure() const;
     
     /**
-     * @brief Sets the flags of the constitutive law
-     * @param rConstituveLawFlags The flags of the constitutive law
-     * @param ComputeStress If the stress vector is computed or not
-     * @param ComputeConstitutiveTensor If the constitutive tensor is computed or not
+     * @brief This method returns if the element provides the strain
      */
-    virtual void SetConstituveLawFlags(
-        Flags& rConstituveLawFlags,
-        const bool ComputeStress = true,
-        const bool ComputeConstitutiveTensor = false
-        );
+    virtual bool UseElementProvidedStrain();
     
     /**
      * @brief This functions calculates both the RHS and the LHS

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -46,8 +46,12 @@ namespace Kratos
 ///@{
     
 /**
+ * @class BaseSolidElement
+ * @ingroup StructuralMechanicsApplication
  * @brief This is base clase used to define the solid elements
  * @details The elements derived from this class are the small displacement element, the total lagrangian element and the updated lagrangian element
+ * @author Riccardo Rossi
+ * @author Vicente Mataix Ferrandiz
  */
 class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) BaseSolidElement
     : public Element
@@ -443,7 +447,7 @@ protected:
     ///@name Protected member Variables
     ///@{
     
-    std::vector<ConstitutiveLaw::Pointer> mConstitutiveLawVector; // The vector containing the constitutive laws
+    std::vector<ConstitutiveLaw::Pointer> mConstitutiveLawVector; /// The vector containing the constitutive laws
 
     ///@}
     ///@name Protected Operators
@@ -454,14 +458,26 @@ protected:
     ///@{
     
     /**
-     * It initializes the material
+     * @brief It initializes the material
      */
     virtual void InitializeMaterial();
     
     /**
-     * Gives the StressMeasure used
+     * @brief Gives the StressMeasure used
      */
     virtual ConstitutiveLaw::StressMeasure GetStressMeasure() const;
+    
+    /**
+     * @brief Sets the flags of the constitutive law
+     * @param rConstituveLawFlags The flags of the constitutive law
+     * @param ComputeStress If the stress vector is computed or not
+     * @param ComputeConstitutiveTensor If the constitutive tensor is computed or not
+     */
+    virtual void SetConstituveLawFlags(
+        Flags& rConstituveLawFlags,
+        const bool ComputeStress = true,
+        const bool ComputeConstitutiveTensor = false
+        );
     
     /**
      * @brief This functions calculates both the RHS and the LHS

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -57,6 +57,20 @@ SmallDisplacement::~SmallDisplacement()
 /***********************************************************************************/
 /***********************************************************************************/
 
+void SmallDisplacement::SetConstituveLawFlags(
+    Flags& rConstituveLawFlags,
+    const bool ComputeStress,
+    const bool ComputeConstitutiveTensor
+    )
+{
+    rConstituveLawFlags.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, true);
+    rConstituveLawFlags.Set(ConstitutiveLaw::COMPUTE_STRESS, ComputeStress);
+    rConstituveLawFlags.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, ComputeConstitutiveTensor);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 void SmallDisplacement::CalculateAll( 
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
@@ -99,9 +113,7 @@ void SmallDisplacement::CalculateAll(
 
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    SetConstituveLawFlags(ConstitutiveLawOptions, true, true);
     
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -57,15 +57,9 @@ SmallDisplacement::~SmallDisplacement()
 /***********************************************************************************/
 /***********************************************************************************/
 
-void SmallDisplacement::SetConstituveLawFlags(
-    Flags& rConstituveLawFlags,
-    const bool ComputeStress,
-    const bool ComputeConstitutiveTensor
-    )
+bool SmallDisplacement::UseElementProvidedStrain()
 {
-    rConstituveLawFlags.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, true);
-    rConstituveLawFlags.Set(ConstitutiveLaw::COMPUTE_STRESS, ComputeStress);
-    rConstituveLawFlags.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, ComputeConstitutiveTensor);
+    return true;
 }
 
 /***********************************************************************************/
@@ -113,7 +107,9 @@ void SmallDisplacement::CalculateAll(
 
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
-    SetConstituveLawFlags(ConstitutiveLawOptions, true, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
     
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.h
@@ -44,8 +44,12 @@ namespace Kratos
 ///@{
 
 /**
+ * @class SmallDisplacement
+ * @ingroup StructuralMechanicsApplication
  * @brief Small displacement element for 2D and 3D geometries.
  * @details Implements a small displacement definition for structural analysis. This works for arbitrary geometries in 2D and 3D
+ * @author Riccardo Rossi
+ * @author Vicente Mataix Ferrandiz
  */
 
 class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) SmallDisplacement
@@ -138,6 +142,18 @@ protected:
     {
     }
 
+    /**
+     * @brief Sets the flags of the constitutive law
+     * @param rConstituveLawFlags The flags of the constitutive law
+     * @param ComputeStress If the stress vector is computed or not
+     * @param ComputeConstitutiveTensor If the constitutive tensor is computed or not
+     */
+    void SetConstituveLawFlags(
+        Flags& rConstituveLawFlags,
+        const bool ComputeStress = true,
+        const bool ComputeConstitutiveTensor = false
+        ) override;
+    
     /**
      * @brief This functions calculates both the RHS and the LHS
      * @param rLeftHandSideMatrix The LHS

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.h
@@ -142,17 +142,10 @@ protected:
     {
     }
 
-    /**
-     * @brief Sets the flags of the constitutive law
-     * @param rConstituveLawFlags The flags of the constitutive law
-     * @param ComputeStress If the stress vector is computed or not
-     * @param ComputeConstitutiveTensor If the constitutive tensor is computed or not
+     /**
+     * @brief This method returns if the element provides the strain
      */
-    void SetConstituveLawFlags(
-        Flags& rConstituveLawFlags,
-        const bool ComputeStress = true,
-        const bool ComputeConstitutiveTensor = false
-        ) override;
+    bool UseElementProvidedStrain() override;
     
     /**
      * @brief This functions calculates both the RHS and the LHS

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -98,9 +98,7 @@ void TotalLagrangian::CalculateAll(
     
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    SetConstituveLawFlags(ConstitutiveLawOptions, true, true);
     
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter
@@ -182,30 +180,6 @@ void TotalLagrangian::CalculateKinematicVariables(
     
     // Calculating operator B
     this->CalculateB( rThisKinematicVariables.B, rThisKinematicVariables.F, rThisKinematicVariables.DN_DX, strain_size, IntegrationPoints, PointNumber );
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void TotalLagrangian::CalculateConstitutiveVariables(
-    KinematicVariables& rThisKinematicVariables, 
-    ConstitutiveVariables& rThisConstitutiveVariables, 
-    ConstitutiveLaw::Parameters& rValues,
-    const unsigned int PointNumber,
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-    const ConstitutiveLaw::StressMeasure ThisStressMeasure
-    )
-{        
-    // Here we essentially set the input parameters
-    rValues.SetDeterminantF(rThisKinematicVariables.detF); //assuming the determinant is computed somewhere else
-    rValues.SetDeformationGradientF(rThisKinematicVariables.F); //F computed somewhere else
-    
-    // Here we set the space on which the results shall be written
-    rValues.SetConstitutiveMatrix(rThisConstitutiveVariables.D); //assuming the determinant is computed somewhere else
-    rValues.SetStressVector(rThisConstitutiveVariables.StressVector); //F computed somewhere else
-    
-    // Actually do the computations in the ConstitutiveLaw    
-    mConstitutiveLawVector[PointNumber]->CalculateMaterialResponse(rValues, ThisStressMeasure); //here the calculations are actually done 
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -98,7 +98,9 @@ void TotalLagrangian::CalculateAll(
     
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
-    SetConstituveLawFlags(ConstitutiveLawOptions, true, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
     
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.h
@@ -7,7 +7,7 @@
 //					 license: structural_mechanics_application/license.txt
 //
 //  Main authors:    Riccardo Rossi
-//                   Vicente Mataix Ferrándiz
+//                   Vicente Mataix Ferrandiz
 //
 
 
@@ -45,8 +45,12 @@ namespace Kratos
 ///@{
 
 /**
+ * @class TotalLagrangian
+ * @ingroup StructuralMechanicsApplication
  * @brief Total Lagrangian element for 2D and 3D geometries.
  * @details Implements a total Lagrangian definition for structural analysis. This works for arbitrary geometries in 2D and 3D
+ * @author Riccardo Rossi
+ * @author Vicente Mataix Ferrandiz
  */
 
 class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) TotalLagrangian
@@ -164,25 +168,6 @@ protected:
         KinematicVariables& rThisKinematicVariables,
         const unsigned int PointNumber,
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints
-        ) override;
-        
-     /**
-     * @brief This functions updates the constitutive variables
-     * @param rThisKinematicVariables The kinematic variables to be calculated 
-     * @param rThisConstitutiveVariables The constitutive variables
-     * @param rValues The CL parameters
-     * @param PointNumber The integration point considered
-     * @param IntegrationPoints The list of integration points
-     * @param ThisStressMeasure The stress measure considered
-     * @param Displacements The displacements vector
-     */ 
-    void CalculateConstitutiveVariables(
-        KinematicVariables& rThisKinematicVariables, 
-        ConstitutiveVariables& rThisConstitutiveVariables, 
-        ConstitutiveLaw::Parameters& rValues,
-        const unsigned int PointNumber,
-        const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-        const ConstitutiveLaw::StressMeasure ThisStressMeasure
         ) override;
     
     ///@}

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -109,9 +109,7 @@ void UpdatedLagrangian::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
 
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+    SetConstituveLawFlags(ConstitutiveLawOptions);
 
     Values.SetStrainVector(this_constitutive_variables.StrainVector);
     
@@ -209,9 +207,7 @@ void UpdatedLagrangian::CalculateAll(
     
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, false);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    SetConstituveLawFlags(ConstitutiveLawOptions, true, true);
     
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter
@@ -295,30 +291,6 @@ void UpdatedLagrangian::CalculateKinematicVariables(
     
     // Calculating operator B
     this->CalculateB( rThisKinematicVariables.B, rThisKinematicVariables.DN_DX, strain_size, IntegrationPoints, PointNumber );
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void UpdatedLagrangian::CalculateConstitutiveVariables(
-    KinematicVariables& rThisKinematicVariables, 
-    ConstitutiveVariables& rThisConstitutiveVariables, 
-    ConstitutiveLaw::Parameters& rValues,
-    const unsigned int PointNumber,
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-    const ConstitutiveLaw::StressMeasure ThisStressMeasure
-    )
-{       
-    // Here we essentially set the input parameters
-    rValues.SetDeterminantF(rThisKinematicVariables.detF); // Assuming the determinant is computed somewhere else
-    rValues.SetDeformationGradientF(rThisKinematicVariables.F); //F computed somewhere else
-    
-    // Here we set the space on which the results shall be written
-    rValues.SetConstitutiveMatrix(rThisConstitutiveVariables.D); // Assuming the determinant is computed somewhere else
-    rValues.SetStressVector(rThisConstitutiveVariables.StressVector); //F computed somewhere else
-    
-    // Actually do the computations in the ConstitutiveLaw    
-    mConstitutiveLawVector[PointNumber]->CalculateMaterialResponse(rValues, ThisStressMeasure); //here the calculations are actually done 
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -109,7 +109,9 @@ void UpdatedLagrangian::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
 
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
-    SetConstituveLawFlags(ConstitutiveLawOptions);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
 
     Values.SetStrainVector(this_constitutive_variables.StrainVector);
     
@@ -207,7 +209,9 @@ void UpdatedLagrangian::CalculateAll(
     
     // Set constitutive law flags:
     Flags& ConstitutiveLawOptions=Values.GetOptions();
-    SetConstituveLawFlags(ConstitutiveLawOptions, true, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
     
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.h
@@ -45,8 +45,12 @@ namespace Kratos
 ///@{
 
 /**
+ * @class TotalLagrangian
+ * @ingroup StructuralMechanicsApplication
  * @brief Updated Lagrangian element for 2D and 3D geometries.
  * @details Implements a total Lagrangian definition for structural analysis. This works for arbitrary geometries in 2D and 3D
+ * @author Riccardo Rossi
+ * @author Vicente Mataix Ferrandiz
  */
 
 class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) UpdatedLagrangian
@@ -276,24 +280,6 @@ protected:
         KinematicVariables& rThisKinematicVariables,
         const unsigned int PointNumber,
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints
-        ) override;
-        
-     /**
-     * @brief This functions updates the constitutive variables
-     * @param rThisKinematicVariables The kinematic variables to be calculated 
-     * @param rThisConstitutiveVariables The constitutive variables
-     * @param rValues The CL parameters
-     * @param PointNumber The integration point considered
-     * @param IntegrationPoints The list of integration points
-     * @param ThisStressMeasure The stress measure considered
-     */ 
-    void CalculateConstitutiveVariables(
-        KinematicVariables& rThisKinematicVariables, 
-        ConstitutiveVariables& rThisConstitutiveVariables, 
-        ConstitutiveLaw::Parameters& rValues,
-        const unsigned int PointNumber,
-        const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-        const ConstitutiveLaw::StressMeasure ThisStressMeasure
         ) override;
     
     /**


### PR DESCRIPTION
This PR creates a method to set the flags in the structural solids. This way the confusion is avoided when using the flags for CL

Besides, I added some Doxygen comments and I removed one duplicated method from the UL and TL