### PR TITLE
Pybind11 - Separate DEM core and interface

### DIFF
--- a/applications/DEM_application/CMakeLists.txt
+++ b/applications/DEM_application/CMakeLists.txt
@@ -2,17 +2,16 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 message("**** configuring KratosDEMApplication ****")
 
+################### PYBIND11
+include(pybind11Tools)
+
 include_directories( ${CMAKE_SOURCE_DIR}/kratos )
 
 ## generate variables with the sources
-set(KRATOS_DEM_APPLICATION_SOURCES
+set(KRATOS_DEM_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/DEM_application.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_strategies/strategies/explicit_solver_strategy.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_strategies/strategies/explicit_solver_continuum.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/DEM_python_application.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_strategies_to_python.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_utilities_to_python.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_constitutive_laws_to_python.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/spheric_particle.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/nanoparticle.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/analytic_spheric_particle.cpp
@@ -75,7 +74,6 @@ set(KRATOS_DEM_APPLICATION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/properties_proxies.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/dem_fem_utilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/excavator_utility.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/AuxiliaryUtilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/analytic_tools/analytic_model_part_filler.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/analytic_tools/analytic_particle_watcher.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/analytic_tools/analytic_face_watcher.cpp
@@ -83,26 +81,24 @@ set(KRATOS_DEM_APPLICATION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_search/bins_dynamic_objects_periodic.cpp
 )
 
-include(pybind11Tools)
+set(KRATOS_DEM_APPLICATION_PYTHON_INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/DEM_python_application.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_strategies_to_python.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_utilities_to_python.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_constitutive_laws_to_python.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/AuxiliaryUtilities.cpp
+)
+
+add_library(KratosDEMCore SHARED ${KRATOS_DEM_APPLICATION_CORE})
+target_link_libraries(KratosDEMCore PUBLIC KratosCore)
+set_target_properties(KratosDEMCore PROPERTIES COMPILE_DEFINITIONS "DEM_APPLICATION=EXPORT,API")
 
 ###############################################################
 ## define library Kratos which defines the basic python interface
-pybind11_add_module(KratosDEMApplication MODULE ${KRATOS_DEM_APPLICATION_SOURCES})
-#if(NOT EXISTS "${PROJECT_SOURCE_DIR}/applications/DEM_application/kratos_DEMApplication_export_dll.h")
-#GENERATE_EXPORT_HEADER( KratosDEMApplication
-#             BASE_NAME KratosDEMApplication
-#             EXPORT_MACRO_NAME KRATOS_DEMAPPLICATION_EXPORT_DLL
-#             EXPORT_FILE_NAME ../../../applications/DEM_application/kratos_DEMApplication_export_dll.h
-#             STATIC_DEFINE KratosDemApplication_BUILT_AS_STATIC
-#)
-#endif(NOT EXISTS "${PROJECT_SOURCE_DIR}/applications/DEM_application/kratos_DEMApplication_export_dll.h")
-ADD_COMPILER_EXPORT_FLAGS()
-
-
-
-target_link_libraries(KratosDEMApplication KratosCore )
+pybind11_add_module(KratosDEMApplication MODULE ${KRATOS_DEM_APPLICATION_PYTHON_INTERFACE})
+target_link_libraries(KratosDEMApplication PUBLIC KratosDEMCore)
 set_target_properties(KratosDEMApplication PROPERTIES PREFIX "")
-set_target_properties(KratosDEMApplication PROPERTIES COMPILE_DEFINITIONS "DEM_APPLICATION=EXPORT,API")
+
 
 if(${ACTIVATE_DEBUG_MACRO} MATCHES ON)        #MSI: Flag defined for debug Macro
     add_definitions(-DDEBUG_MACRO)
@@ -141,11 +137,12 @@ endif(${INSTALL_PYTHON_FILES} MATCHES ON)
 # message("KratosDEMApplication subdir inc_dirs = ${inc_dirs}")
 # Add Cotire
 if(USE_COTIRE MATCHES ON)
+  cotire(KratosDEMCore)
   cotire(KratosDEMApplication)
 endif(USE_COTIRE MATCHES ON)
 
+install(TARGETS KratosDEMCore DESTINATION libs )
 install(TARGETS KratosDEMApplication DESTINATION libs )
-
 
 # Add to the KratosMultiphysics Python module
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/DEMApplication.py" DESTINATION KratosMultiphysics )


### PR DESCRIPTION
This slits the app into core and interface, as with the others.

Notice I added `custom_utilities/AuxiliaryUtilities.cpp` as part of the python interface as it requires pybind11 and hence cannot be linked into the DEMCore Directly