### PR TITLE
Core/fix calculate sensitivity matrix

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -934,6 +934,8 @@ public:
                                             Matrix& rOutput,
                                             const ProcessInfo& rCurrentProcessInfo)
     {
+        if (rOutput.size1() != 0)
+            rOutput.resize(0, 0, false);
     }
 
     /**
@@ -943,6 +945,8 @@ public:
                                             Matrix& rOutput,
                                             const ProcessInfo& rCurrentProcessInfo)
     {
+        if (rOutput.size1() != 0)
+            rOutput.resize(0, 0, false);
     }
 
     //METHODS TO BE CLEANED: DEPRECATED end

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -1,10 +1,10 @@
-//    |  /           | 
-//    ' /   __| _` | __|  _ \   __| 
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ \.
-//   _|\_\_|  \__,_|\__|\___/ ____/ 
-//                   Multi-Physics  
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
@@ -927,6 +927,24 @@ public:
 	  rDampingMatrix.resize(0, 0, false);
     }
 
+    /**
+     * Calculate the transposed gradient of the condition's residual w.r.t. design variable.
+     */
+    virtual void CalculateSensitivityMatrix(const Variable<double>& rDesignVariable,
+                                            Matrix& rOutput,
+                                            const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
+    /**
+     * Calculate the transposed gradient of the condition's residual w.r.t. design variable.
+     */
+    virtual void CalculateSensitivityMatrix(const Variable<array_1d<double,3> >& rDesignVariable,
+                                            Matrix& rOutput,
+                                            const ProcessInfo& rCurrentProcessInfo)
+    {
+    }
+
     //METHODS TO BE CLEANED: DEPRECATED end
 
     ///@}
@@ -986,12 +1004,12 @@ public:
     {
       return mData;
     }
-    
+
     void SetData(DataValueContainer const& rThisData)
     {
       mData = rThisData;
     }
-    
+
     /**
      * Check if the Data exists with Has(..) methods:
      */
@@ -1033,22 +1051,22 @@ public:
     ///@}
     ///@name Flags
     ///@{
-    
+
     Flags& GetFlags()
       {
 	return *this;
       }
-    
+
     Flags const& GetFlags() const
     {
       return *this;
     }
-    
+
     void SetFlags(Flags const& rThisFlags)
     {
       Flags::operator=(rThisFlags);
     }
-    
+
     ///@}
     ///@name Inquiry
     ///@{

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -1,10 +1,10 @@
-//    |  /           | 
-//    ' /   __| _` | __|  _ \   __| 
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ \.
-//   _|\_\_|  \__,_|\__|\___/ ____/ 
-//                   Multi-Physics  
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
@@ -758,7 +758,7 @@ public:
 					      const ProcessInfo& rCurrentProcessInfo)
     {
     }
-    
+
     virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
 					      std::vector< array_1d<double, 6 > >& rOutput,
 					      const ProcessInfo& rCurrentProcessInfo)
@@ -794,7 +794,7 @@ public:
 					     const ProcessInfo& rCurrentProcessInfo)
     {
     }
-    
+
     virtual void SetValueOnIntegrationPoints(const Variable<double>& rVariable,
 					     std::vector<double>& rValues,
 					     const ProcessInfo& rCurrentProcessInfo)
@@ -981,6 +981,8 @@ public:
                                             Matrix& rOutput,
                                             const ProcessInfo& rCurrentProcessInfo)
     {
+        if (rOutput.size1() != 0)
+            rOutput.resize(0, 0, false);
     }
 
     /**
@@ -990,6 +992,8 @@ public:
                                             Matrix& rOutput,
                                             const ProcessInfo& rCurrentProcessInfo)
     {
+        if (rOutput.size1() != 0)
+            rOutput.resize(0, 0, false);
     }
 
 
@@ -1052,12 +1056,12 @@ public:
     {
       return mData;
     }
-    
+
     void SetData(DataValueContainer const& rThisData)
     {
       mData = rThisData;
     }
-    
+
     /**
      * Check if the Data exists with Has(..) methods:
      */
@@ -1105,27 +1109,27 @@ public:
       {
 	return *this;
       }
-    
+
     Flags const& GetFlags() const
     {
       return *this;
     }
-    
+
     void SetFlags(Flags const& rThisFlags)
     {
       Flags::operator=(rThisFlags);
     }
-    
+
     ///@}
     ///@name Inquiry
     ///@{
-        
+
     /// Check that the Element has a correctly initialized pointer to a Properties instance.
     bool HasProperties() const
     {
         return mpProperties != nullptr;
     }
-    
+
     ///@}
     ///@name Input and output
     ///@{


### PR DESCRIPTION
I isolated the changes from PR #1804 that affect the core:

1. The ```CalculateSensitivityMatrix``` function calculates the derivative of the residual w.r.t the design variable. It is already existing in the element base class, but is missing in the condition base. At least for structural sensitivity analysis it can be relevant (e.g. for load intensity as design variable or for pressure loads in shape optimization). I don't know how it is for fluid sensitivity analysis @msandre?

2. The ```CalculateSensitivityMatrix``` function in the element base and the new one in the condition base should resize the output to 0, if the derived element/condition does not overwrite this function. Otherwise it can happen that the wrong values are used for further calculations of the sensitivity.