### PR TITLE
Updating drag utilities according to last changes in reaction computation

### DIFF
--- a/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
@@ -36,6 +36,7 @@ namespace Kratos
         // Get the process info
         ProcessInfo& r_current_process_info = root_model_part.GetProcessInfo();
 
+        // Fractional step case
         if (r_current_process_info.Has(FRACTIONAL_STEP)) {
 
             Vector RHS_Contribution;
@@ -51,7 +52,8 @@ namespace Kratos
             }
 
             // Set the step index to compute the momentum equation
-            int current_fractional_step = r_current_process_info[FRACTIONAL_STEP];
+            int current_fractional_step = 0;
+            current_fractional_step = r_current_process_info[FRACTIONAL_STEP];
             r_current_process_info[FRACTIONAL_STEP] = 1;
 
             // Calculate only if the buffer size is full and the solution is already running
@@ -80,10 +82,13 @@ namespace Kratos
                         r_geom[i_node].UnSetLock();
                     }
                 }
+
+                // Assemble reaction data
+                root_model_part.GetCommunicator().AssembleCurrentData(REACTION);
+
+                // Fractional step case: restore the step index
+                r_current_process_info[FRACTIONAL_STEP] = current_fractional_step;
             }
-            
-            // Restore the step index
-+           r_current_process_info[FRACTIONAL_STEP] = current_fractional_step;
         }
 
         // Sum the reactions in the model part of interest. Note that in the non fractional 
@@ -93,7 +98,6 @@ namespace Kratos
         drag_force *= -1.0;
 
         return drag_force;
-
     }
 
     array_1d<double, 3> DragUtilities::CalculateEmbeddedDrag(ModelPart& rModelPart) {

--- a/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
@@ -36,8 +36,6 @@ namespace Kratos
         // Get the process info
         ProcessInfo& r_current_process_info = root_model_part.GetProcessInfo();
 
-        // Fractional step case
-        int current_fractional_step = 0;
         if (r_current_process_info.Has(FRACTIONAL_STEP)) {
 
             Vector RHS_Contribution;
@@ -53,7 +51,7 @@ namespace Kratos
             }
 
             // Set the step index to compute the momentum equation
-            current_fractional_step = r_current_process_info[FRACTIONAL_STEP];
+            int current_fractional_step = r_current_process_info[FRACTIONAL_STEP];
             r_current_process_info[FRACTIONAL_STEP] = 1;
 
             // Calculate only if the buffer size is full and the solution is already running
@@ -82,6 +80,9 @@ namespace Kratos
                         r_geom[i_node].UnSetLock();
                     }
                 }
+                
+                // Restore the step index
+                r_current_process_info[FRACTIONAL_STEP] = current_fractional_step;
 
                 // Assemble reaction data
                 root_model_part.GetCommunicator().AssembleCurrentData(REACTION);
@@ -93,11 +94,6 @@ namespace Kratos
         VariableUtils variable_utils;
         array_1d<double, 3> drag_force = variable_utils.SumHistoricalNodeVectorVariable(REACTION, rModelPart, 0);
         drag_force *= -1.0;
-
-        // Fractional step case: restore the step index
-        if (r_current_process_info.Has(FRACTIONAL_STEP)) {
-            r_current_process_info[FRACTIONAL_STEP] = current_fractional_step;
-        }
 
         return drag_force;
 

--- a/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
@@ -29,70 +29,8 @@ namespace Kratos
     /* Public functions *******************************************************/
 
     array_1d<double, 3> DragUtilities::CalculateBodyFittedDrag(ModelPart& rModelPart) {
-
-        // Get the root model part
-        ModelPart& root_model_part = rModelPart.GetRootModelPart();
-
-        // Get the process info
-        ProcessInfo& r_current_process_info = root_model_part.GetProcessInfo();
-
-        // Fractional step case
-        if (r_current_process_info.Has(FRACTIONAL_STEP)) {
-
-            Vector RHS_Contribution;
-            Matrix LHS_Contribution;
-            const unsigned int domain_size = r_current_process_info[DOMAIN_SIZE];
-
-            // Initialize the reaction variable
-            const array_1d<double, 3> zero_vect(3,0.0);
-            #pragma omp parallel for firstprivate(zero_vect)
-            for (int i = 0; i < static_cast<int>(root_model_part.NumberOfNodes()); ++i){
-                auto it_node = root_model_part.NodesBegin() + i;
-                noalias(it_node->FastGetSolutionStepValue(REACTION)) = zero_vect;
-            }
-
-            // Set the step index to compute the momentum equation
-            int current_fractional_step = 0;
-            current_fractional_step = r_current_process_info[FRACTIONAL_STEP];
-            r_current_process_info[FRACTIONAL_STEP] = 1;
-
-            // Calculate only if the buffer size is full and the solution is already running
-            // otherwise we might encounter errors due to uninitialized things required by the elements.
-            unsigned int solution_step = r_current_process_info[STEP];
-            if (solution_step+1 >= rModelPart.GetBufferSize() ) {
-
-                #pragma omp parallel for private(RHS_Contribution, LHS_Contribution) firstprivate(domain_size)
-                for (int i_elem = 0; i_elem < static_cast<int>(root_model_part.NumberOfElements()); ++i_elem){
-                    auto it_elem = root_model_part.ElementsBegin() + i_elem;
-
-                    // Build local system
-                    it_elem->CalculateLocalSystem(LHS_Contribution, RHS_Contribution, r_current_process_info);
-
-                    // Get geometry
-                    Element::GeometryType& r_geom = it_elem->GetGeometry();
-                    const unsigned int n_nodes = r_geom.PointsNumber();
-                    const unsigned int block_size = RHS_Contribution.size()/n_nodes;
-
-                    for (unsigned int i_node = 0; i_node < n_nodes; ++i_node){
-                        r_geom[i_node].SetLock();
-                        array_1d<double,3>& r_reaction = r_geom[i_node].FastGetSolutionStepValue(REACTION);
-                        for (unsigned int d = 0; d < domain_size; ++d)
-                            r_reaction[d] -= RHS_Contribution[block_size*i_node + d];
-
-                        r_geom[i_node].UnSetLock();
-                    }
-                }
-
-                // Assemble reaction data
-                root_model_part.GetCommunicator().AssembleCurrentData(REACTION);
-
-                // Fractional step case: restore the step index
-                r_current_process_info[FRACTIONAL_STEP] = current_fractional_step;
-            }
-        }
-
-        // Sum the reactions in the model part of interest. Note that in the non fractional 
-        // step case the reactions are computed if the correspondent flag is set to True
+        // Sum the reactions in the model part of interest.
+        // Note that the reactions are assumed to be already computed.
         VariableUtils variable_utils;
         array_1d<double, 3> drag_force = variable_utils.SumHistoricalNodeVectorVariable(REACTION, rModelPart, 0);
         drag_force *= -1.0;

--- a/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
@@ -81,6 +81,9 @@ namespace Kratos
                     }
                 }
             }
+            
+            // Restore the step index
++           r_current_process_info[FRACTIONAL_STEP] = current_fractional_step;
         }
 
         // Sum the reactions in the model part of interest. Note that in the non fractional 

--- a/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
@@ -33,58 +33,63 @@ namespace Kratos
         // Get the root model part
         ModelPart& root_model_part = rModelPart.GetRootModelPart();
 
-        // Initialize the reaction variable
-        const array_1d<double, 3> zero_vect(3,0.0);
-        #pragma omp parallel for firstprivate(zero_vect)
-        for (int i = 0; i < static_cast<int>(root_model_part.NumberOfNodes()); ++i){
-            auto it_node = root_model_part.NodesBegin() + i;
-            noalias(it_node->FastGetSolutionStepValue(REACTION)) = zero_vect;
-        }
-
-        Vector RHS_Contribution;
-        Matrix LHS_Contribution;
+        // Get the process info
         ProcessInfo& r_current_process_info = root_model_part.GetProcessInfo();
-        const unsigned int domain_size = r_current_process_info[DOMAIN_SIZE];
 
-        // Fractional step case: set the step index to compute the momentum equation
+        // Fractional step case
         int current_fractional_step = 0;
         if (r_current_process_info.Has(FRACTIONAL_STEP)) {
-            current_fractional_step = r_current_process_info[FRACTIONAL_STEP];
-            r_current_process_info[FRACTIONAL_STEP] = 1;
-        }
 
-        // Calculate only if the buffer size is full and the solution is already running
-        // otherwise we might encounter errors due to uninitialized things required by the elements.
-        unsigned int solution_step = r_current_process_info[STEP];
-        if (solution_step+1 >= rModelPart.GetBufferSize() ) {
+            Vector RHS_Contribution;
+            Matrix LHS_Contribution;
+            const unsigned int domain_size = r_current_process_info[DOMAIN_SIZE];
 
-            #pragma omp parallel for private(RHS_Contribution, LHS_Contribution) firstprivate(domain_size)
-            for (int i_elem = 0; i_elem < static_cast<int>(root_model_part.NumberOfElements()); ++i_elem){
-                auto it_elem = root_model_part.ElementsBegin() + i_elem;
-
-                // Build local system
-                it_elem->CalculateLocalSystem(LHS_Contribution, RHS_Contribution, r_current_process_info);
-
-                // Get geometry
-                Element::GeometryType& r_geom = it_elem->GetGeometry();
-                const unsigned int n_nodes = r_geom.PointsNumber();
-                const unsigned int block_size = RHS_Contribution.size()/n_nodes;
-
-                for (unsigned int i_node = 0; i_node < n_nodes; ++i_node){
-                    r_geom[i_node].SetLock();
-                    array_1d<double,3>& r_reaction = r_geom[i_node].FastGetSolutionStepValue(REACTION);
-                    for (unsigned int d = 0; d < domain_size; ++d)
-                        r_reaction[d] -= RHS_Contribution[block_size*i_node + d];
-
-                    r_geom[i_node].UnSetLock();
-                }
+            // Initialize the reaction variable
+            const array_1d<double, 3> zero_vect(3,0.0);
+            #pragma omp parallel for firstprivate(zero_vect)
+            for (int i = 0; i < static_cast<int>(root_model_part.NumberOfNodes()); ++i){
+                auto it_node = root_model_part.NodesBegin() + i;
+                noalias(it_node->FastGetSolutionStepValue(REACTION)) = zero_vect;
             }
 
-            // Assemble reaction data
-            root_model_part.GetCommunicator().AssembleCurrentData(REACTION);
+            // Set the step index to compute the momentum equation
+            current_fractional_step = r_current_process_info[FRACTIONAL_STEP];
+            r_current_process_info[FRACTIONAL_STEP] = 1;
+
+            // Calculate only if the buffer size is full and the solution is already running
+            // otherwise we might encounter errors due to uninitialized things required by the elements.
+            unsigned int solution_step = r_current_process_info[STEP];
+            if (solution_step+1 >= rModelPart.GetBufferSize() ) {
+
+                #pragma omp parallel for private(RHS_Contribution, LHS_Contribution) firstprivate(domain_size)
+                for (int i_elem = 0; i_elem < static_cast<int>(root_model_part.NumberOfElements()); ++i_elem){
+                    auto it_elem = root_model_part.ElementsBegin() + i_elem;
+
+                    // Build local system
+                    it_elem->CalculateLocalSystem(LHS_Contribution, RHS_Contribution, r_current_process_info);
+
+                    // Get geometry
+                    Element::GeometryType& r_geom = it_elem->GetGeometry();
+                    const unsigned int n_nodes = r_geom.PointsNumber();
+                    const unsigned int block_size = RHS_Contribution.size()/n_nodes;
+
+                    for (unsigned int i_node = 0; i_node < n_nodes; ++i_node){
+                        r_geom[i_node].SetLock();
+                        array_1d<double,3>& r_reaction = r_geom[i_node].FastGetSolutionStepValue(REACTION);
+                        for (unsigned int d = 0; d < domain_size; ++d)
+                            r_reaction[d] -= RHS_Contribution[block_size*i_node + d];
+
+                        r_geom[i_node].UnSetLock();
+                    }
+                }
+
+                // Assemble reaction data
+                root_model_part.GetCommunicator().AssembleCurrentData(REACTION);
+            }
         }
 
-        // Sum the reactions in the model part of interest
+        // Sum the reactions in the model part of interest. Note that in the non fractional 
+        // step case the reactions are computed if the correspondent flag is set to True
         VariableUtils variable_utils;
         array_1d<double, 3> drag_force = variable_utils.SumHistoricalNodeVectorVariable(REACTION, rModelPart, 0);
         drag_force *= -1.0;

--- a/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
@@ -82,9 +82,6 @@ namespace Kratos
                         r_geom[i_node].UnSetLock();
                     }
                 }
-
-                // Assemble reaction data
-                root_model_part.GetCommunicator().AssembleCurrentData(REACTION);
             }
         }
 

--- a/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
@@ -36,8 +36,6 @@ namespace Kratos
         // Get the process info
         ProcessInfo& r_current_process_info = root_model_part.GetProcessInfo();
 
-        // Fractional step case
-        int current_fractional_step = 0;
         if (r_current_process_info.Has(FRACTIONAL_STEP)) {
 
             Vector RHS_Contribution;
@@ -53,7 +51,7 @@ namespace Kratos
             }
 
             // Set the step index to compute the momentum equation
-            current_fractional_step = r_current_process_info[FRACTIONAL_STEP];
+            int current_fractional_step = r_current_process_info[FRACTIONAL_STEP];
             r_current_process_info[FRACTIONAL_STEP] = 1;
 
             // Calculate only if the buffer size is full and the solution is already running
@@ -90,11 +88,6 @@ namespace Kratos
         VariableUtils variable_utils;
         array_1d<double, 3> drag_force = variable_utils.SumHistoricalNodeVectorVariable(REACTION, rModelPart, 0);
         drag_force *= -1.0;
-
-        // Fractional step case: restore the step index
-        if (r_current_process_info.Has(FRACTIONAL_STEP)) {
-            r_current_process_info[FRACTIONAL_STEP] = current_fractional_step;
-        }
 
         return drag_force;
 

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
@@ -207,9 +207,8 @@ class NavierStokesSolverFractionalStep(navier_stokes_base_solver.NavierStokesBas
         # Note that the first two time steps are dropped to fill the buffer
         if (self.main_model_part.ProcessInfo[KratosMultiphysics.STEP] >= 2):
             self.solver.Solve()
-
-        if(self.compute_reactions):
-            self.solver.CalculateReactions()
+            if(self.compute_reactions):
+                self.solver.CalculateReactions()
 
 
     def _set_physical_properties(self):


### PR DESCRIPTION
Since the reactions are now computed not only in the fixed DOFs, there is no necessity of computing the RHS in case the drag over a slip boundary is needed. Thus, the drag is obtained as the reaccions summation. 

For the FS case, the reactions are computed as was done before. However, a correction related with this issue has been done in the Python solver. Now, the reaction computation is inside the buffer check.