### PR TITLE
Changing virtual to override to silence clang warning.

### DIFF
--- a/applications/FluidDynamicsApplication/custom_constitutive/bingham_3d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/bingham_3d_law.h
@@ -108,7 +108,7 @@ public:
     /**
      * Turn back information as a string.
      */
-    virtual std::string Info() const;
+    std::string Info() const override;
 
 
 protected:

--- a/applications/FluidDynamicsApplication/custom_constitutive/fluid_constitutive_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/fluid_constitutive_law.h
@@ -125,13 +125,13 @@ public:
     ///@{
 
     /// @return A short string identifying this constitutive law instance.
-    virtual std::string Info() const;
+    std::string Info() const override;
 
     /// Print basic information about this constitutive law instance.
-    virtual void PrintInfo(std::ostream& rOStream) const;
+    void PrintInfo(std::ostream& rOStream) const override;
 
     /// Print detailed information about this constitutive law instance and its managed data.
-    virtual void PrintData(std::ostream& rOStream) const;
+    void PrintData(std::ostream& rOStream) const override;
 
     ///@}
 

--- a/applications/FluidDynamicsApplication/custom_constitutive/herschel_bulkley_3d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/herschel_bulkley_3d_law.h
@@ -110,7 +110,7 @@ public:
     /**
      * Turn back information as a string.
      */
-    virtual std::string Info() const;
+    std::string Info() const override;
 
 protected:
 

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_2d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_2d_law.h
@@ -103,7 +103,7 @@ public:
     /**
      * Turn back information as a string.
      */
-    virtual std::string Info() const;
+    std::string Info() const override;
 
 protected:
 

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_3d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_3d_law.h
@@ -104,7 +104,7 @@ public:
     /**
      * Turn back information as a string.
      */
-    virtual std::string Info() const;
+    std::string Info() const override;
 
 protected:
 


### PR DESCRIPTION
By the way, we all have lots of warnings in clang... @KratosMultiphysics/team-maintainers: we should all be more responsible compiling warings this, please check the clang compilation emails periodically.