### PR TITLE
Remove references to obsolate parameter 'mesh_id' and other minor changes

### DIFF
--- a/applications/DamApplication/custom_processes/dam_added_mass_condition_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_added_mass_condition_process.hpp
@@ -47,7 +47,6 @@ class DamAddedMassConditionProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "Modify"                                                : true,
                 "Gravity_Direction"                                     : "Y",
@@ -65,7 +64,6 @@ class DamAddedMassConditionProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mGravityDirection = rParameters["Gravity_Direction"].GetString();
         mReferenceCoordinate = rParameters["Reservoir_Bottom_Coordinate_in_Gravity_Direction"].GetDouble();
@@ -87,7 +85,7 @@ class DamAddedMassConditionProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
         double added_mass;
 
@@ -102,7 +100,7 @@ class DamAddedMassConditionProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -141,7 +139,7 @@ class DamAddedMassConditionProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
         double added_mass;
 
@@ -156,7 +154,7 @@ class DamAddedMassConditionProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -211,7 +209,6 @@ class DamAddedMassConditionProcess : public Process
     /// Member Variables
 
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     std::string mGravityDirection;
     double mReferenceCoordinate;

--- a/applications/DamApplication/custom_processes/dam_azenha_heat_source_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_azenha_heat_source_process.hpp
@@ -45,7 +45,6 @@ class DamAzenhaHeatFluxProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "activation_energy"                   : 0.0,
                 "gas_constant"                        : 0.0,
@@ -68,7 +67,6 @@ class DamAzenhaHeatFluxProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mActivationEnergy = rParameters["activation_energy"].GetDouble();
         mGasConstant = rParameters["gas_constant"].GetDouble();
@@ -100,12 +98,12 @@ class DamAzenhaHeatFluxProcess : public Process
 
         if (mAging == false)
         {
-            const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+            const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
             Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
 
             if (nnodes != 0)
             {
-                ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+                ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
                 for (int i = 0; i < nnodes; i++)
@@ -139,13 +137,13 @@ class DamAzenhaHeatFluxProcess : public Process
 
         if (mAging == false)
         {
-            const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+            const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
             Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
             double delta_time = mrModelPart.GetProcessInfo()[DELTA_TIME];
 
             if (nnodes != 0)
             {
-                ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+                ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
                 for (int i = 0; i < nnodes; i++)
@@ -185,12 +183,12 @@ class DamAzenhaHeatFluxProcess : public Process
     {
         KRATOS_TRY;
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -218,13 +216,13 @@ class DamAzenhaHeatFluxProcess : public Process
     {
         KRATOS_TRY;
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
         double delta_time = mrModelPart.GetProcessInfo()[DELTA_TIME];
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -277,7 +275,6 @@ class DamAzenhaHeatFluxProcess : public Process
   protected:
     /// Member Variables
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     double mActivationEnergy;
     double mGasConstant;

--- a/applications/DamApplication/custom_processes/dam_bofang_condition_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_bofang_condition_temperature_process.hpp
@@ -47,7 +47,6 @@ class DamBofangConditionTemperatureProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed"                                         : false,
                 "Gravity_Direction"                                : "Y",
@@ -72,7 +71,6 @@ class DamBofangConditionTemperatureProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mIsFixed = rParameters["is_fixed"].GetBool();
         mGravityDirection = rParameters["Gravity_Direction"].GetString();
@@ -112,7 +110,7 @@ class DamBofangConditionTemperatureProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
 
         if (mGravityDirection == "X")
@@ -124,7 +122,7 @@ class DamBofangConditionTemperatureProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -173,7 +171,7 @@ class DamBofangConditionTemperatureProcess : public Process
             mMonth = mpTableMonth->GetValue(time);
         }
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
 
         if (mGravityDirection == "X")
@@ -185,7 +183,7 @@ class DamBofangConditionTemperatureProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -219,12 +217,12 @@ class DamBofangConditionTemperatureProcess : public Process
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if (nnodes != 0)
         {
             
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -260,7 +258,6 @@ class DamBofangConditionTemperatureProcess : public Process
     /// Member Variables
 
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     std::string mGravityDirection;
     bool mIsFixed;

--- a/applications/DamApplication/custom_processes/dam_chemo_mechanical_aging_young_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_chemo_mechanical_aging_young_process.hpp
@@ -45,7 +45,6 @@ class DamChemoMechanicalAgingYoungProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "initial_elastic_modulus"                          : 30.0e9,
                 "initial_porosity"                                 : 0.2,
@@ -64,7 +63,6 @@ class DamChemoMechanicalAgingYoungProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mInitialElasticModulus = rParameters["initial_elastic_modulus"].GetDouble();
         mInitialPorosity = rParameters["initial_porosity"].GetDouble();
@@ -91,7 +89,7 @@ class DamChemoMechanicalAgingYoungProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         // This model works in years so it is necessary to convert time in this unit
         double time = mrModelPart.GetProcessInfo()[TIME] / 31536000.0;
@@ -104,7 +102,7 @@ class DamChemoMechanicalAgingYoungProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -124,7 +122,7 @@ class DamChemoMechanicalAgingYoungProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         // This model works in years so it is necessary to convert time in this unit
         double time = mrModelPart.GetProcessInfo()[TIME] / 31536000.0;
@@ -137,7 +135,7 @@ class DamChemoMechanicalAgingYoungProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -174,7 +172,6 @@ class DamChemoMechanicalAgingYoungProcess : public Process
   protected:
     /// Member Variables
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     double mInitialElasticModulus;
     double mInitialPorosity;

--- a/applications/DamApplication/custom_processes/dam_fix_temperature_condition_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_fix_temperature_condition_process.hpp
@@ -47,7 +47,6 @@ class DamFixTemperatureConditionProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name" : "PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id"         : 0,
                 "variable_name"   : "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed"        : false,
                 "value"           : 0.0,
@@ -62,7 +61,6 @@ class DamFixTemperatureConditionProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mIsFixed = rParameters["is_fixed"].GetBool();
         mTemperature = rParameters["value"].GetDouble();
@@ -89,11 +87,11 @@ class DamFixTemperatureConditionProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -129,11 +127,11 @@ class DamFixTemperatureConditionProcess : public Process
             mTemperature = mpTable->GetValue(time);
         }
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -161,12 +159,12 @@ class DamFixTemperatureConditionProcess : public Process
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if (nnodes != 0)
         {
             
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -202,7 +200,6 @@ class DamFixTemperatureConditionProcess : public Process
     /// Member Variables
 
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     std::string mGravityDirection;
     bool mIsFixed;

--- a/applications/DamApplication/custom_processes/dam_hydro_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_hydro_condition_load_process.hpp
@@ -47,7 +47,6 @@ class DamHydroConditionLoadProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "Modify"                                                : true,
                 "Gravity_Direction"                                     : "Y",
@@ -66,7 +65,6 @@ class DamHydroConditionLoadProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mGravityDirection = rParameters["Gravity_Direction"].GetString();
         mReferenceCoordinate = rParameters["Reservoir_Bottom_Coordinate_in_Gravity_Direction"].GetDouble();
@@ -100,7 +98,7 @@ class DamHydroConditionLoadProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
 
         if (mGravityDirection == "X")
@@ -114,7 +112,7 @@ class DamHydroConditionLoadProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -154,7 +152,7 @@ class DamHydroConditionLoadProcess : public Process
             mWaterLevel = mpTable->GetValue(time);
         }
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         int direction;
 
@@ -169,7 +167,7 @@ class DamHydroConditionLoadProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -215,7 +213,6 @@ class DamHydroConditionLoadProcess : public Process
     /// Member Variables
 
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     std::string mGravityDirection;
     double mReferenceCoordinate;

--- a/applications/DamApplication/custom_processes/dam_nodal_young_modulus_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_nodal_young_modulus_process.hpp
@@ -45,7 +45,6 @@ class DamNodalYoungModulusProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed"                                         : false,
                 "Young_Modulus_1"                                  : 10.0,
@@ -63,7 +62,6 @@ class DamNodalYoungModulusProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mIsFixed = rParameters["is_fixed"].GetBool();
         mYoung1 = rParameters["Young_Modulus_1"].GetDouble();
@@ -87,11 +85,11 @@ class DamNodalYoungModulusProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -125,11 +123,11 @@ class DamNodalYoungModulusProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -178,7 +176,6 @@ class DamNodalYoungModulusProcess : public Process
     /// Member Variables
 
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     bool mIsFixed;
     double mYoung1;

--- a/applications/DamApplication/custom_processes/dam_noorzai_heat_source_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_noorzai_heat_source_process.hpp
@@ -45,7 +45,6 @@ class DamNoorzaiHeatFluxProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "density"                             : 0.0,
                 "specific_heat"                        : 0.0,
@@ -62,7 +61,6 @@ class DamNoorzaiHeatFluxProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mDensity = rParameters["density"].GetDouble();
         mSpecificHeat = rParameters["specific_heat"].GetDouble();
@@ -83,7 +81,7 @@ class DamNoorzaiHeatFluxProcess : public Process
     {
         KRATOS_TRY;
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         double time = mrModelPart.GetProcessInfo()[TIME];
@@ -91,7 +89,7 @@ class DamNoorzaiHeatFluxProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -138,7 +136,6 @@ class DamNoorzaiHeatFluxProcess : public Process
   protected:
     /// Member Variables
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     double mDensity;
     double mSpecificHeat;

--- a/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
@@ -55,7 +55,7 @@ class DamReservoirConstantTemperatureProcess : public Process
                 "Water_temp"                                       : 0.0,
                 "Water_temp_Table"                                 : 0,                
                 "Water_level"                                      : 0.0,
-                "Water_level_Table"                                : 0,
+                "Water_level_Table"                                : 0
             }  )");
 
         // Some values need to be mandatorily prescribed since no meaningful default value exist. For this reason try accessing to them

--- a/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
@@ -47,7 +47,6 @@ class DamReservoirConstantTemperatureProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed"                                         : false,
                 "Gravity_Direction"                                : "Y",
@@ -67,7 +66,6 @@ class DamReservoirConstantTemperatureProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mIsFixed = rParameters["is_fixed"].GetBool();
         mGravityDirection = rParameters["Gravity_Direction"].GetString();
@@ -101,7 +99,7 @@ class DamReservoirConstantTemperatureProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
 
         if (mGravityDirection == "X")
@@ -113,7 +111,7 @@ class DamReservoirConstantTemperatureProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -160,7 +158,7 @@ class DamReservoirConstantTemperatureProcess : public Process
             mWaterLevel = mpTableWater->GetValue(time);
         }
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
 
         if (mGravityDirection == "X")
@@ -172,7 +170,7 @@ class DamReservoirConstantTemperatureProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -203,12 +201,12 @@ class DamReservoirConstantTemperatureProcess : public Process
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if (nnodes != 0)
         {
             
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -244,7 +242,6 @@ class DamReservoirConstantTemperatureProcess : public Process
     /// Member Variables
 
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     std::string mGravityDirection;
     bool mIsFixed;

--- a/applications/DamApplication/custom_processes/dam_t_sol_air_heat_flux_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_t_sol_air_heat_flux_process.hpp
@@ -47,7 +47,6 @@ class DamTSolAirHeatFluxProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "h_0"                             : 0.0,
                 "ambient_temperature"             : 0.0,
@@ -67,7 +66,6 @@ class DamTSolAirHeatFluxProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mH0 = rParameters["h_0"].GetDouble();
         mAmbientTemperature = rParameters["ambient_temperature"].GetDouble();
@@ -97,7 +95,7 @@ class DamTSolAirHeatFluxProcess : public Process
 
         KRATOS_TRY;
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         // Computing the t_soil_air according to t_sol_air criteria
@@ -105,7 +103,7 @@ class DamTSolAirHeatFluxProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -128,7 +126,7 @@ class DamTSolAirHeatFluxProcess : public Process
 
         KRATOS_TRY;
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         // Getting the values of table in case that it exist
@@ -144,7 +142,7 @@ class DamTSolAirHeatFluxProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -184,7 +182,6 @@ class DamTSolAirHeatFluxProcess : public Process
   protected:
     /// Member Variables
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     double mH0;
     double mAmbientTemperature;

--- a/applications/DamApplication/custom_processes/dam_temperature_by_device_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_temperature_by_device_process.hpp
@@ -47,7 +47,6 @@ class DamTemperaturebyDeviceProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "is_fixed"          : false,
                 "value"             : 0.0,
@@ -64,7 +63,6 @@ class DamTemperaturebyDeviceProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mIsFixed = rParameters["is_fixed"].GetBool();
         mValue = rParameters["value"].GetDouble();
@@ -95,7 +93,7 @@ class DamTemperaturebyDeviceProcess : public Process
 
         KRATOS_TRY;
 
-        const int nelements = mrModelPart.GetMesh(mMeshId).Elements().size();
+        const int nelements = mrModelPart.GetMesh(0).Elements().size();
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
         bool IsInside = false;
         array_1d<double, 3> LocalCoordinates;
@@ -175,7 +173,6 @@ class DamTemperaturebyDeviceProcess : public Process
     /// Member Variables
 
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     bool mIsFixed;
     double mValue;

--- a/applications/DamApplication/custom_processes/dam_uplift_circular_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_uplift_circular_condition_load_process.hpp
@@ -47,7 +47,6 @@ class DamUpliftCircularConditionLoadProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "Modify"                                                : true,
                 "Gravity_Direction"                                     : "Y",
@@ -71,7 +70,6 @@ class DamUpliftCircularConditionLoadProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mGravityDirection = rParameters["Gravity_Direction"].GetString();
         mReferenceCoordinate = rParameters["Reservoir_Bottom_Coordinate_in_Gravity_Direction"].GetDouble();
@@ -124,7 +122,7 @@ class DamUpliftCircularConditionLoadProcess : public Process
 
         //Defining necessary variables
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         array_1d<double, 3> auxiliar_vector;
 
         // Gravity direction for computing the hydrostatic pressure
@@ -161,7 +159,7 @@ class DamUpliftCircularConditionLoadProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             double ref_coord = mReferenceCoordinate + mWaterLevel;
 
@@ -241,7 +239,7 @@ class DamUpliftCircularConditionLoadProcess : public Process
 
         //Defining necessary variables
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         array_1d<double, 3> auxiliar_vector;
 
         // Getting the values of table in case that it exist
@@ -286,7 +284,7 @@ class DamUpliftCircularConditionLoadProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             double ref_coord = mReferenceCoordinate + mWaterLevel;
 
@@ -380,7 +378,6 @@ class DamUpliftCircularConditionLoadProcess : public Process
     /// Member Variables
 
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     std::string mGravityDirection;
     double mReferenceCoordinate;

--- a/applications/DamApplication/custom_processes/dam_uplift_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_uplift_condition_load_process.hpp
@@ -47,7 +47,6 @@ class DamUpliftConditionLoadProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "Modify"                                                : true,
                 "Gravity_Direction"                                     : "Y",
@@ -74,7 +73,6 @@ class DamUpliftConditionLoadProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mGravityDirection = rParameters["Gravity_Direction"].GetString();
         mReferenceCoordinate = rParameters["Reservoir_Bottom_Coordinate_in_Gravity_Direction"].GetDouble();
@@ -126,7 +124,7 @@ class DamUpliftConditionLoadProcess : public Process
 
         //Defining necessary variables
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         boost::numeric::ublas::bounded_matrix<double, 3, 3> RotationMatrix;
 
         // Computing the rotation matrix accoding with the introduced points by the user
@@ -150,7 +148,7 @@ class DamUpliftConditionLoadProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             double ref_coord = mReferenceCoordinate + mWaterLevel;
 
@@ -229,7 +227,7 @@ class DamUpliftConditionLoadProcess : public Process
 
         //Defining necessary variables
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         boost::numeric::ublas::bounded_matrix<double, 3, 3> RotationMatrix;
 
         // Getting the values of table in case that it exist
@@ -263,7 +261,7 @@ class DamUpliftConditionLoadProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
             double ref_coord = mReferenceCoordinate + mWaterLevel;
 
@@ -397,7 +395,6 @@ class DamUpliftConditionLoadProcess : public Process
     /// Member Variables
 
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     std::string mGravityDirection;
     double mReferenceCoordinate;

--- a/applications/DamApplication/custom_processes/dam_westergaard_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_westergaard_condition_load_process.hpp
@@ -46,7 +46,6 @@ class DamWestergaardConditionLoadProcess : public Process
         Parameters default_parameters(R"(
             {
                 "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
-                "mesh_id": 0,
                 "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
                 "Modify"                                                : true,
                 "Gravity_Direction"                                     : "Y",
@@ -67,7 +66,6 @@ class DamWestergaardConditionLoadProcess : public Process
         // Now validate agains defaults -- this also ensures no type mismatch
         rParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mMeshId = rParameters["mesh_id"].GetInt();
         mVariableName = rParameters["variable_name"].GetString();
         mGravityDirection = rParameters["Gravity_Direction"].GetString();
         mReferenceCoordinate = rParameters["Reservoir_Bottom_Coordinate_in_Gravity_Direction"].GetDouble();
@@ -106,7 +104,7 @@ class DamWestergaardConditionLoadProcess : public Process
         KRATOS_TRY;
 
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
         double pressure;
 
@@ -122,7 +120,7 @@ class DamWestergaardConditionLoadProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -168,7 +166,7 @@ class DamWestergaardConditionLoadProcess : public Process
             mAcceleration = mpTableAcceleration->GetValue(time);
         }
 
-        const int nnodes = mrModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
         double pressure;
 
@@ -184,7 +182,7 @@ class DamWestergaardConditionLoadProcess : public Process
 
         if (nnodes != 0)
         {
-            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(mMeshId).NodesBegin();
+            ModelPart::NodesContainerType::iterator it_begin = mrModelPart.GetMesh(0).NodesBegin();
 
 #pragma omp parallel for
             for (int i = 0; i < nnodes; i++)
@@ -245,7 +243,6 @@ class DamWestergaardConditionLoadProcess : public Process
     /// Member Variables
 
     ModelPart &mrModelPart;
-    std::size_t mMeshId;
     std::string mVariableName;
     std::string mGravityDirection;
     double mReferenceCoordinate;

--- a/applications/DamApplication/custom_utilities/construction_utility.hpp
+++ b/applications/DamApplication/custom_utilities/construction_utility.hpp
@@ -46,7 +46,6 @@ class ConstructionUtility
         KRATOS_TRY
 
         // Getting values
-        mMeshId = rParameters["mesh_id"].GetInt();
         mGravityDirection = rParameters["gravity_direction"].GetString();
         mReferenceCoordinate = rParameters["reservoir_bottom_coordinate_in_gravity_direction"].GetDouble();
         mHeight = rParameters["height_dam"].GetDouble();
@@ -78,11 +77,11 @@ class ConstructionUtility
     {
         KRATOS_TRY;
 
-        const int nelements = mrMechanicalModelPart.GetMesh(mMeshId).Elements().size();
-        const int nnodes = mrMechanicalModelPart.GetMesh(mMeshId).Nodes().size();
+        const int nelements = mrMechanicalModelPart.GetMesh(0).Elements().size();
+        const int nnodes = mrMechanicalModelPart.GetMesh(0).Nodes().size();
 
-        mMechanicalLastCondition = mrMechanicalModelPart.GetMesh(mMeshId).Conditions().size();
-        mThermalLastCondition = mrThermalModelPart.GetMesh(mMeshId).Conditions().size();
+        mMechanicalLastCondition = mrMechanicalModelPart.GetMesh(0).Conditions().size();
+        mThermalLastCondition = mrThermalModelPart.GetMesh(0).Conditions().size();
 
         if (nelements != 0)
         {
@@ -266,7 +265,7 @@ class ConstructionUtility
     {
         KRATOS_TRY;
 
-        const int nelements = mrThermalModelPart.GetMesh(mMeshId).Elements().size();
+        const int nelements = mrThermalModelPart.GetMesh(0).Elements().size();
         const unsigned int Dim = mrMechanicalModelPart.GetProcessInfo()[DOMAIN_SIZE];
         std::vector<std::size_t> ConditionNodeIds(Dim);
         if (mNumNode == 8)
@@ -363,7 +362,7 @@ class ConstructionUtility
     {
         KRATOS_TRY;
 
-        const int nelements = mrMechanicalModelPart.GetMesh(mMeshId).Elements().size();
+        const int nelements = mrMechanicalModelPart.GetMesh(0).Elements().size();
         const unsigned int Dim = mrMechanicalModelPart.GetProcessInfo()[DOMAIN_SIZE];
         std::vector<std::size_t> ConditionNodeIds(Dim);
         if (mNumNode == 8)
@@ -568,7 +567,6 @@ class ConstructionUtility
     ModelPart &mrMechanicalModelPart;
     ModelPart &mrThermalModelPart;
     int mNumNode;
-    std::size_t mMeshId;
     std::string mGravityDirection;
     std::string mMechanicalSoilPart;
     std::string mThermalSoilPart;
@@ -647,8 +645,8 @@ class ConstructionUtility
         KRATOS_TRY;
 
         const unsigned int size = ConditionNodeIds.size();
-        const unsigned int nnodes = mrThermalModelPart.GetMesh(mMeshId).Nodes().size();
-        ModelPart::NodesContainerType::iterator it_begin_thermal = mrThermalModelPart.GetMesh(mMeshId).NodesBegin();
+        const unsigned int nnodes = mrThermalModelPart.GetMesh(0).Nodes().size();
+        ModelPart::NodesContainerType::iterator it_begin_thermal = mrThermalModelPart.GetMesh(0).NodesBegin();
 
         double time = mrThermalModelPart.GetProcessInfo()[TIME];
         time = time / mTimeUnitConverter;
@@ -682,8 +680,8 @@ class ConstructionUtility
         KRATOS_TRY;
 
         const unsigned int size = ConditionNodeIds.size();
-        const unsigned int nnodes = mrThermalModelPart.GetMesh(mMeshId).Nodes().size();
-        ModelPart::NodesContainerType::iterator it_begin_thermal = mrThermalModelPart.GetMesh(mMeshId).NodesBegin();
+        const unsigned int nnodes = mrThermalModelPart.GetMesh(0).Nodes().size();
+        ModelPart::NodesContainerType::iterator it_begin_thermal = mrThermalModelPart.GetMesh(0).NodesBegin();
 
         if (size != 0)
         {

--- a/applications/DamApplication/python_scripts/apply_constraint_vector_dam_table_process.py
+++ b/applications/DamApplication/python_scripts/apply_constraint_vector_dam_table_process.py
@@ -21,7 +21,6 @@ class ApplyConstraintVectorDamTableProcess(Process):
 
         x_params = Parameters("{}")
         x_params.AddValue("model_part_name",settings["model_part_name"])
-        x_params.AddValue("mesh_id",settings["mesh_id"])
         x_params.AddValue("is_fixed",settings["is_fixed"][0])
         x_params.AddValue("value",settings["value"][0])
         x_params.AddEmptyValue("variable_name").SetString(variable_name+"_X")
@@ -33,7 +32,6 @@ class ApplyConstraintVectorDamTableProcess(Process):
 
         y_params = Parameters("{}")
         y_params.AddValue("model_part_name",settings["model_part_name"])
-        y_params.AddValue("mesh_id",settings["mesh_id"])
         y_params.AddValue("is_fixed",settings["is_fixed"][1])
         y_params.AddValue("value",settings["value"][1])
         y_params.AddEmptyValue("variable_name").SetString(variable_name+"_Y")
@@ -45,7 +43,6 @@ class ApplyConstraintVectorDamTableProcess(Process):
 
         z_params = Parameters("{}")
         z_params.AddValue("model_part_name",settings["model_part_name"])
-        z_params.AddValue("mesh_id",settings["mesh_id"])
         z_params.AddValue("is_fixed",settings["is_fixed"][2])
         z_params.AddValue("value",settings["value"][2])
         z_params.AddEmptyValue("variable_name").SetString(variable_name+"_Z")

--- a/applications/DamApplication/python_scripts/apply_load_vector_dam_table_process.py
+++ b/applications/DamApplication/python_scripts/apply_load_vector_dam_table_process.py
@@ -27,7 +27,6 @@ class ApplyLoadVectorDamTableProcess(Process):
         if abs(self.value[0])>1.0e-15:
             x_params = Parameters("{}")
             x_params.AddValue("model_part_name",settings["model_part_name"])
-            x_params.AddValue("mesh_id",settings["mesh_id"])
             x_params.AddEmptyValue("value").SetDouble(self.value[0])
             x_params.AddEmptyValue("variable_name").SetString(variable_name+"_X")
             if settings["table"].GetInt() == 0:
@@ -39,7 +38,6 @@ class ApplyLoadVectorDamTableProcess(Process):
         if abs(self.value[1])>1.0e-15:
             y_params = Parameters("{}")
             y_params.AddValue("model_part_name",settings["model_part_name"])
-            y_params.AddValue("mesh_id",settings["mesh_id"])
             y_params.AddEmptyValue("value").SetDouble(self.value[1])
             y_params.AddEmptyValue("variable_name").SetString(variable_name+"_Y")
             if settings["table"].GetInt() == 0:
@@ -51,7 +49,6 @@ class ApplyLoadVectorDamTableProcess(Process):
         if abs(self.value[2])>1.0e-15:
             z_params = Parameters("{}")
             z_params.AddValue("model_part_name",settings["model_part_name"])
-            z_params.AddValue("mesh_id",settings["mesh_id"])
             z_params.AddEmptyValue("value").SetDouble(self.value[2])
             z_params.AddEmptyValue("variable_name").SetString(variable_name+"_Z")
             if settings["table"].GetInt() == 0:

--- a/applications/DamApplication/python_scripts/impose_face_heat_flux_process.py
+++ b/applications/DamApplication/python_scripts/impose_face_heat_flux_process.py
@@ -21,7 +21,6 @@ class ImposeFaceHeatFluxProcess(Process):
             if settings["table"].GetInt() == 0:
                 t_uniform = Parameters("{}")
                 t_uniform.AddValue("model_part_name",settings["model_part_name"])
-                t_uniform.AddValue("mesh_id",settings["mesh_id"])
                 t_uniform.AddEmptyValue("is_fixed").SetBool(False)
                 t_uniform.AddValue("variable_name",settings["variable_name"])
                 t_uniform.AddValue("value",settings["value"])
@@ -34,7 +33,6 @@ class ImposeFaceHeatFluxProcess(Process):
         if "TAmbient" in settings["model_part_name"].GetString():
             t_ambient = Parameters("{}")
             t_ambient.AddValue("model_part_name",settings["model_part_name"])
-            t_ambient.AddValue("mesh_id",settings["mesh_id"])
             t_ambient.AddValue("variable_name",settings["variable_name"])
             t_ambient.AddValue("h_0",settings["h_0"])
             t_ambient.AddValue("ambient_temperature",settings["ambient_temperature"])

--- a/applications/DamApplication/python_scripts/impose_reservoir_temperature_condition_process.py
+++ b/applications/DamApplication/python_scripts/impose_reservoir_temperature_condition_process.py
@@ -20,10 +20,10 @@ class ImposeReservoirTemperatureConditionProcess(Process):
         
         self.components_process_list = []
 
-        if "Bofang" in settings["model_part_name"].GetString():
+        if "BOFANG" in settings["model_part_name"].GetString():
             self.components_process_list.append(DamBofangConditionTemperatureProcess(model_part, settings))
 
-        if "Reservoir" in settings["model_part_name"].GetString():
+        if "RESERVOIR" in settings["model_part_name"].GetString():
             self.components_process_list.append(DamReservoirConstantTemperatureProcess(model_part, settings))
 
 

--- a/applications/DamApplication/python_scripts/impose_thermal_parameters_scalar_value_process.py
+++ b/applications/DamApplication/python_scripts/impose_thermal_parameters_scalar_value_process.py
@@ -21,7 +21,6 @@ class ImposeThemalParametersScalarValueProcess(Process):
 
             thermal_density = Parameters("{}")
             thermal_density.AddValue("model_part_name", settings["model_part_name"])
-            thermal_density.AddValue("mesh_id", settings["mesh_id"])
             thermal_density.AddEmptyValue("is_fixed").SetBool(True)
             thermal_density.AddValue("value", settings["ThermalDensity"])
             thermal_density.AddEmptyValue("variable_name").SetString("DENSITY") 
@@ -32,7 +31,6 @@ class ImposeThemalParametersScalarValueProcess(Process):
            
             conductivity = Parameters("{}")
             conductivity.AddValue("model_part_name", settings["model_part_name"])
-            conductivity.AddValue("mesh_id", settings["mesh_id"])
             conductivity.AddEmptyValue("is_fixed").SetBool(True)
             conductivity.AddValue("value", settings["Conductivity"])
             conductivity.AddEmptyValue("variable_name").SetString("CONDUCTIVITY")            
@@ -43,7 +41,6 @@ class ImposeThemalParametersScalarValueProcess(Process):
             
             specific_heat = Parameters("{}")
             specific_heat.AddValue("model_part_name", settings["model_part_name"])
-            specific_heat.AddValue("mesh_id", settings["mesh_id"])
             specific_heat.AddEmptyValue("is_fixed").SetBool(True)
             specific_heat.AddValue("value", settings["SpecificHeat"])
             specific_heat.AddEmptyValue("variable_name").SetString("SPECIFIC_HEAT")       

--- a/applications/DamApplication/python_scripts/impose_uniform_temperature_process.py
+++ b/applications/DamApplication/python_scripts/impose_uniform_temperature_process.py
@@ -19,7 +19,6 @@ class ImposeUniformTemperatureProcess(Process):
         if settings["table"].GetInt() == 0:
             param = Parameters("{}")
             param.AddValue("model_part_name",settings["model_part_name"])
-            param.AddValue("mesh_id",settings["mesh_id"])
             param.AddValue("is_fixed",settings["is_fixed"])
             param.AddValue("variable_name",settings["variable_name"])
             param.AddValue("value",settings["value"])


### PR DESCRIPTION
- On the one hand, references to the parameter 'mesh_id' have been removed. The resason is that this parameter has also been deleted from the GidInterface. If this parameter remains, it results in an error.
- On the other hand, minor but relevant changes have been included to fix and error detected with regard water-temperature-impose process.