### PR TITLE
Removing a few includes of line_2d.h.

### DIFF
--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
@@ -21,7 +21,7 @@
 #include "geometries/tetrahedra_3d_4.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "geometries/hexahedra_3d_8.h"
-#include "geometries/line_2d.h"
+#include "geometries/line_2d_2.h"
 #include "geometries/line_2d_3.h"
 #include "fluid_dynamics_application.h"
 #include "includes/variables.h"

--- a/applications/StabilizedCFDApplication/stabilized_cfd_application.cpp
+++ b/applications/StabilizedCFDApplication/stabilized_cfd_application.cpp
@@ -25,7 +25,7 @@
 #include "geometries/quadrilateral_2d_4.h"
 #include "geometries/tetrahedra_3d_4.h"
 #include "geometries/hexahedra_3d_8.h"
-#include "geometries/line_2d.h"
+#include "geometries/line_2d_2.h"
 
 namespace Kratos {
 

--- a/applications/ThermoMechanicalApplication/thermo_mechanical_application.cpp
+++ b/applications/ThermoMechanicalApplication/thermo_mechanical_application.cpp
@@ -19,7 +19,7 @@
 #include "geometries/triangle_2d_3.h"
 #include "geometries/triangle_3d_3.h"
 #include "geometries/tetrahedra_3d_4.h"
-#include "geometries/line_2d.h"
+#include "geometries/line_2d_2.h"
 #include "thermo_mechanical_application.h"
 #include "includes/variables.h"
 
@@ -63,9 +63,9 @@ void KratosThermoMechanicalApplication::Register()
     KRATOS_REGISTER_ELEMENT("SUPGConvDiff3D", mSUPGConvDiff3D);
     KRATOS_REGISTER_ELEMENT("SUPGConv3D", mSUPGConv3D);
     KRATOS_REGISTER_ELEMENT("SUPGConv2D", mSUPGConv2D);
-    KRATOS_REGISTER_ELEMENT("SUPGConv3D", mSUPGConv3D);    
+    KRATOS_REGISTER_ELEMENT("SUPGConv3D", mSUPGConv3D);
     // KRATOS_REGISTER_ELEMENT("Poisson3D", mPoisson3D);
-	KRATOS_REGISTER_ELEMENT("SUPGConvLevelSet", mSUPGConvLevelSet); 
+	KRATOS_REGISTER_ELEMENT("SUPGConvLevelSet", mSUPGConvLevelSet);
 }
 
 }  // namespace Kratos.


### PR DESCRIPTION
Related to #2070. Removing references to line_2d.h from fluid dynamics and related applications. Curiously, the Line2D class was not used, only the includes were wrong.