### PR TITLE
Hotfix compute submodelparts colormap

### DIFF
--- a/kratos/tests/utilities/test_sub_model_parts_list_utility.cpp
+++ b/kratos/tests/utilities/test_sub_model_parts_list_utility.cpp
@@ -37,10 +37,10 @@ namespace Kratos
         {
             // Creating the reference model part and the relative submodelparts non alphabetically ordered
             ModelPart first_model_part("Main");
-            ModelPart::Pointer p_first_sub_modelpart_1 = first_model_part.CreateSubModelPart("qSubModelPart1");
-            ModelPart::Pointer p_first_sub_modelpart_2 = first_model_part.CreateSubModelPart("rSubModelPart2");
-            ModelPart::Pointer p_first_sub_modelpart_3 = first_model_part.CreateSubModelPart("aSubModelPart3");
-            ModelPart::Pointer p_first_sub_modelpart_4 = first_model_part.CreateSubModelPart("bSubModelPart4");
+            ModelPart::Pointer p_first_sub_modelpart_1 = first_model_part.CreateSubModelPart("BSubModelPart1");
+            ModelPart::Pointer p_first_sub_modelpart_2 = first_model_part.CreateSubModelPart("ASubModelPart2");
+            ModelPart::Pointer p_first_sub_modelpart_3 = first_model_part.CreateSubModelPart("ZSubModelPart3");
+            ModelPart::Pointer p_first_sub_modelpart_4 = first_model_part.CreateSubModelPart("YSubModelPart4");
 
             // Creating the Properties
             Properties::Pointer p_elem_prop = first_model_part.pGetProperties(0);
@@ -104,10 +104,10 @@ namespace Kratos
 
             // Creating the second model part
             ModelPart second_model_part("Main");
-            ModelPart::Pointer p_second_sub_modelpart_1 = second_model_part.CreateSubModelPart("qSubModelPart1");
-            ModelPart::Pointer p_second_sub_modelpart_2 = second_model_part.CreateSubModelPart("rSubModelPart2");
-            ModelPart::Pointer p_second_sub_modelpart_3 = second_model_part.CreateSubModelPart("aSubModelPart3");
-            ModelPart::Pointer p_second_sub_modelpart_4 = second_model_part.CreateSubModelPart("bSubModelPart4");
+            ModelPart::Pointer p_second_sub_modelpart_1 = second_model_part.CreateSubModelPart("BSubModelPart1");
+            ModelPart::Pointer p_second_sub_modelpart_2 = second_model_part.CreateSubModelPart("ASubModelPart2");
+            ModelPart::Pointer p_second_sub_modelpart_3 = second_model_part.CreateSubModelPart("ZSubModelPart3");
+            ModelPart::Pointer p_second_sub_modelpart_4 = second_model_part.CreateSubModelPart("YSubModelPart4");
 
             // We add the nodes and elements from the first model part
             second_model_part.AddNodes(first_model_part.Nodes().begin(), first_model_part.Nodes().end());
@@ -171,12 +171,12 @@ namespace Kratos
         {
             // Creating the refrence model part and the relative submodelparts
             ModelPart first_model_part("Main");
-            ModelPart::Pointer p_first_sub_modelpart_1 = first_model_part.CreateSubModelPart("qSubModelPart1");
+            ModelPart::Pointer p_first_sub_modelpart_1 = first_model_part.CreateSubModelPart("BSubModelPart1");
             ModelPart::Pointer p_first_sub_modelpart_1a = p_first_sub_modelpart_1->CreateSubModelPart("SubModelPart1a");
             ModelPart::Pointer p_first_sub_modelpart_1b = p_first_sub_modelpart_1->CreateSubModelPart("SubModelPart1b");
-            ModelPart::Pointer p_first_sub_modelpart_2 = first_model_part.CreateSubModelPart("rSubModelPart2");
-            ModelPart::Pointer p_first_sub_modelpart_3 = first_model_part.CreateSubModelPart("aSubModelPart3");
-            ModelPart::Pointer p_first_sub_modelpart_4 = first_model_part.CreateSubModelPart("bSubModelPart4");
+            ModelPart::Pointer p_first_sub_modelpart_2 = first_model_part.CreateSubModelPart("ASubModelPart2");
+            ModelPart::Pointer p_first_sub_modelpart_3 = first_model_part.CreateSubModelPart("ZSubModelPart3");
+            ModelPart::Pointer p_first_sub_modelpart_4 = first_model_part.CreateSubModelPart("YSubModelPart4");
 
             // Creaing the Properties
             Properties::Pointer p_elem_prop = first_model_part.pGetProperties(0);
@@ -244,12 +244,12 @@ namespace Kratos
 
             // Creating the second model part
             ModelPart second_model_part("Main");
-            ModelPart::Pointer p_second_sub_modelpart_1 = second_model_part.CreateSubModelPart("qSubModelPart1");
+            ModelPart::Pointer p_second_sub_modelpart_1 = second_model_part.CreateSubModelPart("BSubModelPart1");
             ModelPart::Pointer p_second_sub_modelpart_1a = p_second_sub_modelpart_1->CreateSubModelPart("SubModelPart1a");
             ModelPart::Pointer p_second_sub_modelpart_1b = p_second_sub_modelpart_1->CreateSubModelPart("SubModelPart1b");
-            ModelPart::Pointer p_second_sub_modelpart_2 = second_model_part.CreateSubModelPart("rSubModelPart2");
-            ModelPart::Pointer p_second_sub_modelpart_3 = second_model_part.CreateSubModelPart("aSubModelPart3");
-            ModelPart::Pointer p_second_sub_modelpart_4 = second_model_part.CreateSubModelPart("bSubModelPart4");
+            ModelPart::Pointer p_second_sub_modelpart_2 = second_model_part.CreateSubModelPart("ASubModelPart2");
+            ModelPart::Pointer p_second_sub_modelpart_3 = second_model_part.CreateSubModelPart("ZSubModelPart3");
+            ModelPart::Pointer p_second_sub_modelpart_4 = second_model_part.CreateSubModelPart("YSubModelPart4");
 
             // We add the nodes and elements from the first model part
             second_model_part.AddNodes(first_model_part.Nodes().begin(), first_model_part.Nodes().end());

--- a/kratos/tests/utilities/test_sub_model_parts_list_utility.cpp
+++ b/kratos/tests/utilities/test_sub_model_parts_list_utility.cpp
@@ -35,14 +35,14 @@ namespace Kratos
 
         KRATOS_TEST_CASE_IN_SUITE(TestSubmodelPartsListUtility, KratosSubModelPartsListUtilityFastSuite)
         {
-            // Creating the refrence model part and the relative submodelparts
+            // Creating the reference model part and the relative submodelparts non alphabetically ordered
             ModelPart first_model_part("Main");
-            ModelPart::Pointer p_first_sub_modelpart_1 = first_model_part.CreateSubModelPart("SubModelPart1");
-            ModelPart::Pointer p_first_sub_modelpart_2 = first_model_part.CreateSubModelPart("SubModelPart2");
-            ModelPart::Pointer p_first_sub_modelpart_3 = first_model_part.CreateSubModelPart("SubModelPart3");
-            ModelPart::Pointer p_first_sub_modelpart_4 = first_model_part.CreateSubModelPart("SubModelPart4");
+            ModelPart::Pointer p_first_sub_modelpart_1 = first_model_part.CreateSubModelPart("qSubModelPart1");
+            ModelPart::Pointer p_first_sub_modelpart_2 = first_model_part.CreateSubModelPart("rSubModelPart2");
+            ModelPart::Pointer p_first_sub_modelpart_3 = first_model_part.CreateSubModelPart("aSubModelPart3");
+            ModelPart::Pointer p_first_sub_modelpart_4 = first_model_part.CreateSubModelPart("bSubModelPart4");
 
-            // Creaing the Properties
+            // Creating the Properties
             Properties::Pointer p_elem_prop = first_model_part.pGetProperties(0);
 
             // First we create the nodes
@@ -104,10 +104,10 @@ namespace Kratos
 
             // Creating the second model part
             ModelPart second_model_part("Main");
-            ModelPart::Pointer p_second_sub_modelpart_1 = second_model_part.CreateSubModelPart("SubModelPart1");
-            ModelPart::Pointer p_second_sub_modelpart_2 = second_model_part.CreateSubModelPart("SubModelPart2");
-            ModelPart::Pointer p_second_sub_modelpart_3 = second_model_part.CreateSubModelPart("SubModelPart3");
-            ModelPart::Pointer p_second_sub_modelpart_4 = second_model_part.CreateSubModelPart("SubModelPart4");
+            ModelPart::Pointer p_second_sub_modelpart_1 = second_model_part.CreateSubModelPart("qSubModelPart1");
+            ModelPart::Pointer p_second_sub_modelpart_2 = second_model_part.CreateSubModelPart("rSubModelPart2");
+            ModelPart::Pointer p_second_sub_modelpart_3 = second_model_part.CreateSubModelPart("aSubModelPart3");
+            ModelPart::Pointer p_second_sub_modelpart_4 = second_model_part.CreateSubModelPart("bSubModelPart4");
 
             // We add the nodes and elements from the first model part
             second_model_part.AddNodes(first_model_part.Nodes().begin(), first_model_part.Nodes().end());
@@ -171,12 +171,12 @@ namespace Kratos
         {
             // Creating the refrence model part and the relative submodelparts
             ModelPart first_model_part("Main");
-            ModelPart::Pointer p_first_sub_modelpart_1 = first_model_part.CreateSubModelPart("SubModelPart1");
+            ModelPart::Pointer p_first_sub_modelpart_1 = first_model_part.CreateSubModelPart("qSubModelPart1");
             ModelPart::Pointer p_first_sub_modelpart_1a = p_first_sub_modelpart_1->CreateSubModelPart("SubModelPart1a");
             ModelPart::Pointer p_first_sub_modelpart_1b = p_first_sub_modelpart_1->CreateSubModelPart("SubModelPart1b");
-            ModelPart::Pointer p_first_sub_modelpart_2 = first_model_part.CreateSubModelPart("SubModelPart2");
-            ModelPart::Pointer p_first_sub_modelpart_3 = first_model_part.CreateSubModelPart("SubModelPart3");
-            ModelPart::Pointer p_first_sub_modelpart_4 = first_model_part.CreateSubModelPart("SubModelPart4");
+            ModelPart::Pointer p_first_sub_modelpart_2 = first_model_part.CreateSubModelPart("rSubModelPart2");
+            ModelPart::Pointer p_first_sub_modelpart_3 = first_model_part.CreateSubModelPart("aSubModelPart3");
+            ModelPart::Pointer p_first_sub_modelpart_4 = first_model_part.CreateSubModelPart("bSubModelPart4");
 
             // Creaing the Properties
             Properties::Pointer p_elem_prop = first_model_part.pGetProperties(0);
@@ -244,12 +244,12 @@ namespace Kratos
 
             // Creating the second model part
             ModelPart second_model_part("Main");
-            ModelPart::Pointer p_second_sub_modelpart_1 = second_model_part.CreateSubModelPart("SubModelPart1");
+            ModelPart::Pointer p_second_sub_modelpart_1 = second_model_part.CreateSubModelPart("qSubModelPart1");
             ModelPart::Pointer p_second_sub_modelpart_1a = p_second_sub_modelpart_1->CreateSubModelPart("SubModelPart1a");
             ModelPart::Pointer p_second_sub_modelpart_1b = p_second_sub_modelpart_1->CreateSubModelPart("SubModelPart1b");
-            ModelPart::Pointer p_second_sub_modelpart_2 = second_model_part.CreateSubModelPart("SubModelPart2");
-            ModelPart::Pointer p_second_sub_modelpart_3 = second_model_part.CreateSubModelPart("SubModelPart3");
-            ModelPart::Pointer p_second_sub_modelpart_4 = second_model_part.CreateSubModelPart("SubModelPart4");
+            ModelPart::Pointer p_second_sub_modelpart_2 = second_model_part.CreateSubModelPart("rSubModelPart2");
+            ModelPart::Pointer p_second_sub_modelpart_3 = second_model_part.CreateSubModelPart("aSubModelPart3");
+            ModelPart::Pointer p_second_sub_modelpart_4 = second_model_part.CreateSubModelPart("bSubModelPart4");
 
             // We add the nodes and elements from the first model part
             second_model_part.AddNodes(first_model_part.Nodes().begin(), first_model_part.Nodes().end());

--- a/kratos/utilities/sub_model_parts_list_utility.cpp
+++ b/kratos/utilities/sub_model_parts_list_utility.cpp
@@ -170,9 +170,10 @@ std::vector<std::string> SubModelPartsListUtility::GetRecursiveSubModelPartNames
     }
 
     // Check for repeated names on the submodelparts (this is not checked by model_part.h if we work with subsubmodelparts)
-    std::sort(model_part_names.begin()+1, model_part_names.end());
-    auto last = std::unique(model_part_names.begin()+1, model_part_names.end());
-    KRATOS_ERROR_IF_NOT(last == model_part_names.end()) << "ERROR:: Repeated names in subsubmodelparts. Check subsubmodelparts names please" << std::endl;
+    std::vector<std::string> check_repeated = model_part_names;
+    std::sort(check_repeated.begin()+1, check_repeated.end());
+    auto last = std::unique(check_repeated.begin()+1, check_repeated.end());
+    KRATOS_ERROR_IF_NOT(last == check_repeated.end()) << "ERROR:: Repeated names in subsubmodelparts. Check subsubmodelparts names please" << std::endl;
 
     return model_part_names;
 }

--- a/kratos/utilities/sub_model_parts_list_utility.cpp
+++ b/kratos/utilities/sub_model_parts_list_utility.cpp
@@ -170,8 +170,8 @@ std::vector<std::string> SubModelPartsListUtility::GetRecursiveSubModelPartNames
     }
 
     // Check for repeated names on the submodelparts (this is not checked by model_part.h if we work with subsubmodelparts)
-    std::sort(model_part_names.begin(), model_part_names.end());
-    auto last = std::unique(model_part_names.begin(), model_part_names.end());
+    std::sort(model_part_names.begin()+1, model_part_names.end());
+    auto last = std::unique(model_part_names.begin()+1, model_part_names.end());
     KRATOS_ERROR_IF_NOT(last == model_part_names.end()) << "ERROR:: Repeated names in subsubmodelparts. Check subsubmodelparts names please" << std::endl;
 
     return model_part_names;

--- a/kratos/utilities/sub_model_parts_list_utility.h
+++ b/kratos/utilities/sub_model_parts_list_utility.h
@@ -69,6 +69,9 @@ namespace Kratos
  * combinations of submodelparts each node, condition and element belongs to.
  * Modelpart key is 0. Each submodelpart has 1, 2... key. A submodelpart
  * combination has another key
+ * This class has two limitations:
+ * - A sub_sub_model_part name should not be duplicated
+ * - This class allows two sub_model_part levels
  * @author Miguel Maso Sotomayor
  * @author Vicente Mataix Ferrandiz
  */


### PR DESCRIPTION
I have found a small bug in this utility:

This class checks for repeated names on the sub sub model parts and perform a sort.
After performing the check, main_model_part_name must be in the first place, otherwise the key 0 will point to a sub_model_part.

To avoid this bug I am checking for repeated names on a copy.