### PR TITLE
Porting shallow Water application to pybind

### DIFF
--- a/applications/ShallowWaterApplication/CMakeLists.txt
+++ b/applications/ShallowWaterApplication/CMakeLists.txt
@@ -9,8 +9,8 @@ include_directories( ${CMAKE_SOURCE_DIR}/applications/convection_diffusion_appli
 
 ## generate variables with the sources
 set( KRATOS_SHALLOW_WATER_APPLICATION_SOURCES
-	${CMAKE_CURRENT_SOURCE_DIR}//shallow_water_application.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}//shallow_water_application_variables.cpp 
+	${CMAKE_CURRENT_SOURCE_DIR}/shallow_water_application.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/shallow_water_application_variables.cpp 
 	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/shallow_water_python_application.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_utilities_to_python.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/primitive_var_element.cpp
@@ -22,8 +22,8 @@ set( KRATOS_SHALLOW_WATER_APPLICATION_SOURCES
 
 ###############################################################
 ## define library Kratos which defines the basic python interface
-add_library(KratosShallowWaterApplication SHARED ${KRATOS_SHALLOW_WATER_APPLICATION_SOURCES})
-target_link_libraries(KratosShallowWaterApplication KratosCore )
+pybind11_add_module(KratosShallowWaterApplication MODULE ${KRATOS_SHALLOW_WATER_APPLICATION_SOURCES})
+target_link_libraries(KratosShallowWaterApplication PRIVATE KratosCore )
 set_target_properties(KratosShallowWaterApplication PROPERTIES PREFIX "")
 install(TARGETS KratosShallowWaterApplication DESTINATION libs )
 

--- a/applications/ShallowWaterApplication/custom_conditions/nothing_condition.cpp
+++ b/applications/ShallowWaterApplication/custom_conditions/nothing_condition.cpp
@@ -17,7 +17,6 @@
 
 
 // Project includes
-#include "includes/define.h"
 #include "utilities/math_utils.h"
 #include "utilities/geometry_utilities.h"
 #include "shallow_water_application_variables.h"

--- a/applications/ShallowWaterApplication/custom_conditions/nothing_condition.hpp
+++ b/applications/ShallowWaterApplication/custom_conditions/nothing_condition.hpp
@@ -16,8 +16,7 @@
 // System includes 
 
 
-// External includes 
-#include "boost/smart_ptr.hpp"
+// External includes
 
 
 // Project includes

--- a/applications/ShallowWaterApplication/custom_elements/primitive_var_element.hpp
+++ b/applications/ShallowWaterApplication/custom_elements/primitive_var_element.hpp
@@ -17,7 +17,6 @@
 
 
 // External includes 
-#include "boost/smart_ptr.hpp"
 
 
 // Project includes

--- a/applications/ShallowWaterApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/ShallowWaterApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -13,17 +13,12 @@
 // System includes 
 
 
-// External includes 
-#include <boost/python.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-#include <boost/timer.hpp> 
+// External includes
 
 
 // Project includes
-#include "includes/define.h"
+#include "includes/define_python.h"
 #include "custom_python/add_custom_strategies_to_python.h"
-
-#include "spaces/ublas_space.h"
 
 //strategies
 #include "solving_strategies/strategies/solving_strategy.h"
@@ -38,9 +33,9 @@ namespace Kratos
 
 	namespace Python
 	{		
-		using namespace boost::python;
+		using namespace pybind11;
 
-		void  AddCustomStrategiesToPython()
+		void  AddCustomStrategiesToPython(pybind11::module& m)
 		{
 			typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
 			typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
@@ -52,12 +47,12 @@ namespace Kratos
 			//********************************************************************
 			//********************************************************************
 // 			class_< TestStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType >,	
-// 					bases< BaseSolvingStrategyType >,  boost::noncopyable >
-// 				("TestStrategy", 
-// 				init<ModelPart&, LinearSolverType::Pointer, int, int, bool >() )
+// 				BaseSolvingStrategyType>
+// 				(m,"TestStrategy")
+// 				.def(init<ModelPart&, LinearSolverType::Pointer, int, int, bool >() )
 // 				.def("MoveNodes",&TestStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType >::MoveNodes)
 // 				;
-		 
+
 		}
 
 	}  // namespace Python.

--- a/applications/ShallowWaterApplication/custom_python/add_custom_strategies_to_python.h
+++ b/applications/ShallowWaterApplication/custom_python/add_custom_strategies_to_python.h
@@ -16,10 +16,10 @@
 
 
 // System includes 
+#include <pybind11/pybind11.h>
 
 
 // External includes 
-#include "boost/smart_ptr.hpp"
 
 
 // Project includes
@@ -32,10 +32,7 @@ namespace Kratos
     namespace Python
     {
 
-      void  AddCustomStrategiesToPython()
-      {
-		  using namespace boost::python;
-	  }
+      void  AddCustomStrategiesToPython(pybind11::module& m);
 
     }  // namespace Python.
   

--- a/applications/ShallowWaterApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/ShallowWaterApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -12,19 +12,15 @@
 
 // System includes 
 
+
 // External includes 
-#include <boost/python.hpp>
 
 
 // Project includes
-#include "includes/define.h"
-#include "processes/process.h"
+#include "includes/define_python.h"
 #include "custom_python/add_custom_utilities_to_python.h"
 #include "custom_utilities/move_shallow_water_particle_utility.h"
 #include "custom_utilities/shallow_water_variables_utility.h"
-
-#include "spaces/ublas_space.h"
-#include "linear_solvers/linear_solver.h"
 
 
 namespace Kratos
@@ -33,15 +29,16 @@ namespace Kratos
 namespace Python
 {
 
-  void  AddCustomUtilitiesToPython()
+  void  AddCustomUtilitiesToPython(pybind11::module& m)
   {
-    using namespace boost::python;
+    using namespace pybind11;
 
     //~ typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
     //~ typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
     //~ typedef LinearSolver<SparseSpaceType, LocalSpaceType > LinearSolverType;
 
-    class_< MoveShallowWaterParticleUtility<2> > ("MoveShallowWaterParticleUtility", init<ModelPart& , Parameters >())
+    class_< MoveShallowWaterParticleUtility<2> > (m, "MoveShallowWaterParticleUtility")
+        .def(init<ModelPart& , Parameters >())
         .def("MountBin", &MoveShallowWaterParticleUtility<2>::MountBin)
         .def("MoveParticles", &MoveShallowWaterParticleUtility<2>::MoveParticles)
         .def("CorrectParticlesWithoutMovingUsingDeltaVariables", &MoveShallowWaterParticleUtility<2>::CorrectParticlesWithoutMovingUsingDeltaVariables)
@@ -56,7 +53,8 @@ namespace Python
         .def("ExecuteParticlesPrintingTool", &MoveShallowWaterParticleUtility<2>::ExecuteParticlesPrintingTool)
         ;
 
-    class_< ShallowWaterVariablesUtility > ("ShallowWaterVariablesUtility", init<ModelPart&>())
+    class_< ShallowWaterVariablesUtility > (m, "ShallowWaterVariablesUtility")
+        .def(init<ModelPart&>())
         .def("ComputeFreeSurfaceElevation", &ShallowWaterVariablesUtility::ComputeFreeSurfaceElevation)
         .def("ComputeHeightFromFreeSurface", &ShallowWaterVariablesUtility::ComputeHeightFromFreeSurface)
         .def("ComputeVelocity", &ShallowWaterVariablesUtility::ComputeVelocity)

--- a/applications/ShallowWaterApplication/custom_python/add_custom_utilities_to_python.h
+++ b/applications/ShallowWaterApplication/custom_python/add_custom_utilities_to_python.h
@@ -16,6 +16,7 @@
 
 
 // System includes 
+#include <pybind11/pybind11.h>
 
 
 // External includes 
@@ -31,7 +32,7 @@ namespace Kratos
 namespace Python
 {
 
-  void  AddCustomUtilitiesToPython();
+  void  AddCustomUtilitiesToPython(pybind11::module& m);
 
 }  // namespace Python.
   

--- a/applications/ShallowWaterApplication/custom_python/shallow_water_python_application.cpp
+++ b/applications/ShallowWaterApplication/custom_python/shallow_water_python_application.cpp
@@ -13,12 +13,12 @@
 // System includes 
 
 #if defined(KRATOS_PYTHON)
-
 // External includes 
-#include <boost/python.hpp>
+#include <pybind11/pybind11.h>
+
 
 // Project includes 
-#include "includes/define.h"
+#include "includes/define_python.h"
 #include "shallow_water_application.h"
 #include "custom_python/add_custom_strategies_to_python.h"
 #include "custom_python/add_custom_utilities_to_python.h"
@@ -30,37 +30,38 @@ namespace Kratos
 namespace Python
 {
 
-  using namespace boost::python;
+  using namespace pybind11;
 
   
-  BOOST_PYTHON_MODULE(KratosShallowWaterApplication)
+  PYBIND11_MODULE(KratosShallowWaterApplication, m)
   {
     class_<KratosShallowWaterApplication, 
         KratosShallowWaterApplication::Pointer, 
-        bases<KratosApplication>, boost::noncopyable >("KratosShallowWaterApplication")
+        KratosApplication>(m, "KratosShallowWaterApplication")
+        .def(init<>())
         ;
 
-    AddCustomStrategiesToPython();
-    AddCustomUtilitiesToPython();
+    AddCustomStrategiesToPython(m);
+    AddCustomUtilitiesToPython(m);
 
     // Registering variables in python
     // Shallow water variables
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(HEIGHT);
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(BATHYMETRY);
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(RAIN);
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(FREE_SURFACE_ELEVATION);
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(MANNING);
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,HEIGHT);
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,BATHYMETRY);
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,RAIN);
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,FREE_SURFACE_ELEVATION);
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,MANNING);
 
     // Specific variables for PFEM2
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(MEAN_SIZE);
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(DELTA_SCALAR1)
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(PROJECTED_SCALAR1)
-    KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(DELTA_VECTOR1)
-    KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(PROJECTED_VECTOR1)
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,MEAN_SIZE);
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,DELTA_SCALAR1)
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,PROJECTED_SCALAR1)
+    KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(m,DELTA_VECTOR1)
+    KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(m,PROJECTED_VECTOR1)
 
     // Units conversion
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(TIME_UNIT_CONVERTER)
-    KRATOS_REGISTER_IN_PYTHON_VARIABLE(WATER_HEIGHT_UNIT_CONVERTER)
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,TIME_UNIT_CONVERTER)
+    KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,WATER_HEIGHT_UNIT_CONVERTER)
   }
   
 }  // namespace Python.


### PR DESCRIPTION
I have applied the changes explained in https://github.com/KratosMultiphysics/Kratos/wiki/Porting-to-PyBind11---common-steps

However I get the next compilation warning:
CMakeFiles/KratosShallowWaterApplication.dir/custom_python/add_custom_utilities_to_python.cpp.o (symbol from plugin): aviso: memset used with constant zero length parameter; this could be due to transposed parameters
