### PR TITLE
[Core] ModelPart Check for nodes only if Variable was not added yet

### DIFF
--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -105,10 +105,10 @@ public:
     typedef Dof<double> DofType;
 
 //     typedef PointerVectorSet<DofType, SetIdentityFunction<DofType> > DofsArrayType;
-    typedef PointerVectorSet<DofType, 
-                SetIdentityFunction<DofType>, 
+    typedef PointerVectorSet<DofType,
+                SetIdentityFunction<DofType>,
                 std::less<SetIdentityFunction<DofType>::result_type>,
-                std::equal_to<SetIdentityFunction<DofType>::result_type>, 
+                std::equal_to<SetIdentityFunction<DofType>::result_type>,
                 DofType* > DofsArrayType;
 
 
@@ -309,11 +309,11 @@ public:
     void AddNode(NodeType::Pointer pNewNode, IndexType ThisIndex = 0);
 
     /** Inserts a list of nodes in a submodelpart provided their Id. Does nothing if applied to the top model part
-     */    
+     */
     void AddNodes(std::vector<IndexType> const& NodeIds, IndexType ThisIndex = 0);
-    
+
     /** Inserts a list of pointers to nodes
-     */    
+     */
     template<class TIteratorType >
     void AddNodes(TIteratorType nodes_begin,  TIteratorType nodes_end, IndexType ThisIndex = 0)
     {
@@ -321,7 +321,7 @@ public:
         ModelPart::NodesContainerType  aux;
         ModelPart::NodesContainerType  aux_root; //they may not exist in the root
         ModelPart* root_model_part = &this->GetRootModelPart();
-        
+
         for(TIteratorType it = nodes_begin; it!=nodes_end; it++)
         {
             auto it_found = root_model_part->Nodes().find(it->Id());
@@ -336,28 +336,28 @@ public:
                     KRATOS_ERROR << "attempting to add a new node with Id :" << it_found->Id() << ", unfortunately a (different) node with the same Id already exists" << std::endl;
                 else
                     aux.push_back( *(it.base()) );
-                    
+
             }
         }
-        
+
         //now add to the root model part
         for(auto it = aux_root.begin(); it!=aux_root.end(); it++)
             root_model_part->Nodes().push_back( *(it.base()) );
         root_model_part->Nodes().Unique();
-        
+
         //add to all of the leaves
-        
+
         ModelPart* current_part = this;
         while(current_part->IsSubModelPart())
         {
             for(auto it = aux.begin(); it!=aux.end(); it++)
                 current_part->Nodes().push_back( *(it.base()) );
-            
+
             current_part->Nodes().Unique();
-            
+
             current_part = current_part->GetParentModelPart();
         }
-        
+
         KRATOS_CATCH("")
     }
 
@@ -469,8 +469,11 @@ public:
     template<class TDataType>
     void AddNodalSolutionStepVariable(Variable<TDataType> const& ThisVariable)
     {
-        KRATOS_ERROR_IF((this->GetRootModelPart()).Nodes().size() != 0) << "attempting to add the variable: " << ThisVariable.Name() << " to the model part with name: " << this->Name() << " which is not empty" << std::endl;
-        mpVariablesList->Add(ThisVariable);
+        if (!mpVariablesList->Has(ThisVariable))
+        {
+            KRATOS_ERROR_IF((this->GetRootModelPart()).Nodes().size() != 0) << "attempting to add the variable: " << ThisVariable.Name() << " to the model part with name: " << this->Name() << " which is not empty" << std::endl;
+            mpVariablesList->Add(ThisVariable);
+        }
     }
 
     VariablesList& GetNodalSolutionStepVariablesList()
@@ -587,7 +590,7 @@ public:
         {
             if(IsSubModelPart())
             {
-                PropertiesType::Pointer pprop =  mpParentModelPart->pGetProperties(PropertiesId, ThisIndex);                
+                PropertiesType::Pointer pprop =  mpParentModelPart->pGetProperties(PropertiesId, ThisIndex);
                 GetMesh(ThisIndex).AddProperties(pprop);
                 return pprop;
             }
@@ -612,7 +615,7 @@ public:
         {
             if(IsSubModelPart())
             {
-                PropertiesType::Pointer pprop =  mpParentModelPart->pGetProperties(PropertiesId, ThisIndex);                
+                PropertiesType::Pointer pprop =  mpParentModelPart->pGetProperties(PropertiesId, ThisIndex);
                 GetMesh(ThisIndex).AddProperties(pprop);
                 return *pprop;
             }
@@ -706,13 +709,13 @@ public:
     /** Inserts a element in the current mesh.
      */
     void AddElement(ElementType::Pointer pNewElement, IndexType ThisIndex = 0);
-    
+
     /** Inserts a list of elements to a submodelpart provided their Id. Does nothing if applied to the top model part
-     */    
+     */
     void AddElements(std::vector<IndexType> const& ElementIds, IndexType ThisIndex = 0);
-    
+
     /** Inserts a list of pointers to nodes
-     */    
+     */
     template<class TIteratorType >
     void AddElements(TIteratorType elements_begin,  TIteratorType elements_end, IndexType ThisIndex = 0)
     {
@@ -720,7 +723,7 @@ public:
         ModelPart::ElementsContainerType  aux;
         ModelPart::ElementsContainerType  aux_root;
         ModelPart* root_model_part = &this->GetRootModelPart();
-        
+
         for(TIteratorType it = elements_begin; it!=elements_end; it++)
         {
             auto it_found = root_model_part->Elements().find(it->Id());
@@ -737,24 +740,24 @@ public:
                     aux.push_back( *(it.base()) );
             }
         }
-        
+
         for(auto it = aux_root.begin(); it!=aux_root.end(); it++)
                 root_model_part->Elements().push_back( *(it.base()) );
         root_model_part->Elements().Unique();
-        
+
         //add to all of the leaves
-        
+
         ModelPart* current_part = this;
         while(current_part->IsSubModelPart())
         {
             for(auto it = aux.begin(); it!=aux.end(); it++)
                 current_part->Elements().push_back( *(it.base()) );
-            
+
             current_part->Elements().Unique();
-            
+
             current_part = current_part->GetParentModelPart();
         }
-        
+
         KRATOS_CATCH("")
     }
 
@@ -869,13 +872,13 @@ public:
     /** Inserts a condition in the current mesh.
      */
     void AddCondition(ConditionType::Pointer pNewCondition, IndexType ThisIndex = 0);
-    
+
     /** Inserts a list of conditions to a submodelpart provided their Id. Does nothing if applied to the top model part
-     */    
+     */
     void AddConditions(std::vector<IndexType> const& ConditionIds, IndexType ThisIndex = 0);
-    
+
     /** Inserts a list of pointers to nodes
-     */    
+     */
     template<class TIteratorType >
     void AddConditions(TIteratorType conditions_begin,  TIteratorType conditions_end, IndexType ThisIndex = 0)
     {
@@ -883,7 +886,7 @@ public:
         ModelPart::ConditionsContainerType  aux;
         ModelPart::ConditionsContainerType  aux_root;
         ModelPart* root_model_part = &this->GetRootModelPart();
-        
+
         for(TIteratorType it = conditions_begin; it!=conditions_end; it++)
         {
             auto it_found = root_model_part->Conditions().find(it->Id());
@@ -900,25 +903,25 @@ public:
                     aux.push_back( *(it.base()) );
             }
         }
-        
+
         //now add to the root model part
         for(auto it = aux_root.begin(); it!=aux_root.end(); it++)
                 root_model_part->Conditions().push_back( *(it.base()) );
         root_model_part->Conditions().Unique();
-        
+
         //add to all of the leaves
-        
+
         ModelPart* current_part = this;
         while(current_part->IsSubModelPart())
         {
             for(auto it = aux.begin(); it!=aux.end(); it++)
                 current_part->Conditions().push_back( *(it.base()) );
-            
+
             current_part->Conditions().Unique();
-            
+
             current_part = current_part->GetParentModelPart();
         }
-        
+
         KRATOS_CATCH("")
     }
 
@@ -1223,7 +1226,7 @@ public:
     ///@{
 
     std::vector<std::string> GetSubModelPartNames();
-    
+
     void SetBufferSize(IndexType NewBufferSize);
 
     IndexType GetBufferSize()
@@ -1390,6 +1393,6 @@ KRATOS_API(KRATOS_CORE) inline std::ostream & operator <<(std::ostream& rOStream
 
 } // namespace Kratos.
 
-#endif // KRATOS_MODEL_PART_H_INCLUDED  defined 
+#endif // KRATOS_MODEL_PART_H_INCLUDED  defined
 
 

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -471,7 +471,9 @@ public:
     {
         if (!mpVariablesList->Has(ThisVariable))
         {
-            KRATOS_ERROR_IF((this->GetRootModelPart()).Nodes().size() != 0) << "attempting to add the variable: " << ThisVariable.Name() << " to the model part with name: " << this->Name() << " which is not empty" << std::endl;
+            KRATOS_ERROR_IF((this->GetRootModelPart()).Nodes().size() != 0)
+                << "Attempting to add the variable \"" << ThisVariable.Name()
+                << "\" to the model part with name \"" << this->Name() << "\" which is not empty" << std::endl;
             mpVariablesList->Add(ThisVariable);
         }
     }

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -471,9 +471,11 @@ public:
     {
         if (!mpVariablesList->Has(ThisVariable))
         {
+            // This error prevents memory leaks if variables are being added to a non-empty modelpart
             KRATOS_ERROR_IF((this->GetRootModelPart()).Nodes().size() != 0)
                 << "Attempting to add the variable \"" << ThisVariable.Name()
                 << "\" to the model part with name \"" << this->Name() << "\" which is not empty" << std::endl;
+
             mpVariablesList->Add(ThisVariable);
         }
     }

--- a/kratos/tests/sources/test_model_part.cpp
+++ b/kratos/tests/sources/test_model_part.cpp
@@ -8,7 +8,7 @@
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
-//
+//                   Philipp Bucher
 //
 
 // Project includes
@@ -35,6 +35,20 @@ namespace Kratos {
 			KRATOS_CHECK_EQUAL(model_part.GetSubModelPart("Inlet1").NumberOfNodes(), 1);
 			KRATOS_CHECK_EQUAL(model_part.GetSubModelPart("Outlet").NumberOfNodes(), 1);
 			KRATOS_CHECK_EQUAL(model_part.GetSubModelPart("Outlet").GetNode(2).Id(), 2);
+		}
+
+		KRATOS_TEST_CASE_IN_SUITE(ModelPartAddNodalSolutionStepVariable, KratosCoreFastSuite)
+		{
+			ModelPart model_part("Main");
+
+            model_part.AddNodalSolutionStepVariable(VELOCITY);
+
+            model_part.CreateNewNode(123, 0.00,0.00,0.00);
+
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(model_part.AddNodalSolutionStepVariable(PRESSURE),
+                "Error: Attempting to add the variable \"PRESSURE\" to the model part with name \"Main\" which is not empty");
+
+            model_part.AddNodalSolutionStepVariable(VELOCITY); // Adding the same Variable twice is fine bcs it wont do anything
 		}
 	}
 }  // namespace Kratos.


### PR DESCRIPTION
This PR adds an `if` to only throw the error if the Variable does not exist yet. 

The VariableList checks internally if the Variable was added yet so the function in the ModelPart can be called safely

Sorry for the whitespace changes

@jcotela as discussed