### PR TITLE
removing expected failure from test importing

### DIFF
--- a/kratos/tests/test_importing.py
+++ b/kratos/tests/test_importing.py
@@ -10,7 +10,6 @@ def GetFilePath(fileName):
 
 
 class TestImporting(KratosUnittest.TestCase):
-    @KratosUnittest.expectedFailure
     def test_importing(self):
         #import KratosMultiphysics.FluidDynamicsApplication
         model_part = ModelPart("Main")


### PR DESCRIPTION
Test importing is now passing in my machine, I assume because of #1468. I am removing the expected failure decorator, since it reports that the tests failed otherwise.