### PR TITLE
Adding slicing for ublas vector and tests.

### DIFF
--- a/kratos/python/add_vector_to_python.cpp
+++ b/kratos/python/add_vector_to_python.cpp
@@ -78,13 +78,13 @@ namespace Python
                 self[start] = value[i]; start += step;
             }
         });
-        binder.def("__getitem__", [](const TVectorType &self, pybind11::slice this_slice) -> TVectorType* {
+        binder.def("__getitem__", [](const TVectorType &self, pybind11::slice this_slice) -> TVectorType {
             size_t start, stop, step, slicelength;
             if (!this_slice.compute(self.size(), &start, &stop, &step, &slicelength))
                 throw pybind11::error_already_set();
-            TVectorType *sliced_self = new TVectorType(slicelength);
+            TVectorType sliced_self(slicelength);
             for (size_t i = 0; i < slicelength; ++i) {
-                (*sliced_self)[i] = self[start]; start += step;
+                sliced_self[i] = self[start]; start += step;
             }
             return sliced_self;
         });

--- a/kratos/python/add_vector_to_python.cpp
+++ b/kratos/python/add_vector_to_python.cpp
@@ -33,7 +33,7 @@ namespace Python
 
     template< typename TVectorType > class_< TVectorType > CreateVectorInterface(pybind11::module& m, std::string Name )
         {
-            
+
         class_< TVectorType, std::shared_ptr<TVectorType> > binder(m,Name.c_str());
         binder.def(init<>());
 
@@ -41,16 +41,16 @@ namespace Python
         binder.def("Size", [](const TVectorType& self){return self.size();} );
         binder.def("Resize", [](TVectorType& self, const typename TVectorType::size_type  new_size){if(self.size() != new_size) self.resize(new_size, false);} );
         binder.def("__len__", [](const TVectorType& self){return self.size();} );
-        
+
         //operating on the object itself, +=, -=, *=, etc
         binder.def("__iadd__", [](TVectorType& self, const double scalar){for(unsigned int i=0; i<self.size(); ++i) self[i]+=scalar; return self;}, is_operator());
         binder.def("__isub__", [](TVectorType& self, const double scalar){for(unsigned int i=0; i<self.size(); ++i) self[i]-=scalar; return self;}, is_operator());
         binder.def("__imul__", [](TVectorType& self, const double scalar){for(unsigned int i=0; i<self.size(); ++i) self[i]*=scalar; return self;}, is_operator());
         binder.def("__itruediv__", [](TVectorType& self, const double scalar){for(unsigned int i=0; i<self.size(); ++i) self[i]/=scalar; return self;}, is_operator());
-        
+
         binder.def("__iadd__", [](TVectorType& self, const TVectorType& other_vec){noalias(self) += other_vec; return self;}, is_operator());
         binder.def("__isub__", [](TVectorType& self, const TVectorType& other_vec){noalias(self) -= other_vec; return self; }, is_operator());
-       
+
         //returning a different object
 //         binder.def("__add__", [](TVectorType vec1, const double scalar){for(unsigned int i=0; i<vec1.size(); ++i) vec1[i]+=scalar; return vec1;}, is_operator());
 //         binder.def("__sub__", [](TVectorType vec1, const double scalar){for(unsigned int i=0; i<vec1.size(); ++i) vec1[i]-=scalar; return vec1;}, is_operator());
@@ -62,14 +62,36 @@ namespace Python
          binder.def("__rdiv__", [](TVectorType vec1, const double scalar){for(unsigned int i=0; i<vec1.size(); ++i) vec1[i]/=scalar;}, is_operator());
         binder.def("__add__", [](const TVectorType& vec1, const TVectorType& vec2){Vector aux(vec1); aux += vec2; return aux;}, is_operator());
         binder.def("__sub__", [](const TVectorType& vec1, const TVectorType& vec2){Vector aux(vec1); aux -= vec2; return aux;}, is_operator());
-         
+
         //access operators
         binder.def("__setitem__", [](TVectorType& self, const unsigned int i, const typename TVectorType::value_type value){self[i] = value;} );
         binder.def("__getitem__", [](const TVectorType& self, const unsigned int i){return self[i];} );
-        
+
+        //access using slices
+        binder.def("__setitem__", [](TVectorType &self, pybind11::slice this_slice, const TVectorType &value) {
+            size_t start, stop, step, slicelength;
+            if (!this_slice.compute(self.size(), &start, &stop, &step, &slicelength))
+                throw pybind11::error_already_set();
+            if (slicelength != value.size())
+                throw std::runtime_error("Left and right hand size of slice assignment have different sizes!");
+            for (size_t i = 0; i < slicelength; ++i) {
+                self[start] = value[i]; start += step;
+            }
+        });
+        binder.def("__getitem__", [](const TVectorType &self, pybind11::slice this_slice) -> TVectorType* {
+            size_t start, stop, step, slicelength;
+            if (!this_slice.compute(self.size(), &start, &stop, &step, &slicelength))
+                throw pybind11::error_already_set();
+            TVectorType *sliced_self = new TVectorType(slicelength);
+            for (size_t i = 0; i < slicelength; ++i) {
+                (*sliced_self)[i] = self[start]; start += step;
+            }
+            return sliced_self;
+        });
+
         binder.def("__iter__", [](TVectorType& self){ return make_iterator(self.begin(), self.end(), return_value_policy::reference_internal); } , keep_alive<0,1>() ) ;
-        binder.def("__repr__", [](const TVectorType& self) -> const std::string { std::stringstream ss;  ss << self; const std::string out = ss.str();  return out; }); 
-        
+        binder.def("__repr__", [](const TVectorType& self) -> const std::string { std::stringstream ss;  ss << self; const std::string out = ss.str();  return out; });
+
         return binder;
         }
 
@@ -92,8 +114,8 @@ namespace Python
 
 
 
-        
-        
+
+
         auto array3_binder = CreateVectorInterface< Kratos::array_1d<double,3> >(m, "Array3");
         array3_binder.def(init( [](double value){
                                 array_1d<double,3> tmp;
@@ -104,7 +126,7 @@ namespace Python
         array3_binder.def(init( [](const Vector& input){
                                 if(input.size() != 3)
                                     KRATOS_ERROR << "expected size should be 3 when constructing an Array3. Provide Input  size is: " << input.size() << std::endl;
-                            
+
                                 array_1d<double,3> tmp(input);
                                 return tmp;
                                 })   );
@@ -112,7 +134,7 @@ namespace Python
         array3_binder.def(init( [](const list& input){
                                 if(input.size() != 3)
                                     KRATOS_ERROR << "expected size should be 3 when constructing an Array3. Provide Input  size is: " << input.size() << std::endl;
-                            
+
                                 array_1d<double,3> tmp;
                                 for(unsigned int i=0; i<3; ++i)
                                     tmp[i] = cast<double>(input[i]);

--- a/kratos/tests/test_vector_interface.py
+++ b/kratos/tests/test_vector_interface.py
@@ -67,28 +67,28 @@ class TestVectorInterface(KratosUnittest.TestCase):
 
         slice1 = v[1:4] # simple slice get
         self.assertEqual(len(slice1),3)
-        for i in range(len(slice1)):
-            self.assertEqual(slice1[i], i+1 )
+        for i,value in enumerate(slice1):
+            self.assertEqual(value, i+1 )
 
         slice2 = v[2:] # open slice get
         self.assertEqual(len(slice2),3)
-        for i in range(len(slice2)):
-            self.assertEqual(slice2[i], i+2 )
+        for i,value in enumerate(slice2):
+            self.assertEqual(value, i+2 )
 
         slice3 = v[:3] # open slice get
         self.assertEqual(len(slice3),3)
-        for i in range(len(slice3)):
-            self.assertEqual(slice3[i], i )
+        for i,value in enumerate(slice3):
+            self.assertEqual(value, i )
 
         slice4 = v[0::2] # slice get with step
         self.assertEqual(len(slice4),3)
-        for i in range(len(slice4)):
-            self.assertEqual(slice4[i], 2*i )
+        for i,value in enumerate(slice4):
+            self.assertEqual(value, 2*i )
 
         slice5 = v[::-1] # slice get with reverse step
         self.assertEqual(len(slice5),5)
-        for i in range(len(slice5)):
-            self.assertEqual(slice5[i], 4-i )
+        for i,value in enumerate(slice5):
+            self.assertEqual(value, 4-i )
 
         # slice set
         v[0:3] = [2*i for i in range(3)]

--- a/kratos/tests/test_vector_interface.py
+++ b/kratos/tests/test_vector_interface.py
@@ -96,6 +96,32 @@ class TestVectorInterface(KratosUnittest.TestCase):
         for i in range(5):
             self.assertEqual(v[i],expected[i])
 
+        # modifying the vector through the slice
+        # (numpy-like behaviour)
+        s = v[0:3]
+
+        # double assignment
+        s[0] = 99
+        self.assertEqual(v[0],99)
+
+        # vector assignment
+        w = Vector(3)
+        w[:] = [10.,20.,30.]
+        s[:] = w
+
+        expected = [10,20,30,3,4]
+        for i in range(5):
+            self.assertEqual(v[i],expected[i])
+
+        # slice assignment
+        w = Vector(5)
+        w[:] = [-1.,-2.,-3.,-4.,-5.]
+        s[:] = w[1:4]
+
+        expected = [-2.,-3.,-4.,3,4]
+        for i in range(5):
+            self.assertEqual(v[i],expected[i])
+
     def test_array_construction(self):
         a = Array3(5.0)
         for it in a:

--- a/kratos/tests/test_vector_interface.py
+++ b/kratos/tests/test_vector_interface.py
@@ -6,88 +6,128 @@ import math
 
 
 class TestVectorInterface(KratosUnittest.TestCase):
-        
+
     def test_range(self):
         a = Vector(4)
-        
+
         for i in range(len(a)):
             a[i] = i
-            
+
         for i in range(4):
             self.assertEqual(a[i],i)
-            
+
     def test_sum(self):
         a = Vector(3,1.0)
         b = Vector(3,2.0)
-        
-        c = a+b        
+
+        c = a+b
         for it in c:
             self.assertEqual(it,3.0)
-            
+
         d = b - a;
         for it in d:
             self.assertEqual(it,1.0)
-            
+
         b -= a
         for i in range(len(b)):
             self.assertEqual(b[i], d[i])
-            
+
     def test_list_construction(self):
         a = Vector([1,2,3])
         self.assertEqual(a[0],1)
         self.assertEqual(a[1],2)
         self.assertEqual(a[2],3)
-            
+
     def test_scalar_op(self):
         e = Vector(2)
+        e[0] = 0.0
+        e[1] = 0.0
+        print(e)
         e += 2
+        print(e)
         for it in e:
             self.assertEqual(it,2.0)
-            
+
         e -= 1.0
         for it in e:
             self.assertEqual(it,1.0 )
-            
+
         e *= 5.0
         for it in e:
             self.assertEqual(it,5.0 )
-            
+
         e /= 5.0
         for it in e:
-            self.assertEqual(it,1.0 )            
-            
+            self.assertEqual(it,1.0 )
+
+    def test_slicing(self):
+        v = Vector(5)
+        for i in range(len(v)):
+            v[i] = i
+
+        slice1 = v[1:4] # simple slice get
+        self.assertEqual(len(slice1),3)
+        for i in range(len(slice1)):
+            self.assertEqual(slice1[i], i+1 )
+
+        slice2 = v[2:] # open slice get
+        self.assertEqual(len(slice2),3)
+        for i in range(len(slice2)):
+            self.assertEqual(slice2[i], i+2 )
+
+        slice3 = v[:3] # open slice get
+        self.assertEqual(len(slice3),3)
+        for i in range(len(slice3)):
+            self.assertEqual(slice3[i], i )
+
+        slice4 = v[0::2] # slice get with step
+        self.assertEqual(len(slice4),3)
+        for i in range(len(slice4)):
+            self.assertEqual(slice4[i], 2*i )
+
+        slice5 = v[::-1] # slice get with reverse step
+        self.assertEqual(len(slice5),5)
+        for i in range(len(slice5)):
+            self.assertEqual(slice5[i], 4-i )
+
+        # slice set
+        v[0:3] = [2*i for i in range(3)]
+        expected = [0,2,4,3,4]
+        for i in range(5):
+            self.assertEqual(v[i],expected[i])
+
     def test_array_construction(self):
         a = Array3(5.0)
         for it in a:
             self.assertEqual(it,5.0)
-        
+
         b = Vector(a)
         for it in b:
             self.assertEqual(it,5.0)
-            
+
     def test_iter_read(self):
         a = Vector(4)
-        
+
         counter = 0
         for i in range(len(a)):
             a[i] = i
-            
+
         for it in a:
             self.assertEqual(it,counter)
             counter += 1
-        
+
     #it is not possible to fix the next test. = is always type assignement in python
     #@KratosUnittest.expectedFailure
     #def test_iter_write(self):
         #a = Vector(4)
-        
+
         #for it in a:
             #it = 2.0 #this simply does not work in python
 
         #for it in a:
             #self.assertEqual(it,2.0)
-            
-        
-        
+
+
+
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
Apparently boost::python internally supported slicing of ublas vectors, so I tried to reimplement it for pybind (the code follows a similar example in the pybind documentation).

I do not know how (or if) matrix slicing could be supported, but I guess a similar solution could be found.