### PR TITLE
[Pybind] update required version Intel compiler

### DIFF
--- a/external_libraries/pybind11/detail/common.h
+++ b/external_libraries/pybind11/detail/common.h
@@ -46,8 +46,8 @@
 
 // Compiler version assertions
 #if defined(__INTEL_COMPILER)
-#  if __INTEL_COMPILER < 1500
-#    error pybind11 requires Intel C++ compiler v15 or newer
+#  if __INTEL_COMPILER < 1700
+#    error pybind11 requires Intel C++ compiler v17 or newer
 #  endif
 #elif defined(__clang__) && !defined(__apple_build_version__)
 #  if __clang_major__ < 3 || (__clang_major__ == 3 && __clang_minor__ < 3)


### PR DESCRIPTION
see the related [PR in Pybind](https://github.com/pybind/pybind11/pull/1363)

the required Intel compiler is v17 since pybind version >2.0, see the [readme of pybind](https://github.com/pybind/pybind11#supported-compilers) (we have 2.3 from what I understand, see [here](https://github.com/KratosMultiphysics/Kratos/blob/master/external_libraries/pybind11/detail/common.h#L94))

related to #1971 