### PR TITLE
Pybind11/restoring c tests

### DIFF
--- a/applications/FluidDynamicsApplication/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/CMakeLists.txt
@@ -79,12 +79,12 @@ endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 
 ###############################################################################
 ## FluidDynamicsApplication core library (C++ parts)
-add_library( KratosFluidDynamicsCore SHARED ${KRATOS_FLUID_DYNAMICS_APPLICATION_CORE_SOURCES})
+add_library( KratosFluidDynamicsCore SHARED ${KRATOS_FLUID_DYNAMICS_APPLICATION_CORE_SOURCES} ${KRATOS_FLUID_DYNAMICS_TESTING_SOURCES} )
 target_link_libraries( KratosFluidDynamicsCore PRIVATE KratosCore)
 set_target_properties( KratosFluidDynamicsCore PROPERTIES COMPILE_DEFINITIONS "FLUID_DYNAMICS_APPLICATION=EXPORT,API")
 
 ## FluidDynamicsApplication python module
-pybind11_add_module( KratosFluidDynamicsApplication MODULE ${KRATOS_FLUID_DYNAMICS_PYTHON_INTERFACE_SOURCES})
+pybind11_add_module( KratosFluidDynamicsApplication MODULE ${KRATOS_FLUID_DYNAMICS_PYTHON_INTERFACE_SOURCES} )
 target_link_libraries( KratosFluidDynamicsApplication PRIVATE KratosFluidDynamicsCore)
 set_target_properties( KratosFluidDynamicsApplication PROPERTIES PREFIX "")
 

--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -43,9 +43,9 @@ set( KRATOS_CORE_SOURCES
 	${CMAKE_CURRENT_SOURCE_DIR}/processes/find_intersected_geometrical_objects_process.cpp;
 	${CMAKE_CURRENT_SOURCE_DIR}/processes/calculate_discontinuous_distance_to_skin_process.cpp;
 	${CMAKE_CURRENT_SOURCE_DIR}/processes/calculate_distance_to_skin_process.cpp;
-	${CMAKE_CURRENT_SOURCE_DIR}/processes/reorder_and_optimize_modelpart_process.cpp;	
-    ${CMAKE_CURRENT_SOURCE_DIR}/processes/compute_nodal_gradient_process.cpp;    
-    ${CMAKE_CURRENT_SOURCE_DIR}/processes/find_nodal_h_process.cpp;  
+	${CMAKE_CURRENT_SOURCE_DIR}/processes/reorder_and_optimize_modelpart_process.cpp;
+    ${CMAKE_CURRENT_SOURCE_DIR}/processes/compute_nodal_gradient_process.cpp;
+    ${CMAKE_CURRENT_SOURCE_DIR}/processes/find_nodal_h_process.cpp;
 	${CMAKE_CURRENT_SOURCE_DIR}/sources/bounding_volume_tree.cpp;
 	${CMAKE_CURRENT_SOURCE_DIR}/sources/exception.cpp;
 	${CMAKE_CURRENT_SOURCE_DIR}/sources/code_location.cpp;
@@ -119,7 +119,7 @@ if(${KRATOS_BUILD_TESTING} MATCHES ON)
 endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 
 ## Define library KratosCore to be included in all of the others
-add_library(KratosCore SHARED ${KRATOS_CORE_SOURCES} ${KRATOS_CORE_TESTING_ENGINE_SOURCES} ${KRATOS_CORE_INPUT_OUTPUT_SOURCES})
+add_library(KratosCore SHARED ${KRATOS_CORE_SOURCES} ${KRATOS_CORE_TESTING_ENGINE_SOURCES} ${KRATOS_CORE_INPUT_OUTPUT_SOURCES} ${KRATOS_TEST_SOURCES})
 target_link_libraries(KratosCore PUBLIC gidpost) #${Boost_LIBRARIES} ${PYTHON_LIBRARIES} gidpost )
 set_target_properties(KratosCore PROPERTIES COMPILE_DEFINITIONS "KRATOS_CORE=IMPORT,API")
 
@@ -144,7 +144,7 @@ if(USE_COTIRE MATCHES ON)
     set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/python/add_amgcl_solver_to_python.cpp PROPERTIES COTIRE_EXCLUDED TRUE)
     set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/python/add_strategies_to_python.cpp PROPERTIES COTIRE_EXCLUDED TRUE)
     set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/python/add_utilities_to_python.cpp PROPERTIES COTIRE_EXCLUDED TRUE)
-    
+
     cotire(Kratos)
 endif(USE_COTIRE MATCHES ON)
 
@@ -155,7 +155,7 @@ endif(USE_COTIRE MATCHES ON)
 #     endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 #     set_target_properties(Kratos PROPERTIES SUFFIX .pyd)
 # endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
-# 
+#
 # ## Changing the .dylib suffix to .so (For MacOS)
 # if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 #     if(${KRATOS_BUILD_TESTING} MATCHES ON)

--- a/kratos/includes/thread_fixed_size_memory_pool.h
+++ b/kratos/includes/thread_fixed_size_memory_pool.h
@@ -8,7 +8,7 @@
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
-//                   
+//
 //
 
 
@@ -17,6 +17,7 @@
 
 #include <vector>
 #include <list>
+#include <algorithm>
 
 #include "includes/chunk.h"
 
@@ -32,12 +33,12 @@ namespace Kratos
   /** The memory management of Kratos is implemented based on the design
 	  given in Modern C++ Design by A. Alexandrescu and ThreadFixedSizeMemoryPool is the second
 	  layer of it "Called FixedAllocator" holding chunks.
-	  This class is the owner of the chunks of this thread and the only one who can 
-	  allocate in them. The rest of the threads would only deallocate objects. 
+	  This class is the owner of the chunks of this thread and the only one who can
+	  allocate in them. The rest of the threads would only deallocate objects.
   */
   class ThreadFixedSizeMemoryPool : public LockObject
     {
-    public:    
+    public:
 	  ///@name Type Definitions
 	  ///@{
 
@@ -75,7 +76,7 @@ namespace Kratos
 	  {
 	  }
 
-      /// Destructor 
+      /// Destructor
 	  virtual ~ThreadFixedSizeMemoryPool() {
 
 	  }
@@ -102,7 +103,7 @@ namespace Kratos
 			  r_available_chunk.Initialize();
 		  KRATOS_CHECK_IS_FALSE(r_available_chunk.IsFull());
 		  p_result = r_available_chunk.Allocate();
-		  KRATOS_DEBUG_CHECK_NOT_EQUAL(p_result, nullptr); 
+		  KRATOS_DEBUG_CHECK_NOT_EQUAL(p_result, nullptr);
 		  if (r_available_chunk.IsFull())
 			  mAvailableChunks.pop_front();
 		  return p_result;
@@ -208,9 +209,9 @@ namespace Kratos
 			  overhead_percentage = static_cast<double>(memory_overhead)/(memory_used - memory_overhead);
 		  overhead_percentage *= 100.00;
 
-		  rOStream << GetNumberOfChunks() << " Chunks of " 
-			  << SizeInBytesToString(ChunkSize()) << " bytes each. Total memory usage: " 
-			  << SizeInBytesToString(MemoryUsed()) << " bytes and memory overhead " 
+		  rOStream << GetNumberOfChunks() << " Chunks of "
+			  << SizeInBytesToString(ChunkSize()) << " bytes each. Total memory usage: "
+			  << SizeInBytesToString(MemoryUsed()) << " bytes and memory overhead "
 			  << SizeInBytesToString(MemoryOverhead()) << "(" << overhead_percentage << "%)" << std::endl;
 	  }
 
@@ -237,7 +238,7 @@ namespace Kratos
 		void AddChunk() {
 			if (mThreadNumber != static_cast<std::size_t>(GetThreadNumber()))
                 KRATOS_ERROR;
-                
+
 			KRATOS_DEBUG_CHECK_EQUAL(mThreadNumber, static_cast<std::size_t>(GetThreadNumber()));
 
             mChunks.emplace_back(mBlockSizeInBytes, mChunkSize);

--- a/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/geometries/test_tetrahedra_3d_4.cpp
@@ -26,27 +26,27 @@ namespace Kratos {
 
     typedef Node<3>                   PointType;
     typedef Node<3>::Pointer          PointPtrType;
-    typedef Tetrahedra3D4<PointType>  GeometryType;
-    typedef GeometryType::Pointer     GeometryPtrType;
+    typedef Tetrahedra3D4<PointType>  TetGeometryType;
+    typedef TetGeometryType::Pointer  TetGeometryPtrType;
 
     /** Generates a sample Tetrahedra3D4.
      * Generates a tetrahedra defined by three random points in the space.
      * @return  Pointer to a Tetrahedra3D4
      */
-    GeometryPtrType GenerateTetrahedra3D4(
+    TetGeometryPtrType GenerateTetrahedra3D4(
         PointPtrType PointA = GeneratePoint<PointType>(),
         PointPtrType PointB = GeneratePoint<PointType>(),
         PointPtrType PointC = GeneratePoint<PointType>(),
         PointPtrType PointD = GeneratePoint<PointType>()) {
-      return GeometryPtrType(new GeometryType(PointA, PointB, PointC, PointD));
+      return TetGeometryPtrType(new TetGeometryType(PointA, PointB, PointC, PointD));
     }
 
     /** Generates a sample Tetrahedra3D4.
      * Generates a trirectangular tetrahedra on the origin with positive volume and side 1.
      * @return  Pointer to a Tetrahedra3D4
      */
-    GeometryPtrType GenerateTriRectangularTetrahedra3D4() {
-      return GeometryPtrType(new GeometryType(
+    TetGeometryPtrType GenerateTriRectangularTetrahedra3D4() {
+      return TetGeometryPtrType(new TetGeometryType(
         GeneratePoint<PointType>(0.0, 0.0, 0.0),
         GeneratePoint<PointType>(1.0, 0.0, 0.0),
         GeneratePoint<PointType>(0.0, 1.0, 0.0),
@@ -58,8 +58,8 @@ namespace Kratos {
      * Generates a regular tetrahedra with positive volume and side 1.
      * @return  Pointer to a Tetrahedra3D4
      */
-    GeometryPtrType GenerateRegInvtLen1Tetrahedra3D4() {
-      return GeometryPtrType(new GeometryType(
+    TetGeometryPtrType GenerateRegInvtLen1Tetrahedra3D4() {
+      return TetGeometryPtrType(new TetGeometryType(
         GeneratePoint<PointType>(0.0, 1.0, 1.0),
         GeneratePoint<PointType>(1.0, 0.0, 1.0),
         GeneratePoint<PointType>(1.0, 1.0, 0.0),
@@ -71,8 +71,8 @@ namespace Kratos {
      * Generates a regular tetrahedra with negative volume and side 1.
      * @return  Pointer to a Tetrahedra3D4
      */
-    GeometryPtrType GenerateRegularLen1Tetrahedra3D4() {
-      return GeometryPtrType(new GeometryType(
+    TetGeometryPtrType GenerateRegularLen1Tetrahedra3D4() {
+      return TetGeometryPtrType(new TetGeometryType(
         GeneratePoint<PointType>(0.0, 0.0, 0.0),
         GeneratePoint<PointType>(0.0, 1.0, 1.0),
         GeneratePoint<PointType>(1.0, 0.0, 1.0),
@@ -84,8 +84,8 @@ namespace Kratos {
      * Generates a regular tetrahedra with positive volume with side 2.
      * @return  Pointer to a Tetrahedra3D4
      */
-    GeometryPtrType GenerateRegularLen2Tetrahedra3D4() {
-      return GeometryPtrType(new GeometryType(
+    TetGeometryPtrType GenerateRegularLen2Tetrahedra3D4() {
+      return TetGeometryPtrType(new TetGeometryType(
         GeneratePoint<PointType>(0.0, 0.0, 0.0),
         GeneratePoint<PointType>(0.0, 2.0, 2.0),
         GeneratePoint<PointType>(2.0, 0.0, 2.0),
@@ -257,7 +257,7 @@ namespace Kratos {
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      auto criteria = GeometryType::QualityCriteria::INRADIUS_TO_CIRCUMRADIUS;
+      auto criteria = TetGeometryType::QualityCriteria::INRADIUS_TO_CIRCUMRADIUS;
 
       KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
@@ -276,7 +276,7 @@ namespace Kratos {
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      auto criteria = GeometryType::QualityCriteria::INRADIUS_TO_LONGEST_EDGE;
+      auto criteria = TetGeometryType::QualityCriteria::INRADIUS_TO_LONGEST_EDGE;
 
       KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
@@ -295,7 +295,7 @@ namespace Kratos {
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      auto criteria = GeometryType::QualityCriteria::SHORTEST_TO_LONGEST_EDGE;
+      auto criteria = TetGeometryType::QualityCriteria::SHORTEST_TO_LONGEST_EDGE;
 
       KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), 1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.000000, TOLERANCE);
@@ -314,7 +314,7 @@ namespace Kratos {
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      auto criteria = GeometryType::QualityCriteria::REGULARITY;
+      auto criteria = TetGeometryType::QualityCriteria::REGULARITY;
 
       // KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
       // KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
@@ -337,7 +337,7 @@ namespace Kratos {
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      auto criteria = GeometryType::QualityCriteria::VOLUME_TO_SURFACE_AREA;
+      auto criteria = TetGeometryType::QualityCriteria::VOLUME_TO_SURFACE_AREA;
 
       // KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria), 1.0, TOLERANCE);
       // KRATOS_CHECK_NEAR(geomRegLen2->Quality(criteria), 1.0, TOLERANCE);
@@ -360,7 +360,7 @@ namespace Kratos {
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      auto criteria = GeometryType::QualityCriteria::VOLUME_TO_EDGE_LENGTH;
+      auto criteria = TetGeometryType::QualityCriteria::VOLUME_TO_EDGE_LENGTH;
 
       KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), -1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria),  1.000000, TOLERANCE);
@@ -379,7 +379,7 @@ namespace Kratos {
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      auto criteria = GeometryType::QualityCriteria::VOLUME_TO_AVERAGE_EDGE_LENGTH;
+      auto criteria = TetGeometryType::QualityCriteria::VOLUME_TO_AVERAGE_EDGE_LENGTH;
 
       KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), -1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria),  1.000000, TOLERANCE);
@@ -398,7 +398,7 @@ namespace Kratos {
       auto geomRegLen2 = GenerateRegularLen2Tetrahedra3D4();
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
-      auto criteria = GeometryType::QualityCriteria::VOLUME_TO_RMS_EDGE_LENGTH;
+      auto criteria = TetGeometryType::QualityCriteria::VOLUME_TO_RMS_EDGE_LENGTH;
 
       KRATOS_CHECK_NEAR(geomInvLen1->Quality(criteria), -1.000000, TOLERANCE);
       KRATOS_CHECK_NEAR(geomRegLen1->Quality(criteria),  1.000000, TOLERANCE);


### PR DESCRIPTION
OK I think I need a bit of help with this one...

First, the C++ tests were not even being compiled... Good work everyone (myself included) for not noticing :1st_place_medal: 
I added the tests in the KratosCore library, although they used to be in the Python interface part for the old (boost) cmake. See the last point for my reasoning.

Second, in adding back the tests I discovered that I could not compile the file `thread_fixed_size_memory_pool.h` due to an error in an `std::find` here:
https://github.com/KratosMultiphysics/Kratos/blob/81330ca62e3cd4c9b9657c73447c47ed364cd8a8/kratos/includes/thread_fixed_size_memory_pool.h#L126-L130

The error "resolved itself" when I included `<algorithm>` (the std header defining find) in this file, so I can only wonder what it was using before. However, I have no idea of what that line is doing or if I broke something in the process. The tests pass now, though (in short, @pooyan-dadvand please take a look).

Finally, I noticed we also had to add the test sources to our applications (I have only done it for the FluidDynamicsApplication for now). Here again, I have the doubt of adding them to the interface or core library part of the code. For the FluidDynamics, I must add them to the C++ core library, because I'm linking `KratosCore` as `PRIVATE` (this means that libraries linking to KratosFluidDynamicsCore cannot use functions defined in KratosCore, which I think is clean) and some of the tests call core C++ methods (GiDIO in particular). I'd be willing to change it if we decide that it is better to link as `PUBLIC`, but I'd love to hear your arguments as to why prefer either mode.

Once we decide what to do, we will likely need to add the C++ tests for other applications too (I know at least HDF5Application has some).
