### PR TITLE
Defining Kratos::make_unique and UniquePointer type.

### DIFF
--- a/kratos/includes/shared_pointers.h
+++ b/kratos/includes/shared_pointers.h
@@ -27,10 +27,20 @@ using shared_ptr = std::shared_ptr<T>; //std::shared_ptr<T>;
 
 template<class T>
 using weak_ptr = std::weak_ptr<T>; //std::weak_ptr<T>;
-    
+
+template<class T>
+using unique_ptr = std::unique_ptr<T>;
+
 template<typename C, typename...Args>
 shared_ptr<C> make_shared(Args &&...args) {
     return std::make_shared<C>(std::forward<Args>(args)...);
+
+}
+
+template<typename C, typename...Args>
+unique_ptr<C> make_unique(Args &&...args) {
+    // Note: std::make_unique is C++14, this can be updated once we upgrade from C++11
+    return unique_ptr<C>(new C(std::forward<Args>(args)...));
 }
 
 template<typename C, typename...Args>
@@ -53,10 +63,11 @@ shared_ptr<C> const_pointer_cast(Args &&...args) {
 //     return std::reinterpret_pointer_cast<C>(std::forward<Args>(args)...);
 // }
 } // namespace Kratos
-    
+
 
 #define KRATOS_CLASS_POINTER_DEFINITION(a) typedef Kratos::shared_ptr<a > Pointer; \
 typedef Kratos::shared_ptr<a > SharedPointer; \
-typedef Kratos::weak_ptr<a > WeakPointer
+typedef Kratos::weak_ptr<a > WeakPointer; \
+typedef Kratos::unique_ptr<a > UniquePointer
 
 #endif /* KRATOS_MEMORY_H_INCLUDED  defined */


### PR DESCRIPTION
Defining a UniquePointer type for kratos classes and a `Kratos::make_unique` function to create unique pointers. Note that I could not use `std::make_unique` since that one is C++14, but we can update it if we ever decide to adopt a newer standard.

This came up in the review of #1833 but I'd prefer for it to be reviewed separately.