### PR TITLE
Fluid element cleanup and VorticityUtilities to calculate vorticity-related quantities.

### DIFF
--- a/applications/FluidDynamicsApplication/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/CMakeLists.txt
@@ -18,6 +18,7 @@ set( KRATOS_FLUID_DYNAMICS_APPLICATION_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/fluid_element_utilities.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/drag_utilities.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/element_size_calculator.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/vorticity_utilities.cpp
 
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/vms.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/fluid_element.cpp

--- a/applications/FluidDynamicsApplication/custom_elements/fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/fluid_element.cpp
@@ -18,6 +18,7 @@
 #include "custom_utilities/time_integrated_qsvms_data.h"
 #include "custom_utilities/symbolic_navier_stokes_data.h"
 #include "custom_utilities/element_size_calculator.h"
+#include "custom_utilities/vorticity_utilities.h"
 
 namespace Kratos
 {
@@ -424,6 +425,77 @@ int FluidElement<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo)
     return out;
 }
 
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template< class TElementData >
+void FluidElement<TElementData>::GetValueOnIntegrationPoints(
+    Variable<array_1d<double, 3 > > const& rVariable,
+    std::vector<array_1d<double, 3 > >& rValues,
+    ProcessInfo const& rCurrentProcessInfo)
+{
+    if (rVariable == VORTICITY)
+    {
+        // Get Shape function data
+        Vector gauss_weights;
+        Matrix shape_functions;
+        ShapeFunctionDerivativesArrayType shape_function_gradients;
+        this->CalculateGeometryData(gauss_weights,shape_functions,shape_function_gradients);
+
+        VorticityUtilities<Dim>::CalculateVorticityVector(this->GetGeometry(),shape_function_gradients,rValues);
+    }
+}
+
+
+template< class TElementData >
+void FluidElement<TElementData>::GetValueOnIntegrationPoints(
+    Variable<double> const& rVariable,
+    std::vector<double>& rValues,
+    ProcessInfo const& rCurrentProcessInfo)
+{
+    if (rVariable == Q_VALUE)
+    {
+        // Get Shape function data
+        Vector gauss_weights;
+        Matrix shape_functions;
+        ShapeFunctionDerivativesArrayType shape_function_gradients;
+        this->CalculateGeometryData(gauss_weights,shape_functions,shape_function_gradients);
+
+        VorticityUtilities<Dim>::CalculateQValue(this->GetGeometry(),shape_function_gradients,rValues);
+	}
+	else if (rVariable == VORTICITY_MAGNITUDE)
+	{
+        // Get Shape function data
+        Vector gauss_weights;
+        Matrix shape_functions;
+        ShapeFunctionDerivativesArrayType shape_function_gradients;
+        this->CalculateGeometryData(gauss_weights,shape_functions,shape_function_gradients);
+
+        VorticityUtilities<Dim>::CalculateVorticityMagnitude(this->GetGeometry(),shape_function_gradients,rValues);
+	}
+}
+
+template <class TElementData>
+void FluidElement<TElementData>::GetValueOnIntegrationPoints(
+    Variable<array_1d<double, 6>> const& rVariable,
+    std::vector<array_1d<double, 6>>& rValues,
+    ProcessInfo const& rCurrentProcessInfo)
+{}
+
+template <class TElementData>
+void FluidElement<TElementData>::GetValueOnIntegrationPoints(
+    Variable<Vector> const& rVariable,
+    std::vector<Vector>& rValues,
+    ProcessInfo const& rCurrentProcessInfo)
+{}
+
+template <class TElementData>
+void FluidElement<TElementData>::GetValueOnIntegrationPoints(
+    Variable<Matrix> const& rVariable,
+    std::vector<Matrix>& rValues,
+    ProcessInfo const& rCurrentProcessInfo)
+{}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Input and output
 
@@ -632,34 +704,6 @@ void FluidElement<TElementData>::GetCurrentValuesVector(
         for (unsigned int d = 0; d < Dim; ++d)  // Velocity Dofs
             rValues[local_index++] = r_velocities(i, d);
         rValues[local_index++] = r_pressures[i];  // Pressure Dof
-    }
-}
-
-template <class TElementData>
-void FluidElement<TElementData>::IntegrationPointVorticity(
-    const ShapeFunctionDerivativesType& rDN_DX, array_1d<double, 3>& rVorticity) const
-{
-    rVorticity = array_1d<double, 3>(3, 0.0);
-
-    if (Dim == 2)
-    {
-        for (unsigned int i = 0; i < NumNodes; ++i)
-        {
-            const array_1d<double, 3>& rVelocity =
-                this->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY);
-            rVorticity[2] += rDN_DX(i, 0) * rVelocity[1] - rDN_DX(i, 1) * rVelocity[0];
-        }
-    }
-    else
-    {
-        for (unsigned int i = 0; i < NumNodes; ++i)
-        {
-            const array_1d<double, 3>& rVelocity =
-                this->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY);
-            rVorticity[0] += rDN_DX(i, 1) * rVelocity[2] - rDN_DX(i, 2) * rVelocity[1];
-            rVorticity[1] += rDN_DX(i, 2) * rVelocity[0] - rDN_DX(i, 0) * rVelocity[2];
-            rVorticity[2] += rDN_DX(i, 0) * rVelocity[1] - rDN_DX(i, 1) * rVelocity[0];
-        }
     }
 }
 

--- a/applications/FluidDynamicsApplication/custom_elements/fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/fluid_element.cpp
@@ -462,9 +462,9 @@ void FluidElement<TElementData>::GetValueOnIntegrationPoints(
         this->CalculateGeometryData(gauss_weights,shape_functions,shape_function_gradients);
 
         VorticityUtilities<Dim>::CalculateQValue(this->GetGeometry(),shape_function_gradients,rValues);
-	}
-	else if (rVariable == VORTICITY_MAGNITUDE)
-	{
+    }
+    else if (rVariable == VORTICITY_MAGNITUDE)
+    {
         // Get Shape function data
         Vector gauss_weights;
         Matrix shape_functions;
@@ -472,7 +472,7 @@ void FluidElement<TElementData>::GetValueOnIntegrationPoints(
         this->CalculateGeometryData(gauss_weights,shape_functions,shape_function_gradients);
 
         VorticityUtilities<Dim>::CalculateVorticityMagnitude(this->GetGeometry(),shape_function_gradients,rValues);
-	}
+    }
 }
 
 template <class TElementData>

--- a/applications/FluidDynamicsApplication/custom_elements/fluid_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/fluid_element.h
@@ -284,6 +284,25 @@ public:
     ///@name Access
     ///@{
 
+    void GetValueOnIntegrationPoints(Variable<array_1d<double, 3>> const& rVariable,
+                                     std::vector<array_1d<double, 3>>& rValues,
+                                     ProcessInfo const& rCurrentProcessInfo) override;
+
+    void GetValueOnIntegrationPoints(Variable<double> const& rVariable,
+                                     std::vector<double>& rValues,
+                                     ProcessInfo const& rCurrentProcessInfo) override;
+
+    void GetValueOnIntegrationPoints(Variable<array_1d<double, 6>> const& rVariable,
+                                     std::vector<array_1d<double, 6>>& rValues,
+                                     ProcessInfo const& rCurrentProcessInfo) override;
+
+    void GetValueOnIntegrationPoints(Variable<Vector> const& rVariable,
+                                     std::vector<Vector>& rValues,
+                                     ProcessInfo const& rCurrentProcessInfo) override;
+
+    void GetValueOnIntegrationPoints(Variable<Matrix> const& rVariable,
+                                     std::vector<Matrix>& rValues,
+                                     ProcessInfo const& rCurrentProcessInfo) override;
 
     ///@}
     ///@name Inquiry
@@ -385,11 +404,6 @@ protected:
     void GetCurrentValuesVector(
         const TElementData& rData,
         array_1d<double,LocalSize>& rValues) const;
-
-    void IntegrationPointVorticity(
-        const ShapeFunctionDerivativesType& rDN_DX,
-        array_1d<double,3> &rVorticity) const;
-
 
     ///@}
     ///@name Protected  Access

--- a/applications/FluidDynamicsApplication/custom_elements/fractional_step.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/fractional_step.cpp
@@ -2,6 +2,8 @@
 #include "includes/cfd_variables.h"
 #include "includes/checks.h"
 
+#include "custom_utilities/vorticity_utilities.h"
+
 namespace Kratos {
 
 /*
@@ -379,6 +381,15 @@ void FractionalStep<TDim>::GetValueOnIntegrationPoints(const Variable<array_1d<d
             rOut -= PresProj;
         }
     }
+    else if (rVariable == VORTICITY) {
+        // Shape functions and integration points
+        ShapeFunctionDerivativesArrayType DN_DX;
+        Matrix NContainer;
+        VectorType GaussWeights;
+        this->CalculateGeometryData(DN_DX,NContainer,GaussWeights);
+
+        VorticityUtilities<TDim>::CalculateVorticityVector(this->GetGeometry(),DN_DX,rValues);
+    }
     else
     {
         this->GetElementalValueForOutput< array_1d<double,3> >(rVariable,rValues);
@@ -467,81 +478,23 @@ void FractionalStep<TDim>::GetValueOnIntegrationPoints(const Variable<double>& r
     }
     else if (rVariable == Q_VALUE)
     {
-      // Shape functions and integration points
-      ShapeFunctionDerivativesArrayType DN_DX;
-      Matrix NContainer;
-      VectorType GaussWeights;
-      this->CalculateGeometryData(DN_DX,NContainer,GaussWeights);
-      const unsigned int NumGauss = GaussWeights.size();
-      rValues.resize(NumGauss);
-      Matrix GradVel;
+        // Shape functions and integration points
+        ShapeFunctionDerivativesArrayType DN_DX;
+        Matrix NContainer;
+        VectorType GaussWeights;
+        this->CalculateGeometryData(DN_DX,NContainer,GaussWeights);
 
-      // Loop on integration points
-      for (unsigned int g = 0; g < NumGauss; g++)
-      {
-        GradVel = ZeroMatrix(TDim,TDim);
-        const ShapeFunctionDerivativesType& rDN_DX = DN_DX[g];
-
-        // Compute velocity gradient
-        for (unsigned int i=0; i < TDim; ++i)
-          for (unsigned int j=0; j < TDim; ++j)
-            for (unsigned int iNode=0; iNode < this->GetGeometry().size(); ++iNode)
-            {
-              array_1d<double,3>& Vel =
-                  this->GetGeometry()[iNode].FastGetSolutionStepValue(VELOCITY);
-              GradVel(i,j) += Vel[i] * rDN_DX(iNode,j);
-            }
-
-        // Compute Q-value
-        double qval = 0.0;
-        for (unsigned int i=0; i < TDim; ++i)
-          for (unsigned int j=0; j < TDim; ++j)
-            qval += GradVel(i,j) * GradVel(j,i);
-
-        qval *= -0.5;
-        rValues[g] = qval;
-      }
+        VorticityUtilities<TDim>::CalculateQValue(this->GetGeometry(),DN_DX,rValues);
     }
     else if (rVariable == VORTICITY_MAGNITUDE)
     {
-      // Shape functions and integration points
-      ShapeFunctionDerivativesArrayType DN_DX;
-      Matrix NContainer;
-      VectorType GaussWeights;
-      this->CalculateGeometryData(DN_DX,NContainer,GaussWeights);
-      const unsigned int NumGauss = GaussWeights.size();
-      rValues.resize(NumGauss);
+        // Shape functions and integration points
+        ShapeFunctionDerivativesArrayType DN_DX;
+        Matrix NContainer;
+        VectorType GaussWeights;
+        this->CalculateGeometryData(DN_DX,NContainer,GaussWeights);
 
-      // Loop on integration points
-      for (unsigned int g = 0; g < NumGauss; g++)
-      {
-        const ShapeFunctionDerivativesType& rDN_DX = DN_DX[g];
-        array_1d<double,3> Vorticity(3,0.0);
-
-        if(TDim == 2)
-        {
-          for (unsigned int iNode = 0; iNode < this->GetGeometry().size(); iNode++)
-          {
-            array_1d<double,3>& Vel =
-                this->GetGeometry()[iNode].FastGetSolutionStepValue(VELOCITY);
-            Vorticity[2] += Vel[1] * rDN_DX(iNode,0) - Vel[0] * rDN_DX(iNode,1);
-          }
-        }
-        else
-        {
-          for (unsigned int iNode = 0; iNode < this->GetGeometry().size(); iNode++)
-          {
-            array_1d<double,3>& Vel =
-                this->GetGeometry()[iNode].FastGetSolutionStepValue(VELOCITY);
-            Vorticity[0] += Vel[2] * rDN_DX(iNode,1) - Vel[1] * rDN_DX(iNode,2);
-            Vorticity[1] += Vel[0] * rDN_DX(iNode,2) - Vel[2] * rDN_DX(iNode,0);
-            Vorticity[2] += Vel[1] * rDN_DX(iNode,0) - Vel[0] * rDN_DX(iNode,1);
-          }
-        }
-
-        rValues[g] = sqrt(Vorticity[0] * Vorticity[0] + Vorticity[1] * Vorticity[1]
-                          + Vorticity[2] * Vorticity[2]);
-      }
+        VorticityUtilities<TDim>::CalculateVorticityMagnitude(this->GetGeometry(),DN_DX,rValues);
     }
     else
     {

--- a/applications/FluidDynamicsApplication/custom_elements/qs_vms.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/qs_vms.cpp
@@ -121,12 +121,12 @@ int QSVMS<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo)
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template< class TElementData >
-void QSVMS<TElementData>::GetValueOnIntegrationPoints(Variable<array_1d<double, 3 > > const& rVariable,
-                                            std::vector<array_1d<double, 3 > >& rValues,
-                                            ProcessInfo const& rCurrentProcessInfo)
+void QSVMS<TElementData>::GetValueOnIntegrationPoints(
+    Variable<array_1d<double, 3 > > const& rVariable,
+    std::vector<array_1d<double, 3 > >& rValues,
+    ProcessInfo const& rCurrentProcessInfo)
 {
-    if (rVariable == SUBSCALE_VELOCITY)
-    {
+    if (rVariable == SUBSCALE_VELOCITY) {
         // Get Shape function data
         Vector GaussWeights;
         Matrix ShapeFunctions;
@@ -146,32 +146,19 @@ void QSVMS<TElementData>::GetValueOnIntegrationPoints(Variable<array_1d<double, 
             this->SubscaleVelocity(data, rCurrentProcessInfo, rValues[g]);
         }
     }
-    else if (rVariable == VORTICITY)
-    {
-        // Get Shape function data
-        Vector GaussWeights;
-        Matrix ShapeFunctions;
-        ShapeFunctionDerivativesArrayType ShapeDerivatives;
-        this->CalculateGeometryData(GaussWeights,ShapeFunctions,ShapeDerivatives);
-        const unsigned int NumGauss = GaussWeights.size();
-
-        rValues.resize(NumGauss);
-
-        for (unsigned int g = 0; g < NumGauss; g++)
-        {
-            this->IntegrationPointVorticity(ShapeDerivatives[g],rValues[g]);
-        }
+    else {
+        FluidElement<TElementData>::GetValueOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
     }
 }
 
 
 template< class TElementData >
-void QSVMS<TElementData>::GetValueOnIntegrationPoints(Variable<double> const& rVariable,
-                                            std::vector<double>& rValues,
-                                            ProcessInfo const& rCurrentProcessInfo)
+void QSVMS<TElementData>::GetValueOnIntegrationPoints(
+    Variable<double> const& rVariable,
+    std::vector<double>& rValues,
+    ProcessInfo const& rCurrentProcessInfo)
 {
-    if (rVariable == SUBSCALE_PRESSURE)
-    {
+    if (rVariable == SUBSCALE_PRESSURE) {
         // Get Shape function data
         Vector GaussWeights;
         Matrix ShapeFunctions;
@@ -192,86 +179,36 @@ void QSVMS<TElementData>::GetValueOnIntegrationPoints(Variable<double> const& rV
         }
 
     }
-    else if (rVariable == Q_VALUE)
-    {
-		Vector GaussWeights;
-		Matrix ShapeFunctions;
-		ShapeFunctionDerivativesArrayType ShapeDerivatives;
-		this->CalculateGeometryData(GaussWeights,ShapeFunctions,ShapeDerivatives);
-		const unsigned int NumGauss = GaussWeights.size();
-
-		rValues.resize(NumGauss);
-		Matrix GradVel;
-
-		// Loop on integration points
-		for (unsigned int g = 0; g < NumGauss; g++)
-		{
-			GradVel = ZeroMatrix(Dim,Dim);
-			const ShapeFunctionDerivativesType& rDN_DX = ShapeDerivatives[g];
-
-			// Compute velocity gradient
-			for (unsigned int i=0; i < Dim; ++i)
-				for (unsigned int j=0; j < Dim; ++j)
-					for (unsigned int iNode=0; iNode < NumNodes; ++iNode)
-					{
-						array_1d<double,3>& Vel =
-							this->GetGeometry()[iNode].FastGetSolutionStepValue(VELOCITY);
-						GradVel(i,j) += Vel[i] * rDN_DX(iNode,j);
-					}
-
-			// Compute Q-value
-			double qval = 0.0;
-			for (unsigned int i=0; i < Dim; ++i)
-				for (unsigned int j=0; j < Dim; ++j)
-					qval += GradVel(i,j) * GradVel(j,i);
-
-			qval *= -0.5;
-			rValues[g] = qval;
-		}
-	}
-	else if (rVariable == VORTICITY_MAGNITUDE)
-	{
-		Vector GaussWeights;
-		Matrix ShapeFunctions;
-		ShapeFunctionDerivativesArrayType ShapeDerivatives;
-		this->CalculateGeometryData(GaussWeights,ShapeFunctions,ShapeDerivatives);
-		const unsigned int NumGauss = GaussWeights.size();
-
-		rValues.resize(NumGauss);
-		
-  		// Loop on integration points
-		for (unsigned int g = 0; g < NumGauss; g++)
-		{
-			const ShapeFunctionDerivativesType& rDN_DX = ShapeDerivatives[g];
-			array_1d<double,3> Vorticity(3,0.0);
-
-            this->IntegrationPointVorticity(rDN_DX,Vorticity);
-
-			rValues[g] = sqrt(Vorticity[0] * Vorticity[0] + Vorticity[1] * Vorticity[1]
-					+ Vorticity[2] * Vorticity[2]);
-		}
-	}
+    else {
+        FluidElement<TElementData>::GetValueOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
+    }
 }
 
 template <class TElementData>
-void QSVMS<TElementData>::GetValueOnIntegrationPoints(Variable<array_1d<double, 6>> const& rVariable,
-                                                    std::vector<array_1d<double, 6>>& rValues,
-                                                    ProcessInfo const& rCurrentProcessInfo)
+void QSVMS<TElementData>::GetValueOnIntegrationPoints(
+    Variable<array_1d<double, 6>> const& rVariable,
+    std::vector<array_1d<double, 6>>& rValues,
+    ProcessInfo const& rCurrentProcessInfo)
 {
+    FluidElement<TElementData>::GetValueOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
 }
 
 template <class TElementData>
-void QSVMS<TElementData>::GetValueOnIntegrationPoints(Variable<Vector> const& rVariable,
-                                                    std::vector<Vector>& rValues,
-                                                    ProcessInfo const& rCurrentProcessInfo)
+void QSVMS<TElementData>::GetValueOnIntegrationPoints(
+    Variable<Vector> const& rVariable,
+    std::vector<Vector>& rValues,
+    ProcessInfo const& rCurrentProcessInfo)
 {
+    FluidElement<TElementData>::GetValueOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
 }
 
 template <class TElementData>
-void QSVMS<TElementData>::GetValueOnIntegrationPoints(Variable<Matrix> const& rVariable,
-                                                    std::vector<Matrix>& rValues,
-                                                    ProcessInfo const& rCurrentProcessInfo)
+void QSVMS<TElementData>::GetValueOnIntegrationPoints(
+    Variable<Matrix> const& rVariable,
+    std::vector<Matrix>& rValues,
+    ProcessInfo const& rCurrentProcessInfo)
 {
+    FluidElement<TElementData>::GetValueOnIntegrationPoints(rVariable,rValues,rCurrentProcessInfo);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/applications/FluidDynamicsApplication/custom_elements/qs_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/qs_vms.h
@@ -266,6 +266,8 @@ protected:
     ///@name Protected Operations
     ///@{
 
+    // Protected interface of FluidElement ////////////////////////////////////
+
     void AddTimeIntegratedSystem(
         TElementData& rData,
         MatrixType& rLHS,
@@ -288,16 +290,18 @@ protected:
         TElementData& rData,
         MatrixType& rMassMatrix) override;
 
-    void AddMassStabilization(
-        TElementData& rData,
-        MatrixType& rMassMatrix);
-
     // This function integrates the traction over a cut. It is only required to implement embedded formulations
     void AddBoundaryIntegral(
         TElementData& rData,
         const Vector& rUnitNormal,
         MatrixType& rLHS,
         VectorType& rRHS) override;
+
+    // Implementation details of QSVMS ////////////////////////////////////////
+
+    void AddMassStabilization(
+        TElementData& rData,
+        MatrixType& rMassMatrix);
 
     void AddViscousTerm(
         const TElementData& rData,

--- a/applications/FluidDynamicsApplication/custom_elements/qs_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/qs_vms.h
@@ -314,15 +314,12 @@ protected:
     KRATOS_DEPRECATED virtual double EffectiveViscosity(
         TElementData& rData,
         double ElementSize);
-
     
-    virtual void CalculateStaticTau(
+    virtual void CalculateTau(
         const TElementData& rData,
-        double Density,
-        double DynamicViscosity,
         const array_1d<double,3> &Velocity,
         double &TauOne,
-        double &TauTwo);    
+        double &TauTwo) const;
 
     void CalculateProjections(const ProcessInfo &rCurrentProcessInfo);
 

--- a/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.cpp
@@ -1,17 +1,49 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics 
+//
+//  License:         BSD License 
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Michael Andre, https://github.com/msandre
+//                   Jordi Cotela
+//
+
 #include "vorticity_utilities.h"
 
 namespace Kratos {
 
-VorticityUtilities::~VorticityUtilities() {}
+template<std::size_t TDim>
+VorticityUtilities<TDim>::~VorticityUtilities() {}
 
 template<std::size_t TDim>
-double VorticityUtilities::CalculateQValue(
-        const Geometry<Node<3>>& rGeometry,
-        const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients)
+double VorticityUtilities<TDim>::CalculateQValue(
+    const Geometry<Node<3>>& rGeometry,
+    const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients)
+{
+    return 0.0;
+}
+
+template<std::size_t TDim>
+double VorticityUtilities<TDim>::CalculateVorticityMagnitude(
+    const Geometry<Node<3>>& rGeometry,
+    const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients)
+{
+    return 0.0;
+}
+
+template<std::size_t TDim>
+void VorticityUtilities<TDim>::CalculateVorticityVector(
+    const Geometry<Node<3>>& rGeometry,
+    const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients,
+    array_1d<double,3>& rVorticity)
 {
 
 }
 
-
+template class VorticityUtilities<2>;
+template class VorticityUtilities<3>;
 
 }

--- a/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.cpp
@@ -11,6 +11,7 @@
 //                   Jordi Cotela
 //
 
+#include "includes/variables.h"
 #include "vorticity_utilities.h"
 
 namespace Kratos {
@@ -19,28 +20,128 @@ template<std::size_t TDim>
 VorticityUtilities<TDim>::~VorticityUtilities() {}
 
 template<std::size_t TDim>
-double VorticityUtilities<TDim>::CalculateQValue(
-    const Geometry<Node<3>>& rGeometry,
-    const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients)
-{
-    return 0.0;
-}
-
-template<std::size_t TDim>
-double VorticityUtilities<TDim>::CalculateVorticityMagnitude(
-    const Geometry<Node<3>>& rGeometry,
-    const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients)
-{
-    return 0.0;
-}
-
-template<std::size_t TDim>
-void VorticityUtilities<TDim>::CalculateVorticityVector(
+void VorticityUtilities<TDim>::CalculateQValue(
     const Geometry<Node<3>>& rGeometry,
     const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients,
-    array_1d<double,3>& rVorticity)
+    std::vector<double>& rQValues)
 {
+    const unsigned int integration_point_number = rShapeFunctionsGradients.size();
+    if (rQValues.size() != integration_point_number) {
+        rQValues.resize(integration_point_number);
+    }
 
+    boost::numeric::ublas::bounded_matrix<double,TDim,TDim> velocity_gradients;
+
+    // Loop on integration points
+    for (unsigned int g = 0; g < integration_point_number; g++) {
+        velocity_gradients.clear();
+        const auto& rDN_DX = rShapeFunctionsGradients[g];
+
+        // Compute velocity gradient
+        for (unsigned int i=0; i < TDim; ++i) {
+            for (unsigned int j=0; j < TDim; ++j) {
+                for (unsigned int iNode=0; iNode < rGeometry.size(); ++iNode) {
+                    const array_1d<double,3>& Vel = rGeometry[iNode].FastGetSolutionStepValue(VELOCITY);
+                    velocity_gradients(i,j) += Vel[i] * rDN_DX(iNode,j);
+                }
+            }
+        }
+
+        // Compute Q-value
+        double qval = 0.0;
+        for (unsigned int i=0; i < TDim; ++i)
+          for (unsigned int j=0; j < TDim; ++j)
+            qval += velocity_gradients(i,j) * velocity_gradients(j,i);
+
+        qval *= -0.5;
+        rQValues[g] = qval;
+    }
+}
+
+template<std::size_t TDim>
+void VorticityUtilities<TDim>::CalculateVorticityMagnitude(
+    const Geometry<Node<3>>& rGeometry,
+    const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients,
+    std::vector<double>& rVorticityMagnitudes)
+{
+    const unsigned int integration_point_number = rShapeFunctionsGradients.size();
+    if (rVorticityMagnitudes.size() != integration_point_number) {
+        rVorticityMagnitudes.resize(integration_point_number);
+    }
+
+    // Loop on integration points
+    for (unsigned int g = 0; g < integration_point_number; g++) {
+        const auto& rDN_DX = rShapeFunctionsGradients[g];
+
+        array_1d<double,3> Vorticity(3,0.0);
+
+        if(TDim == 2) {
+            for (unsigned int iNode = 0; iNode < rGeometry.size(); iNode++) {
+                const array_1d<double,3>& Vel = rGeometry[iNode].FastGetSolutionStepValue(VELOCITY);
+                Vorticity[2] += Vel[1] * rDN_DX(iNode,0) - Vel[0] * rDN_DX(iNode,1);
+            }
+        }
+        else {
+            for (unsigned int iNode = 0; iNode < rGeometry.size(); iNode++) {
+                const array_1d<double,3>& Vel = rGeometry[iNode].FastGetSolutionStepValue(VELOCITY);
+                Vorticity[0] += Vel[2] * rDN_DX(iNode,1) - Vel[1] * rDN_DX(iNode,2);
+                Vorticity[1] += Vel[0] * rDN_DX(iNode,2) - Vel[2] * rDN_DX(iNode,0);
+                Vorticity[2] += Vel[1] * rDN_DX(iNode,0) - Vel[0] * rDN_DX(iNode,1);
+            }
+        }
+
+        rVorticityMagnitudes[g] = sqrt(Vorticity[0] * Vorticity[0] + Vorticity[1] * Vorticity[1] + Vorticity[2] * Vorticity[2]);
+    }
+}
+
+template<>
+void VorticityUtilities<2>::CalculateVorticityVector(
+    const Geometry<Node<3>>& rGeometry,
+    const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients,
+    std::vector<array_1d<double,3>>& rVorticities)
+{
+    const unsigned int integration_point_number = rShapeFunctionsGradients.size();
+    if (rVorticities.size() != integration_point_number) {
+        rVorticities.resize(integration_point_number);
+    }
+
+    // Loop on integration points
+    for (unsigned int g = 0; g < integration_point_number; g++) {
+        const auto& rDN_DX = rShapeFunctionsGradients[g];
+        array_1d<double,3>& r_vorticity = rVorticities[g];
+        r_vorticity.clear();
+
+        for (unsigned int iNode = 0; iNode < rGeometry.PointsNumber(); ++iNode) {
+            const array_1d<double, 3 > & rVelocity = rGeometry[iNode].FastGetSolutionStepValue(VELOCITY);
+            r_vorticity[2] += rDN_DX(iNode,0)*rVelocity[1] - rDN_DX(iNode,1)*rVelocity[0];
+        }
+    }
+}
+
+template<>
+void VorticityUtilities<3>::CalculateVorticityVector(
+    const Geometry<Node<3>>& rGeometry,
+    const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients,
+    std::vector<array_1d<double,3>>& rVorticities)
+{
+    const unsigned int integration_point_number = rShapeFunctionsGradients.size();
+    if (rVorticities.size() != integration_point_number) {
+        rVorticities.resize(integration_point_number);
+    }
+
+    // Loop on integration points
+    for (unsigned int g = 0; g < integration_point_number; g++) {
+        const auto& rDN_DX = rShapeFunctionsGradients[g];
+        array_1d<double,3>& r_vorticity = rVorticities[g];
+        r_vorticity.clear();
+
+        for (unsigned int iNode = 0; iNode < rGeometry.PointsNumber(); ++iNode) {
+            const array_1d<double, 3 > & rVelocity = rGeometry[iNode].FastGetSolutionStepValue(VELOCITY);
+            r_vorticity[0] += rDN_DX(iNode,1)*rVelocity[2] - rDN_DX(iNode,2)*rVelocity[1];
+            r_vorticity[1] += rDN_DX(iNode,2)*rVelocity[0] - rDN_DX(iNode,0)*rVelocity[2];
+            r_vorticity[2] += rDN_DX(iNode,0)*rVelocity[1] - rDN_DX(iNode,1)*rVelocity[0];
+        }
+    }
 }
 
 template class VorticityUtilities<2>;

--- a/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.cpp
@@ -1,0 +1,17 @@
+#include "vorticity_utilities.h"
+
+namespace Kratos {
+
+VorticityUtilities::~VorticityUtilities() {}
+
+template<std::size_t TDim>
+double VorticityUtilities::CalculateQValue(
+        const Geometry<Node<3>>& rGeometry,
+        const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients)
+{
+
+}
+
+
+
+}

--- a/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.h
@@ -39,10 +39,6 @@ public:
     /// Pointer definition of VorticityUtilities
     KRATOS_CLASS_POINTER_DEFINITION(VorticityUtilities);
 
-
-    /// Type for a matrix containing the shape function gradients
-    typedef Kratos::Matrix ShapeFunctionDerivativesType;
-
     /// Type for an array of shape function gradient matrices
     typedef Geometry< Node<3> >::ShapeFunctionsGradientsType ShapeFunctionDerivativesArrayType;
 
@@ -70,18 +66,20 @@ public:
     ///@name Operations
     ///@{
 
-    static double CalculateQValue(
+    static void CalculateQValue(
         const Geometry<Node<3>>& rGeometry,
-        const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients);
+        const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients,
+        std::vector<double>& rQValues);
 
-    static double CalculateVorticityMagnitude(
+    static void CalculateVorticityMagnitude(
         const Geometry<Node<3>>& rGeometry,
-        const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients);
+        const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients,
+        std::vector<double>& rVorticityMagnitudes);
 
     static void CalculateVorticityVector(
         const Geometry<Node<3>>& rGeometry,
         const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients,
-        array_1d<double,3>& rVorticity);
+        std::vector<array_1d<double,3>>& rVorticities);
 
     ///@}
 

--- a/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.h
@@ -1,0 +1,98 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics 
+//
+//  License:         BSD License 
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Michael Andre, https://github.com/msandre
+//                   Jordi Cotela
+//
+
+#if !defined(KRATOS_VORTICITY_UTILITIES_H )
+#define  KRATOS_VORTICITY_UTILITIES_H
+
+// External includes 
+
+// Project includes
+#include "includes/define.h"
+#include "includes/node.h"
+#include "geometries/geometry.h"
+
+namespace Kratos
+{
+///@addtogroup FluidDynamicsApplication
+///@{
+
+///@name Kratos Classes
+///@{
+
+/// A set of functions to compute quantities of interest for turbulent flows.
+template< std::size_t TDim >
+class VorticityUtilities {
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of VorticityUtilities
+    KRATOS_CLASS_POINTER_DEFINITION(VorticityUtilities);
+
+
+    /// Type for a matrix containing the shape function gradients
+    typedef Kratos::Matrix ShapeFunctionDerivativesType;
+
+    /// Type for an array of shape function gradient matrices
+    typedef GeometryType::ShapeFunctionsGradientsType ShapeFunctionDerivativesArrayType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    // Deleted default constructor
+    VorticityUtilities() = delete;
+    
+    /// Deleted copy constructor.
+    VorticityUtilities(VorticityUtilities const& rOther) = delete;
+
+    /// Destructor.
+    ~VorticityUtilities();
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Deleted assignment operator.
+    VorticityUtilities& operator=(VorticityUtilities const& rOther) = delete;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    static double CalculateQValue(
+        const Geometry<Node<3>>& rGeometry,
+        const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients);
+
+    static double CalculateVorticityMagnitude(
+        const Geometry<Node<3>>& rGeometry,
+        const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients);
+
+    static void CalculateVorticityVector(
+        const Geometry<Node<3>>& rGeometry,
+        const ShapeFunctionDerivativesArrayType& rShapeFunctionsGradients,
+        array_1d<double,3>& rVorticity);
+
+    ///@}
+
+};  // Class VorticityUtilities
+
+///@}
+
+///@} addtogroup block
+  
+}  // namespace Kratos.
+
+#endif // KRATOS_VORTICITY_UTILITIES_H  defined 
+
+

--- a/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.h
@@ -44,7 +44,7 @@ public:
     typedef Kratos::Matrix ShapeFunctionDerivativesType;
 
     /// Type for an array of shape function gradient matrices
-    typedef GeometryType::ShapeFunctionsGradientsType ShapeFunctionDerivativesArrayType;
+    typedef Geometry< Node<3> >::ShapeFunctionsGradientsType ShapeFunctionDerivativesArrayType;
 
     ///@}
     ///@name Life Cycle

--- a/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/vorticity_utilities.h
@@ -82,6 +82,18 @@ public:
         std::vector<array_1d<double,3>>& rVorticities);
 
     ///@}
+private:
+
+    ///@name Private Operations
+    ///@{
+
+    static void NodalContributionToVorticityVector(
+        const Matrix& rDN_DX,
+        const array_1d<double, 3 > & rVelocity,
+        const unsigned int iNode,
+        array_1d<double,3>& rVorticity);
+
+    ///@}
 
 };  // Class VorticityUtilities
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_element_data.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_element_data.cpp
@@ -552,19 +552,20 @@ KRATOS_TEST_CASE_IN_SUITE(QSVMS2D4N, FluidDynamicsApplicationFastSuite)
     reference_velocity(0,0) = 0.0; reference_velocity(0,1) = 0.1;
     reference_velocity(1,0) = 0.1; reference_velocity(1,1) = 0.2;
     reference_velocity(2,0) = 0.2; reference_velocity(2,1) = 0.3;
-    reference_velocity(3,0) = 0.3; reference_velocity(2,1) = 0.4;
+    reference_velocity(3,0) = 0.3; reference_velocity(3,1) = 0.4;
 
 
-    Element::Pointer p_element = model_part.pGetElement(1);
+    Geometry<Node<3>>& r_geometry = model_part.ElementsBegin()->GetGeometry();
+
 
     for(unsigned int i=0; i<4; i++){
-        p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE)    = 0.0;
-        p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 1) = 0.0;
+        r_geometry[i].FastGetSolutionStepValue(PRESSURE)    = 0.0;
+        r_geometry[i].FastGetSolutionStepValue(PRESSURE, 1) = 0.0;
         for(unsigned int k=0; k<2; k++){
-            p_element->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY)[k]    = reference_velocity(i,k);
-            p_element->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY, 1)[k] = 0.9*reference_velocity(i,k);
-            p_element->GetGeometry()[i].FastGetSolutionStepValue(MESH_VELOCITY)[k]    = 0.0;
-            p_element->GetGeometry()[i].FastGetSolutionStepValue(MESH_VELOCITY, 1)[k] = 0.0;
+            r_geometry[i].FastGetSolutionStepValue(VELOCITY)[k]    = reference_velocity(i,k);
+            r_geometry[i].FastGetSolutionStepValue(VELOCITY, 1)[k] = 0.9*reference_velocity(i,k);
+            r_geometry[i].FastGetSolutionStepValue(MESH_VELOCITY)[k]    = 0.0;
+            r_geometry[i].FastGetSolutionStepValue(MESH_VELOCITY, 1)[k] = 0.0;
         }
     }
 
@@ -572,9 +573,7 @@ KRATOS_TEST_CASE_IN_SUITE(QSVMS2D4N, FluidDynamicsApplicationFastSuite)
     Vector RHS = ZeroVector(12);
     Matrix LHS = ZeroMatrix(12,12);
 
-    std::vector< std::vector<double> > output(1);
-    output[0] = {-2.862147056,-1.707621905,0.02977881865,-7.703277072,-6.260649109,-0.02264084539,-12.65363298,-31.7996871,-0.05398482725,-5.280942892,-13.64870855,-0.003153146014}; // QSVMS2D4N
-    int counter = 0;
+    std::vector<double> output = {-2.665425819,-1.87894198,-0.02477280423,-10.27651236,-5.037560437,-0.05013494554,-19.87147169,-19.57971097,-0.06709466598,-14.8532568,-21.17045328,-0.05799758425}; // QSVMS2D4N
 
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); i++) {
         i->Initialize(); // Initialize constitutive law
@@ -584,11 +583,9 @@ KRATOS_TEST_CASE_IN_SUITE(QSVMS2D4N, FluidDynamicsApplicationFastSuite)
         //std::cout << i->Info() << std::setprecision(10) << std::endl;
         //KRATOS_WATCH(RHS);
 
-        for (unsigned int j = 0; j < RHS.size(); j++) {
-            KRATOS_CHECK_NEAR(RHS[j], output[counter][j], 1e-6);
+        for (unsigned int j = 0; j < output.size(); j++) {
+            KRATOS_CHECK_NEAR(RHS[j], output[j], 1e-6);
         }
-
-        counter++;
     }
 }
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_vorticity_utilities.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_vorticity_utilities.cpp
@@ -1,0 +1,176 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Jordi Cotela
+//
+//
+
+#include "testing/testing.h"
+#include "includes/model_part.h"
+#include "includes/cfd_variables.h"
+
+#include "custom_elements/fractional_step.h"
+#include "custom_utilities/vorticity_utilities.h"
+
+namespace Kratos {
+namespace Testing {
+
+void TriangleModelPartForVorticityTests(ModelPart& rModelPart) {
+    
+    rModelPart.AddNodalSolutionStepVariable(VELOCITY);
+    rModelPart.SetBufferSize(3);
+    Properties::Pointer p_properties = rModelPart.pGetProperties(0);
+
+    // Geometry creation
+    rModelPart.CreateNewNode(1, 0.0, 0.0, 0.0);
+    rModelPart.CreateNewNode(2, 1.0, 0.0, 0.0);
+    rModelPart.CreateNewNode(3, 0.0, 1.0, 0.0);
+    std::vector<ModelPart::IndexType> element_nodes{1, 2, 3};
+    rModelPart.CreateNewElement("FractionalStep2D3N", 1, element_nodes, p_properties);
+
+    // Nodal data
+    Element& r_element = *(rModelPart.ElementsBegin());
+    Geometry< Node<3> >& r_geometry = r_element.GetGeometry();
+
+    constexpr double omega = 1.0;
+    constexpr double center[2] = {1.0,-1.0};
+
+    for (unsigned int i = 0; i < 3; i++) {
+        Node<3>& r_node = r_geometry[i];
+        double dx = r_node.X() - center[0];
+        double dy = r_node.Y() - center[1];
+        double r = std::sqrt(dx*dx + dy*dy);
+        double cosine = dx/r;
+        double sine = dy/r;
+        
+        r_node.FastGetSolutionStepValue(VELOCITY_X) = omega*r*sine;
+        r_node.FastGetSolutionStepValue(VELOCITY_Y) = -omega*r*cosine;
+    }
+}
+
+void TetrahedraModelPartForVorticityTests(ModelPart& rModelPart) {
+    
+    rModelPart.AddNodalSolutionStepVariable(VELOCITY);
+    rModelPart.SetBufferSize(3);
+    Properties::Pointer p_properties = rModelPart.pGetProperties(0);
+
+    // Geometry creation
+    rModelPart.CreateNewNode(1, 0.0, 0.0, 0.0);
+    rModelPart.CreateNewNode(2, 1.0, 0.0, 0.0);
+    rModelPart.CreateNewNode(3, 0.0, 1.0, 0.0);
+    rModelPart.CreateNewNode(4, 0.0, 0.0, 1.0);
+    std::vector<ModelPart::IndexType> element_nodes{1, 2, 3, 4};
+    rModelPart.CreateNewElement("FractionalStep3D4N", 1, element_nodes, p_properties);
+
+    // Nodal data
+    Element& r_element = *(rModelPart.ElementsBegin());
+    Geometry< Node<3> >& r_geometry = r_element.GetGeometry();
+
+    constexpr double omega = 1.0;
+    constexpr double center[3] = {1.0,0.0,-1.0};
+
+    for (unsigned int i = 0; i < 4; i++) {
+        Node<3>& r_node = r_geometry[i];
+        double dx = r_node.X() - center[0];
+        //double dy = r_node.Y() - center[1];
+        double dz = r_node.Z() - center[2];
+        double r = std::sqrt(dx*dx + dz*dz);
+        double cosine = dx/r;
+        double sine = dz/r;
+        
+        r_node.FastGetSolutionStepValue(VELOCITY_X) = omega*r*sine;
+        r_node.FastGetSolutionStepValue(VELOCITY_Z) = -omega*r*cosine;
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(VorticityUtilities2DQValue, FluidDynamicsApplicationFastSuite) {
+    ModelPart ModelPart("TestPart");
+    TriangleModelPartForVorticityTests(ModelPart);
+
+    std::vector<double> QValues;
+    ModelPart.ElementsBegin()->GetValueOnIntegrationPoints(Q_VALUE,QValues,ModelPart.GetProcessInfo());
+
+    KRATOS_CHECK_EQUAL(QValues.size(),3);
+    for (unsigned int i = 0; i < QValues.size(); i++) {
+        KRATOS_CHECK_NEAR(QValues[i],1.0,1e-6);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(VorticityUtilities2DVorticityMagnitude, FluidDynamicsApplicationFastSuite) {
+    ModelPart ModelPart("TestPart");
+    TriangleModelPartForVorticityTests(ModelPart);
+
+    std::vector<double> VorticityMagnitudes;
+    ModelPart.ElementsBegin()->GetValueOnIntegrationPoints(VORTICITY_MAGNITUDE,VorticityMagnitudes,ModelPart.GetProcessInfo());
+    
+    KRATOS_CHECK_EQUAL(VorticityMagnitudes.size(),3);
+    for (unsigned int i = 0; i < VorticityMagnitudes.size(); i++) {
+        KRATOS_CHECK_NEAR(VorticityMagnitudes[i],2.0,1e-6);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(VorticityUtilities2DVorticity, FluidDynamicsApplicationFastSuite) {
+    ModelPart ModelPart("TestPart");
+    TriangleModelPartForVorticityTests(ModelPart);
+
+    std::vector< array_1d<double,3> > Vorticities;
+    ModelPart.ElementsBegin()->GetValueOnIntegrationPoints(VORTICITY,Vorticities,ModelPart.GetProcessInfo());
+    
+    KRATOS_CHECK_EQUAL(Vorticities.size(),3);
+    for (unsigned int i = 0; i < Vorticities.size(); i++) {
+        KRATOS_CHECK_NEAR(Vorticities[i][0], 0.0,1e-6);
+        KRATOS_CHECK_NEAR(Vorticities[i][1], 0.0,1e-6);
+        KRATOS_CHECK_NEAR(Vorticities[i][2],-2.0,1e-6);
+    }
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(VorticityUtilities3DQValue, FluidDynamicsApplicationFastSuite) {
+    ModelPart ModelPart("TestPart");
+    TetrahedraModelPartForVorticityTests(ModelPart);
+
+    std::vector<double> QValues;
+    ModelPart.ElementsBegin()->GetValueOnIntegrationPoints(Q_VALUE,QValues,ModelPart.GetProcessInfo());
+
+    KRATOS_CHECK_EQUAL(QValues.size(),4);
+    for (unsigned int i = 0; i < QValues.size(); i++) {
+        KRATOS_CHECK_NEAR(QValues[i],1.0,1e-6);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(VorticityUtilities3DVorticityMagnitude, FluidDynamicsApplicationFastSuite) {
+    ModelPart ModelPart("TestPart");
+    TetrahedraModelPartForVorticityTests(ModelPart);
+
+    std::vector<double> VorticityMagnitudes;
+    ModelPart.ElementsBegin()->GetValueOnIntegrationPoints(VORTICITY_MAGNITUDE,VorticityMagnitudes,ModelPart.GetProcessInfo());
+
+    KRATOS_CHECK_EQUAL(VorticityMagnitudes.size(),4);
+    for (unsigned int i = 0; i < VorticityMagnitudes.size(); i++) {
+        KRATOS_CHECK_NEAR(VorticityMagnitudes[i],2.0,1e-6);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(VorticityUtilities3DVorticity, FluidDynamicsApplicationFastSuite) {
+    ModelPart ModelPart("TestPart");
+    TetrahedraModelPartForVorticityTests(ModelPart);
+
+    std::vector< array_1d<double,3> > Vorticities;
+    ModelPart.ElementsBegin()->GetValueOnIntegrationPoints(VORTICITY,Vorticities,ModelPart.GetProcessInfo());
+    
+    KRATOS_CHECK_EQUAL(Vorticities.size(),4);
+    for (unsigned int i = 0; i < Vorticities.size(); i++) {
+        KRATOS_CHECK_NEAR(Vorticities[i][0], 0.0,1e-6);
+        KRATOS_CHECK_NEAR(Vorticities[i][1], 2.0,1e-6);
+        KRATOS_CHECK_NEAR(Vorticities[i][2], 0.0,1e-6);
+    }
+}
+
+}
+}


### PR DESCRIPTION
Cleaning of `FluidElement` and derived classes. The most notable change is the centralization of methods to compute Q_VALUE, VORTICITY_MAGNITUDE and VORTICITY to a new utility, since duplicate methods to compute those were scattered among different elements.

@msandre your methods have been moved to `vorticity_utilities.h/cpp`, I'd be grateful if you could take a look.