### PR TITLE
Carefully opening parameter files (using a with statement).

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/fluid_main.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_main.py
@@ -12,8 +12,8 @@ from KratosMultiphysics.MeshingApplication import *
 ##PARSING THE PARAMETERS
 #import define_output
 
-parameter_file = open("ProjectParameters.json",'r')
-ProjectParameters = Parameters( parameter_file.read())
+with open("ProjectParameters.json",'r') as parameter_file:
+    ProjectParameters = Parameters( parameter_file.read())
 
 
 ## defining a model part for the fluid

--- a/applications/FluidDynamicsApplication/tests/SmallTests.py
+++ b/applications/FluidDynamicsApplication/tests/SmallTests.py
@@ -36,8 +36,8 @@ class EmbeddedTestFactory(KratosUnittest.TestCase):
         # Within this location context:
         with controlledExecutionScope(os.path.dirname(os.path.realpath(__file__))):
             # Get the ProjectParameters file
-            parameter_file = open(self.file_name + "_parameters.json", 'r')
-            ProjectParameters = Parameters(parameter_file.read())
+            with open(self.file_name + "_parameters.json", 'r') as parameter_file:
+                ProjectParameters = Parameters(parameter_file.read())
 
             # Create the test
             self.test = ExecuteEmbeddedTest.KratosExecuteEmbeddedTest(ProjectParameters)
@@ -56,8 +56,8 @@ class ManufacturedSolutionTestFactory(KratosUnittest.TestCase):
         # Within this location context:
         with controlledExecutionScope(os.path.dirname(os.path.realpath(__file__))):
             # Get the ProjectParameters file
-            parameter_file = open(self.file_name + "_parameters.json", 'r')
-            ProjectParameters = Parameters(parameter_file.read())
+            with open(self.file_name + "_parameters.json", 'r') as parameter_file:
+                ProjectParameters = Parameters(parameter_file.read())
 
             # Create the test
             self.test = ExecuteManufacturedSolutionTest.KratosExecuteManufacturedSolutionTest(ProjectParameters)

--- a/applications/FluidDynamicsApplication/tests/embedded_ausas_couette_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_ausas_couette_test.py
@@ -97,9 +97,8 @@ class EmbeddedAusasCouetteTest(UnitTest.TestCase):
 
     def setUpProblem(self):
         with WorkFolderScope(self.work_folder):
-            parameter_file = open(self.settings, 'r')
-
-            self.ProjectParameters = KratosMultiphysics.Parameters(parameter_file.read())
+            with open(self.settings, 'r') as parameter_file:
+                self.ProjectParameters = KratosMultiphysics.Parameters(parameter_file.read())
 
             self.main_model_part = KratosMultiphysics.ModelPart(self.ProjectParameters["problem_data"]["model_part_name"].GetString())
             self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, self.ProjectParameters["problem_data"]["domain_size"].GetInt())

--- a/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
@@ -92,9 +92,8 @@ class EmbeddedReservoirTest(UnitTest.TestCase):
 
     def setUpProblem(self):
         with WorkFolderScope(self.work_folder):
-            parameter_file = open(self.settings, 'r')
-
-            self.ProjectParameters = KratosMultiphysics.Parameters(parameter_file.read())
+            with open(self.settings, 'r') as parameter_file:
+                self.ProjectParameters = KratosMultiphysics.Parameters(parameter_file.read())
 
             self.main_model_part = KratosMultiphysics.ModelPart(self.ProjectParameters["problem_data"]["model_part_name"].GetString())
             self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, self.ProjectParameters["problem_data"]["domain_size"].GetInt())


### PR DESCRIPTION
Minor, but could introduce memory errors (since file was left open indefinitely).