### PR TITLE
Core warnigs removed (redefinitions of macros were detected)

### DIFF
--- a/kratos/python/add_kernel_to_python.cpp
+++ b/kratos/python/add_kernel_to_python.cpp
@@ -13,14 +13,13 @@
 
 // External includes
 
-// System includes
-#include <sstream>
-
 // Project includes
 #include "includes/define_python.h"
 #include "includes/kernel.h"
 #include "python/add_kernel_to_python.h"
 
+// System includes
+#include <sstream>
 
 namespace Kratos {
 namespace Python {

--- a/kratos/python/add_logger_to_python.cpp
+++ b/kratos/python/add_logger_to_python.cpp
@@ -15,7 +15,6 @@
 
 // Project includes
 #include "includes/define_python.h"
-#include "includes/define.h"
 #include "input_output/logger.h"
 
 

--- a/kratos/python/add_logger_to_python.cpp
+++ b/kratos/python/add_logger_to_python.cpp
@@ -14,8 +14,8 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "includes/define_python.h"
+#include "includes/define.h"
 #include "input_output/logger.h"
 
 


### PR DESCRIPTION
These are the warnings (sorry about the spanish language):
```
In file included from /usr/include/python2.7/Python.h:8:0,
                 from /home/maceli/kratos/external_libraries/pybind11/detail/common.h:111,
                 from /home/maceli/kratos/external_libraries/pybind11/pytypes.h:12,
                 from /home/maceli/kratos/external_libraries/pybind11/cast.h:13,
                 from /home/maceli/kratos/external_libraries/pybind11/attr.h:13,
                 from /home/maceli/kratos/external_libraries/pybind11/pybind11.h:43,
                 from /home/maceli/kratos/kratos/includes/define_python.h:17,
                 from /home/maceli/kratos/kratos/python/add_kernel_to_python.cpp:20:
/usr/include/python2.7/pyconfig.h:1193:0: aviso: se redefinió "_POSIX_C_SOURCE"
 #define _POSIX_C_SOURCE 200112L
 ^
In file included from /usr/include/c++/5/x86_64-suse-linux/bits/os_defines.h:39:0,
                 from /usr/include/c++/5/x86_64-suse-linux/bits/c++config.h:2255,
                 from /usr/include/c++/5/iosfwd:38,
                 from /usr/include/c++/5/ios:38,
                 from /usr/include/c++/5/istream:38,
                 from /usr/include/c++/5/sstream:38,
                 from /home/maceli/kratos/kratos/python/add_kernel_to_python.cpp:17:
/usr/include/features.h:225:0: nota: esta es la ubicación de la definición previa
 # define _POSIX_C_SOURCE 200809L
 ^
In file included from /usr/include/python2.7/Python.h:8:0,
                 from /home/maceli/kratos/external_libraries/pybind11/detail/common.h:111,
                 from /home/maceli/kratos/external_libraries/pybind11/pytypes.h:12,
                 from /home/maceli/kratos/external_libraries/pybind11/cast.h:13,
                 from /home/maceli/kratos/external_libraries/pybind11/attr.h:13,
                 from /home/maceli/kratos/external_libraries/pybind11/pybind11.h:43,
                 from /home/maceli/kratos/kratos/includes/define_python.h:17,
                 from /home/maceli/kratos/kratos/python/add_kernel_to_python.cpp:20:
/usr/include/python2.7/pyconfig.h:1215:0: aviso: se redefinió "_XOPEN_SOURCE"
 #define _XOPEN_SOURCE 600
 ^
In file included from /usr/include/c++/5/x86_64-suse-linux/bits/os_defines.h:39:0,
                 from /usr/include/c++/5/x86_64-suse-linux/bits/c++config.h:2255,
                 from /usr/include/c++/5/iosfwd:38,
                 from /usr/include/c++/5/ios:38,
                 from /usr/include/c++/5/istream:38,
                 from /usr/include/c++/5/sstream:38,
                 from /home/maceli/kratos/kratos/python/add_kernel_to_python.cpp:17:
/usr/include/features.h:166:0: nota: esta es la ubicación de la definición previa
 # define _XOPEN_SOURCE 700

```