### PR TITLE
Core/fix modelpart io tests

### DIFF
--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -143,7 +143,7 @@ class Commander(object):
                     print('\t', p, file=sys.stderr)
         else:
             script = path+'/'+possiblePaths[0]['Found']+'/tests/'+'test_'+application+'.py'
-            print(script)
+            print(script, file=sys.stderr)
 
             if possiblePaths[0]['Found'] != possiblePaths[0]['Expected']:
                 print(

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -80,7 +80,9 @@ namespace Kratos
     }
 
     /// Destructor.
-    ModelPartIO::~ModelPartIO() {}
+    ModelPartIO::~ModelPartIO() {
+        Timer::CloseOuputFile();
+    }
 
     ///@}
     ///@name Operators

--- a/kratos/tests/input_output/test_logger.cpp
+++ b/kratos/tests/input_output/test_logger.cpp
@@ -43,7 +43,7 @@ namespace Kratos {
 			KRATOS_CHECK_EQUAL(message.GetSeverity(), LoggerMessage::Severity::DETAIL);
             KRATOS_CHECK_EQUAL(message.GetCategory(), LoggerMessage::Category::CRITICAL);
             KRATOS_CHECK_NOT_EQUAL(message.GetLocation().GetFileName().find("test_logger.cpp"), std::string::npos);
-            KRATOS_CHECK_EQUAL(message.GetLocation().GetFunctionName(), "virtual void Kratos::Testing::TestLoggerMessageStream::TestFunction()");
+            KRATOS_CHECK_EQUAL(message.GetLocation().GetFunctionName(), KRATOS_CURRENT_FUNCTION);
             KRATOS_CHECK_EQUAL(message.GetLocation().GetLineNumber(), 40);
 		}
 

--- a/kratos/tests/sources/test_model_part_io.cpp
+++ b/kratos/tests/sources/test_model_part_io.cpp
@@ -126,8 +126,8 @@ KRATOS_TEST_CASE_IN_SUITE(
     model_part_0.AddNodalSolutionStepVariable(PARTITION_INDEX);
     model_part_0.GetCommunicator().SetNumberOfColors(number_of_colors);
 
-    ModelPartIO model_part_io_0(p_output_0);
-    model_part_io_0.ReadModelPart(model_part_0);
+    ModelPartIO * model_part_io_0 = new ModelPartIO(p_output_0);
+    model_part_io_0->ReadModelPart(model_part_0);
 
     KRATOS_CHECK_EQUAL(model_part_0.NumberOfNodes(), 3);
     KRATOS_CHECK_EQUAL(model_part_0.NumberOfElements(), 1);
@@ -147,8 +147,8 @@ KRATOS_TEST_CASE_IN_SUITE(
     model_part_1.AddNodalSolutionStepVariable(PARTITION_INDEX);
     model_part_1.GetCommunicator().SetNumberOfColors(number_of_colors + 1);
 
-    ModelPartIO model_part_io_1(p_output_1);
-    model_part_io_1.ReadModelPart(model_part_1);
+    ModelPartIO * model_part_io_1 = new ModelPartIO(p_output_1);
+    model_part_io_1->ReadModelPart(model_part_1);
 
     KRATOS_CHECK_EQUAL(model_part_1.NumberOfNodes(), 3);
     KRATOS_CHECK_EQUAL(model_part_1.NumberOfElements(), 1);
@@ -161,6 +161,10 @@ KRATOS_TEST_CASE_IN_SUITE(
         model_part_1.GetSubModelPart("BasePart").NumberOfElements(), 0);
     KRATOS_CHECK_EQUAL(
         model_part_1.GetSubModelPart("BasePart").NumberOfConditions(), 0);
+
+    // Free the modelparts to prevent files still being opened
+    delete model_part_io_0;
+    delete model_part_io_1;
 
     //KRATOS_CHECK_STRING_CONTAIN_SUB_STRING(p_output_1->str(), R"/(Begin SubModelPart BaseNodes
     //Begin SubModelPartNodes
@@ -231,13 +235,13 @@ KRATOS_TEST_CASE_IN_SUITE(ModelPartIOWriteModelPart, KratosCoreFastSuite) {
     output_file.close();
 
     // Fill the output .mdpa file
-    ModelPartIO model_part_io_write(output_file_name, IO::WRITE);
-    model_part_io_write.WriteModelPart(main_model_part);
+    ModelPartIO * model_part_io_write = new ModelPartIO(output_file_name, IO::WRITE);
+    model_part_io_write->WriteModelPart(main_model_part);
 
     // Read and check the written .mdpa file
-    ModelPartIO model_part_io_output(output_file_name);
+    ModelPartIO * model_part_io_output = new ModelPartIO(output_file_name);
     ModelPart main_model_part_output("MainModelPartOutput");
-    model_part_io_output.ReadModelPart(main_model_part_output);
+    model_part_io_output->ReadModelPart(main_model_part_output);
 
     // Assert results
     KRATOS_CHECK_EQUAL(main_model_part_output.NumberOfProperties(), 1);
@@ -259,6 +263,9 @@ KRATOS_TEST_CASE_IN_SUITE(ModelPartIOWriteModelPart, KratosCoreFastSuite) {
     KRATOS_CHECK_EQUAL(main_model_part_output.GetMesh().GetCondition(1).GetValue(TEMPERATURE), temperature);
     KRATOS_CHECK_EQUAL(main_model_part_output.GetMesh().GetCondition(1).GetValue(DISPLACEMENT_X), displacement_x);
 
+    // Free the modelparts to prevent files still being opened
+    delete model_part_io_write;
+    delete model_part_io_output;
 
     // Remove the generated files
     std::string aux_string_mdpa = output_file_name + ".mdpa"; 

--- a/kratos/tests/test_model_part_io.py
+++ b/kratos/tests/test_model_part_io.py
@@ -19,6 +19,12 @@ class TestModelPartIO(KratosUnittest.TestCase):
         if (sys.version_info < (3, 2)):
             self.assertRaisesRegex = self.assertRaisesRegexp
 
+    def tearDown(self):
+        # Clean up temporary files
+        kratos_utils.DeleteFileIfExisting(GetFilePath("test_model_part_io_write.out.mdpa"))
+        kratos_utils.DeleteFileIfExisting(GetFilePath("test_model_part_io_write.out.time"))
+        kratos_utils.DeleteFileIfExisting(GetFilePath("test_model_part_io_write.time"))
+
     def test_model_part_io_read_model_part(self):
         model_part = KratosMultiphysics.ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
@@ -138,11 +144,6 @@ class TestModelPartIO(KratosUnittest.TestCase):
         import filecmp
         value = filecmp.cmp(GetFilePath("test_model_part_io_write.mdpa"), GetFilePath("test_model_part_io_write.out.mdpa"))
         self.assertEqual(value, True)
-
-        # Clean up temporary files
-        kratos_utils.DeleteFileIfExisting(GetFilePath("test_model_part_io_write.out.mdpa"))
-        kratos_utils.DeleteFileIfExisting(GetFilePath("test_model_part_io_write.out.time"))
-        kratos_utils.DeleteFileIfExisting(GetFilePath("test_model_part_io_write.time"))
 
     @KratosUnittest.expectedFailure
     def test_error_on_wrong_input(self):

--- a/kratos/utilities/timer.h
+++ b/kratos/utilities/timer.h
@@ -190,6 +190,13 @@ public:
         return msOutputFile.is_open();
     }
 
+    static int CloseOuputFile()
+    {
+        if(msOutputFile.is_open())
+            msOutputFile.close();
+
+        return msOutputFile.is_open();
+    }
 
     static bool GetPrintOnScreen()
     {


### PR DESCRIPTION
Fixes #1720:
- Time files related with the model_part_io are now correctly freed so can be deleted once the object is destroyed. @philbucher can you confirm that this solves also the problem with the `*.time` file you had in #1715 ?

- Tests with model_part_io now use that class as a pointer so it can be deleted an hence the mdpa files cleaned. @maceligueta, at the end I solved it without the need of an auxiliary function making de io objects pointers. Should be the same.

- The comparison for function names in the logger tests now compares against the macro used to generate the CodeLocation object instead of a fixed macro. You will have to trust me in that one :)

@PhilippeBussetta can you check that now the fails are gone in win?