### PR TITLE
Fix remove stabilized cfd warnings

### DIFF
--- a/applications/StabilizedCFDApplication/custom_conditions/dss_face.h
+++ b/applications/StabilizedCFDApplication/custom_conditions/dss_face.h
@@ -134,7 +134,7 @@ namespace Kratos
         DSSFace(DSSFace const& rOther);
 
         /// Destructor.
-        virtual ~DSSFace();
+        ~DSSFace() override;
 
 
         ///@}
@@ -154,11 +154,11 @@ namespace Kratos
           @param ThisNodes An array containing the nodes of the new condition
           @param pProperties Pointer to the element's properties
           */
-        virtual Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const;
+        Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
 
 
-        virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                           ProcessInfo& rCurrentProcessInfo);
+        void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                                   ProcessInfo& rCurrentProcessInfo) override;
 
 
 
@@ -168,18 +168,18 @@ namespace Kratos
           @param rRightHandSideVector Right-hand side vector
           @param rCurrentProcessInfo ProcessInfo instance (unused)
           */
-        virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
-                                          VectorType& rRightHandSideVector,
-                                          ProcessInfo& rCurrentProcessInfo);
+        void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+                                  VectorType& rRightHandSideVector,
+                                  ProcessInfo& rCurrentProcessInfo) override;
 
 
-        virtual void CalculateLocalVelocityContribution(MatrixType& rDampMatrix,
-                                                        VectorType& rRightHandSideVector,
-                                                        ProcessInfo& rCurrentProcessInfo);
+        void CalculateLocalVelocityContribution(MatrixType& rDampMatrix,
+                                                VectorType& rRightHandSideVector,
+                                                ProcessInfo& rCurrentProcessInfo) override;
 
 
         /// Check that all data required by this condition is available and reasonable
-        virtual int Check(const ProcessInfo& rCurrentProcessInfo);
+        int Check(const ProcessInfo& rCurrentProcessInfo) override;
 
 
         /// Provides the global indices for each one of this element's local rows.
@@ -187,8 +187,8 @@ namespace Kratos
          * @param rResult A vector containing the global Id of each row
          * @param rCurrentProcessInfo the current process info object (unused)
          */
-        virtual void EquationIdVector(EquationIdVectorType& rResult,
-                                      ProcessInfo& rCurrentProcessInfo);
+        void EquationIdVector(EquationIdVectorType& rResult,
+                              ProcessInfo& rCurrentProcessInfo) override;
 
 
         /// Returns a list of the element's Dofs
@@ -196,8 +196,8 @@ namespace Kratos
          * @param ElementalDofList the list of DOFs
          * @param rCurrentProcessInfo the current process info instance
          */
-        virtual void GetDofList(DofsVectorType& ConditionDofList,
-                                ProcessInfo& CurrentProcessInfo);
+        void GetDofList(DofsVectorType& ConditionDofList,
+                        ProcessInfo& CurrentProcessInfo) override;
 
 
         /// Returns VELOCITY_X, VELOCITY_Y, (VELOCITY_Z,) PRESSURE for each node
@@ -205,33 +205,33 @@ namespace Kratos
          * @param Values Vector of nodal unknowns
          * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
          */
-        virtual void GetValuesVector(Vector& Values,
-                                     int Step = 0);
+        void GetValuesVector(Vector& Values,
+                                     int Step = 0) override;
 
 
-        virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
-                                                 std::vector<array_1d<double, 3 > >& rValues,
-                                                 const ProcessInfo& rCurrentProcessInfo);
+        void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+                                         std::vector<array_1d<double, 3 > >& rValues,
+                                         const ProcessInfo& rCurrentProcessInfo) override;
 
 
 
-        virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
-                                                 std::vector<double>& rValues,
-                                                 const ProcessInfo& rCurrentProcessInfo);
+        void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+                                         std::vector<double>& rValues,
+                                         const ProcessInfo& rCurrentProcessInfo) override;
 
 
-        virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
-                                                 std::vector<array_1d<double, 6 > >& rValues,
-                                                 const ProcessInfo& rCurrentProcessInfo);
+        void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+                                         std::vector<array_1d<double, 6 > >& rValues,
+                                         const ProcessInfo& rCurrentProcessInfo) override;
 
-        virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
-                                                 std::vector<Vector>& rValues,
-                                                 const ProcessInfo& rCurrentProcessInfo);
+        void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+                                         std::vector<Vector>& rValues,
+                                         const ProcessInfo& rCurrentProcessInfo) override;
 
 
-        virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
-                                                 std::vector<Matrix>& rValues,
-                                                 const ProcessInfo& rCurrentProcessInfo);
+        void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+                                         std::vector<Matrix>& rValues,
+                                         const ProcessInfo& rCurrentProcessInfo) override;
 
 
         ///@}
@@ -249,13 +249,13 @@ namespace Kratos
         ///@{
 
         /// Turn back information as a string.
-        virtual std::string Info() const;
+        std::string Info() const override;
 
         /// Print information about this object.
-        virtual void PrintInfo(std::ostream& rOStream) const;
+        void PrintInfo(std::ostream& rOStream) const override;
 
         /// Print object's data.
-        virtual void PrintData(std::ostream& rOStream) const;
+        void PrintData(std::ostream& rOStream) const override;
 
 
         ///@}
@@ -363,9 +363,9 @@ namespace Kratos
 
         friend class Serializer;
 
-        virtual void save(Serializer& rSerializer) const;
+        void save(Serializer& rSerializer) const override;
 
-        virtual void load(Serializer& rSerializer);
+        void load(Serializer& rSerializer) override;
 
         ///@}
         ///@name Private Operators

--- a/applications/StabilizedCFDApplication/custom_elements/dss.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dss.h
@@ -150,7 +150,7 @@ public:
      */
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const;
+                            PropertiesType::Pointer pProperties) const override;
 
 
     /**
@@ -161,9 +161,9 @@ public:
      * @param rRightHandSideVector Local finite element residual vector (output)
      * @param rCurrentProcessInfo Current ProcessInfo values (input)
      */
-    virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
-                                      VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo);
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+                              VectorType& rRightHandSideVector,
+                              ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * @brief CalculateLeftHandSide Return an empty matrix of appropriate size.
@@ -172,8 +172,8 @@ public:
      * @param rLeftHandSideMatrix Local finite element system matrix (output)
      * @param rCurrentProcessInfo Current ProcessInfo values (input)
      */
-    virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                       ProcessInfo& rCurrentProcessInfo);
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                               ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * @brief CalculateRightHandSide Return an empty matrix of appropriate size.
@@ -182,8 +182,8 @@ public:
      * @param rRightHandSideVector Local finite element residual vector (output)
      * @param rCurrentProcessInfo Current ProcessInfo values (input)
      */
-    virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo);
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * @brief CalculateLocalVelocityContribution Calculate the local contribution in terms of velocity and pressure.
@@ -191,50 +191,50 @@ public:
      * @param rRightHandSideVector Local finite element residual vector (output)
      * @param rCurrentProcessInfo Current ProcessInfo values (input)
      */
-    virtual void CalculateLocalVelocityContribution(MatrixType &rDampMatrix,
-                                                    VectorType &rRightHandSideVector,
-                                                    ProcessInfo &rCurrentProcessInfo);
+    void CalculateLocalVelocityContribution(MatrixType &rDampMatrix,
+                                            VectorType &rRightHandSideVector,
+                                            ProcessInfo &rCurrentProcessInfo) override;
 
     /**
      * @brief MassMatrix Calculate the local mass matrix.
      * @param rMassMatrix Local mass matrix (output)
      * @param rCurrentProcessInfo Current ProcessInfo values (input)
      */
-    virtual void CalculateMassMatrix(MatrixType &rMassMatrix,
-                                     ProcessInfo &rCurrentProcessInfo);
+    void CalculateMassMatrix(MatrixType &rMassMatrix,
+                             ProcessInfo &rCurrentProcessInfo) override;
 
 
     /**
      * @brief AddExplicitContribution Calculate projection terms for iterative OSS projection scheme.
      * @param rCurrentProcessInfo
      */
-    virtual void AddExplicitContribution(ProcessInfo& rCurrentProcessInfo);
+    void AddExplicitContribution(ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void Calculate(const Variable<double>& rVariable,
-                           double& rOutput,
-                           const ProcessInfo& rCurrentProcessInfo);
+    void Calculate(const Variable<double>& rVariable,
+                   double& rOutput,
+                   const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
-                           array_1d<double, 3 > & rOutput,
-                           const ProcessInfo& rCurrentProcessInfo);
+    void Calculate(const Variable<array_1d<double, 3 > >& rVariable,
+                   array_1d<double, 3 > & rOutput,
+                   const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * @brief EquationIdVector Returns the global system rows corresponding to each local row.
      * @param rResult rResult[i] is the global index of local row i (output)
      * @param rCurrentProcessInfo Current ProcessInfo values (input)
      */
-    virtual void EquationIdVector(EquationIdVectorType& rResult,
-                                  ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult,
+                          ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * @brief GetDofList Returns a list of the element's Dofs.
      * @param rElementalDofList List of DOFs. (output)
      * @param rCurrentProcessInfo Current ProcessInfo instance. (input)
      */
-    virtual void GetDofList(DofsVectorType& rElementalDofList,
-                            ProcessInfo& rCurrentProcessInfo);
+    void GetDofList(DofsVectorType& rElementalDofList,
+                    ProcessInfo& rCurrentProcessInfo) override;
 
 
     /**
@@ -242,7 +242,7 @@ public:
      * @param Values Vector of nodal unknowns
      * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
      */
-    virtual void GetFirstDerivativesVector(Vector& Values, int Step = 0);
+    void GetFirstDerivativesVector(Vector& Values, int Step = 0) override;
 
 
 
@@ -251,39 +251,39 @@ public:
      * @param Values Vector of nodal second derivatives
      * @param Step Get result from 'Step' steps back, 0 is current step. (Must be smaller than buffer size)
      */
-    virtual void GetSecondDerivativesVector(Vector& Values, int Step = 0);
+    void GetSecondDerivativesVector(Vector& Values, int Step = 0) override;
 
 
     /**
      * @brief GetIntegrationMethod Return the integration order to be used.
      * @return Gauss Order
      */
-    virtual GeometryData::IntegrationMethod GetIntegrationMethod() const;
+    GeometryData::IntegrationMethod GetIntegrationMethod() const override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
-                                             std::vector<array_1d<double, 3 > >& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+                                     std::vector<array_1d<double, 3 > >& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
-                                             std::vector<double>& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+                                     std::vector<double>& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
-                                             std::vector<array_1d<double, 6 > >& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+                                     std::vector<array_1d<double, 6 > >& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
-                                             std::vector<Vector>& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+                                     std::vector<Vector>& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
-                                             std::vector<Matrix>& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+                                     std::vector<Matrix>& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
 
     ///@}
@@ -295,18 +295,18 @@ public:
     ///@name Inquiry
     ///@{
 
-    virtual int Check(const ProcessInfo &rCurrentProcessInfo);
+    int Check(const ProcessInfo &rCurrentProcessInfo) override;
 
     ///@}
     ///@name Input and output
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const;
+    std::string Info() const override;
 
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const;
+    void PrintInfo(std::ostream& rOStream) const override;
 
 
     ///@}
@@ -642,9 +642,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer);
+    void load(Serializer& rSerializer) override;
 
     ///@}
     ///@name Private Operators

--- a/applications/StabilizedCFDApplication/custom_elements/dss_fic.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dss_fic.h
@@ -151,7 +151,7 @@ public:
      */
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const;
+                            PropertiesType::Pointer pProperties) const override;
 
 
     void CalculateMassMatrix(MatrixType &rMassMatrix, ProcessInfo &rCurrentProcessInfo) override;
@@ -273,9 +273,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer);
+    void load(Serializer& rSerializer) override;
 
     ///@}
     ///@name Private Operators

--- a/applications/StabilizedCFDApplication/custom_elements/dss_fic_limited.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dss_fic_limited.h
@@ -129,7 +129,7 @@ public:
     DSS_FIC_LIMITED(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties);
 
     /// Destructor.
-    virtual ~DSS_FIC_LIMITED();
+    ~DSS_FIC_LIMITED() override;
 
     ///@}
     ///@name Operators
@@ -151,15 +151,15 @@ public:
      */
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const;
+                            PropertiesType::Pointer pProperties) const override;
 
     Element::Pointer Create(IndexType NewId,
                             GeometryType::Pointer pGeom,
-                            PropertiesType::Pointer pProperties) const;
+                            PropertiesType::Pointer pProperties) const override;
 
 
     /// InitializeSolutionStep is used to compute new values for beta coefficients
-    virtual void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo);
+    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
 
 
     ///@}
@@ -184,31 +184,31 @@ protected:
     ///@name Protected Operations
     ///@{
 
-    virtual void CalculateAllTaus(double Density,
-                                  double KinematicVisc,
-                                  const array_1d<double,3>& Velocity,
-                                  const ProcessInfo& rProcessInfo,
-                                  double& TauIncompr,
-                                  array_1d<double,3>& TauMomentum,
-                                  array_1d<double,3>& TauGrad);
+    void CalculateAllTaus(double Density,
+                          double KinematicVisc,
+                          const array_1d<double,3>& Velocity,
+                          const ProcessInfo& rProcessInfo,
+                          double& TauIncompr,
+                          array_1d<double,3>& TauMomentum,
+                          array_1d<double,3>& TauGrad);
 
 
-    virtual void AddSystemTerms(unsigned int GaussIndex,
-                                double GaussWeight,
-                                const ShapeFunctionsType& rN,
-                                const ShapeFunctionDerivativesType& rDN_DX,
-                                const ProcessInfo& rProcessInfo,
-                                MatrixType& rLHS,
-                                VectorType& rRHS);
+    void AddSystemTerms(unsigned int GaussIndex,
+                        double GaussWeight,
+                        const ShapeFunctionsType& rN,
+                        const ShapeFunctionDerivativesType& rDN_DX,
+                        const ProcessInfo& rProcessInfo,
+                        MatrixType& rLHS,
+                        VectorType& rRHS) override;
 
 
 
-    virtual void AddMassStabilization(unsigned int GaussIndex,
-                                      double GaussWeight,
-                                      const ShapeFunctionsType& rN,
-                                      const ShapeFunctionDerivativesType& rDN_DX,
-                                      const ProcessInfo& rProcessInfo,
-                                      MatrixType& rMassMatrix);
+    void AddMassStabilization(unsigned int GaussIndex,
+                              double GaussWeight,
+                              const ShapeFunctionsType& rN,
+                              const ShapeFunctionDerivativesType& rDN_DX,
+                              const ProcessInfo& rProcessInfo,
+                              MatrixType& rMassMatrix) override;
 
 
 
@@ -246,9 +246,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer);
+    void load(Serializer& rSerializer) override;
 
     ///@}
     ///@name Private Operators

--- a/applications/StabilizedCFDApplication/custom_elements/dss_gls.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dss_gls.h
@@ -151,7 +151,7 @@ public:
      */
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const;
+                            PropertiesType::Pointer pProperties) const override;
 
     ///@}
 
@@ -176,13 +176,13 @@ protected:
     ///@{
 
 
-    virtual void CalculateStaticTau(double Density,
-                                    double KinematicVisc,
-                                    const array_1d<double,3> &Velocity,
-                                    const ProcessInfo& rProcessInfo,
-                                    double &TauIncompr,
-                                    double &TauMomentum,
-                                    array_1d<double,3> &TauGrad);
+    void CalculateStaticTau(double Density,
+                            double KinematicVisc,
+                            const array_1d<double,3> &Velocity,
+                            const ProcessInfo& rProcessInfo,
+                            double &TauIncompr,
+                            double &TauMomentum,
+                            array_1d<double,3> &TauGrad) override;
 
 
 
@@ -218,9 +218,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer);
+    void load(Serializer& rSerializer) override;
 
     ///@}
     ///@name Private Operators

--- a/applications/StabilizedCFDApplication/custom_elements/dss_notau2.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dss_notau2.h
@@ -149,7 +149,7 @@ public:
      */
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const;
+                            PropertiesType::Pointer pProperties) const override;
 
 
     ///@}
@@ -167,11 +167,11 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const;
+    std::string Info() const override;
 
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const;
+    void PrintInfo(std::ostream& rOStream) const override;
 
 
     ///@}
@@ -202,13 +202,13 @@ protected:
     ///@{
 
 
-    virtual void CalculateStaticTau(double Density,
-                                    double KinematicVisc,
-                                    const array_1d<double,3> &Velocity,
-                                    double ElemSize,
-                                    const ProcessInfo& rProcessInfo,
-                                    double &TauOne,
-                                    double &TauTwo);
+    void CalculateStaticTau(double Density,
+                            double KinematicVisc,
+                            const array_1d<double,3> &Velocity,
+                            double ElemSize,
+                            const ProcessInfo& rProcessInfo,
+                            double &TauOne,
+                            double &TauTwo) override;
 
     ///@}
     ///@name Protected  Access
@@ -242,9 +242,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer);
+    void load(Serializer& rSerializer) override;
 
     ///@}
     ///@name Private Operators

--- a/applications/StabilizedCFDApplication/custom_elements/dss_ps.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dss_ps.h
@@ -149,7 +149,7 @@ public:
      */
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const;
+                            PropertiesType::Pointer pProperties) const override;
 
 
     /**
@@ -158,9 +158,9 @@ public:
      * @param rRightHandSideVector Local finite element residual vector (output)
      * @param rCurrentProcessInfo Current ProcessInfo values (input)
      */
-    virtual void CalculateLocalVelocityContribution(MatrixType &rDampMatrix,
-                                                    VectorType &rRightHandSideVector,
-                                                    ProcessInfo &rCurrentProcessInfo);
+    void CalculateLocalVelocityContribution(MatrixType &rDampMatrix,
+                                            VectorType &rRightHandSideVector,
+                                            ProcessInfo &rCurrentProcessInfo) override;
 
 //    virtual void CalculateMassMatrix(MatrixType &rMassMatrix,
 //                                     ProcessInfo &rCurrentProcessInfo);
@@ -181,11 +181,11 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const;
+    std::string Info() const override;
 
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const;
+    void PrintInfo(std::ostream& rOStream) const override;
 
 
     ///@}
@@ -216,13 +216,13 @@ protected:
     ///@{
 
 
-    virtual void CalculateStaticTau(double Density,
-                                    double KinematicVisc,
-                                    const array_1d<double,3> &Velocity,
-                                    double ElemSize,
-                                    const ProcessInfo& rProcessInfo,
-                                    double &TauOne,
-                                    double &TauTwo);
+    void CalculateStaticTau(double Density,
+                            double KinematicVisc,
+                            const array_1d<double,3> &Velocity,
+                            double ElemSize,
+                            const ProcessInfo& rProcessInfo,
+                            double &TauOne,
+                            double &TauTwo) override;
 
 
     virtual void AddPressureSubscale(MatrixType& rLHS,
@@ -287,9 +287,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer);
+    void load(Serializer& rSerializer) override;
 
     ///@}
     ///@name Private Operators

--- a/applications/StabilizedCFDApplication/custom_elements/dynss.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dynss.h
@@ -149,20 +149,20 @@ public:
      */
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const;
+                            PropertiesType::Pointer pProperties) const override;
 
     Element::Pointer Create(IndexType NewId,
                            GeometryType::Pointer pGeom,
-                           PropertiesType::Pointer pProperties) const;
+                           PropertiesType::Pointer pProperties) const override;
 
     /// Allocate memory for small scale values to be tracked.
-    virtual void Initialize();
+    void Initialize() override;
 
     /// Update the values of tracked small scale quantities.
-    virtual void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo);
+    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
 
     /// Predict the value of the small scale velocity for the current iteration.
-    virtual void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo);
+    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
 
 
     ///@}
@@ -170,59 +170,59 @@ public:
     ///@{
 
 
-    virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
-                                             std::vector<double>& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+                                     std::vector<double>& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
-                                             std::vector<array_1d<double, 3 > >& rValues,
-                                             const ProcessInfo& rCurrentProcessInfo);
-
-    /**
-     * TO COPY SUBSCALE VALUES AFTER SERIALIZATION
-     */
-    virtual void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
-                          std::vector<double>& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo);
-
-    virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
-                          std::vector< array_1d<double, 3 > >& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo);
-
-    virtual void CalculateOnIntegrationPoints(const Variable<Vector >& rVariable,
-                          std::vector< Vector >& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo);
-
-    virtual void CalculateOnIntegrationPoints(const Variable<Matrix >& rVariable,
-                          std::vector< Matrix >& rOutput,
-                          const ProcessInfo& rCurrentProcessInfo);
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+                                     std::vector<array_1d<double, 3 > >& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * TO COPY SUBSCALE VALUES AFTER SERIALIZATION
      */
-    virtual void SetValueOnIntegrationPoints(const Variable<double>& rVariable,
-                         std::vector<double>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo);
+    void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
+                  std::vector<double>& rOutput,
+                  const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void SetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
-                         std::vector<array_1d<double, 3 > > rValues,
-                         const ProcessInfo& rCurrentProcessInfo);
+    void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+                  std::vector< array_1d<double, 3 > >& rOutput,
+                  const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void SetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
-                         std::vector<array_1d<double, 6 > > rValues,
-                         const ProcessInfo& rCurrentProcessInfo);
+    void CalculateOnIntegrationPoints(const Variable<Vector >& rVariable,
+                  std::vector< Vector >& rOutput,
+                  const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void SetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
-                         std::vector<Vector>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo);
+    void CalculateOnIntegrationPoints(const Variable<Matrix >& rVariable,
+                  std::vector< Matrix >& rOutput,
+                  const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void SetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
-                         std::vector<Matrix>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo);
+    /**
+     * TO COPY SUBSCALE VALUES AFTER SERIALIZATION
+     */
+    void SetValueOnIntegrationPoints(const Variable<double>& rVariable,
+                 std::vector<double>& rValues,
+                 const ProcessInfo& rCurrentProcessInfo) override;
 
-    virtual void SetValueOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
-                         std::vector<ConstitutiveLaw::Pointer>& rValues,
-                         const ProcessInfo& rCurrentProcessInfo);
+    void SetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+                 std::vector<array_1d<double, 3 > > rValues,
+                 const ProcessInfo& rCurrentProcessInfo) override;
+
+    void SetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+                 std::vector<array_1d<double, 6 > > rValues,
+                 const ProcessInfo& rCurrentProcessInfo) override;
+
+    void SetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+                 std::vector<Vector>& rValues,
+                 const ProcessInfo& rCurrentProcessInfo) override;
+
+    void SetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+                 std::vector<Matrix>& rValues,
+                 const ProcessInfo& rCurrentProcessInfo) override;
+
+    void SetValueOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
+                 std::vector<ConstitutiveLaw::Pointer>& rValues,
+                 const ProcessInfo& rCurrentProcessInfo) override;
 
 
     ///@}
@@ -235,11 +235,11 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const;
+    std::string Info() const override;
 
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const;
+    void PrintInfo(std::ostream& rOStream) const override;
 
 
     ///@}
@@ -289,10 +289,10 @@ protected:
                                       array_1d<double,3>& rMomentumRes);
 
 
-    virtual void ASGSMassResidual(double GaussIndex,
-                                  const ShapeFunctionsType &rN,
-                                  const ShapeFunctionDerivativesType &rDN_DX,
-                                  double& rMomentumRes);
+    void ASGSMassResidual(double GaussIndex,
+                          const ShapeFunctionsType &rN,
+                          const ShapeFunctionDerivativesType &rDN_DX,
+                          double& rMomentumRes) override;
 
 
     virtual void OSSMomentumResidual(const ShapeFunctionsType &rN,
@@ -300,10 +300,10 @@ protected:
                                      const array_1d<double,3> &rConvVel,
                                      array_1d<double,3>& rMomentumRes);
 
-    virtual void OSSMassResidual(double GaussIndex,
-                                 const ShapeFunctionsType& rN,
-                                 const ShapeFunctionDerivativesType& rDN_DX,
-                                 double& rMassRes);
+    void OSSMassResidual(double GaussIndex,
+                         const ShapeFunctionsType& rN,
+                         const ShapeFunctionDerivativesType& rDN_DX,
+                         double& rMassRes) override;
 
 
     virtual void MomentumProjTerm(const ShapeFunctionsType &rN,
@@ -312,10 +312,10 @@ protected:
                                   array_1d<double,3>& rMomentumRHS);
 
 
-    virtual void MassProjTerm(double GaussIndex,
-                             const ShapeFunctionsType &rN,
-                             const ShapeFunctionDerivativesType &rDN_DX,
-                             double& rMassRHS);
+    void MassProjTerm(double GaussIndex,
+                     const ShapeFunctionsType &rN,
+                     const ShapeFunctionDerivativesType &rDN_DX,
+                     double& rMassRHS) override;
 
 
     virtual void FullConvectiveVelocity(array_1d<double,3>& rConvVel,
@@ -324,38 +324,38 @@ protected:
 
 
 
-    virtual void AddSystemTerms(unsigned int GaussIndex,
-                                double GaussWeight,
-                                const ShapeFunctionsType& rN,
-                                const ShapeFunctionDerivativesType& rDN_DX,
-                                const ProcessInfo& rProcessInfo,
-                                MatrixType& rLHS,
-                                VectorType& rRHS);
+    void AddSystemTerms(unsigned int GaussIndex,
+                        double GaussWeight,
+                        const ShapeFunctionsType& rN,
+                        const ShapeFunctionDerivativesType& rDN_DX,
+                        const ProcessInfo& rProcessInfo,
+                        MatrixType& rLHS,
+                        VectorType& rRHS) override;
 
 
-    virtual void AddMassStabilization(unsigned int GaussIndex,
-                                      double GaussWeight,
-                                      const ShapeFunctionsType& rN,
-                                      const ShapeFunctionDerivativesType& rDN_DX,
-                                      const ProcessInfo& rProcessInfo,
-                                      MatrixType& rMassMatrix);
+    void AddMassStabilization(unsigned int GaussIndex,
+                              double GaussWeight,
+                              const ShapeFunctionsType& rN,
+                              const ShapeFunctionDerivativesType& rDN_DX,
+                              const ProcessInfo& rProcessInfo,
+                              MatrixType& rMassMatrix) override;
 
 
     virtual void DenseSystemSolve(const Matrix &rA,
                                   const Vector &rB,
                                   Vector &rX) const;
 
-    virtual void SubscaleVelocity(unsigned int GaussIndex,
-                                  const ShapeFunctionsType& rN,
-                                  const ShapeFunctionDerivativesType& rDN_DX,
-                                  const ProcessInfo& rProcessInfo,
-                                  array_1d<double,3>& rVelocitySubscale);
+    void SubscaleVelocity(unsigned int GaussIndex,
+                          const ShapeFunctionsType& rN,
+                          const ShapeFunctionDerivativesType& rDN_DX,
+                          const ProcessInfo& rProcessInfo,
+                          array_1d<double,3>& rVelocitySubscale) override;
 
-    virtual void SubscalePressure(unsigned int GaussIndex,
-                                  const ShapeFunctionsType& rN,
-                                  const ShapeFunctionDerivativesType& rDN_DX,
-                                  const ProcessInfo& rProcessInfo,
-                                  double &rPressureSubscale);
+    void SubscalePressure(unsigned int GaussIndex,
+                          const ShapeFunctionsType& rN,
+                          const ShapeFunctionDerivativesType& rDN_DX,
+                          const ProcessInfo& rProcessInfo,
+                          double &rPressureSubscale) override;
 
 
 
@@ -392,9 +392,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer);
+    void load(Serializer& rSerializer) override;
 
     ///@}
     ///@name Private Operators

--- a/applications/StabilizedCFDApplication/custom_elements/dynss_notau2.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dynss_notau2.h
@@ -149,7 +149,7 @@ public:
      */
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
-                            PropertiesType::Pointer pProperties) const;
+                            PropertiesType::Pointer pProperties) const override;
 
 
     ///@}
@@ -167,11 +167,11 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const;
+    std::string Info() const override;
 
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const;
+    void PrintInfo(std::ostream& rOStream) const  override;
 
 
     ///@}
@@ -201,14 +201,14 @@ protected:
     ///@name Protected Operations
     ///@{
 
-    virtual void CalculateTau(double Density,
-                              double KinematicVisc,
-                              const array_1d<double,3> &Velocity,
-                              const ProcessInfo& rProcessInfo,
-                              double ElementSize,
-                              double &TauOne,
-                              double &TauTwo,
-                              double &TauP);
+    void CalculateTau(double Density,
+                      double KinematicVisc,
+                      const array_1d<double,3> &Velocity,
+                      const ProcessInfo& rProcessInfo,
+                      double ElementSize,
+                      double &TauOne,
+                      double &TauTwo,
+                      double &TauP) override;
 
     ///@}
     ///@name Protected  Access
@@ -242,9 +242,9 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const;
+    void save(Serializer& rSerializer) const override;
 
-    virtual void load(Serializer& rSerializer);
+    void load(Serializer& rSerializer) override;
 
     ///@}
     ///@name Private Operators

--- a/applications/trilinos_application/custom_python/add_trilinos_convergence_criterias_to_python.cpp
+++ b/applications/trilinos_application/custom_python/add_trilinos_convergence_criterias_to_python.cpp
@@ -67,16 +67,16 @@ void  AddConvergenceCriterias(pybind11::module& m)
     //typedef LinearSolver<TrilinosSparseSpaceType, TrilinosLocalSpaceType > TrilinosLinearSolverType;
     typedef UblasSpace<double, Matrix, Vector> TrilinosLocalSpaceType;
 
-    typedef Epetra_FECrsMatrix FECrsMatrix;
+    //typedef Epetra_FECrsMatrix FECrsMatrix;
 
 
     //********************************************************************
     //********************************************************************
     //convergence criteria base class
     typedef ConvergenceCriteria< TrilinosSparseSpaceType, TrilinosLocalSpaceType > TrilinosConvergenceCriteria;
-    
+
     typedef typename ConvergenceCriteria< TrilinosSparseSpaceType, TrilinosLocalSpaceType > ::Pointer TrilinosConvergenceCriteriaPointer;
-    
+
     class_< TrilinosConvergenceCriteria, TrilinosConvergenceCriteriaPointer > (m,"TrilinosConvergenceCriteria")
     .def(init<>())
     .def("SetActualizeRHSFlag", &ConvergenceCriteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >::SetActualizeRHSFlag)
@@ -102,19 +102,19 @@ void  AddConvergenceCriterias(pybind11::module& m)
             .def(init< double, double, double, double >());
 
     class_< ResidualCriteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >,
-            typename ResidualCriteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >::Pointer,  
+            typename ResidualCriteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >::Pointer,
             TrilinosConvergenceCriteria >
             (m,"TrilinosResidualCriteria")
             .def(init< TrilinosSparseSpaceType::DataType, TrilinosSparseSpaceType::DataType >());
 
-    class_<And_Criteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >, 
-            typename And_Criteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >::Pointer,  
+    class_<And_Criteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >,
+            typename And_Criteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >::Pointer,
             TrilinosConvergenceCriteria>
             (m,"TrilinosAndCriteria")
             .def(init<TrilinosConvergenceCriteriaPointer, TrilinosConvergenceCriteriaPointer > ());
 
-    class_<Or_Criteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >, 
-            typename Or_Criteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >::Pointer,  
+    class_<Or_Criteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >,
+            typename Or_Criteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >::Pointer,
             TrilinosConvergenceCriteria>
             (m,"TrilinosOrCriteria")
             .def(init<TrilinosConvergenceCriteriaPointer, TrilinosConvergenceCriteriaPointer > ());


### PR DESCRIPTION
More warnings after the recent adddition of suggest-override, plus one pre-existing warning from the trilinos application.