### PR TITLE
Changed typename to class to fix clang warning

### DIFF
--- a/applications/HDF5Application/custom_utilities/registered_variable_lookup.h
+++ b/applications/HDF5Application/custom_utilities/registered_variable_lookup.h
@@ -48,7 +48,7 @@ namespace Kratos
 template <typename ...TVariables> 
 class RegisteredVariableLookup
 {
-    template <template<typename T> typename TFunctor, typename ...Targs>
+    template <template<typename T> class TFunctor, typename ...Targs>
     struct FunctorWrapper
     {
         template <typename TVariable>
@@ -67,7 +67,7 @@ public:
     explicit RegisteredVariableLookup(std::string const& rName) : mName(rName)
     {}
 
-  template <template<typename T> typename TFunctor, typename ...Targs>
+  template <template<typename T> class TFunctor, typename ...Targs>
   void Execute(Targs&... args)
   {
       bool found = false;


### PR DESCRIPTION
This should eliminate the warning:

warning: template template parameter using 'typename' is a c++17 extension

The explanation is given at https://stackoverflow.com/questions/24081405/why-does-not-a-template-template-parameter-allow-typename-after-the-parameter.