### PR TITLE
correcting an index. also removing a wrong vector initialization

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_large_strain.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_large_strain.py
@@ -78,7 +78,7 @@ class TestPatchTestLargeStrain(KratosUnittest.TestCase):
             A = KratosMultiphysics.Matrix(3,3)
             A[0,0] =   0.10;  A[0,1] = 0.12; A[0,2] = 0.0
             A[1,0] = - 0.05;  A[1,1] = 0.07; A[1,2] = 0.0
-            A[2,1] =   0.00;  A[2,1] = 0.0;  A[2,2] = 0.0
+            A[2,0] =   0.00;  A[2,1] = 0.0;  A[2,2] = 0.0
                     
             b = KratosMultiphysics.Vector(3)
             b[0] =  0.05
@@ -91,7 +91,7 @@ class TestPatchTestLargeStrain(KratosUnittest.TestCase):
             A = KratosMultiphysics.Matrix(3,3)
             A[0,0] =   0.10; A[0,1] = 0.12; A[0,2] = 0.0
             A[1,0] = - 0.05; A[1,1] = 0.07; A[1,2] = 0.1
-            A[2,1] = - 0.02; A[2,1] = 0.0;  A[2,2] = -0.3
+            A[2,0] = - 0.02; A[2,1] = 0.0;  A[2,2] = -0.3
                     
             b = KratosMultiphysics.Vector(3)
             b[0] =  0.05
@@ -166,12 +166,11 @@ class TestPatchTestLargeStrain(KratosUnittest.TestCase):
         
         ##check that the results are exact on the nodes
         for node in mp.Nodes:
-            xvec = KratosMultiphysics.Vector(len(b))
+            xvec = KratosMultiphysics.Vector(3)
             xvec[0] = node.X0
             xvec[1] = node.Y0
             xvec[2] = node.Z0
             
-            u = KratosMultiphysics.Vector(2)
             u = A*xvec
             u += b            
             

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain.py
@@ -27,7 +27,6 @@ class TestPatchTestSmallStrain(KratosUnittest.TestCase):
             xvec[1] = node.Y0
             xvec[2] = node.Z0
             
-            u = KratosMultiphysics.Vector()
             u = A*xvec
             u += b
             
@@ -47,7 +46,7 @@ class TestPatchTestSmallStrain(KratosUnittest.TestCase):
             cl = StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw()
         else:
             cl = StructuralMechanicsApplication.LinearElastic3DLaw()
-        mp.GetProperties()[1].SetValue(KratosMultiphysics.CONSTITUTIVE_LAW,cl) 
+        mp.GetProperties()[1].SetValue(KratosMultiphysics.CONSTITUTIVE_LAW,cl)
             
     def _define_movement(self,dim):
         if(dim == 2):
@@ -56,7 +55,7 @@ class TestPatchTestSmallStrain(KratosUnittest.TestCase):
             A = KratosMultiphysics.Matrix(3,3)
             A[0,0] = 1.0e-10;  A[0,1] = 2.0e-10; A[0,2] = 0.0
             A[1,0] = 0.5e-10;  A[1,1] = 0.7e-10; A[1,2] = 0.0
-            A[2,1] = 0.0;  A[2,1] = 0.0; A[2,2] = 0.0
+            A[2,0] = 0.0;      A[2,1] = 0.0;     A[2,2] = 0.0
                     
             b = KratosMultiphysics.Vector(3)
             b[0] = 0.5e-10
@@ -69,7 +68,7 @@ class TestPatchTestSmallStrain(KratosUnittest.TestCase):
             A = KratosMultiphysics.Matrix(3,3)
             A[0,0] = 1.0e-10;   A[0,1] = 2.0e-10; A[0,2] = 0.0
             A[1,0] = 0.5e-10;   A[1,1] = 0.7e-10; A[1,2] = 0.1e-10
-            A[2,1] = -0.2e-10;  A[2,1] = 0.0;     A[2,2] = -0.3e-10
+            A[2,0] = -0.2e-10;  A[2,1] = 0.0;     A[2,2] = -0.3e-10
                     
             b = KratosMultiphysics.Vector(3)
             b[0] = 0.5e-10
@@ -122,12 +121,11 @@ class TestPatchTestSmallStrain(KratosUnittest.TestCase):
         
         ##check that the results are exact on the nodes
         for node in mp.Nodes:
-            xvec = KratosMultiphysics.Vector(len(b))
+            xvec = KratosMultiphysics.Vector(3)
             xvec[0] = node.X0
             xvec[1] = node.Y0
             xvec[2] = node.Z0
             
-            u = KratosMultiphysics.Vector(2)
             u = A*xvec
             u += b            
             

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain_bbar.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain_bbar.py
@@ -27,7 +27,6 @@ class TestPatchTestSmallStrainBbar(KratosUnittest.TestCase):
             xvec[1] = node.Y0
             xvec[2] = node.Z0
             
-            u = KratosMultiphysics.Vector()
             u = A*xvec
             u += b
             
@@ -59,7 +58,7 @@ class TestPatchTestSmallStrainBbar(KratosUnittest.TestCase):
             A = KratosMultiphysics.Matrix(3,3)
             A[0,0] = 1.0e-10;  A[0,1] = 2.0e-10; A[0,2] = 0.0
             A[1,0] = 0.5e-10;  A[1,1] = 0.7e-10; A[1,2] = 0.0
-            A[2,1] = 0.0;  A[2,1] = 0.0; A[2,2] = 0.0
+            A[2,0] = 0.0;      A[2,1] = 0.0;     A[2,2] = 0.0
                     
             b = KratosMultiphysics.Vector(3)
             b[0] = 0.5e-10
@@ -72,7 +71,7 @@ class TestPatchTestSmallStrainBbar(KratosUnittest.TestCase):
             A = KratosMultiphysics.Matrix(3,3)
             A[0,0] = 1.0e-10;   A[0,1] = 2.0e-10; A[0,2] = 0.0
             A[1,0] = 0.5e-10;   A[1,1] = 0.7e-10; A[1,2] = 0.1e-10
-            A[2,1] = -0.2e-10;  A[2,1] = 0.0;     A[2,2] = -0.3e-10
+            A[2,0] = -0.2e-10;  A[2,1] = 0.0;     A[2,2] = -0.3e-10
                     
             b = KratosMultiphysics.Vector(3)
             b[0] = 0.5e-10
@@ -126,12 +125,11 @@ class TestPatchTestSmallStrainBbar(KratosUnittest.TestCase):
         
         ##check that the results are exact on the nodes
         for node in mp.Nodes:
-            xvec = KratosMultiphysics.Vector(len(b))
+            xvec = KratosMultiphysics.Vector(3)
             xvec[0] = node.X0
             xvec[1] = node.Y0
             xvec[2] = node.Z0
             
-            u = KratosMultiphysics.Vector(2)
             u = A*xvec
             u += b            
             


### PR DESCRIPTION
@philbucher @marandra this fixes the bug. It was a wrong index in the initialization of A. 

also note that if you do
     
     u = Vector(2)
     u = A*b

the first operation is completely useless (not an error, simply useless for how python works). 

It would be good to have this merged, so please merge directly on approval