### PR TITLE
[StructuralMechanics] removing dynamic dofs from solvers

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_explicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_explicit_dynamic_solver.py
@@ -13,9 +13,6 @@ import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsA
 import structural_mechanics_solver
 
 
-
-
-
 def CreateSolver(main_model_part, custom_settings):
     return ExplicitMechanicalSolver(main_model_part, custom_settings)
 
@@ -42,7 +39,6 @@ class ExplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
         self.validate_and_transfer_matching_settings(custom_settings, self.dynamic_settings)
         # Validate the remaining settings in the base class.
 
-
         # Construct the base solver.
         super(ExplicitMechanicalSolver, self).__init__(main_model_part, custom_settings)
         self.print_on_rank_zero("::[ExplicitMechanicalSolver]:: Construction finished")
@@ -62,13 +58,8 @@ class ExplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
 
         self.print_on_rank_zero("::[ExplicitMechanicalSolver]:: Variables ADDED")
 
-    def AddDofs(self):
-        super(ExplicitMechanicalSolver, self).AddDofs()
-        self._add_dynamic_dofs()
-        self.print_on_rank_zero("::[ExplicitMechanicalSolver]:: DOF's ADDED")
-
-
     #### Specific internal functions ####
+
     def _create_solution_scheme(self):
         scheme_type = self.dynamic_settings["scheme_type"].GetString()
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -56,11 +56,6 @@ class ImplicitMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
         self._add_dynamic_variables()
         self.print_on_rank_zero("::[ImplicitMechanicalSolver]:: ", "Variables ADDED")
 
-    def AddDofs(self):
-        super(ImplicitMechanicalSolver, self).AddDofs()
-        self._add_dynamic_dofs()
-        self.print_on_rank_zero("::[ImplicitMechanicalSolver]:: ", "DOF's ADDED")
-
     #### Private functions ####
 
     def _create_solution_scheme(self):

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -449,22 +449,6 @@ class MechanicalSolver(object):
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_VELOCITY)
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ANGULAR_ACCELERATION)
 
-    def _add_dynamic_dofs(self):
-        # For being consistent for Serial and Trilinos
-        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_X,self.main_model_part)
-        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_Y,self.main_model_part)
-        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.VELOCITY_Z,self.main_model_part)
-        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ACCELERATION_X,self.main_model_part)
-        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ACCELERATION_Y,self.main_model_part)
-        KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ACCELERATION_Z,self.main_model_part)
-        if(self.settings["rotation_dofs"].GetBool()):
-            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_VELOCITY_X,self.main_model_part)
-            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_VELOCITY_Y,self.main_model_part)
-            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_VELOCITY_Z,self.main_model_part)
-            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_X,self.main_model_part)
-            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Y,self.main_model_part)
-            KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.ANGULAR_ACCELERATION_Z,self.main_model_part)
-
     def _get_restart_settings(self):
         restart_settings = self.settings["restart_settings"].Clone()
         restart_settings.AddValue("input_filename", self.settings["model_import_settings"]["input_filename"])

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
@@ -41,7 +41,7 @@ class TrilinosImplicitMechanicalSolver(trilinos_structural_mechanics_solver.Tril
         """)
         self.validate_and_transfer_matching_settings(custom_settings, self.dynamic_settings)
         # Validate the remaining settings in the base class.
-        
+
         # Construct the base solver.
         super(TrilinosImplicitMechanicalSolver, self).__init__(main_model_part, custom_settings)
 
@@ -49,11 +49,6 @@ class TrilinosImplicitMechanicalSolver(trilinos_structural_mechanics_solver.Tril
         super(TrilinosImplicitMechanicalSolver, self).AddVariables()
         self._add_dynamic_variables()
         self.print_on_rank_zero("::[TrilinosImplicitMechanicalSolver]:: Variables ADDED")
-    
-    def AddDofs(self):
-        super(TrilinosImplicitMechanicalSolver, self).AddDofs()
-        self._add_dynamic_dofs()
-        self.print_on_rank_zero("::[TrilinosImplicitMechanicalSolver]:: DOF's ADDED")
 
     #### Private functions ####
 


### PR DESCRIPTION
@KratosMultiphysics/structural-mechanics for some reason we were adding dynamic dofs in dynamic problems, even though none of our elements has those dofs ...

I think this is wrong but please let me know if we have to do this

all the tests are still working, including the dynamic ones