### PR TITLE
mpi-python can be compiled without metis if wanted

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,7 +303,9 @@ endif(${BLAS_INCLUDE_NEEDED} MATCHES ON )
 
 ##*****************************
 #finding Mpi
-set(MPI_NEEDED OFF)
+if(NOT ${MPI_NEEDED} MATCHES ON )
+  set(MPI_NEEDED OFF)
+endif(NOT ${MPI_NEEDED} MATCHES ON )
 if(${METIS_APPLICATION} MATCHES ON )
   set(MPI_NEEDED ON)
 endif(${METIS_APPLICATION} MATCHES ON )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,9 +303,6 @@ endif(${BLAS_INCLUDE_NEEDED} MATCHES ON )
 
 ##*****************************
 #finding Mpi
-if(NOT ${MPI_NEEDED} MATCHES ON )
-  set(MPI_NEEDED OFF)
-endif(NOT ${MPI_NEEDED} MATCHES ON )
 if(${METIS_APPLICATION} MATCHES ON )
   set(MPI_NEEDED ON)
 endif(${METIS_APPLICATION} MATCHES ON )


### PR DESCRIPTION
The pre-existing variable MPI_NEEDED can be set to ON in the configure.