### PR TITLE
Fixed ambiguous call to std::real in AMGCL

### DIFF
--- a/external_libraries/amgcl/solver/bicgstabl.hpp
+++ b/external_libraries/amgcl/solver/bicgstabl.hpp
@@ -74,8 +74,8 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <amgcl/detail/qr.hpp>
 #include <amgcl/util.hpp>
 
-#if __cplusplus <= 199711L
 // std::real is not overloaded for scalar arguments pre c++11:
+#ifndef BOOST_HAS_TR1_COMPLEX_OVERLOADS
 namespace std {
 inline float real(float x) { return x; }
 inline double real(double x) { return x; }

--- a/external_libraries/amgcl/solver/bicgstabl.hpp
+++ b/external_libraries/amgcl/solver/bicgstabl.hpp
@@ -75,7 +75,9 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <amgcl/util.hpp>
 
 // std::real is not overloaded for scalar arguments pre c++11:
-#ifndef BOOST_HAS_TR1_COMPLEX_OVERLOADS
+// BOOST_HAS_TR1_COMPLEX_OVERLOADS Checks agains the define in "libstdcpp3.hpp" but is not present in other headers of "config/stdlib"
+// __cplusplus <= 199711L Checks if the compiler implements C++11 in general.
+#if !defined(BOOST_HAS_TR1_COMPLEX_OVERLOADS) || __cplusplus <= 199711L
 namespace std {
 inline float real(float x) { return x; }
 inline double real(double x) { return x; }

--- a/external_libraries/amgcl/solver/bicgstabl.hpp
+++ b/external_libraries/amgcl/solver/bicgstabl.hpp
@@ -74,11 +74,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <amgcl/detail/qr.hpp>
 #include <amgcl/util.hpp>
 
+#if __cplusplus <= 199711L
 // std::real is not overloaded for scalar arguments pre c++11:
 namespace std {
 inline float real(float x) { return x; }
 inline double real(double x) { return x; }
 }
+#endif
 
 namespace amgcl {
 namespace solver {


### PR DESCRIPTION
This should fix the problem in #1634. 

Probably not the best solution as MSVC will not define that var correctly. Ideas on how to solve this cleanly?
@ddemidov Has anyone had this problem before with amgcl?
