### PR TITLE
Core/hotfix issue 1997

### DIFF
--- a/applications/DamApplication/python_scripts/gid_dam_output_process.py
+++ b/applications/DamApplication/python_scripts/gid_dam_output_process.py
@@ -383,6 +383,7 @@ class GiDDamOutputProcess(Process):
         self.cut_model_part = ModelPart("CutPart")
         self.cut_manager = CuttingUtility()
         self.cut_manager.FindSmallestEdge(self.model_part)
+        self.cut_manager.AddVariablesToCutModelPart(self.model_part,self.cut_model_part)
         if self.skin_output:
             self.cut_manager.AddSkinConditions(self.model_part,self.cut_model_part,self.output_surface_index)
             self.output_surface_index += 1

--- a/applications/FluidDynamicsApplication/test_examples/cyl_bench/run_test.py
+++ b/applications/FluidDynamicsApplication/test_examples/cyl_bench/run_test.py
@@ -344,8 +344,9 @@ if(ProjectParameters.VolumeOutput):
         f.write('Multiple\n')
 else:
     # generate the cuts
-    Cut_App = Cutting_Application();
+    Cut_App = Cutting_Application()
     Cut_App.FindSmallestEdge(fluid_model_part)
+    Cut_App.AddVariablesToCutModelPart(fluid_model_part,cut_model_part)
 
     cut_number = 1
 

--- a/applications/trilinos_application/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/trilinos_application/custom_python/add_custom_utilities_to_python.cpp
@@ -72,6 +72,7 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
     .def("FindSmallestEdge", &TrilinosCuttingApplication::FindSmallestEdge )
     .def("GenerateCut", &TrilinosCuttingApplication::GenerateCut )
     .def("AddSkinConditions", &TrilinosCuttingApplication::AddSkinConditions )
+    .def("AddVariablesToCutModelPart", &TrilinosCuttingApplication::AddVariablesToCutModelPart )
     .def("UpdateCutData", &TrilinosCuttingApplication::UpdateCutData )
     ;
 

--- a/applications/trilinos_application/custom_utilities/trilinos_cutting_app.h
+++ b/applications/trilinos_application/custom_utilities/trilinos_cutting_app.h
@@ -249,7 +249,7 @@ public:
                     int node_position = this_model_part.Nodes().find(geom[i].Id()) - it_begin_node_old; //probably there-s a better way to do this, i only need the position in the array, (not the ID)
                     used_nodes[node_position]=true; //we will have to clone this node into the new model part, no matter if owned or not.
                     int ierr = aux_non_overlapping_graph->ReplaceGlobalValues( 1 , &aux_ids, &this_partition_index,0); // saving that this processor owns this node
-                    if (ierr < 0) KRATOS_THROW_ERROR(std::logic_error, "epetra failure ->ln 183", "");
+                    KRATOS_ERROR_IF(ierr < 0) << "epetra failure" << std::endl;
                 }
             }
         }
@@ -257,13 +257,13 @@ public:
 
         int ierr = -1;
         ierr = aux_non_overlapping_graph->GlobalAssemble(Insert,true); //Epetra_CombineMode mode=Add);
-        KRATOS_ERROR_IF(ierr < 0) << "epetra failure --> " << __LINE__ << std::endl;
+        KRATOS_ERROR_IF(ierr < 0) << "epetra failure" << std::endl;
         //now in our local graph we have also the nodes that are required by other processors
 
 
         double* local_non_ov = new double  [nlocal_nodes]; //a human readeable copy of the FEvector
         ierr = aux_non_overlapping_graph->ExtractCopy(local_non_ov,nlocal_nodes);
-        KRATOS_ERROR_IF(ierr < 0) << "epetra failure --> " << __LINE__ << std::endl;
+        KRATOS_ERROR_IF(ierr < 0) << "epetra failure" << std::endl;
 
 
         int n_owned_nonzeros = 0;
@@ -332,13 +332,13 @@ public:
                 ++node_id;
                 double node_id_double=double(node_id);
                 ierr = IDs_non_overlapping_graph->ReplaceMyValue ( index  ,  0 ,  node_id_double ); //saving the ID
-                if (ierr < 0) KRATOS_THROW_ERROR(std::logic_error, "epetra failure ->ln 183", "");
+                KRATOS_ERROR_IF(ierr < 0) << "epetra failure" << std::endl;
             }
         }
 
         ierr = -1;
         ierr = IDs_non_overlapping_graph->GlobalAssemble(Insert,true); //Epetra_CombineMode mode=Add);
-        if (ierr < 0) KRATOS_THROW_ERROR(std::logic_error, "epetra failure --> ln 249", "");
+        KRATOS_ERROR_IF(ierr < 0) << "epetra failure" << std::endl;
 
         //KRATOS_WATCH('line333')
 
@@ -612,7 +612,7 @@ public:
                 aux_ids[i] = geom[i].Id() - 1;
 
             int ierr = mp_non_overlapping_graph->InsertGlobalIndices(geom.size(), aux_ids, geom.size(), aux_ids);
-            if (ierr < 0) KRATOS_THROW_ERROR(std::logic_error, "epetra failure ->ln174", "");
+            KRATOS_ERROR_IF(ierr < 0) << "epetra failure" << std::endl;
         }
         for (ModelPart::ConditionsContainerType::iterator it = this_model_part.ConditionsBegin(); it != this_model_part.ConditionsEnd(); it++)
         {
@@ -621,7 +621,7 @@ public:
                 aux_ids[i] = geom[i].Id() - 1;
 
             int ierr = mp_non_overlapping_graph->InsertGlobalIndices(geom.size(), aux_ids, geom.size(), aux_ids);
-            if (ierr < 0) KRATOS_THROW_ERROR(std::logic_error, "epetra failure ->ln 183", "");
+            KRATOS_ERROR_IF(ierr < 0) << "epetra failure" << std::endl;
         }
         mp_non_overlapping_graph->GlobalAssemble();
 
@@ -969,13 +969,10 @@ public:
             GlobalRow = p_edge_ids->GRID(Row);
             int num_id_entries = -1;
             int ierr = p_edge_ids->ExtractGlobalRowCopy(GlobalRow, MaxNumEntries, num_id_entries, id_values, Indices);
-            if (ierr < 0) KRATOS_THROW_ERROR(std::logic_error, "epetra failure ->ln420", "");
+            KRATOS_ERROR_IF(ierr < 0) << "epetra failure" << std::endl;
 
             ierr = p_partition_ids->ExtractGlobalRowCopy(GlobalRow, MaxNumEntries, NumEntries, partition_values, Indices);
-            if (ierr < 0) KRATOS_THROW_ERROR(std::logic_error, "epetra failure ->ln423", "");
-
-            //ierr = used_nodes_matrix->ExtractGlobalRowCopy(GlobalRow, MaxNumEntries, NumEntries, used_nodes_matrix_row, Indices);
-            //if (ierr < 0) KRATOS_THROW_ERROR(std::logic_error, "epetra failure ->ln423", "");
+            KRATOS_ERROR_IF(ierr < 0) << "epetra failure" << std::endl;
 
             if (NumEntries != num_id_entries) KRATOS_THROW_ERROR(std::logic_error, "we should have the same number of new_ids and of partition_values", "");
             for (Col = 0; Col < NumEntries; ++Col)

--- a/applications/trilinos_application/python_scripts/gid_output_process_mpi.py
+++ b/applications/trilinos_application/python_scripts/gid_output_process_mpi.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import, division #makes KratosMu
 import os
 from KratosMultiphysics import *
 from KratosMultiphysics.mpi import *
+from KratosMultiphysics.TrilinosApplication import *
 CheckForPreviousImport()
 
 import gid_output_process
@@ -59,6 +60,9 @@ class GiDOutputProcessMPI(gid_output_process.GiDOutputProcess):
 
         # Generate the cuts and store them in self.cut_model_part
         if self.skin_output or self.num_planes > 0:
+            self.cut_model_part = ModelPart("CutPart")
+            self.epetra_comm = CreateCommunicator()
+            self.cut_manager = TrilinosCuttingApplication(self.epetra_comm)
             self._initialize_cut_output(plane_output_configuration)
 
         # Retrieve gidpost flags and setup GiD output tool

--- a/applications/trilinos_application/python_scripts/trilinos_gid_output.py
+++ b/applications/trilinos_application/python_scripts/trilinos_gid_output.py
@@ -59,6 +59,7 @@ class TrilinosGiDOutput(gid_output.GiDOutput):
             self.comm = CreateCommunicator()
             self.cut_app = TrilinosCuttingApplication(self.comm)
             self.cut_app.FindSmallestEdge(model_part)
+            self.cut_app.AddVariablesToCutModelPart(model_part,self.cut_model_part)
 
         for cut_data in cut_list:
             self.cut_number += 1

--- a/kratos/python/add_utilities_to_python.cpp
+++ b/kratos/python/add_utilities_to_python.cpp
@@ -65,7 +65,7 @@ void AddUtilitiesToPython(pybind11::module& m)
     typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
     typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
     typedef LinearSolver<SparseSpaceType, LocalSpaceType> LinearSolverType;
-    
+
     // NOTE: this function is special in that it accepts a "pyObject" - this is the reason for which it is defined in this same file
     class_<PythonGenericFunctionUtility,  PythonGenericFunctionUtility::Pointer >(m,"PythonGenericFunctionUtility")
     .def(init<const std::string&>() )
@@ -96,7 +96,7 @@ void AddUtilitiesToPython(pybind11::module& m)
 
     InputGetConditionNumber ThisGetConditionNumber = &ConditionNumberUtility::GetConditionNumber;
     DirectGetConditionNumber ThisDirectGetConditionNumber = &ConditionNumberUtility::GetConditionNumber;
-    
+
     class_<ConditionNumberUtility>(m,"ConditionNumberUtility")
     .def(init<>())
     .def(init<LinearSolverType::Pointer, LinearSolverType::Pointer>())
@@ -374,6 +374,7 @@ void AddUtilitiesToPython(pybind11::module& m)
     .def("GenerateCut", &CuttingUtility::GenerateCut)
     .def("UpdateCutData", &CuttingUtility ::UpdateCutData)
     .def("AddSkinConditions", &CuttingUtility ::AddSkinConditions)
+    .def("AddVariablesToCutModelPart", &CuttingUtility::AddVariablesToCutModelPart )
     .def("FindSmallestEdge", &CuttingUtility ::FindSmallestEdge)
     ;
 
@@ -383,13 +384,13 @@ void AddUtilitiesToPython(pybind11::module& m)
     .def("GetIntervalEnd", &IntervalUtility::GetIntervalEnd)
     .def("IsInInterval", &IntervalUtility ::IsInInterval)
     ;
-    
+
     // Adding table from table stream to python
     class_<TableStreamUtility, typename TableStreamUtility::Pointer>(m,"TableStreamUtility")
     .def(init<>())
     .def(init< bool >())
     ;
-    
+
     // Exact integration (for testing)
     class_<ExactMortarIntegrationUtility<2,2>>(m,"ExactMortarIntegrationUtility2D2N")
     .def(init<>())
@@ -403,7 +404,7 @@ void AddUtilitiesToPython(pybind11::module& m)
     .def("TestGetExactIntegration",&ExactMortarIntegrationUtility<3,3>::TestGetExactIntegration)
     .def("TestGetExactAreaIntegration",&ExactMortarIntegrationUtility<3,3>::TestGetExactAreaIntegration)
     ;
-    
+
     class_<ExactMortarIntegrationUtility<3,4>>(m,"ExactMortarIntegrationUtility3D4N")
     .def(init<>())
     .def(init<const unsigned int>())

--- a/kratos/python_scripts/gid_output.py
+++ b/kratos/python_scripts/gid_output.py
@@ -118,6 +118,7 @@ class GiDOutput(object):
             self.cut_model_part = ModelPart("CutPart")
             self.cut_app = CuttingUtility()
             self.cut_app.FindSmallestEdge(model_part)
+            self.cut_app.AddVariablesToCutModelPart(model_part,self.cut_model_part)
 
         for cut_data in cut_list:
             self.cut_number += 1

--- a/kratos/python_scripts/gid_output_process.py
+++ b/kratos/python_scripts/gid_output_process.py
@@ -348,6 +348,7 @@ class GiDOutputProcess(Process):
         self.cut_model_part = ModelPart("CutPart")
         self.cut_manager = CuttingUtility()
         self.cut_manager.FindSmallestEdge(self.model_part)
+        self.cut_manager.AddVariablesToCutModelPart(self.model_part,self.cut_model_part)
         if self.skin_output:
             self.cut_manager.AddSkinConditions(self.model_part,self.cut_model_part,self.output_surface_index)
             self.output_surface_index += 1
@@ -504,7 +505,7 @@ class GiDOutputProcess(Process):
         if self.cut_io is not None:
             self.cut_manager.UpdateCutData(self.cut_model_part, self.model_part)
             for variable in self.nodal_variables:
-                self.cut_io.WriteNodalResults(variable, self.cut_model_part.GetCommunicator().LocalMesh().Nodes, label, 0)      
+                self.cut_io.WriteNodalResults(variable, self.cut_model_part.GetCommunicator().LocalMesh().Nodes, label, 0)
 
     def __write_gp_results(self, label):
 

--- a/kratos/python_scripts/gid_output_process.py
+++ b/kratos/python_scripts/gid_output_process.py
@@ -126,7 +126,9 @@ class GiDOutputProcess(Process):
 
         # Generate the cuts and store them in self.cut_model_part
         if self.skin_output or self.num_planes > 0:
-            self.__initialize_cut_output(plane_output_configuration)
+            self.cut_model_part = ModelPart("CutPart")
+            self.cut_manager = CuttingUtility()
+            self._initialize_cut_output(plane_output_configuration)
 
         # Retrieve gidpost flags and setup GiD output tool
         gidpost_flags = result_file_configuration["gidpost_flags"]
@@ -342,11 +344,9 @@ class GiDOutputProcess(Process):
         return value
 
 
-    def __initialize_cut_output(self,plane_output_configuration):
+    def _initialize_cut_output(self,plane_output_configuration):
         '''Set up tools used to produce output in skin and cut planes.'''
 
-        self.cut_model_part = ModelPart("CutPart")
-        self.cut_manager = CuttingUtility()
         self.cut_manager.FindSmallestEdge(self.model_part)
         self.cut_manager.AddVariablesToCutModelPart(self.model_part,self.cut_model_part)
         if self.skin_output:

--- a/kratos/utilities/cutting_utility.h
+++ b/kratos/utilities/cutting_utility.h
@@ -2,13 +2,13 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pablo Becker
-//                    
+//
 //
 
 #if !defined(KRATOS_CUTTING_UTILITY)
@@ -136,7 +136,6 @@ public:
         KRATOS_WATCH(smallest_edge);
     } //closing function
 
-
     ///************************************************************************************************
     ///************************************************************************************************
 
@@ -156,6 +155,12 @@ public:
         KRATOS_WATCH(versor);
         KRATOS_WATCH(Xp);
         KRATOS_TRY
+
+        if (!mr_new_model_part.GetNodalSolutionStepVariablesList().Has(FATHER_NODES) ||
+            !mr_new_model_part.GetNodalSolutionStepVariablesList().Has(WEIGHT_FATHER_NODES) )
+            KRATOS_ERROR << "The cut model part was not initialized. "
+                            "Please call AddVariablesToCutModelPart before GenerateCut."
+                         << std::endl;
 
         DenseVector<array_1d<int, 2 > > Position_Node;
         DenseVector<int> List_New_Nodes;
@@ -209,11 +214,13 @@ public:
         int number_of_triangles = 0; //we set it to zero to start
         int number_of_nodes = 0; //same as above
         int number_of_previous_nodes = 0; // nodes from the previous conditions (planes) created
-        int number_of_conditions = 0; 
+        int number_of_conditions = 0;
 
-        new_model_part.GetNodalSolutionStepVariablesList() = this_model_part.GetNodalSolutionStepVariablesList();
-        new_model_part.AddNodalSolutionStepVariable(FATHER_NODES);
-        new_model_part.AddNodalSolutionStepVariable(WEIGHT_FATHER_NODES);
+        if (!new_model_part.GetNodalSolutionStepVariablesList().Has(FATHER_NODES) ||
+            !new_model_part.GetNodalSolutionStepVariablesList().Has(WEIGHT_FATHER_NODES) )
+            KRATOS_ERROR << "The cut model part was not initialized. "
+                            "Please call AddVariablesToCutModelPart before AddSkinConditions."
+                         << std::endl;
 
         ConditionsArrayType& rConditions = this_model_part.Conditions();
         ConditionsArrayType::iterator cond_it_begin = rConditions.ptr_begin();
@@ -241,7 +248,7 @@ public:
         }
 
 
-		if (number_of_conditions!=0) 
+		if (number_of_conditions!=0)
 		{
 			for (unsigned int index=0 ; index != this_model_part.Nodes().size() ; ++index) Condition_Nodes[index]=0; //initializing in zero the whole vector (meaning no useful nodes for the condition layer)
 
@@ -305,6 +312,19 @@ public:
 
     }
 
+    /// Initialize the solution step data container for the cut model part.
+    /** Please call this function before either GenerateCut or AddSkinCondition.
+     *  @param rModelPart the reference (problem) model part.
+     *  @param rNewModelPart the new model part, where cut data will be stored.
+     */
+    void AddVariablesToCutModelPart(
+        const ModelPart& rModelPart,
+        ModelPart& rNewModelPart) const
+    {
+        rNewModelPart.GetNodalSolutionStepVariablesList() = rModelPart.GetNodalSolutionStepVariablesList();
+        rNewModelPart.AddNodalSolutionStepVariable(FATHER_NODES);
+        rNewModelPart.AddNodalSolutionStepVariable(WEIGHT_FATHER_NODES);
+    }
 
 
     //************************************************************************************************
@@ -585,11 +605,6 @@ public:
         Coordinate_New_Node.resize(Position_Node.size());
         //unsigned int step_data_size = this_model_part.GetNodalSolutionStepDataSize();
         //Node < 3 > ::DofsContainerType& reference_dofs = (this_model_part.NodesBegin())->GetDofs();
-
-        //assigning variables to the new model part (original + father nodes (pointers) and weight (double)
-        new_model_part.GetNodalSolutionStepVariablesList() = this_model_part.GetNodalSolutionStepVariablesList();
-        new_model_part.AddNodalSolutionStepVariable(FATHER_NODES);
-        new_model_part.AddNodalSolutionStepVariable(WEIGHT_FATHER_NODES);
 
         for (unsigned int i = 0; i < Position_Node.size(); i++) //looping the new nodes
         {


### PR DESCRIPTION
The cut plane generation utility was adding variables to the nodal solution step variable list of its output model part every time a cut was defined. This is no longer allowed to prevent memory errors, so an error was thrown.

A new function was implemented to define the solution step variables of the cut model part, which must be called before defining the cuts. The functions that were modifying the solution step variable list previously will now only check that the required variables have been added and throw an error otherwise (the error message instructs users to call the new function).

The change has been ported to the trilinos version of the utility, and a separate bug (missing function in python wrapper utility) has been fixed there.

Finally, the change has been propagated by adding calls to the new function to other python modules that also use the cut utility.

This fixes #1997 @jginternational 