### PR TITLE
FluiDynamics - error in two fluid element

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
@@ -403,7 +403,7 @@ KRATOS_WATCH(Ngauss);  */
             if (ndivisions > 1)
             {
 //                 KRATOS_WATCH(Nenriched);
-
+                this->EvaluateInPoint(bf, BODY_FORCE, N);
 
                 //note that here we compute only a part of the acceleration term
                 //this is done like this since the velocity*BDFVector[0] is treated implicitly


### PR DESCRIPTION
@RiccardoRossi  @jrubiogonzalez  @jcotela 
bf vector was not initialized with the correct value when using it in the stabilization of the cut elements.

There might be more small bugs, but this is the one that was giving us problems.

