### PR TITLE
Only compute strain in HyperElasticIsotropicKirchhoff3D when flag is set (2)

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.cpp
@@ -90,10 +90,6 @@ void  HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponsePK2(Constitutiv
     }
 
     if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
-         if (rValues.IsSetDeformationGradientF() == true) {
-            CalculateGreenLagrangianStrain(rValues, strain_vector);
-        }
-
         if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
             Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
             noalias(stress_vector) = prod(constitutive_matrix, strain_vector);

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
@@ -91,10 +91,6 @@ void  HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateMaterialResponsePK2(
     }
 
     if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
-        if (rValues.IsSetDeformationGradientF() == true) {
-            CalculateGreenLagrangianStrain(rValues, strain_vector);
-        }
-
         if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
             Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
             noalias(stress_vector) = prod(constitutive_matrix, strain_vector);

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
@@ -90,10 +90,6 @@ void  HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateMaterialResponsePK2(
     }
 
     if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
-        if (rValues.IsSetDeformationGradientF() == true) {
-            CalculateGreenLagrangianStrain(rValues, strain_vector);
-        }
-
         if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) )  {
             Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
             noalias(stress_vector) = prod(constitutive_matrix, strain_vector);


### PR DESCRIPTION
Made CL to only compute strain for PK2 stress if flag USE_ELEMENT_PROVIDED_STRAIN is set.

Tests pass.