### PR TITLE
[ContactStructuralMechanicsApplication] Creating new properties instead of copying for contact conditions

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_processes/alm_fast_init_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/alm_fast_init_process.cpp
@@ -59,7 +59,6 @@ void ALMFastInit::Execute()
     for(int i = 0; i < static_cast<int>(conditions_array.size()); ++i)
         (conditions_array.begin() + i)->SetValue(NORMAL, ZeroVector(3)); // The normal and tangents vectors
 
-
     KRATOS_CATCH("");
 } // class ALMFastInit
 } // namespace Kratos

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/alm_variables_calculation_process.cpp
@@ -54,7 +54,7 @@ void ALMVariablesCalculationProcess::Execute()
         const unsigned num_nodes_geometry = r_this_geometry.size();
         
         // We get the values from the condition
-        Kratos::Properties& this_properties = it_cond->GetProperties();
+        Properties& this_properties = it_cond->GetProperties();
         const double young_modulus = this_properties[YOUNG_MODULUS];
         const double element_volume = it_cond->GetGeometry().Area();
         
@@ -62,8 +62,7 @@ void ALMVariablesCalculationProcess::Execute()
         const double condition_area = r_this_geometry.Area();
         const double nodal_condition_area = condition_area/num_nodes_geometry;
         
-        if (it_cond->Is(SLAVE) == true)
-        {
+        if (it_cond->Is(SLAVE)) {
             total_volume_slave += element_volume;
             total_area_slave += condition_area;
             mean_young_modulus_slave += young_modulus * element_volume;
@@ -72,8 +71,7 @@ void ALMVariablesCalculationProcess::Execute()
                 mean_nodal_h_slave += r_this_geometry[i_node].FastGetSolutionStepValue(mrNodalLengthVariable) * nodal_condition_area;
         }
         
-        if (it_cond->Is(MASTER) == true)
-        {
+        if (it_cond->Is(MASTER)) {
             total_volume_master += element_volume;
             total_area_master += condition_area;
             mean_young_modulus_master += young_modulus * element_volume;

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.cpp
@@ -149,7 +149,7 @@ std::unordered_map<IndexType, Properties::Pointer> InterfacePreprocessCondition:
 
         // Now we copy (an remove) the properties we have interest
         CopyProperties(p_original_prop, p_new_prop, FRICTION_COEFFICIENT);
-        CopyProperties(p_original_prop, p_new_prop, THICKNESS);
+        CopyProperties(p_original_prop, p_new_prop, THICKNESS, false);
         CopyProperties(p_original_prop, p_new_prop, YOUNG_MODULUS);
     }
 

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.cpp
@@ -47,24 +47,24 @@ void InterfacePreprocessCondition::GenerateInterfacePart<2>(
     
     const bool simplest_geometry = ThisParameters["simplify_geometry"].GetBool();
     
-    unsigned int cond_counter = 0;
+    IndexType cond_counter = 0;
     
     // We reorder the conditions
-    unsigned int cond_id = ReorderConditions();
+    IndexType cond_id = ReorderConditions();
     
     // Generate Conditions from original the edges that can be considered interface
     for (auto it_elem = rOriginPart.ElementsBegin(); it_elem != rOriginPart.ElementsEnd(); ++it_elem) {
         GeometryType& this_geometry = it_elem->GetGeometry();
         Properties::Pointer p_prop = it_elem->pGetProperties();
         
-        for (unsigned int i_edge = 0; i_edge < this_geometry.EdgesNumber(); ++i_edge)
+        for (IndexType i_edge = 0; i_edge < this_geometry.EdgesNumber(); ++i_edge)
             GenerateEdgeCondition(rInterfacePart, p_prop, this_geometry.Edges()[i_edge], simplest_geometry, cond_counter, cond_id);
     }
     
     
     // NOTE: Reorder ID if parallellization
     
-    const unsigned int num_nodes = static_cast<int>(mrMainModelPart.Nodes().size());
+    const IndexType num_nodes = mrMainModelPart.Nodes().size();
     PrintNodesAndConditions(num_nodes, cond_counter);
     
     KRATOS_CATCH("");
@@ -91,10 +91,10 @@ void InterfacePreprocessCondition::GenerateInterfacePart<3>(
     
     const bool simplest_geometry = ThisParameters["simplify_geometry"].GetBool();
     
-    unsigned int cond_counter = 0;
+    IndexType cond_counter = 0;
     
     // We reorder the conditions
-    unsigned int cond_id = ReorderConditions();
+    IndexType cond_id = ReorderConditions();
     
     // Generate Conditions from original the faces that can be considered interface
     for (auto it_elem = rOriginPart.ElementsBegin(); it_elem != rOriginPart.ElementsEnd(); ++it_elem) {          
@@ -102,7 +102,7 @@ void InterfacePreprocessCondition::GenerateInterfacePart<3>(
         Properties::Pointer p_prop = it_elem->pGetProperties();
         
         if (this_geometry.LocalSpaceDimension() == 3) {
-            for (unsigned int i_face = 0; i_face < this_geometry.FacesNumber(); ++i_face)
+            for (IndexType i_face = 0; i_face < this_geometry.FacesNumber(); ++i_face)
                 GenerateFaceCondition(rInterfacePart, p_prop, this_geometry.Faces()[i_face], simplest_geometry, cond_counter, cond_id);
         } else
             GenerateFaceCondition(rInterfacePart, p_prop, this_geometry, simplest_geometry, cond_counter, cond_id);
@@ -110,7 +110,7 @@ void InterfacePreprocessCondition::GenerateInterfacePart<3>(
     
     // NOTE: Reorder ID if parallellization
     
-    const unsigned int num_nodes = static_cast<int>(mrMainModelPart.Nodes().size());
+    const IndexType num_nodes = mrMainModelPart.Nodes().size();
     PrintNodesAndConditions(num_nodes, cond_counter);
     
     KRATOS_CATCH("");
@@ -122,7 +122,7 @@ void InterfacePreprocessCondition::GenerateInterfacePart<3>(
 void InterfacePreprocessCondition::CreateNewCondition(
         Properties::Pointer pThisProperties,
         GeometryType& rGeometry,
-        const unsigned int CondId,
+        const IndexType CondId,
         Condition const& rCondition
         )
 {
@@ -134,7 +134,7 @@ void InterfacePreprocessCondition::CreateNewCondition(
     // We set the condition as master or slave (master by default)
     GeometryType& this_geometry = p_cond->GetGeometry();
     bool is_slave = true;
-    for (unsigned int it_node = 0; it_node < this_geometry.size(); ++it_node)
+    for (IndexType it_node = 0; it_node < this_geometry.size(); ++it_node)
         if (this_geometry[it_node].Is(SLAVE) == false) is_slave = false;
     if (is_slave == true)  p_cond->Set(SLAVE, true);
     else  p_cond->Set(MASTER, true);
@@ -146,8 +146,8 @@ void InterfacePreprocessCondition::CreateNewCondition(
 /***********************************************************************************/
 
 void InterfacePreprocessCondition::PrintNodesAndConditions(
-    const int NodesCounter,
-    const int CondCounter
+    const IndexType NodesCounter,
+    const IndexType CondCounter
     )
 {
     KRATOS_INFO("Nodes found") << "\t" << NodesCounter << " nodes ";
@@ -161,13 +161,13 @@ void InterfacePreprocessCondition::PrintNodesAndConditions(
 /***********************************************************************************/
 /***********************************************************************************/
 
-unsigned int InterfacePreprocessCondition::ReorderConditions()
+IndexType InterfacePreprocessCondition::ReorderConditions()
 {
     // We reorder the conditions
     ConditionsArrayType& conditions_array = mrMainModelPart.Conditions();
-    const unsigned int num_conditions = static_cast<int>(conditions_array.size());
+    const IndexType num_conditions = static_cast<int>(conditions_array.size());
     
-    for(unsigned int i = 0; i < num_conditions; ++i) {
+    for(IndexType i = 0; i < num_conditions; ++i) {
         auto it_condition = conditions_array.begin() + i;
         it_condition->SetId(i + 1);
     }
@@ -183,13 +183,13 @@ inline void InterfacePreprocessCondition::GenerateEdgeCondition(
     Properties::Pointer pThisProperties,
     GeometryType& EdgeGeometry,
     const bool SimplestGeometry,
-    unsigned int& CondCounter,
-    unsigned int& CondId
+    IndexType& CondCounter,
+    IndexType& CondId
     )
 {    
-    unsigned int count = 0;
-    const unsigned int number_of_points = EdgeGeometry.PointsNumber();
-    for (unsigned int it_node = 0; it_node < number_of_points; ++it_node) {
+    IndexType count = 0;
+    const IndexType number_of_points = EdgeGeometry.PointsNumber();
+    for (IndexType it_node = 0; it_node < number_of_points; ++it_node) {
         if (EdgeGeometry[it_node].IsDefined(INTERFACE) == true)
             if (EdgeGeometry[it_node].Is(INTERFACE) == true) ++count;
     }
@@ -223,12 +223,12 @@ inline void InterfacePreprocessCondition::GenerateEdgeCondition(
                 // We initialize a vector for the IDs
                 std::vector<std::size_t> condition_ids(2);
 
-                Line2D2< Node<3> > lin_1(EdgeGeometry(0), EdgeGeometry(1));
+                Line2D2< NodeType > lin_1(EdgeGeometry(0), EdgeGeometry(1));
                 CreateNewCondition(pThisProperties, lin_1, CondId, r_condition);
                 condition_ids[0] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Line2D2< Node<3> > lin_2(EdgeGeometry(1), EdgeGeometry(2));
+                Line2D2< NodeType > lin_2(EdgeGeometry(1), EdgeGeometry(2));
                 CreateNewCondition(pThisProperties, lin_2, CondId, r_condition);
                 condition_ids[1] = CondId;
                 ++CondCounter;
@@ -247,13 +247,13 @@ inline void InterfacePreprocessCondition::GenerateFaceCondition(
     Properties::Pointer pThisProperties,
     GeometryType& FaceGeometry,
     const bool SimplestGeometry,
-    unsigned int& CondCounter,
-    unsigned int& CondId
+    IndexType& CondCounter,
+    IndexType& CondId
     )
 {
-    unsigned int count = 0;
-    const unsigned int number_of_points = FaceGeometry.PointsNumber();
-    for (unsigned int it_node = 0; it_node < number_of_points; ++it_node) {
+    IndexType count = 0;
+    const IndexType number_of_points = FaceGeometry.PointsNumber();
+    for (IndexType it_node = 0; it_node < number_of_points; ++it_node) {
         if (FaceGeometry[it_node].IsDefined(INTERFACE) == true)  
             if (FaceGeometry[it_node].Is(INTERFACE) == true) ++count;
     }
@@ -287,12 +287,12 @@ inline void InterfacePreprocessCondition::GenerateFaceCondition(
                 // We initialize a vector for the IDs
                 std::vector<std::size_t> condition_ids(2);
                 
-                Triangle3D3< Node<3> > tri_1(FaceGeometry(0), FaceGeometry(1), FaceGeometry(2));
+                Triangle3D3< NodeType > tri_1(FaceGeometry(0), FaceGeometry(1), FaceGeometry(2));
                 CreateNewCondition(pThisProperties, tri_1, CondId, r_condition);
                 condition_ids[0] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_2(FaceGeometry(2), FaceGeometry(3), FaceGeometry(0));
+                Triangle3D3< NodeType > tri_2(FaceGeometry(2), FaceGeometry(3), FaceGeometry(0));
                 CreateNewCondition(pThisProperties, tri_2, CondId, r_condition);
                 condition_ids[1] = CondId;
                 ++CondCounter;
@@ -313,22 +313,22 @@ inline void InterfacePreprocessCondition::GenerateFaceCondition(
                 // We initialize a vector for the IDs
                 std::vector<std::size_t> condition_ids(4);
                 
-                Triangle3D3< Node<3> > tri_1(FaceGeometry(0), FaceGeometry(1), FaceGeometry(5));
+                Triangle3D3< NodeType > tri_1(FaceGeometry(0), FaceGeometry(1), FaceGeometry(5));
                 CreateNewCondition(pThisProperties, tri_1, CondId, r_condition);
                 condition_ids[0] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_2(FaceGeometry(1), FaceGeometry(2), FaceGeometry(3));
+                Triangle3D3< NodeType > tri_2(FaceGeometry(1), FaceGeometry(2), FaceGeometry(3));
                 CreateNewCondition(pThisProperties, tri_2, CondId, r_condition);
                 condition_ids[1] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_3(FaceGeometry(1), FaceGeometry(3), FaceGeometry(5));
+                Triangle3D3< NodeType > tri_3(FaceGeometry(1), FaceGeometry(3), FaceGeometry(5));
                 CreateNewCondition(pThisProperties, tri_3, CondId, r_condition);
                 condition_ids[2] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_4(FaceGeometry(3), FaceGeometry(4), FaceGeometry(5));
+                Triangle3D3< NodeType > tri_4(FaceGeometry(3), FaceGeometry(4), FaceGeometry(5));
                 CreateNewCondition(pThisProperties, tri_4, CondId, r_condition);
                 condition_ids[3] = CondId;
                 ++CondCounter;
@@ -349,32 +349,32 @@ inline void InterfacePreprocessCondition::GenerateFaceCondition(
                 // We initialize a vector for the IDs
                 std::vector<std::size_t> condition_ids(6);
 
-                Triangle3D3< Node<3> > tri_1(FaceGeometry(0), FaceGeometry(1), FaceGeometry(7));
+                Triangle3D3< NodeType > tri_1(FaceGeometry(0), FaceGeometry(1), FaceGeometry(7));
                 CreateNewCondition(pThisProperties, tri_1, CondId, r_condition);
                 condition_ids[0] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_2(FaceGeometry(1), FaceGeometry(5), FaceGeometry(7));
+                Triangle3D3< NodeType > tri_2(FaceGeometry(1), FaceGeometry(5), FaceGeometry(7));
                 CreateNewCondition(pThisProperties, tri_2, CondId, r_condition);
                 condition_ids[1] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_3(FaceGeometry(1), FaceGeometry(3), FaceGeometry(5));
+                Triangle3D3< NodeType > tri_3(FaceGeometry(1), FaceGeometry(3), FaceGeometry(5));
                 CreateNewCondition(pThisProperties, tri_3, CondId, r_condition);
                 condition_ids[2] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_4(FaceGeometry(1), FaceGeometry(2), FaceGeometry(3));
+                Triangle3D3< NodeType > tri_4(FaceGeometry(1), FaceGeometry(2), FaceGeometry(3));
                 CreateNewCondition(pThisProperties, tri_4, CondId, r_condition);
                 condition_ids[3] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_5(FaceGeometry(3), FaceGeometry(4), FaceGeometry(5));
+                Triangle3D3< NodeType > tri_5(FaceGeometry(3), FaceGeometry(4), FaceGeometry(5));
                 CreateNewCondition(pThisProperties, tri_5, CondId, r_condition);
                 condition_ids[4] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_6(FaceGeometry(5), FaceGeometry(6), FaceGeometry(7));
+                Triangle3D3< NodeType > tri_6(FaceGeometry(5), FaceGeometry(6), FaceGeometry(7));
                 CreateNewCondition(pThisProperties, tri_6, CondId, r_condition);
                 condition_ids[5] = CondId;
                 ++CondCounter;
@@ -395,42 +395,42 @@ inline void InterfacePreprocessCondition::GenerateFaceCondition(
                 // We initialize a vector for the IDs
                 std::vector<std::size_t> condition_ids(8);
 
-                Triangle3D3< Node<3> > tri_1(FaceGeometry(0), FaceGeometry(1), FaceGeometry(8));
+                Triangle3D3< NodeType > tri_1(FaceGeometry(0), FaceGeometry(1), FaceGeometry(8));
                 CreateNewCondition(pThisProperties, tri_1, CondId, r_condition);
                 condition_ids[0] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_2(FaceGeometry(1), FaceGeometry(2), FaceGeometry(3));
+                Triangle3D3< NodeType > tri_2(FaceGeometry(1), FaceGeometry(2), FaceGeometry(3));
                 CreateNewCondition(pThisProperties, tri_2, CondId, r_condition);
                 condition_ids[1] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_3(FaceGeometry(1), FaceGeometry(3), FaceGeometry(8));
+                Triangle3D3< NodeType > tri_3(FaceGeometry(1), FaceGeometry(3), FaceGeometry(8));
                 CreateNewCondition(pThisProperties, tri_3, CondId, r_condition);
                 condition_ids[2] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_4(FaceGeometry(8), FaceGeometry(3), FaceGeometry(4));
+                Triangle3D3< NodeType > tri_4(FaceGeometry(8), FaceGeometry(3), FaceGeometry(4));
                 CreateNewCondition(pThisProperties, tri_4, CondId, r_condition);
                 condition_ids[3] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_5(FaceGeometry(8), FaceGeometry(4), FaceGeometry(5));
+                Triangle3D3< NodeType > tri_5(FaceGeometry(8), FaceGeometry(4), FaceGeometry(5));
                 CreateNewCondition(pThisProperties, tri_5, CondId, r_condition);
                 condition_ids[4] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_6(FaceGeometry(5), FaceGeometry(6), FaceGeometry(7));
+                Triangle3D3< NodeType > tri_6(FaceGeometry(5), FaceGeometry(6), FaceGeometry(7));
                 CreateNewCondition(pThisProperties, tri_6, CondId, r_condition);
                 condition_ids[5] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_7(FaceGeometry(5), FaceGeometry(7), FaceGeometry(8));
+                Triangle3D3< NodeType > tri_7(FaceGeometry(5), FaceGeometry(7), FaceGeometry(8));
                 CreateNewCondition(pThisProperties, tri_7, CondId, r_condition);
                 condition_ids[6] = CondId;
                 ++CondCounter;
                 ++CondId;
-                Triangle3D3< Node<3> > tri_8(FaceGeometry(0), FaceGeometry(8), FaceGeometry(7));
+                Triangle3D3< NodeType > tri_8(FaceGeometry(0), FaceGeometry(8), FaceGeometry(7));
                 CreateNewCondition(pThisProperties, tri_8, CondId, r_condition);
                 condition_ids[7] = CondId;
                 ++CondCounter;

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.cpp
@@ -153,6 +153,11 @@ std::unordered_map<IndexType, Properties::Pointer> InterfacePreprocessCondition:
         CopyProperties(p_original_prop, p_new_prop, YOUNG_MODULUS);
     }
 
+    // Adding created properties to the parent model part
+    for (auto& prop : new_properties) {
+        mrMainModelPart.AddProperties(prop.second);
+    }
+
     return new_properties;
 }
 

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.cpp
@@ -138,24 +138,28 @@ std::unordered_map<IndexType, Properties::Pointer> InterfacePreprocessCondition:
         ++count;
         it_prop->SetId(count);
     }
-    // Create new properties
+
+    // Create a vector with the ids of the old properties
+    const SizeType number_properties_origin = rOriginPart.NumberOfProperties();
+    std::vector<IndexType> index_vector(number_properties_origin);
     count = 0;
     for (auto it_prop = rOriginPart.PropertiesBegin(); it_prop < rOriginPart.PropertiesEnd(); ++it_prop) {
-        Properties::Pointer p_original_prop = *(it_prop.base());
+        index_vector[count] = it_prop->Id();
         ++count;
-        Properties new_prop(number_properties + count + 1);
-        Properties::Pointer p_new_prop = Kratos::make_shared<Properties>(new_prop);
-        new_properties.insert({p_original_prop->Id(), p_new_prop});
+    }
+
+    // Copy to the new properties
+    count = 0;
+    for (auto& i_prop : index_vector) {
+        Properties::Pointer p_original_prop = mrMainModelPart.pGetProperties(i_prop);;
+        ++count;
+        Properties::Pointer p_new_prop = mrMainModelPart.pGetProperties(number_properties + count + 1);
+        new_properties.insert({i_prop, p_new_prop});
 
         // Now we copy (an remove) the properties we have interest
         CopyProperties(p_original_prop, p_new_prop, FRICTION_COEFFICIENT);
         CopyProperties(p_original_prop, p_new_prop, THICKNESS, false);
         CopyProperties(p_original_prop, p_new_prop, YOUNG_MODULUS);
-    }
-
-    // Adding created properties to the parent model part
-    for (auto& prop : new_properties) {
-        mrMainModelPart.AddProperties(prop.second);
     }
 
     return new_properties;

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.cpp
@@ -179,8 +179,12 @@ void InterfacePreprocessCondition::CreateNewCondition(
     // We set the condition as master or slave (master by default)
     GeometryType& this_geometry = p_cond->GetGeometry();
     bool is_slave = true;
-    for (IndexType it_node = 0; it_node < this_geometry.size(); ++it_node)
-        if (this_geometry[it_node].Is(SLAVE) == false) is_slave = false;
+    for (IndexType i_node = 0; i_node < this_geometry.size(); ++i_node) {
+        if (this_geometry[i_node].Is(SLAVE) == false) {
+            is_slave = false;
+            break;
+        }
+    }
     if (is_slave == true)  p_cond->Set(SLAVE, true);
     else  p_cond->Set(MASTER, true);
 

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.h
@@ -183,12 +183,16 @@ private:
     void CopyProperties(
         Properties::Pointer pOriginalProperty,
         Properties::Pointer pNewProperty,
-        const Variable<TClass>& rVariable
+        const Variable<TClass>& rVariable,
+        const bool AssignZero = true
         )
     {
         if(pOriginalProperty->Has(rVariable)) {
             const TClass& value = pOriginalProperty->GetValue(rVariable);
             pNewProperty->SetValue(rVariable, value);
+        } else if (AssignZero) {
+            KRATOS_INFO("InterfacePreprocessCondition") << "WARNING:: Property " << rVariable.Name() << " not available. Assigning zero value" << std::endl;
+            pNewProperty->SetValue(rVariable, rVariable.Zero());
         }
     }
 

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.h
@@ -31,7 +31,7 @@ namespace Kratos
 ///@}
 ///@name Type Definitions
 ///@{
-    
+
 ///@}
 ///@name  Enum's
 ///@{
@@ -58,18 +58,21 @@ public:
     ///@{
     
     /// Geometric definitions
-    typedef Point                                         PointType;
-    typedef Node<3>                                        NodeType;
-    typedef Geometry<NodeType>                         GeometryType;
-    typedef Geometry<PointType>                   GeometryPointType;
+    typedef Point                                              PointType;
+    typedef Node<3>                                             NodeType;
+    typedef Geometry<NodeType>                              GeometryType;
+    typedef Geometry<PointType>                        GeometryPointType;
 
     /// The index type
-    typedef std::size_t                                   IndexType;
+    typedef std::size_t                                        IndexType;
+
+    /// The size type
+    typedef std::size_t                                         SizeType;
 
     /// Definition of the entities container
-    typedef ModelPart::NodesContainerType            NodesArrayType;
-    typedef ModelPart::ElementsContainerType      ElementsArrayType;
-    typedef ModelPart::ConditionsContainerType  ConditionsArrayType;
+    typedef ModelPart::NodesContainerType                 NodesArrayType;
+    typedef ModelPart::ElementsContainerType           ElementsArrayType;
+    typedef ModelPart::ConditionsContainerType       ConditionsArrayType;
     
     /// Pointer definition of ExactMortarIntegrationUtility
     KRATOS_CLASS_POINTER_DEFINITION(InterfacePreprocessCondition);
@@ -151,7 +154,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    ModelPart&  mrMainModelPart;
+    ModelPart&  mrMainModelPart; /// The main model part storing all the information
     
     ///@}
     ///@name Private Operators
@@ -160,6 +163,34 @@ private:
     ///@}
     ///@name Private Operations
     ///@{
+
+    /**
+     * @brief Creates a new properties (contaning just values related with contact)
+     * @details These values are removed from the original property (in order to reduce overload of properties on the original elements)
+     * @param rOriginPart The original model part
+     * @return A map containing new properties
+     */
+
+    std::unordered_map<IndexType, Properties::Pointer> CreateNewProperties(ModelPart& rOriginPart);
+
+    /**
+     * @brief Copies a value from the original property to the new one
+     * @param pOriginalProperty The original property
+     * @param pNewProperty The new property
+     * @param rVariable The variable to copy an erase
+     */
+    template<class TClass>
+    void CopyProperties(
+        Properties::Pointer pOriginalProperty,
+        Properties::Pointer pNewProperty,
+        const Variable<TClass>& rVariable
+        )
+    {
+        if(pOriginalProperty->Has(rVariable)) {
+            const TClass& value = pOriginalProperty->GetValue(rVariable);
+            pNewProperty->SetValue(rVariable, value);
+        }
+    }
 
     /**
      * @brief Creates a new condition with a giving name

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.h
@@ -23,8 +23,6 @@
 #include "includes/define.h"
 #include "includes/kratos_parameters.h"
 
-// TODO: Add parallellization!!!
-
 namespace Kratos
 {
 ///@name Kratos Globals
@@ -33,11 +31,6 @@ namespace Kratos
 ///@}
 ///@name Type Definitions
 ///@{
-    
-    typedef Point                                     PointType;
-    typedef Node<3>                                    NodeType;
-    typedef Geometry<NodeType>                     GeometryType;
-    typedef Geometry<PointType>               GeometryPointType;
     
 ///@}
 ///@name  Enum's
@@ -51,8 +44,12 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
   
-/** \brief InterfacePreprocessCondition 
- * Creates Model Parts containing the interface
+/**
+ * @ingroup ContactStructuralMechanicsApplication
+ * @class InterfacePreprocessCondition
+ * @brief Creates Model Parts containing the interface
+ * @todo Add parallelization
+ * @author Vicebte Mataix Ferrandiz
  */
 class InterfacePreprocessCondition
 {
@@ -60,9 +57,19 @@ public:
     ///@name Type Definitions
     ///@{
     
-    typedef ModelPart::NodesContainerType                   NodesArrayType;
-    typedef ModelPart::ElementsContainerType             ElementsArrayType;
-    typedef ModelPart::ConditionsContainerType         ConditionsArrayType;
+    /// Geometric definitions
+    typedef Point                                         PointType;
+    typedef Node<3>                                        NodeType;
+    typedef Geometry<NodeType>                         GeometryType;
+    typedef Geometry<PointType>                   GeometryPointType;
+
+    /// The index type
+    typedef std::size_t                                   IndexType;
+
+    /// Definition of the entities container
+    typedef ModelPart::NodesContainerType            NodesArrayType;
+    typedef ModelPart::ElementsContainerType      ElementsArrayType;
+    typedef ModelPart::ConditionsContainerType  ConditionsArrayType;
     
     /// Pointer definition of ExactMortarIntegrationUtility
     KRATOS_CLASS_POINTER_DEFINITION(InterfacePreprocessCondition);
@@ -74,7 +81,7 @@ public:
     /// Constructor
     
     /**
-     * This is the default constructor
+     * @brief This is the default constructor
      * @param rMainModelPrt The model part to consider
      */
     
@@ -95,18 +102,18 @@ public:
     ///@{
 
     /**
-     * Generate a new ModelPart containing only the interface. It will contain the conditions addressed in the call 
+     * @brief Generate a new ModelPart containing only the interface. It will contain the conditions addressed in the call
      * @param rOriginPart The original model part
      * @param rInterfacePart The interface model part
      * @param ThisParameters The configuration parameters
      */
     
-    template<const unsigned int TDim>
+    template<const IndexType TDim>
     void GenerateInterfacePart(
-            ModelPart& rOriginPart,
-            ModelPart& rInterfacePart,
-            Parameters ThisParameters =  Parameters(R"({})")
-            );
+        ModelPart& rOriginPart,
+        ModelPart& rInterfacePart,
+        Parameters ThisParameters =  Parameters(R"({})")
+        );
     
 protected:
     ///@name Protected static Member Variables
@@ -155,7 +162,7 @@ private:
     ///@{
 
     /**
-     * Creates a new condition with a giving name
+     * @brief Creates a new condition with a giving name
      * @param prThisProperties The pointer to the element
      * @param rGeometry The  geometry considered
      * @param CondId The Id of the condition
@@ -163,32 +170,32 @@ private:
      */
 
     void CreateNewCondition(
-            Properties::Pointer prThisProperties,
-            GeometryType& rGeometry,
-            const unsigned int CondId,
-            Condition const& rCondition
-            );
+        Properties::Pointer prThisProperties,
+        GeometryType& rGeometry,
+        const IndexType CondId,
+        Condition const& rCondition
+        );
     
     /**
-     * It prints the nodes and conditions in the interface, gives an error otherwise there are not
+     * @brief It prints the nodes and conditions in the interface, gives an error otherwise there are not
      * @param NodesCounter Number of nodes in the interface
      * @param CondCounter Number of conditions in the interface
      */
 
     void PrintNodesAndConditions(
-            const int NodesCounter,
-            const int CondCounter
-            );
+        const IndexType NodesCounter,
+        const IndexType CondCounter
+        );
     
     /**
-     * It reorders the Ids of the conditions
+     * @brief It reorders the Ids of the conditions
      * @return cond_id: The Id from the last condition
      */
 
-    unsigned int ReorderConditions();
+    IndexType ReorderConditions();
     
     /**
-     * This method creates the conditions for the edges
+     * @brief This method creates the conditions for the edges
      * @param rInterfacePart The model part of the interface
      * @param prThisProperties The properties of the base element
      * @param EdgeGeometry Geometry considered
@@ -202,12 +209,12 @@ private:
         Properties::Pointer prThisProperties,
         GeometryType& EdgeGeometry,
         const bool SimplestGeometry,
-        unsigned int& CondCounter,
-        unsigned int& CondId
+        IndexType& CondCounter,
+        IndexType& CondId
         );
     
     /**
-     * This method creates the conditions for the faces
+     * @brief This method creates the conditions for the faces
      * @param rInterfacePart The model part of the interface
      * @param prThisProperties The properties of the base element
      * @param FaceGeometry Geometry considered
@@ -221,8 +228,8 @@ private:
         Properties::Pointer prThisProperties,
         GeometryType& FaceGeometry,
         const bool SimplestGeometry,
-        unsigned int& CondCounter,
-        unsigned int& CondId
+        IndexType& CondCounter,
+        IndexType& CondId
         );
     
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/interface_preprocess.h
@@ -49,7 +49,7 @@ namespace Kratos
  * @class InterfacePreprocessCondition
  * @brief Creates Model Parts containing the interface
  * @todo Add parallelization
- * @author Vicebte Mataix Ferrandiz
+ * @author Vicente Mataix Ferrandiz
  */
 class InterfacePreprocessCondition
 {
@@ -191,7 +191,7 @@ private:
             const TClass& value = pOriginalProperty->GetValue(rVariable);
             pNewProperty->SetValue(rVariable, value);
         } else if (AssignZero) {
-            KRATOS_INFO("InterfacePreprocessCondition") << "WARNING:: Property " << rVariable.Name() << " not available. Assigning zero value" << std::endl;
+            KRATOS_INFO("InterfacePreprocessCondition") << "Property " << rVariable.Name() << " not available. Assigning zero value" << std::endl;
             pNewProperty->SetValue(rVariable, rVariable.Zero());
         }
     }

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
@@ -181,13 +181,6 @@ class ALMContactProcess(python_process.PythonProcess):
         if self.settings["contact_type"].GetString() == "Frictional":
             process_info[CSMA.TANGENT_FACTOR] = self.settings["tangent_factor"].GetDouble()
 
-        # Copying the properties in the contact model part
-        self.contact_model_part.SetProperties(computing_model_part.GetProperties())
-
-        # Setting the integration order and active check factor
-        for prop in computing_model_part.GetProperties():
-            prop[CSMA.INTEGRATION_ORDER_CONTACT] = self.settings["integration_order"].GetInt()
-
         # We set the interface flag
         KM.VariableUtils().SetFlag(KM.INTERFACE, True, self.contact_model_part.Nodes)
 
@@ -197,6 +190,10 @@ class ALMContactProcess(python_process.PythonProcess):
         else:
             master_slave_process = CSMA.MasterSlaveProcess(computing_model_part)
             master_slave_process.Execute()
+
+        # Setting the integration order and active check factor
+        for prop in self.contact_model_part.GetProperties():
+            prop[CSMA.INTEGRATION_ORDER_CONTACT] = self.settings["integration_order"].GetInt()
 
         # We initialize the contact values
         self._initialize_contact_values(computing_model_part)
@@ -369,11 +366,8 @@ class ALMContactProcess(python_process.PythonProcess):
         if self.settings["contact_type"].GetString() == "Frictional":
             process_info[CSMA.TANGENT_FACTOR] = self.settings["tangent_factor"].GetDouble()
 
-        # Copying the properties in the contact model part
-        self.contact_model_part.SetProperties(computing_model_part.GetProperties())
-
         # Setting the integration order and active check factor
-        for prop in computing_model_part.GetProperties():
+        for prop in self.contact_model_part.GetProperties():
             prop[CSMA.INTEGRATION_ORDER_CONTACT] = self.settings["integration_order"].GetInt()
             prop[CSMA.ACTIVE_CHECK_FACTOR] = self.settings["search_parameters"]["active_check_factor"].GetDouble()
 


### PR DESCRIPTION
This gives more independence to the conditions created + in GiD postprocess are represented as an independent group