### PR TITLE
removing incorrect warning message.

### DIFF
--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
@@ -319,7 +319,12 @@ public:
     bool SolveSolutionStep() override
     {
         double norm_dp = this->Solve();
-        return this->CheckPressureConvergence(norm_dp);
+        /* If not doing predictor corrector iterations, norm_dp will
+         * typically be "large" since we are not iterating on pressure.
+         * It makes no sense to report that the iteration didn't converge
+         * based on this.
+         */
+        return mPredictorCorrector ? this->CheckPressureConvergence(norm_dp) : true;
     }
 
 


### PR DESCRIPTION
Changing the return value of SolveSolutionStep to true in non-predictor-corrector mode (this supresses a warning due to lack of pressure convergence: there are no pressure iterations in this case).