### PR TITLE
Plane 3D migrated to geometries and continuous distance CalculateElementalDistances

### DIFF
--- a/kratos/geometries/plane_3d.h
+++ b/kratos/geometries/plane_3d.h
@@ -1,0 +1,274 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//  contributors:    Ruben Zorrilla
+//
+
+#if !defined(KRATOS_PLANE_3D_H_INCLUDED)
+#define  KRATOS_PLANE_3D_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "geometries/point.h"
+#include "includes/checks.h"
+#include "utilities/math_utils.h"
+
+namespace Kratos
+{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/**
+*/
+class Plane3D
+{
+public:
+    ///@}
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of Point2D
+    KRATOS_CLASS_POINTER_DEFINITION(Plane3D);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    Plane3D() = delete;
+
+    Plane3D(array_1d<double, 3> const &rNormal, double DistanceToOrigin) : mD(DistanceToOrigin), mNormal(rNormal) {}
+
+    Plane3D(const Point &Point1, const Point &Point2, const Point &Point3)
+    {
+        array_1d<double,3> v_1 = Point2 - Point1;
+        array_1d<double,3> v_2 = Point3 - Point1;
+        MathUtils<double>::CrossProduct(mNormal, v_1, v_2);
+        auto normal_length = norm_2(mNormal);
+        KRATOS_DEBUG_CHECK_GREATER(normal_length, std::numeric_limits<double>::epsilon());
+        mNormal /= normal_length;
+        mD = -inner_prod(mNormal, Point1);
+    }
+
+    /// Destructor. Do nothing!!!
+    ~Plane3D() {}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /** Return the plane normal vector
+    @return Array containing the plane normal
+    */
+    array_1d<double,3> const& GetNormal()
+    { 
+        return mNormal; 
+    }
+
+    /** Return the plane distance value
+    @return Plane distance value
+    */
+    double GetDistance()
+    { 
+        return mD; 
+    }
+
+    /** Calculates the plane signed distance value
+    @return Plane signed distance value
+    */
+    double CalculateSignedDistance(Point const &rPoint)
+    {
+        return inner_prod(mNormal, rPoint) + mD;
+    }
+
+    /** Turn back information as a string.
+    @return String contains information about this geometry.
+    @see PrintData()
+    @see PrintInfo()
+    */
+    std::string Info() const
+    {
+        return "a 3D plane auxiliar class";
+    }
+
+    /** Print information about this object.
+    @param rOStream Stream to print into it.
+    @see PrintData()
+    @see Info()
+    */
+    void PrintInfo(std::ostream& rOStream) const
+    {
+        rOStream << "a 3D plane auxiliar class";
+    }
+
+    /** Print geometry's data into given stream. Prints it's points
+    by the order they stored in the geometry and then center
+    point of geometry.
+    @param rOStream Stream to print into it.
+    @see PrintInfo()
+    @see Info()
+    */
+    void PrintData(std::ostream& rOStream) const
+    {
+        rOStream << "a 3D plane auxiliar class";
+    }
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+
+private:
+
+    ///@name Static Member Variables
+    ///@{
+
+    double                       mD;
+    array_1d<double,3>      mNormal;
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+   
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Private Friends
+    ///@{
+
+
+    ///@}
+    ///@name Serialization
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+
+    ///@}
+
+}; // Class Plane3D
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream,
+                                  Plane3D& rThis);
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                                  const Plane3D& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+
+}  // namespace Kratos.
+
+#endif // KRATOS_PLANE_3D_H_INCLUDED  defined 
+
+

--- a/kratos/geometries/plane_3d.h
+++ b/kratos/geometries/plane_3d.h
@@ -99,7 +99,7 @@ public:
     /** Return the plane distance value
     @return Plane distance value
     */
-    double GetDistance()
+    double GetDistanceToOrigin()
     { 
         return mD; 
     }
@@ -141,7 +141,9 @@ public:
     */
     void PrintData(std::ostream& rOStream) const
     {
-        rOStream << "a 3D plane auxiliar class";
+        rOStream << "a 3D plane auxiliar class with:\n";
+        rOStream << "\t- distance to origin: " << mD << "\n";
+        rOStream << "\t- normal: (" << mNormal[0] << " , " << mNormal[1] << " , " << mNormal[2] << ")";
     }
 
     ///@}
@@ -151,91 +153,14 @@ public:
 
     ///@}
 
-protected:
-    ///@name Protected static Member Variables
-    ///@{
-
-
-    ///@}
-    ///@name Protected member Variables
-    ///@{
-
-
-    ///@}
-    ///@name Protected Operators
-    ///@{
-
-
-    ///@}
-    ///@name Protected Operations
-    ///@{
-
-
-    ///@}
-    ///@name Protected  Access
-    ///@{
-
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-
-
-    ///@}
-
 private:
 
-    ///@name Static Member Variables
+    ///@name Member Variables
     ///@{
 
     double                       mD;
     array_1d<double,3>      mNormal;
-
-    ///@}
-    ///@name Member Variables
-    ///@{
-
    
-    ///@}
-    ///@name Private Operators
-    ///@{
-
-
-    ///@}
-    ///@name Private Operations
-    ///@{
-
-
-    ///@}
-    ///@name Private  Access
-    ///@{
-
-
-    ///@}
-    ///@name Private Inquiry
-    ///@{
-
-
-    ///@}
-    ///@name Private Friends
-    ///@{
-
-
-    ///@}
-    ///@name Serialization
-    ///@{
-
-
-    ///@}
-    ///@name Un accessible methods
-    ///@{
-
-
     ///@}
 
 }; // Class Plane3D

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -22,6 +22,7 @@
 // External includes
 
 // Project includes
+#include "geometries/plane_3d.h"
 #include "geometries/line_3d_2.h"
 #include "integration/triangle_gauss_legendre_integration_points.h"
 #include "integration/triangle_collocation_integration_points.h"
@@ -2322,33 +2323,6 @@ private:
         if(min_max.first>rad || min_max.second<-rad) return true;
         else return false;
     }
-
-
-	// TODO: I should move this class to a separate file but is out of scope of this branch
-	class Plane3D {
-	public:
-		using VectorType = array_1d<double, 3>;
-		using PointType = Point;
-
-		Plane3D(VectorType const& TheNormal, double DistanceToOrigin) :mNormal(TheNormal), mD(DistanceToOrigin) {}
-		Plane3D() = delete;
-		Plane3D(PointType const& Point1, PointType const& Point2, PointType const& Point3) {
-			VectorType v1 = Point2 - Point1;
-			VectorType v2 = Point3 - Point1;
-			MathUtils<double>::CrossProduct(mNormal, v1, v2);
-			mD = -inner_prod(mNormal, Point1);
-		}
-		VectorType const& GetNormal() { return mNormal; }
-		double GetDistance() { return mD; }
-		double CalculateSignedDistance(PointType const& ThePoint) {
-			return inner_prod(mNormal, ThePoint) + mD;
-		}
-
-	private:
-		VectorType mNormal;
-		double mD;
-	};
-
 
     ///@}
     ///@name Private  Access

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -17,6 +17,7 @@
 
 
 // Project includes
+#include "geometries/plane_3d.h"
 #include "processes/calculate_discontinuous_distance_to_skin_process.h"
 #include "utilities/geometry_utilities.h"
 

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
@@ -24,9 +24,9 @@
 
 
 // Project includes
+#include "includes/checks.h"
 #include "processes/process.h"
 #include "processes/find_intersected_geometrical_objects_process.h"
-#include "includes/checks.h"
 
 
 namespace Kratos
@@ -117,34 +117,6 @@ namespace Kratos
       ///@}
 
     private:
-
-		// TODO: I should move this class to a separate file but is out of scope of this branch
-		class Plane3D {
-		public:
-			using VectorType = array_1d<double, 3>;
-			using PointType = Point;
-
-			Plane3D(VectorType const& TheNormal, double DistanceToOrigin) :mNormal(TheNormal), mD(DistanceToOrigin) {}
-			Plane3D() = delete;
-			Plane3D(PointType const& Point1, PointType const& Point2, PointType const& Point3) {
-				VectorType v1 = Point2 - Point1;
-				VectorType v2 = Point3 - Point1;
-				MathUtils<double>::CrossProduct(mNormal, v1, v2);
-				auto normal_length = norm_2(mNormal);
-				KRATOS_DEBUG_CHECK_GREATER(normal_length, std::numeric_limits<double>::epsilon());
-				mNormal /= normal_length;
-				mD = -inner_prod(mNormal, Point1);
-			}
-			VectorType const& GetNormal() { return mNormal; }
-			double GetDistance() { return mD; }
-			double CalculateSignedDistance(PointType const& ThePoint) {
-				return inner_prod(mNormal, ThePoint) + mD;
-			}
-
-		private:
-			VectorType mNormal;
-			double mD;
-		};
 
       ///@name Member Variables
       ///@{

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -18,7 +18,9 @@
 
 
 // Project includes
+#include "geometries/plane_3d.h"
 #include "processes/calculate_distance_to_skin_process.h"
+#include "utilities/geometry_utilities.h"
 
 
 namespace Kratos
@@ -51,9 +53,74 @@ namespace Kratos
 
 	void CalculateDistanceToSkinProcess::CalculateDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects)
 	{
-		CalculateDiscontinuousDistanceToSkinProcess::CalculateDistances(rIntersectedObjects);
+		this->CalculateElementalDistances(rIntersectedObjects);
 		this->CalculateNodalDistances();
 		this->CalculateNodesDistances();
+	}
+
+	void CalculateDistanceToSkinProcess::CalculateElementalDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects)
+	{
+		const int number_of_elements = (mFindIntersectedObjectsProcess.GetModelPart1()).NumberOfElements();
+		auto& r_elements = (mFindIntersectedObjectsProcess.GetModelPart1()).ElementsArray();
+
+		#pragma omp parallel for schedule(dynamic)
+		for (int i = 0; i < number_of_elements; ++i)
+		{
+			Element &r_element = *(r_elements[i]);
+			PointerVector<GeometricalObject>& r_element_intersections = rIntersectedObjects[i]; 
+
+			// Check if the element has intersections
+			if (r_element_intersections.empty())
+			{
+				r_element.Set(TO_SPLIT, false);
+			} 
+			else 
+			{
+				// This function assumes tetrahedra element and triangle intersected object as input at this moment
+				constexpr int number_of_tetrahedra_points = 4;
+				constexpr double epsilon = std::numeric_limits<double>::epsilon();
+				Vector &elemental_distances = r_element.GetValue(ELEMENTAL_DISTANCES);
+
+				if (elemental_distances.size() != number_of_tetrahedra_points)
+					elemental_distances.resize(number_of_tetrahedra_points, false);
+
+				for (int i = 0; i < number_of_tetrahedra_points; i++)
+				{
+					elemental_distances[i] = this->CalculateDistanceToNode(r_element, i, r_element_intersections, epsilon);
+				}
+
+				bool has_positive_distance = false;
+				bool has_negative_distance = false;
+				for (int i = 0; i < number_of_tetrahedra_points; i++)
+					if (elemental_distances[i] > epsilon)
+						has_positive_distance = true;
+					else
+						has_negative_distance = true;
+
+				r_element.Set(TO_SPLIT, has_positive_distance && has_negative_distance);
+			}
+		}
+	}
+
+	double CalculateDistanceToSkinProcess::CalculateDistanceToNode(Element& rElement1, int NodeIndex, PointerVector<GeometricalObject>& rIntersectedObjects, const double Epsilon)
+	{
+		double result_distance = std::numeric_limits<double>::max();
+		for (auto triangle : rIntersectedObjects.GetContainer()) {
+			auto distance = GeometryUtils::PointDistanceToTriangle3D(triangle->GetGeometry()[0], triangle->GetGeometry()[1], triangle->GetGeometry()[2], rElement1.GetGeometry()[NodeIndex]);
+			if (fabs(result_distance) > distance)
+			{
+				if (distance < Epsilon) {
+					result_distance = -Epsilon;
+				}
+				else {
+					result_distance = distance;
+					Plane3D plane(triangle->GetGeometry()[0], triangle->GetGeometry()[1], triangle->GetGeometry()[2]);
+					if (plane.CalculateSignedDistance(rElement1.GetGeometry()[NodeIndex]) < 0)
+						result_distance = -result_distance;
+				}
+			}
+		}
+		return result_distance;
 	}
 
 	void CalculateDistanceToSkinProcess::CalculateNodalDistances()

--- a/kratos/processes/calculate_distance_to_skin_process.h
+++ b/kratos/processes/calculate_distance_to_skin_process.h
@@ -80,7 +80,11 @@ namespace Kratos
       ///@{
       void Initialize() override;
 
-      void CalculateDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects) override;
+      void CalculateDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects);
+
+      double CalculateDistanceToNode(Element &rElement1, int NodeIndex, PointerVector<GeometricalObject> &rIntersectedObjects, const double Epsilon);
+
+      void CalculateElementalDistances(std::vector<PointerVector<GeometricalObject>> &rIntersectedObjects);
 
       virtual void InitializeNodalDistances();
 

--- a/kratos/processes/calculate_distance_to_skin_process.h
+++ b/kratos/processes/calculate_distance_to_skin_process.h
@@ -80,7 +80,7 @@ namespace Kratos
       ///@{
       void Initialize() override;
 
-      void CalculateDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects);
+      void CalculateDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects) override;
 
       double CalculateDistanceToNode(Element &rElement1, int NodeIndex, PointerVector<GeometricalObject> &rIntersectedObjects, const double Epsilon);
 

--- a/kratos/tests/utilities/test_geometry_utils.cpp
+++ b/kratos/tests/utilities/test_geometry_utils.cpp
@@ -1,0 +1,55 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:     BSD License
+//           Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "includes/checks.h"
+#include "includes/gid_io.h"
+#include "utilities/geometry_utilities.h"
+
+namespace Kratos {
+namespace Testing {
+
+    KRATOS_TEST_CASE_IN_SUITE(GeometryUtilsPointDistanceToTriangleOutOfPlane, KratosCoreFastSuite)
+    {
+        // Triangle plane points
+        Point triangle_point_1(-1.0,-1.0, 0.0);
+        Point triangle_point_2( 1.0,-1.0, 0.0);
+        Point triangle_point_3(-1.0, 1.0, 0.0);
+
+        // Point out of plane to compute the distance to
+        Point distance_point(0.357143, -0.214286, 0.0714286);
+
+        
+        const double dist = GeometryUtils::PointDistanceToTriangle3D(triangle_point_1, triangle_point_2, triangle_point_3, distance_point);
+
+        KRATOS_CHECK_NEAR(dist, 0.123718, 1e-6);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(GeometryUtilsPointDistanceToTriangleInPlane, KratosCoreFastSuite)
+    {
+        // Triangle plane points
+        Point triangle_point_1( 1.0,-1.0, 0.0);
+        Point triangle_point_2( 1.0, 1.0, 0.0);
+        Point triangle_point_3(-1.0, 1.0, 0.0);
+
+        // Point over the plane to compute the distance to
+        Point distance_point(0.357143, -0.214286, 0.0714286);
+        
+        const double dist = GeometryUtils::PointDistanceToTriangle3D(triangle_point_1, triangle_point_2, triangle_point_3, distance_point);
+
+        KRATOS_CHECK_NEAR(dist, distance_point.Z(), 1e-6);
+    }
+
+}  // namespace Testing.
+}  // namespace Kratos.


### PR DESCRIPTION
In this PR:

- ThePlane3D class in the discontinuous distance process has been removed and implemented in the geometries folder. Since this is an auxiliar geometry, it does not derive from the Kratos base Geometry class.
- A method for computing the elemental distances has been implemented in the CalculateDistanceToSkinProcess (continuous distance tool). By doing that, this operation is now independent of the base CalculateDiscontinuousDistanceToSkinProcess (discontinuous distance tool). Even though the code is duplicated now,  it is expected that the elemental distance computation will be modified in the base class (this is why we decided to migrate this operations to the continuous distance tool).