### PR TITLE
Ignoring unsupported variables in data value container during hdf5 write.

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_data_value_container_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_data_value_container_io.cpp
@@ -54,9 +54,15 @@ void WriteDataValueContainer(File& rFile, std::string const& rPrefix, DataValueC
     KRATOS_TRY;
     rFile.AddPath(rPrefix + "/DataValues");
     for (auto it = rData.begin(); it != rData.end(); ++it)
-        RegisteredVariableLookup<Variable<int>, Variable<double>, Variable<Vector<double>>,
-                                 Variable<Matrix<double>>>(it->first->Name())
-            .Execute<WriteVariableFunctor>(rFile, rPrefix, rData);
+        try
+        {
+            RegisteredVariableLookup<Variable<int>, Variable<double>, Variable<Vector<double>>,
+                                     Variable<Matrix<double>>>(it->first->Name())
+                .Execute<WriteVariableFunctor>(rFile, rPrefix, rData);
+        }
+        catch (Exception& e)
+        {
+        }
     KRATOS_CATCH("Path: \"" + rPrefix + "/DataValues\".");
 }
 


### PR DESCRIPTION
This is a fix for #1676. @marandra can you test this on your problem?