### PR TITLE
Core/feature make modelpart registration automatic

### DIFF
--- a/kratos/containers/model.cpp
+++ b/kratos/containers/model.cpp
@@ -20,6 +20,7 @@
 // Project includes
 #include "includes/define.h"
 #include "containers/model.h"
+#include "includes/kernel.h"
 #include <iostream>
 #include <string>
 #include <sstream>
@@ -27,12 +28,29 @@
 
 namespace Kratos
 {
+      Model::Model()
+      {
+          Model*& pregistered_model = Kernel::GetModel();
+          if(pregistered_model != nullptr)
+              KRATOS_ERROR << "trying to create a new Model, however one is already existing" << std::endl;
+          pregistered_model = &(*this);
+      };
+
+      /// Destructor.
+      Model::~Model()
+      {
+        Model*& pregistered_model = Kernel::GetModel();    
+        pregistered_model = nullptr;
+      };
     
     ModelPart& Model::CreateModelPart( const std::string ModelPartName ) 
     {
         KRATOS_TRY
         
-        std::cout << "within CreateModelPart address of Model is " <<  &(*this) << std::endl;
+        if(Kernel::GetModel() == nullptr)
+              KRATOS_ERROR << "trying to create a new ModelPart however a Model has not yet been registered in the kernel. Please ensure that the Model is allocated before calling the model part constructor. This is achieved by simply adding something like       model = Model(). note however that this function can be called just once" << std::endl;
+        
+//         std::cout << "within CreateModelPart address of Model is " <<  &(*this) << std::endl;
         
         auto search = mRootModelPartMap.find(ModelPartName);
         if( search == mRootModelPartMap.end())

--- a/kratos/containers/model.cpp
+++ b/kratos/containers/model.cpp
@@ -27,30 +27,53 @@
 
 namespace Kratos
 {
-    void Model::AddModelPart( ModelPart::Pointer pModelPart) //TODO: DEPRECATED. to be removed. this is TEMPORARY
+    
+    ModelPart& Model::CreateModelPart( const std::string ModelPartName ) 
     {
         KRATOS_TRY
-
+        
         //TODO: flat map should disappear in the future!!
-        auto search = mflat_map.find(pModelPart->Name());
-        if( search == mflat_map.end())
+        auto search = mRootModelPartMap.find(ModelPartName);
+        if( search == mRootModelPartMap.end())
         {
-            mflat_map[pModelPart->Name()] = pModelPart.get();
-
-            //walk the submodelparts
-            for(auto& part : pModelPart->SubModelParts())
-                AddModelPartRawPointer(&part);
+            mRootModelPartMap[ModelPartName] = std::unique_ptr<ModelPart>(new ModelPart(ModelPartName));
+            return *(mRootModelPartMap[ModelPartName].get());
         }
         else
         {
-            if(&(*search->second) != &*(pModelPart.get()))
-                KRATOS_ERROR << "trying to add to the Model two DISTINCT model parts with the same name. This should be possible (and it will be in the future) if they belong to two different root model_parts, but it is currently disallowed";
-
+            KRATOS_ERROR << "trying to create a root modelpart with name " << ModelPartName << " however a ModelPart with the same name already exists";
         }
 
-        //add the root model part to the list
-        ModelPart& root_model_part = pModelPart->GetRootModelPart();
-        mRootModelPartMap[root_model_part.Name()] = &root_model_part;
+        KRATOS_CATCH("")
+    }
+
+    
+    void Model::AddModelPart( ModelPart::Pointer pModelPart) //TODO: DEPRECATED. to be removed. this is TEMPORARY
+    {
+        KRATOS_TRY
+        
+        std::cout << "Model::AddModelPart is deprecated and is currently doing nothing" << std::endl;
+
+//         //TODO: flat map should disappear in the future!!
+//         auto search = mflat_map.find(pModelPart->Name());
+//         if( search == mflat_map.end())
+//         {
+//             mflat_map[pModelPart->Name()] = pModelPart.get();
+// 
+//             //walk the submodelparts
+//             for(auto& part : pModelPart->SubModelParts())
+//                 AddModelPartRawPointer(&part);
+//         }
+//         else
+//         {
+//             if(&(*search->second) != &*(pModelPart.get()))
+//                 KRATOS_ERROR << "trying to add to the Model two DISTINCT model parts with the same name. This should be possible (and it will be in the future) if they belong to two different root model_parts, but it is currently disallowed";
+// 
+//         }
+// 
+//         //add the root model part to the list
+//         ModelPart& root_model_part = pModelPart->GetRootModelPart();
+//         mRootModelPartMap[root_model_part.Name()] = &root_model_part;
 
         KRATOS_CATCH("")
     }
@@ -59,26 +82,28 @@ namespace Kratos
     {
         KRATOS_TRY
 
-        //TODO: flat map should disappear in the future!!
-        auto search = mflat_map.find(pModelPart->Name());
-        if( search == mflat_map.end())
-        {
-            mflat_map[pModelPart->Name()] = pModelPart;
+        std::cout << "Model::AddModelPartRawPointer is deprecated and is currently doing nothing" << std::endl;
 
-            //walk the submodelparts
-            for(auto& part : pModelPart->SubModelParts())
-                AddModelPartRawPointer(&part);
-        }
-        else
-        {
-            if(&(*search->second) != &*(pModelPart))
-                KRATOS_ERROR << "trying to add to the Model two DISTINCT model parts with the same name. This should be possible (and it will be in the future) if they belong to two different root model_parts, but it is currently disallowed";
-
-        }
-
-        //add the root model part to the list
-        ModelPart& root_model_part = pModelPart->GetRootModelPart();
-        mRootModelPartMap[root_model_part.Name()] = &root_model_part;
+//         //TODO: flat map should disappear in the future!!
+//         auto search = mflat_map.find(pModelPart->Name());
+//         if( search == mflat_map.end())
+//         {
+//             mflat_map[pModelPart->Name()] = pModelPart;
+// 
+//             //walk the submodelparts
+//             for(auto& part : pModelPart->SubModelParts())
+//                 AddModelPartRawPointer(&part);
+//         }
+//         else
+//         {
+//             if(&(*search->second) != &*(pModelPart))
+//                 KRATOS_ERROR << "trying to add to the Model two DISTINCT model parts with the same name. This should be possible (and it will be in the future) if they belong to two different root model_parts, but it is currently disallowed";
+// 
+//         }
+// 
+//         //add the root model part to the list
+//         ModelPart& root_model_part = pModelPart->GetRootModelPart();
+//         mRootModelPartMap[root_model_part.Name()] = &root_model_part;
 
         KRATOS_CATCH("")
     }
@@ -89,46 +114,89 @@ namespace Kratos
 
         KRATOS_ERROR_IF( rFullModelPartName.empty() ) << "Attempting to find a "
             << "ModelPart with empty name (\"\")!" << std::endl;
-
-        auto search = mflat_map.find(rFullModelPartName);
-        if(search != mflat_map.end()) {
-            // TODO enable the warning
-            // KRATOS_WARNING_IF("Model", (search->second)->IsSubModelPart())
-            //     << "Getting a SubModelPart from the Model without "
-            //     << "specifying the RootModelPart is deprecated and will be removed\n"
-            //     << "Please use e.g \"RootModelPart.SubModelPart.SubSubModelPart\" "
-            //     << "as input for this function" << std::endl;
-            return *(search->second);
-        }
-        else //look for it in the "root_map" which is where it is suppossed to be finally
+            
+        std::vector< std::string > subparts_list;
+        GetSubPartsList(rFullModelPartName, subparts_list);
+        
+        if(subparts_list.size() == 1) //it is a root model part
         {
-            std::vector< std::string > subparts_list;
-            GetSubPartsList(rFullModelPartName, subparts_list);
-
-            //token 0 is the root
             auto search = mRootModelPartMap.find(subparts_list[0]);
             if(search != mRootModelPartMap.end())
             {
-                ModelPart* mp = search->second;
-                for(unsigned int i=1; i<subparts_list.size(); i++)
-                {
-                    KRATOS_ERROR_IF_NOT(mp->HasSubModelPart(subparts_list[i]))
-                        << "The ModelPart named : \"" << subparts_list[i]
-                        << "\" was not found as SubModelPart of : \""
-                        << subparts_list[i-1] << "\". The total input string was \""
-                        << rFullModelPartName << "\"" << std::endl;
-                    mp = &(mp->GetSubModelPart(subparts_list[i]));
-                }
-                return *mp;
+                return *(search->second);
             }
-            else
+            else //let's also search it as a flat name - a feature that SHOULD BE DEPRECATED
             {
-                KRATOS_ERROR << "The ModelPart named : \"" << subparts_list[0]
-                    << "\" was not found as root-ModelPart. The total input string was \""
-                    << rFullModelPartName << "\"" << std::endl;
+                for(auto it = mRootModelPartMap.begin(); it!=mRootModelPartMap.end(); it++)
+                {
+                     ModelPart* pmodel_part = RecursiveSearchByName(subparts_list[0], (it->second.get()));
+                     if(pmodel_part != nullptr) //give back the first one that was found
+                         return *pmodel_part;
+                }
+                
+                //if we are here we did not find it
+                KRATOS_ERROR << "model part with name " << subparts_list[0] << " is not found either as root or as submodelpart of any level" << std::endl;
             }
-
         }
+        else //it is a submodelpart with the full name provided
+        {
+            std::cout << rFullModelPartName << std::endl;
+            auto search = mRootModelPartMap.find(subparts_list[0]);
+            if(search != mRootModelPartMap.end())
+            {
+                ModelPart* p_model_part = (search->second).get();
+                for(unsigned int i=1; i<subparts_list.size(); ++i)
+                {
+                    p_model_part = &p_model_part->GetSubModelPart(subparts_list[i]);
+                }
+                return *p_model_part;
+            }
+            else 
+            {
+                KRATOS_ERROR << "root model part " << rFullModelPartName << " not found" << std::endl;
+            }
+            
+        }
+
+//         auto search = mflat_map.find(rFullModelPartName);
+//         if(search != mflat_map.end()) {
+//             // TODO enable the warning
+//             // KRATOS_WARNING_IF("Model", (search->second)->IsSubModelPart())
+//             //     << "Getting a SubModelPart from the Model without "
+//             //     << "specifying the RootModelPart is deprecated and will be removed\n"
+//             //     << "Please use e.g \"RootModelPart.SubModelPart.SubSubModelPart\" "
+//             //     << "as input for this function" << std::endl;
+//             return *(search->second);
+//         }
+//         else //look for it in the "root_map" which is where it is suppossed to be finally
+//         {
+//             std::vector< std::string > subparts_list;
+//             GetSubPartsList(rFullModelPartName, subparts_list);
+// 
+//             //token 0 is the root
+//             auto search = mRootModelPartMap.find(subparts_list[0]);
+//             if(search != mRootModelPartMap.end())
+//             {
+//                 ModelPart* mp = search->second;
+//                 for(unsigned int i=1; i<subparts_list.size(); i++)
+//                 {
+//                     KRATOS_ERROR_IF_NOT(mp->HasSubModelPart(subparts_list[i]))
+//                         << "The ModelPart named : \"" << subparts_list[i]
+//                         << "\" was not found as SubModelPart of : \""
+//                         << subparts_list[i-1] << "\". The total input string was \""
+//                         << rFullModelPartName << "\"" << std::endl;
+//                     mp = &(mp->GetSubModelPart(subparts_list[i]));
+//                 }
+//                 return *mp;
+//             }
+//             else
+//             {
+//                 KRATOS_ERROR << "The ModelPart named : \"" << subparts_list[0]
+//                     << "\" was not found as root-ModelPart. The total input string was \""
+//                     << rFullModelPartName << "\"" << std::endl;
+//             }
+// 
+//         }
 
         KRATOS_CATCH("")
     }
@@ -147,7 +215,7 @@ namespace Kratos
         auto search = mRootModelPartMap.find(subparts_list[0]);
         if(search != mRootModelPartMap.end())
         {
-            ModelPart* mp = search->second;
+            ModelPart* mp = (search->second).get();
             for(unsigned int i=1; i<subparts_list.size(); i++)
             {
                 if(!mp->HasSubModelPart(subparts_list[i]))
@@ -169,7 +237,7 @@ namespace Kratos
         std::stringstream ss;
         for(auto it = mRootModelPartMap.begin(); it!=mRootModelPartMap.end(); it++)
         {
-            ss<< it->second->Info() << std::endl << std::endl;
+//             ss<< (it->second).get()->Info() << std::endl << std::endl;
         }
         return ss.str();
     }
@@ -197,6 +265,19 @@ namespace Kratos
         {
             rSubPartsList.push_back(token);
         }
+    }
+    
+    ModelPart* Model::RecursiveSearchByName(const std::string& ModelPartName, ModelPart* pModelPart)
+    {
+
+        for(auto& part : pModelPart->SubModelParts())
+        {
+            if(part.Name() == ModelPartName)
+                return &part;
+            else
+                RecursiveSearchByName(ModelPartName, &part);
+        }
+        return nullptr;
     }
 
 }  // namespace Kratos.

--- a/kratos/containers/model.cpp
+++ b/kratos/containers/model.cpp
@@ -32,10 +32,12 @@ namespace Kratos
     {
         KRATOS_TRY
         
-        //TODO: flat map should disappear in the future!!
+        std::cout << "within CreateModelPart address of Model is " <<  &(*this) << std::endl;
+        
         auto search = mRootModelPartMap.find(ModelPartName);
         if( search == mRootModelPartMap.end())
         {
+            std::cout << ModelPartName << std::endl;
             mRootModelPartMap[ModelPartName] = std::unique_ptr<ModelPart>(new ModelPart(ModelPartName));
             return *(mRootModelPartMap[ModelPartName].get());
         }
@@ -87,7 +89,7 @@ namespace Kratos
 //         //TODO: flat map should disappear in the future!!
 //         auto search = mflat_map.find(pModelPart->Name());
 //         if( search == mflat_map.end())
-//         {
+//         {ModelPartName
 //             mflat_map[pModelPart->Name()] = pModelPart;
 // 
 //             //walk the submodelparts
@@ -111,12 +113,17 @@ namespace Kratos
     ModelPart& Model::GetModelPart(const std::string& rFullModelPartName)
     {
         KRATOS_TRY
+        
+        std::cout << "within GetModelPart address of Model is " <<  &(*this) << std::endl;
 
         KRATOS_ERROR_IF( rFullModelPartName.empty() ) << "Attempting to find a "
             << "ModelPart with empty name (\"\")!" << std::endl;
             
         std::vector< std::string > subparts_list;
         GetSubPartsList(rFullModelPartName, subparts_list);
+        
+        KRATOS_WATCH(subparts_list.size())
+        KRATOS_WATCH(subparts_list[0])
         
         if(subparts_list.size() == 1) //it is a root model part
         {
@@ -135,7 +142,10 @@ namespace Kratos
                 }
                 
                 //if we are here we did not find it
-                KRATOS_ERROR << "model part with name " << subparts_list[0] << " is not found either as root or as submodelpart of any level" << std::endl;
+//                 KRATOS_ERROR << "model part with name " << subparts_list[0] << " is not found either as root or as submodelpart of any level" << std::endl;
+                KRATOS_ERROR << "The ModelPart named : \"" << subparts_list[0]
+                     << "\" was not found as root-ModelPart. The total input string was \""
+                     << rFullModelPartName << "\"" << std::endl;
             }
         }
         else //it is a submodelpart with the full name provided
@@ -147,6 +157,11 @@ namespace Kratos
                 ModelPart* p_model_part = (search->second).get();
                 for(unsigned int i=1; i<subparts_list.size(); ++i)
                 {
+                    KRATOS_ERROR_IF_NOT(p_model_part->HasSubModelPart(subparts_list[i]))
+                        << "The ModelPart named : \"" << subparts_list[i]
+                        << "\" was not found as SubModelPart of : \""
+                        << subparts_list[i-1] << "\". The total input string was \""
+                        << rFullModelPartName << "\"" << std::endl;
                     p_model_part = &p_model_part->GetSubModelPart(subparts_list[i]);
                 }
                 return *p_model_part;

--- a/kratos/containers/model.h
+++ b/kratos/containers/model.h
@@ -73,11 +73,16 @@ namespace Kratos
 
       /// Destructor.
       virtual ~Model(){};
+      
+      Model & operator=(const Model&) = delete;
+      Model(const Model&) = delete;
 
 
       ///@}
       ///@name Operators
       ///@{
+      ModelPart& CreateModelPart( const std::string ModelPartName );
+      
       void AddModelPart(ModelPart::Pointer pModelPart); //TODO: change this conveniently
 
       ModelPart& GetModelPart(const std::string& rFullModelPartName);
@@ -165,8 +170,7 @@ namespace Kratos
       ///@}
       ///@name Member Variables
       ///@{
-      std::unordered_map< std::string, ModelPart* > mflat_map; //TODO: deprecate this
-      std::unordered_map< std::string, ModelPart* > mRootModelPartMap;
+      std::map< std::string, std::unique_ptr<ModelPart> > mRootModelPartMap;
 
 
       ///@}
@@ -177,7 +181,8 @@ namespace Kratos
       ///@}
       ///@name Private Operations
       ///@{
-
+      ModelPart* RecursiveSearchByName(const std::string& ModelPartName, ModelPart* pModelPart);
+      
       void GetSubPartsList(const std::string& rFullModelPartName,
                            std::vector<std::string>& rSubPartsList);
 

--- a/kratos/containers/model.h
+++ b/kratos/containers/model.h
@@ -69,10 +69,20 @@ namespace Kratos
       ///@{
 
       /// Default constructor.
-      Model(){};
+      Model();
+//       {
+//           Model*& pregistered_model = Kernel::GetModel();
+//           if(pregistered_model != nullptr)
+//               KRATOS_ERROR << "trying to create a new Model, however one is already existing" << std::endl;
+//           pregistered_model = &(*this);
+//       };
 
       /// Destructor.
-      virtual ~Model(){};
+      virtual ~Model();
+//       {
+//         Model*& pregistered_model = Kernel::GetModel();    
+//         pregistered_model = nullptr;
+//       };
       
       Model & operator=(const Model&) = delete;
       Model(const Model&) = delete;

--- a/kratos/includes/kernel.h
+++ b/kratos/includes/kernel.h
@@ -127,7 +127,8 @@ class KRATOS_API(KRATOS_CORE) Kernel {
 
     static std::unordered_set<std::string>& GetApplicationsList();
     
-    static Model& GetModel();
+//     static Model& GetModel();
+    static Model*& GetModel();
 
     ///@}
    protected:

--- a/kratos/includes/kernel.h
+++ b/kratos/includes/kernel.h
@@ -25,9 +25,10 @@
 #include "includes/define.h"
 #include "includes/variables.h"
 #include "includes/kratos_application.h"
+// #include "containers/model.h"
 
 namespace Kratos {
-
+class Model;
 ///@name Kratos Classes
 ///@{
 
@@ -124,8 +125,9 @@ class KRATOS_API(KRATOS_CORE) Kernel {
     /// Print object's data.
     virtual void PrintData(std::ostream& rOStream) const;
 
-    static std::unordered_set<std::string>&
-    GetApplicationsList();
+    static std::unordered_set<std::string>& GetApplicationsList();
+    
+    static Model& GetModel();
 
     ///@}
    protected:

--- a/kratos/python/add_kernel_to_python.cpp
+++ b/kratos/python/add_kernel_to_python.cpp
@@ -150,7 +150,7 @@ void AddKernelToPython(pybind11::module& m) {
                                 self.Initialize(); 
                                 /*RegisterInPythonApplicationVariables(App);*/ }) //&Kernel::InitializeApplication)
         //.def(""A,&Kernel::Initialize)
-        .def("GetModel", [](Kernel& self) -> Model& { return self.GetModel();}, return_value_policy::reference_internal)
+        .def("GetModel", [](Kernel& self) -> Model& { return *(self.GetModel());}, return_value_policy::reference_internal)
         .def("IsImported", &Kernel::IsImported)
         .def("HasFlag", HasFlag)
         .def("GetFlag", GetFlag)

--- a/kratos/python/add_kernel_to_python.cpp
+++ b/kratos/python/add_kernel_to_python.cpp
@@ -16,6 +16,7 @@
 // Project includes
 #include "includes/define_python.h"
 #include "includes/kernel.h"
+#include "containers/model.h"
 #include "python/add_kernel_to_python.h"
 
 // System includes
@@ -149,6 +150,7 @@ void AddKernelToPython(pybind11::module& m) {
                                 self.Initialize(); 
                                 /*RegisterInPythonApplicationVariables(App);*/ }) //&Kernel::InitializeApplication)
         //.def(""A,&Kernel::Initialize)
+        .def_static("GetModel", &Kernel::GetModel, return_value_policy::reference_internal)
         .def("IsImported", &Kernel::IsImported)
         .def("HasFlag", HasFlag)
         .def("GetFlag", GetFlag)

--- a/kratos/python/add_kernel_to_python.cpp
+++ b/kratos/python/add_kernel_to_python.cpp
@@ -150,7 +150,7 @@ void AddKernelToPython(pybind11::module& m) {
                                 self.Initialize(); 
                                 /*RegisterInPythonApplicationVariables(App);*/ }) //&Kernel::InitializeApplication)
         //.def(""A,&Kernel::Initialize)
-        .def_static("GetModel", &Kernel::GetModel, return_value_policy::reference_internal)
+        .def("GetModel", [](Kernel& self) -> Model& { return self.GetModel();}, return_value_policy::reference_internal)
         .def("IsImported", &Kernel::IsImported)
         .def("HasFlag", HasFlag)
         .def("GetFlag", GetFlag)

--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -612,9 +612,9 @@ void AddModelPartToPython(pybind11::module& m)
         
         ;
 
-	class_<ModelPart/*, ModelPart::Pointer*/, DataValueContainer, Flags >(m,"ModelPartInterface") //NOTE: name changed to ModelPartInterface to allow using a function as constructor, and to call the function ModelPart()
-// 		.def(init<std::string const&>())
-// 		.def(init<>())
+        //NOTE: name changed to ModelPartInterface to allow using a function as constructor, and to call the function ModelPart()
+	class_<ModelPart, ModelPart::Pointer, DataValueContainer, Flags >(m,"ModelPartInterface") 
+// 		.def(init<std::string const&>()) //this constructor is deliberately removed
 		.def_property("Name", GetModelPartName, SetModelPartName)
 		//  .def_property("ProcessInfo", GetProcessInfo, SetProcessInfo)
 		.def_property("ProcessInfo", pointer_to_get_process_info, pointer_to_set_process_info)

--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -21,6 +21,8 @@
 
 // Project includes
 #include "includes/define_python.h"
+#include "includes/kernel.h"
+#include "containers/model.h"
 #include "includes/model_part.h"
 #include "python/add_model_part_to_python.h"
 #include "includes/process_info.h"
@@ -610,9 +612,9 @@ void AddModelPartToPython(pybind11::module& m)
         
         ;
 
-	class_<ModelPart, ModelPart::Pointer, DataValueContainer, Flags >(m,"ModelPart")
-		.def(init<std::string const&>())
-		.def(init<>())
+	class_<ModelPart/*, ModelPart::Pointer*/, DataValueContainer, Flags >(m,"ModelPartInterface") //NOTE: name changed to ModelPartInterface to allow using a function as constructor, and to call the function ModelPart()
+// 		.def(init<std::string const&>())
+// 		.def(init<>())
 		.def_property("Name", GetModelPartName, SetModelPartName)
 		//  .def_property("ProcessInfo", GetProcessInfo, SetProcessInfo)
 		.def_property("ProcessInfo", pointer_to_get_process_info, pointer_to_set_process_info)
@@ -742,6 +744,10 @@ void AddModelPartToPython(pybind11::module& m)
                                         [](ModelPart& self, ModelPart::SubModelPartsContainerType& subs){ KRATOS_ERROR << "setting submodelparts is not allowed"; }) 
  		.def("__repr__", [](const ModelPart& self) -> const std::string { std::stringstream ss;  ss << self; return ss.str(); })
 		;
+                
+        //defining the "constructor"
+        m.def("ModelPart", [](std::string const& name) -> ModelPart& { return Kernel::GetModel().CreateModelPart(name);}, return_value_policy::reference);
+
 }
 
 } // namespace Python.

--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -746,7 +746,7 @@ void AddModelPartToPython(pybind11::module& m)
 		;
                 
         //defining the "constructor"
-        m.def("ModelPart", [](std::string const& name) -> ModelPart& { return Kernel::GetModel().CreateModelPart(name);}, return_value_policy::reference);
+        m.def("ModelPart", [](std::string const& name) -> ModelPart& { return Kernel::GetModel()->CreateModelPart(name);}, return_value_policy::reference);
 
 }
 

--- a/kratos/python/add_model_to_python.cpp
+++ b/kratos/python/add_model_to_python.cpp
@@ -31,10 +31,11 @@ using namespace pybind11;
 
 void  AddModelToPython(pybind11::module& m)
 {
-    m.def("Model", &Kernel::GetModel, return_value_policy::reference);
+//     m.def("Model", &Kernel::GetModel, return_value_policy::reference);
     
-    //NOTE: we call this class "ModelInterface" instead of "Model" since the cosntructor is emulated as a standalone function which gets it from the kernel
-    class_<Model >(m,"ModelInterface")
+// // // // //     //NOTE: we call this class "ModelInterface" instead of "Model" since the cosntructor is emulated as a standalone function which gets it from the kernel
+    class_<Model >(m,"Model")
+    .def(init<>())
     .def("AddModelPart", &Model::AddModelPart)
     .def("GetModelPart", &Model::GetModelPart, return_value_policy::reference_internal)
     .def("HasModelPart", &Model::HasModelPart)

--- a/kratos/python/add_model_to_python.cpp
+++ b/kratos/python/add_model_to_python.cpp
@@ -31,11 +31,10 @@ using namespace pybind11;
 
 void  AddModelToPython(pybind11::module& m)
 {
-    m.def("GetModel", &Kernel::GetModel, return_value_policy::reference_internal);
+    m.def("Model", &Kernel::GetModel, return_value_policy::reference);
     
-    class_<Model/*, Model::Pointer*/ >(m,"Model")
-//     .def(init([]() { return Kernel::GetModel(); }), )
-//     .def(init<>())
+    //NOTE: we call this class "ModelInterface" instead of "Model" since the cosntructor is emulated as a standalone function which gets it from the kernel
+    class_<Model >(m,"ModelInterface")
     .def("AddModelPart", &Model::AddModelPart)
     .def("GetModelPart", &Model::GetModelPart, return_value_policy::reference_internal)
     .def("HasModelPart", &Model::HasModelPart)

--- a/kratos/python/add_model_to_python.cpp
+++ b/kratos/python/add_model_to_python.cpp
@@ -17,6 +17,7 @@
 
 // Project includes
 #include "includes/define_python.h"
+#include "includes/kernel.h"
 #include "containers/model.h"
 #include "python/add_model_to_python.h"
 
@@ -30,8 +31,11 @@ using namespace pybind11;
 
 void  AddModelToPython(pybind11::module& m)
 {
-    class_<Model, Model::Pointer >(m,"Model")
-    .def(init<>())
+    m.def("GetModel", &Kernel::GetModel, return_value_policy::reference_internal);
+    
+    class_<Model/*, Model::Pointer*/ >(m,"Model")
+//     .def(init([]() { return Kernel::GetModel(); }), )
+//     .def(init<>())
     .def("AddModelPart", &Model::AddModelPart)
     .def("GetModelPart", &Model::GetModelPart, return_value_policy::reference_internal)
     .def("HasModelPart", &Model::HasModelPart)

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -37,10 +37,16 @@ std::unordered_set<std::string> &Kernel::GetApplicationsList() {
   return application_list;
 }
 
-Model& Kernel::GetModel()
+// Model& Kernel::GetModel()
+// {
+//     static Model smodel;
+//     return smodel;
+// }
+
+Model*& Kernel::GetModel()
 {
-    static Model smodel;
-    return smodel;
+    static Model* spmodel;
+    return spmodel;
 }
 
 bool Kernel::IsImported(std::string ApplicationName) const {

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -14,6 +14,8 @@
 #include "includes/kernel.h"
 #include "includes/kratos_version.h"
 #include "input_output/logger.h"
+#include "containers/model.h"
+
 
 namespace Kratos {
 Kernel::Kernel() : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(
@@ -33,6 +35,12 @@ Kernel::Kernel() : mpKratosCoreApplication(Kratos::make_shared<KratosApplication
 std::unordered_set<std::string> &Kernel::GetApplicationsList() {
   static std::unordered_set<std::string> application_list;
   return application_list;
+}
+
+Model& Kernel::GetModel()
+{
+    static Model smodel;
+    return smodel;
 }
 
 bool Kernel::IsImported(std::string ApplicationName) const {

--- a/kratos/tests/test_model.py
+++ b/kratos/tests/test_model.py
@@ -14,9 +14,14 @@ class TestModel(KratosUnittest.TestCase):
         outlet = model_part.CreateSubModelPart("Outlet")
 
         model = KratosMultiphysics.Model()
-        model.AddModelPart(model_part)
+        #model.AddModelPart(model_part)
+        print("----------------")
 
         aaa = model["Main.Outlet"].CreateSubModelPart("aaa")
+        print(" Main -->",model["Main"])
+        print("---------------------")
+        print(" Main.Outlet -->",model["Main.Outlet"])
+        print(aaa)
 
         if (sys.version_info < (3, 2)):
             self.assertRaisesRegex = self.assertRaisesRegexp

--- a/kratos/tests/test_model.py
+++ b/kratos/tests/test_model.py
@@ -8,12 +8,14 @@ import sys
 class TestModel(KratosUnittest.TestCase):
 
     def test_model(self):
+        model = KratosMultiphysics.Model() #this should go before the creation of any modelpart
+        
         model_part = KratosMultiphysics.ModelPart("Main")
         model_part.CreateSubModelPart("Inlets")
         model_part.CreateSubModelPart("Temp")
         outlet = model_part.CreateSubModelPart("Outlet")
 
-        model = KratosMultiphysics.Model()
+        
         #model.AddModelPart(model_part)
         print("----------------")
 

--- a/kratos/tests/test_model_part.py
+++ b/kratos/tests/test_model_part.py
@@ -12,6 +12,8 @@ class TestModelPart(KratosUnittest.TestCase):
             self.assertRaisesRegex = self.assertRaisesRegexp
 
     def test_model_part_sub_model_parts(self):
+        model = Model() #this should go before the creation of any modelpart
+        
         model_part = ModelPart("Main")
 
         self.assertEqual(model_part.NumberOfSubModelParts(), 0)
@@ -65,6 +67,8 @@ class TestModelPart(KratosUnittest.TestCase):
         #print (model_part)
 
     def test_variables_list(self):
+        model = Model() #this should go before the creation of any modelpart
+        
         model_part = ModelPart("Main")
 
         self.assertEqual(model_part.GetNodalSolutionStepDataSize(), 0)
@@ -98,6 +102,7 @@ class TestModelPart(KratosUnittest.TestCase):
 
 
     def test_model_part_nodes(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part = ModelPart("Main")
 
         self.assertEqual(model_part.NumberOfNodes(), 0)
@@ -190,6 +195,7 @@ class TestModelPart(KratosUnittest.TestCase):
         self.assertEqual(model_part.NumberOfNodes(), 7)
 
     def test_model_part_tables(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part = ModelPart("Main")
 
         self.assertEqual(model_part.NumberOfTables(), 0)
@@ -212,6 +218,7 @@ class TestModelPart(KratosUnittest.TestCase):
         #self.assertEqual(model_part.NumberOfTables(), 0)
 
     def test_model_part_properties(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part = ModelPart("Main")
 
         self.assertEqual(model_part.NumberOfProperties(), 0)
@@ -287,6 +294,7 @@ class TestModelPart(KratosUnittest.TestCase):
         self.assertEqual(model_part.NumberOfProperties(), 7)
 
     def test_model_part_elements(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part = ModelPart("Main")
 
         self.assertEqual(model_part.NumberOfElements(), 0)
@@ -380,6 +388,7 @@ class TestModelPart(KratosUnittest.TestCase):
         self.assertEqual(model_part.NumberOfElements(), 7)
 
     def test_model_part_conditions(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part = ModelPart("Main")
 
         self.assertEqual(model_part.NumberOfConditions(), 0)
@@ -472,6 +481,7 @@ class TestModelPart(KratosUnittest.TestCase):
         self.assertEqual(model_part.NumberOfConditions(), 7)
 
     def test_modelpart_variables_list(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part = ModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VELOCITY)
 
@@ -482,6 +492,7 @@ class TestModelPart(KratosUnittest.TestCase):
         self.assertTrue(model_part.Nodes[1].SolutionStepsDataHas(VELOCITY))
 
     def test_modelpart_buffersize(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part = ModelPart("Main")
         model_part.SetBufferSize(3)
         
@@ -490,6 +501,7 @@ class TestModelPart(KratosUnittest.TestCase):
         self.assertEqual(model_part.GetBufferSize(), submodel.GetBufferSize() )
         
     def test_add_node(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part1 = ModelPart("Main")
         sub1 = model_part1.CreateSubModelPart("sub1")
         sub2 = model_part1.CreateSubModelPart("sub2")
@@ -536,6 +548,7 @@ class TestModelPart(KratosUnittest.TestCase):
         self.assertFalse( n5.Id in sub2.Nodes )
         
     def test_add_condition(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part1 = ModelPart("Main")
         sub1 = model_part1.CreateSubModelPart("sub1")
         sub2 = model_part1.CreateSubModelPart("sub2")
@@ -585,6 +598,7 @@ class TestModelPart(KratosUnittest.TestCase):
 
             
     def test_add_element(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part1 = ModelPart("Main")
         sub1 = model_part1.CreateSubModelPart("sub1")
         sub2 = model_part1.CreateSubModelPart("sub2")
@@ -633,6 +647,7 @@ class TestModelPart(KratosUnittest.TestCase):
         self.assertFalse( e5.Id in sub2.Elements )
         
     def test_model_part_iterators(self):
+        model = Model() #this should go before the creation of any modelpart
         model_part1 = ModelPart("Main")
         sub1 = model_part1.CreateSubModelPart("sub1")
         sub2 = model_part1.CreateSubModelPart("sub2")


### PR DESCRIPTION
This is a PR for discussion in the @KratosMultiphysics/technical-committee 

it is a first stride towards having the ModelParts registered automatically in the Model.

In the current proposal all root model_parts are automatically registered in the Model who becomes "the unique owner of root modelparts" with a lifetime tied, as of now, to the one of the kernel. 
Submodelparts are owned by their father moedlparts.
Indeed in the current proposal the Model is a static of the kernel, hence a single model is possible.

On the good side, making the Model as a static global variable makes it possible to maintain identical the current interface of the ModelPart and of the Model.

On the bad side, since the lifespan is as the one of the kernel, it for example outlives single tests, so we would have to "reset" it at the end of each test. This is definitely something that i don't like... and something to be discussd very carefully.



