### PR TITLE
Hotfix visualization process skin interpolation

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
@@ -101,6 +101,10 @@ EmbeddedSkinVisualizationProcess::EmbeddedSkinVisualizationProcess(
 void EmbeddedSkinVisualizationProcess::ExecuteInitialize() {
     KRATOS_TRY;
 
+    // Check that model part is not empty
+    KRATOS_ERROR_IF(mrModelPart.Nodes().size() == 0) << "There are no nodes in the origin model part.";
+    KRATOS_ERROR_IF(mrModelPart.Elements().size() == 0) << "There are no elements in the origin model part.";
+
     // Required variables check
     const auto &r_orig_node = *mrModelPart.NodesBegin();
 

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
@@ -183,7 +183,7 @@ void EmbeddedSkinVisualizationProcess::ComputeNewNodesInterpolation(){
     const int n_new_elems = mNewElementsPointers.size();
     ModelPart::ElementIterator new_elems_begin = mNewElementsPointers.begin();
 
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for (int i_elem = 0; i_elem < n_new_elems; ++i_elem){
         // Get element geometry
         auto it_elem = new_elems_begin + i_elem;
@@ -243,7 +243,7 @@ void EmbeddedSkinVisualizationProcess::CopyOriginNodes(){
     ModelPart::NodeIterator orig_nodes_begin = mrModelPart.NodesBegin();
     for (int i_node = 0; i_node < n_nodes; ++i_node){
         auto it_node = orig_nodes_begin + i_node;
-        auto p_node = mrVisualizationModelPart.CreateNewNode(it_node->Id(), it_node->X(), it_node->Y(), it_node->Z());
+        auto p_node = mrVisualizationModelPart.CreateNewNode(it_node->Id(), *it_node);
     }
 }
 
@@ -252,7 +252,7 @@ void EmbeddedSkinVisualizationProcess::CopyOriginNodalValues(){
     ModelPart::NodeConstantIterator old_nodes_begin = mrModelPart.NodesBegin();
     ModelPart::NodeIterator new_nodes_begin = mrVisualizationModelPart.NodesBegin();
 
-    #pragma omp parallel for
+    //#pragma omp parallel for
     for (int i_node = 0; i_node < static_cast<int>(n_old_nodes); ++i_node){
         auto it_new_node = new_nodes_begin + i_node;
         const auto it_old_node = old_nodes_begin + i_node;
@@ -398,6 +398,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries(){
             // Get the interface geometries from the splitting pattern 
             const unsigned int n_pos_interface_geom = (p_split_utility->mPositiveInterfaces).size();
             const unsigned int n_neg_interface_geom = (p_split_utility->mNegativeInterfaces).size();
+
             std::vector<DivideGeometry::IndexedPointGeometryPointerType> split_interface_geometries;
             split_interface_geometries.reserve(n_pos_interface_geom + n_neg_interface_geom);
             split_interface_geometries.insert(split_interface_geometries.end(), (p_split_utility->mPositiveInterfaces).begin(), (p_split_utility->mPositiveInterfaces).end());

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
@@ -54,36 +54,22 @@ namespace Kratos
 ///@name  Functions
 ///@{
 
-// struct NodeKeyComparor {
-//     bool operator()(const Node<3>::Pointer& p_lhs, const Node<3>::Pointer& p_rhs) const {
-//         if (p_lhs->Id() != p_rhs->Id()){
-//             return false;
-//         }
-
-//         return true;
-//     }
-// };
-
-// struct NodeKeyHasher {
-//     std::size_t operator()(const Node<3>::Pointer& k) const {
-//         return k->Id();
-//     }
-// };
-
 ///@}
 ///@name Kratos Classes
 ///@{
 
-/// This process saves the intersected elements in a different model part for its visualization.
-/** For a given model part, this process checks if its elements are intersected. If they are, 
- *  calls the corresponding splitting utility to get the subgeometries that conform the splitting
- *  pattern. Then, it saves that subgeometries in another model part for its visualization.
- * 
- *  It has to be mentioned that all the origin model part nodes are kept. Then, the unique nodes
- *  that are created are that ones in the intersection edge points.
- * 
- *  Finally, the values in the visualization model part are computed using the corresponding 
- *  modify shape functions utility. 
+/**
+ * @class EmbeddedSkinVisualizationProcess
+ * @ingroup FluidDynamicsApplication
+ * @brief This process saves the intersected elements in a different model part for its visualization.
+ * @details For a given model part, this process checks if its elements are intersected. If they are, 
+ * calls the corresponding splitting utility to get the subgeometries that conform the splitting
+ * pattern. Then, it saves that subgeometries in another model part for its visualization.
+ * It has to be mentioned that all the origin model part nodes are kept. Then, the unique nodes
+ * that are created are that ones in the intersection edge points.
+ * Finally, the values in the visualization model part are computed using the corresponding 
+ * modify shape functions utility. 
+ * @author Ruben Zorrilla
  */
 class EmbeddedSkinVisualizationProcess : public Process
 {
@@ -119,6 +105,17 @@ public:
     ///@{
 
     /// Constructor.
+
+    /**
+     * @brief Default constructor
+     * @param rModelPart The origin model part
+     * @param rVisualizationModelPart The visualization model part to be filled
+     * @param rVisualizationScalarVariables Scalar variables to be interpolated in the visualization model part
+     * @param rVisualizationVectorVariables Vector variables to be interpolated in the visualization model part
+     * @param rVisualizationComponentVariables Component variables to be interpolated in the visualization model part
+     * @param rShapeFunctions Shape functions type. So far "standard" and "ausas" are implemented
+     * @param ReformModelPartAtEachTimeStep Redo visualization model part at each time step flag
+     */
     EmbeddedSkinVisualizationProcess(
         ModelPart& rModelPart,
         ModelPart& rVisualizationModelPart,
@@ -128,7 +125,12 @@ public:
         const std::string& rShapeFunctions = "standard",
         const bool ReformModelPartAtEachTimeStep = false);
 
-    /// Constructor with Kratos parameters.
+    /**
+     * @brief Constructor with Kratos parameters
+     * @param rModelPart The origin model part
+     * @param rVisualizationModelPart The visualization model part to be filled
+     * @param rParameters Kratos parameters encapsulating the settings
+     */
     EmbeddedSkinVisualizationProcess(
         ModelPart& rModelPart,
         ModelPart& rVisualizationModelPart,
@@ -221,32 +223,80 @@ private:
     ///@name Private Operations
     ///@{
 
+    /**
+     * Computes the interpolation in the new (interface) nodes
+     */
     void ComputeNewNodesInterpolation();
 
+    /**
+     * Copies the non-interface nodes from the origin model part to the visualization one
+     */
     void CopyOriginNodes();
 
+    /**
+     * Copies the non-interface nodes values from the origin model part to the visualization one
+     */
     void CopyOriginNodalValues();
 
+    /**
+     * Creates the new geometrical entities (elements and conditions) in the visualization model part
+     */
     void CreateVisualizationGeometries();
 
+    /**
+     * Checks wether the element is split or not
+     * @param pGeometry Pointer to the element geometry
+     * @param rNodalDistances Vector containing the distance values
+     * @return True if it is split and false if not
+     */
     const bool ElementIsSplit(
         Geometry<Node<3>>::Pointer pGeometry,
         const Vector &rNodalDistances);
 
+    /**
+     * Checks wether the element is in the positive side or not
+     * @param pGeometry Pointer to the element geometry
+     * @param rNodalDistances Vector containing the distance values
+     * @return True if it is split and false if not
+     */
     const bool ElementIsPositive(
         Geometry<Node<3>>::Pointer pGeometry,
         const Vector &rNodalDistances);
 
+    /**
+     * Sets the distance values. If Ausas shape functions are used, 
+     * it takes the ELEMENTAL_DISTANCES. Otherwise, the nodal ones
+     * @param ItElem Element iterator
+     * @return Vector containing the distance values
+     */
     const Vector SetDistancesVector(ModelPart::ElementIterator ItElem);
 
+    /**
+     * Sets the the modified shape functions utility according to the
+     * distance values.
+     * @param pGeometry Pointer to the element geometry
+     * @param rNodalDistances Vector containing the distance values
+     * @return A pointer to the modified shape functions utility
+     */
     ModifiedShapeFunctions::Pointer SetModifiedShapeFunctionsUtility(
         const Geometry<Node<3>>::Pointer pGeometry,
         const Vector &rNodalDistances);
 
+    /**
+     * Sets the new interface condition geometry 
+     * @param rOriginGeometryType Interface subgeometry type
+     * @param rNewNodesArray Nodes that conform the new interface geometry 
+     * @return A pointer to the new geometry
+     */
     Geometry< Node<3> >::Pointer SetNewConditionGeometry(
         const GeometryData::KratosGeometryType &rOriginGeometryType,
         const Condition::NodesArrayType &rNewNodesArray);
 
+    /**
+     * Sets the visualization properties (one for the positive side 
+     * and one for the negative)
+     * @return Tuple containing two properties pointers
+     */
     std::tuple< Properties::Pointer , Properties::Pointer > SetVisualizationProperties();
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
@@ -91,6 +91,20 @@ public:
     ///@name Type Definitions
     ///@{
 
+    struct Hash{
+        std::size_t operator()(const std::pair<unsigned int,bool>& k) const{
+            std::size_t h1 = std::hash<unsigned int>()(std::get<0>(k));
+            std::size_t h2 = std::hash<bool>()(std::get<1>(k));
+            return h1 ^ (h2 << 1);
+        }
+    };
+
+    struct KeyEqual{
+        bool operator()(const std::pair<unsigned int,bool>& lhs, const std::pair<unsigned int,bool>& rhs) const{
+            return ((std::get<0>(lhs) == std::get<0>(rhs)) && (std::get<1>(lhs) == std::get<1>(rhs)));
+        }
+    };
+
     /// Pointer definition of EmbeddedSkinVisualizationProcess
     KRATOS_CLASS_POINTER_DEFINITION(EmbeddedSkinVisualizationProcess);
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_skin_visualization_process.cpp
@@ -20,9 +20,6 @@
 #include "includes/gid_io.h"
 #include "includes/model_part.h"
 #include "includes/cfd_variables.h"
-#include "geometries/hexahedra_3d_8.h"
-#include "geometries/quadrilateral_2d_4.h"
-#include "processes/structured_mesh_generator_process.h"
 
 // Application includes
 #include "fluid_dynamics_application_variables.h"
@@ -31,87 +28,122 @@
 namespace Kratos {
 	namespace Testing {
 
-        void SetElement2D3NModelPart(ModelPart& rNewModelPart){
-            // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
-            Node<3>::Pointer p_point_1 = Kratos::make_shared<Node<3>>(1, 10.00,  0.00, 0.00);
-            Node<3>::Pointer p_point_2 = Kratos::make_shared<Node<3>>(2, 0.00,   0.00, 0.00);
-            Node<3>::Pointer p_point_3 = Kratos::make_shared<Node<3>>(3, 0.00,  10.00, 0.00);
-            Node<3>::Pointer p_point_4 = Kratos::make_shared<Node<3>>(4, 10.00, 10.00, 0.00);
-
-            Quadrilateral2D4<Node<3>> square_domain(p_point_1, p_point_2, p_point_3, p_point_4);
-
-            Parameters mesher_parameters(R"(
-            {
-                "number_of_divisions" :  5,
-                "element_name"        : "Element2D3N"
-            })");
+        void SetUniqueTriangleModelPart(ModelPart& rNewModelPart){
 
             rNewModelPart.AddNodalSolutionStepVariable(DISTANCE);
             rNewModelPart.AddNodalSolutionStepVariable(VELOCITY);
             rNewModelPart.AddNodalSolutionStepVariable(PRESSURE);
-            StructuredMeshGeneratorProcess(square_domain, rNewModelPart, mesher_parameters).Execute();
-        }
 
-        void SetElement3D4NModelPart(ModelPart& rNewModelPart){
-            // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
-            Node<3>::Pointer p_point1 = Kratos::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
-            Node<3>::Pointer p_point2 = Kratos::make_shared<Node<3>>(2, 10.00, 0.00, 0.00);
-            Node<3>::Pointer p_point3 = Kratos::make_shared<Node<3>>(3, 10.00, 10.00, 0.00);
-            Node<3>::Pointer p_point4 = Kratos::make_shared<Node<3>>(4, 0.00, 10.00, 0.00);
-            Node<3>::Pointer p_point5 = Kratos::make_shared<Node<3>>(5, 0.00, 0.00, 10.00);
-            Node<3>::Pointer p_point6 = Kratos::make_shared<Node<3>>(6, 10.00, 0.00, 10.00);
-            Node<3>::Pointer p_point7 = Kratos::make_shared<Node<3>>(7, 10.00, 10.00, 10.00);
-            Node<3>::Pointer p_point8 = Kratos::make_shared<Node<3>>(8, 0.00, 10.00, 10.00);
-
-            Hexahedra3D8<Node<3>> cube_domain(p_point1, p_point2, p_point3, p_point4, p_point5, p_point6, p_point7, p_point8);
-
-            Parameters mesher_parameters(R"(
-            {
-                "number_of_divisions" :  1,
-                "element_name"        : "Element3D4N"
-            })");
-
-            rNewModelPart.AddNodalSolutionStepVariable(DISTANCE);
-            rNewModelPart.AddNodalSolutionStepVariable(VELOCITY);
-            rNewModelPart.AddNodalSolutionStepVariable(PRESSURE);
-            StructuredMeshGeneratorProcess(cube_domain, rNewModelPart, mesher_parameters).Execute();
-        }
-
-	    /** 
-	     * Checks the embedded skin visualization process for triangular meshes.
-	     */
-	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessTriangle, FluidDynamicsApplicationFastSuite)
-		{
-            // Set the triangular elements mesh
-            ModelPart main_model_part("MainModelPart");
-            SetElement2D3NModelPart(main_model_part);
+            // Generate a tetrahedron
+            Properties::Pointer p_properties(new Properties(0));
+            Node<3>::Pointer p_point_1 = rNewModelPart.CreateNewNode(1, 0.0, 0.0, 0.0);
+            Node<3>::Pointer p_point_2 = rNewModelPart.CreateNewNode(2, 10.0, 0.0, 0.0);
+            Node<3>::Pointer p_point_3 = rNewModelPart.CreateNewNode(3, 0.0, 10.0, 0.0);
+            rNewModelPart.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties);
 
             // Set the nodal values
+            const double p_pos = 1.0;
+            const double p_neg = -1.0;
+            array_1d<double, 3> v_pos(3, 0.0);
+            array_1d<double, 3> v_neg(3, 0.0);
+            v_pos[0] = 1.0;
+            v_neg[0] = -1.0;
             const double level_set_height = 4.5;
-            for (unsigned int i_node = 0; i_node < main_model_part.NumberOfNodes(); ++i_node){
-                auto it_node = main_model_part.NodesBegin() + i_node;
+
+            for (unsigned int i_node = 0; i_node < rNewModelPart.NumberOfNodes(); ++i_node){
+                auto it_node = rNewModelPart.NodesBegin() + i_node;
 
                 // Set DISTANCE values
                 const double node_distance = (it_node->Y()) - level_set_height;
                 it_node->FastGetSolutionStepValue(DISTANCE) = node_distance;
 
                 // Set the VELOCITY and PRESSURE values
-                double p_node;
-                array_1d<double, 3> v_node = ZeroVector(3);
                 if (node_distance > 0.0){
-                    v_node[0] = it_node->Y();
-                    v_node[1] = std::pow(it_node->Y(), 2);
-                    p_node = (it_node->X())*(it_node->Y());
+                    it_node->FastGetSolutionStepValue(VELOCITY) = v_pos;
+                    it_node->FastGetSolutionStepValue(PRESSURE) = p_pos;
                 } else {
-                    v_node[0] = -(it_node->Y());
-                    v_node[1] = -(std::pow(it_node->Y(), 2));
-                    p_node = -(it_node->X())*(it_node->Y());
+                    it_node->FastGetSolutionStepValue(VELOCITY) = v_neg;
+                    it_node->FastGetSolutionStepValue(PRESSURE) = p_neg;
                 }
-
-                it_node->FastGetSolutionStepValue(VELOCITY) = v_node;
-                it_node->FastGetSolutionStepValue(PRESSURE) = p_node;
-
             }
+
+            // Copy the nodal distance to ELEMENTAL_DISTANCES variable
+            // (needed in case the Ausas functions are tested)
+            for (unsigned int i_elem = 0; i_elem < rNewModelPart.NumberOfElements(); ++i_elem){
+                auto it_elem = rNewModelPart.ElementsBegin() + i_elem;
+                auto &r_geom = it_elem->GetGeometry();
+                const unsigned int elem_n_nodes = r_geom.PointsNumber();
+                Vector elem_dist(elem_n_nodes);
+                for (unsigned int i_node = 0; i_node < elem_n_nodes; ++i_node)
+                {
+                    elem_dist[i_node] = r_geom[i_node].GetSolutionStepValue(DISTANCE);
+                }
+                it_elem->SetValue(ELEMENTAL_DISTANCES, elem_dist);
+            }
+        }
+
+        void SetUniqueTetrahedronModelPart(ModelPart& rNewModelPart){
+
+            rNewModelPart.AddNodalSolutionStepVariable(DISTANCE);
+            rNewModelPart.AddNodalSolutionStepVariable(VELOCITY);
+            rNewModelPart.AddNodalSolutionStepVariable(PRESSURE);
+
+            // Generate a tetrahedron
+            Properties::Pointer p_properties(new Properties(0));
+            Node<3>::Pointer p_point_1 = rNewModelPart.CreateNewNode(1,  0.0,  0.0,  0.0);
+            Node<3>::Pointer p_point_2 = rNewModelPart.CreateNewNode(2, 10.0,  0.0,  0.0);
+            Node<3>::Pointer p_point_3 = rNewModelPart.CreateNewNode(3,  0.0, 10.0,  0.0);
+            Node<3>::Pointer p_point_4 = rNewModelPart.CreateNewNode(4,  0.0,  0.0, 10.0);
+            rNewModelPart.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
+
+            // Set the nodal values
+            const double p_pos = 1.0;
+            const double p_neg = -1.0;
+            array_1d<double,3> v_pos(3,0.0);
+            array_1d<double,3> v_neg(3,0.0);
+            v_pos[0] = 1.0;
+            v_neg[0] = -1.0;
+            const double level_set_height = 4.5;
+
+            for (unsigned int i_node = 0; i_node < rNewModelPart.NumberOfNodes(); ++i_node){
+                auto it_node = rNewModelPart.NodesBegin() + i_node;
+
+                // Set DISTANCE values
+                const double node_distance = (it_node->Z()) - level_set_height;
+                it_node->FastGetSolutionStepValue(DISTANCE) = node_distance;
+
+                // Set the VELOCITY and PRESSURE values
+                if (node_distance > 0.0){
+                    it_node->FastGetSolutionStepValue(VELOCITY) = v_pos;
+                    it_node->FastGetSolutionStepValue(PRESSURE) = p_pos;
+                } else {
+                    it_node->FastGetSolutionStepValue(VELOCITY) = v_neg;
+                    it_node->FastGetSolutionStepValue(PRESSURE) = p_neg;
+                }
+            }
+
+            // Copy the nodal distance to ELEMENTAL_DISTANCES variable
+            // (needed in case the Ausas functions are tested)
+            for (unsigned int i_elem = 0; i_elem < rNewModelPart.NumberOfElements(); ++i_elem){
+                auto it_elem = rNewModelPart.ElementsBegin() + i_elem;
+                auto &r_geom = it_elem->GetGeometry();
+                const unsigned int elem_n_nodes = r_geom.PointsNumber();
+                Vector elem_dist(elem_n_nodes);
+                for (unsigned int i_node = 0; i_node < elem_n_nodes; ++i_node){
+                    elem_dist[i_node] = r_geom[i_node].GetSolutionStepValue(DISTANCE);
+                }
+                it_elem->SetValue(ELEMENTAL_DISTANCES, elem_dist);
+            }
+        }
+
+	    /** 
+	     * Checks the embedded skin visualization process for a unique triangle with the standard shape functions
+	     */
+	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessUniqueTriangleStandard, FluidDynamicsApplicationFastSuite)
+		{
+            // Set the test model part
+            ModelPart main_model_part("MainModelPart");
+            SetUniqueTriangleModelPart(main_model_part);
 
             // Create the visualization model part
             ModelPart visualization_model_part("VisualizationModelPart");
@@ -137,63 +169,31 @@ namespace Kratos {
             skin_visualization_process.ExecuteBeforeOutputStep();
             skin_visualization_process.ExecuteFinalizeSolutionStep();
 
-            GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/visualizaton_model_part_2d", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
-            gid_io_fluid.InitializeMesh(0);
-            gid_io_fluid.WriteMesh(visualization_model_part.GetMesh());
-            gid_io_fluid.FinalizeMesh();
-            gid_io_fluid.InitializeResults(0, visualization_model_part.GetMesh());
-            gid_io_fluid.WriteNodalResults(VELOCITY, visualization_model_part.Nodes(), 0, 0);
-            gid_io_fluid.WriteNodalResults(PRESSURE, visualization_model_part.Nodes(), 0, 0);
-            gid_io_fluid.FinalizeResults();
-        }
+            // Check values
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(1).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(2).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(3).FastGetSolutionStepValue(PRESSURE), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(4).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(5).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(6).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(7).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(1).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(2).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(3).FastGetSolutionStepValue(VELOCITY_X), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(4).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(5).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(6).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(7).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+	    }
 
 	    /** 
-	     * Checks the embedded skin visualization process for triangular meshes.
+	     * Checks the embedded skin visualization process for a unique triangle with the Ausas shape functions
 	     */
-	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessTriangleAusas, FluidDynamicsApplicationFastSuite)
-        {
-            // Set the triangular elements mesh
+	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessUniqueTriangleAusas, FluidDynamicsApplicationFastSuite)
+		{
+            // Set the test model part
             ModelPart main_model_part("MainModelPart");
-            SetElement2D3NModelPart(main_model_part);
-
-            // Set the nodal values
-            const double p_pos = 1.0;
-            const double p_neg = -1.0;
-            array_1d<double,3> v_pos(3,0.0);
-            array_1d<double,3> v_neg(3,0.0);
-            v_pos[0] = 1.0;
-            v_neg[0] = -1.0;
-            const double level_set_height = 4.5;
-
-            for (unsigned int i_node = 0; i_node < main_model_part.NumberOfNodes(); ++i_node){
-                auto it_node = main_model_part.NodesBegin() + i_node;
-
-                // Set DISTANCE values
-                const double node_distance = (it_node->Y()) - level_set_height;
-                it_node->FastGetSolutionStepValue(DISTANCE) = node_distance;
-
-                // Set the VELOCITY and PRESSURE values
-                if (node_distance > 0.0){
-                    it_node->FastGetSolutionStepValue(VELOCITY) = v_pos;
-                    it_node->FastGetSolutionStepValue(PRESSURE) = p_pos;
-                } else {
-                    it_node->FastGetSolutionStepValue(VELOCITY) = v_neg;
-                    it_node->FastGetSolutionStepValue(PRESSURE) = p_neg;
-                }
-            }
-
-            // Copy the nodal distance to ELEMENTAL_DISTANCES variable
-            // (needed in case the Ausas functions are tested)
-            for (unsigned int i_elem = 0; i_elem < main_model_part.NumberOfElements(); ++i_elem){
-                auto it_elem = main_model_part.ElementsBegin() + i_elem;
-                auto &r_geom = it_elem->GetGeometry();
-                const unsigned int elem_n_nodes = r_geom.PointsNumber();
-                Vector elem_dist(elem_n_nodes);
-                for (unsigned int i_node = 0; i_node < elem_n_nodes; ++i_node){
-                    elem_dist[i_node] = r_geom[i_node].GetSolutionStepValue(DISTANCE);
-                }
-                it_elem->SetValue(ELEMENTAL_DISTANCES, elem_dist);
-            }
+            SetUniqueTriangleModelPart(main_model_part);
 
             // Create the visualization model part
             ModelPart visualization_model_part("VisualizationModelPart");
@@ -219,51 +219,31 @@ namespace Kratos {
             skin_visualization_process.ExecuteBeforeOutputStep();
             skin_visualization_process.ExecuteFinalizeSolutionStep();
 
-            GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/visualizaton_model_part_2d_ausas", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
-            gid_io_fluid.InitializeMesh(0);
-            gid_io_fluid.WriteMesh(visualization_model_part.GetMesh());
-            gid_io_fluid.FinalizeMesh();
-            gid_io_fluid.InitializeResults(0, visualization_model_part.GetMesh());
-            gid_io_fluid.WriteNodalResults(VELOCITY, visualization_model_part.Nodes(), 0, 0);
-            gid_io_fluid.WriteNodalResults(PRESSURE, visualization_model_part.Nodes(), 0, 0);
-            gid_io_fluid.FinalizeResults();
-        }
+            // Check values
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(1).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(2).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(3).FastGetSolutionStepValue(PRESSURE), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(4).FastGetSolutionStepValue(PRESSURE), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(5).FastGetSolutionStepValue(PRESSURE), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(6).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(7).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(1).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(2).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(3).FastGetSolutionStepValue(VELOCITY_X), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(4).FastGetSolutionStepValue(VELOCITY_X), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(5).FastGetSolutionStepValue(VELOCITY_X), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(6).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(7).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+	    }
 
 	    /** 
-	     * Checks the embedded skin visualization process for tetrahedral meshes.
+	     * Checks the embedded skin visualization process for a unique tetrahedron using the standard shape functions
 	     */
-	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessTetrahedra, FluidDynamicsApplicationFastSuite)
+	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessUniqueTetrahedronStandard, FluidDynamicsApplicationFastSuite)
 		{
-            // Set tetrahedral elements mesh
+            // Set the test model part
             ModelPart main_model_part("MainModelPart");
-            SetElement3D4NModelPart(main_model_part);
-
-            // Set the nodal values
-            const double level_set_height = 4.5;
-            for (unsigned int i_node = 0; i_node < main_model_part.NumberOfNodes(); ++i_node){
-                auto it_node = main_model_part.NodesBegin() + i_node;
-
-                // Set DISTANCE values
-                const double node_distance = (it_node->Z()) - level_set_height;
-                it_node->FastGetSolutionStepValue(DISTANCE) = node_distance;
-
-                // Set the VELOCITY and PRESSURE values
-                double p_node;
-                array_1d<double, 3> v_node = ZeroVector(3);
-                if (node_distance > 0.0){
-                    v_node[0] = it_node->X()*it_node->Z();
-                    v_node[1] = it_node->X()*it_node->Z();
-                    p_node = (std::pow(it_node->X(), 3))*it_node->Z();
-                } else {
-                    v_node[0] = -(it_node->X()*it_node->Z());
-                    v_node[1] = -(it_node->X()*it_node->Z());
-                    p_node = -(std::pow(it_node->X(), 2.5))*it_node->Z();
-                }
-
-                it_node->FastGetSolutionStepValue(VELOCITY) = v_node;
-                it_node->FastGetSolutionStepValue(PRESSURE) = p_node;
-
-            }
+            SetUniqueTetrahedronModelPart(main_model_part);
 
             // Create the visualization model part
             ModelPart visualization_model_part("VisualizationModelPart");
@@ -289,157 +269,43 @@ namespace Kratos {
             skin_visualization_process.ExecuteBeforeOutputStep();
             skin_visualization_process.ExecuteFinalizeSolutionStep();
 
-            GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/visualizaton_model_part_3d", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
-            gid_io_fluid.InitializeMesh(0.0);
-            gid_io_fluid.WriteMesh(visualization_model_part.GetMesh());
-            gid_io_fluid.FinalizeMesh();
-            gid_io_fluid.InitializeResults(0, visualization_model_part.GetMesh());
-            gid_io_fluid.WriteNodalResults(VELOCITY, visualization_model_part.Nodes(), 0, 0);
-            gid_io_fluid.WriteNodalResults(PRESSURE, visualization_model_part.Nodes(), 0, 0);
-            gid_io_fluid.FinalizeResults();
-
+            // Check values
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(1).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(2).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(3).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(4).FastGetSolutionStepValue(PRESSURE), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(5).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(6).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(7).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(8).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(9).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(10).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(11).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(12).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(13).FastGetSolutionStepValue(PRESSURE), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(1).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(2).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(3).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(4).FastGetSolutionStepValue(VELOCITY_X), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(5).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(6).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(7).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(8).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(9).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(10).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(11).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(12).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(13).FastGetSolutionStepValue(VELOCITY_X), -0.1, 1e-8);
 	    }
 
 	    /** 
-	     * Checks the embedded skin visualization process for tetrahedral meshes.
-	     */
-	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessTetrahedraAusas, FluidDynamicsApplicationFastSuite)
-		{
-            // Set tetrahedral elements mesh
-            ModelPart main_model_part("MainModelPart");
-            SetElement3D4NModelPart(main_model_part);
-
-            // Set the nodal values
-            const double p_pos = 1.0;
-            const double p_neg = -1.0;
-            array_1d<double,3> v_pos(3,0.0);
-            array_1d<double,3> v_neg(3,0.0);
-            v_pos[0] = 1.0;
-            v_neg[0] = -1.0;
-            const double level_set_height = 4.5;
-
-            for (unsigned int i_node = 0; i_node < main_model_part.NumberOfNodes(); ++i_node){
-                auto it_node = main_model_part.NodesBegin() + i_node;
-
-                // Set DISTANCE values
-                const double node_distance = (it_node->Z()) - level_set_height;
-                it_node->FastGetSolutionStepValue(DISTANCE) = node_distance;
-
-                // Set the VELOCITY and PRESSURE values
-                if (node_distance > 0.0){
-                    it_node->FastGetSolutionStepValue(VELOCITY) = v_pos;
-                    it_node->FastGetSolutionStepValue(PRESSURE) = p_pos;
-                } else {
-                    it_node->FastGetSolutionStepValue(VELOCITY) = v_neg;
-                    it_node->FastGetSolutionStepValue(PRESSURE) = p_neg;
-                }
-            }
-
-            // Copy the nodal distance to ELEMENTAL_DISTANCES variable
-            // (needed in case the Ausas functions are tested)
-            for (unsigned int i_elem = 0; i_elem < main_model_part.NumberOfElements(); ++i_elem){
-                auto it_elem = main_model_part.ElementsBegin() + i_elem;
-                auto &r_geom = it_elem->GetGeometry();
-                const unsigned int elem_n_nodes = r_geom.PointsNumber();
-                Vector elem_dist(elem_n_nodes);
-                for (unsigned int i_node = 0; i_node < elem_n_nodes; ++i_node){
-                    elem_dist[i_node] = r_geom[i_node].GetSolutionStepValue(DISTANCE);
-                }
-                it_elem->SetValue(ELEMENTAL_DISTANCES, elem_dist);
-            }
-
-            // Create the visualization model part
-            ModelPart visualization_model_part("VisualizationModelPart");
-            visualization_model_part.AddNodalSolutionStepVariable(DISTANCE);
-            visualization_model_part.AddNodalSolutionStepVariable(VELOCITY);
-            visualization_model_part.AddNodalSolutionStepVariable(PRESSURE);
-
-            // Set the embedded skin visualization process
-            Parameters visualization_settings(R"(
-            {
-                "shape_functions"         : "ausas",
-                "visualization_variables" : ["VELOCITY","PRESSURE"]
-            })");
-
-            EmbeddedSkinVisualizationProcess skin_visualization_process(
-                main_model_part, 
-                visualization_model_part, 
-                visualization_settings);
-
-            skin_visualization_process.ExecuteInitialize();
-            skin_visualization_process.ExecuteBeforeSolutionLoop();
-            skin_visualization_process.ExecuteInitializeSolutionStep();
-            skin_visualization_process.ExecuteBeforeOutputStep();
-            skin_visualization_process.ExecuteFinalizeSolutionStep();
-
-            GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/visualizaton_model_part_3d_ausas", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
-            gid_io_fluid.InitializeMesh(0.0);
-            gid_io_fluid.WriteMesh(visualization_model_part.GetMesh());
-            gid_io_fluid.FinalizeMesh();
-            gid_io_fluid.InitializeResults(0, visualization_model_part.GetMesh());
-            gid_io_fluid.WriteNodalResults(VELOCITY, visualization_model_part.Nodes(), 0, 0);
-            gid_io_fluid.WriteNodalResults(PRESSURE, visualization_model_part.Nodes(), 0, 0);
-            gid_io_fluid.FinalizeResults();
-
-	    }
-
-	    /** 
-	     * Checks the embedded skin visualization process for tetrahedral meshes.
+	     * Checks the embedded skin visualization process for a unique tetrahedron using the Ausas shape functions
 	     */
 	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessUniqueTetrahedronAusas, FluidDynamicsApplicationFastSuite)
 		{
             // Set the test model part
             ModelPart main_model_part("MainModelPart");
-            main_model_part.AddNodalSolutionStepVariable(DISTANCE);
-            main_model_part.AddNodalSolutionStepVariable(VELOCITY);
-            main_model_part.AddNodalSolutionStepVariable(PRESSURE);
-
-            // Generate a tetrahedron
-            Properties::Pointer p_properties(new Properties(0));
-            Node<3>::Pointer p_point_1 = main_model_part.CreateNewNode(1,  0.0,  0.0,  0.0);
-            Node<3>::Pointer p_point_2 = main_model_part.CreateNewNode(2, 10.0,  0.0,  0.0);
-            Node<3>::Pointer p_point_3 = main_model_part.CreateNewNode(3,  0.0, 10.0,  0.0);
-            Node<3>::Pointer p_point_4 = main_model_part.CreateNewNode(4,  0.0,  0.0, 10.0);
-            main_model_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties);
-
-            // Set the nodal values
-            const double p_pos = 1.0;
-            const double p_neg = -1.0;
-            array_1d<double,3> v_pos(3,0.0);
-            array_1d<double,3> v_neg(3,0.0);
-            v_pos[0] = 1.0;
-            v_neg[0] = -1.0;
-            const double level_set_height = 4.5;
-
-            for (unsigned int i_node = 0; i_node < main_model_part.NumberOfNodes(); ++i_node){
-                auto it_node = main_model_part.NodesBegin() + i_node;
-
-                // Set DISTANCE values
-                const double node_distance = (it_node->Z()) - level_set_height;
-                it_node->FastGetSolutionStepValue(DISTANCE) = node_distance;
-
-                // Set the VELOCITY and PRESSURE values
-                if (node_distance > 0.0){
-                    it_node->FastGetSolutionStepValue(VELOCITY) = v_pos;
-                    it_node->FastGetSolutionStepValue(PRESSURE) = p_pos;
-                } else {
-                    it_node->FastGetSolutionStepValue(VELOCITY) = v_neg;
-                    it_node->FastGetSolutionStepValue(PRESSURE) = p_neg;
-                }
-            }
-
-            // Copy the nodal distance to ELEMENTAL_DISTANCES variable
-            // (needed in case the Ausas functions are tested)
-            for (unsigned int i_elem = 0; i_elem < main_model_part.NumberOfElements(); ++i_elem){
-                auto it_elem = main_model_part.ElementsBegin() + i_elem;
-                auto &r_geom = it_elem->GetGeometry();
-                const unsigned int elem_n_nodes = r_geom.PointsNumber();
-                Vector elem_dist(elem_n_nodes);
-                for (unsigned int i_node = 0; i_node < elem_n_nodes; ++i_node){
-                    elem_dist[i_node] = r_geom[i_node].GetSolutionStepValue(DISTANCE);
-                }
-                it_elem->SetValue(ELEMENTAL_DISTANCES, elem_dist);
-            }
+            SetUniqueTetrahedronModelPart(main_model_part);
 
             // Create the visualization model part
             ModelPart visualization_model_part("VisualizationModelPart");
@@ -465,15 +331,33 @@ namespace Kratos {
             skin_visualization_process.ExecuteBeforeOutputStep();
             skin_visualization_process.ExecuteFinalizeSolutionStep();
 
-            GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/visualizaton_model_part_3d_ausas", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
-            gid_io_fluid.InitializeMesh(0.0);
-            gid_io_fluid.WriteMesh(visualization_model_part.GetMesh());
-            gid_io_fluid.FinalizeMesh();
-            gid_io_fluid.InitializeResults(0, visualization_model_part.GetMesh());
-            gid_io_fluid.WriteNodalResults(VELOCITY, visualization_model_part.Nodes(), 0, 0);
-            gid_io_fluid.WriteNodalResults(PRESSURE, visualization_model_part.Nodes(), 0, 0);
-            gid_io_fluid.FinalizeResults();
-
+            // Check values
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(1).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(2).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(3).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(4).FastGetSolutionStepValue(PRESSURE), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(5).FastGetSolutionStepValue(PRESSURE), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(6).FastGetSolutionStepValue(PRESSURE), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(7).FastGetSolutionStepValue(PRESSURE), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(8).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(9).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(10).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(11).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(12).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(13).FastGetSolutionStepValue(PRESSURE), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(1).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(2).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(3).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(4).FastGetSolutionStepValue(VELOCITY_X), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(5).FastGetSolutionStepValue(VELOCITY_X), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(6).FastGetSolutionStepValue(VELOCITY_X), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(7).FastGetSolutionStepValue(VELOCITY_X), 1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(8).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(9).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(10).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(11).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(12).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
+            KRATOS_CHECK_NEAR(visualization_model_part.GetNode(13).FastGetSolutionStepValue(VELOCITY_X), -1.0, 1e-8);
 	    }
     } // namespace Testing
 }  // namespace Kratos.

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_skin_visualization_process.cpp
@@ -17,7 +17,6 @@
 
 // Project includes
 #include "testing/testing.h"
-#include "includes/gid_io.h"
 #include "includes/model_part.h"
 #include "includes/cfd_variables.h"
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_skin_visualization_process.cpp
@@ -31,12 +31,7 @@
 namespace Kratos {
 	namespace Testing {
 
-	    /** 
-	     * Checks the embedded skin visualization process for triangular meshes.
-	     */
-	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessTriangle, FluidDynamicsApplicationFastSuite)
-		{
-
+        void SetElement2D3NModelPart(ModelPart& rNewModelPart){
             // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
             Node<3>::Pointer p_point_1 = Kratos::make_shared<Node<3>>(1, 10.00,  0.00, 0.00);
             Node<3>::Pointer p_point_2 = Kratos::make_shared<Node<3>>(2, 0.00,   0.00, 0.00);
@@ -51,11 +46,45 @@ namespace Kratos {
                 "element_name"        : "Element2D3N"
             })");
 
+            rNewModelPart.AddNodalSolutionStepVariable(DISTANCE);
+            rNewModelPart.AddNodalSolutionStepVariable(VELOCITY);
+            rNewModelPart.AddNodalSolutionStepVariable(PRESSURE);
+            StructuredMeshGeneratorProcess(square_domain, rNewModelPart, mesher_parameters).Execute();
+        }
+
+        void SetElement3D4NModelPart(ModelPart& rNewModelPart){
+            // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
+            Node<3>::Pointer p_point1 = Kratos::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
+            Node<3>::Pointer p_point2 = Kratos::make_shared<Node<3>>(2, 10.00, 0.00, 0.00);
+            Node<3>::Pointer p_point3 = Kratos::make_shared<Node<3>>(3, 10.00, 10.00, 0.00);
+            Node<3>::Pointer p_point4 = Kratos::make_shared<Node<3>>(4, 0.00, 10.00, 0.00);
+            Node<3>::Pointer p_point5 = Kratos::make_shared<Node<3>>(5, 0.00, 0.00, 10.00);
+            Node<3>::Pointer p_point6 = Kratos::make_shared<Node<3>>(6, 10.00, 0.00, 10.00);
+            Node<3>::Pointer p_point7 = Kratos::make_shared<Node<3>>(7, 10.00, 10.00, 10.00);
+            Node<3>::Pointer p_point8 = Kratos::make_shared<Node<3>>(8, 0.00, 10.00, 10.00);
+
+            Hexahedra3D8<Node<3>> cube_domain(p_point1, p_point2, p_point3, p_point4, p_point5, p_point6, p_point7, p_point8);
+
+            Parameters mesher_parameters(R"(
+            {
+                "number_of_divisions" :  1,
+                "element_name"        : "Element3D4N"
+            })");
+
+            rNewModelPart.AddNodalSolutionStepVariable(DISTANCE);
+            rNewModelPart.AddNodalSolutionStepVariable(VELOCITY);
+            rNewModelPart.AddNodalSolutionStepVariable(PRESSURE);
+            StructuredMeshGeneratorProcess(cube_domain, rNewModelPart, mesher_parameters).Execute();
+        }
+
+	    /** 
+	     * Checks the embedded skin visualization process for triangular meshes.
+	     */
+	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessTriangle, FluidDynamicsApplicationFastSuite)
+		{
+            // Set the triangular elements mesh
             ModelPart main_model_part("MainModelPart");
-            main_model_part.AddNodalSolutionStepVariable(DISTANCE);
-            main_model_part.AddNodalSolutionStepVariable(VELOCITY);
-            main_model_part.AddNodalSolutionStepVariable(PRESSURE);
-            StructuredMeshGeneratorProcess(square_domain, main_model_part, mesher_parameters).Execute();
+            SetElement2D3NModelPart(main_model_part);
 
             // Set the nodal values
             const double level_set_height = 4.5;
@@ -84,19 +113,6 @@ namespace Kratos {
 
             }
 
-            // Copy the nodal distance to ELEMENTAL_DISTANCES variable
-            // (needed in case the Ausas functions are tested)
-            // for (unsigned int i_elem = 0; i_elem < main_model_part.NumberOfElements(); ++i_elem){
-            //     auto it_elem = main_model_part.ElementsBegin() + i_elem;
-            //     auto &r_geom = it_elem->GetGeometry();
-            //     const unsigned int elem_n_nodes = r_geom.PointsNumber();
-            //     Vector elem_dist(elem_n_nodes);
-            //     for (unsigned int i_node = 0; i_node < elem_n_nodes; ++i_node){
-            //         elem_dist[i_node] = r_geom[i_node].GetSolutionStepValue(DISTANCE);
-            //     }
-            //     it_elem->SetValue(ELEMENTAL_DISTANCES, elem_dist);
-            // }
-
             // Create the visualization model part
             ModelPart visualization_model_part("VisualizationModelPart");
             visualization_model_part.AddNodalSolutionStepVariable(DISTANCE);
@@ -121,7 +137,89 @@ namespace Kratos {
             skin_visualization_process.ExecuteBeforeOutputStep();
             skin_visualization_process.ExecuteFinalizeSolutionStep();
 
-            GidIO<> gid_io_fluid("/home/rzorrilla/Kratos/tests/visualizaton_model_part_2d", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
+            GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/visualizaton_model_part_2d", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
+            gid_io_fluid.InitializeMesh(0);
+            gid_io_fluid.WriteMesh(visualization_model_part.GetMesh());
+            gid_io_fluid.FinalizeMesh();
+            gid_io_fluid.InitializeResults(0, visualization_model_part.GetMesh());
+            gid_io_fluid.WriteNodalResults(VELOCITY, visualization_model_part.Nodes(), 0, 0);
+            gid_io_fluid.WriteNodalResults(PRESSURE, visualization_model_part.Nodes(), 0, 0);
+            gid_io_fluid.FinalizeResults();
+        }
+
+	    /** 
+	     * Checks the embedded skin visualization process for triangular meshes.
+	     */
+	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessTriangleAusas, FluidDynamicsApplicationFastSuite)
+        {
+            // Set the triangular elements mesh
+            ModelPart main_model_part("MainModelPart");
+            SetElement2D3NModelPart(main_model_part);
+
+            // Set the nodal values
+            const double p_pos = 1.0;
+            const double p_neg = -1.0;
+            array_1d<double,3> v_pos(0.0);
+            array_1d<double,3> v_neg(0.0);
+            v_pos[0] = 1.0;
+            v_neg[0] = -1.0;
+            const double level_set_height = 4.5;
+
+            for (unsigned int i_node = 0; i_node < main_model_part.NumberOfNodes(); ++i_node){
+                auto it_node = main_model_part.NodesBegin() + i_node;
+
+                // Set DISTANCE values
+                const double node_distance = (it_node->Y()) - level_set_height;
+                it_node->FastGetSolutionStepValue(DISTANCE) = node_distance;
+
+                // Set the VELOCITY and PRESSURE values
+                if (node_distance > 0.0){
+                    it_node->FastGetSolutionStepValue(VELOCITY) = v_pos;
+                    it_node->FastGetSolutionStepValue(PRESSURE) = p_pos;
+                } else {
+                    it_node->FastGetSolutionStepValue(VELOCITY) = v_neg;
+                    it_node->FastGetSolutionStepValue(PRESSURE) = p_neg;
+                }
+            }
+
+            // Copy the nodal distance to ELEMENTAL_DISTANCES variable
+            // (needed in case the Ausas functions are tested)
+            for (unsigned int i_elem = 0; i_elem < main_model_part.NumberOfElements(); ++i_elem){
+                auto it_elem = main_model_part.ElementsBegin() + i_elem;
+                auto &r_geom = it_elem->GetGeometry();
+                const unsigned int elem_n_nodes = r_geom.PointsNumber();
+                Vector elem_dist(elem_n_nodes);
+                for (unsigned int i_node = 0; i_node < elem_n_nodes; ++i_node){
+                    elem_dist[i_node] = r_geom[i_node].GetSolutionStepValue(DISTANCE);
+                }
+                it_elem->SetValue(ELEMENTAL_DISTANCES, elem_dist);
+            }
+
+            // Create the visualization model part
+            ModelPart visualization_model_part("VisualizationModelPart");
+            visualization_model_part.AddNodalSolutionStepVariable(DISTANCE);
+            visualization_model_part.AddNodalSolutionStepVariable(VELOCITY);
+            visualization_model_part.AddNodalSolutionStepVariable(PRESSURE);
+
+            // Set the embedded skin visualization process
+            Parameters visualization_settings(R"(
+            {
+                "shape_functions"         : "ausas",
+                "visualization_variables" : ["VELOCITY","PRESSURE"]
+            })");
+
+            EmbeddedSkinVisualizationProcess skin_visualization_process(
+                main_model_part, 
+                visualization_model_part, 
+                visualization_settings);
+
+            skin_visualization_process.ExecuteInitialize();
+            skin_visualization_process.ExecuteBeforeSolutionLoop();
+            skin_visualization_process.ExecuteInitializeSolutionStep();
+            skin_visualization_process.ExecuteBeforeOutputStep();
+            skin_visualization_process.ExecuteFinalizeSolutionStep();
+
+            GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/visualizaton_model_part_2d_ausas", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
             gid_io_fluid.InitializeMesh(0);
             gid_io_fluid.WriteMesh(visualization_model_part.GetMesh());
             gid_io_fluid.FinalizeMesh();
@@ -136,30 +234,9 @@ namespace Kratos {
 	     */
 	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessTetrahedra, FluidDynamicsApplicationFastSuite)
 		{
-
-            // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
-            Node<3>::Pointer p_point1 = Kratos::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
-            Node<3>::Pointer p_point2 = Kratos::make_shared<Node<3>>(2, 10.00, 0.00, 0.00);
-            Node<3>::Pointer p_point3 = Kratos::make_shared<Node<3>>(3, 10.00, 10.00, 0.00);
-            Node<3>::Pointer p_point4 = Kratos::make_shared<Node<3>>(4, 0.00, 10.00, 0.00);
-            Node<3>::Pointer p_point5 = Kratos::make_shared<Node<3>>(5, 0.00, 0.00, 10.00);
-            Node<3>::Pointer p_point6 = Kratos::make_shared<Node<3>>(6, 10.00, 0.00, 10.00);
-            Node<3>::Pointer p_point7 = Kratos::make_shared<Node<3>>(7, 10.00, 10.00, 10.00);
-            Node<3>::Pointer p_point8 = Kratos::make_shared<Node<3>>(8, 0.00, 10.00, 10.00);
-
-            Hexahedra3D8<Node<3>> cube_domain(p_point1, p_point2, p_point3, p_point4, p_point5, p_point6, p_point7, p_point8);
-
-            Parameters mesher_parameters(R"(
-            {
-                "number_of_divisions" :  5,
-                "element_name"        : "Element3D4N"
-            })");
-
+            // Set tetrahedral elements mesh
             ModelPart main_model_part("MainModelPart");
-            main_model_part.AddNodalSolutionStepVariable(DISTANCE);
-            main_model_part.AddNodalSolutionStepVariable(VELOCITY);
-            main_model_part.AddNodalSolutionStepVariable(PRESSURE);
-            StructuredMeshGeneratorProcess(cube_domain, main_model_part, mesher_parameters).Execute();
+            SetElement3D4NModelPart(main_model_part);
 
             // Set the nodal values
             const double level_set_height = 4.5;
@@ -188,19 +265,6 @@ namespace Kratos {
 
             }
 
-            // Copy the nodal distance to ELEMENTAL_DISTANCES variable
-            // (needed in case the Ausas functions are tested)
-            // for (unsigned int i_elem = 0; i_elem < main_model_part.NumberOfElements(); ++i_elem){
-            //     auto it_elem = main_model_part.ElementsBegin() + i_elem;
-            //     auto &r_geom = it_elem->GetGeometry();
-            //     const unsigned int elem_n_nodes = r_geom.PointsNumber();
-            //     Vector elem_dist(elem_n_nodes);
-            //     for (unsigned int i_node = 0; i_node < elem_n_nodes; ++i_node){
-            //         elem_dist[i_node] = r_geom[i_node].GetSolutionStepValue(DISTANCE);
-            //     }
-            //     it_elem->SetValue(ELEMENTAL_DISTANCES, elem_dist);
-            // }
-
             // Create the visualization model part
             ModelPart visualization_model_part("VisualizationModelPart");
             visualization_model_part.AddNodalSolutionStepVariable(DISTANCE);
@@ -225,7 +289,90 @@ namespace Kratos {
             skin_visualization_process.ExecuteBeforeOutputStep();
             skin_visualization_process.ExecuteFinalizeSolutionStep();
 
-            GidIO<> gid_io_fluid("/home/rzorrilla/Kratos/tests/visualizaton_model_part_3d", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
+            GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/visualizaton_model_part_3d", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
+            gid_io_fluid.InitializeMesh(0.0);
+            gid_io_fluid.WriteMesh(visualization_model_part.GetMesh());
+            gid_io_fluid.FinalizeMesh();
+            gid_io_fluid.InitializeResults(0, visualization_model_part.GetMesh());
+            gid_io_fluid.WriteNodalResults(VELOCITY, visualization_model_part.Nodes(), 0, 0);
+            gid_io_fluid.WriteNodalResults(PRESSURE, visualization_model_part.Nodes(), 0, 0);
+            gid_io_fluid.FinalizeResults();
+
+	    }
+
+	    /** 
+	     * Checks the embedded skin visualization process for tetrahedral meshes.
+	     */
+	    KRATOS_TEST_CASE_IN_SUITE(EmbeddedSkinVisualizationProcessTetrahedraAusas, FluidDynamicsApplicationFastSuite)
+		{
+            // Set tetrahedral elements mesh
+            ModelPart main_model_part("MainModelPart");
+            SetElement3D4NModelPart(main_model_part);
+
+            // Set the nodal values
+            const double p_pos = 1.0;
+            const double p_neg = -1.0;
+            array_1d<double,3> v_pos(0.0);
+            array_1d<double,3> v_neg(0.0);
+            v_pos[0] = 1.0;
+            v_neg[0] = -1.0;
+            const double level_set_height = 4.5;
+
+            for (unsigned int i_node = 0; i_node < main_model_part.NumberOfNodes(); ++i_node){
+                auto it_node = main_model_part.NodesBegin() + i_node;
+
+                // Set DISTANCE values
+                const double node_distance = (it_node->Z()) - level_set_height;
+                it_node->FastGetSolutionStepValue(DISTANCE) = node_distance;
+
+                // Set the VELOCITY and PRESSURE values
+                if (node_distance > 0.0){
+                    it_node->FastGetSolutionStepValue(VELOCITY) = v_pos;
+                    it_node->FastGetSolutionStepValue(PRESSURE) = p_pos;
+                } else {
+                    it_node->FastGetSolutionStepValue(VELOCITY) = v_neg;
+                    it_node->FastGetSolutionStepValue(PRESSURE) = p_neg;
+                }
+            }
+
+            // Copy the nodal distance to ELEMENTAL_DISTANCES variable
+            // (needed in case the Ausas functions are tested)
+            for (unsigned int i_elem = 0; i_elem < main_model_part.NumberOfElements(); ++i_elem){
+                auto it_elem = main_model_part.ElementsBegin() + i_elem;
+                auto &r_geom = it_elem->GetGeometry();
+                const unsigned int elem_n_nodes = r_geom.PointsNumber();
+                Vector elem_dist(elem_n_nodes);
+                for (unsigned int i_node = 0; i_node < elem_n_nodes; ++i_node){
+                    elem_dist[i_node] = r_geom[i_node].GetSolutionStepValue(DISTANCE);
+                }
+                it_elem->SetValue(ELEMENTAL_DISTANCES, elem_dist);
+            }
+
+            // Create the visualization model part
+            ModelPart visualization_model_part("VisualizationModelPart");
+            visualization_model_part.AddNodalSolutionStepVariable(DISTANCE);
+            visualization_model_part.AddNodalSolutionStepVariable(VELOCITY);
+            visualization_model_part.AddNodalSolutionStepVariable(PRESSURE);
+
+            // Set the embedded skin visualization process
+            Parameters visualization_settings(R"(
+            {
+                "shape_functions"         : "ausas",
+                "visualization_variables" : ["VELOCITY","PRESSURE"]
+            })");
+
+            EmbeddedSkinVisualizationProcess skin_visualization_process(
+                main_model_part, 
+                visualization_model_part, 
+                visualization_settings);
+
+            skin_visualization_process.ExecuteInitialize();
+            skin_visualization_process.ExecuteBeforeSolutionLoop();
+            skin_visualization_process.ExecuteInitializeSolutionStep();
+            skin_visualization_process.ExecuteBeforeOutputStep();
+            skin_visualization_process.ExecuteFinalizeSolutionStep();
+
+            GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/visualizaton_model_part_3d_ausas", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
             gid_io_fluid.InitializeMesh(0.0);
             gid_io_fluid.WriteMesh(visualization_model_part.GetMesh());
             gid_io_fluid.FinalizeMesh();


### PR DESCRIPTION
Bug correction in the creation of the skin conditions. An enhanced version of the new nodes map has been done to distinguish between the positive and negative faces. Besides, the tests have been simplified and improved.

@RiccardoRossi by the way, I did comment the OpenMP pragmas in lines 186 and 255. Otherwise a memory leak was drop in Valgrind. I was sure that this operations were threadsafe. Can you have a look to it before merging?