### PR TITLE
Core bugfix. GetModelPart was crashing with an empty name of ModelPart ("")

### DIFF
--- a/kratos/containers/model.cpp
+++ b/kratos/containers/model.cpp
@@ -86,7 +86,9 @@ namespace Kratos
     ModelPart& Model::GetModelPart(std::string name)
     {
         KRATOS_TRY
-        
+
+        KRATOS_ERROR_IF( name.empty() ) << "Attempting to find a model part with empty name (\"\")!" << std::endl;
+                
         auto search = mflat_map.find(name);
         if(search != mflat_map.end()) {
             //TODO: issue a warning message telling that this behaviour is DEPRECATED and that it will be removed

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -58,6 +58,7 @@ ModelPart::ModelPart(std::string const& NewName)
     , mpParentModelPart(NULL)
     , mSubModelParts()
 {
+    KRATOS_ERROR_IF( NewName.empty() ) << "Please don't use empty names (\"\") when creating a ModelPart" << std::endl;
     mName = NewName;
     MeshType mesh;
     mMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
@@ -76,6 +77,7 @@ ModelPart::ModelPart(std::string const& NewName, IndexType NewBufferSize)
     , mpParentModelPart(NULL)
     , mSubModelParts()
 {
+    KRATOS_ERROR_IF( NewName.empty() ) << "Please don't use empty names (\"\") when creating a ModelPart" << std::endl;
     mName = NewName;
     MeshType mesh;
     mMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));


### PR DESCRIPTION
The crash was at this line:
auto search = mroot_map.find(subparts_list[0]);
A verification has been introduced at the beginning of the function.