### PR TITLE
Restore changes in time integration methods for Solids

### DIFF
--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/emc_step_rotation_method.cpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/emc_step_rotation_method.cpp
@@ -19,7 +19,16 @@ namespace Kratos
 {
  
   // specilization to array_1d
-  
+  template<class TVariableType, class TValueType>
+  void EmcStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
+  {
+      KRATOS_TRY
+
+      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in EmcStepRotationMethod " <<std::endl;
+	
+      KRATOS_CATCH( "" )
+  }
+
   template<>
   void EmcStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode)
   {

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/emc_step_rotation_method.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/emc_step_rotation_method.hpp
@@ -101,14 +101,7 @@ namespace Kratos
     ///@{
 
     // update
-    virtual void Update(NodeType& rNode) override
-    {
-      KRATOS_TRY
-
-      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS " <<std::endl;
-	
-      KRATOS_CATCH( "" )
-    }
+    virtual void Update(NodeType& rNode) override;
        
     ///@}
     ///@name Access
@@ -238,6 +231,17 @@ namespace Kratos
   template<>
   void EmcStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode);
 
+
+  template<class TVariableType, class TValueType>
+  void EmcStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
+  {
+      KRATOS_TRY
+
+      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in EmcStepRotationMethod " <<std::endl;
+	
+      KRATOS_CATCH( "" )
+  }
+
   ///@}
   ///@name Input and output
   ///@{
@@ -254,9 +258,6 @@ namespace Kratos
     return rOStream << rThis.Info();
   }
 
-
-  // template<>
-  // class EmcStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> > : public EmcStepMethod<Variable<array_1d<double, 3> >, array_1d<double,3> > {};
   
   ///@}
 

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/emc_step_rotation_method.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/emc_step_rotation_method.hpp
@@ -231,17 +231,6 @@ namespace Kratos
   template<>
   void EmcStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode);
 
-
-  template<class TVariableType, class TValueType>
-  void EmcStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
-  {
-      KRATOS_TRY
-
-      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in EmcStepRotationMethod " <<std::endl;
-	
-      KRATOS_CATCH( "" )
-  }
-
   ///@}
   ///@name Input and output
   ///@{

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/newmark_step_rotation_method.cpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/newmark_step_rotation_method.cpp
@@ -19,6 +19,15 @@ namespace Kratos
 {
 
   // specilization to array_1d
+  template<class TVariableType, class TValueType>
+  void NewmarkStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
+  {
+      KRATOS_TRY
+
+      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in NewmarkStepRotationMethod " <<std::endl;
+	
+      KRATOS_CATCH( "" )
+  }
   
   template<>
   void NewmarkStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode)

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/newmark_step_rotation_method.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/newmark_step_rotation_method.hpp
@@ -251,16 +251,6 @@ namespace Kratos
   template<>
   void NewmarkStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode);
 
-  template<class TVariableType, class TValueType>
-  void NewmarkStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
-  {
-      KRATOS_TRY
-
-      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in NewmarkStepRotationMethod " <<std::endl;
-	
-      KRATOS_CATCH( "" )
-  }
-
   ///@}
   ///@name Input and output
   ///@{

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/newmark_step_rotation_method.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/newmark_step_rotation_method.hpp
@@ -103,17 +103,9 @@ namespace Kratos
     ///@name Operations
     ///@{
     
-    
-    
+        
     // update
-    virtual void Update(NodeType& rNode) override 
-    {
-      KRATOS_TRY
-
-      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS " <<std::endl;
-	
-      KRATOS_CATCH( "" )
-    }
+    virtual void Update(NodeType& rNode) override;
  
     ///@}
     ///@name Access
@@ -259,7 +251,15 @@ namespace Kratos
   template<>
   void NewmarkStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode);
 
-  // template class KRATOS_API(SOLID_MECHANICS_APPLICATION) NewmarkStepRotationMethod<VariableComponent<VectorComponentAdaptor<array_1d<double, 3>>> , double>;
+  template<class TVariableType, class TValueType>
+  void NewmarkStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
+  {
+      KRATOS_TRY
+
+      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in NewmarkStepRotationMethod " <<std::endl;
+	
+      KRATOS_CATCH( "" )
+  }
 
   ///@}
   ///@name Input and output

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/simo_step_rotation_method.cpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/simo_step_rotation_method.cpp
@@ -19,6 +19,15 @@ namespace Kratos
 {
 
   // specilization to array_1d
+  template<class TVariableType, class TValueType>
+  void SimoStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
+  {
+      KRATOS_TRY
+
+      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in SimoStepRotationScheme " <<std::endl;
+	
+      KRATOS_CATCH( "" )
+  }
   
   template<>
   void SimoStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode)

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/simo_step_rotation_method.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/simo_step_rotation_method.hpp
@@ -231,17 +231,6 @@ namespace Kratos
   template<>
   void SimoStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode);
 
-  template<class TVariableType, class TValueType>
-  void SimoStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
-  {
-      KRATOS_TRY
-
-      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in SimoStepRotationScheme " <<std::endl;
-	
-      KRATOS_CATCH( "" )
-  }
-
-
   ///@}
   ///@name Input and output
   ///@{

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/simo_step_rotation_method.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/simo_step_rotation_method.hpp
@@ -101,14 +101,7 @@ namespace Kratos
     ///@{
 
     // update
-    virtual void Update(NodeType& rNode) override 
-    {
-      KRATOS_TRY
-
-      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS " <<std::endl;
-	
-      KRATOS_CATCH( "" )
-    }
+    virtual void Update(NodeType& rNode) override;
     
     ///@}
     ///@name Access
@@ -235,8 +228,19 @@ namespace Kratos
   ///@name Type Definitions
   ///@{
   
-  // template<>
-  // void SimoStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode);
+  template<>
+  void SimoStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode);
+
+  template<class TVariableType, class TValueType>
+  void SimoStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
+  {
+      KRATOS_TRY
+
+      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in SimoStepRotationScheme " <<std::endl;
+	
+      KRATOS_CATCH( "" )
+  }
+
 
   ///@}
   ///@name Input and output

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/static_step_rotation_method.cpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/static_step_rotation_method.cpp
@@ -19,6 +19,16 @@ namespace Kratos
 {
 
   // specilization to array_1d
+  template<class TVariableType, class TValueType>
+  void StaticStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
+  {
+      KRATOS_TRY
+
+      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in StaticStepRotationMethod " <<std::endl;
+	
+      KRATOS_CATCH( "" )
+  }
+
   
   template<>
   void StaticStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode)

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/static_step_rotation_method.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/static_step_rotation_method.hpp
@@ -246,17 +246,7 @@ namespace Kratos
   
   template<>
   void StaticStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode);
-
-  template<class TVariableType, class TValueType>
-  void StaticStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
-  {
-      KRATOS_TRY
-
-      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in StaticStepRotationMethod " <<std::endl;
-	
-      KRATOS_CATCH( "" )
-  }
-
+  
   ///@}
   ///@name Input and output
   ///@{

--- a/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/static_step_rotation_method.hpp
+++ b/applications/SolidMechanicsApplication/custom_solvers/time_integration_methods/static_step_rotation_method.hpp
@@ -101,15 +101,8 @@ namespace Kratos
     ///@{
 
     // update
-    virtual void Update(NodeType& rNode) override 
-    {
-      KRATOS_TRY
-
-      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS " <<std::endl;
-	
-      KRATOS_CATCH( "" )
-    }
-    
+    virtual void Update(NodeType& rNode) override;
+     
     ///@}
     ///@name Access
     ///@{
@@ -251,8 +244,18 @@ namespace Kratos
   ///@name Type Definitions
   ///@{
   
-  // template<>
-  // void StaticStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode);
+  template<>
+  void StaticStepRotationMethod<Variable<array_1d<double, 3> >, array_1d<double,3> >::Update(NodeType& rNode);
+
+  template<class TVariableType, class TValueType>
+  void StaticStepRotationMethod<TVariableType,TValueType>::Update(NodeType& rNode)
+  {
+      KRATOS_TRY
+
+      KRATOS_ERROR << " Calling a non compatible type update for ROTATIONS in StaticStepRotationMethod " <<std::endl;
+	
+      KRATOS_CATCH( "" )
+  }
 
   ///@}
   ///@name Input and output


### PR DESCRIPTION
The template specialization was ignored with the introduced changes. Tests failed. If it does not compile in windows, a different solution is needed.