### PR TITLE
Updating scripts and CI

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,11 +45,9 @@ before_build:
   - cmd: cd C:\projects\kratos\cmake_build
   - cmd: .\configure_appveyor_VS2017.bat
 
-# Build
-build:
+# Custom build script
+build_script:
   SET preferredToolArchitecture=x64
-  project: C:\projects\kratos\cmake_build\kratosMultiphysics.sln  # path to Visual Studio solution or project
-  parallel: true                                                  # enable MSBuild parallel builds
-  verbosity: minimal                                              # MSBuild verbosity level (quiet|minimal|normal|detailed)
+  MSBuild.exe kratos/all_unity.vcxproj /p:Configuration:Debug /p:Platform:"x64"
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,7 +47,7 @@ before_build:
 
 # Custom build script
 build_script:
-  SET preferredToolArchitecture=x64
-  MSBuild.exe kratos/all_unity.vcxproj /p:Configuration:Debug /p:Platform:"x64"
+  - cmd: SET preferredToolArchitecture=x64
+  - cmd: MSBuild.exe kratos/all_unity.vcxproj /p:Configuration:Debug /p:Platform:"x64"
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ branches:
 version: "{build}"
 
 # set clone depth
-clone_depth: 1
+shallow_clone: true
 
 # Image
 image: Visual Studio 2017

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,6 @@ before_build:
 # Custom build script
 build_script:
   - cmd: SET preferredToolArchitecture=x64
-  - cmd: MSBuild.exe kratos/all_unity.vcxproj /p:Configuration:Debug /p:Platform:"x64"
+  - cmd: MSBuild.exe kratos/all_unity.vcxproj /p:Configuration=Debug /p:Platform="x64"
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,6 +47,7 @@ before_build:
 
 # Build
 build:
+  SET preferredToolArchitecture=x64
   project: C:\projects\kratos\cmake_build\kratosMultiphysics.sln  # path to Visual Studio solution or project
   parallel: true                                                  # enable MSBuild parallel builds
   verbosity: minimal                                              # MSBuild verbosity level (quiet|minimal|normal|detailed)

--- a/cmake_build/example_configure.bat.do_not_touch
+++ b/cmake_build/example_configure.bat.do_not_touch
@@ -11,14 +11,15 @@ cmake -G "Visual Studio 14 2015 Win64"                                          
 -DCMAKE_BUILD_TYPE=Release                                                          ^
 -DCMAKE_CXX_FLAGS=" -D_SCL_SECURE_NO_WARNINGS "                                     ^
 -DBOOST_ROOT="C:\boost_1_59_0"                                                      ^
--DPYTHON_LIBRARY="C:\Python33\libs\python33.lib"                                    ^
--DPYTHON_INCLUDE_PATH="C:\Python33\include"                                         ^
+-DPYTHON_EXECUTABLE="C:\Python33\python.exe"                                        ^
 -DLAPACK_LIBRARIES="C:\external_libraries\liblapack.lib"                            ^
 -DBLAS_LIBRARIES="C:\external_libraries\libblas.lib"                                ^
 -DMESHING_APPLICATION=ON                                                            ^
 -DEXTERNAL_SOLVERS_APPLICATION=ON                                                   ^
--DSTRUCTURAL_APPLICATION=ON                                                         ^
+-DSTRUCTURAL_MECHANICS_APPLICATION=ON                                               ^
 -DCONVECTION_DIFFUSION_APPLICATION=ON                                               ^
+-DSOLID_MECHANICS_APPLICATION=ON                                                    ^
+-DCONSTITUTIVE_MODELS_APPLICATION=ON                                                ^
 -DFLUID_DYNAMICS_APPLICATION=ON                                                     ^
 -DALE_APPLICATION=ON                                                                ^
 -DFSI_APPLICATION=ON                                                                ^
@@ -27,6 +28,4 @@ cmake -G "Visual Studio 14 2015 Win64"                                          
 -DINSTALL_PYTHON_FILES=ON                                                           ^
 -DINSTALL_EMBEDDED_PYTHON=ON                                                        ^
 -DEXCLUDE_ITSOL=ON                                                                  ^
--DSOLID_MECHANICS_APPLICATION=ON                                                    ^
--DCONSTITUTIVE_MODELS_APPLICATION=ON                                                ^
 ..

--- a/cmake_build/example_configure.sh.do_not_touch
+++ b/cmake_build/example_configure.sh.do_not_touch
@@ -23,40 +23,33 @@ rm CMakeCache.txt
 rm *.cmake
 rm -rf CMakeFiles\
 
-cmake ..  									                                                    \
--DCMAKE_C_COMPILER=/usr/bin/gcc							                                    \
--DCMAKE_INSTALL_RPATH="/home/youruser/kratos/libs"                              \
--DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE                                        \
--DCMAKE_CXX_COMPILER=/usr/bin/g++						                                    \
--DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -msse3 -std=c++11 " 					                        \
--DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -msse3 " 					                            \
--DCMAKE_BUILD_TYPE=Release  							                                      \
--DSOLID_MECHANICS_APPLICATION=ON   					                                    \
--DFLUID_DYNAMICS_APPLICATION=ON 						                                    \
--DCONVECTION_DIFFUSION_APPLICATION=ON 						                              \
--DDEM_APPLICATION=OFF								                                            \
--DSWIMMING_DEM_APPLICATION=OFF                                                  \
--DINCOMPRESSIBLE_FLUID_APPLICATION=ON  						                              \
--DMESHING_APPLICATION=ON 							                                          \
--DEXTERNAL_SOLVERS_APPLICATION=ON						                                    \
--DSTRUCTURAL_APPLICATION=ON 							                                      \
--DSTRUCTURAL_MECHANICS_APPLICATION=ON 					                                \
--DCONSTITUTIVE_MODELS_APPLICATION=ON                                             \
--DALE_APPLICATION=ON 								                                            \
--DFSI_APPLICATION=ON 								                                            \
--DMAPPING_APPLICATION=OFF 								                                            \
--DOPENCL_APPLICATION=OFF							                                          \
--DMIXED_ELEMENT_APPLICATION=ON							                                    \
--DMKL_SOLVERS_APPLICATION=OFF							                                      \
--DMKLSOLVER_INCLUDE_DIR="/opt/intel/Compiler/11.1/072/mkl/include"	            \
--DMKLSOLVER_LIB_DIR="/opt/intel/Compiler/11.1/072/mkl/lib/em64t"	              \
--DMETIS_APPLICATION=OFF								                                          \
--DPARMETIS_ROOT_DIR="/home/youruser/compiled_libraries/ParMetis-3.1.1"          \
--DTRILINOS_APPLICATION=OFF							                                        \
--DTRILINOS_ROOT="/home/youruser/compiled_libraries/trilinos-10.2.0"		          \
--DINSTALL_EMBEDDED_PYTHON=ON                                                    \
--DSHAPE_OPTIMIZATION_APPLICATION=OFF \
--DTOPOLOGY_OPTIMIZATION_APPLICATION=OFF \
+cmake ..                                                                            \
+-DCMAKE_C_COMPILER=/usr/bin/gcc                                                     \
+-DCMAKE_INSTALL_RPATH="/home/youruser/kratos/libs"                                  \
+-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=TRUE                                            \
+-DCMAKE_CXX_COMPILER=/usr/bin/g++                                                   \
+-DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -msse3 -std=c++11 "                           \
+-DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -msse3 "                                          \
+-DCMAKE_BUILD_TYPE=Release                                                          \
+-DMESHING_APPLICATION=ON                                                            \
+-DEXTERNAL_SOLVERS_APPLICATION=ON                                                   \
+-DSTRUCTURAL_MECHANICS_APPLICATION=ON                                               \
+-DCONVECTION_DIFFUSION_APPLICATION=ON                                               \
+-DSOLID_MECHANICS_APPLICATION=ON                                                    \
+-DCONSTITUTIVE_MODELS_APPLICATION=ON                                                \
+-DFLUID_DYNAMICS_APPLICATION=ON                                                     \
+-DALE_APPLICATION=ON                                                                \
+-DFSI_APPLICATION=ON                                                                \
+-DDEM_APPLICATION=OFF                                                               \
+-DSWIMMING_DEM_APPLICATION=OFF                                                      \
+-DMIXED_ELEMENT_APPLICATION=OFF                                                     \
+-DSHAPE_OPTIMIZATION_APPLICATION=OFF                                                \
+-DTOPOLOGY_OPTIMIZATION_APPLICATION=OFF                                             \
+-DMETIS_APPLICATION=OFF                                                             \
+-DPARMETIS_ROOT_DIR="/home/youruser/compiled_libraries/ParMetis-3.1.1"              \
+-DTRILINOS_APPLICATION=OFF                                                          \
+-DTRILINOS_ROOT="/home/youruser/compiled_libraries/trilinos-10.2.0"                 \
+-DINSTALL_EMBEDDED_PYTHON=ON
 
 #decomment this to have it verbose
 # make VERBOSE=1 -j4

--- a/cmake_build/example_configure.sh.do_not_touch
+++ b/cmake_build/example_configure.sh.do_not_touch
@@ -30,6 +30,8 @@ cmake ..                                                                        
 -DCMAKE_CXX_COMPILER=/usr/bin/g++                                                   \
 -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -msse3 -std=c++11 "                           \
 -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -msse3 "                                          \
+-DBOOST_ROOT="${HOME}/boost"                                                        \
+-DPYTHON_EXECUTABLE="/usr/bin/python3"                                              \
 -DCMAKE_BUILD_TYPE=Release                                                          \
 -DMESHING_APPLICATION=ON                                                            \
 -DEXTERNAL_SOLVERS_APPLICATION=ON                                                   \

--- a/embedded_python/krun_main.cpp
+++ b/embedded_python/krun_main.cpp
@@ -1,4 +1,4 @@
-#ifdef KRATOS_DEBUG
+#if defined(KRATOS_DEBUG) && ! defined(EXCLUDE_EMBEDDED_PYTHON_DEBUG)
   #include <Python.h>
 #else
   #ifdef _DEBUG

--- a/scripts/build/appveyor/configure_appveyor_VS2017.bat
+++ b/scripts/build/appveyor/configure_appveyor_VS2017.bat
@@ -1,6 +1,6 @@
 cmake .. -G "Visual Studio 15 2017 Win64"                                       ^
--DCMAKE_CXX_FLAGS="/D KRATOS_DISABLE_AMGCL" 								    ^
--DCMAKE_C_FLAGS="/D KRATOS_DISABLE_AMGCL" 									    ^
+-DCMAKE_CXX_FLAGS="/D KRATOS_DISABLE_AMGCL /D EXCLUDE_EMBEDDED_PYTHON_DEBUG" 	^
+-DCMAKE_C_FLAGS="/D KRATOS_DISABLE_AMGCL /D EXCLUDE_EMBEDDED_PYTHON_DEBUG" 		^
 -DBOOST_ROOT="C:\Libraries\boost_1_65_1"                                        ^
 -DPYTHON_EXECUTABLE="C:\Python27-x64\python.exe"							    ^
 -DCMAKE_BUILD_TYPE="Debug"  													^

--- a/scripts/build/appveyor/configure_appveyor_VS2017.bat
+++ b/scripts/build/appveyor/configure_appveyor_VS2017.bat
@@ -2,7 +2,7 @@ cmake .. -G "Visual Studio 15 2017 Win64"                                       
 -DCMAKE_CXX_FLAGS="/D KRATOS_DISABLE_AMGCL /D EXCLUDE_EMBEDDED_PYTHON_DEBUG" 	^
 -DCMAKE_C_FLAGS="/D KRATOS_DISABLE_AMGCL /D EXCLUDE_EMBEDDED_PYTHON_DEBUG" 		^
 -DBOOST_ROOT="C:\Libraries\boost_1_65_1"                                        ^
--DPYTHON_EXECUTABLE="C:\Python27-x64\python.exe"							    ^
+-DPYTHON_EXECUTABLE="C:\Python36-x64\python.exe"							    ^
 -DCMAKE_BUILD_TYPE="Debug"  													^
 -DDEM_APPLICATION=ON                                                            ^
 -DEXTERNAL_SOLVERS_APPLICATION=OFF                                              ^

--- a/scripts/build/appveyor/configure_appveyor_VS2017.bat
+++ b/scripts/build/appveyor/configure_appveyor_VS2017.bat
@@ -1,11 +1,9 @@
 cmake .. -G "Visual Studio 15 2017 Win64"                                       ^
--DCMAKE_CXX_FLAGS="/D KRATOS_DISABLE_AMGCL" 								                    ^
--DCMAKE_C_FLAGS="/D KRATOS_DISABLE_AMGCL" 									                    ^
+-DCMAKE_CXX_FLAGS="/D KRATOS_DISABLE_AMGCL" 								    ^
+-DCMAKE_C_FLAGS="/D KRATOS_DISABLE_AMGCL" 									    ^
 -DBOOST_ROOT="C:\Libraries\boost_1_65_1"                                        ^
--DPYTHON_EXECUTABLE="C:\Python27-x64\python.exe"							                  ^
--DPYTHON_INCLUDE_PATH="C:\Python27-x64\include"							                    ^
--DPYTHON_LIBRARY="C:\Python27-x64\libs\python27.lib"					                  ^
--DCMAKE_BUILD_TYPE="Release"  													                        ^
+-DPYTHON_EXECUTABLE="C:\Python27-x64\python.exe"							    ^
+-DCMAKE_BUILD_TYPE="Debug"  													^
 -DDEM_APPLICATION=ON                                                            ^
 -DEXTERNAL_SOLVERS_APPLICATION=OFF                                              ^
 -DFLUID_DYNAMICS_APPLICATION=ON                                                 ^
@@ -16,4 +14,5 @@ cmake .. -G "Visual Studio 15 2017 Win64"                                       
 -DTRILINOS_APPLICATION=OFF                                                      ^
 -DTRILINOS_ROOT="UNSET"                                                         ^
 -DINSTALL_EMBEDDED_PYTHON=ON                                                    ^
--DINCLUDE_FEAST=OFF
+-DINCLUDE_FEAST=OFF                                                             ^
+-DUSE_COTIRE=ON

--- a/scripts/build/appveyor/configure_appveyor_VS2017.bat
+++ b/scripts/build/appveyor/configure_appveyor_VS2017.bat
@@ -1,6 +1,6 @@
 cmake .. -G "Visual Studio 15 2017 Win64"                                       ^
--DCMAKE_CXX_FLAGS="/D KRATOS_DISABLE_AMGCL /D EXCLUDE_EMBEDDED_PYTHON_DEBUG" 	^
--DCMAKE_C_FLAGS="/D KRATOS_DISABLE_AMGCL /D EXCLUDE_EMBEDDED_PYTHON_DEBUG" 		^
+-DCMAKE_CXX_FLAGS="/D EXCLUDE_EMBEDDED_PYTHON_DEBUG" 	^
+-DCMAKE_C_FLAGS="/D EXCLUDE_EMBEDDED_PYTHON_DEBUG" 		^
 -DBOOST_ROOT="C:\Libraries\boost_1_65_1"                                        ^
 -DPYTHON_EXECUTABLE="C:\Python36-x64\python.exe"							    ^
 -DCMAKE_BUILD_TYPE="Debug"  													^

--- a/scripts/build/compile_and_pack_linux_x86_64.sh
+++ b/scripts/build/compile_and_pack_linux_x86_64.sh
@@ -69,7 +69,6 @@ cmake ..  																		                                 \
 -DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -msse3   " 								               \
 -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -msse3   " 									                 \
 -DBOOST_LIBRARYDIR="${BOOST_ROOT}/stage/lib"									                 \
--DPYTHON_INCLUDE_PATH="/home/odin/Python-3.3.4/Include"							           \
 -DPYTHON_EXECUTABLE="/usr/bin/python${PYTHON_VERSION_S}.${PYTHON_VERSION_M}"                    \
 -DCMAKE_BUILD_TYPE=Release  													                         \
 -DINCOMPRESSIBLE_FLUID_APPLICATION=ON  											                   \


### PR DESCRIPTION
Some changes I've been testing for a while now and were delayed by pybind.

Summary of changes:
* Updated example scripts and made them consistent across Kratos
* Appveyor fetch time reduced from ~15min to ~2min
* Appveyor using python 3.6
* Appveyor using cotire
* Appveyor being able to build in debug

Aside from the cosmetic changes in the scripts this should make Appveyor builds reliable and noticeably faster (from not being able to finish in >50min in time to ~15min). Sadly right now I still cannot run the tests and AMGCL is still disabled but I will keep working on it 