### PR TITLE
[StructuralMechanics] Disabling Arc-Length

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/StructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -29,7 +29,7 @@
 #include "custom_strategies/custom_strategies/eigensolver_strategy.hpp"
 #include "custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp"
 #include "custom_strategies/custom_strategies/formfinding_updated_reference_strategy.hpp"
-#include "custom_strategies/custom_strategies/mechanical_explicit_strategy.hpp" 
+#include "custom_strategies/custom_strategies/mechanical_explicit_strategy.hpp"
 
 // Schemes
 #include "solving_strategies/schemes/scheme.h"
@@ -74,7 +74,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
     typedef ConvergenceCriteriaType::Pointer ConvergenceCriteriaPointer;
     typedef BuilderAndSolver< SparseSpaceType, LocalSpaceType, LinearSolverType > BuilderAndSolverType;
     typedef BuilderAndSolverType::Pointer BuilderAndSolverPointer;
-    
+
     // Custom strategy types
     typedef ResidualBasedArcLengthStrategy< SparseSpaceType, LocalSpaceType , LinearSolverType >  ResidualBasedArcLengthStrategyType;
     typedef EigensolverStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType > EigensolverStrategyType;
@@ -87,7 +87,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
     typedef ResidualBasedRelaxationScheme< SparseSpaceType, LocalSpaceType >  ResidualBasedRelaxationSchemeType;
     typedef EigensolverDynamicScheme< SparseSpaceType, LocalSpaceType > EigensolverDynamicSchemeType;
     typedef ExplicitCentralDifferencesScheme< SparseSpaceType, LocalSpaceType >  ExplicitCentralDifferencesSchemeType;
-    
+
 
     // Custom convergence criterion types
     typedef DisplacementAndOtherDoFCriteria< SparseSpaceType,  LocalSpaceType > DisplacementAndOtherDoFCriteriaType;
@@ -98,18 +98,19 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
     //********************************************************************
     //*************************STRATEGY CLASSES***************************
     //********************************************************************
-    
-    // Residual Based Arc Length Strategy      
-    class_< ResidualBasedArcLengthStrategyType,typename ResidualBasedArcLengthStrategyType::Pointer, BaseSolvingStrategyType >(m,"ResidualBasedArcLengthStrategy")
-    .def(init<ModelPart&, BaseSchemeType::Pointer, LinearSolverPointer, ConvergenceCriteriaPointer,
-                                                                unsigned int, unsigned int, unsigned int,long double,bool, bool, bool>() )
-            ;
+
+    // Residual Based Arc Length Strategy
+    // Currently not woking
+    // class_< ResidualBasedArcLengthStrategyType,typename ResidualBasedArcLengthStrategyType::Pointer, BaseSolvingStrategyType >(m,"ResidualBasedArcLengthStrategy")
+    // .def(init<ModelPart&, BaseSchemeType::Pointer, LinearSolverPointer, ConvergenceCriteriaPointer,
+    //                                                             unsigned int, unsigned int, unsigned int,long double,bool, bool, bool>() )
+    //        ;
 
     // Eigensolver Strategy
     class_< EigensolverStrategyType, typename EigensolverStrategyType::Pointer,BaseSolvingStrategyType >(m,"EigensolverStrategy")
     .def(init<ModelPart&, BaseSchemeType::Pointer, BuilderAndSolverPointer>() )
             ;
-             
+
 
     class_< FormfindingUpdatedReferenceStrategyType,typename FormfindingUpdatedReferenceStrategyType::Pointer, BaseSolvingStrategyType >(m,"FormfindingUpdatedReferenceStrategy")
         .def(init < ModelPart&, BaseSchemeType::Pointer, LinearSolverPointer, ConvergenceCriteriaPointer, int, bool, bool, bool >())
@@ -140,7 +141,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
     //********************************************************************
     //*************************SCHEME CLASSES*****************************
     //********************************************************************
-    
+
     // Residual Based Relaxation Scheme Type
     class_< ResidualBasedRelaxationSchemeType,typename ResidualBasedRelaxationSchemeType::Pointer, BaseSchemeType >(m,"ResidualBasedRelaxationScheme")
     .def(init< double , double >() )
@@ -151,7 +152,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
     class_< EigensolverDynamicSchemeType,typename EigensolverDynamicSchemeType::Pointer, BaseSchemeType>(m,"EigensolverDynamicScheme")
     .def(init<>() )
             ;
-    
+
     // Explicit Central Differences Scheme Type
     class_< ExplicitCentralDifferencesSchemeType,typename ExplicitCentralDifferencesSchemeType::Pointer, BaseSchemeType >(m,"ExplicitCentralDifferencesScheme")
     .def(init< const double, const double, const double>() );
@@ -159,19 +160,19 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
     //********************************************************************
     //*******************CONVERGENCE CRITERIA CLASSES*********************
     //********************************************************************
-            
+
     // Displacement and other DoF Convergence Criterion
     class_< DisplacementAndOtherDoFCriteriaType,typename DisplacementAndOtherDoFCriteriaType::Pointer,ConvergenceCriteriaType>(m,"DisplacementAndOtherDoFCriteria")
             .def(init< double, double, std::string >())
             .def(init< double, double>())
             ;
-            
+
     // Displacement and other DoF residual Convergence Criterion
     class_< ResidualDisplacementAndOtherDoFCriteriaType,typename ResidualDisplacementAndOtherDoFCriteriaType::Pointer, ConvergenceCriteriaType >(m,"ResidualDisplacementAndOtherDoFCriteria")
     .def( init< double, double, std::string >())
             .def(init< double, double>())
             ;
-            
+
     //********************************************************************
     //*************************BUILDER AND SOLVER*************************
     //********************************************************************

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -109,6 +109,7 @@ class StaticMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
             else:
                 mechanical_solution_strategy = self._create_line_search_strategy()
         elif analysis_type == "arc_length":
+            raise Exception('"arc_length is not available at the moment"')
             mechanical_solution_strategy = self._create_arc_length_strategy()
         elif analysis_type == "formfinding":
             mechanical_solution_strategy = self._create_formfinding_strategy()


### PR DESCRIPTION
This PR disables the currently not working Arc-Length Strategy.
In the future it will be replaced by the one that @loumalouomega is currently working on

Reason is that I get the following compiler warning if compiling with the Intel Compiler:
~~~
/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/cast.h(956): warning #239: floating point underflow
                         (py_value < (py_type) std::numeric_limits<T>::min() ||
                                               ^
          detected during:
            instantiation of "bool pybind11::detail::type_caster<T, pybind11::detail::enable_if_t<<expression>, void>>::load(pybind11::handle, bool) [with T=pybind11::detail::intrinsic_t<long double>={long double}]" at line 1861
            instantiation of "bool pybind11::detail::argument_loader<Args...>::load_impl_sequence(pybind11::detail::function_call &, pybind11::detail::index_sequence<Is...>) [with Args=<pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double,
                      Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int,
                      long double, bool, bool, bool>, Is=<0UL, 1UL, 2UL, 3UL, 4UL, 5UL, 6UL, 7UL, 8UL, 9UL, 10UL, 11UL>]" at line 1841
            instantiation of "bool pybind11::detail::argument_loader<Args...>::load_args(pybind11::detail::function_call &) [with Args=<pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double,
                      Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int, long double, bool, bool, bool>]" at line 136 of
                      "/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/pybind11.h"
            instantiation of "void pybind11::cpp_function::initialize(Func &&, Return (*)(Args...), const Extra &...) [with Func=lambda [](pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double,
                      Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int, long double, bool, bool, bool)->void, Return=void,
                      Args=<pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix,
                      Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int, long double, bool, bool, bool>, Extra=<pybind11::name, pybind11::is_method, pybind11::sibling, pybind11::detail::is_new_style_constructor>]" at line 67 of
                      "/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/pybind11.h"
            instantiation of "pybind11::cpp_function::cpp_function(Func &&, const Extra &...) [with Func=lambda [](pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix,
                      Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int, long double, bool, bool, bool)->void, Extra=<pybind11::name, pybind11::is_method,
                      pybind11::sibling, pybind11::detail::is_new_style_constructor>, <unnamed>=void]" at line 1086 of "/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/pybind11.h"
            instantiation of "pybind11::class_<type_, options...> &pybind11::class_<type_, options...>::def(const char *, Func &&, const Extra &...) [with type_=Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>,
                      Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, options=<Kratos::shared_ptr<Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double,
                      Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>>, Kratos::SolvingStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix,
                      Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>>, Func=lambda [](pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double,
                      Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int,
                      long double, bool, bool, bool)->void, Extra=<pybind11::detail::is_new_style_constructor>]" at line 175 of "/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/detail/init.h"
            instantiation of "void pybind11::detail::initimpl::constructor<Args...>::execute(Class &, const Extra &...) [with Args=<Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>,
                      Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int, long double, bool, bool, bool>,
                      Class=pybind11::class_<Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix,
                      Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double,
                      Kratos::Matrix, Kratos::Vector>>>>>, Kratos::SolvingStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix,
                      Kratos::Vector>>>>>, Extra=<>, <unnamed>=0]" at line 1115 of "/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/pybind11.h"
            instantiation of "pybind11::class_<type_, options...> &pybind11::class_<type_, options...>::def(const pybind11::detail::initimpl::constructor<Args...> &, const Extra &...) [with type_=Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix,
                      Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, options=<Kratos::shared_ptr<Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>,
                      Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>>, Kratos::SolvingStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>,
                      Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>>, Args=<Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double,
                      Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int,
                      long double, bool, bool, bool>, Extra=<>]" at line 104 of "/home/hpc/pr94va/ga59vax3/software/Kratos/applications/StructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp"

/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/cast.h(957): warning #264: floating-point value does not fit in required floating-point type
                          py_value > (py_type) std::numeric_limits<T>::max()))) {
                                     ^
          detected during:
            instantiation of "bool pybind11::detail::type_caster<T, pybind11::detail::enable_if_t<<expression>, void>>::load(pybind11::handle, bool) [with T=pybind11::detail::intrinsic_t<long double>={long double}]" at line 1861
            instantiation of "bool pybind11::detail::argument_loader<Args...>::load_impl_sequence(pybind11::detail::function_call &, pybind11::detail::index_sequence<Is...>) [with Args=<pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double,
                      Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int,
                      long double, bool, bool, bool>, Is=<0UL, 1UL, 2UL, 3UL, 4UL, 5UL, 6UL, 7UL, 8UL, 9UL, 10UL, 11UL>]" at line 1841
            instantiation of "bool pybind11::detail::argument_loader<Args...>::load_args(pybind11::detail::function_call &) [with Args=<pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double,
                      Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int, long double, bool, bool, bool>]" at line 136 of
                      "/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/pybind11.h"
            instantiation of "void pybind11::cpp_function::initialize(Func &&, Return (*)(Args...), const Extra &...) [with Func=lambda [](pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double,
                      Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int, long double, bool, bool, bool)->void, Return=void,
                      Args=<pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix,
                      Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int, long double, bool, bool, bool>, Extra=<pybind11::name, pybind11::is_method, pybind11::sibling, pybind11::detail::is_new_style_constructor>]" at line 67 of
                      "/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/pybind11.h"
            instantiation of "pybind11::cpp_function::cpp_function(Func &&, const Extra &...) [with Func=lambda [](pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix,
                      Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int, long double, bool, bool, bool)->void, Extra=<pybind11::name, pybind11::is_method,
                      pybind11::sibling, pybind11::detail::is_new_style_constructor>, <unnamed>=void]" at line 1086 of "/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/pybind11.h"
            instantiation of "pybind11::class_<type_, options...> &pybind11::class_<type_, options...>::def(const char *, Func &&, const Extra &...) [with type_=Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>,
                      Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, options=<Kratos::shared_ptr<Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double,
                      Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>>, Kratos::SolvingStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix,
                      Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>>, Func=lambda [](pybind11::detail::value_and_holder &, Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double,
                      Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int,
                      long double, bool, bool, bool)->void, Extra=<pybind11::detail::is_new_style_constructor>]" at line 175 of "/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/detail/init.h"
            instantiation of "void pybind11::detail::initimpl::constructor<Args...>::execute(Class &, const Extra &...) [with Args=<Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>,
                      Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int, long double, bool, bool, bool>,
                      Class=pybind11::class_<Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix,
                      Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double,
                      Kratos::Matrix, Kratos::Vector>>>>>, Kratos::SolvingStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix,
                      Kratos::Vector>>>>>, Extra=<>, <unnamed>=0]" at line 1115 of "/home/hpc/pr94va/ga59vax3/software/Kratos/external_libraries/pybind11/pybind11.h"
            instantiation of "pybind11::class_<type_, options...> &pybind11::class_<type_, options...>::def(const pybind11::detail::initimpl::constructor<Args...> &, const Extra &...) [with type_=Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix,
                      Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, options=<Kratos::shared_ptr<Kratos::ResidualBasedArcLengthStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>,
                      Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>>, Kratos::SolvingStrategy<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::LinearSolver<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>,
                      Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>>, Args=<Kratos::ModelPart &, Kratos::shared_ptr<Kratos::Scheme<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, Kratos::shared_ptr<Kratos::LinearSolver<Kratos::UblasSpace<double,
                      Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>, Kratos::Reorderer<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>>, Kratos::shared_ptr<Kratos::ConvergenceCriteria<Kratos::UblasSpace<double, Kratos::CompressedMatrix, Kratos::Vector>, Kratos::UblasSpace<double, Kratos::Matrix, Kratos::Vector>>>, unsigned int, unsigned int, unsigned int,
                      long double, bool, bool, bool>, Extra=<>]" at line 104 of "/home/hpc/pr94va/ga59vax3/software/Kratos/applications/StructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp"
~~~