### PR TITLE
solving an important flaw in the connectivity_preserve_modeler and in…

### DIFF
--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -731,7 +731,7 @@ public:
             }
             else //if it does exist verify it is the same node
             {
-                if(&(*it_found) != &(*it_found))//check if the pointee coincides
+                if(&(*it_found) != &(*it))//check if the pointee coincides
                     KRATOS_ERROR << "attempting to add a new element with Id :" << it_found->Id() << ", unfortunately a (different) element with the same Id already exists" << std::endl;
                 else
                     aux.push_back( *(it.base()) );
@@ -894,8 +894,8 @@ public:
             }
             else //if it does exist verify it is the same node
             {
-                if(&(*it_found) != &(*it_found))//check if the pointee coincides
-                    KRATOS_ERROR << "attempting to add a new node with Id :" << it_found->Id() << ", unfortunately a (different) node with the same Id already exists" << std::endl;
+                if(&(*it_found) != &(*it))//check if the pointee coincides
+                    KRATOS_ERROR << "attempting to add a new Condition with Id :" << it_found->Id() << ", unfortunately a (different) Condition with the same Id already exists" << std::endl;
                 else
                     aux.push_back( *(it.base()) );
             }

--- a/kratos/sources/connectivity_preserve_modeler.cpp
+++ b/kratos/sources/connectivity_preserve_modeler.cpp
@@ -215,18 +215,18 @@ void ConnectivityPreserveModeler::DuplicateSubModelParts(
 
         destination_part.AddNodes(i_part->NodesBegin(), i_part->NodesEnd());
 
-        std::vector<ModelPart::IndexType> aux;
-        aux.reserve(i_part->Elements().size());
+        std::vector<ModelPart::IndexType> ids;
+        ids.reserve(i_part->Elements().size());
         
         //adding by index
         for(auto it=i_part->ElementsBegin(); it!=i_part->ElementsEnd(); ++it)
-            aux.push_back(it->Id());
-        destination_part.AddElements(aux, 0); //adding by index
+            ids.push_back(it->Id());
+        destination_part.AddElements(ids, 0); //adding by index
 
-        aux.clear();
+        ids.clear();
         for(auto it=i_part->ConditionsBegin(); it!=i_part->ConditionsEnd(); ++it)
-            aux.push_back(it->Id());
-        destination_part.AddConditions(aux, 0);
+            ids.push_back(it->Id());
+        destination_part.AddConditions(ids, 0);
 
         // Duplicate the Communicator for this SubModelPart
         this->DuplicateCommunicatorData(*i_part, destination_part);

--- a/kratos/sources/connectivity_preserve_modeler.cpp
+++ b/kratos/sources/connectivity_preserve_modeler.cpp
@@ -205,7 +205,6 @@ void ConnectivityPreserveModeler::DuplicateCommunicatorData(
     rDestinationModelPart.SetCommunicator( pDestinationComm );
 }
 
-
 void ConnectivityPreserveModeler::DuplicateSubModelParts(
     ModelPart &rOriginModelPart,
     ModelPart &rDestinationModelPart)
@@ -216,9 +215,18 @@ void ConnectivityPreserveModeler::DuplicateSubModelParts(
 
         destination_part.AddNodes(i_part->NodesBegin(), i_part->NodesEnd());
 
-        destination_part.AddElements(i_part->ElementsBegin(), i_part->ElementsEnd());
+        std::vector<ModelPart::IndexType> aux;
+        aux.reserve(i_part->Elements().size());
+        
+        //adding by index
+        for(auto it=i_part->ElementsBegin(); it!=i_part->ElementsEnd(); ++it)
+            aux.push_back(it->Id());
+        destination_part.AddElements(aux, 0); //adding by index
 
-        destination_part.AddConditions(i_part->ConditionsBegin(), i_part->ConditionsEnd());
+        aux.clear();
+        for(auto it=i_part->ConditionsBegin(); it!=i_part->ConditionsEnd(); ++it)
+            aux.push_back(it->Id());
+        destination_part.AddConditions(aux, 0);
 
         // Duplicate the Communicator for this SubModelPart
         this->DuplicateCommunicatorData(*i_part, destination_part);

--- a/kratos/tests/test_connectivity_preserve_modeler.py
+++ b/kratos/tests/test_connectivity_preserve_modeler.py
@@ -24,6 +24,7 @@ class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
         model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
         
         model_part1.CreateNewCondition("Condition2D2N", 2, [2,4], model_part1.GetProperties()[1])
+        sub1.AddConditions([2])
         
         new_model_part = KratosMultiphysics.ModelPart("Other")
         modeler = KratosMultiphysics.ConnectivityPreserveModeler()
@@ -57,6 +58,12 @@ class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
                 self.assertTrue( cond.Id in new_part.Conditions)
             for elem in part.Elements:
                 self.assertTrue( elem.Id in new_part.Elements)
+                
+        model_part1.GetSubModelPart("sub1").Conditions[2].SetValue(KratosMultiphysics.TEMPERATURE, 1234.0)
+        self.assertEqual(model_part1.Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
+        self.assertEqual(model_part1.GetSubModelPart("sub1").Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
+        self.assertEqual(new_model_part.Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 0.0)
+        self.assertEqual(new_model_part.GetSubModelPart("sub1").Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 0.0)
 
         
 if __name__ == '__main__':


### PR DESCRIPTION
important error in AddConditions and AddElements as detected by @pablobecker 

this error was causing the ConnectivityPreserveModeler to incorrectly copy pointers from one submodelpart to another. The ConnectivityPreserveModeler is also patched