### PR TITLE
defaulting to the scalar backend when block_size is greater than 4. 

### DIFF
--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -507,7 +507,8 @@ public:
                 else if(mndof == 2) BlockSolve<2>(rA,rX,rB, iters, resid);
                 else if(mndof == 3) BlockSolve<3>(rA,rX,rB, iters, resid);
                 else if(mndof == 4) BlockSolve<4>(rA,rX,rB, iters, resid);
-                else if(mndof == 6) BlockSolve<6>(rA,rX,rB, iters, resid);
+                else
+                    ScalarSolve(rA,rX,rB, iters, resid);
             }
             else
             {


### PR DESCRIPTION
…note that it still considers the blocks but does not allocate a matrix made of blocks.

before this PR it was not solving in the case of block_size==5 or block_size > 6