### PR TITLE
Core/corrections elimination builder reactions whole domain

### DIFF
--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
@@ -888,7 +888,7 @@ public:
         //if needed resize the vector for the calculation of reactions
         if (BaseType::mCalculateReactionsFlag == true)
         {
-            unsigned int ReactionsVectorSize = BaseType::mDofSet.size();// - BaseType::mEquationSystemSize;
+            unsigned int ReactionsVectorSize = BaseType::mDofSet.size();
             if (BaseType::mpReactionsVector->size() != ReactionsVectorSize)
                 BaseType::mpReactionsVector->resize(ReactionsVectorSize, false);
         }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
@@ -888,7 +888,7 @@ public:
         //if needed resize the vector for the calculation of reactions
         if (BaseType::mCalculateReactionsFlag == true)
         {
-            unsigned int ReactionsVectorSize = BaseType::mDofSet.size() - BaseType::mEquationSystemSize;
+            unsigned int ReactionsVectorSize = BaseType::mDofSet.size();// - BaseType::mEquationSystemSize;
             if (BaseType::mpReactionsVector->size() != ReactionsVectorSize)
                 BaseType::mpReactionsVector->resize(ReactionsVectorSize, false);
         }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
@@ -419,7 +419,7 @@ public:
         //if needed resize the vector for the calculation of reactions
         if(BaseType::mCalculateReactionsFlag == true)
         {
-            unsigned int ReactionsVectorSize = BaseType::mDofSet.size();//-BaseType::mEquationSystemSize;
+            unsigned int ReactionsVectorSize = BaseType::mDofSet.size();
             if(BaseType::mpReactionsVector->size() != ReactionsVectorSize)
                 BaseType::mpReactionsVector->resize(ReactionsVectorSize,false);
         }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
@@ -419,7 +419,7 @@ public:
         //if needed resize the vector for the calculation of reactions
         if(BaseType::mCalculateReactionsFlag == true)
         {
-            unsigned int ReactionsVectorSize = BaseType::mDofSet.size()-BaseType::mEquationSystemSize;
+            unsigned int ReactionsVectorSize = BaseType::mDofSet.size();//-BaseType::mEquationSystemSize;
             if(BaseType::mpReactionsVector->size() != ReactionsVectorSize)
                 BaseType::mpReactionsVector->resize(ReactionsVectorSize,false);
         }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_slip.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_slip.h
@@ -449,7 +449,7 @@ public:
         //if needed resize the vector for the calculation of reactions
         if (BaseType::mCalculateReactionsFlag == true)
         {
-            unsigned int ReactionsVectorSize = BaseType::mDofSet.size() - BaseType::mEquationSystemSize;
+            unsigned int ReactionsVectorSize = BaseType::mDofSet.size();// - BaseType::mEquationSystemSize;
             if (BaseType::mpReactionsVector->size() != ReactionsVectorSize)
                 BaseType::mpReactionsVector->resize(ReactionsVectorSize, false);
         }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_slip.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_slip.h
@@ -449,7 +449,7 @@ public:
         //if needed resize the vector for the calculation of reactions
         if (BaseType::mCalculateReactionsFlag == true)
         {
-            unsigned int ReactionsVectorSize = BaseType::mDofSet.size();// - BaseType::mEquationSystemSize;
+            unsigned int ReactionsVectorSize = BaseType::mDofSet.size();
             if (BaseType::mpReactionsVector->size() != ReactionsVectorSize)
                 BaseType::mpReactionsVector->resize(ReactionsVectorSize, false);
         }


### PR DESCRIPTION
This pr includes changes to resize the reaction vector constructed in elimination builder and solvers to calculate the reactions over the whole domain. 
This solves errors in  #1660 
and the fail is solved in #1664 