### PR TITLE
hotfix-check-in-shape-opt

### DIFF
--- a/applications/ShapeOptimizationApplication/custom_utilities/mapping/mapper_vertex_morphing.h
+++ b/applications/ShapeOptimizationApplication/custom_utilities/mapping/mapper_vertex_morphing.h
@@ -511,7 +511,7 @@ private:
         for(auto& node_i : mrDesignSurface.Nodes())
         {
             array_3d& coord = node_i.Coordinates();
-            sumOfAllCoordinates += coord[0] + coord[1] + coord[2];
+            sumOfAllCoordinates += std::abs(coord[0]) + std::abs(coord[1]) + std::abs(coord[2]);
         }
 
         if (mControlSum == sumOfAllCoordinates)

--- a/applications/ShapeOptimizationApplication/custom_utilities/mapping/mapper_vertex_morphing_matrix_free.h
+++ b/applications/ShapeOptimizationApplication/custom_utilities/mapping/mapper_vertex_morphing_matrix_free.h
@@ -485,7 +485,7 @@ private:
         for(auto& node_i : mrDesignSurface.Nodes())
         {
             array_3d& coord = node_i.Coordinates();
-            sumOfAllCoordinates += coord[0] + coord[1] + coord[2];
+            sumOfAllCoordinates += std::abs(coord[0]) + std::abs(coord[1]) + std::abs(coord[2]);
         }
 
         if(IsFirstMappingOperation())


### PR DESCRIPTION
Within the vertex morphing, the check whether the geometry has changed requires absolute values, otherwise, it fails in some cases (e.g. square plate)