### PR TITLE
Fixing compilation error and linking error after pybind port

### DIFF
--- a/applications/DamApplication/CMakeLists.txt
+++ b/applications/DamApplication/CMakeLists.txt
@@ -77,7 +77,7 @@ if(${USE_DAM_MPI} MATCHES ON)
 
     ## DamApplication core library (C++ parts)
     add_library(KratosDamCore SHARED ${KRATOS_DAM_APPLICATION_CORE_SOURCES})
-    target_link_libraries(KratosDamCore PRIVATE KratosCore KratosTrilinosApplication KratosPoromechanicsCore)
+    target_link_libraries(KratosDamCore PRIVATE KratosCore KratosTrilinosApplication KratosSolidMechanicsCore KratosPoromechanicsCore)
 
 else()
 
@@ -93,7 +93,7 @@ else()
     
     ## DamApplication core library (C++ parts)
     add_library(KratosDamCore SHARED ${KRATOS_DAM_APPLICATION_CORE_SOURCES})
-    target_link_libraries(KratosDamCore PRIVATE KratosCore KratosPoromechanicsCore)
+    target_link_libraries(KratosDamCore PRIVATE KratosCore KratosSolidMechanicsCore KratosPoromechanicsCore)
 
 endif()
 
@@ -103,7 +103,7 @@ endif()
 ###############################################################################
 ## DamApplication core library (C++ parts)
 #add_library(KratosDamCore SHARED ${KRATOS_DAM_APPLICATION_CORE_SOURCES})
-#target_link_libraries(KratosDamCore PRIVATE KratosCore KratosPoromechanicsCore)
+#target_link_libraries(KratosDamCore PRIVATE KratosCore KratosSolidMechanicsCore KratosPoromechanicsCore)
 
 ## DamApplication python module
 pybind11_add_module(KratosDamApplication MODULE ${KRATOS_DAM_APPLICATION_PYTHON_INTERFACE_SOURCES})

--- a/applications/DamApplication/custom_utilities/construction_utility.hpp
+++ b/applications/DamApplication/custom_utilities/construction_utility.hpp
@@ -14,12 +14,12 @@
 #if !defined(KRATOS_CONSTRUCTION_UTILITIES)
 #define KRATOS_CONSTRUCTION_UTILITIES
 
+// System includes
 #include <cmath>
 
 // Project includes
-#include "includes/kratos_flags.h"
+#include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
-#include "processes/process.h"
 #include "utilities/openmp_utils.h"
 #include "utilities/math_utils.h"
 #include "includes/element.h"

--- a/applications/DamApplication/custom_utilities/global_joint_stress_utility.hpp
+++ b/applications/DamApplication/custom_utilities/global_joint_stress_utility.hpp
@@ -14,12 +14,12 @@
 #if !defined(KRATOS_GLOBAL_JOINT_STRESS_UTILITIES)
 #define KRATOS_GLOBAL_JOINT_STRESS_UTILITIES
 
+// System includes
 #include <cmath>
 
 // Project includes
-#include "includes/kratos_flags.h"
+#include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
-#include "processes/process.h"
 #include "utilities/openmp_utils.h"
 #include "utilities/math_utils.h"
 #include "includes/element.h"

--- a/applications/DamApplication/custom_utilities/streamlines_output_3D_utilities.hpp
+++ b/applications/DamApplication/custom_utilities/streamlines_output_3D_utilities.hpp
@@ -14,15 +14,15 @@
 #if !defined(KRATOS_STREAMLINES_OUTPUT_3D_UTILITIES)
 #define KRATOS_STREAMLINES_OUTPUT_3D_UTILITIES
 
+// System includes
 #include <cmath>
 
 // Project includes
-#include "includes/kratos_flags.h"
+#include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
-#include "processes/process.h"
-#include "custom_utilities/solid_mechanics_math_utilities.hpp"
 #include "utilities/openmp_utils.h"
 #include "utilities/math_utils.h"
+#include "custom_utilities/solid_mechanics_math_utilities.hpp"
 
 // Application includes
 #include "dam_application_variables.h"

--- a/applications/DamApplication/custom_utilities/transfer_selfweight_stress_utility.hpp
+++ b/applications/DamApplication/custom_utilities/transfer_selfweight_stress_utility.hpp
@@ -14,12 +14,12 @@
 #if !defined(KRATOS_TRANSFER_SELFWEIGHT_STRESS_UTILITIES)
 #define KRATOS_TRANSFER_SELFWEIGHT_STRESS_UTILITIES
 
+// System includes
 #include <cmath>
 
 // Project includes
-#include "includes/kratos_flags.h"
+#include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
-#include "processes/process.h"
 #include "utilities/openmp_utils.h"
 #include "utilities/math_utils.h"
 #include "includes/element.h"


### PR DESCRIPTION
I just tried to compile the master branch after the merge of the pybind port and I found a linking error in Dam Application. I repaired it just by linking Dam to both SolidMechanics and Poromechanics Apps.

I also found some compilation errors in some utilities that weren't including the modelpart.

With these changes I managed to compile properly, but please @joaquinirazabal try to run some of your tests to see if everything works as expected.