### PR TITLE
Replaced ublas aliases in Poromechanics and Dam applications

### DIFF
--- a/applications/DamApplication/custom_conditions/UP_condition.hpp
+++ b/applications/DamApplication/custom_conditions/UP_condition.hpp
@@ -80,7 +80,7 @@ protected:
         ///Variables computed at each GP
         Vector Np;
         Vector NormalVector;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu;
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu;
 		double IntegrationCoefficient;
 
 		///Nodal variables
@@ -88,8 +88,8 @@ protected:
         Vector AccelerationVector;
 
         ///Auxiliary Variables
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes*TDim,TNumNodes> UPMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes*TDim> PUMatrix;
+        BoundedMatrix<double,TNumNodes*TDim,TNumNodes> UPMatrix;
+        BoundedMatrix<double,TNumNodes,TNumNodes*TDim> PUMatrix;
         array_1d<double,TNumNodes*TDim> UVector;
         array_1d<double,TNumNodes> PVector;
     };

--- a/applications/DamApplication/custom_conditions/added_mass_condition.cpp
+++ b/applications/DamApplication/custom_conditions/added_mass_condition.cpp
@@ -163,7 +163,7 @@ void AddedMassCondition<TDim,TNumNodes>::CalculateLHS( MatrixType& rLeftHandSide
 		const unsigned int LocalDim = Geom.LocalSpaceDimension();
 			
 		// Components of the Jacobian for computing the normal vector and shape functions container
-		boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu;
+		BoundedMatrix<double,TDim, TNumNodes*TDim> Nu;
         //const Vector& ShapeFunctionsValues = Geom.ShapeFunctionsValues();
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
 		GeometryType::JacobiansType JContainer(NumGPoints);
@@ -213,7 +213,7 @@ void AddedMassCondition<TDim,TNumNodes>::CalculateRHS( VectorType& rRightHandSid
 		const unsigned int LocalDim = Geom.LocalSpaceDimension();
 			
 		// Components of the Jacobian for computing the normal vector and shape functions container
-		boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu;
+		BoundedMatrix<double,TDim, TNumNodes*TDim> Nu;
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
 		GeometryType::JacobiansType JContainer(NumGPoints);
 		for(unsigned int i = 0; i<NumGPoints; i++)
@@ -221,7 +221,7 @@ void AddedMassCondition<TDim,TNumNodes>::CalculateRHS( VectorType& rRightHandSid
 		Geom.Jacobian( JContainer, mThisIntegrationMethod );
         
         double IntegrationCoefficient;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> MassMatrix;
+        BoundedMatrix<double,TNumNodes,TNumNodes> MassMatrix;
         Vector ShapeFunctionsValues;
         ShapeFunctionsValues.resize(TNumNodes,false);
         Vector AccelerationVector;

--- a/applications/DamApplication/custom_conditions/free_surface_condition.cpp
+++ b/applications/DamApplication/custom_conditions/free_surface_condition.cpp
@@ -198,7 +198,7 @@ void FreeSurfaceCondition<TDim,TNumNodes>::CalculateRHS( VectorType& rRightHandS
 		noalias( rRightHandSideVector ) = ZeroVector( element_size );
 		
 
-		boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> MassMatrix;
+		BoundedMatrix<double,TNumNodes,TNumNodes> MassMatrix;
 		
 		 //Defining the shape functions, the jacobian and the shape functions local gradients Containers
 		array_1d<double,TNumNodes> Np;

--- a/applications/DamApplication/custom_conditions/infinite_domain_condition.cpp
+++ b/applications/DamApplication/custom_conditions/infinite_domain_condition.cpp
@@ -91,7 +91,7 @@ void InfiniteDomainCondition<TDim,TNumNodes>::CalculateRHS( VectorType& rRightHa
 		noalias( rRightHandSideVector ) = ZeroVector( element_size );
 		
 
-		boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> DampingMatrix;
+		BoundedMatrix<double,TNumNodes,TNumNodes> DampingMatrix;
 		
 		 //Defining the shape functions, the jacobian and the shape functions local gradients Containers
 		array_1d<double,TNumNodes> Np;

--- a/applications/DamApplication/custom_elements/small_displacement_interface_element.cpp
+++ b/applications/DamApplication/custom_elements/small_displacement_interface_element.cpp
@@ -171,12 +171,12 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateMassMatrix( Mat
     //Defining necessary variables
     double IntegrationCoefficient;
     const double Density = Prop[DENSITY];
-    boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nut = ZeroMatrix(TDim, TNumNodes*TDim);
+    BoundedMatrix<double,TDim, TNumNodes*TDim> Nut = ZeroMatrix(TDim, TNumNodes*TDim);
     array_1d<double,TNumNodes*TDim> DisplacementVector;
     ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+    BoundedMatrix<double,TDim, TDim> RotationMatrix;
     this->CalculateRotationMatrix(RotationMatrix,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+    BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
     array_1d<double,TDim> LocalRelDispVector;
     array_1d<double,TDim> RelDispVector;
     const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
@@ -246,9 +246,9 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::FinalizeSolutionStep( Pr
     const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
     array_1d<double,TNumNodes*TDim> DisplacementVector;
     ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+    BoundedMatrix<double,TDim, TDim> RotationMatrix;
     this->CalculateRotationMatrix(RotationMatrix,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+    BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
     array_1d<double,TDim> RelDispVector;
     const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
     double JointWidth;
@@ -676,9 +676,9 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPo
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
         double JointWidth;
@@ -730,9 +730,9 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPo
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
                 
@@ -1082,7 +1082,7 @@ void SmallDisplacementInterfaceElement<TDim,TNumNodes>::InitializeElementVariabl
 //----------------------------------------------------------------------------------------
 
 template<>
-void SmallDisplacementInterfaceElement<2,4>::CalculateRotationMatrix(boost::numeric::ublas::bounded_matrix<double,2,2>& rRotationMatrix, const GeometryType& Geom)
+void SmallDisplacementInterfaceElement<2,4>::CalculateRotationMatrix(BoundedMatrix<double,2,2>& rRotationMatrix, const GeometryType& Geom)
 {
     KRATOS_TRY
     
@@ -1139,7 +1139,7 @@ void SmallDisplacementInterfaceElement<2,4>::CalculateRotationMatrix(boost::nume
 //----------------------------------------------------------------------------------------
 
 template<>
-void SmallDisplacementInterfaceElement<3,6>::CalculateRotationMatrix(boost::numeric::ublas::bounded_matrix<double,3,3>& rRotationMatrix, const GeometryType& Geom)
+void SmallDisplacementInterfaceElement<3,6>::CalculateRotationMatrix(BoundedMatrix<double,3,3>& rRotationMatrix, const GeometryType& Geom)
 {
     KRATOS_TRY
     
@@ -1191,7 +1191,7 @@ void SmallDisplacementInterfaceElement<3,6>::CalculateRotationMatrix(boost::nume
 //----------------------------------------------------------------------------------------
 
 template<>
-void SmallDisplacementInterfaceElement<3,8>::CalculateRotationMatrix(boost::numeric::ublas::bounded_matrix<double,3,3>& rRotationMatrix, const GeometryType& Geom)
+void SmallDisplacementInterfaceElement<3,8>::CalculateRotationMatrix(BoundedMatrix<double,3,3>& rRotationMatrix, const GeometryType& Geom)
 {
     KRATOS_TRY
     
@@ -1328,7 +1328,7 @@ template< unsigned int TDim, unsigned int TNumNodes >
 void SmallDisplacementInterfaceElement<TDim,TNumNodes>::CalculateAndAddStiffnessMatrix(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables)
 {
     noalias(rVariables.DimMatrix) = prod(trans(rVariables.RotationMatrix),
-                                        boost::numeric::ublas::bounded_matrix<double,TDim,TDim>(prod(rVariables.ConstitutiveMatrix,
+                                        BoundedMatrix<double,TDim,TDim>(prod(rVariables.ConstitutiveMatrix,
                                         rVariables.RotationMatrix)));
     noalias(rVariables.UDimMatrix) = prod(trans(rVariables.Nu),rVariables.DimMatrix); 
     noalias(rVariables.UMatrix) = prod(rVariables.UDimMatrix,rVariables.Nu)*rVariables.IntegrationCoefficient;

--- a/applications/DamApplication/custom_elements/small_displacement_interface_element.hpp
+++ b/applications/DamApplication/custom_elements/small_displacement_interface_element.hpp
@@ -111,7 +111,7 @@ protected:
         array_1d<double,TNumNodes*TDim> VolumeAcceleration;
 
         //General elemental variables
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         array_1d<double,TDim> VoigtVector;
 
         //Variables computed at each GP
@@ -125,13 +125,13 @@ protected:
         Matrix F;
         double detF;
         //Auxiliary Variables
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu;
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu;
         array_1d<double,TDim> BodyAcceleration;
         double IntegrationCoefficient;
         double JointWidth;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes*TDim,TNumNodes*TDim> UMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TDim,TDim> DimMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes*TDim,TDim> UDimMatrix;
+        BoundedMatrix<double,TNumNodes*TDim,TNumNodes*TDim> UMatrix;
+        BoundedMatrix<double,TDim,TDim> DimMatrix;
+        BoundedMatrix<double,TNumNodes*TDim,TDim> UDimMatrix;
         array_1d<double,TNumNodes*TDim> UVector;
     };
 
@@ -156,7 +156,7 @@ protected:
     void InitializeElementVariables(ElementVariables& rVariables,ConstitutiveLaw::Parameters& rConstitutiveParameters,
                                     const GeometryType& Geom, const PropertiesType& Prop, const ProcessInfo& CurrentProcessInfo);
 
-    void CalculateRotationMatrix(boost::numeric::ublas::bounded_matrix<double,TDim,TDim>& rRotationMatrix, const GeometryType& Geom);
+    void CalculateRotationMatrix(BoundedMatrix<double,TDim,TDim>& rRotationMatrix, const GeometryType& Geom);
 
     void CalculateJointWidth(double& rJointWidth,const double& NormalRelDisp,const double& MinimumJointWidth,const unsigned int& GPoint);
 

--- a/applications/DamApplication/custom_elements/small_displacement_thermo_mechanic_element.cpp
+++ b/applications/DamApplication/custom_elements/small_displacement_thermo_mechanic_element.cpp
@@ -176,10 +176,10 @@ void SmallDisplacementThermoMechanicElement::ExtrapolateGPStress(const Matrix& S
         else if(NumNodes == 4)
         {
             // Quadrilateral_2d_4 with GI_GAUSS_2
-            boost::numeric::ublas::bounded_matrix<double,4,4> ExtrapolationMatrix;
+            BoundedMatrix<double,4,4> ExtrapolationMatrix;
             ElementUtilities::CalculateExtrapolationMatrix(ExtrapolationMatrix);
             
-            boost::numeric::ublas::bounded_matrix<double,4,3> AuxNodalStress;
+            BoundedMatrix<double,4,3> AuxNodalStress;
             noalias(AuxNodalStress) = prod(ExtrapolationMatrix,StressContainer);
 
             /* INFO:
@@ -223,10 +223,10 @@ void SmallDisplacementThermoMechanicElement::ExtrapolateGPStress(const Matrix& S
         else if(NumNodes == 8)
         {
             // Hexahedra_3d_8 with GI_GAUSS_2
-            boost::numeric::ublas::bounded_matrix<double,8,8> ExtrapolationMatrix;
+            BoundedMatrix<double,8,8> ExtrapolationMatrix;
             ElementUtilities::CalculateExtrapolationMatrix(ExtrapolationMatrix);
             
-            boost::numeric::ublas::bounded_matrix<double,8,6> AuxNodalStress;
+            BoundedMatrix<double,8,6> AuxNodalStress;
             noalias(AuxNodalStress) = prod(ExtrapolationMatrix,StressContainer);
 
             for(unsigned int i = 0; i < 8; i++) //TNumNodes

--- a/applications/DamApplication/custom_elements/wave_equation_element.cpp
+++ b/applications/DamApplication/custom_elements/wave_equation_element.cpp
@@ -260,7 +260,7 @@ void WaveEquationElement<TDim,TNumNodes>::CalculateLHS( MatrixType& rLeftHandSid
 		
 		 //Defining the shape functions, the jacobian and the shape functions local gradients Containers
 		array_1d<double,TNumNodes> Np;
-		boost::numeric::ublas::bounded_matrix<double,TNumNodes,TDim> GradNpT; 
+		BoundedMatrix<double,TNumNodes,TDim> GradNpT; 
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         GeometryType::ShapeFunctionsGradientsType DN_DXContainer(NumGPoints);
 		Vector detJContainer(NumGPoints);
@@ -305,12 +305,12 @@ void WaveEquationElement<TDim,TNumNodes>::CalculateRHS(VectorType& rRightHandSid
 		const GeometryType::IntegrationPointsArrayType& integration_points = Geom.IntegrationPoints( mThisIntegrationMethod );
 		const unsigned int NumGPoints = integration_points.size();
 		
-		boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> MassMatrix;
-		boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> SiffnessMatrix;
+		BoundedMatrix<double,TNumNodes,TNumNodes> MassMatrix;
+		BoundedMatrix<double,TNumNodes,TNumNodes> SiffnessMatrix;
 
 		//Defining the shape functions, the jacobian and the shape functions local gradients Containers
 		array_1d<double,TNumNodes> Np;
-		boost::numeric::ublas::bounded_matrix<double,TNumNodes,TDim> GradNpT; 
+		BoundedMatrix<double,TNumNodes,TDim> GradNpT; 
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         GeometryType::ShapeFunctionsGradientsType DN_DXContainer(NumGPoints);
 		Vector detJContainer(NumGPoints);

--- a/applications/DamApplication/custom_processes/dam_uplift_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_uplift_condition_load_process.hpp
@@ -125,7 +125,7 @@ class DamUpliftConditionLoadProcess : public Process
         //Defining necessary variables
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
-        boost::numeric::ublas::bounded_matrix<double, 3, 3> RotationMatrix;
+        BoundedMatrix<double, 3, 3> RotationMatrix;
 
         // Computing the rotation matrix accoding with the introduced points by the user
         this->CalculateRotationMatrix(RotationMatrix);
@@ -228,7 +228,7 @@ class DamUpliftConditionLoadProcess : public Process
         //Defining necessary variables
         Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
-        boost::numeric::ublas::bounded_matrix<double, 3, 3> RotationMatrix;
+        BoundedMatrix<double, 3, 3> RotationMatrix;
 
         // Getting the values of table in case that it exist
         if (mTableId != 0)
@@ -331,7 +331,7 @@ class DamUpliftConditionLoadProcess : public Process
         KRATOS_CATCH("");
     }
 
-    void CalculateRotationMatrix(boost::numeric::ublas::bounded_matrix<double, 3, 3> &rRotationMatrix)
+    void CalculateRotationMatrix(BoundedMatrix<double, 3, 3> &rRotationMatrix)
     {
         KRATOS_TRY;
 

--- a/applications/DamApplication/custom_utilities/global_joint_stress_utility.hpp
+++ b/applications/DamApplication/custom_utilities/global_joint_stress_utility.hpp
@@ -80,7 +80,7 @@ class GlobalJointStressUtility
         ModelPart::ElementsContainerType::iterator el_begin = mr_model_part.ElementsBegin();
         GeometryData::IntegrationMethod MyIntegrationMethod;
         const ProcessInfo &CurrentProcessInfo = mr_model_part.GetProcessInfo();
-        boost::numeric::ublas::bounded_matrix<double, 3, 3> RotationPlane;
+        BoundedMatrix<double, 3, 3> RotationPlane;
 
         //Definition of the plane
         array_1d<double, 3> point_mid0;
@@ -108,7 +108,7 @@ class GlobalJointStressUtility
         {
             ModelPart::ElementsContainerType::iterator it = el_begin + k;
             Element::GeometryType &rGeom = it->GetGeometry();
-            boost::numeric::ublas::bounded_matrix<double, 3, 3> RotationMatrix;
+            BoundedMatrix<double, 3, 3> RotationMatrix;
 
             //Define mid-plane points for prism_interface_3d_6
             noalias(point_mid0) = 0.5 * (rGeom.GetPoint(0) + rGeom.GetPoint(3));
@@ -158,7 +158,7 @@ class GlobalJointStressUtility
 
     //Currently is just working for prism element
 
-    void CalculateRotationMatrix(boost::numeric::ublas::bounded_matrix<double, 3, 3> &rRotationMatrix, array_1d<double, 3> &point_mid0, array_1d<double, 3> &point_mid1, array_1d<double, 3> &point_mid2)
+    void CalculateRotationMatrix(BoundedMatrix<double, 3, 3> &rRotationMatrix, array_1d<double, 3> &point_mid0, array_1d<double, 3> &point_mid1, array_1d<double, 3> &point_mid2)
     {
         KRATOS_TRY
 

--- a/applications/DamApplication/custom_utilities/streamlines_output_3D_utilities.hpp
+++ b/applications/DamApplication/custom_utilities/streamlines_output_3D_utilities.hpp
@@ -118,7 +118,7 @@ class StreamlinesOutput3DUtilities
         array_1d<double, 3> vap2;
         array_1d<double, 3> vap3;
         array_1d<double, 3> Result;
-        boost::numeric::ublas::bounded_matrix<double, 3, 3> AutovectorMatrix;
+        BoundedMatrix<double, 3, 3> AutovectorMatrix;
 
         // Tangential Components
         const double &Sxy = Tangential_components[0];

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_face_load_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_face_load_condition.cpp
@@ -38,7 +38,7 @@ void UPwFaceLoadCondition<TDim,TNumNodes>::CalculateRHS( VectorType& rRightHandS
     //Condition variables
     array_1d<double,TNumNodes*TDim> FaceLoadVector;
     ConditionUtilities::GetFaceLoadVector(FaceLoadVector,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+    BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
     array_1d<double,TDim> TractionVector;
     array_1d<double,TNumNodes*TDim> UVector;
     double IntegrationCoefficient;

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.cpp
@@ -82,14 +82,14 @@ void UPwFaceLoadInterfaceCondition<TDim,TNumNodes>::CalculateRHS( VectorType& rR
     ConditionUtilities::GetDisplacementsVector(DisplacementVector,Geom);
     array_1d<double,TNumNodes*TDim> FaceLoadVector;
     ConditionUtilities::GetFaceLoadVector(FaceLoadVector,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim,TDim> RotationMatrix;
+    BoundedMatrix<double,TDim,TDim> RotationMatrix;
     const double& MinimumJointWidth = this->GetProperties()[MINIMUM_JOINT_WIDTH];
     bool ComputeJointWidth;
     double JointWidth;
     this->CheckJointWidth(JointWidth,ComputeJointWidth,RotationMatrix,MinimumJointWidth,Geom);
     array_1d<double,TDim> LocalRelDispVector;
     array_1d<double,TDim> RelDispVector;
-    boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+    BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
     array_1d<double,TDim> TractionVector;
     array_1d<double,TNumNodes*TDim> UVector;
     double IntegrationCoefficient;
@@ -118,7 +118,7 @@ void UPwFaceLoadInterfaceCondition<TDim,TNumNodes>::CalculateRHS( VectorType& rR
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwFaceLoadInterfaceCondition<2,2>::CheckJointWidth(double& rJointWidth, bool& rComputeJointWidth, boost::numeric::ublas::bounded_matrix<double,2,2>& rRotationMatrix,
+void UPwFaceLoadInterfaceCondition<2,2>::CheckJointWidth(double& rJointWidth, bool& rComputeJointWidth, BoundedMatrix<double,2,2>& rRotationMatrix,
                                                                 const double& MinimumJointWidth, const Element::GeometryType& Geom)
 {
     //Line_interface_2d_2
@@ -177,7 +177,7 @@ void UPwFaceLoadInterfaceCondition<2,2>::CheckJointWidth(double& rJointWidth, bo
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwFaceLoadInterfaceCondition<3,4>::CheckJointWidth(double& rJointWidth, bool& rComputeJointWidth, boost::numeric::ublas::bounded_matrix<double,3,3>& rRotationMatrix,
+void UPwFaceLoadInterfaceCondition<3,4>::CheckJointWidth(double& rJointWidth, bool& rComputeJointWidth, BoundedMatrix<double,3,3>& rRotationMatrix,
                                                             const double& MinimumJointWidth, const Element::GeometryType& Geom)
 {
     //Quadrilateral_interface_3d_4
@@ -235,9 +235,9 @@ void UPwFaceLoadInterfaceCondition<3,4>::CheckJointWidth(double& rJointWidth, bo
 //----------------------------------------------------------------------------------------
     
 template< >
-void UPwFaceLoadInterfaceCondition<2,2>::CalculateJointWidth( double& rJointWidth, const boost::numeric::ublas::bounded_matrix<double,2,4>& Nu,
+void UPwFaceLoadInterfaceCondition<2,2>::CalculateJointWidth( double& rJointWidth, const BoundedMatrix<double,2,4>& Nu,
                                                                         const array_1d<double,4>& DisplacementVector, array_1d<double,2>& rRelDispVector,
-                                                                        const boost::numeric::ublas::bounded_matrix<double,2,2>& RotationMatrix,
+                                                                        const BoundedMatrix<double,2,2>& RotationMatrix,
                                                                         array_1d<double,2>& rLocalRelDispVector, const double& MinimumJointWidth,
                                                                         const unsigned int& GPoint )
 {
@@ -258,9 +258,9 @@ void UPwFaceLoadInterfaceCondition<2,2>::CalculateJointWidth( double& rJointWidt
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwFaceLoadInterfaceCondition<3,4>::CalculateJointWidth( double& rJointWidth, const boost::numeric::ublas::bounded_matrix<double,3,12>& Nu,
+void UPwFaceLoadInterfaceCondition<3,4>::CalculateJointWidth( double& rJointWidth, const BoundedMatrix<double,3,12>& Nu,
                                                                         const array_1d<double,12>& DisplacementVector, array_1d<double,3>& rRelDispVector,
-                                                                        const boost::numeric::ublas::bounded_matrix<double,3,3>& RotationMatrix,
+                                                                        const BoundedMatrix<double,3,3>& RotationMatrix,
                                                                         array_1d<double,3>& rLocalRelDispVector, const double& MinimumJointWidth,
                                                                         const unsigned int& GPoint )
 {

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.hpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_face_load_interface_condition.hpp
@@ -75,12 +75,12 @@ protected:
     
     void CalculateRHS( VectorType& rRightHandSideVector, const ProcessInfo& CurrentProcessInfo ) override;
 
-    void CheckJointWidth(double& rJointWidth, bool& rComputeJointWidth, boost::numeric::ublas::bounded_matrix<double,TDim,TDim>& rRotationMatrix,
+    void CheckJointWidth(double& rJointWidth, bool& rComputeJointWidth, BoundedMatrix<double,TDim,TDim>& rRotationMatrix,
                             const double& MinimumJointWidth, const GeometryType& Geom);
 
-    void CalculateJointWidth( double& rJointWidth, const boost::numeric::ublas::bounded_matrix<double,TDim,TDim*TNumNodes>& Nu,
+    void CalculateJointWidth( double& rJointWidth, const BoundedMatrix<double,TDim,TDim*TNumNodes>& Nu,
                                 const array_1d<double,TDim*TNumNodes>& DisplacementVector, array_1d<double,TDim>& rRelDispVector,
-                                const boost::numeric::ublas::bounded_matrix<double,TDim,TDim>& RotationMatrix,
+                                const BoundedMatrix<double,TDim,TDim>& RotationMatrix,
                                 array_1d<double,TDim>& rLocalRelDispVector, const double& MinimumJointWidth, const unsigned int& GPoint );
 
     void CalculateIntegrationCoefficient(double& rIntegrationCoefficient, const Matrix& Jacobian, const double& Weight, const double& JointWidth);

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_normal_face_load_condition.cpp
@@ -39,7 +39,7 @@ void UPwNormalFaceLoadCondition<TDim,TNumNodes>::CalculateRHS( VectorType& rRigh
     NormalFaceLoadVariables Variables;
     this->InitializeConditionVariables(Variables,Geom);
     array_1d<double,TDim> TractionVector;
-    boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+    BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
     double IntegrationCoefficient;
     array_1d<double,TNumNodes*TDim> UVector;
     

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.cpp
@@ -182,7 +182,7 @@ void UPwNormalFluxFICCondition<TDim,TNumNodes>::CalculateAndAddBoundaryMassMatri
                                         outer_prod(rVariables.Np,rVariables.Np)*rVariables.IntegrationCoefficient;
     
     //Distribute boundary mass matrix into the elemental matrix
-    ElementUtilities::AssemblePBlockMatrix< boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rFICVariables.PMatrix,TDim,TNumNodes);
+    ElementUtilities::AssemblePBlockMatrix< BoundedMatrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rFICVariables.PMatrix,TDim,TNumNodes);
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.hpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_normal_flux_FIC_condition.hpp
@@ -68,7 +68,7 @@ protected:
         double BiotModulusInverse;
         
         array_1d<double,TNumNodes> DtPressureVector;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> PMatrix;
+        BoundedMatrix<double,TNumNodes,TNumNodes> PMatrix;
     };
     
     // Member Variables

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_normal_flux_interface_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_normal_flux_interface_condition.cpp
@@ -43,12 +43,12 @@ void UPwNormalFluxInterfaceCondition<TDim,TNumNodes>::CalculateRHS( VectorType& 
     {
         NormalFluxVector[i] = Geom[i].FastGetSolutionStepValue(NORMAL_FLUID_FLUX);
     }
-    boost::numeric::ublas::bounded_matrix<double,TDim,TDim> RotationMatrix;
+    BoundedMatrix<double,TDim,TDim> RotationMatrix;
     const double& MinimumJointWidth = this->GetProperties()[MINIMUM_JOINT_WIDTH];
     bool ComputeJointWidth;
     double JointWidth;
     this->CheckJointWidth(JointWidth,ComputeJointWidth,RotationMatrix,MinimumJointWidth,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+    BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
     array_1d<double,TDim> LocalRelDispVector;
     array_1d<double,TDim> RelDispVector;
     array_1d<double,TNumNodes> Np;

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_element.cpp
@@ -378,7 +378,7 @@ void UPwElement<TDim,TNumNodes>::CalculateMassMatrix( MatrixType& rMassMatrix, P
     double IntegrationCoefficient;
     const double& Porosity = Prop[POROSITY];
     const double Density = Porosity*Prop[DENSITY_WATER] + (1.0-Porosity)*Prop[DENSITY_SOLID];
-    boost::numeric::ublas::bounded_matrix<double,TDim+1, TNumNodes*(TDim+1)> Nut = ZeroMatrix(TDim+1, TNumNodes*(TDim+1));
+    BoundedMatrix<double,TDim+1, TNumNodes*(TDim+1)> Nut = ZeroMatrix(TDim+1, TNumNodes*(TDim+1));
     
     //Loop over integration points
     for ( unsigned int GPoint = 0; GPoint < NumGPoints; GPoint++ )

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.cpp
@@ -268,10 +268,10 @@ void UPwSmallStrainFICElement<2,4>::ExtrapolateGPConstitutiveTensor(const array_
 {
     // Quadrilateral_2d_4 with GI_GAUSS_2
     
-    boost::numeric::ublas::bounded_matrix<double,4,4> ExtrapolationMatrix;
+    BoundedMatrix<double,4,4> ExtrapolationMatrix;
     ElementUtilities::CalculateExtrapolationMatrix(ExtrapolationMatrix);
     
-    boost::numeric::ublas::bounded_matrix<double,4,3> AuxNodalConstitutiveTensor;
+    BoundedMatrix<double,4,3> AuxNodalConstitutiveTensor;
     
     for(unsigned int i = 0; i < 2; i++) //TDim
     {
@@ -306,10 +306,10 @@ void UPwSmallStrainFICElement<3,8>::ExtrapolateGPConstitutiveTensor(const array_
 {
     // Hexahedra_3d_8 with GI_GAUSS_2
     
-    boost::numeric::ublas::bounded_matrix<double,8,8> ExtrapolationMatrix;
+    BoundedMatrix<double,8,8> ExtrapolationMatrix;
     ElementUtilities::CalculateExtrapolationMatrix(ExtrapolationMatrix);
     
-    boost::numeric::ublas::bounded_matrix<double,8,6> AuxNodalConstitutiveTensor;
+    BoundedMatrix<double,8,6> AuxNodalConstitutiveTensor;
     
     for(unsigned int i = 0; i < 3; i++) //TDim
     {
@@ -350,10 +350,10 @@ void UPwSmallStrainFICElement<2,4>::ExtrapolateGPDtStress(const Matrix& DtStress
 {
     // Quadrilateral_2d_4 with GI_GAUSS_2
 
-    boost::numeric::ublas::bounded_matrix<double,4,4> ExtrapolationMatrix;
+    BoundedMatrix<double,4,4> ExtrapolationMatrix;
     ElementUtilities::CalculateExtrapolationMatrix(ExtrapolationMatrix);
     
-    boost::numeric::ublas::bounded_matrix<double,4,2> AuxNodalDtStress;
+    BoundedMatrix<double,4,2> AuxNodalDtStress;
     noalias(AuxNodalDtStress) = prod(ExtrapolationMatrix,DtStressContainer);
     
     for(unsigned int i = 0; i < 2; i++) // TDim
@@ -381,10 +381,10 @@ void UPwSmallStrainFICElement<3,8>::ExtrapolateGPDtStress(const Matrix& DtStress
 {
     // Hexahedra_3d_8 with GI_GAUSS_2
     
-    boost::numeric::ublas::bounded_matrix<double,8,8> ExtrapolationMatrix;
+    BoundedMatrix<double,8,8> ExtrapolationMatrix;
     ElementUtilities::CalculateExtrapolationMatrix(ExtrapolationMatrix);
     
-    boost::numeric::ublas::bounded_matrix<double,8,3> AuxNodalDtStress;
+    BoundedMatrix<double,8,3> AuxNodalDtStress;
     noalias(AuxNodalDtStress) = prod(ExtrapolationMatrix,DtStressContainer);
     
     for(unsigned int i = 0; i < 3; i++) // TDim
@@ -560,7 +560,7 @@ void UPwSmallStrainFICElement<2,4>::ExtrapolateShapeFunctionsGradients(array_1d<
 {
     // Quadrilateral_2d_4 with GI_GAUSS_2
 
-    boost::numeric::ublas::bounded_matrix<double,4,8> ShapeFunctionsGradientsContainer; //NumGPoints X TDim*TNumNodes
+    BoundedMatrix<double,4,8> ShapeFunctionsGradientsContainer; //NumGPoints X TDim*TNumNodes
     unsigned int index;
     
     for(unsigned int i = 0; i < 4; i++) //NumGPoints
@@ -574,10 +574,10 @@ void UPwSmallStrainFICElement<2,4>::ExtrapolateShapeFunctionsGradients(array_1d<
         }
     }
     
-    boost::numeric::ublas::bounded_matrix<double,4,4> ExtrapolationMatrix;
+    BoundedMatrix<double,4,4> ExtrapolationMatrix;
     ElementUtilities::CalculateExtrapolationMatrix(ExtrapolationMatrix);
     
-    boost::numeric::ublas::bounded_matrix<double,4,8> AuxNodalShapeFunctionsGradients;
+    BoundedMatrix<double,4,8> AuxNodalShapeFunctionsGradients;
     noalias(AuxNodalShapeFunctionsGradients) = prod(ExtrapolationMatrix,ShapeFunctionsGradientsContainer);
     
     for(unsigned int i = 0; i < 4; i++) //TNumNodes
@@ -627,7 +627,7 @@ void UPwSmallStrainFICElement<3,8>::ExtrapolateShapeFunctionsGradients(array_1d<
 {
     // Hexahedra_3d_8 with GI_GAUSS_2
 
-    boost::numeric::ublas::bounded_matrix<double,8,24> ShapeFunctionsGradientsContainer; //NumGPoints X TDim*TNumNodes
+    BoundedMatrix<double,8,24> ShapeFunctionsGradientsContainer; //NumGPoints X TDim*TNumNodes
     unsigned int index;
     
     for(unsigned int i = 0; i < 8; i++) //NumGPoints
@@ -642,10 +642,10 @@ void UPwSmallStrainFICElement<3,8>::ExtrapolateShapeFunctionsGradients(array_1d<
         }
     }
     
-    boost::numeric::ublas::bounded_matrix<double,8,8> ExtrapolationMatrix;
+    BoundedMatrix<double,8,8> ExtrapolationMatrix;
     ElementUtilities::CalculateExtrapolationMatrix(ExtrapolationMatrix);
     
-    boost::numeric::ublas::bounded_matrix<double,8,24> AuxNodalShapeFunctionsGradients;
+    BoundedMatrix<double,8,24> AuxNodalShapeFunctionsGradients;
     noalias(AuxNodalShapeFunctionsGradients) = prod(ExtrapolationMatrix,ShapeFunctionsGradientsContainer);
     
     for(unsigned int i = 0; i < 8; i++) //TNumNodes
@@ -1123,7 +1123,7 @@ void UPwSmallStrainFICElement<TDim,TNumNodes>::CalculateAndAddPressureGradientMa
                                       prod(rVariables.GradNpT,trans(rVariables.GradNpT))*rVariables.IntegrationCoefficient;
     
     //Distribute pressure gradient block matrix into the elemental matrix
-    ElementUtilities::AssemblePBlockMatrix< boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rVariables.PMatrix,TDim,TNumNodes);
+    ElementUtilities::AssemblePBlockMatrix< BoundedMatrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rVariables.PMatrix,TDim,TNumNodes);
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
@@ -90,14 +90,14 @@ protected:
         Matrix VoigtMatrix;
         
         /// Variables computed at each GP
-        boost::numeric::ublas::bounded_matrix<double,TDim,TDim*TNumNodes> StrainGradients;
+        BoundedMatrix<double,TDim,TDim*TNumNodes> StrainGradients;
         array_1d<Vector,TNumNodes> ShapeFunctionsSecondOrderGradients;
         array_1d< array_1d<double,TDim> , TDim > DtStressGradients;
         array_1d< std::vector< array_1d<double,TDim> > , TDim > ConstitutiveTensorGradients;
         ///Auxiliary variables
         array_1d<double,TDim> DimVector;
         Matrix DimVoigtMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TDim,TDim*TNumNodes> DimUMatrix;
+        BoundedMatrix<double,TDim,TDim*TNumNodes> DimUMatrix;
     };
     
     /// Member Variables

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -307,10 +307,10 @@ void UPwSmallStrainElement<2,4>::ExtrapolateGPStress(const Matrix& StressContain
         NodalStressTensor[Node].resize(2,2);
     }
 
-    boost::numeric::ublas::bounded_matrix<double,4,4> ExtrapolationMatrix;
+    BoundedMatrix<double,4,4> ExtrapolationMatrix;
     ElementUtilities::CalculateExtrapolationMatrix(ExtrapolationMatrix);
     
-    boost::numeric::ublas::bounded_matrix<double,4,3> AuxNodalStress;
+    BoundedMatrix<double,4,3> AuxNodalStress;
     noalias(AuxNodalStress) = prod(ExtrapolationMatrix,StressContainer);
 
     /* INFO:
@@ -391,10 +391,10 @@ void UPwSmallStrainElement<3,8>::ExtrapolateGPStress(const Matrix& StressContain
         NodalStressTensor[Node].resize(3,3);
     }
 
-    boost::numeric::ublas::bounded_matrix<double,8,8> ExtrapolationMatrix;
+    BoundedMatrix<double,8,8> ExtrapolationMatrix;
     ElementUtilities::CalculateExtrapolationMatrix(ExtrapolationMatrix);
     
-    boost::numeric::ublas::bounded_matrix<double,8,6> AuxNodalStress;
+    BoundedMatrix<double,8,6> AuxNodalStress;
     noalias(AuxNodalStress) = prod(ExtrapolationMatrix,StressContainer);
 
     for(unsigned int i = 0; i < 8; i++) //TNumNodes
@@ -501,8 +501,8 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         array_1d<double,TNumNodes*TDim> VolumeAcceleration;
         ElementUtilities::GetVolumeAccelerationVector(VolumeAcceleration,Geom);
         array_1d<double,TDim> BodyAcceleration;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes, TDim> GradNpT;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> PermeabilityMatrix;
+        BoundedMatrix<double,TNumNodes, TDim> GradNpT;
+        BoundedMatrix<double,TDim, TDim> PermeabilityMatrix;
         ElementUtilities::CalculatePermeabilityMatrix(PermeabilityMatrix,Prop);
         const double& DynamicViscosityInverse = 1.0/Prop[DYNAMIC_VISCOSITY];
         const double& FluidDensity = Prop[DENSITY_WATER];
@@ -709,7 +709,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateOnIntegrationPoints( const 
         const unsigned int NumGPoints = this->GetGeometry().IntegrationPointsNumber( mThisIntegrationMethod );
         
         //If the permeability of the element is a given property
-        boost::numeric::ublas::bounded_matrix<double,TDim,TDim> PermeabilityMatrix;
+        BoundedMatrix<double,TDim,TDim> PermeabilityMatrix;
         ElementUtilities::CalculatePermeabilityMatrix(PermeabilityMatrix,this->GetProperties());
     
         //Loop over integration points
@@ -1120,7 +1120,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddCompressibilityMatrix
     noalias(rVariables.PMatrix) = rVariables.DtPressureCoefficient*rVariables.BiotModulusInverse*outer_prod(rVariables.Np,rVariables.Np)*rVariables.IntegrationCoefficient;
     
     //Distribute compressibility block matrix into the elemental matrix
-    ElementUtilities::AssemblePBlockMatrix< boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rVariables.PMatrix,TDim,TNumNodes);
+    ElementUtilities::AssemblePBlockMatrix< BoundedMatrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rVariables.PMatrix,TDim,TNumNodes);
 }
 
 //----------------------------------------------------------------------------------------
@@ -1133,7 +1133,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::CalculateAndAddPermeabilityMatrix(Ma
     noalias(rVariables.PMatrix) = rVariables.DynamicViscosityInverse*prod(rVariables.PDimMatrix,trans(rVariables.GradNpT))*rVariables.IntegrationCoefficient;
     
     //Distribute permeability block matrix into the elemental matrix
-    ElementUtilities::AssemblePBlockMatrix< boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rVariables.PMatrix,TDim,TNumNodes);
+    ElementUtilities::AssemblePBlockMatrix< BoundedMatrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rVariables.PMatrix,TDim,TNumNodes);
 }
 
 //----------------------------------------------------------------------------------------

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -91,7 +91,7 @@ protected:
         double Density;
         double BiotCoefficient;
         double BiotModulusInverse;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> PermeabilityMatrix;
+        BoundedMatrix<double,TDim, TDim> PermeabilityMatrix;
         
         ///ProcessInfo variables
         double VelocityCoefficient;
@@ -109,7 +109,7 @@ protected:
         
         ///Variables computed at each GP
         Matrix B;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu;
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu;
         array_1d<double,TDim> BodyAcceleration;
         double IntegrationCoefficient;
         ///Constitutive Law parameters
@@ -121,12 +121,12 @@ protected:
         Matrix F;
         double detF;
         ///Auxiliary Variables
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes*TDim,TNumNodes*TDim> UMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes*TDim,TNumNodes> UPMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes*TDim> PUMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> PMatrix;
+        BoundedMatrix<double,TNumNodes*TDim,TNumNodes*TDim> UMatrix;
+        BoundedMatrix<double,TNumNodes*TDim,TNumNodes> UPMatrix;
+        BoundedMatrix<double,TNumNodes,TNumNodes*TDim> PUMatrix;
+        BoundedMatrix<double,TNumNodes,TNumNodes> PMatrix;
         Matrix UVoigtMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TDim> PDimMatrix;
+        BoundedMatrix<double,TNumNodes,TDim> PDimMatrix;
         array_1d<double,TNumNodes*TDim> UVector;
         array_1d<double,TNumNodes> PVector;
     };

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -118,12 +118,12 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateMassMatrix( Matrix
     double IntegrationCoefficient;
     const double& Porosity = Prop[POROSITY];
     const double Density = Porosity*Prop[DENSITY_WATER] + (1.0-Porosity)*Prop[DENSITY_SOLID];
-    boost::numeric::ublas::bounded_matrix<double,TDim+1, TNumNodes*(TDim+1)> Nut = ZeroMatrix(TDim+1, TNumNodes*(TDim+1));
+    BoundedMatrix<double,TDim+1, TNumNodes*(TDim+1)> Nut = ZeroMatrix(TDim+1, TNumNodes*(TDim+1));
     array_1d<double,TNumNodes*TDim> DisplacementVector;
     ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+    BoundedMatrix<double,TDim, TDim> RotationMatrix;
     this->CalculateRotationMatrix(RotationMatrix,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+    BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
     array_1d<double,TDim> LocalRelDispVector;
     array_1d<double,TDim> RelDispVector;
     const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
@@ -165,9 +165,9 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::FinalizeSolutionStep( Proce
     const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
     array_1d<double,TNumNodes*TDim> DisplacementVector;
     ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+    BoundedMatrix<double,TDim, TDim> RotationMatrix;
     this->CalculateRotationMatrix(RotationMatrix,Geom);
-    boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+    BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
     array_1d<double,TDim> RelDispVector;
     const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
     double JointWidth;
@@ -343,16 +343,16 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoint
         array_1d<double,TDim> BodyAcceleration;
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
         double JointWidth;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes, TDim> GradNpT;
+        BoundedMatrix<double,TNumNodes, TDim> GradNpT;
         const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
         const double& DynamicViscosityInverse = 1.0/Prop[DYNAMIC_VISCOSITY];
         const double& FluidDensity = Prop[DENSITY_WATER];
         array_1d<double,TDim> LocalFluidFlux;
@@ -371,7 +371,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoint
                 
             this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
         
-            this->CalculateShapeFunctionsGradients< boost::numeric::ublas::bounded_matrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
+            this->CalculateShapeFunctionsGradients< BoundedMatrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
                                                                                                                 DN_DeContainer[GPoint],NContainer,JointWidth,GPoint);
             
             ElementUtilities::InterpolateVariableWithComponents(BodyAcceleration,NContainer,VolumeAcceleration,GPoint);
@@ -396,9 +396,9 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoint
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
         double JointWidth;
@@ -450,9 +450,9 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoint
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
                 
@@ -489,16 +489,16 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoint
         array_1d<double,TDim> BodyAcceleration;
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
         double JointWidth;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes, TDim> GradNpT; 
+        BoundedMatrix<double,TNumNodes, TDim> GradNpT; 
         const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
         const double& DynamicViscosityInverse = 1.0/Prop[DYNAMIC_VISCOSITY];
         const double& FluidDensity = Prop[DENSITY_WATER];
         array_1d<double,TDim> LocalFluidFlux;
@@ -516,7 +516,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoint
             
             this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
 
-            this->CalculateShapeFunctionsGradients< boost::numeric::ublas::bounded_matrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
+            this->CalculateShapeFunctionsGradients< BoundedMatrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
                                                                                                                 DN_DeContainer[GPoint],NContainer,JointWidth,GPoint);
             
             ElementUtilities::InterpolateVariableWithComponents(BodyAcceleration,NContainer,VolumeAcceleration,GPoint);
@@ -554,16 +554,16 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoint
         //Defining necessary variables
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
         double JointWidth;
         const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> PermeabilityMatrix;
+        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+        BoundedMatrix<double,TDim, TDim> PermeabilityMatrix;
     
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
@@ -578,7 +578,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoint
 
             InterfaceElementUtilities::CalculatePermeabilityMatrix(LocalPermeabilityMatrix,JointWidth,Transversal_Permeability);
             
-            noalias(PermeabilityMatrix) = prod(trans(RotationMatrix),boost::numeric::ublas::bounded_matrix<double,TDim, TDim>(prod(LocalPermeabilityMatrix,RotationMatrix)));
+            noalias(PermeabilityMatrix) = prod(trans(RotationMatrix),BoundedMatrix<double,TDim, TDim>(prod(LocalPermeabilityMatrix,RotationMatrix)));
             
             rOutput[GPoint].resize(TDim,TDim,false);
             noalias(rOutput[GPoint]) = PermeabilityMatrix;
@@ -595,15 +595,15 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationPoint
         //Defining necessary variables
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
         double JointWidth;
         const double& Transversal_Permeability = Prop[TRANSVERSAL_PERMEABILITY];
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
     
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
@@ -985,7 +985,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::InitializeElementVariables(
 //----------------------------------------------------------------------------------------
 
 template<>
-void UPwSmallStrainInterfaceElement<2,4>::CalculateRotationMatrix(boost::numeric::ublas::bounded_matrix<double,2,2>& rRotationMatrix, const GeometryType& Geom)
+void UPwSmallStrainInterfaceElement<2,4>::CalculateRotationMatrix(BoundedMatrix<double,2,2>& rRotationMatrix, const GeometryType& Geom)
 {
     KRATOS_TRY
     
@@ -1042,7 +1042,7 @@ void UPwSmallStrainInterfaceElement<2,4>::CalculateRotationMatrix(boost::numeric
 //----------------------------------------------------------------------------------------
 
 template<>
-void UPwSmallStrainInterfaceElement<3,6>::CalculateRotationMatrix(boost::numeric::ublas::bounded_matrix<double,3,3>& rRotationMatrix, const GeometryType& Geom)
+void UPwSmallStrainInterfaceElement<3,6>::CalculateRotationMatrix(BoundedMatrix<double,3,3>& rRotationMatrix, const GeometryType& Geom)
 {
     KRATOS_TRY
     
@@ -1094,7 +1094,7 @@ void UPwSmallStrainInterfaceElement<3,6>::CalculateRotationMatrix(boost::numeric
 //----------------------------------------------------------------------------------------
 
 template<>
-void UPwSmallStrainInterfaceElement<3,8>::CalculateRotationMatrix(boost::numeric::ublas::bounded_matrix<double,3,3>& rRotationMatrix, const GeometryType& Geom)
+void UPwSmallStrainInterfaceElement<3,8>::CalculateRotationMatrix(BoundedMatrix<double,3,3>& rRotationMatrix, const GeometryType& Geom)
 {
     KRATOS_TRY
     
@@ -1198,7 +1198,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CheckAndCalculateJointWidth
 template< >
 template< class TMatrixType >
 void UPwSmallStrainInterfaceElement<2,4>::CalculateShapeFunctionsGradients(TMatrixType& rGradNpT,SFGradAuxVariables& rAuxVariables,
-                                                    const Matrix& Jacobian,const boost::numeric::ublas::bounded_matrix<double,2,2>& RotationMatrix,
+                                                    const Matrix& Jacobian,const BoundedMatrix<double,2,2>& RotationMatrix,
                                                     const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint)
 {
     //Quadrilateral_interface_2d_4
@@ -1217,7 +1217,7 @@ void UPwSmallStrainInterfaceElement<2,4>::CalculateShapeFunctionsGradients(TMatr
 template< >
 template< class TMatrixType >
 void UPwSmallStrainInterfaceElement<3,6>::CalculateShapeFunctionsGradients(TMatrixType& rGradNpT,SFGradAuxVariables& rAuxVariables,
-                                                    const Matrix& Jacobian,const boost::numeric::ublas::bounded_matrix<double,3,3>& RotationMatrix,
+                                                    const Matrix& Jacobian,const BoundedMatrix<double,3,3>& RotationMatrix,
                                                     const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint)
 {
     //Prism_interface_3d_6
@@ -1259,7 +1259,7 @@ void UPwSmallStrainInterfaceElement<3,6>::CalculateShapeFunctionsGradients(TMatr
 template< >
 template< class TMatrixType >
 void UPwSmallStrainInterfaceElement<3,8>::CalculateShapeFunctionsGradients(TMatrixType& rGradNpT,SFGradAuxVariables& rAuxVariables,
-                                                    const Matrix& Jacobian,const boost::numeric::ublas::bounded_matrix<double,3,3>& RotationMatrix,
+                                                    const Matrix& Jacobian,const BoundedMatrix<double,3,3>& RotationMatrix,
                                                     const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint)
 {
     //Hexahedral_interface_3d_8
@@ -1319,7 +1319,7 @@ template< unsigned int TDim, unsigned int TNumNodes >
 void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateAndAddStiffnessMatrix(MatrixType& rLeftHandSideMatrix, InterfaceElementVariables& rVariables)
 {
     noalias(rVariables.DimMatrix) = prod(trans(rVariables.RotationMatrix),
-                                        boost::numeric::ublas::bounded_matrix<double,TDim,TDim>(prod(rVariables.ConstitutiveMatrix,
+                                        BoundedMatrix<double,TDim,TDim>(prod(rVariables.ConstitutiveMatrix,
                                         rVariables.RotationMatrix)));
     noalias(rVariables.UDimMatrix) = prod(trans(rVariables.Nu),rVariables.DimMatrix);
     noalias(rVariables.UMatrix) = prod(rVariables.UDimMatrix,rVariables.Nu)*rVariables.IntegrationCoefficient;
@@ -1356,7 +1356,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateAndAddCompressibil
     noalias(rVariables.PMatrix) = rVariables.DtPressureCoefficient*rVariables.BiotModulusInverse*outer_prod(rVariables.Np,rVariables.Np)*rVariables.JointWidth*rVariables.IntegrationCoefficient;
     
     //Distribute compressibility block matrix into the elemental matrix
-    ElementUtilities::AssemblePBlockMatrix< boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rVariables.PMatrix,TDim,TNumNodes);
+    ElementUtilities::AssemblePBlockMatrix< BoundedMatrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rVariables.PMatrix,TDim,TNumNodes);
 }
 
 //----------------------------------------------------------------------------------------
@@ -1369,7 +1369,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateAndAddPermeability
     noalias(rVariables.PMatrix) = rVariables.DynamicViscosityInverse*prod(rVariables.PDimMatrix,trans(rVariables.GradNpT))*rVariables.JointWidth*rVariables.IntegrationCoefficient;
     
     //Distribute permeability block matrix into the elemental matrix
-    ElementUtilities::AssemblePBlockMatrix< boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rVariables.PMatrix,TDim,TNumNodes);
+    ElementUtilities::AssemblePBlockMatrix< BoundedMatrix<double,TNumNodes,TNumNodes> >(rLeftHandSideMatrix,rVariables.PMatrix,TDim,TNumNodes);
 }
 
 //----------------------------------------------------------------------------------------
@@ -1632,29 +1632,29 @@ void UPwSmallStrainInterfaceElement<3,8>::InterpolateOutputValues( std::vector<T
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-template void UPwSmallStrainInterfaceElement<2,4>::CalculateShapeFunctionsGradients< boost::numeric::ublas::bounded_matrix<double,4,2> >
-                                                    ( boost::numeric::ublas::bounded_matrix<double,4,2>& rGradNpT, SFGradAuxVariables& rAuxVariables,
-                                                    const Matrix& Jacobian,const boost::numeric::ublas::bounded_matrix<double,2,2>& RotationMatrix,
+template void UPwSmallStrainInterfaceElement<2,4>::CalculateShapeFunctionsGradients< BoundedMatrix<double,4,2> >
+                                                    ( BoundedMatrix<double,4,2>& rGradNpT, SFGradAuxVariables& rAuxVariables,
+                                                    const Matrix& Jacobian,const BoundedMatrix<double,2,2>& RotationMatrix,
                                                     const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint );
 template void UPwSmallStrainInterfaceElement<2,4>::CalculateShapeFunctionsGradients< Matrix >
                                                     ( Matrix& rGradNpT, SFGradAuxVariables& rAuxVariables,const Matrix& Jacobian, 
-                                                    const boost::numeric::ublas::bounded_matrix<double,2,2>& RotationMatrix,
+                                                    const BoundedMatrix<double,2,2>& RotationMatrix,
                                                     const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint );
-template void UPwSmallStrainInterfaceElement<3,6>::CalculateShapeFunctionsGradients< boost::numeric::ublas::bounded_matrix<double,6,3> >
-                                                    ( boost::numeric::ublas::bounded_matrix<double,6,3>& rGradNpT, SFGradAuxVariables& rAuxVariables,
-                                                    const Matrix& Jacobian,const boost::numeric::ublas::bounded_matrix<double,3,3>& RotationMatrix,
+template void UPwSmallStrainInterfaceElement<3,6>::CalculateShapeFunctionsGradients< BoundedMatrix<double,6,3> >
+                                                    ( BoundedMatrix<double,6,3>& rGradNpT, SFGradAuxVariables& rAuxVariables,
+                                                    const Matrix& Jacobian,const BoundedMatrix<double,3,3>& RotationMatrix,
                                                     const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint );
 template void UPwSmallStrainInterfaceElement<3,6>::CalculateShapeFunctionsGradients< Matrix >
                                                     ( Matrix& rGradNpT, SFGradAuxVariables& rAuxVariables,const Matrix& Jacobian, 
-                                                    const boost::numeric::ublas::bounded_matrix<double,3,3>& RotationMatrix,
+                                                    const BoundedMatrix<double,3,3>& RotationMatrix,
                                                     const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint );
-template void UPwSmallStrainInterfaceElement<3,8>::CalculateShapeFunctionsGradients< boost::numeric::ublas::bounded_matrix<double,8,3> >
-                                                    ( boost::numeric::ublas::bounded_matrix<double,8,3>& rGradNpT, SFGradAuxVariables& rAuxVariables,
-                                                    const Matrix& Jacobian,const boost::numeric::ublas::bounded_matrix<double,3,3>& RotationMatrix,
+template void UPwSmallStrainInterfaceElement<3,8>::CalculateShapeFunctionsGradients< BoundedMatrix<double,8,3> >
+                                                    ( BoundedMatrix<double,8,3>& rGradNpT, SFGradAuxVariables& rAuxVariables,
+                                                    const Matrix& Jacobian,const BoundedMatrix<double,3,3>& RotationMatrix,
                                                     const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint );
 template void UPwSmallStrainInterfaceElement<3,8>::CalculateShapeFunctionsGradients< Matrix >
                                                     ( Matrix& rGradNpT, SFGradAuxVariables& rAuxVariables,const Matrix& Jacobian, 
-                                                    const boost::numeric::ublas::bounded_matrix<double,3,3>& RotationMatrix,
+                                                    const BoundedMatrix<double,3,3>& RotationMatrix,
                                                     const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint );
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
@@ -96,10 +96,10 @@ protected:
         array_1d<double,TDim> GlobalCoordinatesGradients;
         array_1d<double,TDim> LocalCoordinatesGradients;
         
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TDim-1> ShapeFunctionsNaturalGradientsMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TDim-1,TDim-1> LocalCoordinatesGradientsMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TDim-1,TDim-1> LocalCoordinatesGradientsInvMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TDim-1> ShapeFunctionsGradientsMatrix;
+        BoundedMatrix<double,TNumNodes,TDim-1> ShapeFunctionsNaturalGradientsMatrix;
+        BoundedMatrix<double,TDim-1,TDim-1> LocalCoordinatesGradientsMatrix;
+        BoundedMatrix<double,TDim-1,TDim-1> LocalCoordinatesGradientsInvMatrix;
+        BoundedMatrix<double,TNumNodes,TDim-1> ShapeFunctionsGradientsMatrix;
     };
         
     struct InterfaceElementVariables
@@ -123,7 +123,7 @@ protected:
         array_1d<double,TNumNodes*TDim> VolumeAcceleration;
 
         ///General elemental variables
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         array_1d<double,TDim> VoigtVector;
         
         ///Variables computed at each GP
@@ -137,18 +137,18 @@ protected:
         Matrix F;
         double detF;
         ///Auxiliary Variables
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> LocalPermeabilityMatrix;
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu;
+        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix;
         array_1d<double,TDim> BodyAcceleration;
         double IntegrationCoefficient;
         double JointWidth;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes*TDim,TNumNodes*TDim> UMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes*TDim,TNumNodes> UPMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes*TDim> PUMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TNumNodes> PMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TDim,TDim> DimMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes*TDim,TDim> UDimMatrix;
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes,TDim> PDimMatrix;
+        BoundedMatrix<double,TNumNodes*TDim,TNumNodes*TDim> UMatrix;
+        BoundedMatrix<double,TNumNodes*TDim,TNumNodes> UPMatrix;
+        BoundedMatrix<double,TNumNodes,TNumNodes*TDim> PUMatrix;
+        BoundedMatrix<double,TNumNodes,TNumNodes> PMatrix;
+        BoundedMatrix<double,TDim,TDim> DimMatrix;
+        BoundedMatrix<double,TNumNodes*TDim,TDim> UDimMatrix;
+        BoundedMatrix<double,TNumNodes,TDim> PDimMatrix;
         array_1d<double,TNumNodes*TDim> UVector;
         array_1d<double,TNumNodes> PVector;
     };
@@ -173,7 +173,7 @@ protected:
     void InitializeElementVariables(InterfaceElementVariables& rVariables,ConstitutiveLaw::Parameters& rConstitutiveParameters,
                                     const GeometryType& Geom, const PropertiesType& Prop, const ProcessInfo& CurrentProcessInfo);
                                     
-    void CalculateRotationMatrix(boost::numeric::ublas::bounded_matrix<double,TDim,TDim>& rRotationMatrix, const GeometryType& Geom);
+    void CalculateRotationMatrix(BoundedMatrix<double,TDim,TDim>& rRotationMatrix, const GeometryType& Geom);
     
     void CalculateJointWidth(double& rJointWidth,const double& NormalRelDisp,const double& MinimumJointWidth,const unsigned int& GPoint);
     
@@ -182,7 +182,7 @@ protected:
 
     template< class TMatrixType >
     void CalculateShapeFunctionsGradients(TMatrixType& rGradNpT, SFGradAuxVariables& rAuxVariables,const Matrix& Jacobian, 
-                                            const boost::numeric::ublas::bounded_matrix<double,TDim,TDim>& RotationMatrix,
+                                            const BoundedMatrix<double,TDim,TDim>& RotationMatrix,
                                             const Matrix& DN_De,const Matrix& Ncontainer, const double& JointWidth,const unsigned int& GPoint);
                                             
                                     

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_link_interface_element.cpp
@@ -46,15 +46,15 @@ void UPwSmallStrainLinkInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationP
         array_1d<double,TNumNodes*TDim> VolumeAcceleration;
         ElementUtilities::GetVolumeAccelerationVector(VolumeAcceleration,Geom);
         array_1d<double,TDim> BodyAcceleration;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes, TDim> GradNpT; 
+        BoundedMatrix<double,TNumNodes, TDim> GradNpT; 
         double JointWidth;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
         const double& DynamicViscosityInverse = 1.0/Prop[DYNAMIC_VISCOSITY];
         const double& FluidDensity = Prop[DENSITY_WATER];
         array_1d<double,TDim> LocalFluidFlux;
@@ -73,7 +73,7 @@ void UPwSmallStrainLinkInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationP
             
             this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
 
-            this->template CalculateShapeFunctionsGradients< boost::numeric::ublas::bounded_matrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
+            this->template CalculateShapeFunctionsGradients< BoundedMatrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
                                                                                                                 DN_DeContainer[GPoint],NContainer,JointWidth,GPoint);
             
             ElementUtilities::InterpolateVariableWithComponents(BodyAcceleration,NContainer,VolumeAcceleration,GPoint);
@@ -98,9 +98,9 @@ void UPwSmallStrainLinkInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationP
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
         double JointWidth;
@@ -152,9 +152,9 @@ void UPwSmallStrainLinkInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationP
         const Matrix& NContainer = Geom.ShapeFunctionsValues( mThisIntegrationMethod );
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
                 
@@ -191,15 +191,15 @@ void UPwSmallStrainLinkInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationP
         array_1d<double,TNumNodes*TDim> VolumeAcceleration;
         ElementUtilities::GetVolumeAccelerationVector(VolumeAcceleration,Geom);
         array_1d<double,TDim> BodyAcceleration;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
-        boost::numeric::ublas::bounded_matrix<double,TNumNodes, TDim> GradNpT; 
+        BoundedMatrix<double,TNumNodes, TDim> GradNpT; 
         double JointWidth;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
         const double& DynamicViscosityInverse = 1.0/Prop[DYNAMIC_VISCOSITY];
         const double& FluidDensity = Prop[DENSITY_WATER];
         array_1d<double,TDim> LocalFluidFlux;
@@ -217,7 +217,7 @@ void UPwSmallStrainLinkInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationP
             
             this->CalculateJointWidth(JointWidth, LocalRelDispVector[TDim-1], MinimumJointWidth,GPoint);
 
-            this->template CalculateShapeFunctionsGradients< boost::numeric::ublas::bounded_matrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
+            this->template CalculateShapeFunctionsGradients< BoundedMatrix<double,TNumNodes,TDim> >(GradNpT,SFGradAuxVars,JContainer[GPoint],RotationMatrix,
                                                                                                                 DN_DeContainer[GPoint],NContainer,JointWidth,GPoint);
             
             ElementUtilities::InterpolateVariableWithComponents(BodyAcceleration,NContainer,VolumeAcceleration,GPoint);
@@ -255,15 +255,15 @@ void UPwSmallStrainLinkInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationP
         //Defining necessary variables
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
         double JointWidth;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> PermeabilityMatrix;
+        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+        BoundedMatrix<double,TDim, TDim> PermeabilityMatrix;
     
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )
@@ -278,7 +278,7 @@ void UPwSmallStrainLinkInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationP
 
             InterfaceElementUtilities::CalculateLinkPermeabilityMatrix(LocalPermeabilityMatrix,JointWidth);
             
-            noalias(PermeabilityMatrix) = prod(trans(RotationMatrix),boost::numeric::ublas::bounded_matrix<double,TDim, TDim>(prod(LocalPermeabilityMatrix,RotationMatrix)));
+            noalias(PermeabilityMatrix) = prod(trans(RotationMatrix),BoundedMatrix<double,TDim, TDim>(prod(LocalPermeabilityMatrix,RotationMatrix)));
             
             rOutput[GPoint].resize(TDim,TDim,false);
             noalias(rOutput[GPoint]) = PermeabilityMatrix;
@@ -295,14 +295,14 @@ void UPwSmallStrainLinkInterfaceElement<TDim,TNumNodes>::CalculateOnIntegrationP
         //Defining necessary variables
         array_1d<double,TNumNodes*TDim> DisplacementVector;
         ElementUtilities::GetDisplacementsVector(DisplacementVector,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> RotationMatrix;
+        BoundedMatrix<double,TDim, TDim> RotationMatrix;
         this->CalculateRotationMatrix(RotationMatrix,Geom);
-        boost::numeric::ublas::bounded_matrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
+        BoundedMatrix<double,TDim, TNumNodes*TDim> Nu = ZeroMatrix(TDim, TNumNodes*TDim);
         array_1d<double,TDim> LocalRelDispVector;
         array_1d<double,TDim> RelDispVector;
         const double& MinimumJointWidth = Prop[MINIMUM_JOINT_WIDTH];
         double JointWidth;
-        boost::numeric::ublas::bounded_matrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
+        BoundedMatrix<double,TDim, TDim> LocalPermeabilityMatrix = ZeroMatrix(TDim,TDim);
     
         //Loop over integration points
         for ( unsigned int GPoint = 0; GPoint < mConstitutiveLawVector.size(); GPoint++ )

--- a/applications/PoromechanicsApplication/custom_utilities/condition_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/condition_utilities.hpp
@@ -21,7 +21,7 @@ public:
         
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,2,4>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,2,4>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Line_2d_2
         rNu(0,0) = Ncontainer(GPoint,0); rNu(0,2) = Ncontainer(GPoint,1); 
@@ -30,7 +30,7 @@ public:
     
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,3,9>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,3,9>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Triangle_3d_3
         rNu(0,0) = Ncontainer(GPoint,0); rNu(0,3) = Ncontainer(GPoint,1); rNu(0,6) = Ncontainer(GPoint,2);
@@ -40,7 +40,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,3,12>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,3,12>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Quadrilateral_3d_4
         rNu(0,0) = Ncontainer(GPoint,0); rNu(0,3) = Ncontainer(GPoint,1); rNu(0,6) = Ncontainer(GPoint,2); rNu(0,9) = Ncontainer(GPoint,3);
@@ -246,7 +246,7 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------   
 
-	static inline void AssembleUPMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,4,2>& UPBlockMatrix)
+	static inline void AssembleUPMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,4,2>& UPBlockMatrix)
     {        
         //Line_2d_2
         unsigned int Global_i, Global_j, Local_i;
@@ -268,7 +268,7 @@ public:
     
 //----------------------------------------------------------------------------------------
  
-	static inline void AssembleUPMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,9,3>& UPBlockMatrix)
+	static inline void AssembleUPMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,9,3>& UPBlockMatrix)
     {
         //Triangle_3d_3  
         unsigned int Global_i, Global_j, Local_i;
@@ -291,7 +291,7 @@ public:
     
 //----------------------------------------------------------------------------------------
  
-	static inline void AssembleUPMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,12,4>& UPBlockMatrix)
+	static inline void AssembleUPMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,12,4>& UPBlockMatrix)
     {
         //Quadrilateral_3d_4
         unsigned int Global_i, Global_j, Local_i;
@@ -314,7 +314,7 @@ public:
     
 //----------------------------------------------------------------------------------------
 
-	static inline void AssemblePUMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,2,4>& PUBlockMatrix)
+	static inline void AssemblePUMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,2,4>& PUBlockMatrix)
     {        
         //Line_2d_2
         unsigned int Global_i, Global_j, Local_j;
@@ -336,7 +336,7 @@ public:
 
 //----------------------------------------------------------------------------------------
 
-	static inline void AssemblePUMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,3,9>& PUBlockMatrix)
+	static inline void AssemblePUMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,3,9>& PUBlockMatrix)
     {
         //Triangle_3d_3 
         unsigned int Global_i, Global_j, Local_j;
@@ -359,7 +359,7 @@ public:
     
 //----------------------------------------------------------------------------------------
 
-	static inline void AssemblePUMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,4,12>& PUBlockMatrix)
+	static inline void AssemblePUMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,4,12>& PUBlockMatrix)
     {
         //Quadrilateral_3d_4
         unsigned int Global_i, Global_j, Local_j;

--- a/applications/PoromechanicsApplication/custom_utilities/element_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/element_utilities.hpp
@@ -28,7 +28,7 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,2,6>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,2,6>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Triangle_2d_3
         rNu(0,0) = Ncontainer(GPoint,0); rNu(0,2) = Ncontainer(GPoint,1); rNu(0,4) = Ncontainer(GPoint,2);
@@ -37,7 +37,7 @@ public:
     
     //----------------------------------------------------------------------------------------
     
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,2,8>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,2,8>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Quadrilateral_2d_4
         rNu(0,0) = Ncontainer(GPoint,0); rNu(0,2) = Ncontainer(GPoint,1); rNu(0,4) = Ncontainer(GPoint,2); rNu(0,6) = Ncontainer(GPoint,3);
@@ -46,7 +46,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,3,12>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,3,12>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Tetrahedra_3d_4
         rNu(0,0) = Ncontainer(GPoint,0); rNu(0,3) = Ncontainer(GPoint,1); rNu(0,6) = Ncontainer(GPoint,2); rNu(0,9)  = Ncontainer(GPoint,3);
@@ -56,7 +56,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,3,18>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,3,18>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Prism_3d_6
         rNu(0,0) = Ncontainer(GPoint,0); rNu(0,3) = Ncontainer(GPoint,1); rNu(0,6) = Ncontainer(GPoint,2);
@@ -70,7 +70,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,3,24>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,3,24>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Hexahedron_3d_8
         rNu(0,0) = Ncontainer(GPoint,0); rNu(0,3) = Ncontainer(GPoint,1); rNu(0,6) = Ncontainer(GPoint,2); rNu(0,9)  = Ncontainer(GPoint,3);
@@ -84,7 +84,7 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    static inline void CalculateNuElementMatrix(boost::numeric::ublas::bounded_matrix<double,3,9>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuElementMatrix(BoundedMatrix<double,3,9>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Triangle_2d_3
         rNut(0,0) = Ncontainer(GPoint,0); rNut(0,3) = Ncontainer(GPoint,1); rNut(0,6) = Ncontainer(GPoint,2);
@@ -93,7 +93,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuElementMatrix(boost::numeric::ublas::bounded_matrix<double,3,12>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuElementMatrix(BoundedMatrix<double,3,12>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Quadrilateral_2d_4
         rNut(0,0) = Ncontainer(GPoint,0); rNut(0,3) = Ncontainer(GPoint,1); rNut(0,6) = Ncontainer(GPoint,2); rNut(0,9) = Ncontainer(GPoint,3);
@@ -102,7 +102,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuElementMatrix(boost::numeric::ublas::bounded_matrix<double,4,16>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuElementMatrix(BoundedMatrix<double,4,16>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Tetrahedra_3d_4
         rNut(0,0) = Ncontainer(GPoint,0); rNut(0,4) = Ncontainer(GPoint,1); rNut(0,8)  = Ncontainer(GPoint,2); rNut(0,12) = Ncontainer(GPoint,3);
@@ -112,7 +112,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuElementMatrix(boost::numeric::ublas::bounded_matrix<double,4,24>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuElementMatrix(BoundedMatrix<double,4,24>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Prism_3d_6
         rNut(0,0) = Ncontainer(GPoint,0); rNut(0,4) = Ncontainer(GPoint,1); rNut(0,8) = Ncontainer(GPoint,2);
@@ -126,7 +126,7 @@ public:
     
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuElementMatrix(boost::numeric::ublas::bounded_matrix<double,4,32>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuElementMatrix(BoundedMatrix<double,4,32>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Hexahedron_3d_8
         rNut(0,0) = Ncontainer(GPoint,0); rNut(0,4) = Ncontainer(GPoint,1); rNut(0,8) = Ncontainer(GPoint,2); rNut(0,12) = Ncontainer(GPoint,3);
@@ -475,7 +475,7 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    static inline void CalculatePermeabilityMatrix(boost::numeric::ublas::bounded_matrix<double,2,2>& rPermeabilityMatrix,
+    static inline void CalculatePermeabilityMatrix(BoundedMatrix<double,2,2>& rPermeabilityMatrix,
                                                     const Element::PropertiesType& Prop)
     {
         //2D
@@ -488,7 +488,7 @@ public:
 
     //----------------------------------------------------------------------------------------
     
-    static inline void CalculatePermeabilityMatrix(boost::numeric::ublas::bounded_matrix<double,3,3>& rPermeabilityMatrix,
+    static inline void CalculatePermeabilityMatrix(BoundedMatrix<double,3,3>& rPermeabilityMatrix,
                                                     const Element::PropertiesType& Prop)
     {
         //3D
@@ -509,8 +509,8 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    static inline void InvertMatrix2(boost::numeric::ublas::bounded_matrix<double,2,2>& rInvertedMatrix,
-                                    const boost::numeric::ublas::bounded_matrix<double,2,2>& InputMatrix)
+    static inline void InvertMatrix2(BoundedMatrix<double,2,2>& rInvertedMatrix,
+                                    const BoundedMatrix<double,2,2>& InputMatrix)
     {
         double InputMatrixDet = InputMatrix(0,0)*InputMatrix(1,1)-InputMatrix(0,1)*InputMatrix(1,0);
         
@@ -550,7 +550,7 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    static inline void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,6,6>& UBlockMatrix)
+    static inline void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,6,6>& UBlockMatrix)
     {        
         //Triangle_2d_3
         unsigned int Global_i, Global_j, Local_i, Local_j;
@@ -575,7 +575,7 @@ public:
     
     //----------------------------------------------------------------------------------------
 
-    static inline void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,8,8>& UBlockMatrix)
+    static inline void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,8,8>& UBlockMatrix)
     {        
         //Quadrilateral_2d_4
         unsigned int Global_i, Global_j, Local_i, Local_j;
@@ -600,7 +600,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,12,12>& UBlockMatrix)
+    static inline void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,12,12>& UBlockMatrix)
     {
         //Tetrahedra_3d_4
         unsigned int Global_i, Global_j, Local_i, Local_j;
@@ -631,7 +631,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,18,18>& UBlockMatrix)
+    static inline void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,18,18>& UBlockMatrix)
     {        
         //Prism_3d_6
         unsigned int Global_i, Global_j, Local_i, Local_j;
@@ -662,7 +662,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,24,24>& UBlockMatrix)
+    static inline void AssembleUBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,24,24>& UBlockMatrix)
     {
         //Hexahedra_3d_8
         unsigned int Global_i, Global_j, Local_i, Local_j;
@@ -693,7 +693,7 @@ public:
 
     //----------------------------------------------------------------------------------------
     
-    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,6,3>& UPBlockMatrix)
+    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,6,3>& UPBlockMatrix)
     {
         //Triangle_2d_3
         unsigned int Global_i, Global_j, Local_i;
@@ -715,7 +715,7 @@ public:
 
     //----------------------------------------------------------------------------------------
     
-    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,8,4>& UPBlockMatrix)
+    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,8,4>& UPBlockMatrix)
     {        
         //Quadrilateral_2d_4
         unsigned int Global_i, Global_j, Local_i;
@@ -737,7 +737,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,12,4>& UPBlockMatrix)
+    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,12,4>& UPBlockMatrix)
     {
         //Tetrahedra_3d_4
         unsigned int Global_i, Global_j, Local_i;
@@ -760,7 +760,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,18,6>& UPBlockMatrix)
+    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,18,6>& UPBlockMatrix)
     {
         //Prism_3d_6
         unsigned int Global_i, Global_j, Local_i;
@@ -783,7 +783,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,24,8>& UPBlockMatrix)
+    static inline void AssembleUPBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,24,8>& UPBlockMatrix)
     {        
         //Hexahedra_3d_8
         unsigned int Global_i, Global_j, Local_i;
@@ -806,7 +806,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,3,6>& PUBlockMatrix)
+    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,3,6>& PUBlockMatrix)
     {        
         //Triangle_2d_3
         unsigned int Global_i, Global_j, Local_j;
@@ -828,7 +828,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,4,8>& PUBlockMatrix)
+    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,4,8>& PUBlockMatrix)
     {        
         //Quadrilateral_2d_4
         unsigned int Global_i, Global_j, Local_j;
@@ -850,7 +850,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,4,12>& PUBlockMatrix)
+    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,4,12>& PUBlockMatrix)
     {
         //Tetrahedra_3d_4
         unsigned int Global_i, Global_j, Local_j;
@@ -873,7 +873,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,6,18>& PUBlockMatrix)
+    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,6,18>& PUBlockMatrix)
     {
         //Prism_3d_6
         unsigned int Global_i, Global_j, Local_j;
@@ -896,7 +896,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix, const boost::numeric::ublas::bounded_matrix<double,8,24>& PUBlockMatrix)
+    static inline void AssemblePUBlockMatrix(Matrix& rLeftHandSideMatrix, const BoundedMatrix<double,8,24>& PUBlockMatrix)
     {        
         //Hexahedra_3d_8
         unsigned int Global_i, Global_j, Local_j;
@@ -1047,7 +1047,7 @@ public:
     /// Rows: nodes
     /// Columns: GP
             
-    static inline void CalculateExtrapolationMatrix(boost::numeric::ublas::bounded_matrix<double,4,4>& rExtrapolationMatrix)
+    static inline void CalculateExtrapolationMatrix(BoundedMatrix<double,4,4>& rExtrapolationMatrix)
     {
         //Quadrilateral_2d_4
         //GI_GAUSS_2
@@ -1060,7 +1060,7 @@ public:
     
     //----------------------------------------------------------------------------------------    
     
-    static inline void CalculateExtrapolationMatrix(boost::numeric::ublas::bounded_matrix<double,8,8>& rExtrapolationMatrix)
+    static inline void CalculateExtrapolationMatrix(BoundedMatrix<double,8,8>& rExtrapolationMatrix)
     {
         //Hexahedra_3d_8
         //GI_GAUSS_2

--- a/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_2D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_2D_utilities.hpp
@@ -85,7 +85,7 @@ protected:
 
     struct PropagationLocalVariables
     {
-        boost::numeric::ublas::bounded_matrix<double,2,2> RotationMatrix;
+        BoundedMatrix<double,2,2> RotationMatrix;
         array_1d<double,2> TipCoordinates;
         array_1d<double,2> TipLocalCoordinates;
         std::vector<FracturePoint*> TopFrontFracturePoints;
@@ -1495,7 +1495,7 @@ private:
 
     void CalculateTipRotationMatrix(
         const unsigned int& itFracture,
-        boost::numeric::ublas::bounded_matrix<double,2,2>& rRotationMatrix,
+        BoundedMatrix<double,2,2>& rRotationMatrix,
         Parameters& rParameters)
     {
         array_1d<double,3> TipPointCoordinates;

--- a/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_3D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/fracture_propagation_3D_utilities.hpp
@@ -101,7 +101,7 @@ protected:
 
     struct PropagationLocalVariables
     {
-        boost::numeric::ublas::bounded_matrix<double,3,3> RotationMatrix;
+        BoundedMatrix<double,3,3> RotationMatrix;
         array_1d<double,3> TipCoordinates;
         array_1d<double,3> TipLocalCoordinates;
         std::vector<FracturePoint*> TopFrontFracturePoints;
@@ -1888,7 +1888,7 @@ private:
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void CalculateTipRotationMatrix(
-        boost::numeric::ublas::bounded_matrix<double,3,3>& rRotationMatrix,
+        BoundedMatrix<double,3,3>& rRotationMatrix,
         const array_1d<double,3>& TipPointCoordinates,
         const array_1d<double,3>& LeftPointCoordinates,
         const array_1d<double,3>& RightPointCoordinates)

--- a/applications/PoromechanicsApplication/custom_utilities/interface_element_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/interface_element_utilities.hpp
@@ -21,7 +21,7 @@ public:
         
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
     
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,2,4>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,2,4>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Line_interface_2d_2
         rNu(0,0) = -Ncontainer(GPoint,0); rNu(0,2) = Ncontainer(GPoint,1); 
@@ -30,7 +30,7 @@ public:
     
     //----------------------------------------------------------------------------------------
     
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,2,8>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,2,8>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Quadrilateral_interface_2d_4
         rNu(0,0) = -Ncontainer(GPoint,0); rNu(0,2) = -Ncontainer(GPoint,1); 
@@ -42,7 +42,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,3,12>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,3,12>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Quadrilateral_interface_3d_4
         rNu(0,0) = -Ncontainer(GPoint,0); rNu(0,3) = -Ncontainer(GPoint,1); 
@@ -56,7 +56,7 @@ public:
     
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,3,18>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,3,18>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Prism_interface_3d_6
         rNu(0,0) = -Ncontainer(GPoint,0); rNu(0,3) = -Ncontainer(GPoint,1); rNu(0,6) = -Ncontainer(GPoint,2); 
@@ -70,7 +70,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuMatrix(boost::numeric::ublas::bounded_matrix<double,3,24>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuMatrix(BoundedMatrix<double,3,24>& rNu, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Hexahedral_interface_3d_8
         rNu(0,0) = -Ncontainer(GPoint,0); rNu(0,3) = -Ncontainer(GPoint,1); rNu(0,6) = -Ncontainer(GPoint,2); rNu(0,9)  = -Ncontainer(GPoint,3);
@@ -84,7 +84,7 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    static inline void CalculateNuElementMatrix(boost::numeric::ublas::bounded_matrix<double,3,12>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuElementMatrix(BoundedMatrix<double,3,12>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Quadrilateral_interface_2d_4
         rNut(0,0) = -Ncontainer(GPoint,0); rNut(0,3) = -Ncontainer(GPoint,1); 
@@ -96,7 +96,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuElementMatrix(boost::numeric::ublas::bounded_matrix<double,4,24>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuElementMatrix(BoundedMatrix<double,4,24>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Prism_interface_3d_6
         rNut(0,0) = -Ncontainer(GPoint,0); rNut(0,4) = -Ncontainer(GPoint,1); rNut(0,8)  = -Ncontainer(GPoint,2); 
@@ -110,7 +110,7 @@ public:
 
     //----------------------------------------------------------------------------------------
 
-    static inline void CalculateNuElementMatrix(boost::numeric::ublas::bounded_matrix<double,4,32>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
+    static inline void CalculateNuElementMatrix(BoundedMatrix<double,4,32>& rNut, const Matrix& Ncontainer, const unsigned int& GPoint)
     {
         //Hexahedral_interface_3d_8
         rNut(0,0) = -Ncontainer(GPoint,0); rNut(0,4) = -Ncontainer(GPoint,1); rNut(0,8)  = -Ncontainer(GPoint,2); rNut(0,12) = -Ncontainer(GPoint,3);
@@ -124,7 +124,7 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    static inline void CalculatePermeabilityMatrix(boost::numeric::ublas::bounded_matrix<double,2,2>& rPermeabilityMatrix,
+    static inline void CalculatePermeabilityMatrix(BoundedMatrix<double,2,2>& rPermeabilityMatrix,
                                                     const double& JointWidth, const double& Transversal_Permeability)
     {
         //Quadrilateral_interface_2d_4
@@ -134,7 +134,7 @@ public:
     
     //----------------------------------------------------------------------------------------
     
-    static inline void CalculatePermeabilityMatrix(boost::numeric::ublas::bounded_matrix<double,3,3>& rPermeabilityMatrix,
+    static inline void CalculatePermeabilityMatrix(BoundedMatrix<double,3,3>& rPermeabilityMatrix,
                                                     const double& JointWidth, const double& Transversal_Permeability)
     {
         //Prism_interface_3d_6 & Hexahedral_interface_3d_8
@@ -164,7 +164,7 @@ public:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    static inline void CalculateLinkPermeabilityMatrix(boost::numeric::ublas::bounded_matrix<double,2,2>& rPermeabilityMatrix,
+    static inline void CalculateLinkPermeabilityMatrix(BoundedMatrix<double,2,2>& rPermeabilityMatrix,
                                                     const double& JointWidth)
     {
         //Quadrilateral_interface_2d_4
@@ -174,7 +174,7 @@ public:
     
     //----------------------------------------------------------------------------------------
     
-    static inline void CalculateLinkPermeabilityMatrix(boost::numeric::ublas::bounded_matrix<double,3,3>& rPermeabilityMatrix,
+    static inline void CalculateLinkPermeabilityMatrix(BoundedMatrix<double,3,3>& rPermeabilityMatrix,
                                                     const double& JointWidth)
     {
         //Prism_interface_3d_6 & Hexahedral_interface_3d_8


### PR DESCRIPTION
I essentially replaced boost::numeric::ublas::bounded_matrix by BoundedMatrix to start the migration from ublas to AMatrix