### PR TITLE
Change variable names in accordance with such imported from DamInterface

### DIFF
--- a/applications/DamApplication/python_scripts/impose_face_heat_flux_process.py
+++ b/applications/DamApplication/python_scripts/impose_face_heat_flux_process.py
@@ -17,7 +17,7 @@ class ImposeFaceHeatFluxProcess(Process):
         self.components_process_list = []
 
         ## This process assign and uniform heat flux
-        if "Uniform" in settings["model_part_name"].GetString():
+        if ("UniformFlux2D" in settings["model_part_name"].GetString()) or ("UniformFlux3D" in settings["model_part_name"].GetString()):
             if settings["table"].GetInt() == 0:
                 t_uniform = Parameters("{}")
                 t_uniform.AddValue("model_part_name",settings["model_part_name"])
@@ -30,7 +30,7 @@ class ImposeFaceHeatFluxProcess(Process):
 
         ## This process compute the heat flux according to q = h(t_ambient - t_current).
         ## Setting the extra values to 0.0 it is possible to use the same process.
-        if "TAmbient" in settings["model_part_name"].GetString():
+        if ("TAmbientFlux2D" in settings["model_part_name"].GetString()) or ("TAmbientFlux3D" in settings["model_part_name"].GetString()):
             t_ambient = Parameters("{}")
             t_ambient.AddValue("model_part_name",settings["model_part_name"])
             t_ambient.AddValue("variable_name",settings["variable_name"])
@@ -44,7 +44,7 @@ class ImposeFaceHeatFluxProcess(Process):
             self.components_process_list.append(DamTSolAirHeatFluxProcess(model_part, t_ambient))        
 
         ## This process compute the heat flux according to q = h(t_sol_air - t_current)
-        if "TSolAir" in settings["model_part_name"].GetString():
+        if ("TSolAirFluxCondition2D" in settings["model_part_name"].GetString()) or ("TSolAirFluxCondition3D" in settings["model_part_name"].GetString()):
             self.components_process_list.append(DamTSolAirHeatFluxProcess(model_part, settings))
              
     def ExecuteInitialize(self):

--- a/applications/DamApplication/python_scripts/impose_heat_source_process.py
+++ b/applications/DamApplication/python_scripts/impose_heat_source_process.py
@@ -17,10 +17,10 @@ class ImposeHeatSourceProcess(Process):
         
         self.components_process_list = []
         
-        if "Noorzai" in settings["model_part_name"].GetString():
+        if ("NoorzaiHeatFlux2D" in settings["model_part_name"].GetString()) or ("NoorzaiHeatFlux3D" in settings["model_part_name"].GetString()):
             self.components_process_list.append(DamNoorzaiHeatFluxProcess(model_part, settings))
                        
-        if "Azenha" in settings["model_part_name"].GetString(): 
+        if ("AzenhaHeatFlux2D" in settings["model_part_name"].GetString()) or ("AzenhaHeatFlux3D" in settings["model_part_name"].GetString()): 
             self.components_process_list.append(DamAzenhaHeatFluxProcess(model_part, settings))
           
     def ExecuteInitialize(self):

--- a/applications/DamApplication/python_scripts/impose_reservoir_temperature_condition_process.py
+++ b/applications/DamApplication/python_scripts/impose_reservoir_temperature_condition_process.py
@@ -20,10 +20,10 @@ class ImposeReservoirTemperatureConditionProcess(Process):
         
         self.components_process_list = []
 
-        if "BOFANG" in settings["model_part_name"].GetString():
+        if "BOFANGTEMPERATURE" in settings["model_part_name"].GetString():
             self.components_process_list.append(DamBofangConditionTemperatureProcess(model_part, settings))
 
-        if "RESERVOIR" in settings["model_part_name"].GetString():
+        if "CONSTANTRESERVOIRTEMPERATURE" in settings["model_part_name"].GetString():
             self.components_process_list.append(DamReservoirConstantTemperatureProcess(model_part, settings))
 
 

--- a/applications/DamApplication/python_scripts/impose_water_loads_condition_process.py
+++ b/applications/DamApplication/python_scripts/impose_water_loads_condition_process.py
@@ -17,19 +17,19 @@ class ImposeWaterLoadsConditionProcess(Process):
         
         self.components_process_list = []
         
-        if "Hydrostatic" in settings["model_part_name"].GetString():
+        if ("HydroLinePressure2D" in settings["model_part_name"].GetString()) or ("HydroSurfacePressure3D" in settings["model_part_name"].GetString()):
 
             self.components_process_list.append(DamHydroConditionLoadProcess(model_part, settings))
             
-        if "Straight" in settings["model_part_name"].GetString():
+        if ("StraightUpliftLinePressure2D" in settings["model_part_name"].GetString()) or ("StraightUpliftSurfacePressure3D" in settings["model_part_name"].GetString()):
             
             self.components_process_list.append(DamUpliftConditionLoadProcess(model_part, settings))
             
-        if "Circular" in settings["model_part_name"].GetString():
+        if "CircularUpliftSurfacePressure3D" in settings["model_part_name"].GetString():
             
             self.components_process_list.append(DamUpliftCircularConditionLoadProcess(model_part, settings))
         
-        if "Hydrodynamic" in settings["model_part_name"].GetString():
+        if ("HydroDynamicLinePressure2D" in settings["model_part_name"].GetString()) or ("HydroDynamicSurfacePressure3D" in settings["model_part_name"].GetString()):
             
             self.components_process_list.append(DamWestergaardConditionLoadProcess(model_part, settings))   
         


### PR DESCRIPTION
Some changes have been introduced in order to match the names of the variables of DamInterface with the variables referred in certain python script processes. 
This will result in fewer problems related to connections between the interface and Kratos processes.