### PR TITLE
Fluid/hotfix clang warnings

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/d_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/d_vms.h
@@ -291,6 +291,25 @@ protected:
 
     void CalculateProjections(const ProcessInfo &rCurrentProcessInfo) override;
 
+    void CalculateStabilizationParameters(
+        const TElementData& rData,
+        const array_1d<double,3> &Velocity,
+        double &TauOne,
+        double &TauTwo,
+        double &TauP) const;
+
+    void SubscaleVelocity(
+        const TElementData& rData,
+        array_1d<double,3>& rVelocitySubscale) const override;
+
+    void SubscalePressure(
+        const TElementData& rData,
+        double &rPressureSubscale) const override;
+
+    array_1d<double,3> FullConvectiveVelocity(
+        const TElementData& rData) const;
+
+
     ///@}
     ///@name Protected  Access
     ///@{
@@ -350,26 +369,8 @@ private:
     ///@name Private Operations
     ///@{
 
-    void CalculateTau(
-        const TElementData& rData,
-        const array_1d<double,3> &Velocity,
-        double &TauOne,
-        double &TauTwo,
-        double &TauP) const;
-
-    void SubscaleVelocity(
-        const TElementData& rData,
-        array_1d<double,Dim>& rVelocitySubscale);
-
-    void SubscalePressure(
-        const TElementData& rData,
-        double &rPressureSubscale);
-
     void UpdateSubscaleVelocityPrediction(
         const TElementData& rData);
-
-    array_1d<double,3> FullConvectiveVelocity(
-        const TElementData& rData) const;
 
     ///@}
     ///@name Private  Access

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -135,7 +135,6 @@ void DistanceModificationProcess::ExecuteFinalizeSolutionStep() {
 void DistanceModificationProcess::ModifyDistance() {
 
     ModelPart::NodesContainerType& r_nodes = mrModelPart.Nodes();
-    //ModelPart::ElementsContainerType& rElements = mrModelPart.Elements();
 
     // Distance modification
     // Case in where the original distance does not need to be preserved (e.g. CFD)

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -51,7 +51,7 @@ DistanceModificationProcess::DistanceModificationProcess(
     Parameters default_parameters( R"(
     {
         "model_part_name"                        : "default_model_part_name",
-        "distance_factor"                        : 2.0, 
+        "distance_factor"                        : 2.0,
         "distance_threshold"                     : 0.001,
         "continuous_distance"                    : true,
         "check_at_each_time_step"                : false,
@@ -75,7 +75,7 @@ void DistanceModificationProcess::ExecuteInitialize() {
 
     KRATOS_TRY;
 
-    // Continuous distance field required variables check 
+    // Continuous distance field required variables check
     if (mContinuousDistance){
         const auto& r_node = *mrModelPart.NodesBegin();
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(NODAL_H, r_node);
@@ -135,7 +135,7 @@ void DistanceModificationProcess::ExecuteFinalizeSolutionStep() {
 void DistanceModificationProcess::ModifyDistance() {
 
     ModelPart::NodesContainerType& r_nodes = mrModelPart.Nodes();
-    ModelPart::ElementsContainerType& rElements = mrModelPart.Elements();
+    //ModelPart::ElementsContainerType& rElements = mrModelPart.Elements();
 
     // Distance modification
     // Case in where the original distance does not need to be preserved (e.g. CFD)
@@ -166,7 +166,7 @@ void DistanceModificationProcess::ModifyDistance() {
     // Case in where the original distance needs to be kept to track the interface (e.g. FSI)
     else {
 
-        const unsigned int num_chunks = 2 * OpenMPUtils::GetNumThreads();
+        const int num_chunks = 2 * OpenMPUtils::GetNumThreads();
         OpenMPUtils::PartitionVector partition_vec;
         OpenMPUtils::DivideInPartitions(r_nodes.size(),num_chunks,partition_vec);
 

--- a/applications/FluidDynamicsApplication/tests/artificial_compressibility_test.py
+++ b/applications/FluidDynamicsApplication/tests/artificial_compressibility_test.py
@@ -1,6 +1,11 @@
 import KratosMultiphysics
-import KratosMultiphysics.ExternalSolversApplication
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+try:
+    import KratosMultiphysics.ExternalSolversApplication
+    have_external_solvers = True
+except ImportError as e:
+    have_external_solvers = False
+
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 
@@ -17,6 +22,7 @@ class WorkFolderScope:
     def __exit__(self, type, value, traceback):
         os.chdir(self.currentPath)
 
+@UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
 class ArtificialCompressibilityTest(UnitTest.TestCase):
     def testArtificialCompressibility(self):
         self.setUp()
@@ -29,7 +35,7 @@ class ArtificialCompressibilityTest(UnitTest.TestCase):
         self.check_tolerance = 1e-6
         self.print_output = False
         self.print_reference_values = False
-        self.work_folder = "ArtificialCompressibilityTest"   
+        self.work_folder = "ArtificialCompressibilityTest"
         self.reference_file = "reference_cavity_compressibility"
         self.settings = "ArtificialCompressibilityTestParameters.json"
 
@@ -174,4 +180,4 @@ if __name__ == '__main__':
     test.runTest()
     test.tearDown()
     test.checkResults()
-    
+

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
@@ -1,6 +1,11 @@
 import KratosMultiphysics
-import KratosMultiphysics.ExternalSolversApplication
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+try:
+    import KratosMultiphysics.ExternalSolversApplication
+    have_external_solvers = True
+except ImportError as e:
+    have_external_solvers = False
+
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 
@@ -17,13 +22,14 @@ class WorkFolderScope:
     def __exit__(self, type, value, traceback):
         os.chdir(self.currentPath)
 
+@UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
 class EmbeddedCouetteImposedTest(UnitTest.TestCase):
 
     # Embedded element tests
     def testEmbeddedCouetteImposed2D(self):
         self.distance = 1.65
         self.embedded_velocity = 2.56
-        self.work_folder = "EmbeddedCouetteImposed2DTest"   
+        self.work_folder = "EmbeddedCouetteImposed2DTest"
         self.reference_file = "reference_couette_imposed_2D"
         self.settings = "EmbeddedCouetteImposed2DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -31,7 +37,7 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
     def testEmbeddedCouetteImposed3D(self):
         self.distance = 1.65
         self.embedded_velocity = 2.56
-        self.work_folder = "EmbeddedCouetteImposed3DTest"   
+        self.work_folder = "EmbeddedCouetteImposed3DTest"
         self.reference_file = "reference_couette_imposed_3D"
         self.settings = "EmbeddedCouetteImposed3DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -106,11 +112,11 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
     def setUpDistanceField(self):
         # Set the distance function
         domain_size = self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE]
-        if (domain_size == 2): 
+        if (domain_size == 2):
             for node in self.main_model_part.Nodes:
                 distance = self.distance - node.Y
                 node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, 0, distance)
-        elif (domain_size == 3): 
+        elif (domain_size == 3):
             for node in self.main_model_part.Nodes:
                 distance = self.distance - node.Z
                 node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, 0, distance)
@@ -132,7 +138,7 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
     def setUpNoSlipBoundaryConditions(self):
         # Set the inlet function
         domain_size = self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE]
-        if (domain_size == 2): 
+        if (domain_size == 2):
             for node in self.main_model_part.GetSubModelPart("Inlet").Nodes:
                 dist = node.GetSolutionStepValue(KratosMultiphysics.DISTANCE)
                 if (dist > 0.0):
@@ -145,7 +151,7 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
                 node.Fix(KratosMultiphysics.VELOCITY_X)
                 node.Fix(KratosMultiphysics.VELOCITY_Y)
                 node.Fix(KratosMultiphysics.VELOCITY_Z)
-        else: 
+        else:
             for node in self.main_model_part.GetSubModelPart("Inlet").Nodes:
                 dist = node.GetSolutionStepValue(KratosMultiphysics.DISTANCE)
                 if (dist > 0.0):
@@ -161,7 +167,7 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
 
     def setUpNoSlipInitialCondition(self):
         domain_size = self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE]
-        if (domain_size == 2): 
+        if (domain_size == 2):
             for node in self.main_model_part.Nodes:
                 dist = node.GetSolutionStepValue(KratosMultiphysics.DISTANCE)
                 if (dist > 0.0):
@@ -210,7 +216,7 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
                 for process in self.list_of_processes:
                     process.ExecuteInitializeSolutionStep()
 
-                
+
                 self.solver.Solve()
 
                 for process in self.list_of_processes:
@@ -236,7 +242,7 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
     def checkResults(self):
         with WorkFolderScope(self.work_folder):
             ## 2D results check
-            if (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 2): 
+            if (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 2):
                 if self.print_reference_values:
                     with open(self.reference_file+'.csv','w') as ref_file:
                         ref_file.write("#ID, VELOCITY_X, VELOCITY_Y\n")
@@ -262,7 +268,7 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
                         if line != '': # If we did not reach the end of the reference file
                             self.fail("The number of nodes in the mdpa is smaller than the number of nodes in the output file")
             ## 3D results check
-            elif (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 3): 
+            elif (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 3):
                 if self.print_reference_values:
                     with open(self.reference_file+'.csv','w') as ref_file:
                         ref_file.write("#ID, VELOCITY_X, VELOCITY_Y, VELOCITY_Z\n")
@@ -298,7 +304,7 @@ if __name__ == '__main__':
     test.print_output = False
     test.print_reference_values = False
     test.work_folder = "EmbeddedCouetteImposed2DTest"
-    test.reference_file = "reference_couette_imposed_2D"   
+    test.reference_file = "reference_couette_imposed_2D"
     test.settings = "EmbeddedCouetteImposed2DTestParameters.json"
     test.setUpProblem()
     test.setUpDistanceField()
@@ -307,4 +313,4 @@ if __name__ == '__main__':
     test.runTest()
     test.tearDown()
     test.checkResults()
-    
+

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
@@ -1,6 +1,11 @@
 import KratosMultiphysics
-import KratosMultiphysics.ExternalSolversApplication
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+try:
+    import KratosMultiphysics.ExternalSolversApplication
+    have_external_solvers = True
+except ImportError as e:
+    have_external_solvers = False
+
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 
@@ -17,13 +22,14 @@ class WorkFolderScope:
     def __exit__(self, type, value, traceback):
         os.chdir(self.currentPath)
 
+@UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
 class EmbeddedCouetteTest(UnitTest.TestCase):
 
     # Embedded element tests
     def testEmbeddedCouette2D(self):
         self.distance = 0.25
         self.slip_flag = False
-        self.work_folder = "EmbeddedCouette2DTest"   
+        self.work_folder = "EmbeddedCouette2DTest"
         self.reference_file = "reference_couette_embedded_2D"
         self.settings = "EmbeddedCouette2DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -31,7 +37,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
     def testEmbeddedCouette3D(self):
         self.distance = 0.25
         self.slip_flag = False
-        self.work_folder = "EmbeddedCouette3DTest"   
+        self.work_folder = "EmbeddedCouette3DTest"
         self.reference_file = "reference_couette_embedded_3D"
         self.settings = "EmbeddedCouette3DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -39,7 +45,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
     def testEmbeddedSlipCouette2D(self):
         self.distance = 0.25
         self.slip_flag = True
-        self.work_folder = "EmbeddedCouette2DTest"   
+        self.work_folder = "EmbeddedCouette2DTest"
         self.reference_file = "reference_couette_embedded_slip_2D"
         self.settings = "EmbeddedCouette2DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -47,7 +53,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
     def testEmbeddedSlipCouette3D(self):
         self.distance = 0.25
         self.slip_flag = True
-        self.work_folder = "EmbeddedCouette3DTest"   
+        self.work_folder = "EmbeddedCouette3DTest"
         self.reference_file = "reference_couette_embedded_slip_3D"
         self.settings = "EmbeddedCouette3DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -56,7 +62,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
     def testEmbeddedAusasCouette2D(self):
         self.distance = 0.25
         self.slip_flag = True
-        self.work_folder = "EmbeddedCouette2DTest"   
+        self.work_folder = "EmbeddedCouette2DTest"
         self.reference_file = "reference_couette_ausas_2D"
         self.settings = "EmbeddedAusasCouette2DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -64,7 +70,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
     def testEmbeddedAusasCouette3D(self):
         self.distance = 0.25
         self.slip_flag = True
-        self.work_folder = "EmbeddedCouette3DTest"   
+        self.work_folder = "EmbeddedCouette3DTest"
         self.reference_file = "reference_couette_ausas_3D"
         self.settings = "EmbeddedAusasCouette3DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -73,7 +79,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
     def testEmbeddedDevelopmentCouette2D(self):
         self.distance = 0.25
         self.slip_flag = False
-        self.work_folder = "EmbeddedCouette2DTest"   
+        self.work_folder = "EmbeddedCouette2DTest"
         self.reference_file = "reference_couette_development_2D"
         self.settings = "EmbeddedDevelopmentCouette2DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -81,7 +87,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
     def testEmbeddedSlipDevelopmentCouette2D(self):
         self.distance = 0.25
         self.slip_flag = True
-        self.work_folder = "EmbeddedCouette2DTest"   
+        self.work_folder = "EmbeddedCouette2DTest"
         self.reference_file = "reference_couette_development_slip_2D"
         self.settings = "EmbeddedDevelopmentCouette2DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -89,15 +95,15 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
     def testEmbeddedDevelopmentCouette3D(self):
         self.distance = 0.25
         self.slip_flag = False
-        self.work_folder = "EmbeddedCouette3DTest"   
+        self.work_folder = "EmbeddedCouette3DTest"
         self.reference_file = "reference_couette_development_3D"
-        self.settings = "EmbeddedDevelopmentCouette3DTestParameters.json"  
+        self.settings = "EmbeddedDevelopmentCouette3DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
 
     def testEmbeddedSlipDevelopmentCouette3D(self):
         self.distance = 0.25
         self.slip_flag = True
-        self.work_folder = "EmbeddedCouette3DTest"   
+        self.work_folder = "EmbeddedCouette3DTest"
         self.reference_file = "reference_couette_development_slip_3D"
         self.settings = "EmbeddedDevelopmentCouette3DTestParameters.json"
         self.ExecuteEmbeddedCouetteTest()
@@ -175,11 +181,11 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
 
     def setUpDistanceField(self):
         # Set the distance function
-        if (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 2): 
+        if (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 2):
             for node in self.main_model_part.Nodes:
                 distance = node.Y-self.distance
                 node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, 0, distance)
-        elif (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 3): 
+        elif (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 3):
             for node in self.main_model_part.Nodes:
                 distance = node.Z-self.distance
                 node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, 0, distance)
@@ -205,7 +211,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
             node.Fix(KratosMultiphysics.VELOCITY_X)
             node.Fix(KratosMultiphysics.VELOCITY_Y)
             node.Fix(KratosMultiphysics.VELOCITY_Z)
-        
+
         # Set the SLIP elemental flag (only used in Winter's formulation)
         if (self.slip_flag):
             for element in self.main_model_part.Elements:
@@ -280,7 +286,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
                 for process in self.list_of_processes:
                     process.ExecuteInitializeSolutionStep()
 
-                
+
                 self.solver.Solve()
 
                 for process in self.list_of_processes:
@@ -306,7 +312,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
     def checkResults(self):
         with WorkFolderScope(self.work_folder):
             ## 2D results check
-            if (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 2): 
+            if (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 2):
                 if self.print_reference_values:
                     with open(self.reference_file+'.csv','w') as ref_file:
                         ref_file.write("#ID, VELOCITY_X, VELOCITY_Y\n")
@@ -332,7 +338,7 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
                         if line != '': # If we did not reach the end of the reference file
                             self.fail("The number of nodes in the mdpa is smaller than the number of nodes in the output file")
             ## 3D results check
-            elif (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 3): 
+            elif (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 3):
                 if self.print_reference_values:
                     with open(self.reference_file+'.csv','w') as ref_file:
                         ref_file.write("#ID, VELOCITY_X, VELOCITY_Y, VELOCITY_Z\n")
@@ -368,7 +374,7 @@ if __name__ == '__main__':
     test.print_output = False
     test.print_reference_values = False
     test.work_folder = "EmbeddedCouette2DTest"
-    test.reference_file = "reference_couette_embedded_2D"   
+    test.reference_file = "reference_couette_embedded_2D"
     test.settings = "EmbeddedCouette2DTestParameters.json"
     test.setUpProblem()
     test.setUpDistanceField()
@@ -381,4 +387,4 @@ if __name__ == '__main__':
     test.runTest()
     test.tearDown()
     test.checkResults()
-    
+

--- a/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
@@ -1,6 +1,11 @@
 import KratosMultiphysics
-import KratosMultiphysics.ExternalSolversApplication
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+try:
+    import KratosMultiphysics.ExternalSolversApplication
+    have_external_solvers = True
+except ImportError as e:
+    have_external_solvers = False
+
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 
@@ -17,11 +22,12 @@ class WorkFolderScope:
     def __exit__(self, type, value, traceback):
         os.chdir(self.currentPath)
 
+@UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
 class EmbeddedReservoirTest(UnitTest.TestCase):
     def testEmbeddedReservoir2D(self):
         self.distance = 0.5
         self.slip_level_set = False
-        self.work_folder = "EmbeddedReservoirTest"   
+        self.work_folder = "EmbeddedReservoirTest"
         self.reference_file = "reference_reservoir_2D"
         self.settings = "EmbeddedReservoir2DTest_parameters.json"
         self.ExecuteEmbeddedReservoirTest()
@@ -29,7 +35,7 @@ class EmbeddedReservoirTest(UnitTest.TestCase):
     def testEmbeddedReservoir3D(self):
         self.distance = 0.5
         self.slip_level_set = False
-        self.work_folder = "EmbeddedReservoirTest"   
+        self.work_folder = "EmbeddedReservoirTest"
         self.reference_file = "reference_reservoir_3D"
         self.settings = "EmbeddedReservoir3DTest_parameters.json"
         self.ExecuteEmbeddedReservoirTest()
@@ -37,7 +43,7 @@ class EmbeddedReservoirTest(UnitTest.TestCase):
     def testEmbeddedSlipReservoir2D(self):
         self.distance = 0.5
         self.slip_level_set = True
-        self.work_folder = "EmbeddedReservoirTest"   
+        self.work_folder = "EmbeddedReservoirTest"
         self.reference_file = "reference_slip_reservoir_2D"
         self.settings = "EmbeddedReservoir2DTest_parameters.json"
         self.ExecuteEmbeddedReservoirTest()
@@ -45,7 +51,7 @@ class EmbeddedReservoirTest(UnitTest.TestCase):
     def testEmbeddedSlipReservoir3D(self):
         self.distance = 0.5
         self.slip_level_set = True
-        self.work_folder = "EmbeddedReservoirTest"   
+        self.work_folder = "EmbeddedReservoirTest"
         self.reference_file = "reference_slip_reservoir_3D"
         self.settings = "EmbeddedReservoir3DTest_parameters.json"
         self.ExecuteEmbeddedReservoirTest()
@@ -117,11 +123,11 @@ class EmbeddedReservoirTest(UnitTest.TestCase):
 
     def setUpDistanceField(self):
         # Set the distance function
-        if (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 2): 
+        if (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 2):
             for node in self.main_model_part.Nodes:
                 distance = node.Y-self.distance
                 node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, 0, distance)
-        elif (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 3): 
+        elif (self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] == 3):
             for node in self.main_model_part.Nodes:
                 distance = node.Z-self.distance
                 node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, 0, distance)
@@ -229,11 +235,11 @@ if __name__ == '__main__':
     test.print_output = False
     test.print_reference_values = False
     test.work_folder = "EmbeddedReservoirTest"
-    test.reference_file = "reference_slip_reservoir_2D"   
+    test.reference_file = "reference_slip_reservoir_2D"
     test.settings = "EmbeddedReservoir2DTest_parameters.json"
     test.setUpProblem()
     test.setUpDistanceField()
     test.runTest()
     test.tearDown()
     test.checkResults()
-    
+

--- a/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
+++ b/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
@@ -1,6 +1,11 @@
 import KratosMultiphysics
-import KratosMultiphysics.ExternalSolversApplication
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+try:
+    import KratosMultiphysics.ExternalSolversApplication
+    have_external_solvers = True
+except ImportError as e:
+    have_external_solvers = False
+
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 
@@ -17,6 +22,7 @@ class WorkFolderScope:
     def __exit__(self, type, value, traceback):
         os.chdir(self.currentPath)
 
+@UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
 class NavierStokesWallConditionTest(UnitTest.TestCase):
     def testNavierStokesWallCondition(self):
         self.setUp()
@@ -29,7 +35,7 @@ class NavierStokesWallConditionTest(UnitTest.TestCase):
         self.ext_pres_res = 1000.0
         self.check_tolerance = 2e-2
         self.print_output = False
-        self.work_folder = "NavierStokesWallConditionTest"   
+        self.work_folder = "NavierStokesWallConditionTest"
         self.settings = "NavierStokesWallConditionTestParameters.json"
 
     def tearDown(self):
@@ -154,4 +160,4 @@ if __name__ == '__main__':
     test.runTest()
     test.tearDown()
     test.checkResults()
-    
+

--- a/applications/StabilizedCFDApplication/custom_elements/dss.cpp
+++ b/applications/StabilizedCFDApplication/custom_elements/dss.cpp
@@ -750,7 +750,7 @@ void DSS<TDim>::GetValueOnIntegrationPoints(const Variable<double>& rVariable,
 		const unsigned int NumGauss = GaussWeights.size();
 
 		rValues.resize(NumGauss);
-		
+
   		// Loop on integration points
 		for (unsigned int g = 0; g < NumGauss; g++)
 		{
@@ -1826,17 +1826,17 @@ void DSS<TDim>::ModulatedGradientDiffusion(MatrixType &rDampMatrix, const ShapeF
 
     // Element lengths
     array_1d<double,3> Delta(3,0.0);
-    Delta[0] = abs(rGeom[NumNodes-1].X()-rGeom[0].X());
-    Delta[1] = abs(rGeom[NumNodes-1].Y()-rGeom[0].Y());
-    Delta[2] = abs(rGeom[NumNodes-1].Z()-rGeom[0].Z());
+    Delta[0] = fabs(rGeom[NumNodes-1].X()-rGeom[0].X());
+    Delta[1] = fabs(rGeom[NumNodes-1].Y()-rGeom[0].Y());
+    Delta[2] = fabs(rGeom[NumNodes-1].Z()-rGeom[0].Z());
 
     for (unsigned int n = 1; n < NumNodes; n++)
     {
-        double hx = abs(rGeom[n].X()-rGeom[n-1].X());
+        double hx = fabs(rGeom[n].X()-rGeom[n-1].X());
         if (hx > Delta[0]) Delta[0] = hx;
-        double hy = abs(rGeom[n].Y()-rGeom[n-1].Y());
+        double hy = fabs(rGeom[n].Y()-rGeom[n-1].Y());
         if (hy > Delta[1]) Delta[1] = hy;
-        double hz = abs(rGeom[n].Z()-rGeom[n-1].Z());
+        double hz = fabs(rGeom[n].Z()-rGeom[n-1].Z());
         if (hz > Delta[2]) Delta[2] = hz;
     }
 

--- a/applications/StabilizedCFDApplication/custom_elements/dss_fic.cpp
+++ b/applications/StabilizedCFDApplication/custom_elements/dss_fic.cpp
@@ -101,7 +101,7 @@ void DSS_FIC<TDim>::CalculateMassMatrix(MatrixType &rMassMatrix, ProcessInfo &rC
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template< unsigned int TDim >
-void DSS_FIC<TDim>::CalculateStaticTau(double Density,
+void DSS_FIC<TDim>::CalculateStabilizationParameters(double Density,
                                        double KinematicVisc,
                                        const array_1d<double,3> &Velocity,
                                        const ProcessInfo& rProcessInfo,
@@ -474,7 +474,7 @@ void DSS_FIC<TDim>::AddSystemTerms(unsigned int GaussIndex,
     double TauIncompr;
     double TauMomentum;
     array_1d<double,3> TauGrad(3,0.0);
-    this->CalculateStaticTau(Density,Viscosity,ConvVel,rProcessInfo,TauIncompr,TauMomentum,TauGrad);
+    this->CalculateStabilizationParameters(Density,Viscosity,ConvVel,rProcessInfo,TauIncompr,TauMomentum,TauGrad);
 
     Vector AGradN;
     this->ConvectionOperator(AGradN,ConvVel,rDN_DX);
@@ -590,7 +590,7 @@ void DSS_FIC<TDim>::AddMassStabilization(unsigned int GaussIndex,
     double TauIncompr;
     double TauMomentum;
     array_1d<double,3> TauGrad(3,0.0);
-    this->CalculateStaticTau(Density,Viscosity,ConvVel,rProcessInfo,TauIncompr,TauMomentum,TauGrad);
+    this->CalculateStabilizationParameters(Density,Viscosity,ConvVel,rProcessInfo,TauIncompr,TauMomentum,TauGrad);
 
     Vector AGradN;
     this->ConvectionOperator(AGradN,ConvVel,rDN_DX);

--- a/applications/StabilizedCFDApplication/custom_elements/dss_fic.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dss_fic.h
@@ -179,7 +179,7 @@ protected:
     ///@{
 
 
-    virtual void CalculateStaticTau(double Density,
+    virtual void CalculateStabilizationParameters(double Density,
                                     double KinematicVisc,
                                     const array_1d<double,3> &Velocity,
                                     const ProcessInfo& rProcessInfo,

--- a/applications/StabilizedCFDApplication/custom_elements/dss_gls.cpp
+++ b/applications/StabilizedCFDApplication/custom_elements/dss_gls.cpp
@@ -63,7 +63,7 @@ Element::Pointer DSS_GLS<TDim>::Create(IndexType NewId,NodesArrayType const& Thi
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template< unsigned int TDim >
-void DSS_GLS<TDim>::CalculateStaticTau(double Density,
+void DSS_GLS<TDim>::CalculateStabilizationParameters(double Density,
                                        double KinematicVisc,
                                        const array_1d<double,3> &Velocity,
                                        const ProcessInfo& rProcessInfo,

--- a/applications/StabilizedCFDApplication/custom_elements/dss_gls.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dss_gls.h
@@ -176,7 +176,7 @@ protected:
     ///@{
 
 
-    void CalculateStaticTau(double Density,
+    void CalculateStabilizationParameters(double Density,
                             double KinematicVisc,
                             const array_1d<double,3> &Velocity,
                             const ProcessInfo& rProcessInfo,

--- a/applications/StabilizedCFDApplication/custom_elements/dynss.cpp
+++ b/applications/StabilizedCFDApplication/custom_elements/dynss.cpp
@@ -189,9 +189,9 @@ void DynSS<TDim>::InitializeNonLinearIteration(ProcessInfo &rCurrentProcessInfo)
         this->ResolvedConvectiveVelocity(ResolvedConvVel,N);
 
         if (rCurrentProcessInfo[OSS_SWITCH] != 1.0)
-            this->ASGSMomentumResidual(N,rDN_DX,ResolvedConvVel,StaticResidual);
+            this->DASGSMomentumResidual(N,rDN_DX,ResolvedConvVel,StaticResidual);
         else
-            this->OSSMomentumResidual(N,rDN_DX,ResolvedConvVel,StaticResidual);
+            this->DOSSMomentumResidual(N,rDN_DX,ResolvedConvVel,StaticResidual);
 
 
         // Add the time discretization term to obtain the part of the residual that does not change during iteration
@@ -501,7 +501,7 @@ void DynSS<TDim>::CalculateTau(double Density,
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 template< unsigned int TDim >
-void DynSS<TDim>::ASGSMomentumResidual(const ShapeFunctionsType &rN,
+void DynSS<TDim>::DASGSMomentumResidual(const ShapeFunctionsType &rN,
                                        const ShapeFunctionDerivativesType &rDN_DX,
                                        const array_1d<double,3>& rConvVel,
                                        array_1d<double,3> &rMomentumRes)
@@ -541,12 +541,12 @@ void DynSS<TDim>::ASGSMassResidual(double GaussIndex,
 
 
 template< unsigned int TDim >
-void DynSS<TDim>::OSSMomentumResidual(const ShapeFunctionsType &rN,
+void DynSS<TDim>::DOSSMomentumResidual(const ShapeFunctionsType &rN,
                                       const ShapeFunctionDerivativesType &rDN_DX,
                                       const array_1d<double,3>& rConvVel,
                                       array_1d<double,3> &rMomentumRes)
 {
-    this->MomentumProjTerm(rN,rDN_DX,rConvVel,rMomentumRes);
+    this->DynamicMomentumProjTerm(rN,rDN_DX,rConvVel,rMomentumRes);
 
     const GeometryType& rGeom = this->GetGeometry();
     const unsigned int NumNodes = rGeom.PointsNumber();
@@ -581,7 +581,7 @@ void DynSS<TDim>::OSSMassResidual(double GaussIndex,
 
 
 template< unsigned int TDim >
-void DynSS<TDim>::MomentumProjTerm(const ShapeFunctionsType &rN,
+void DynSS<TDim>::DynamicMomentumProjTerm(const ShapeFunctionsType &rN,
                                    const ShapeFunctionDerivativesType &rDN_DX,
                                    const array_1d<double,3> &rConvVel,
                                    array_1d<double,3> &rMomentumRHS)
@@ -927,9 +927,9 @@ void DynSS<TDim>::SubscaleVelocity(unsigned int GaussIndex,
         array_1d<double,3> Residual(3,0.0);
 
         if (rProcessInfo[OSS_SWITCH] != 1.0)
-            this->ASGSMomentumResidual(rN,rDN_DX,ConvVel,Residual);
+            this->DASGSMomentumResidual(rN,rDN_DX,ConvVel,Residual);
         else
-            this->OSSMomentumResidual(rN,rDN_DX,ConvVel,Residual);
+            this->DOSSMomentumResidual(rN,rDN_DX,ConvVel,Residual);
 
         rVelocitySubscale = TauOne*(Residual + (Density/Dt)*mOldSsVel[GaussIndex]);
     }

--- a/applications/StabilizedCFDApplication/custom_elements/dynss.h
+++ b/applications/StabilizedCFDApplication/custom_elements/dynss.h
@@ -283,7 +283,7 @@ protected:
                               double &TauP);
 
 
-    virtual void ASGSMomentumResidual(const ShapeFunctionsType &rN,
+    virtual void DASGSMomentumResidual(const ShapeFunctionsType &rN,
                                       const ShapeFunctionDerivativesType &rDN_DX,
                                       const array_1d<double,3> &rConvVel,
                                       array_1d<double,3>& rMomentumRes);
@@ -295,7 +295,7 @@ protected:
                           double& rMomentumRes) override;
 
 
-    virtual void OSSMomentumResidual(const ShapeFunctionsType &rN,
+    virtual void DOSSMomentumResidual(const ShapeFunctionsType &rN,
                                      const ShapeFunctionDerivativesType &rDN_DX,
                                      const array_1d<double,3> &rConvVel,
                                      array_1d<double,3>& rMomentumRes);
@@ -306,7 +306,7 @@ protected:
                          double& rMassRes) override;
 
 
-    virtual void MomentumProjTerm(const ShapeFunctionsType &rN,
+    virtual void DynamicMomentumProjTerm(const ShapeFunctionsType &rN,
                                   const ShapeFunctionDerivativesType &rDN_DX,
                                   const array_1d<double,3> &rConvVel,
                                   array_1d<double,3>& rMomentumRHS);

--- a/kratos/modified_shape_functions/modified_shape_functions.h
+++ b/kratos/modified_shape_functions/modified_shape_functions.h
@@ -73,7 +73,7 @@ public:
     ModifiedShapeFunctions(const GeometryPointerType pInputGeometry, const Vector& rNodalDistances);
 
     /// Destructor
-    ~ModifiedShapeFunctions();
+    virtual ~ModifiedShapeFunctions();
 
     ///@}
     ///@name Access
@@ -200,7 +200,7 @@ public:
         Vector &rNegativeExteriorFaceWeightsValues,
         const unsigned int FaceId,
         const IntegrationMethodType IntegrationMethod) = 0;
-        
+
     /**
     * Returns the positive side outwards area normal vector values for the Gauss pts. of given quadrature.
     * @return rPositiveSideInterfaceAreaNormal: Outwards area normal vector list.
@@ -218,7 +218,7 @@ public:
     virtual void ComputeNegativeSideInterfaceAreaNormals(
         std::vector<Vector> &rNegativeSideInterfaceAreaNormal,
         const IntegrationMethodType IntegrationMethod) = 0;
-        
+
     /**
     * Returns the positive side outwards area normal vector values for the Gauss pts. of given quadrature.
     * @return rPositiveExteriorFaceAreaNormal: Outwards area normal vector list.
@@ -243,7 +243,7 @@ public:
 
     /**
     * Returns the positive side edge intersections shape function values.
-    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes, 
+    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes,
     * containing the positive side edge intersection shape function values.
     */
     virtual void ComputeShapeFunctionsOnPositiveEdgeIntersections(
@@ -251,7 +251,7 @@ public:
 
     /**
     * Returns the negative side edge intersections shape function values.
-    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes, 
+    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes,
     * containing the negative side edge intersection shape function values.
     */
     virtual void ComputeShapeFunctionsOnNegativeEdgeIntersections(

--- a/kratos/modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.h
+++ b/kratos/modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.h
@@ -70,7 +70,7 @@ public:
     Tetrahedra3D4ModifiedShapeFunctions(const GeometryPointerType rpInputGeometry, const Vector& rNodalDistances);
 
     /// Destructor
-    ~Tetrahedra3D4ModifiedShapeFunctions();
+    ~Tetrahedra3D4ModifiedShapeFunctions() override;
 
     ///@}
     ///@name Access
@@ -232,7 +232,7 @@ public:
 
     /**
     * Returns the positive side edge intersections shape function values.
-    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes, 
+    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes,
     * containing the positive side edge intersection shape function values. For non-split edges,
     * the corresponding row is plenty of zeros.
     */
@@ -241,7 +241,7 @@ public:
 
     /**
     * Returns the negative side edge intersections shape function values.
-    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes, 
+    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes,
     * containing the negative side edge intersection shape function values. For non-split edges,
     * the corresponding row is plenty of zeros.
     */

--- a/kratos/modified_shape_functions/triangle_2d_3_modified_shape_functions.h
+++ b/kratos/modified_shape_functions/triangle_2d_3_modified_shape_functions.h
@@ -70,7 +70,7 @@ public:
     Triangle2D3ModifiedShapeFunctions(const GeometryPointerType rpInputGeometry, const Vector& rNodalDistances);
 
     /// Destructor
-    ~Triangle2D3ModifiedShapeFunctions();
+    ~Triangle2D3ModifiedShapeFunctions() override;
 
     ///@}
     ///@name Access
@@ -100,7 +100,7 @@ public:
     ///@}
     ///@name Operations
     ///@{
-    
+
     /**
     * Returns the member pointer to the splitting utility.
     */
@@ -232,7 +232,7 @@ public:
 
     /**
     * Returns the positive side edge intersections shape function values.
-    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes, 
+    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes,
     * containing the positive side edge intersection shape function values. For non-split edges,
     * the corresponding row is plenty of zeros.
     */
@@ -241,7 +241,7 @@ public:
 
     /**
     * Returns the negative side edge intersections shape function values.
-    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes, 
+    * @return rPositiveEdgeIntersectionsShapeFunctionsValues A matrix, which size is edges x nodes,
     * containing the negative side edge intersection shape function values. For non-split edges,
     * the corresponding row is plenty of zeros.
     */


### PR DESCRIPTION
Fixing assorted clang warnings in the FluidDynamics and StabilizedCFD applications and related classes.
@rubenzorrilla I changed your files in e4d68636efc5d473fca473656d9d02bb4eb257ce and 375f7db8e651644f989c5a4c08e42c3f689446fd.

I left the warnings related to the new compressible element there for now, since I understand they will be fixed in a different branch.