### PR TITLE
fixed linear beam3d mass matrix

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_3D2N.hpp
@@ -67,6 +67,10 @@ namespace Kratos
 				MatrixType& rLeftHandSideMatrix,
 				ProcessInfo& rCurrentProcessInfo) override;
 
+			void CalculateMassMatrix(
+				MatrixType& rMassMatrix,
+				ProcessInfo& rCurrentProcessInfo) override;
+
 			/**
 			 * @brief This function calculates the element stiffness w.r.t. deformation modes
 			 */


### PR DESCRIPTION
hi I noticed that the linear beam 3d needs its own mass matrix calculation. After we inherited the elements I forgot that.