### PR TITLE
[StructuralMechanics] fixing Membrane test

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/membrane_test/Membrane_Q4_PointLoad_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/membrane_test/Membrane_Q4_PointLoad_test_parameters.json
@@ -35,7 +35,7 @@
         },
         "problem_domain_sub_model_part_list" : ["Parts_Membrane"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_NavierSupport","PointLoad3D_Membrane"],
-        "rotation_dofs"                      : true
+        "rotation_dofs"                      : false
     },
     "constraints_process_list" : [{
         "python_module" : "assign_vector_variable_process",
@@ -99,5 +99,5 @@
             "time_frequency"   : 0.90
         }
     }
-    ]     
+    ]
 }

--- a/applications/StructuralMechanicsApplication/tests/membrane_test/Membrane_Q4_Truss_PointLoad.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/membrane_test/Membrane_Q4_Truss_PointLoad.mdpa
@@ -34,14 +34,6 @@ Begin Elements PreStressMembraneElement3D4N// GUI group identifier: membrane
          2          0          2          4          8          5
          3          0          3          6          7          4
          4          0          3          4          2          1
-         5          0          9          7          2          1
-         6          0          8          9          2          1
-         7          0          5          2          2          1
-         8          0          5          8          2          1
-         9          0          3          6          2          1
-        10          0          7          6          2          1
-        11          0          1          3          2          1
-        12          0          1          2          2          1
 End Elements
 
 Begin Conditions PointLoadCondition3D1N// GUI group identifier: pointload
@@ -89,14 +81,6 @@ Begin SubModelPart Parts_membrane // Group membrane // Subtree Parts
          2
          3
          4
-         5
-         6
-         7
-         8
-         9
-        10
-        11
-        12
     End SubModelPartElements
     Begin SubModelPartConditions
     End SubModelPartConditions


### PR DESCRIPTION
Hi guys,
the tests breaks after #1694 (I think) , the mdpa had some duplicated element numbers
@longchentum I assumed this setup is the correct one but we can speak abt it tmr

Also the other membrane test fails if I set rotational_dofs to false (which would be correct). Also this we can speak tmr