### PR TITLE
Fix windows not having copysign in the std

### DIFF
--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -685,7 +685,7 @@ public:
 
       double vol = Volume();
 
-      return std::copysign(normFactor * std::pow(9 * vol * vol, 1.0 / 3.0) / (sa + sb + sc + sd + se + sf), vol);
+      return std::abs(normFactor * std::pow(9 * vol * vol, 1.0 / 3.0) / (sa + sb + sc + sd + se + sf)) * (vol < 0 ? -1 : 1);
     }
 
     /** Calculates the volume to average edge lenght quality metric.


### PR DESCRIPTION
One day windows will follow the standards and the sun will shine bright in the sky. In the meantime this should solve the problem with the tetrahedroa_3d_4.h

I've changed the way the value is returned.

@pablobecker I doubt it but try to compile with that fix to see if the error dissapears.  