### PR TITLE
Adding pointer and base arguments to some classes to fix runtime errors

### DIFF
--- a/applications/AdjointFluidApplication/custom_python/add_custom_response_functions_to_python.cpp
+++ b/applications/AdjointFluidApplication/custom_python/add_custom_response_functions_to_python.cpp
@@ -16,7 +16,7 @@ using namespace pybind11;
 
 void AddCustomResponseFunctionsToPython(pybind11::module& m)
 {
-  class_<ResponseFunction>(m,"ResponseFunction")
+  class_<ResponseFunction, ResponseFunction::Pointer>(m,"ResponseFunction")
         .def(init<ModelPart&, Parameters&>())
         .def("Initialize", &ResponseFunction::Initialize)
         .def("InitializeSolutionStep", &ResponseFunction::InitializeSolutionStep)
@@ -32,10 +32,16 @@ void AddCustomResponseFunctionsToPython(pybind11::module& m)
         .def("CalculateValue", &ResponseFunction::CalculateValue)
         .def("UpdateSensitivities", &ResponseFunction::UpdateSensitivities);
 
-    class_<DragResponseFunction<2>>(m,"DragResponseFunction2D")
+    class_<
+        DragResponseFunction<2>,
+        typename DragResponseFunction<2>::Pointer,
+        ResponseFunction>(m,"DragResponseFunction2D")
         .def(init<ModelPart&, Parameters&>());
 
-    class_<DragResponseFunction<3>>(m,"DragResponseFunction3D")
+    class_<
+        DragResponseFunction<3>,
+        typename DragResponseFunction<3>::Pointer,
+        ResponseFunction>(m,"DragResponseFunction3D")
         .def(init<ModelPart&, Parameters&>());
 
 }

--- a/applications/AdjointFluidApplication/custom_python/add_custom_schemes_to_python.cpp
+++ b/applications/AdjointFluidApplication/custom_python/add_custom_schemes_to_python.cpp
@@ -23,11 +23,17 @@ void AddCustomSchemesToPython(pybind11::module& m)
     typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
     typedef Scheme<SparseSpaceType, LocalSpaceType> SchemeType;
 
-    class_<AdjointBossakScheme<SparseSpaceType, LocalSpaceType>>(m,"AdjointBossakScheme")
+    class_<
+        AdjointBossakScheme<SparseSpaceType, LocalSpaceType>,
+        typename AdjointBossakScheme<SparseSpaceType, LocalSpaceType>::Pointer,
+        SchemeType>(m,"AdjointBossakScheme")
         .def(init<Parameters&, ResponseFunction::Pointer>())
         ;
 
-    class_<AdjointSteadyVelocityPressureScheme<SparseSpaceType, LocalSpaceType>>(m,"AdjointSteadyVelocityPressureScheme")
+    class_<
+        AdjointSteadyVelocityPressureScheme<SparseSpaceType, LocalSpaceType>,
+        typename AdjointSteadyVelocityPressureScheme<SparseSpaceType, LocalSpaceType>::Pointer,
+        SchemeType>(m,"AdjointSteadyVelocityPressureScheme")
         .def(init<Parameters&, ResponseFunction::Pointer>())
         ;
 }


### PR DESCRIPTION
I missed them in the original porting, and they were causing some tests to fail. Note that one of the application tests still fails, but I hope to fix it through #1850.