### PR TITLE
[Core] Bugfix StructuredMeshGenerator

### DIFF
--- a/kratos/processes/structured_mesh_generator_process.cpp
+++ b/kratos/processes/structured_mesh_generator_process.cpp
@@ -124,10 +124,15 @@ namespace Kratos
 				local_coordinates[0] = rMinPoint[0] + (i * local_element_size[0]);
 				local_coordinates[1] = rMinPoint[1] + (j * local_element_size[1]);
 				mrGeometry.GlobalCoordinates(global_coordinates, local_coordinates);
-				if ((i == 0) || (i == mNumberOfDivisions) || (j == 0) || (j == mNumberOfDivisions))  // Is on skin
-					mrOutputModelPart.GetSubModelPart("Skin").CreateNewNode(node_id++, global_coordinates[0], global_coordinates[1], global_coordinates[2]);
+				if (mCreateSkinSubModelPart && (
+                    (i == 0) || (i == mNumberOfDivisions) || (j == 0) || (j == mNumberOfDivisions)))  // Is on skin
+					mrOutputModelPart.GetSubModelPart("Skin").CreateNewNode(node_id++, global_coordinates[0],
+                                                                                       global_coordinates[1],
+                                                                                       global_coordinates[2]);
 				else
-					mrOutputModelPart.CreateNewNode(node_id++, global_coordinates[0], global_coordinates[1], global_coordinates[2]);
+					mrOutputModelPart.CreateNewNode(node_id++, global_coordinates[0],
+                                                               global_coordinates[1],
+                                                               global_coordinates[2]);
 			}
 		}
 	}
@@ -146,10 +151,16 @@ namespace Kratos
 					local_coordinates[1] = rMinPoint[1] + (j * local_element_size[1]);
 					local_coordinates[2] = rMinPoint[2] + (k * local_element_size[2]);
 					mrGeometry.GlobalCoordinates(global_coordinates, local_coordinates);
-					if ((i == 0) || (i == mNumberOfDivisions) || (j == 0) || (j == mNumberOfDivisions) || (k == 0) || (k == mNumberOfDivisions))  // Is on skin
-						mrOutputModelPart.GetSubModelPart("Skin").CreateNewNode(node_id++, global_coordinates[0], global_coordinates[1], global_coordinates[2]);
+					if (mCreateSkinSubModelPart && (
+                        (i == 0) || (i == mNumberOfDivisions) || (j == 0) ||
+                        (j == mNumberOfDivisions) || (k == 0) || (k == mNumberOfDivisions)))  // Is on skin
+						mrOutputModelPart.GetSubModelPart("Skin").CreateNewNode(node_id++, global_coordinates[0],
+                                                                                           global_coordinates[1],
+                                                                                           global_coordinates[2]);
 					else
-						mrOutputModelPart.CreateNewNode(node_id++, global_coordinates[0], global_coordinates[1], global_coordinates[2]);
+						mrOutputModelPart.CreateNewNode(node_id++, global_coordinates[0],
+                                                                   global_coordinates[1],
+                                                                   global_coordinates[2]);
 				}
 			}
 		}

--- a/kratos/tests/processes/test_structured_mesh_generator_process.cpp
+++ b/kratos/tests/processes/test_structured_mesh_generator_process.cpp
@@ -2,19 +2,19 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
-//                   
 //
-	           
+//
+
 // System includes
 
 
-// External includes 
+// External includes
 
 
 // Project includes
@@ -45,7 +45,7 @@ namespace Kratos {
 
 			ModelPart model_part("Generated");
 
-			Parameters mesher_parameters(R"( 
+			Parameters mesher_parameters(R"(
             {
                 "number_of_divisions":10,
                 "element_name": "Element3D4N"
@@ -70,6 +70,11 @@ namespace Kratos {
 				total_volume += element_volume;
 			}
 			KRATOS_CHECK_NEAR(total_volume, 1000., 1.E-6) << "with total_volume = " << total_volume;
+
+            KRATOS_CHECK(model_part.HasSubModelPart("Skin"));
+
+            KRATOS_CHECK_EQUAL(model_part.GetSubModelPart("Skin").NumberOfNodes(), 602);
+            KRATOS_CHECK_EQUAL(model_part.GetSubModelPart("Skin").NumberOfElements(), 0);
 		}
 
 		KRATOS_TEST_CASE_IN_SUITE(StructuredMeshGeneratorProcessQuadrilateral, KratosCoreFastSuite)
@@ -85,10 +90,11 @@ namespace Kratos {
 
 			ModelPart model_part("Generated");
 
-			Parameters mesher_parameters(R"( 
+			Parameters mesher_parameters(R"(
             {
                 "number_of_divisions":10,
-                "element_name": "Element2D3N"
+                "element_name": "Element2D3N",
+	            "create_skin_sub_model_part": false
             }  )");
 
 			std::size_t number_of_divisions = mesher_parameters["number_of_divisions"].GetInt();
@@ -108,6 +114,8 @@ namespace Kratos {
 				total_area += element_area;
 			}
 			KRATOS_CHECK_NEAR(total_area, 100., 1.E-6) << "with total_area = " << total_area;
+
+            KRATOS_CHECK_IS_FALSE(model_part.HasSubModelPart("Skin"));
 		}
 	}
 }  // namespace Kratos.


### PR DESCRIPTION
Hi @pooyan-dadvand 
there is a small bug in the Process, one cannot turn off the creation of a skin part because the check was missing in an if statement
Therfore I changed 
`(i == 0) || (i == mNumberOfDivisions) || (j == 0) || (j == mNumberOfDivisions)`
to 
`mCreateSkinSubModelPart && ( (i == 0) || (i == mNumberOfDivisions) || (j == 0) || (j == mNumberOfDivisions) )`

I also adapted one test to disable the creation of a skin part