### PR TITLE
Disabling sdem until ported to pybind

### DIFF
--- a/scripts/build/nightly/configure_clang.sh
+++ b/scripts/build/nightly/configure_clang.sh
@@ -33,7 +33,7 @@ cmake .. \
 -DSOLID_MECHANICS_APPLICATION=ON                                                                \
 -DCONSTITUTIVE_MODELS_APPLICATION=ON                                                            \
 -DSTRUCTURAL_MECHANICS_APPLICATION=ON                                                           \
--DSWIMMING_DEM_APPLICATION=ON                                                                   \
+-DSWIMMING_DEM_APPLICATION=OFF                                                                  \
 -DTHERMO_MECHANICAL_APPLICATION=ON                                                              \
 -DCONTACT_STRUCTURAL_MECHANICS_APPLICATION=ON                                                   \
 -DMAPPING_APPLICATION=ON                                                                        \

--- a/scripts/build/nightly/configure_gcc.sh
+++ b/scripts/build/nightly/configure_gcc.sh
@@ -33,7 +33,7 @@ cmake .. \
 -DSOLID_MECHANICS_APPLICATION=ON                                                                \
 -DCONSTITUTIVE_MODELS_APPLICATION=ON                                                            \
 -DSTRUCTURAL_MECHANICS_APPLICATION=ON                                                           \
--DSWIMMING_DEM_APPLICATION=ON                                                                   \
+-DSWIMMING_DEM_APPLICATION=OFF                                                                  \
 -DTHERMO_MECHANICAL_APPLICATION=ON                                                              \
 -DCONTACT_STRUCTURAL_MECHANICS_APPLICATION=ON                                                   \
 -DMAPPING_APPLICATION=ON                                                                        \


### PR DESCRIPTION
I have to disable this until its ported, otherwise nightly builds won't compile. Apart from this detail should be fine.

A little off-topic, maybe it would be a good idea to extend the nightly builds so they can detect errors in the configuration process.