### PR TITLE
Plane approximation utility: bug correction in 2D plus @pooyan-dadvand suggestions.

### DIFF
--- a/kratos/tests/utilities/test_plane_approximation_utility.cpp
+++ b/kratos/tests/utilities/test_plane_approximation_utility.cpp
@@ -35,7 +35,7 @@ namespace Testing {
 
         // Compute the plane approximation
         array_1d<double,3> base_point_coords, normal;
-        PlaneApproximationUtility::ComputePlaneApproximation(points_coordinates, base_point_coords, normal);
+        PlaneApproximationUtility<2>::ComputePlaneApproximation(points_coordinates, base_point_coords, normal);
 
         // Compute and check the obtained plane distance values
         const double d_1 = inner_prod(normal , point_1.Coordinates() - base_point_coords);
@@ -64,7 +64,7 @@ namespace Testing {
 
         // Compute the plane approximation
         array_1d<double,3> base_point_coords, normal;
-        PlaneApproximationUtility::ComputePlaneApproximation(points_coordinates, base_point_coords, normal);
+        PlaneApproximationUtility<2>::ComputePlaneApproximation(points_coordinates, base_point_coords, normal);
 
         // Compute and check the obtained plane distance values
         const double d_1 = inner_prod(normal , point_1.Coordinates() - base_point_coords);
@@ -72,10 +72,10 @@ namespace Testing {
         const double d_3 = inner_prod(normal , point_3.Coordinates() - base_point_coords);
         const double d_4 = inner_prod(normal , point_4.Coordinates() - base_point_coords);
 
-        KRATOS_CHECK_NEAR(d_1, -0.89886, 1e-6);
-        KRATOS_CHECK_NEAR(d_2, -0.110655, 1e-6);
-        KRATOS_CHECK_NEAR(d_3, 0.110655, 1e-6);
-        KRATOS_CHECK_NEAR(d_4, 0.89886, 1e-6);
+        KRATOS_CHECK_NEAR(d_1, 0.0674564, 1e-6);
+        KRATOS_CHECK_NEAR(d_2, -0.547956, 1e-6);
+        KRATOS_CHECK_NEAR(d_3, 0.547956, 1e-6);
+        KRATOS_CHECK_NEAR(d_4, -0.0674564, 1e-6);
     }
 
     KRATOS_TEST_CASE_IN_SUITE(PlaneApproximationUtilityCircleTriangleIntersection, KratosCoreFastSuite)
@@ -95,7 +95,7 @@ namespace Testing {
 
         // Compute the plane approximation
         array_1d<double,3> base_point_coords, normal;
-        PlaneApproximationUtility::ComputePlaneApproximation(points_coordinates, base_point_coords, normal);
+        PlaneApproximationUtility<2>::ComputePlaneApproximation(points_coordinates, base_point_coords, normal);
 
         // Compute and check the obtained plane distance values
         const double d_1 = inner_prod(normal , point_1.Coordinates() - base_point_coords);
@@ -103,10 +103,10 @@ namespace Testing {
         const double d_3 = inner_prod(normal , point_3.Coordinates() - base_point_coords);
         const double d_4 = inner_prod(normal , point_4.Coordinates() - base_point_coords);
 
-        KRATOS_CHECK_NEAR(d_1, 0.636396, 1e-6);
-        KRATOS_CHECK_NEAR(d_2, -0.636396, 1e-6);
-        KRATOS_CHECK_NEAR(d_3, 0.556776, 1e-6);
-        KRATOS_CHECK_NEAR(d_4, -0.556776, 1e-6);
+        KRATOS_CHECK_NEAR(d_1, -0.0353553, 1e-6);
+        KRATOS_CHECK_NEAR(d_2, -0.0353553, 1e-6);
+        KRATOS_CHECK_NEAR(d_3, 0.0353553, 1e-6);
+        KRATOS_CHECK_NEAR(d_4, 0.0353553, 1e-6);
     }
 
 }  // namespace Testing.

--- a/kratos/tests/utilities/test_plane_approximation_utility.cpp
+++ b/kratos/tests/utilities/test_plane_approximation_utility.cpp
@@ -109,5 +109,32 @@ namespace Testing {
         KRATOS_CHECK_NEAR(d_4, 0.0353553, 1e-6);
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(PlaneApproximationUtilityAlignedIntersection, KratosCoreFastSuite)
+    {
+        // Set of points to be approximated by the plane
+        // Note that they are selected such that, a 2D case is solved in 3D
+        Point point_1(0.0, 0.0, 0.0);
+        Point point_2(1.0, 0.0, 0.0);
+        Point point_3(0.0, 1.0, 0.0);
+
+        // Fill the array of coordinates
+        std::vector< array_1d<double,3> > points_coordinates;
+        points_coordinates.push_back(point_1.Coordinates());
+        points_coordinates.push_back(point_2.Coordinates());
+        points_coordinates.push_back(point_3.Coordinates());
+
+        // Compute the plane approximation
+        array_1d<double,3> base_point_coords, normal;
+        PlaneApproximationUtility<3>::ComputePlaneApproximation(points_coordinates, base_point_coords, normal);
+
+        // Compute and check the obtained plane values
+        KRATOS_CHECK_NEAR(base_point_coords[0], 1.0/3.0, 1e-6);
+        KRATOS_CHECK_NEAR(base_point_coords[1], 1.0/3.0, 1e-6);
+        KRATOS_CHECK_NEAR(base_point_coords[2], 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(normal[0], 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(normal[1], 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(normal[2], 1.0, 1e-6);
+    }
+
 }  // namespace Testing.
 }  // namespace Kratos.

--- a/kratos/utilities/plane_approximation_utility.h
+++ b/kratos/utilities/plane_approximation_utility.h
@@ -162,14 +162,14 @@ private:
     static void SetMatrixA(
         const std::vector< array_1d< double,3 > > &rPointsCoords,
         const array_1d<double,3> &rPlaneBasePointCoords,
-        bounded_matrix<double,3,3> &rA) 
+        bounded_matrix<double,TDim,TDim> &rA) 
     {
-        noalias(rA) = ZeroMatrix(3);
+        noalias(rA) = ZeroMatrix(TDim);
         const unsigned int n_points = rPointsCoords.size();
 
-        for (unsigned int i = 0; i < 3; ++i){
+        for (unsigned int i = 0; i < TDim; ++i){
             const double base_i = rPlaneBasePointCoords(i);
-            for (unsigned int j = 0; j < 3; ++j){
+            for (unsigned int j = 0; j < TDim; ++j){
                 const double base_j = rPlaneBasePointCoords(j);
                 for (unsigned int m = 0; m < n_points; ++m){
                     const double pt_m_i = rPointsCoords[m](i);
@@ -192,9 +192,9 @@ private:
         array_1d<double,3> &rPlaneNormal) 
     {
         // Solve the A matrix eigenvalue problem 
-        bounded_matrix<double, 3, 3> a_mat, eigenval_mat, eigenvector_mat;
+        bounded_matrix<double, TDim, TDim> a_mat, eigenval_mat, eigenvector_mat;
         SetMatrixA(rPointsCoords, rPlaneBasePointCoords, a_mat);
-        bool converged = MathUtils<double>::EigenSystem<3>(a_mat, eigenvector_mat, eigenval_mat);
+        bool converged = MathUtils<double>::EigenSystem<TDim>(a_mat, eigenvector_mat, eigenval_mat);
         KRATOS_ERROR_IF(!converged) << "Plane normal can't be computed. Eigenvalue problem did not converge." << std::endl;
 
         // Find the minimum eigenvalue
@@ -208,7 +208,8 @@ private:
         }
 
         // Set as plane normal the eigenvector associated to the minimum eigenvalue
-        for (unsigned int i = 0; i < 3; ++i){
+        noalias(rPlaneNormal) = ZeroVector(3);
+        for (unsigned int i = 0; i < TDim; ++i){
             rPlaneNormal(i) = eigenvector_mat(min_eigval_id,i);
         }
     }

--- a/kratos/utilities/plane_approximation_utility.h
+++ b/kratos/utilities/plane_approximation_utility.h
@@ -54,6 +54,7 @@ namespace Kratos
  * the base point and each one of the points to approximate.
  * @author Ruben Zorrilla
  */
+template <unsigned int TDim> 
 class PlaneApproximationUtility
 {
 public:
@@ -96,8 +97,8 @@ public:
         array_1d<double,3> &rPlaneBasePointCoords,
         array_1d<double,3> &rPlaneNormal)
     {
-        GetPlaneBasePoint(rPointsCoords,rPlaneBasePointCoords);
-        GetPlaneNormal(rPointsCoords, rPlaneBasePointCoords, rPlaneNormal);
+        ComputeBasePoint(rPointsCoords,rPlaneBasePointCoords);
+        ComputePlaneNormal(rPointsCoords, rPlaneBasePointCoords, rPlaneNormal);
     }
 
     ///@}
@@ -138,7 +139,7 @@ private:
      * @param rPointsCoords Vector containing the set of point coordinates
      * @return rBasePointCoords Plane base point coordinates
      */
-    static void GetPlaneBasePoint(
+    static void ComputeBasePoint(
         const std::vector< array_1d<double,3> > &rPointsCoords,
         array_1d<double,3> &rBasePointCoords) 
     {
@@ -185,7 +186,7 @@ private:
      * @param rBasePointCoords Plane base point coordinates
      * @return rPlaneNormal The plane unit normal
      */
-    static void GetPlaneNormal(
+    static void ComputePlaneNormal(
         const std::vector< array_1d<double,3> > &rPointsCoords,
         const array_1d<double,3> &rPlaneBasePointCoords,
         array_1d<double,3> &rPlaneNormal) 
@@ -197,12 +198,12 @@ private:
         KRATOS_ERROR_IF(!converged) << "Plane normal can't be computed. Eigenvalue problem did not converge." << std::endl;
 
         // Find the minimum eigenvalue
-        double min_eigval = 0.0;
+        double min_eigval = std::numeric_limits<double>::max();
         unsigned int min_eigval_id = 0;
-        for (unsigned int i = 0; i < 3; ++i){
+        for (unsigned int i = 0; i < TDim; ++i){
             if (eigenval_mat(i,i) < min_eigval){
                 min_eigval_id = i;
-                min_eigval = std::min(min_eigval, eigenval_mat(i,i));
+                min_eigval = eigenval_mat(i,i);
             }
         }
 


### PR DESCRIPTION
This PR complements PR #1707 (we did the merge before @pooyan-dadvand review). 

@pooyan-dadvand , I've added a template argument to distinguish between 2D and 3D cases, IMO its cleaner than passing the problem dimension as a function argument (and in the future it might be used in more than one place). 

Note that the dimension argument is needed since the third eigenvalue is always 0.0 in 2D cases because of the null z-coordinate. If it is the case that the rest of eigenvalues are positive, this meaningless one becomes the minimum.