### PR TITLE
Removing missing override warnings.

### DIFF
--- a/applications/convection_diffusion_application/custom_conditions/thermal_face2D.h
+++ b/applications/convection_diffusion_application/custom_conditions/thermal_face2D.h
@@ -123,16 +123,16 @@ public:
     ///@name Operations
     ///@{
 
-    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const;
+    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
     //virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo);
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& CurrentProcessInfo);
+    void GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& CurrentProcessInfo) override;
 
     ///@}
     ///@name Access
@@ -235,12 +235,12 @@ private:
     {
     }
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition);
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition);
     }
@@ -305,6 +305,6 @@ private:
 
 }  // namespace Kratos.
 
-#endif // KRATOS_THERMAL_FACE2D_CONDITION_H_INCLUDED   defined 
+#endif // KRATOS_THERMAL_FACE2D_CONDITION_H_INCLUDED   defined
 
 

--- a/applications/convection_diffusion_application/custom_conditions/thermal_face3D.h
+++ b/applications/convection_diffusion_application/custom_conditions/thermal_face3D.h
@@ -124,16 +124,16 @@ public:
     ///@name Operations
     ///@{
 
-    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const;
+    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
     //virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo);
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& CurrentProcessInfo);
+    void GetDofList(DofsVectorType& ConditionalDofList,ProcessInfo& CurrentProcessInfo) override;
 
     ///@}
     ///@name Access
@@ -233,12 +233,12 @@ private:
     {
     }
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition);
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition);
     }
@@ -304,6 +304,6 @@ private:
 
 }  // namespace Kratos.
 
-#endif // KRATOS_THERMAL_FACE3D_CONDITION_H_INCLUDED   defined 
+#endif // KRATOS_THERMAL_FACE3D_CONDITION_H_INCLUDED   defined
 
 

--- a/applications/convection_diffusion_application/custom_elements/conv_diff_2d.h
+++ b/applications/convection_diffusion_application/custom_elements/conv_diff_2d.h
@@ -130,24 +130,24 @@ public:
     ///@name Operations
     ///@{
     //IntegrationMethod GetIntegrationMethod();
-    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const;
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
     ///Evaluates  \f$ L h s = \frac{\rho C}{\Delta t} (W, N) + (W, v. \nabla N) + \kappa (\nabla W, \nabla N)  \f$ and \f$R h s = \rho (W, Q) + \frac{\rho C}{\Delta t} (W, T^n) - L h s \ast T \f$
 
 
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
     //virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo);
 
     ///Provides the global indices for each one of this element's local rows. @see NoNewtonianASGS2D
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
 
     ///Returns a list of the element's Dofs. @see NoNewtonianASGS2D
-    void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo);
+    void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
     /// Calculates the temperature convective projection
-    void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo);
+    void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
 
    /* double ComputeSmagorinskyViscosity(const boost::numeric::ublas::bounded_matrix<double, 3, 2 > & DN_DX,const double& h,const double& C,const double nu);*/
 
@@ -240,12 +240,12 @@ private:
     {
     }
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }
@@ -316,6 +316,6 @@ private:
 
 }  // namespace Kratos.
 
-#endif // KRATOS_TRIANGULAR_CONVDIFF_ELEM_H_INCLUDED  defined 
+#endif // KRATOS_TRIANGULAR_CONVDIFF_ELEM_H_INCLUDED  defined
 
 

--- a/applications/convection_diffusion_application/custom_elements/conv_diff_3d.h
+++ b/applications/convection_diffusion_application/custom_elements/conv_diff_3d.h
@@ -123,20 +123,20 @@ public:
     ///@name Operations
     ///@{
 
-    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const;
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
     ///Evaluates  \f$ L h s = \frac{\rho C}{\Delta t} (W, N) + (W, v. \nabla N) + \kappa (\nabla W, \nabla N)  \f$ and \f$R h s = \rho (W, Q) + \frac{\rho C}{\Delta t} (W, T^n) - L h s \ast T \f$
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
     //virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo);
     ///Provides the global indices for each one of this element's local rows. @see NoNewtonianASGS2D
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
 
     ///Returns a list of the element's Dofs. @see NoNewtonianASGS2D
-    void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo);
+    void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
     /// Calculates the temperature convective projection
-    void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo);
+    void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override;
 
 /*    double ComputeSmagorinskyViscosity(const boost::numeric::ublas::bounded_matrix<double, 4, 3 > & DN_DX,const double& h,const double& C, const double nu);*/
 
@@ -234,12 +234,12 @@ private:
     {
     }
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }
@@ -310,6 +310,6 @@ private:
 
 }  // namespace Kratos.
 
-#endif // KRATOS_CONVDIFF_ELEM_3D_H_INCLUDED  defined 
+#endif // KRATOS_CONVDIFF_ELEM_3D_H_INCLUDED  defined
 
 

--- a/applications/convection_diffusion_application/custom_elements/eulerian_conv_diff.h
+++ b/applications/convection_diffusion_application/custom_elements/eulerian_conv_diff.h
@@ -96,31 +96,31 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override
     {
         KRATOS_TRY
         return Element::Pointer(new EulerianConvectionDiffusionElement(NewId, GetGeometry().Create(ThisNodes), pProperties));
         KRATOS_CATCH("");
     }
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& rCurrentProcessInfo);
+    void GetDofList(DofsVectorType& ElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-	void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+	void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    virtual std::string Info() const
+    std::string Info() const override
     {
         return "LevelSetConvectionElementSimplex #";
     }
 
     /// Print information about this object.
 
-    virtual void PrintInfo(std::ostream& rOStream) const
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << Info() << Id();
     }
@@ -169,12 +169,12 @@ private:
 
     friend class Serializer;
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }

--- a/applications/convection_diffusion_application/custom_elements/laplacian_element.h
+++ b/applications/convection_diffusion_application/custom_elements/laplacian_element.h
@@ -122,15 +122,15 @@ public:
     ///@name Operations
     ///@{
 
-    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const;
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes,  PropertiesType::Pointer pProperties) const override;
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo);
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo);
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo);
+    void GetDofList(DofsVectorType& ElementalDofList,ProcessInfo& CurrentProcessInfo) override;
 
     ///@}
     ///@name Access
@@ -193,7 +193,7 @@ protected:
 private:
     ///@name Static Member Variables
     ///@{
-    
+
 
     ///@}
     ///@name Member Variables
@@ -210,16 +210,16 @@ private:
     {
     }
 
-    virtual void save(Serializer& rSerializer) const
+    void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
     }
 
-    virtual void load(Serializer& rSerializer)
+    void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
     }
-    
+
     ///@}
     ///@name Private Operators
     ///@{
@@ -284,6 +284,6 @@ private:
 
 }  // namespace Kratos.
 
-#endif // KRATOS_LAPLACIAN_ELEMENT_H_INCLUDED  defined 
+#endif // KRATOS_LAPLACIAN_ELEMENT_H_INCLUDED  defined
 
 

--- a/applications/convection_diffusion_application/custom_strategies/strategies/residualbased_convdiff_strategy.h
+++ b/applications/convection_diffusion_application/custom_strategies/strategies/residualbased_convdiff_strategy.h
@@ -185,7 +185,7 @@ public:
 
     //*********************************************************************************
     //**********************************************************************
-    double Solve()
+    double Solve() override
     {
       KRATOS_TRY
 
@@ -193,7 +193,7 @@ public:
         ProcessInfo& rCurrentProcessInfo = BaseType::GetModelPart().GetProcessInfo();
       double Dt = rCurrentProcessInfo[DELTA_TIME];
       int stationary= rCurrentProcessInfo[STATIONARY];
-      
+
       double Dp_norm;
       if(stationary==1)
 	{
@@ -208,10 +208,10 @@ public:
 	      if(BaseType::GetModelPart().GetBufferSize() < 3)
                 KRATOS_THROW_ERROR(std::logic_error,"insufficient buffer size for BDF2","")
 		  double dt_old = rCurrentProcessInfo.GetPreviousTimeStepInfo(1)[DELTA_TIME];
-	      
+
 	      double rho = dt_old/Dt;
 	      double coeff = 1.0/(Dt*rho*rho+Dt*rho);
-	      
+
 	      rCurrentProcessInfo[BDF_COEFFICIENTS].resize(3);
 	      Vector& BDFcoeffs = rCurrentProcessInfo[BDF_COEFFICIENTS];
 	      BDFcoeffs[0] =	coeff*(rho*rho+2.0*rho);	//coefficient for step n+1
@@ -225,16 +225,16 @@ public:
 	      BDFcoeffs[0] =	1.0 / Dt;	//coefficient for step n+1
 	      BDFcoeffs[1] =	-1.0 / Dt;//coefficient for step n
 	    }
-	  
+
 	  //second order prediction for the velocity
 	  if(mprediction_order == 2)
 	    {
 	      if(BaseType::GetModelPart().GetBufferSize() < 3)
                 KRATOS_THROW_ERROR(std::logic_error,"insufficient buffer size for second order prediction","")
-		  
+
 		  ConvectionDiffusionSettings::Pointer my_settings = rCurrentProcessInfo.GetValue(CONVECTION_DIFFUSION_SETTINGS);
 	      const Variable<double>& rUnknownVar= my_settings->GetUnknownVariable();
-	      
+
 	      for(ModelPart::NodeIterator i = BaseType::GetModelPart().NodesBegin() ;
                     i != BaseType::GetModelPart().NodesEnd() ; ++i)
 		{
@@ -242,20 +242,20 @@ public:
 		}
 	      CalculateProjection();
 	    }
-	  
+
 	  //SOLVING THE PROBLEM
 	  rCurrentProcessInfo[FRACTIONAL_STEP] = 1;
-	  
+
 	  Dp_norm = mstep1->Solve();
         CalculateProjection();
-	
+
 	}
       return Dp_norm;
       KRATOS_CATCH("")
 	}
-    
-    
-    
+
+
+
     //******************************************************************************************************
     //******************************************************************************************************
     //calculation of projection
@@ -298,17 +298,17 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void SetEchoLevel(int Level)
+    void SetEchoLevel(int Level) override
     {
         mstep1->SetEchoLevel(Level);
     }
 
-    virtual void Clear()
+    void Clear() override
     {
         mstep1->Clear();
     }
 
-    virtual int Check()
+    int Check() override
     {
         KRATOS_TRY
 
@@ -320,7 +320,7 @@ public:
         const Variable<double>& rSourceVar = my_settings->GetVolumeSourceVariable();
         const Variable<array_1d<double, 3 > >& rMeshVelocityVar = my_settings->GetMeshVelocityVariable();
         const Variable<double>& rProjectionVariable = my_settings->GetProjectionVariable();
-        
+
         //const Variable<double>& rSpecificHeatVar = my_settings->GetSpecificHeatVariable();
         //const Variable<array_1d<double, 3 > >& rVelocityVar = my_settings->GetVelocityVariable();
 

--- a/applications/convection_diffusion_application/custom_strategies/strategies/residualbased_convdiff_strategy_nonlinear.h
+++ b/applications/convection_diffusion_application/custom_strategies/strategies/residualbased_convdiff_strategy_nonlinear.h
@@ -98,7 +98,7 @@ public:
 
     /** Counted pointer of ClassName */
     KRATOS_CLASS_POINTER_DEFINITION(ResidualBasedConvectionDiffusionStrategyNonLinear);
- 
+
     typedef SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
 
     typedef typename BaseType::TDataType TDataType;
@@ -188,21 +188,21 @@ public:
     //*********************************************************************************
     //**********************************************************************
 
-    double Solve()
+    double Solve() override
     {
       KRATOS_TRY
-	
+
         //calculate the BDF coefficients
         ProcessInfo& rCurrentProcessInfo = BaseType::GetModelPart().GetProcessInfo();
       double Dt = rCurrentProcessInfo[DELTA_TIME];
       int stationary= rCurrentProcessInfo[STATIONARY];
-	
+
       unsigned int iter = 0;
       double ratio;
       bool is_converged = false;
       double dT_norm = 0.0;
       double T_norm = 0.0;
-      
+
       if(stationary==1){
 	iter = 0;
         //ratio;
@@ -215,7 +215,7 @@ public:
             dT_norm = mstep1->Solve();
             T_norm = CalculateTemperatureNorm();
             CalculateProjection();
-	    
+
             ratio = 1.00;
             if (T_norm != 0.00)
 	      ratio = dT_norm / T_norm;
@@ -223,30 +223,30 @@ public:
 	      {
                 std::cout << "T_norm = " << T_norm << " dT_norm = " << dT_norm << std::endl;
 	      }
-	    
+
             if (dT_norm < 1e-11)
 	      ratio = 0; //converged
-	    
+
             if (ratio < mtoll)
 	      is_converged = true;
-	    
+
             std::cout << " iter = " << iter << " ratio = " << ratio << std::endl;
 	  }
       }
       else{
-	
+
         if (mOldDt == 0.00) //needed for the first step
 	  mOldDt = Dt;
         if (mtime_order == 2)
 	  {
             if (BaseType::GetModelPart().GetBufferSize() < 3)
 	      KRATOS_THROW_ERROR(std::logic_error, "insufficient buffer size for BDF2", "")
-		
+
                 double dt_old = rCurrentProcessInfo.GetPreviousTimeStepInfo(1)[DELTA_TIME];
-	    
+
             double rho = dt_old / Dt;
             double coeff = 1.0 / (Dt * rho * rho + Dt * rho);
-	    
+
             rCurrentProcessInfo[BDF_COEFFICIENTS].resize(3);
             Vector& BDFcoeffs = rCurrentProcessInfo[BDF_COEFFICIENTS];
             BDFcoeffs[0] = coeff * (rho * rho + 2.0 * rho); //coefficient for step n+1
@@ -260,20 +260,20 @@ public:
             BDFcoeffs[0] = 1.0 / Dt; //coefficient for step n+1
             BDFcoeffs[1] = -1.0 / Dt; //coefficient for step n
         }
-	
+
 	iter = 0;
         //ratio;
         is_converged = false;
         dT_norm = 0.0;
         T_norm = 0.0;
-	
+
         while (iter++ < mmax_iter && is_converged == false)
 	  {
             rCurrentProcessInfo[FRACTIONAL_STEP] = 1;
             dT_norm = mstep1->Solve();
             T_norm = CalculateTemperatureNorm();
             CalculateProjection();
-	    
+
             ratio = 1.00;
             if (T_norm != 0.00)
 	      ratio = dT_norm / T_norm;
@@ -281,17 +281,17 @@ public:
             {
 	      std::cout << "T_norm = " << T_norm << " dT_norm = " << dT_norm << std::endl;
             }
-	    
+
             if (dT_norm < 1e-11)
 	      ratio = 0; //converged
-	    
+
             if (ratio < mtoll)
 	      is_converged = true;
-	    
+
             std::cout << " iter = " << iter << " ratio = " << ratio << std::endl;
 	  }
       }
-      
+
       return dT_norm;
       KRATOS_CATCH("")
 	}
@@ -373,17 +373,17 @@ public:
         KRATOS_CATCH("")
     }
 
-    virtual void SetEchoLevel(int Level)
+    void SetEchoLevel(int Level) override
     {
         mstep1->SetEchoLevel(Level);
     }
 
-    virtual void Clear()
+    void Clear() override
     {
         mstep1->Clear();
     }
 
-    virtual int Check()
+    int Check() override
     {
         KRATOS_TRY
 

--- a/applications/convection_diffusion_application/custom_strategies/strategies/residualbased_eulerian_convdiff_strategy.h
+++ b/applications/convection_diffusion_application/custom_strategies/strategies/residualbased_eulerian_convdiff_strategy.h
@@ -190,7 +190,7 @@ public:
 
     //*********************************************************************************
     //**********************************************************************
-    double Solve()
+    double Solve() override
     {
       KRATOS_TRY
 
@@ -209,17 +209,17 @@ public:
 
 
 
-    virtual void SetEchoLevel(int Level)
+    void SetEchoLevel(int Level) override
     {
         mstep1->SetEchoLevel(Level);
     }
 
-    virtual void Clear()
+    void Clear() override
     {
         mstep1->Clear();
     }
 
-    virtual int Check()
+    int Check() override
     {
         KRATOS_TRY
         ProcessInfo& rCurrentProcessInfo = BaseType::GetModelPart().GetProcessInfo();

--- a/applications/convection_diffusion_application/custom_strategies/strategies/residualbased_semi_eulerian_convdiff_strategy.h
+++ b/applications/convection_diffusion_application/custom_strategies/strategies/residualbased_semi_eulerian_convdiff_strategy.h
@@ -132,7 +132,7 @@ public:
         //ConvectionDiffusionSettings::Pointer my_settings = rCurrentProcessInfo.GetValue(CONVECTION_DIFFUSION_SETTINGS);
         //(mpConvectionModelPart->GetProcessInfo()).GetValue(CONVECTION_DIFFUSION_SETTINGS) = my_settings;
 		Check();
-        
+
 
         //initializing fractional velocity solution step
         typedef Scheme< TSparseSpace,  TDenseSpace > SchemeType;
@@ -154,11 +154,11 @@ public:
         //const Variable<double>& rUnknownVar= my_settings->GetUnknownVariable();
         //BuilderSolverTypePointer componentwise_build = BuilderSolverTypePointer(new	ResidualBasedEliminationBuilderAndSolverComponentwise<TSparseSpace,TDenseSpace,TLinearSolver,Variable<double> > (pNewLinearSolver,rUnknownVar) );
         //mstep1 = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,  TDenseSpace, TLinearSolver > 				(*mpConvectionModelPart,pscheme,pNewLinearSolver,componentwise_build,CalculateReactions,ReformDofAtEachIteration,CalculateNormDxFlag)  );
-        
+
         BuilderSolverTypePointer pBuilderSolver = BuilderSolverTypePointer(new ResidualBasedBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>(pNewLinearSolver) );
         mstep1 = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(*mpConvectionModelPart,pscheme,pNewLinearSolver,pBuilderSolver,CalculateReactions,ReformDofAtEachIteration,CalculateNormDxFlag) );
 
-        
+
         mstep1->SetEchoLevel(2);
 
         KRATOS_CATCH("")
@@ -175,7 +175,7 @@ public:
 
     //*********************************************************************************
     //**********************************************************************
-    double Solve()
+    double Solve() override
     {
       KRATOS_TRY
 
@@ -184,38 +184,38 @@ public:
       //ProcessInfo& rCurrentProcessInfo = BaseType::GetModelPart().GetProcessInfo();
       //double Dt = rCurrentProcessInfo[DELTA_TIME];
       //int stationary= rCurrentProcessInfo[STATIONARY];
-            
-	  //SOLVING THE PROBLEM	  
+
+	  //SOLVING THE PROBLEM
 	  double Dp_norm = mstep1->Solve();
-	
+
       return Dp_norm;
       KRATOS_CATCH("")
 	}
-    
-    
 
-    virtual void SetEchoLevel(int Level)
+
+
+    void SetEchoLevel(int Level) override
     {
         mstep1->SetEchoLevel(Level);
     }
 
-    virtual void Clear()
+    void Clear() override
     {
         mstep1->Clear();
     }
 
-    virtual int Check()
+    int Check() override
     {
         KRATOS_TRY
         ProcessInfo& rCurrentProcessInfo = BaseType::GetModelPart().GetProcessInfo();
         if (rCurrentProcessInfo.Has(CONVECTION_DIFFUSION_SETTINGS)==false)
 			KRATOS_THROW_ERROR(std::logic_error, "no CONVECTION_DIFFUSION_SETTINGS in model_part", "");
         //std::cout << "ConvDiff::Check(). If crashes, check CONVECTION_DIFFUSION_SETTINGS is defined" << std::endl;
-        
+
         ConvectionDiffusionSettings::Pointer my_settings = rCurrentProcessInfo.GetValue(CONVECTION_DIFFUSION_SETTINGS);
-		
+
 		//DENSITY VARIABLE
-		if(my_settings->IsDefinedDensityVariable()==true) 
+		if(my_settings->IsDefinedDensityVariable()==true)
 		{
 			if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetDensityVariable()) == false)
 				KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: Density Variable defined but not contained in the model part", "");
@@ -224,7 +224,7 @@ public:
 			std::cout << "No density variable assigned for ConvDiff. Assuming density=1" << std::endl;
 
 		//DIFFUSION VARIABLE
-		if(my_settings->IsDefinedDiffusionVariable()==true) 
+		if(my_settings->IsDefinedDiffusionVariable()==true)
 		{
 			if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetDiffusionVariable()) == false)
 				KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: Diffusion Variable defined but not contained in the model part", "");
@@ -233,39 +233,39 @@ public:
 			std::cout << "No diffusion variable assigned for ConvDiff. Assuming diffusivity=0" << std::endl;
 
 		//UNKNOWN VARIABLE
-		if(my_settings->IsDefinedUnknownVariable()==true) 
+		if(my_settings->IsDefinedUnknownVariable()==true)
 		{
 			if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetUnknownVariable()) == false)
 				KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: Unknown Variable defined but not contained in the model part", "");
 		}
 		else
 			KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: Unknown Variable not defined!", "");
-		
+
 		//VOLUME SOURCE VARIABLE
-		//if(my_settings->IsDefinedVolumeSourceVariable()==true) 
+		//if(my_settings->IsDefinedVolumeSourceVariable()==true)
 		//{
 		//	if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetVolumeSourceVariable()) == false)
 		//		KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: VolumeSource Variable defined but not contained in the model part", "");
 		//}
 		//else
 		//	std::cout << "No VolumeSource variable assigned for ConvDiff. Assuming VolumeSource=0" << std::endl;
-		if(my_settings->IsDefinedVolumeSourceVariable()==true) 
+		if(my_settings->IsDefinedVolumeSourceVariable()==true)
 			KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: VolumeSource not yet implemented", "");
-		
+
 		//SURFACE SOURCE VARIABLE
-		//if(my_settings->IsDefinedSurfaceSourceVariable()==true) 
+		//if(my_settings->IsDefinedSurfaceSourceVariable()==true)
 		//{
 		//	if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetSurfaceSourceVariable()) == false)
 		//		KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: SurfaceSource Variable defined but not contained in the model part", "");
 		//}
 		//else
 		//	std::cout << "No SurfaceSource variable assigned for ConvDiff. Assuming SurfaceSource=0" << std::endl;
-		if(my_settings->IsDefinedSurfaceSourceVariable()==true) 
+		if(my_settings->IsDefinedSurfaceSourceVariable()==true)
 			KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: SurfaceSource not yet implemented", "");
 
 		//PROJECTION VARIABLE
 		//used as intermediate variable, is the variable at time n+1 but only accounting for the convective term.
-		if(my_settings->IsDefinedProjectionVariable()==true) 
+		if(my_settings->IsDefinedProjectionVariable()==true)
 		{
 			if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetProjectionVariable()) == false)
 				KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: Projection Variable defined but not contained in the model part", "");
@@ -274,54 +274,54 @@ public:
 		{
 			std::cout << "No Projection variable assigned for ConvDiff. Using PROJECTED_SCALAR1" << std::endl;
 			my_settings->SetProjectionVariable(PROJECTED_SCALAR1);
-			
+
 		}
-		//if(my_settings->IsDefinedProjectionVariable()==true) 
+		//if(my_settings->IsDefinedProjectionVariable()==true)
 		//	KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: ProjectionVariable not useed. Remove it", "");
 
 		//CONVECTION VELOCITY VARIABLE
 		//CURRENTLY WE ARE USING (VELOCITY -MESH_VELOCITY) TO CONVECT, so the ConvectionVariable must not be used:
-		//if(my_settings->IsDefinedConvectionVariable()==true) 
+		//if(my_settings->IsDefinedConvectionVariable()==true)
 		//{
 		//	if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetConvectionVariable()) == false)
 		//		KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: Convection Variable defined but not contained in the model part", "");
 		//}
 		//else
 		//	std::cout << "No Projection variable assigned for ConvDiff. Assuming Convection=0" << std::endl;
-		if(my_settings->IsDefinedConvectionVariable()==true) 
+		if(my_settings->IsDefinedConvectionVariable()==true)
 			KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: ConvectionVariable not used. Use VelocityVariable instead", "");
 
 		//MESH VELOCITY VARIABLE
-		if(my_settings->IsDefinedMeshVelocityVariable()==true) 
+		if(my_settings->IsDefinedMeshVelocityVariable()==true)
 		{
 			if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetMeshVelocityVariable()) == false)
 				KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: MeshVelocity Variable defined but not contained in the model part", "");
 		}
 		else
 			std::cout << "No MeshVelocity variable assigned for ConvDiff. Assuming MeshVelocity=0" << std::endl;
-		
-		//VELOCITY VARIABLE	
-		if(my_settings->IsDefinedVelocityVariable()==true) 
+
+		//VELOCITY VARIABLE
+		if(my_settings->IsDefinedVelocityVariable()==true)
 		{
 			if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetVelocityVariable()) == false)
 				KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: Velocity Variable defined but not contained in the model part", "");
 		}
 		else
 			std::cout << "No Velocity variable assigned for ConvDiff. Assuming Velocity=0" << std::endl;
-		
+
 		//TRANSFER COEFFICIENT VARIABLE
-		//if(my_settings->IsDefinedTransferCoefficientVariable()==true) 
+		//if(my_settings->IsDefinedTransferCoefficientVariable()==true)
 		//{
 		//	if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetTransferCoefficientVariable()) == false)
 		//		KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: TransferCoefficient Variable defined but not contained in the model part", "");
 		//}
 		//else
 		//	std::cout << "No TransferCoefficient variable assigned for ConvDiff. Assuming TransferCoefficient=0" << std::endl;
-		if(my_settings->IsDefinedTransferCoefficientVariable()==true) 
+		if(my_settings->IsDefinedTransferCoefficientVariable()==true)
 			KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: TransferCoefficient not yet implemented", "");
-		
-		//SPECIFIC HEAT VARIABLE	
-		if(my_settings->IsDefinedSpecificHeatVariable()==true) 
+
+		//SPECIFIC HEAT VARIABLE
+		if(my_settings->IsDefinedSpecificHeatVariable()==true)
 		{
 			if (BaseType::GetModelPart().NodesBegin()->SolutionStepsDataHas(my_settings->GetSpecificHeatVariable()) == false)
 				KRATOS_THROW_ERROR(std::logic_error, "ConvDiffSettings: SpecificHeat Variable defined but not contained in the model part", "");


### PR DESCRIPTION
In relation to #1899. This should solve the warnings coming from the convection-diffusion application.