### PR TITLE
Cleanup of solid elements in StructuralMechanicsApplication

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -74,12 +74,7 @@ void BaseSolidElement::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessI
 
 void BaseSolidElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
 {
-    // Create and initialize element variables:
-    const unsigned int number_of_nodes = GetGeometry().size();
-    const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
     const unsigned int strain_size = mConstitutiveLawVector[0]->GetStrainSize();
-
-    KinematicVariables this_kinematic_variables(strain_size, dimension, number_of_nodes);
     ConstitutiveVariables this_constitutive_variables(strain_size);
 
     // Create constitutive law parameters:
@@ -98,9 +93,6 @@ void BaseSolidElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
 
     // Reading integration points
     for ( unsigned int point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
-        // Compute element kinematics B, F, DN_DX ...
-        CalculateKinematicVariables(this_kinematic_variables, point_number, integration_points);
-
         // Call the constitutive law to update material variables
         mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());
 

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1105,7 +1105,7 @@ void BaseSolidElement::CalculateConstitutiveVariables(
 /***********************************************************************************/
 /***********************************************************************************/
 
-Matrix BaseSolidElement::CalculateDeltaDisplacement(Matrix& DeltaDisplacement)
+Matrix& BaseSolidElement::CalculateDeltaDisplacement(Matrix& DeltaDisplacement)
 {
     KRATOS_TRY
 

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -465,10 +465,12 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const ProcessInfo& rCurrentProcessInfo
     )
 {
-    const GeometryType::IntegrationPointsArrayType &integration_points = GetGeometry().IntegrationPoints();
+    const GeometryType::IntegrationMethod integration_method =
+        GetGeometry().GetDefaultIntegrationMethod();
+    const GeometryType::IntegrationPointsArrayType &integration_points = GetGeometry().IntegrationPoints(integration_method);
 
-    if ( rOutput.size() != GetGeometry().IntegrationPoints(  ).size() )
-        rOutput.resize( GetGeometry().IntegrationPoints(  ).size() );
+    if ( rOutput.size() != integration_points.size() )
+        rOutput.resize( integration_points.size() );
 
     if (rVariable == INTEGRATION_WEIGHT) {
         const unsigned int number_of_nodes = GetGeometry().size();
@@ -482,7 +484,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
                                                                                 this_kinematic_variables.InvJ0,
                                                                                 this_kinematic_variables.DN_DX,
                                                                                 point_number,
-                                                                                GetGeometry().GetDefaultIntegrationMethod());
+                                                                                integration_method);
 
             double integration_weight = GetIntegrationWeight(integration_points,
                                                                 point_number,
@@ -512,7 +514,7 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
         for (unsigned int point_number = 0; point_number < integration_points.size(); ++point_number) {
             // Compute element kinematics B, F, DN_DX ...
-            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_points);
+            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_method);
 
             // Compute material reponse
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
@@ -542,12 +544,9 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
         Values.SetStrainVector(this_constitutive_variables.StrainVector);
 
-        // Reading integration points
-        const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(  );
-
         for (unsigned int point_number = 0; point_number < integration_points.size(); ++point_number) {
             // Compute element kinematics B, F, DN_DX ...
-            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_points);
+            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_method);
 
             // Compute material reponse
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
@@ -619,8 +618,11 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const ProcessInfo& rCurrentProcessInfo
     )
 {
-    if ( rOutput.size() != GetGeometry().IntegrationPoints(  ).size() )
-        rOutput.resize( GetGeometry().IntegrationPoints(  ).size() );
+    const GeometryType::IntegrationMethod integration_method =
+        GetGeometry().GetDefaultIntegrationMethod();
+    const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints( integration_method );
+    if ( rOutput.size() != integration_points.size() )
+        rOutput.resize( integration_points.size() );
 
     if ( rVariable == INSITU_STRESS ) {
         const unsigned int strain_size = mConstitutiveLawVector[0]->GetStrainSize();
@@ -653,12 +655,9 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
         Values.SetStrainVector(this_constitutive_variables.StrainVector);
 
         // Reading integration points
-        const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(  );
-
-        // Reading integration points
         for ( unsigned int point_number = 0; point_number < integration_points.size(); ++point_number ) {
             // Compute element kinematics B, F, DN_DX ...
-            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_points);
+            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_method);
 
             //call the constitutive law to update material variables
             if( rVariable == CAUCHY_STRESS_VECTOR) {
@@ -694,13 +693,10 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
         Values.SetStrainVector(this_constitutive_variables.StrainVector);
 
-        // Reading integration points
-        const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(  );
-
         //reading integration points
         for ( unsigned int point_number = 0; point_number < integration_points.size(); ++point_number ) {
             // Compute element kinematics B, F, DN_DX ...
-            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_points);
+            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_method);
 
             // Compute material reponse
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
@@ -711,9 +707,6 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
             rOutput[point_number] = this_constitutive_variables.StrainVector;
         }
     } else {
-        if ( rOutput.size() != GetGeometry().IntegrationPoints(  ).size() )
-            rOutput.resize( GetGeometry().IntegrationPoints(  ).size() );
-
         for ( unsigned int ii = 0; ii < mConstitutiveLawVector.size(); ++ii )
             rOutput[ii] = mConstitutiveLawVector[ii]->GetValue( rVariable, rOutput[ii] );
     }
@@ -728,10 +721,13 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
     const ProcessInfo& rCurrentProcessInfo
     )
 {
+    const GeometryType::IntegrationMethod integration_method =
+        GetGeometry().GetDefaultIntegrationMethod();
+    const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints( integration_method );
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
 
-    if ( rOutput.size() != GetGeometry().IntegrationPoints(  ).size() )
-        rOutput.resize( GetGeometry().IntegrationPoints(  ).size() );
+    if ( rOutput.size() != integration_points.size() )
+        rOutput.resize( integration_points.size() );
 
     if ( rVariable == CAUCHY_STRESS_TENSOR || rVariable == PK2_STRESS_TENSOR ) {
         std::vector<Vector> stress_vector;
@@ -783,12 +779,9 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
         Values.SetConstitutiveMatrix(this_constitutive_variables.D); //this is the output parameter
 
         // Reading integration points
-        const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(  );
-
-        // Reading integration points
         for ( unsigned int point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
             // Compute element kinematics B, F, DN_DX ...
-            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_points);
+            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_method);
 
             // Compute material reponse
             CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
@@ -809,16 +802,13 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
         KinematicVariables this_kinematic_variables(strain_size, dimension, number_of_nodes);
         ConstitutiveVariables this_constitutive_variables(strain_size);
 
-        // Reading integration points
-        const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(  );
-
         // Create constitutive law parameters:
         ConstitutiveLaw::Parameters Values(GetGeometry(),GetProperties(),rCurrentProcessInfo);
 
         // Reading integration points
         for ( unsigned int point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
             // Compute element kinematics B, F, DN_DX ...
-            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_points);
+            CalculateKinematicVariables(this_kinematic_variables, point_number, integration_method);
 
             if( rOutput[point_number].size2() != this_kinematic_variables.F.size2() )
                 rOutput[point_number].resize( this_kinematic_variables.F.size1() , this_kinematic_variables.F.size2() , false );
@@ -1072,7 +1062,7 @@ double BaseSolidElement::GetIntegrationWeight(
 void BaseSolidElement::CalculateKinematicVariables(
     KinematicVariables& rThisKinematicVariables,
     const unsigned int PointNumber,
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+    const GeometryType::IntegrationMethod& rIntegrationMethod
     )
 {
     KRATOS_ERROR << "You have called to the CalculateKinematicVariables from the base class for solid elements" << std::endl;

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -535,7 +535,7 @@ protected:
     virtual void CalculateKinematicVariables(
         KinematicVariables& rThisKinematicVariables, 
         const unsigned int PointNumber,
-        const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+        const GeometryType::IntegrationMethod& rIntegrationMethod
         );
         
     /**

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -561,7 +561,7 @@ protected:
      * @param DeltaDisplacement The matrix containing the increment of displacements
      * @return DeltaDisplacement: The matrix containing the increment of displacements
      */
-    Matrix CalculateDeltaDisplacement(Matrix& DeltaDisplacement);
+    Matrix& CalculateDeltaDisplacement(Matrix& DeltaDisplacement);
     
     /**
      * @brief This functions calculate the derivatives in the reference frame

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -101,7 +101,9 @@ void SmallDisplacement::CalculateAll(
     }
 
     // Reading integration points and local gradients
-    const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(  );
+    const GeometryType::IntegrationMethod integration_method =
+        GetGeometry().GetDefaultIntegrationMethod();
+    const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(integration_method);
     
     ConstitutiveLaw::Parameters Values(GetGeometry(),GetProperties(),rCurrentProcessInfo);
 
@@ -119,7 +121,7 @@ void SmallDisplacement::CalculateAll(
         const Vector body_force = this->GetBodyForce(integration_points, point_number);
         
         // Compute element kinematics B, F, DN_DX ...
-        CalculateKinematicVariables(this_kinematic_variables, point_number, integration_points);
+        CalculateKinematicVariables(this_kinematic_variables, point_number, integration_method);
         
         // Compute material reponse
         CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
@@ -149,18 +151,20 @@ void SmallDisplacement::CalculateAll(
 void SmallDisplacement::CalculateKinematicVariables(
     KinematicVariables& rThisKinematicVariables, 
     const unsigned int PointNumber,
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+    const GeometryType::IntegrationMethod& rIntegrationMethod
     )
 {        
+    const GeometryType::IntegrationPointsArrayType& r_integration_points =
+        GetGeometry().IntegrationPoints(rIntegrationMethod);
     // Shape functions
-    rThisKinematicVariables.N = GetGeometry().ShapeFunctionsValues(rThisKinematicVariables.N, IntegrationPoints[PointNumber].Coordinates());
+    rThisKinematicVariables.N = GetGeometry().ShapeFunctionsValues(rThisKinematicVariables.N, r_integration_points[PointNumber].Coordinates());
     
-    rThisKinematicVariables.detJ0 = CalculateDerivativesOnReferenceConfiguration(rThisKinematicVariables.J0, rThisKinematicVariables.InvJ0, rThisKinematicVariables.DN_DX, PointNumber, GetGeometry().GetDefaultIntegrationMethod()); 
+    rThisKinematicVariables.detJ0 = CalculateDerivativesOnReferenceConfiguration(rThisKinematicVariables.J0, rThisKinematicVariables.InvJ0, rThisKinematicVariables.DN_DX, PointNumber, rIntegrationMethod); 
     
     KRATOS_ERROR_IF(rThisKinematicVariables.detJ0 < 0.0) << "WARNING:: ELEMENT ID: " << this->Id() << " INVERTED. DETJ0: " << rThisKinematicVariables.detJ0 << std::endl;
     
     // Compute B
-    CalculateB( rThisKinematicVariables.B, rThisKinematicVariables.DN_DX, IntegrationPoints, PointNumber );
+    CalculateB( rThisKinematicVariables.B, rThisKinematicVariables.DN_DX, r_integration_points, PointNumber );
     
     // Compute equivalent F
     Vector displacements;

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.h
@@ -171,7 +171,7 @@ protected:
     void CalculateKinematicVariables(
         KinematicVariables& rThisKinematicVariables,
         const unsigned int PointNumber,
-        const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+        const GeometryType::IntegrationMethod& rIntegrationMethod
         ) override;
         
      /**

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.h
@@ -201,7 +201,7 @@ public:
         void CalculateKinematicVariables(
                 KinematicVariables& rThisKinematicVariables,
                 const unsigned int PointNumber,
-                const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+                const GeometryType::IntegrationMethod& rIntegrationMethod
                 ) override;
 
         /**
@@ -245,9 +245,7 @@ public:
          */
         virtual void CalculateB(
                 Matrix& rB,
-                const Matrix& DN_DX,
-                const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-                const unsigned int PointNumber
+                const Matrix& DN_DX
         );
         virtual Matrix ComputeEquivalentF(const Vector& rStrainTensor);
 

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -18,6 +18,7 @@
 // Project includes
 #include "custom_elements/total_lagrangian.h"
 #include "utilities/math_utils.h"
+#include "utilities/geometry_utilities.h"
 #include "structural_mechanics_application_variables.h"
 #include "custom_utilities/structural_mechanics_math_utilities.hpp"
 
@@ -161,7 +162,8 @@ void TotalLagrangian::CalculateKinematicVariables(
     KRATOS_ERROR_IF(rThisKinematicVariables.detJ0 < 0.0) << "WARNING:: ELEMENT ID: " << this->Id() << " INVERTED. DETJ0: " << rThisKinematicVariables.detJ0 << std::endl;
     
     // Deformation gradient
-    noalias( rThisKinematicVariables.F ) = prod( J, rThisKinematicVariables.InvJ0 );
+    GeometryUtils::DeformationGradient(J, rThisKinematicVariables.InvJ0,
+                                       rThisKinematicVariables.F);
 
     // Axisymmetric case
     const unsigned int strain_size = (rThisKinematicVariables.B).size1();
@@ -175,8 +177,6 @@ void TotalLagrangian::CalculateKinematicVariables(
                 rThisKinematicVariables.F(i, j) = F2x2(i, j);
             rThisKinematicVariables.F(i, 2) = rThisKinematicVariables.F(2, i) = 0.0;
         }
-        rThisKinematicVariables.N =
-            row(GetGeometry().ShapeFunctionsValues(this_integration_method), PointNumber);
         const double current_radius = StructuralMechanicsMathUtilities::CalculateRadius(
             rThisKinematicVariables.N, this->GetGeometry(), Current);
         const double initial_radius = StructuralMechanicsMathUtilities::CalculateRadius(

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -150,7 +150,7 @@ void TotalLagrangian::CalculateKinematicVariables(
     const IntegrationMethod this_integration_method = this->GetGeometry().GetDefaultIntegrationMethod();
     
     // Shape functions
-    rThisKinematicVariables.N = row(GetGeometry().ShapeFunctionsValues(this_integration_method), PointNumber);;
+    rThisKinematicVariables.N = row(GetGeometry().ShapeFunctionsValues(this_integration_method), PointNumber);
 
     // Calculating jacobian
     Matrix J;
@@ -172,7 +172,7 @@ void TotalLagrangian::CalculateKinematicVariables(
             rThisKinematicVariables.F(2, index) = 0.0;
         }
 
-        rThisKinematicVariables.N = row(GetGeometry().ShapeFunctionsValues(this_integration_method), PointNumber);;
+        rThisKinematicVariables.N = row(GetGeometry().ShapeFunctionsValues(this_integration_method), PointNumber);
         const double current_radius = StructuralMechanicsMathUtilities::CalculateRadius(rThisKinematicVariables.N, this->GetGeometry(), Current);
         const double initial_radius = StructuralMechanicsMathUtilities::CalculateRadius(rThisKinematicVariables.N, this->GetGeometry(), Initial);
         rThisKinematicVariables.F(2, 2) = current_radius/initial_radius;
@@ -206,7 +206,7 @@ void TotalLagrangian::CalculateB(
     double Radius = 0.0f;
     
     if ( StrainSize == 4 ) {
-        N = row(this->GetGeometry().ShapeFunctionsValues(), PointNumber);;
+        N = row(this->GetGeometry().ShapeFunctionsValues(), PointNumber);
         Radius = StructuralMechanicsMathUtilities::CalculateRadius(N, this->GetGeometry());
     }
     

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -165,69 +165,59 @@ void TotalLagrangian::CalculateKinematicVariables(
 
     // Axisymmetric case
     const unsigned int strain_size = (rThisKinematicVariables.B).size1();
-    if (strain_size == 4) {
-        rThisKinematicVariables.F.resize(3, 3); // We keep the old values
-        for (unsigned int index = 0; index < 1; ++index) {
-            rThisKinematicVariables.F(index, 2) = 0.0;
-            rThisKinematicVariables.F(2, index) = 0.0;
+    if (strain_size == 4)
+    {
+        BoundedMatrix<double, 2, 2> F2x2 = rThisKinematicVariables.F;
+        rThisKinematicVariables.F.resize(3, 3, false);
+        for (unsigned i = 0; i < 2; ++i)
+        {
+            for (unsigned j = 0; j < 2; ++j)
+                rThisKinematicVariables.F(i, j) = F2x2(i, j);
+            rThisKinematicVariables.F(i, 2) = rThisKinematicVariables.F(2, i) = 0.0;
         }
+        rThisKinematicVariables.N =
+            row(GetGeometry().ShapeFunctionsValues(this_integration_method), PointNumber);
+        const double current_radius = StructuralMechanicsMathUtilities::CalculateRadius(
+            rThisKinematicVariables.N, this->GetGeometry(), Current);
+        const double initial_radius = StructuralMechanicsMathUtilities::CalculateRadius(
+            rThisKinematicVariables.N, this->GetGeometry(), Initial);
+        rThisKinematicVariables.F(2, 2) = current_radius / initial_radius;
 
-        rThisKinematicVariables.N = row(GetGeometry().ShapeFunctionsValues(this_integration_method), PointNumber);
-        const double current_radius = StructuralMechanicsMathUtilities::CalculateRadius(rThisKinematicVariables.N, this->GetGeometry(), Current);
-        const double initial_radius = StructuralMechanicsMathUtilities::CalculateRadius(rThisKinematicVariables.N, this->GetGeometry(), Initial);
-        rThisKinematicVariables.F(2, 2) = current_radius/initial_radius;
+        CalculateAxisymmetricB(
+            rThisKinematicVariables.B, rThisKinematicVariables.F,
+            rThisKinematicVariables.DN_DX, rThisKinematicVariables.N);
     }
-    
+    else
+    {
+        CalculateB(rThisKinematicVariables.B, rThisKinematicVariables.F,
+                   rThisKinematicVariables.DN_DX);
+    }
+
     rThisKinematicVariables.detF = MathUtils<double>::Det(rThisKinematicVariables.F);
     
-    // Calculating operator B
-    this->CalculateB( rThisKinematicVariables.B, rThisKinematicVariables.F, rThisKinematicVariables.DN_DX, strain_size, IntegrationPoints, PointNumber );
 }
 
 /***********************************************************************************/
 /***********************************************************************************/
 
-void TotalLagrangian::CalculateB(
-    Matrix& rB,
-    const Matrix& rF,
-    const Matrix& rDN_DX,
-    const unsigned int StrainSize,
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-    const unsigned int PointNumber
-    )
+void TotalLagrangian::CalculateB(Matrix& rB, const Matrix& rF, const Matrix& rDN_DX)
 {
     KRATOS_TRY
     
     const unsigned int number_of_nodes = this->GetGeometry().PointsNumber();
     const unsigned int dimension = this->GetGeometry().WorkingSpaceDimension();
-
-    // rFor axisymmetric case
-    Vector N;
-    double Radius = 0.0f;
-    
-    if ( StrainSize == 4 ) {
-        N = row(this->GetGeometry().ShapeFunctionsValues(), PointNumber);
-        Radius = StructuralMechanicsMathUtilities::CalculateRadius(N, this->GetGeometry());
-    }
+    const unsigned strain_size = GetProperties()[CONSTITUTIVE_LAW]->GetStrainSize();
     
     for ( unsigned int i = 0; i < number_of_nodes; ++i ){
         const unsigned int index = dimension * i;
 
-        if ( StrainSize == 3 ) {
+        if ( strain_size == 3 ) {
             rB( 0, index + 0 ) = rF( 0, 0 ) * rDN_DX( i, 0 );
             rB( 0, index + 1 ) = rF( 1, 0 ) * rDN_DX( i, 0 );
             rB( 1, index + 0 ) = rF( 0, 1 ) * rDN_DX( i, 1 );
             rB( 1, index + 1 ) = rF( 1, 1 ) * rDN_DX( i, 1 );
             rB( 2, index + 0 ) = rF( 0, 0 ) * rDN_DX( i, 1 ) + rF( 0, 1 ) * rDN_DX( i, 0 );
             rB( 2, index + 1 ) = rF( 1, 0 ) * rDN_DX( i, 1 ) + rF( 1, 1 ) * rDN_DX( i, 0 );
-        } else if ( StrainSize == 4 ) {
-            rB( 0, index + 0 ) = rF( 0, 0 ) * rDN_DX( i, 0 );
-            rB( 0, index + 1 ) = rF( 1, 0 ) * rDN_DX( i, 0 );
-            rB( 1, index + 1 ) = rF( 0, 1 ) * rDN_DX( i, 1 );
-            rB( 1, index + 1 ) = rF( 1, 1 ) * rDN_DX( i, 1 );
-            rB( 2, index + 0 ) = N[i]/Radius;
-            rB( 3, index + 0 ) = rF( 0, 0 ) * rDN_DX( i, 1 ) + rF( 0, 1 ) * rDN_DX( i, 0 );
-            rB( 3, index + 1 ) = rF( 1, 0 ) * rDN_DX( i, 1 ) + rF( 1, 1 ) * rDN_DX( i, 0 );
         } else {
             rB( 0, index + 0 ) = rF( 0, 0 ) * rDN_DX( i, 0 );
             rB( 0, index + 1 ) = rF( 1, 0 ) * rDN_DX( i, 0 );
@@ -251,6 +241,33 @@ void TotalLagrangian::CalculateB(
     }
 
     KRATOS_CATCH( "" )
+}
+
+void TotalLagrangian::CalculateAxisymmetricB(Matrix& rB,
+                                             const Matrix& rF,
+                                             const Matrix& rDN_DX,
+                                             const Vector& rN)
+{
+    KRATOS_TRY
+
+    const unsigned int number_of_nodes = this->GetGeometry().PointsNumber();
+    const unsigned int dimension = this->GetGeometry().WorkingSpaceDimension();
+    double radius = 0.0;
+    radius = StructuralMechanicsMathUtilities::CalculateRadius(rN, this->GetGeometry());
+    for (unsigned int i = 0; i < number_of_nodes; ++i)
+    {
+        const unsigned int index = dimension * i;
+
+            rB(0, index + 0) = rF(0, 0) * rDN_DX(i, 0);
+            rB(0, index + 1) = rF(1, 0) * rDN_DX(i, 0);
+            rB(1, index + 1) = rF(0, 1) * rDN_DX(i, 1);
+            rB(1, index + 1) = rF(1, 1) * rDN_DX(i, 1);
+            rB(2, index + 0) = rN[i] / radius;
+            rB(3, index + 0) = rF(0, 0) * rDN_DX(i, 1) + rF(0, 1) * rDN_DX(i, 0);
+            rB(3, index + 1) = rF(1, 0) * rDN_DX(i, 1) + rF(1, 1) * rDN_DX(i, 0);
+    }
+
+    KRATOS_CATCH("")
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.h
@@ -201,18 +201,11 @@ private:
      * @param rB The deformation matrix
      * @param rF The deformation gradient
      * @param rDN_DX The gradient derivative of the shape function
-     * @param StrainSize The size of the Voigt notation stress vector
-     * @param IntegrationPoints The array containing the integration points
      * @param PointNumber The integration point considered
      */
-    void CalculateB(
-        Matrix& rB,
-        const Matrix& rF,
-        const Matrix& rDN_DX,
-        const unsigned int StrainSize,
-        const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-        const unsigned int PointNumber
-        );
+    void CalculateB(Matrix& rB, const Matrix& rF, const Matrix& rDN_DX);
+
+    void CalculateAxisymmetricB(Matrix& rB, const Matrix& rF, const Matrix& rDN_DX, const Vector& rN);
 
     ///@}
     ///@name Private Operations

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.h
@@ -167,7 +167,7 @@ protected:
     void CalculateKinematicVariables(
         KinematicVariables& rThisKinematicVariables,
         const unsigned int PointNumber,
-        const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+        const GeometryType::IntegrationMethod& rIntegrationMethod
         ) override;
     
     ///@}

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -277,12 +277,14 @@ void UpdatedLagrangian::CalculateKinematicVariables(
     
     // Axisymmetric case
     if (strain_size == 4) {
-        DF.resize(3, 3); // We keep the old values
-        for (unsigned int index = 0; index < 1; index++) {
-            DF(index, 2) = 0.0;
-            DF(2, index) = 0.0;
+        BoundedMatrix<double, 2, 2> DF2x2 = DF;
+        DF.resize(3, 3, false);
+        for (unsigned i = 0; i < 2; ++i)
+        {
+            for (unsigned j = 0; j < 2; ++j)
+                DF(i, j) = DF2x2(i, j);
+            DF(i, 2) = DF(2, i) = 0.0;
         }
-
         rThisKinematicVariables.N = row(GetGeometry().ShapeFunctionsValues(this_integration_method), PointNumber);
         const double current_radius = StructuralMechanicsMathUtilities::CalculateRadius(rThisKinematicVariables.N, GetGeometry(), Current);
         const double initial_radius = StructuralMechanicsMathUtilities::CalculateRadius(rThisKinematicVariables.N, GetGeometry(), Initial);

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -116,8 +116,9 @@ void UpdatedLagrangian::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
     Values.SetStrainVector(this_constitutive_variables.StrainVector);
     
     // Reading integration points
-    const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(  );
-    
+    const GeometryType::IntegrationMethod integration_method =
+        GetGeometry().GetDefaultIntegrationMethod();
+
     // Displacements vector
     Vector displacements;
     GetValuesVector(displacements);
@@ -125,7 +126,7 @@ void UpdatedLagrangian::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
     // Reading integration points
     for ( unsigned int point_number = 0; point_number < mConstitutiveLawVector.size(); ++point_number ) {
         // Compute element kinematics B, F, DN_DX ...
-        this->CalculateKinematicVariables(this_kinematic_variables, point_number, integration_points);
+        this->CalculateKinematicVariables(this_kinematic_variables, point_number, integration_method);
         
         // Call the constitutive law to update material variables
         mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());
@@ -203,8 +204,11 @@ void UpdatedLagrangian::CalculateAll(
     }
 
     // Reading integration points
-    const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(  );
-    
+    const GeometryType::IntegrationMethod integration_method =
+        GetGeometry().GetDefaultIntegrationMethod();
+    const GeometryType::IntegrationPointsArrayType& integration_points =
+        GetGeometry().IntegrationPoints(integration_method);
+
     ConstitutiveLaw::Parameters Values(GetGeometry(),GetProperties(),rCurrentProcessInfo);
     
     // Set constitutive law flags:
@@ -221,7 +225,7 @@ void UpdatedLagrangian::CalculateAll(
         const Vector body_force = this->GetBodyForce(integration_points, point_number);
         
         // Compute element kinematics B, F, DN_DX ...
-        this->CalculateKinematicVariables(this_kinematic_variables, point_number, integration_points);
+        this->CalculateKinematicVariables(this_kinematic_variables, point_number, integration_method);
         
         // Compute material reponse
         this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure());
@@ -255,19 +259,17 @@ void UpdatedLagrangian::CalculateAll(
 void UpdatedLagrangian::CalculateKinematicVariables(
     KinematicVariables& rThisKinematicVariables,
     const unsigned int PointNumber,
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+    const GeometryType::IntegrationMethod& rIntegrationMethod
     )
 {
-    const IntegrationMethod this_integration_method = this->GetGeometry().GetDefaultIntegrationMethod();
-    
     // Shape functions
-    rThisKinematicVariables.N = row(GetGeometry().ShapeFunctionsValues(this_integration_method), PointNumber);
+    rThisKinematicVariables.N = row(GetGeometry().ShapeFunctionsValues(rIntegrationMethod), PointNumber);
     
-    rThisKinematicVariables.detJ0 = this->CalculateDerivativesOnReferenceConfiguration(rThisKinematicVariables.J0, rThisKinematicVariables.InvJ0, rThisKinematicVariables.DN_DX, PointNumber, this_integration_method);
+    rThisKinematicVariables.detJ0 = this->CalculateDerivativesOnReferenceConfiguration(rThisKinematicVariables.J0, rThisKinematicVariables.InvJ0, rThisKinematicVariables.DN_DX, PointNumber, rIntegrationMethod);
     
     // Calculating jacobian
     Matrix J, inv_J;
-    rThisKinematicVariables.detJ0 = this->CalculateDerivativesOnCurrentConfiguration(J, inv_J, rThisKinematicVariables.DN_DX, PointNumber, this_integration_method);
+    rThisKinematicVariables.detJ0 = this->CalculateDerivativesOnCurrentConfiguration(J, inv_J, rThisKinematicVariables.DN_DX, PointNumber, rIntegrationMethod);
     
     KRATOS_ERROR_IF(rThisKinematicVariables.detJ0 < 0.0) << "WARNING:: ELEMENT ID: " << this->Id() << " INVERTED. DETJ0: " << rThisKinematicVariables.detJ0 << std::endl;
     
@@ -285,7 +287,6 @@ void UpdatedLagrangian::CalculateKinematicVariables(
                 DF(i, j) = DF2x2(i, j);
             DF(i, 2) = DF(2, i) = 0.0;
         }
-        rThisKinematicVariables.N = row(GetGeometry().ShapeFunctionsValues(this_integration_method), PointNumber);
         const double current_radius = StructuralMechanicsMathUtilities::CalculateRadius(rThisKinematicVariables.N, GetGeometry(), Current);
         const double initial_radius = StructuralMechanicsMathUtilities::CalculateRadius(rThisKinematicVariables.N, GetGeometry(), Initial);
         DF(2, 2) = current_radius/initial_radius;
@@ -296,7 +297,7 @@ void UpdatedLagrangian::CalculateKinematicVariables(
     noalias(rThisKinematicVariables.F) = prod(DF, this->ReferenceConfigurationDeformationGradient(PointNumber));
     
     // Calculating operator B
-    this->CalculateB( rThisKinematicVariables.B, rThisKinematicVariables.DN_DX, strain_size, IntegrationPoints, PointNumber );
+    this->CalculateB( rThisKinematicVariables.B, rThisKinematicVariables.DN_DX, strain_size, PointNumber );
 }
 
 /***********************************************************************************/
@@ -335,7 +336,6 @@ void UpdatedLagrangian::CalculateB(
     Matrix& rB,
     const Matrix& rDN_DX,
     const unsigned int StrainSize,
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
     const unsigned int PointNumber
     )
 {

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.h
@@ -279,7 +279,7 @@ protected:
     void CalculateKinematicVariables(
         KinematicVariables& rThisKinematicVariables,
         const unsigned int PointNumber,
-        const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+        const GeometryType::IntegrationMethod& rIntegrationMethod
         ) override;
     
     /**
@@ -337,7 +337,6 @@ private:
         Matrix& rB,
         const Matrix& rDN_DX,
         const unsigned int StrainSize,
-        const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const unsigned int PointNumber
         );
     

--- a/kratos/utilities/geometry_utilities.h
+++ b/kratos/utilities/geometry_utilities.h
@@ -765,8 +765,52 @@ public:
         return std::sqrt(square_distance);
     }
 
+    /**
+     * @brief Calculate the gradients of shape functions.
+     * @param rDN_De local gradient of shape functions.
+     * @param rInvJ inverse of the element Jacobian.
+     * @param rDN_DX gradient of shape functions.
+     */
+    static void ShapeFunctionsGradients(Matrix const& rDN_De, Matrix const& rInvJ, Matrix& rDN_DX)
+    {
+        if (rDN_DX.size1() != rDN_De.size1() || rDN_DX.size2() != rInvJ.size2())
+            rDN_DX.resize(rDN_De.size1(), rInvJ.size2(), false);
+        noalias(rDN_DX) = prod(rDN_De, rInvJ);
+    }
 
+    /**
+     * @brief Calculate the deformation gradient.
+     * 
+     * See, e.g., P. Wriggers, Nonlinear Finite Element Methods, Springer, 2008.
+     * @param rJ element Jacobian.
+     * @param rInvJ0 inverse of the element Jacobian of the initial configuration.
+     * @param rF deformation gradient.
+     */
+    static void DeformationGradient(Matrix const& rJ, Matrix const& rInvJ0, Matrix& rF)
+    {
+        if (rF.size1() != rJ.size1() || rF.size2() != rInvJ0.size2())
+            rF.resize(rJ.size1(), rInvJ0.size2(), false);
+        noalias(rF) = prod(rJ, rInvJ0);
+    }
 
+    /**
+     * @brief Calculate the Jacobian on the initial configuration.
+     * 
+     * @param rGeom element geometry.
+     * @param rCoords local coordinates of the current integration point.
+     * @param rJ0 Jacobian on the initial configuration.
+     */
+    static void JacobianOnInitialConfiguration(Element::GeometryType const& rGeom,
+                                               Element::GeometryType::CoordinatesArrayType const& rCoords,
+                                               Matrix& rJ0)
+    {
+        Matrix delta_position(rGeom.PointsNumber(), rGeom.WorkingSpaceDimension());
+        for (std::size_t i = 0; i < rGeom.PointsNumber(); ++i)
+            for (std::size_t j = 0; j < rGeom.WorkingSpaceDimension(); ++j)
+                delta_position(i, j) = rGeom[i].Coordinates()[j] -
+                                       rGeom[i].GetInitialPosition().Coordinates()[j];
+        rGeom.Jacobian(rJ0, rCoords, delta_position);
+    }
 };
 
 }  // namespace Kratos.


### PR DESCRIPTION
These are some initial changes related to CalculateKinematicVariables() of the solid element implementation of @KratosMultiphysics/structural-mechanics. The purpose is to make it possible to change the integration method by passing the method through the parameters instead of the integration points. Previously, the points were passed and some internal functions were assuming default integration method and calling the corresponding functions for the geometry class so in order to change the integration, one would have to change it in multiple places in addition to the parameter being passed to the function.

The behaviour of the elements should not change with this pr with one exception. In total and updated lagrangian elements, I changed the way F is resized for the axisymmetric case since it will no longer work with the new AMatrix lib. @loumalouomega this is what I think you said on the skype call today. There was a strange piece of code where the extended F matrix is set to zero on the off-diagonal except the previous code only looped over one index instead of two like it does after my modification. @loumalouomega can you please check my modification for this? It is in the CalculateKinematicVariables() where I define F2x2 and DF2x2 matrices.

