### PR TITLE
Core/python process handler

### DIFF
--- a/applications/ContactMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/ContactMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -47,32 +47,32 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 
   //**********MESH MODELLER PROCESS*********//
 
-  class_<ContactModelStartEndMeshingProcess, ModelStartEndMeshingProcess>
+  class_<ContactModelStartEndMeshingProcess, ContactModelStartEndMeshingProcess::Pointer, ModelStartEndMeshingProcess>
       (m, "ContactModelMeshing")
       .def(init<ModelPart&, Flags, int>())
       ;
 
-  class_<ParametricWallContactSearchProcess, Process>
+  class_<ParametricWallContactSearchProcess, ParametricWallContactSearchProcess::Pointer, Process>
       (m,"ParametricWallContactSearch")
       .def(init<ModelPart&, std::string, SpatialBoundingBox::Pointer, Parameters>())
       ;
 
-  class_<BuildContactModelPartProcess, Process>
+  class_<BuildContactModelPartProcess, BuildContactModelPartProcess::Pointer, Process>
       (m,"BuildContactModelPart")
       .def(init<ModelPart&, ModelerUtilities::MeshingParameters&, std::vector<std::string>&, int>())
       ;
 
-  class_<ClearPointContactConditionsProcess, Process>
+  class_<ClearPointContactConditionsProcess, ClearPointContactConditionsProcess::Pointer, Process>
       (m,"ClearPointContactConditions")
       .def(init<ModelPart&, int>())
       ;
 
-  class_<ClearContactConditionsProcess, Process>
+  class_<ClearContactConditionsProcess, ClearContactConditionsProcess::Pointer, Process>
       (m,"ClearContactConditions")
       .def(init<ModelPart&, int>())
       ;
 
-  class_<BuildContactConditionsProcess, Process>
+  class_<BuildContactConditionsProcess, BuildContactConditionsProcess::Pointer, Process>
       (m,"BuildContactConditions")
       .def(init<ModelPart&,  ModelerUtilities::MeshingParameters&, int>())
       ;

--- a/applications/DamApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/DamApplication/custom_python/add_custom_processes_to_python.cpp
@@ -41,72 +41,72 @@ void  AddCustomProcessesToPython(pybind11::module& m)
     using namespace pybind11;
 
     // Fix Temperature
-    class_< DamFixTemperatureConditionProcess, Process >
+    class_<DamFixTemperatureConditionProcess, DamFixTemperatureConditionProcess::Pointer, Process>
     (m, "DamFixTemperatureConditionProcess")
     .def(init < ModelPart&, Parameters&>());
     
     // Bofang Process
-    class_< DamBofangConditionTemperatureProcess, Process >
+    class_<DamBofangConditionTemperatureProcess, DamBofangConditionTemperatureProcess::Pointer, Process>
     (m, "DamBofangConditionTemperatureProcess")
     .def(init < ModelPart&, Parameters&>());
 
     // Uniform Reservoir Temperature Process
-    class_< DamReservoirConstantTemperatureProcess, Process >
+    class_<DamReservoirConstantTemperatureProcess, DamReservoirConstantTemperatureProcess::Pointer, Process>
     (m, "DamReservoirConstantTemperatureProcess")
     .def(init < ModelPart&, Parameters&>());
         
     // Hydrostatic condition
-    class_< DamHydroConditionLoadProcess, Process >
+    class_<DamHydroConditionLoadProcess, DamHydroConditionLoadProcess::Pointer, Process>
     (m, "DamHydroConditionLoadProcess")
     .def(init < ModelPart&, Parameters&>());
         
     // Uplift Condition
-    class_< DamUpliftConditionLoadProcess, Process >
+    class_<DamUpliftConditionLoadProcess, DamUpliftConditionLoadProcess::Pointer, Process>
     (m, "DamUpliftConditionLoadProcess")
     .def(init < ModelPart&, Parameters&>());
     
     // Uplift Condition for arch dams   
-    class_< DamUpliftCircularConditionLoadProcess, Process >
+    class_<DamUpliftCircularConditionLoadProcess, DamUpliftCircularConditionLoadProcess::Pointer, Process>
     (m, "DamUpliftCircularConditionLoadProcess")
     .def(init < ModelPart&, Parameters&>());
    
    // Westergaard Condition (for hydrostatic + hydrodynamic pressure)     
-    class_< DamWestergaardConditionLoadProcess, Process >
+    class_<DamWestergaardConditionLoadProcess, DamWestergaardConditionLoadProcess::Pointer, Process>
     (m, "DamWestergaardConditionLoadProcess")
     .def(init < ModelPart&, Parameters&>());
 
     // Nodal Young Modulus Process     
-    class_< DamNodalYoungModulusProcess, Process >
+    class_<DamNodalYoungModulusProcess, DamNodalYoungModulusProcess::Pointer, Process>
     (m, "DamNodalYoungModulusProcess")
     .def(init < ModelPart&, Parameters&>());
 
     // Chemo Mechanical Aging Young Modulus Process     
-    class_< DamChemoMechanicalAgingYoungProcess, Process >
+    class_<DamChemoMechanicalAgingYoungProcess, DamChemoMechanicalAgingYoungProcess::Pointer, Process>
     (m, "DamChemoMechanicalAgingYoungProcess")
     .def(init < ModelPart&, Parameters&>());
 
     // Added Mass Distribution     
-    class_< DamAddedMassConditionProcess, Process >
+    class_<DamAddedMassConditionProcess, DamAddedMassConditionProcess::Pointer, Process>
     (m, "DamAddedMassConditionProcess")
     .def(init < ModelPart&, Parameters&>());
 
     //Temperature by device     
-    class_< DamTemperaturebyDeviceProcess, Process >
+    class_<DamTemperaturebyDeviceProcess, DamTemperaturebyDeviceProcess::Pointer, Process>
     (m, "DamTemperaturebyDeviceProcess")
     .def(init < ModelPart&, Parameters&>());
 
     // Heat Flux by t_sol_air      
-    class_< DamTSolAirHeatFluxProcess, Process >
+    class_<DamTSolAirHeatFluxProcess, DamTSolAirHeatFluxProcess::Pointer, Process>
     (m, "DamTSolAirHeatFluxProcess")
     .def(init < ModelPart&, Parameters&>());
 
     // Heat Source According Noorzai (Adiabatic Hidratation)      
-    class_< DamNoorzaiHeatFluxProcess, Process >
+    class_<DamNoorzaiHeatFluxProcess, DamNoorzaiHeatFluxProcess::Pointer, Process>
     (m, "DamNoorzaiHeatFluxProcess")
     .def(init < ModelPart&, Parameters&>());
     
     // Heat Source according Azenha (Arrhenius formulation NonAdiabatic Hidratation)
-    class_< DamAzenhaHeatFluxProcess, Process >
+    class_<DamAzenhaHeatFluxProcess, DamAzenhaHeatFluxProcess::Pointer, Process>
     (m, "DamAzenhaHeatFluxProcess")
     .def(init < ModelPart&, Parameters&>());
     }

--- a/applications/FluidDynamicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/FluidDynamicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -52,46 +52,46 @@ void AddCustomProcessesToPython(pybind11::module& m)
 
     typedef LinearSolver<SparseSpaceType, LocalSpaceType > LinearSolverType;
 
-    class_<SpalartAllmarasTurbulenceModel< SparseSpaceType, LocalSpaceType, LinearSolverType >, Process >
+    class_<SpalartAllmarasTurbulenceModel< SparseSpaceType, LocalSpaceType, LinearSolverType >, SpalartAllmarasTurbulenceModel< SparseSpaceType, LocalSpaceType, LinearSolverType >::Pointer, Process>
     (m,"SpalartAllmarasTurbulenceModel")
     .def(init < ModelPart&, LinearSolverType::Pointer, unsigned int, double, unsigned int, bool, unsigned int>())
     .def("ActivateDES", &SpalartAllmarasTurbulenceModel< SparseSpaceType, LocalSpaceType, LinearSolverType >::ActivateDES)
     .def("AdaptForFractionalStep", &SpalartAllmarasTurbulenceModel< SparseSpaceType, LocalSpaceType, LinearSolverType >::AdaptForFractionalStep)
     ;
 
-    class_<StokesInitializationProcess< SparseSpaceType, LocalSpaceType, LinearSolverType >, Process >
+    class_<StokesInitializationProcess< SparseSpaceType, LocalSpaceType, LinearSolverType >, StokesInitializationProcess< SparseSpaceType, LocalSpaceType, LinearSolverType >::Pointer, Process>
     (m,"StokesInitializationProcess")
     .def(init<ModelPart::Pointer, LinearSolverType::Pointer, unsigned int, const Kratos::Variable<int>& >())
     .def("SetConditions",&StokesInitializationProcess<SparseSpaceType, LocalSpaceType, LinearSolverType>::SetConditions)
     ;
 
-    class_<BoussinesqForceProcess, Process >
+    class_<BoussinesqForceProcess, BoussinesqForceProcess::Pointer, Process>
     (m,"BoussinesqForceProcess")
     .def(init<ModelPart::Pointer, Parameters& >())
     ;
 
-    class_<WindkesselModel, Process >
+    class_<WindkesselModel, WindkesselModel::Pointer, Process>
     (m,"WindkesselModel")
     .def(init < ModelPart&>())
     ;
 
-    class_<DistanceModificationProcess, Process >
+    class_<DistanceModificationProcess, DistanceModificationProcess::Pointer, Process>
     (m,"DistanceModificationProcess")
     .def(init < ModelPart&, const double, const double, const bool, const bool, const bool >())
     .def(init< ModelPart&, Parameters& >())
     ;
 
-    class_<EmbeddedNodesInitializationProcess, Process >
+    class_<EmbeddedNodesInitializationProcess, EmbeddedNodesInitializationProcess::Pointer, Process>
     (m,"EmbeddedNodesInitializationProcess")
     .def(init < ModelPart&, unsigned int >())
     ;
 
-    class_<EmbeddedPostprocessProcess, Process >
+    class_<EmbeddedPostprocessProcess, EmbeddedPostprocessProcess::Pointer, Process>
     (m,"EmbeddedPostprocessProcess")
     .def(init < ModelPart& >())
     ;
 
-    class_<EmbeddedSkinVisualizationProcess, Process >
+    class_<EmbeddedSkinVisualizationProcess, EmbeddedSkinVisualizationProcess::Pointer, Process>
     (m,"EmbeddedSkinVisualizationProcess")
     .def(init < 
         ModelPart&, 
@@ -104,7 +104,7 @@ void AddCustomProcessesToPython(pybind11::module& m)
     .def(init< ModelPart&, ModelPart&, Parameters& >())
     ;
 
-    class_<MoveRotorProcess, Process >
+    class_<MoveRotorProcess, MoveRotorProcess::Pointer, Process>
     (m,"MoveRotorProcess")
     .def(init < ModelPart&, const double, const double, const double, const double, const double, const unsigned int >())
     .def(init< ModelPart&, Parameters& >())

--- a/applications/FluidDynamicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/FluidDynamicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -52,46 +52,46 @@ void AddCustomProcessesToPython(pybind11::module& m)
 
     typedef LinearSolver<SparseSpaceType, LocalSpaceType > LinearSolverType;
 
-    class_< SpalartAllmarasTurbulenceModel< SparseSpaceType, LocalSpaceType, LinearSolverType >, Process >
+    class_<SpalartAllmarasTurbulenceModel< SparseSpaceType, LocalSpaceType, LinearSolverType >, Process >
     (m,"SpalartAllmarasTurbulenceModel")
     .def(init < ModelPart&, LinearSolverType::Pointer, unsigned int, double, unsigned int, bool, unsigned int>())
     .def("ActivateDES", &SpalartAllmarasTurbulenceModel< SparseSpaceType, LocalSpaceType, LinearSolverType >::ActivateDES)
     .def("AdaptForFractionalStep", &SpalartAllmarasTurbulenceModel< SparseSpaceType, LocalSpaceType, LinearSolverType >::AdaptForFractionalStep)
     ;
 
-    class_< StokesInitializationProcess< SparseSpaceType, LocalSpaceType, LinearSolverType >, Process >
+    class_<StokesInitializationProcess< SparseSpaceType, LocalSpaceType, LinearSolverType >, Process >
     (m,"StokesInitializationProcess")
     .def(init<ModelPart::Pointer, LinearSolverType::Pointer, unsigned int, const Kratos::Variable<int>& >())
     .def("SetConditions",&StokesInitializationProcess<SparseSpaceType, LocalSpaceType, LinearSolverType>::SetConditions)
     ;
 
-    class_< BoussinesqForceProcess, Process >
+    class_<BoussinesqForceProcess, Process >
     (m,"BoussinesqForceProcess")
     .def(init<ModelPart::Pointer, Parameters& >())
     ;
 
-    class_< WindkesselModel, Process >
+    class_<WindkesselModel, Process >
     (m,"WindkesselModel")
     .def(init < ModelPart&>())
     ;
 
-    class_< DistanceModificationProcess, Process >
+    class_<DistanceModificationProcess, Process >
     (m,"DistanceModificationProcess")
     .def(init < ModelPart&, const double, const double, const bool, const bool, const bool >())
     .def(init< ModelPart&, Parameters& >())
     ;
 
-    class_< EmbeddedNodesInitializationProcess, Process >
+    class_<EmbeddedNodesInitializationProcess, Process >
     (m,"EmbeddedNodesInitializationProcess")
     .def(init < ModelPart&, unsigned int >())
     ;
 
-    class_< EmbeddedPostprocessProcess, Process >
+    class_<EmbeddedPostprocessProcess, Process >
     (m,"EmbeddedPostprocessProcess")
     .def(init < ModelPart& >())
     ;
 
-    class_< EmbeddedSkinVisualizationProcess, Process >
+    class_<EmbeddedSkinVisualizationProcess, Process >
     (m,"EmbeddedSkinVisualizationProcess")
     .def(init < 
         ModelPart&, 
@@ -104,7 +104,7 @@ void AddCustomProcessesToPython(pybind11::module& m)
     .def(init< ModelPart&, ModelPart&, Parameters& >())
     ;
 
-    class_< MoveRotorProcess, Process >
+    class_<MoveRotorProcess, Process >
     (m,"MoveRotorProcess")
     .def(init < ModelPart&, const double, const double, const double, const double, const double, const unsigned int >())
     .def(init< ModelPart&, Parameters& >())

--- a/applications/HDF5Application/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/HDF5Application/custom_python/add_custom_processes_to_python.cpp
@@ -17,7 +17,7 @@ void AddCustomProcessesToPython(pybind11::module& m)
 {
     using namespace pybind11;
 
-    class_<HDF5::XdmfConnectivitiesWriterProcess, Process>(m,"HDF5XdmfConnectivitiesWriterProcess")
+    class_<HDF5::XdmfConnectivitiesWriterProcess, HDF5::XdmfConnectivitiesWriterProcess::Pointer, Process>(m,"HDF5XdmfConnectivitiesWriterProcess")
     .def(init<const std::string&, const std::string&>())
     ;
 }

--- a/applications/MeshingApplication/custom_python/add_processes_to_python.cpp
+++ b/applications/MeshingApplication/custom_python/add_processes_to_python.cpp
@@ -45,28 +45,28 @@ namespace Python
 void  AddProcessesToPython(pybind11::module& m)
 {
 
-// 	   class_<SetHMapProcess, SetHMapProcess::Pointer, Process >(m, "SetHMapProcess")
+// 	   class_<SetHMapProcess, SetHMapProcess::Pointer, Process>(m, "SetHMapProcess")
 //     .def(init<ModelPart&>())
 //     .def("CalculateOptimalH",&SetHMapProcess::CalculateOptimalH)
 // 		 ;
-// 	  class_<EmbeddedMeshLocatorProcess, EmbeddedMeshLocatorProcess::Pointer, Process >(m, "EmbeddedMeshLocatorProcess")
+// 	  class_<EmbeddedMeshLocatorProcess, EmbeddedMeshLocatorProcess::Pointer, Process>(m, "EmbeddedMeshLocatorProcess")
 //     .def(init<ModelPart&>())
 //     .def("Locate",&EmbeddedMeshLocatorProcess::Locate)
 // 		 ;
 //         // The process to interpolate nodal values
-//         class_<NodalValuesInterpolationProcess<2>, NodalValuesInterpolationProcess<2>::Pointer, Process >(m, "NodalValuesInterpolationProcess2D")
+//         class_<NodalValuesInterpolationProcess<2>, NodalValuesInterpolationProcess<2>::Pointer, Process>(m, "NodalValuesInterpolationProcess2D")
 //         .def(init<ModelPart&, ModelPart&>())
 //         .def(init<ModelPart&, ModelPart&, Parameters>())
 //         .def("Execute",&NodalValuesInterpolationProcess<2>::Execute)
 //         ;
-//         class_<NodalValuesInterpolationProcess<3>, NodalValuesInterpolationProcess<3>::Pointer, Process >(m, "NodalValuesInterpolationProcess3D")
+//         class_<NodalValuesInterpolationProcess<3>, NodalValuesInterpolationProcess<3>::Pointer, Process>(m, "NodalValuesInterpolationProcess3D")
 //         .def(init<ModelPart&, ModelPart&>())
 //         .def(init<ModelPart&, ModelPart&, Parameters>())
 //         .def("Execute",&NodalValuesInterpolationProcess<3>::Execute)
 //         ;
     
         // The process to interpolate internal variables 
-        class_<InternalVariablesInterpolationProcess,  Process >(m, "InternalVariablesInterpolationProcess")
+        class_<InternalVariablesInterpolationProcess, InternalVariablesInterpolationProcess::Pointer, Process>(m, "InternalVariablesInterpolationProcess")
         .def(init<ModelPart&, ModelPart&>())
         .def(init<ModelPart&, ModelPart&, Parameters>())
         .def("Execute",&InternalVariablesInterpolationProcess::Execute)
@@ -74,63 +74,63 @@ void  AddProcessesToPython(pybind11::module& m)
         
         /* METRICS PROCESSES */
         // Fast metric initializer
-        class_<MetricFastInit<2>,  Process >(m, "MetricFastInit2D")
+        class_<MetricFastInit<2>, MetricFastInit<2>::Pointer, Process>(m, "MetricFastInit2D")
         .def(init<ModelPart&>())
         .def("Execute",&MetricFastInit<2>::Execute)
         ;
         
-        class_<MetricFastInit<3>,  Process >(m, "MetricFastInit3D")
+        class_<MetricFastInit<3>, MetricFastInit<3>::Pointer, Process>(m, "MetricFastInit3D")
         .def(init<ModelPart&>())
         .def("Execute",&MetricFastInit<3>::Execute)
         ;
         
         // LEVEL SET
-        class_<ComputeLevelSetSolMetricProcess<2>,  Process >(m, "ComputeLevelSetSolMetricProcess2D")
+        class_<ComputeLevelSetSolMetricProcess<2>, ComputeLevelSetSolMetricProcess<2>::Pointer, Process>(m, "ComputeLevelSetSolMetricProcess2D")
         .def(init<ModelPart&, const Variable<array_1d<double,3>>>())
         .def(init<ModelPart&, const Variable<array_1d<double,3>>, Parameters>())
         .def("Execute",&ComputeLevelSetSolMetricProcess<2>::Execute)
         ;
         
-        class_<ComputeLevelSetSolMetricProcess<3>,  Process >(m, "ComputeLevelSetSolMetricProcess3D")
+        class_<ComputeLevelSetSolMetricProcess<3>, ComputeLevelSetSolMetricProcess<3>::Pointer, Process>(m, "ComputeLevelSetSolMetricProcess3D")
         .def(init<ModelPart&, const Variable<array_1d<double,3>>>())
         .def(init<ModelPart&, const Variable<array_1d<double,3>>, Parameters>())
         .def("Execute",&ComputeLevelSetSolMetricProcess<3>::Execute)
         ;
         
         // HESSIAN DOUBLE
-        class_<ComputeHessianSolMetricProcess<2, Variable<double>>,  Process >(m, "ComputeHessianSolMetricProcess2D")
+        class_<ComputeHessianSolMetricProcess<2, Variable<double>>, ComputeHessianSolMetricProcess<2, Variable<double>>::Pointer, Process>(m, "ComputeHessianSolMetricProcess2D")
         .def(init<ModelPart&, Variable<double>&>())
         .def(init<ModelPart&, Variable<double>&, Parameters>())
         .def("Execute",&ComputeHessianSolMetricProcess<2, Variable<double>>::Execute)
         ;
    
-        class_<ComputeHessianSolMetricProcess<3, Variable<double>>,  Process >(m, "ComputeHessianSolMetricProcess3D")
+        class_<ComputeHessianSolMetricProcess<3, Variable<double>>, ComputeHessianSolMetricProcess<3, Variable<double>>::Pointer, Process>(m, "ComputeHessianSolMetricProcess3D")
         .def(init<ModelPart&, Variable<double>&>())
         .def(init<ModelPart&, Variable<double>&, Parameters>())
         .def("Execute",&ComputeHessianSolMetricProcess<3, Variable<double>>::Execute)
         ;
         
         // HESSIAN ARRAY 1D
-        class_<ComputeHessianSolMetricProcess<2, ComponentType>,  Process >(m, "ComputeHessianSolMetricProcessComp2D")
+        class_<ComputeHessianSolMetricProcess<2, ComponentType>, ComputeHessianSolMetricProcess<2, ComponentType>::Pointer, Process>(m, "ComputeHessianSolMetricProcessComp2D")
         .def(init<ModelPart&, ComponentType&>())
         .def(init<ModelPart&, ComponentType&, Parameters>())
         .def("Execute",&ComputeHessianSolMetricProcess<2, ComponentType>::Execute)
         ;
         
-        class_<ComputeHessianSolMetricProcess<3, ComponentType>,  Process >(m, "ComputeHessianSolMetricProcessComp3D")
+        class_<ComputeHessianSolMetricProcess<3, ComponentType>, ComputeHessianSolMetricProcess<3, ComponentType>::Pointer, Process>(m, "ComputeHessianSolMetricProcessComp3D")
         .def(init<ModelPart&, ComponentType&>())
         .def(init<ModelPart&, ComponentType&, Parameters>())
         .def("Execute",&ComputeHessianSolMetricProcess<3, ComponentType>::Execute)
         ;
         
         // ERROR
-        class_<ComputeErrorSolMetricProcess<2>,  Process >(m, "ComputeErrorSolMetricProcess2D")
+        class_<ComputeErrorSolMetricProcess<2>, ComputeErrorSolMetricProcess<2>::Pointer, Process>(m, "ComputeErrorSolMetricProcess2D")
         .def(init<ModelPart&>())
         .def(init<ModelPart&, Parameters>())
         .def("Execute",&ComputeErrorSolMetricProcess<2>::Execute)
         ;
    
-        class_<ComputeErrorSolMetricProcess<3>,  Process >(m, "ComputeErrorSolMetricProcess3D")
+        class_<ComputeErrorSolMetricProcess<3>, ComputeErrorSolMetricProcess<3>::Pointer, Process>(m, "ComputeErrorSolMetricProcess3D")
         .def(init<ModelPart&>())
         .def(init<ModelPart&, Parameters>())
         .def("Execute",&ComputeErrorSolMetricProcess<3>::Execute)
@@ -139,14 +139,14 @@ void  AddProcessesToPython(pybind11::module& m)
         /* MMG PROCESS */
     #ifdef INCLUDE_MMG
         // 2D
-        class_<MmgProcess<2>,  Process >(m, "MmgProcess2D")
+        class_<MmgProcess<2>, MmgProcess<2>::Pointer, Process>(m, "MmgProcess2D")
         .def(init<ModelPart&>())
         .def(init<ModelPart&, Parameters>())
         .def("Execute", &MmgProcess<2>::Execute)
         ;
         
         // 3D
-        class_<MmgProcess<3>,  Process >(m, "MmgProcess3D")
+        class_<MmgProcess<3>, MmgProcess<3>::Pointer, Process>(m, "MmgProcess3D")
         .def(init<ModelPart&>())
         .def(init<ModelPart&, Parameters>())
         .def("Execute", &MmgProcess<3>::Execute)

--- a/applications/ParticleMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/ParticleMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -35,7 +35,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 {
     using namespace pybind11;
 
-    class_<ParticleEraseProcess, Process>(m,"ParticleEraseProcess")
+    class_<ParticleEraseProcess, ParticleEraseProcess::Pointer, Process>(m,"ParticleEraseProcess")
     .def(init<ModelPart&>());
       
 }

--- a/applications/PfemApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/PfemApplication/custom_python/add_custom_processes_to_python.cpp
@@ -74,13 +74,13 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 
   //***************NEIGHBOURS**************//
       
-  class_<NodalNeighboursSearchProcess, Process>
+  class_<NodalNeighboursSearchProcess, NodalNeighboursSearchProcess::Pointer, Process>
       (m,"NodalNeighboursSearch")
       .def(init<ModelPart&, int, int, int>())
       .def("CleanNeighbours", &NodalNeighboursSearchProcess::ClearNeighbours)
       ;
       
-  class_<ElementalNeighboursSearchProcess, Process>
+  class_<ElementalNeighboursSearchProcess, ElementalNeighboursSearchProcess::Pointer, Process>
       (m,"ElementalNeighboursSearch")
       .def(init<ModelPart&, int, int, int>())
       .def("CleanNeighbours", &ElementalNeighboursSearchProcess::ClearNeighbours)
@@ -89,7 +89,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 
   //***************BOUNDARY**************//
 
-  class_<BuildModelPartBoundaryProcess, Process>
+  class_<BuildModelPartBoundaryProcess, BuildModelPartBoundaryProcess::Pointer, Process>
       (m,"BuildModelPartBoundary")
       .def(init<ModelPart&, std::string, int>())
       .def("SearchConditionMasters", &BuildModelPartBoundaryProcess::SearchConditionMasters)
@@ -98,61 +98,61 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 
   //**********MESH MODELLER PROCESS*********//
 
-  class_<ModelStartEndMeshingProcess, Process>
+  class_<ModelStartEndMeshingProcess, ModelStartEndMeshingProcess::Pointer, Process>
       (m,"ModelMeshing")
       .def(init<ModelPart&, Flags, int>())
       ;
 
 
-  class_<RefineMeshElementsOnThresholdProcess, Process>
+  class_<RefineMeshElementsOnThresholdProcess, RefineMeshElementsOnThresholdProcess::Pointer, Process>
       (m,"SetElementNodesToRefineOnThreshold")
       .def(init<ModelPart&,  ModelerUtilities::MeshingParameters&, int>())
       ;
 
-  class_<RefineMeshElementsInEdgesProcess, Process>
+  class_<RefineMeshElementsInEdgesProcess, RefineMeshElementsInEdgesProcess::Pointer, Process>
       (m,"SetElementEdgesToRefine")
       .def(init<ModelPart&, ModelerUtilities::MeshingParameters&, int>())
       ;
       
-  class_<RefineMeshElementsOnSizeProcess, Process>
+  class_<RefineMeshElementsOnSizeProcess, RefineMeshElementsOnSizeProcess::Pointer, Process>
       (m,"SetElementsToRefineOnSize")
       .def(init<ModelPart&,  ModelerUtilities::MeshingParameters&, int>())
       ;
 
-  class_<RefineMeshBoundaryProcess, Process>
+  class_<RefineMeshBoundaryProcess, RefineMeshBoundaryProcess::Pointer, Process>
       (m,"RefineMeshBoundary")
       .def(init<ModelPart&,  ModelerUtilities::MeshingParameters&, int>())
       ;
 
-  class_<RemoveMeshNodesProcess, Process>
+  class_<RemoveMeshNodesProcess, RemoveMeshNodesProcess::Pointer, Process>
       (m,"RemoveMeshNodes")
       .def(init<ModelPart&, ModelerUtilities::MeshingParameters&, int>())
       ;
 
 
-  class_<GenerateNewNodesProcess, Process>
+  class_<GenerateNewNodesProcess, GenerateNewNodesProcess::Pointer, Process>
       (m,"GenerateNewNodes")
       .def(init<ModelPart&,  ModelerUtilities::MeshingParameters&, int>())
       ;
 
-  class_<SelectMeshElementsProcess, Process>
+  class_<SelectMeshElementsProcess, SelectMeshElementsProcess::Pointer, Process>
       (m,"SelectMeshElements")
       .def(init<ModelPart&,  ModelerUtilities::MeshingParameters&, int>())
       ;
 
-  class_<BuildMeshElementsProcess, Process>
+  class_<BuildMeshElementsProcess, BuildMeshElementsProcess::Pointer, Process>
       (m,"BuildMeshElements")
       .def(init<ModelPart&,  ModelerUtilities::MeshingParameters&, int>())
       ;
 
 
-  class_<BuildMeshBoundaryProcess, BuildModelPartBoundaryProcess>
+  class_<BuildMeshBoundaryProcess, BuildMeshBoundaryProcess::Pointer, BuildModelPartBoundaryProcess>
       (m,"BuildMeshBoundary")
       .def(init<ModelPart&, ModelerUtilities::MeshingParameters&, int>())
       ;
 
 
-  class_<PrintOutputMeshProcess, Process>
+  class_<PrintOutputMeshProcess, PrintOutputMeshProcess::Pointer, Process>
       (m,"PrintOutputMeshProcess")
       .def(init<ModelPart&,  ModelerUtilities::MeshingParameters&, std::string, int>())
       ;
@@ -160,7 +160,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 
   //********MODEL VOLUME CALCULATION*********//
 
-  class_<ModelVolumeCalculationProcess, Process>
+  class_<ModelVolumeCalculationProcess, ModelVolumeCalculationProcess::Pointer, Process>
       (m,"ModelVolumeCalculation")
       .def(init<ModelPart&, bool, int>())
       .def("ExecuteInitializeSolutionStep", &ModelVolumeCalculationProcess::ExecuteInitializeSolutionStep)
@@ -169,7 +169,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
       
   //********MODEL VOLUME CALCULATION*********//
 
-  class_<ConstantRotationProcess, Process>
+  class_<ConstantRotationProcess, ConstantRotationProcess::Pointer, Process>
       (m,"ConstantRotationProcess")
       .def(init<ModelPart&, const double, const double, const double, const double, const double, const double>())	 
       .def(init< ModelPart&, Parameters& >())

--- a/applications/PfemSolidMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/PfemSolidMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -32,12 +32,12 @@ void  AddCustomProcessesToPython(pybind11::module& m)
   typedef std::vector<SpatialBoundingBox::Pointer>   BoundingBoxContainer;
 
   // Mesh modeler process
-  class_<ContactRefineMeshBoundaryProcess, RefineMeshBoundaryProcess>(m,"ContactRefineMeshBoundary")
+  class_<ContactRefineMeshBoundaryProcess, ContactRefineMeshBoundaryProcess::Pointer, RefineMeshBoundaryProcess>(m,"ContactRefineMeshBoundary")
       .def(init<ModelPart&, BoundingBoxContainer&, ModelerUtilities::MeshingParameters&, int>())
       ;
 
   // Set initial mechanical state
-  class_<SetMechanicalInitialStateProcess, Process>(m,"SetMechanicalInitialStateProcess")
+  class_<SetMechanicalInitialStateProcess, SetMechanicalInitialStateProcess::Pointer, Process>(m,"SetMechanicalInitialStateProcess")
       .def(init<ModelPart&, Parameters>())
       .def(init< ModelPart&, Parameters >())
       .def("Execute", &SetMechanicalInitialStateProcess::Execute)

--- a/applications/PoromechanicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/PoromechanicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -30,19 +30,19 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 {
     using namespace pybind11;
 
-    class_< ApplyComponentTableProcess, Process >
+    class_<ApplyComponentTableProcess, ApplyComponentTableProcess::Pointer, Process>
     (m, "ApplyComponentTableProcess")
     .def(init < ModelPart&, Parameters>());
-    class_< ApplyDoubleTableProcess, Process >
+    class_<ApplyDoubleTableProcess, ApplyDoubleTableProcess::Pointer, Process>
     (m, "ApplyDoubleTableProcess")
     .def(init < ModelPart&, Parameters>());
-    class_< ApplyConstantHydrostaticPressureProcess, Process >
+    class_<ApplyConstantHydrostaticPressureProcess, ApplyConstantHydrostaticPressureProcess::Pointer, Process>
     (m, "ApplyConstantHydrostaticPressureProcess")
     .def(init < ModelPart&, Parameters>());
-    class_< ApplyHydrostaticPressureTableProcess, Process >
+    class_<ApplyHydrostaticPressureTableProcess, ApplyHydrostaticPressureTableProcess::Pointer, Process>
     (m, "ApplyHydrostaticPressureTableProcess")
     .def(init < ModelPart&, Parameters>());
-    class_< PeriodicInterfaceProcess, Process >
+    class_<PeriodicInterfaceProcess, PeriodicInterfaceProcess::Pointer, Process>
     (m, "PeriodicInterfaceProcess")
     .def(init < ModelPart&, Parameters>());
 }

--- a/applications/SolidMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/SolidMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -43,7 +43,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
       
   //**********TRANSFER NODES TO MODEL PART*********//
 
-  class_<TransferNodesToModelPartProcess, Process>(m,"TransferNodesProcess")
+  class_<TransferNodesToModelPartProcess, TransferNodesToModelPartProcess::Pointer, Process>(m,"TransferNodesProcess")
       .def(init<ModelPart&, ModelPart&, const FlagsContainer&>())
       .def(init<ModelPart&, ModelPart&, const FlagsContainer&, const FlagsContainer& >())
       .def("Execute", &TransferNodesToModelPartProcess::Execute)
@@ -51,7 +51,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
       
   //**********TRANSFER ENTITIES BETWEEN MODEL PARTS*********//
 
-  class_<TransferEntitiesBetweenModelPartsProcess, Process>(m,"TransferEntitiesProcess")
+  class_<TransferEntitiesBetweenModelPartsProcess, TransferEntitiesBetweenModelPartsProcess::Pointer, Process>(m,"TransferEntitiesProcess")
       .def(init<ModelPart&, ModelPart&, const std::string>())	
       .def(init<ModelPart&, ModelPart&, const std::string, const FlagsContainer&>())
       .def(init<ModelPart&, ModelPart&, const std::string, const FlagsContainer&, const FlagsContainer& >())
@@ -61,25 +61,25 @@ void  AddCustomProcessesToPython(pybind11::module& m)
       
   //**********ASSIGN VALUES TO VARIABLES PROCESSES*********//
 
-  class_<AssignScalarVariableToEntitiesProcess, Process>(m,"AssignScalarToEntitiesProcess")
+  class_<AssignScalarVariableToEntitiesProcess, AssignScalarVariableToEntitiesProcess::Pointer, Process>(m,"AssignScalarToEntitiesProcess")
       .def(init<ModelPart&, Parameters>())
       .def(init< ModelPart&, Parameters& >())
       .def("Execute", &AssignScalarVariableToEntitiesProcess::Execute)
       ;
 
-  class_<AssignScalarFieldToEntitiesProcess, Process>(m,"AssignScalarFieldToEntitiesProcess")
+  class_<AssignScalarFieldToEntitiesProcess, AssignScalarFieldToEntitiesProcess::Pointer, Process>(m,"AssignScalarFieldToEntitiesProcess")
       .def(init<ModelPart&, pybind11::object&, const std::string, const bool, Parameters>())
       .def(init< ModelPart&, pybind11::object&, const std::string, const bool, Parameters& >())
       .def("Execute", &AssignScalarFieldToEntitiesProcess::Execute)
       ;
   
-  class_<AssignVectorFieldToEntitiesProcess, Process>(m,"AssignVectorFieldToEntitiesProcess")
+  class_<AssignVectorFieldToEntitiesProcess, AssignVectorFieldToEntitiesProcess::Pointer, Process>(m,"AssignVectorFieldToEntitiesProcess")
       .def(init<ModelPart&, pybind11::object&,const std::string,const bool, Parameters>())
       .def(init< ModelPart&, pybind11::object&,const std::string,const bool, Parameters& >())
       .def("Execute", &AssignVectorFieldToEntitiesProcess::Execute)
       ;
 
-  class_<AssignVectorVariableToConditionsProcess, Process>(m,"AssignVectorToConditionsProcess")
+  class_<AssignVectorVariableToConditionsProcess, AssignVectorVariableToConditionsProcess::Pointer, Process>(m,"AssignVectorToConditionsProcess")
       .def(init<ModelPart&, Parameters>())
       .def(init< ModelPart&, Parameters& >())
       .def(init<ModelPart&, const Variable<array_1d<double,3> >&, array_1d<double,3>&>())
@@ -88,7 +88,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 	
   //**********FIX AND FREE DOFS PROCESSES*********//
 
-  class_<FixScalarDofProcess, Process>(m,"FixScalarDofProcess")
+  class_<FixScalarDofProcess, FixScalarDofProcess::Pointer, Process>(m,"FixScalarDofProcess")
       .def(init<ModelPart&, Parameters>())
       .def(init<ModelPart&, Parameters&>())
       .def(init<ModelPart&, const VariableComponent<VectorComponentAdaptor<array_1d<double, 3> > >&>())
@@ -100,7 +100,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
       ;
 
 
-  class_<FreeScalarDofProcess, Process>(m,"FreeScalarDofProcess")
+  class_<FreeScalarDofProcess, FreeScalarDofProcess::Pointer, Process>(m,"FreeScalarDofProcess")
       .def(init<ModelPart&, Parameters>())
       .def(init<ModelPart&, Parameters&>())
       .def(init<ModelPart&, const VariableComponent<VectorComponentAdaptor<array_1d<double, 3> > >&>())
@@ -114,7 +114,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
  
   //**********ADD DOFS PROCESS*********//
 
-  class_<AddDofsProcess, Process>(m,"AddDofsProcess")
+  class_<AddDofsProcess, AddDofsProcess::Pointer, Process>(m,"AddDofsProcess")
       .def(init<ModelPart&, Parameters>())
       .def(init<ModelPart&, Parameters&>())
       .def(init<ModelPart&, const pybind11::list&, const pybind11::list&>())
@@ -125,7 +125,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 
   //**********ASSIGN ROTATION ABOUT AND AXIS*********//
 
-  class_<AssignRotationAboutAnAxisToNodesProcess, Process>(m,"AssignRotationAboutAnAxisToNodesProcess")
+  class_<AssignRotationAboutAnAxisToNodesProcess, AssignRotationAboutAnAxisToNodesProcess::Pointer, Process>(m,"AssignRotationAboutAnAxisToNodesProcess")
       .def(init<ModelPart&, Parameters>())
       .def(init< ModelPart&, Parameters& >())
       .def("Execute", &AssignRotationAboutAnAxisToNodesProcess::Execute)
@@ -133,7 +133,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
       ;
 
       
-  class_<AssignRotationFieldAboutAnAxisToNodesProcess, Process>(m,"AssignRotationFieldAboutAnAxisToNodesProcess")
+  class_<AssignRotationFieldAboutAnAxisToNodesProcess, AssignRotationFieldAboutAnAxisToNodesProcess::Pointer, Process>(m,"AssignRotationFieldAboutAnAxisToNodesProcess")
       .def(init<ModelPart&, pybind11::object&, const std::string,const bool, Parameters>())
       .def(init< ModelPart&, pybind11::object&, const std::string,const bool, Parameters& >())
       .def("Execute", &AssignRotationFieldAboutAnAxisToNodesProcess::Execute)
@@ -142,7 +142,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 
   //**********ASSIGN TORQUE ABOUT AN AXIS*********//
 
-  class_<AssignTorqueAboutAnAxisToConditionsProcess, Process>(m,"AssignTorqueAboutAnAxisToConditionsProcess")
+  class_<AssignTorqueAboutAnAxisToConditionsProcess, AssignTorqueAboutAnAxisToConditionsProcess::Pointer, Process>(m,"AssignTorqueAboutAnAxisToConditionsProcess")
       .def(init< ModelPart&, Parameters >())
       .def(init< ModelPart&, Parameters& >())
       .def("Execute", &AssignTorqueAboutAnAxisToConditionsProcess::Execute)
@@ -150,7 +150,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
       ;
 
       
-  class_<AssignTorqueFieldAboutAnAxisToConditionsProcess, Process>(m,"AssignTorqueFieldAboutAnAxisToConditionsProcess")
+  class_<AssignTorqueFieldAboutAnAxisToConditionsProcess, AssignTorqueFieldAboutAnAxisToConditionsProcess::Pointer, Process>(m,"AssignTorqueFieldAboutAnAxisToConditionsProcess")
       .def(init< ModelPart&, pybind11::object&,const std::string,const bool, Parameters >())
       .def(init< ModelPart&, pybind11::object&,const std::string,const bool, Parameters& >())
       .def("Execute", &AssignTorqueFieldAboutAnAxisToConditionsProcess::Execute)
@@ -160,7 +160,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
 
   //**********BUILD STRING SKIN PROCESS*********//
 
-  class_<BuildStringSkinProcess, Process>(m,"BuildStringSkinProcess")
+  class_<BuildStringSkinProcess, BuildStringSkinProcess::Pointer, Process>(m,"BuildStringSkinProcess")
       .def(init<ModelPart&, unsigned int, double>())
       .def("ExecuteInitialize", &BuildStringSkinProcess::ExecuteInitialize)
       .def("ExecuteFinalizeSolutionStep", &BuildStringSkinProcess::ExecuteFinalizeSolutionStep)

--- a/applications/StructuralMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/StructuralMechanicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -36,7 +36,7 @@ void  AddCustomProcessesToPython(pybind11::module& m)
     using namespace pybind11;
 
     /// Processes
-    class_<ApplyMultipointConstraintsProcess, Process>(m,"ApplyMultipointConstraintsProcess")
+    class_<ApplyMultipointConstraintsProcess, ApplyMultipointConstraintsProcess::Pointer, Process>(m,"ApplyMultipointConstraintsProcess")
         .def(init<ModelPart&>())
         .def(init< ModelPart&, Parameters& >())
 	.def("AddMasterSlaveRelation", &ApplyMultipointConstraintsProcess::AddMasterSlaveRelationWithNodesAndVariableComponents)
@@ -46,29 +46,29 @@ void  AddCustomProcessesToPython(pybind11::module& m)
         .def("SetActive", &ApplyMultipointConstraintsProcess::SetActive)      
         .def("PrintData", &ApplyMultipointConstraintsProcess::PrintData);
 
-    class_<PostprocessEigenvaluesProcess, Process>(m,"PostprocessEigenvaluesProcess")
+    class_<PostprocessEigenvaluesProcess, PostprocessEigenvaluesProcess::Pointer, Process>(m,"PostprocessEigenvaluesProcess")
         .def(init<ModelPart&, Parameters>());
     
-    class_<TotalStructuralMassProcess, Process >(m,"TotalStructuralMassProcess")
+    class_<TotalStructuralMassProcess, TotalStructuralMassProcess::Pointer, Process>(m,"TotalStructuralMassProcess")
         .def(init<ModelPart&>())
         .def("Execute", &TotalStructuralMassProcess::Execute)
         ;
     
 
-    class_<PrismNeighboursProcess, Process>(m, "PrismNeighboursProcess")
+    class_<PrismNeighboursProcess, PrismNeighboursProcess::Pointer, Process>(m, "PrismNeighboursProcess")
         .def(init<ModelPart&>())
         .def(init<ModelPart&, const bool >())
         .def("Execute",&PrismNeighboursProcess::Execute)
         .def("ClearNeighbours",&PrismNeighboursProcess::ClearNeighbours)
         ;
 
-    class_<ShellToSolidShellProcess<3>, Process>(m, "TriangleShellToSolidShellProcess")
+    class_<ShellToSolidShellProcess<3>, ShellToSolidShellProcess<3>::Pointer, Process>(m, "TriangleShellToSolidShellProcess")
         .def(init<ModelPart&>())
         .def(init< ModelPart&, Parameters >())
         .def("Execute",&ShellToSolidShellProcess<3>::Execute)
         ;
 
-    class_<ShellToSolidShellProcess<4>, Process>(m, "QuadrilateralShellToSolidShellProcess")
+    class_<ShellToSolidShellProcess<4>, ShellToSolidShellProcess<4>::Pointer, Process>(m, "QuadrilateralShellToSolidShellProcess")
         .def(init<ModelPart&>())
         .def(init< ModelPart&, Parameters >())
         .def("Execute",&ShellToSolidShellProcess<4>::Execute)

--- a/applications/ThermoMechanicalApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/ThermoMechanicalApplication/custom_python/add_custom_processes_to_python.cpp
@@ -76,19 +76,19 @@ void  AddCustomProcessesToPython(pybind11::module& m)
     using namespace pybind11;
 
 
-    class_<DuplicateInterfaceNodesCreateConditionsProcess, Process >
+    class_<DuplicateInterfaceNodesCreateConditionsProcess, DuplicateInterfaceNodesCreateConditionsProcess::Pointer, Process>
     (m,"DuplicateInterfaceNodesCreateConditionsProcess")
     .def( init<ModelPart&, char* ,int, const Matrix >())
     .def("Execute", &DuplicateInterfaceNodesCreateConditionsProcess::Execute)
     .def("PairToId", &DuplicateInterfaceNodesCreateConditionsProcess::PairToId)
     .def("IdToPair", &DuplicateInterfaceNodesCreateConditionsProcess::IdToPair)
     ;
-    class_<ActivationDeactivationConditionsProcess, Process >
+    class_<ActivationDeactivationConditionsProcess, ActivationDeactivationConditionsProcess::Pointer, Process>
     (m, "ActivationDeactivationConditionsProcess")
     .def( init<ModelPart& ,int, const Matrix >())
     .def("Execute", &ActivationDeactivationConditionsProcess::Execute)
     ;
-    class_<SolidificationProcess, Process >
+    class_<SolidificationProcess, SolidificationProcess::Pointer, Process>
     (m, "SolidificationProcess")
     .def(init<ModelPart& ,const double  >())
     .def("Execute", &SolidificationProcess::Execute)

--- a/applications/metis_application/custom_python/add_processes_to_python.cpp
+++ b/applications/metis_application/custom_python/add_processes_to_python.cpp
@@ -51,49 +51,49 @@ void AddProcessesToPython(pybind11::module& m)
 
 
 #ifndef KRATOS_USE_METIS_5
-    class_<MetisScalarReorder, Process >(m,"MetisScalarReorder").def(init<ModelPart&>())
+    class_<MetisScalarReorder, MetisScalarReorder::Pointer, Process>(m,"MetisScalarReorder").def(init<ModelPart&>())
     ;
 
-    class_<MetisPartitioningProcess, Process >(m,"MetisPartitioningProcess")
+    class_<MetisPartitioningProcess, MetisPartitioningProcess::Pointer, Process>(m,"MetisPartitioningProcess")
     .def(init<ModelPart&, IO&, unsigned int, unsigned int>())
     .def(init<ModelPart&, IO&, unsigned int>())
     ;
 
-    class_<MetisDivideInputToPartitionsProcess, Process >(m,"MetisDivideInputToPartitionsProcess")
+    class_<MetisDivideInputToPartitionsProcess, MetisDivideInputToPartitionsProcess::Pointer, Process>(m,"MetisDivideInputToPartitionsProcess")
     .def(init<IO&, unsigned int, unsigned int>())
     .def(init<IO&, unsigned int>())
     ;
 
-    class_<MetisContactPartitioningProcess, MetisPartitioningProcess >(m, "MetisContactPartitioningProcess")
+    class_<MetisContactPartitioningProcess, MetisContactPartitioningProcess::Pointer, MetisPartitioningProcess>(m, "MetisContactPartitioningProcess")
     .def(init<ModelPart&, IO&, unsigned int, std::vector<int>, unsigned int>())
     .def(init<ModelPart&, IO&, unsigned int, std::vector<int> >())
     ;
 
-    class_<MetisPartitioningProcessQuadratic, MetisPartitioningProcess >(m, "MetisPartitioningProcessQuadratic")
+    class_<MetisPartitioningProcessQuadratic, MetisPartitioningProcessQuadratic::Pointer, MetisPartitioningProcess >(m, "MetisPartitioningProcessQuadratic")
     .def(init<ModelPart&, IO&, unsigned int, unsigned int>())
     .def(init<ModelPart&, IO&, unsigned int>())
     ;
 #endif
-    class_<MetisDivideHeterogeneousInputProcess, Process >(m,"MetisDivideHeterogeneousInputProcess")
+    class_<MetisDivideHeterogeneousInputProcess, MetisDivideHeterogeneousInputProcess::Pointer, Process>(m,"MetisDivideHeterogeneousInputProcess")
     .def(init<IO&, unsigned int>())
             .def(init<IO&, unsigned int, int>())
             .def(init<IO&, unsigned int, int, int>())
             .def(init<IO&, unsigned int, int, int, bool>())
             ;
 
-    class_<MetisDivideHeterogeneousInputInMemoryProcess, Process >(m,"MetisDivideHeterogeneousInputInMemoryProcess")
+    class_<MetisDivideHeterogeneousInputInMemoryProcess, MetisDivideHeterogeneousInputInMemoryProcess::Pointer, Process>(m,"MetisDivideHeterogeneousInputInMemoryProcess")
     .def(init<IO&, unsigned int>())
             .def(init<IO&, unsigned int, int>())
             .def(init<IO&, unsigned int, int, int>())
             .def(init<IO&, unsigned int, int, int, bool>())
             ;
 
-    class_<MortonDivideInputToPartitionsProcess, Process >(m,"MetisDivideNodalInputToPartitionsProcess")
+    class_<MortonDivideInputToPartitionsProcess, MortonDivideInputToPartitionsProcess::Pointer, Process>(m,"MetisDivideNodalInputToPartitionsProcess")
     .def(init<IO&, std::size_t, int>())
             .def(init<IO&, std::size_t>())
     ;
 
-    class_<SetMPICommunicatorProcess, Process >(m,"SetMPICommunicatorProcess")
+    class_<SetMPICommunicatorProcess, SetMPICommunicatorProcess::Pointer, Process>(m,"SetMPICommunicatorProcess")
     .def(init<ModelPart&>())
     ;
 

--- a/applications/pfem_2_application/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/pfem_2_application/custom_python/add_custom_utilities_to_python.cpp
@@ -201,7 +201,7 @@ using namespace pybind11;
    .def("TransferToEulerianMesh_2", &ParticleUtils < 3 > ::TransferToEulerianMesh_2)	
    ;
  
- class_<Pfem2ApplyBCProcess,Process >(m,"Pfem2ApplyBCProcess").def(init<ModelPart&>());
+ class_<Pfem2ApplyBCProcess, Pfem2ApplyBCProcess::Pointer, Process>(m,"Pfem2ApplyBCProcess").def(init<ModelPart&>());
  
  class_<Pfem2Utils>(m,"Pfem2Utils").def(init<>())
    .def("ApplyBoundaryConditions",&Pfem2Utils::ApplyBoundaryConditions)
@@ -215,16 +215,14 @@ using namespace pybind11;
    .def ("MarkLonelyNodesForErasing", &Pfem2Utils::MarkLonelyNodesForErasing)
    .def ("SaveReducedPart", &Pfem2Utils::SaveReducedPart)
    ;
- class_<MarkOuterNodesProcess, Process >(m,"MarkOuterNodesProcess").def(init<ModelPart&>())
+ class_<MarkOuterNodesProcess, MarkOuterNodesProcess::Pointer, Process>(m,"MarkOuterNodesProcess").def(init<ModelPart&>())
    .def("MarkOuterNodes",&MarkOuterNodesProcess::MarkOuterNodes)
-   
    ;
  
- class_<MarkFluidProcess, Process >(m,"MarkFluidProcess").def(init<ModelPart&>());
+ class_<MarkFluidProcess, MarkFluidProcess::Pointer, Process>(m,"MarkFluidProcess").def(init<ModelPart&>());
  
  
- 
- class_<SaveLagrangianSurfaceProcess_p, Process >(m,"SaveLagrangianSurfaceProcess_p").def(init<> ())
+ class_<SaveLagrangianSurfaceProcess_p, SaveLagrangianSurfaceProcess_p::Pointer, Process>(m,"SaveLagrangianSurfaceProcess_p").def(init<> ())
    .def("SaveSurfaceConditions_p", &SaveLagrangianSurfaceProcess_p::SaveSurfaceConditions_p)
    ;
  

--- a/applications/trilinos_application/custom_python/add_trilinos_processes_to_python.cpp
+++ b/applications/trilinos_application/custom_python/add_trilinos_processes_to_python.cpp
@@ -47,7 +47,7 @@ void AddProcesses(pybind11::module& m)
 {
     typedef SpalartAllmarasTurbulenceModel<TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType> BaseSpAlModelType;
 
-    class_ < BaseSpAlModelType,Process  >(m, "TrilinosBaseSpAlModel" );
+    class_<BaseSpAlModelType, BaseSpAlModelType::Pointer, Process>(m, "TrilinosBaseSpAlModel" );
 
     // Turbulence models
     class_< TrilinosSpalartAllmarasTurbulenceModel< TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType >, BaseSpAlModelType >
@@ -59,11 +59,11 @@ void AddProcesses(pybind11::module& m)
 
     typedef StokesInitializationProcess<TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType> BaseStokesInitializationType;
 
-    class_ < BaseStokesInitializationType,Process  >
+    class_<BaseStokesInitializationType, BaseStokesInitializationType::Pointer, Process>
             (m, "TrilinosBaseStokesInitialization" )
             .def("SetConditions",&BaseStokesInitializationType::SetConditions);
 
-    class_< TrilinosStokesInitializationProcess< TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType >, BaseStokesInitializationType >
+    class_<TrilinosStokesInitializationProcess< TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType >, BaseStokesInitializationType >
             (m,"TrilinosStokesInitializationProcess")
             .def(init<Epetra_MpiComm&, ModelPart::Pointer,TrilinosLinearSolverType::Pointer, unsigned int, const Kratos::Variable<int>& >())
             ;
@@ -71,8 +71,8 @@ void AddProcesses(pybind11::module& m)
     typedef VariationalDistanceCalculationProcess<2,TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType> BaseDistanceCalculationType2D;
     typedef VariationalDistanceCalculationProcess<3,TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType> BaseDistanceCalculationType3D;
 
-    class_< BaseDistanceCalculationType2D, Process  >(m,"BaseDistanceCalculation2D");
-    class_< BaseDistanceCalculationType3D, Process  >(m,"BaseDistanceCalculation3D");
+    class_<BaseDistanceCalculationType2D, BaseDistanceCalculationType2D::Pointer, Process>(m,"BaseDistanceCalculation2D");
+    class_<BaseDistanceCalculationType3D, BaseDistanceCalculationType3D::Pointer, Process>(m,"BaseDistanceCalculation3D");
 
     class_< TrilinosVariationalDistanceCalculationProcess<2,TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType>,
             BaseDistanceCalculationType2D >(m,"TrilinosVariationalDistanceCalculationProcess2D")

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -70,7 +70,7 @@ void  AddProcessesToPython(pybind11::module& m)
 {
     using namespace pybind11;
 
-    class_<Process>(m,"Process")
+    class_<Process, Process::Pointer>(m,"Process")
     .def(init<>())
     .def("Execute",&Process::Execute)
     .def("ExecuteInitialize",&Process::ExecuteInitialize)
@@ -83,105 +83,105 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("__repr__", &Process::Info)
     ;
     
-    class_<FindNodalHProcess, Process >(m,"FindNodalHProcess")
+    class_<FindNodalHProcess, FindNodalHProcess::Pointer, Process>(m,"FindNodalHProcess")
     .def(init<ModelPart&>())
     .def("Execute",&FindNodalHProcess::Execute)
     ;
     
-    class_<FindNodalNeighboursProcess, Process >(m,"FindNodalNeighboursProcess")
+    class_<FindNodalNeighboursProcess, FindNodalNeighboursProcess::Pointer, Process>(m,"FindNodalNeighboursProcess")
             .def(init<ModelPart&, unsigned int, unsigned int>())
     .def("ClearNeighbours",&FindNodalNeighboursProcess::ClearNeighbours)
     ;
 
-    class_<FindConditionsNeighboursProcess, Process >(m,"FindConditionsNeighboursProcess")
+    class_<FindConditionsNeighboursProcess, FindConditionsNeighboursProcess::Pointer, Process>(m,"FindConditionsNeighboursProcess")
             .def(init<ModelPart&, int, unsigned int>())
     .def("ClearNeighbours",&FindConditionsNeighboursProcess::ClearNeighbours)
     ;
 
-    class_<FindElementalNeighboursProcess, Process >(m,"FindElementalNeighboursProcess")
+    class_<FindElementalNeighboursProcess, FindElementalNeighboursProcess::Pointer, Process>(m,"FindElementalNeighboursProcess")
             .def(init<ModelPart&, int, unsigned int>())
     .def("ClearNeighbours",&FindElementalNeighboursProcess::ClearNeighbours)
     ;
 
-    class_<CalculateNodalAreaProcess, Process >(m,"CalculateNodalAreaProcess")
+    class_<CalculateNodalAreaProcess, CalculateNodalAreaProcess::Pointer, Process>(m,"CalculateNodalAreaProcess")
             .def(init<ModelPart&, unsigned int>())
     ;
 
-    class_<NodeEraseProcess, Process >(m,"NodeEraseProcess")
+    class_<NodeEraseProcess, NodeEraseProcess::Pointer, Process>(m,"NodeEraseProcess")
             .def(init<ModelPart&>())
     ;
 
-    class_<ElementEraseProcess, Process >(m,"ElementEraseProcess")
+    class_<ElementEraseProcess, ElementEraseProcess::Pointer, Process>(m,"ElementEraseProcess")
             .def(init<ModelPart&>())
     ;
 
-    class_<ConditionEraseProcess, Process >(m,"ConditionEraseProcess")
+    class_<ConditionEraseProcess, ConditionEraseProcess::Pointer, Process>(m,"ConditionEraseProcess")
             .def(init<ModelPart&>())
     ;
 
-    class_<EliminateIsolatedNodesProcess, Process >(m,"EliminateIsolatedNodesProcess")
+    class_<EliminateIsolatedNodesProcess, EliminateIsolatedNodesProcess::Pointer, Process>(m,"EliminateIsolatedNodesProcess")
             .def(init<ModelPart&>())
     ;
 
-    class_<CalculateSignedDistanceTo3DSkinProcess, Process>(m,"CalculateSignedDistanceTo3DSkinProcess")
+    class_<CalculateSignedDistanceTo3DSkinProcess, CalculateSignedDistanceTo3DSkinProcess::Pointer, Process>(m,"CalculateSignedDistanceTo3DSkinProcess")
             .def(init<ModelPart&, ModelPart&>())
     .def("GenerateSkinModelPart",&CalculateSignedDistanceTo3DSkinProcess::GenerateSkinModelPart)
     .def("MappingPressureToStructure",&CalculateSignedDistanceTo3DSkinProcess::MappingPressureToStructure)
     ;
 
-    class_<CalculateEmbeddedSignedDistanceTo3DSkinProcess, Process>(m,"CalculateEmbeddedSignedDistanceTo3DSkinProcess")
+    class_<CalculateEmbeddedSignedDistanceTo3DSkinProcess, CalculateEmbeddedSignedDistanceTo3DSkinProcess::Pointer, Process>(m,"CalculateEmbeddedSignedDistanceTo3DSkinProcess")
             .def(init< ModelPart&, ModelPart& >())
     .def(init< ModelPart&, ModelPart&, bool>())
     ;
 
-   class_<CalculateSignedDistanceTo3DConditionSkinProcess, Process >(m,"CalculateSignedDistanceTo3DConditionSkinProcess")
+   class_<CalculateSignedDistanceTo3DConditionSkinProcess, CalculateSignedDistanceTo3DConditionSkinProcess::Pointer, Process>(m,"CalculateSignedDistanceTo3DConditionSkinProcess")
             .def(init<ModelPart&, ModelPart&>())
     ;
 
-    class_<TranslationOperation, Process >(m,"TranslationOperation")
+    class_<TranslationOperation, TranslationOperation::Pointer, Process>(m,"TranslationOperation")
             .def(init<ModelPart&, DenseVector<int> ,DenseVector<int> ,unsigned int>())
     ;
 
-    class_<RotationOperation, Process >(m,"RotationOperation")
+    class_<RotationOperation, RotationOperation::Pointer, Process>(m,"RotationOperation")
             .def(init<ModelPart&, DenseVector<int> ,DenseVector<int> ,unsigned int>())
     ;
 
-    class_<StructuredMeshGeneratorProcess, Process>(m,"StructuredMeshGeneratorProcess")
+    class_<StructuredMeshGeneratorProcess, StructuredMeshGeneratorProcess::Pointer, Process>(m,"StructuredMeshGeneratorProcess")
             .def(init<const Geometry< Node<3> >&, ModelPart&, Parameters&>()) //TODO: VERIFY IF THE NEXT IS NEEDED: [with_custodian_and_ward<1, 2>()])
     ;
 
-    class_<TetrahedralMeshOrientationCheck, Process>(m,"TetrahedralMeshOrientationCheck")
+    class_<TetrahedralMeshOrientationCheck, TetrahedralMeshOrientationCheck::Pointer, Process>(m,"TetrahedralMeshOrientationCheck")
             .def(init<ModelPart&, bool>())
     .def("SwapAll",&TetrahedralMeshOrientationCheck::SwapAll)
     .def("SwapNegativeElements",&TetrahedralMeshOrientationCheck::SwapNegativeElements)
     ;
 
-    class_<ComputeBDFCoefficientsProcess, Process>(m,"ComputeBDFCoefficientsProcess")
+    class_<ComputeBDFCoefficientsProcess, ComputeBDFCoefficientsProcess::Pointer, Process>(m,"ComputeBDFCoefficientsProcess")
             .def(init<ModelPart&, const unsigned int>())
     ;
 
     typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
     typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
     typedef LinearSolver<SparseSpaceType, LocalSpaceType > LinearSolverType;
-    class_<VariationalDistanceCalculationProcess<2,SparseSpaceType,LocalSpaceType,LinearSolverType > , Process>(m,"VariationalDistanceCalculationProcess2D")
+    class_<VariationalDistanceCalculationProcess<2,SparseSpaceType,LocalSpaceType,LinearSolverType>, VariationalDistanceCalculationProcess<2,SparseSpaceType,LocalSpaceType,LinearSolverType>::Pointer, Process>(m,"VariationalDistanceCalculationProcess2D")
             .def(init<ModelPart&, LinearSolverType::Pointer, unsigned int>())
     ;
-    class_<VariationalDistanceCalculationProcess<3,SparseSpaceType,LocalSpaceType,LinearSolverType > , Process>(m,"VariationalDistanceCalculationProcess3D")
+    class_<VariationalDistanceCalculationProcess<3,SparseSpaceType,LocalSpaceType,LinearSolverType>, VariationalDistanceCalculationProcess<3,SparseSpaceType,LocalSpaceType,LinearSolverType>::Pointer, Process>(m,"VariationalDistanceCalculationProcess3D")
             .def(init<ModelPart&, LinearSolverType::Pointer, unsigned int>())
     ;
 
-    class_<LevelSetConvectionProcess<2> , Process>(m,"LevelSetConvectionProcess2D")
+    class_<LevelSetConvectionProcess<2>, LevelSetConvectionProcess<2>::Pointer, Process>(m,"LevelSetConvectionProcess2D")
             .def(init<Variable<double>& , ModelPart& , LinearSolverType::Pointer ,double >())
     .def(init< Variable<double>& , ModelPart& , LinearSolverType::Pointer ,double, double>())
     .def(init< Variable<double>&, ModelPart&, LinearSolverType::Pointer, double, double,int>())
     ;
-    class_<LevelSetConvectionProcess<3> , Process>(m,"LevelSetConvectionProcess3D")
+    class_<LevelSetConvectionProcess<3>, LevelSetConvectionProcess<3>::Pointer, Process>(m,"LevelSetConvectionProcess3D")
             .def(init<Variable<double>& , ModelPart& , LinearSolverType::Pointer ,double>())
             .def(init< Variable<double>& , ModelPart& , LinearSolverType::Pointer ,double, double>())
 			.def(init< Variable<double>&, ModelPart&, LinearSolverType::Pointer, double, double,int>())
     ;
 
-    class_<ApplyConstantScalarValueProcess , Process>(m,"ApplyConstantScalarValueProcess")
+    class_<ApplyConstantScalarValueProcess, ApplyConstantScalarValueProcess::Pointer, Process>(m,"ApplyConstantScalarValueProcess")
             .def(init<ModelPart&, Parameters>())
             .def(init<ModelPart&, const Variable<double>&, double, std::size_t, Flags>())
             .def(init< ModelPart&, Parameters& >())
@@ -192,7 +192,7 @@ void  AddProcessesToPython(pybind11::module& m)
             .def_readonly_static("VARIABLE_IS_FIXED", &ApplyConstantScalarValueProcess::VARIABLE_IS_FIXED)
     ;
 
-    class_<ApplyConstantVectorValueProcess , Process>(m,"ApplyConstantVectorValueProcess")
+    class_<ApplyConstantVectorValueProcess, ApplyConstantVectorValueProcess::Pointer, Process>(m,"ApplyConstantVectorValueProcess")
             .def(init<ModelPart&, Parameters>())
             .def(init<ModelPart&, const Variable<array_1d<double, 3 > >& , const double, const Vector , std::size_t, Flags>())
             .def(init< ModelPart&, Parameters& >())
@@ -201,66 +201,66 @@ void  AddProcessesToPython(pybind11::module& m)
             .def_readonly_static("Z_COMPONENT_FIXED", &ApplyConstantVectorValueProcess::Z_COMPONENT_FIXED)
     ;
 
-    class_<CheckSkinProcess , Process>(m,"CheckSkinProcess")
+    class_<CheckSkinProcess, CheckSkinProcess::Pointer, Process>(m,"CheckSkinProcess")
             .def(init<ModelPart&, Flags>())
     ;
 
-    class_<ReplaceElementsAndConditionsProcess , Process>(m,"ReplaceElementsAndConditionsProcess")
+    class_<ReplaceElementsAndConditionsProcess, ReplaceElementsAndConditionsProcess::Pointer, Process>(m,"ReplaceElementsAndConditionsProcess")
             .def(init<ModelPart&, Parameters>())
     ;
 
     /* Historical */
     // DOUBLE
-    class_<ComputeNodalGradientProcess<2, Variable<double>, Historical> , Process>(m,"ComputeNodalGradientProcess2D")
+    class_<ComputeNodalGradientProcess<2, Variable<double>, Historical>, ComputeNodalGradientProcess<2, Variable<double>, Historical>::Pointer, Process>(m,"ComputeNodalGradientProcess2D")
             .def(init<ModelPart&, Variable<double>&, Variable<array_1d<double,3> >& , Variable<double>& >())
     ;
 
-    class_<ComputeNodalGradientProcess<3, Variable<double>, Historical> , Process>(m,"ComputeNodalGradientProcess3D")
+    class_<ComputeNodalGradientProcess<3, Variable<double>, Historical>, ComputeNodalGradientProcess<3, Variable<double>, Historical>::Pointer, Process>(m,"ComputeNodalGradientProcess3D")
             .def(init<ModelPart&, Variable<double>&, Variable<array_1d<double,3> >& , Variable<double>& >())
     ;
 
     // COMPONENT
-    class_<ComputeNodalGradientProcess<2, component_type, Historical> , Process>(m,"ComputeNodalGradientProcessComp2D")
+    class_<ComputeNodalGradientProcess<2, component_type, Historical>, ComputeNodalGradientProcess<2, component_type, Historical>::Pointer, Process>(m,"ComputeNodalGradientProcessComp2D")
             .def(init<ModelPart&, component_type&, Variable<array_1d<double,3> >& , Variable<double>& >())
     ;
 
-    class_<ComputeNodalGradientProcess<3, component_type, Historical> , Process>(m,"ComputeNodalGradientProcessComp3D")
+    class_<ComputeNodalGradientProcess<3, component_type, Historical>, ComputeNodalGradientProcess<3, component_type, Historical>::Pointer, Process>(m,"ComputeNodalGradientProcessComp3D")
             .def(init<ModelPart&, component_type&, Variable<array_1d<double,3> >& , Variable<double>& >())
     ;
     
     /* Non-Historical */
     // DOUBLE
-    class_<ComputeNodalGradientProcess<2, Variable<double>, NonHistorical> , Process>(m,"ComputeNonHistoricalNodalGradientProcess2D")
+    class_<ComputeNodalGradientProcess<2, Variable<double>, NonHistorical>, ComputeNodalGradientProcess<2, Variable<double>, NonHistorical>::Pointer, Process>(m,"ComputeNonHistoricalNodalGradientProcess2D")
             .def(init<ModelPart&, Variable<double>&, Variable<array_1d<double,3> >& , Variable<double>& >())
             ;
 
-    class_<ComputeNodalGradientProcess<3, Variable<double>, NonHistorical> , Process>(m,"ComputeNonHistoricalNodalGradientProcess3D")
+    class_<ComputeNodalGradientProcess<3, Variable<double>, NonHistorical>, ComputeNodalGradientProcess<3, Variable<double>, NonHistorical>::Pointer, Process>(m,"ComputeNonHistoricalNodalGradientProcess3D")
             .def(init<ModelPart&, Variable<double>&, Variable<array_1d<double,3> >& , Variable<double>& >())
             ;
 
     // COMPONENT
-    class_<ComputeNodalGradientProcess<2, component_type, NonHistorical> , Process>(m,"ComputeNonHistoricalNodalGradientProcessComp2D")
+    class_<ComputeNodalGradientProcess<2, component_type, NonHistorical>, ComputeNodalGradientProcess<2, component_type, NonHistorical>::Pointer, Process>(m,"ComputeNonHistoricalNodalGradientProcessComp2D")
             .def(init<ModelPart&, component_type&, Variable<array_1d<double,3> >& , Variable<double>& >())
     ;
 
-    class_<ComputeNodalGradientProcess<3, component_type, NonHistorical> , Process>(m,"ComputeNonHistoricalNodalGradientProcessComp3D")
+    class_<ComputeNodalGradientProcess<3, component_type, NonHistorical>, ComputeNodalGradientProcess<3, component_type, NonHistorical>::Pointer, Process>(m,"ComputeNonHistoricalNodalGradientProcessComp3D")
             .def(init<ModelPart&, component_type&, Variable<array_1d<double,3> >& , Variable<double>& >())
     ;
 
-    class_<CalculateDiscontinuousDistanceToSkinProcess, Process>(m,"CalculateDiscontinuousDistanceToSkinProcess")
+    class_<CalculateDiscontinuousDistanceToSkinProcess, CalculateDiscontinuousDistanceToSkinProcess::Pointer, Process>(m,"CalculateDiscontinuousDistanceToSkinProcess")
             .def(init<ModelPart&, ModelPart&>())
             ;
 
-    class_<ReorderAndOptimizeModelPartProcess, Process>(m,"ReorderAndOptimizeModelPartProcess")
+    class_<ReorderAndOptimizeModelPartProcess, ReorderAndOptimizeModelPartProcess::Pointer, Process>(m,"ReorderAndOptimizeModelPartProcess")
             .def(init<ModelPart&, Parameters>())
             ;
 
 
-    class_<AssignScalarVariableToConditionsProcess, Process>(m,"AssignScalarVariableToConditionsProcess")
+    class_<AssignScalarVariableToConditionsProcess, AssignScalarVariableToConditionsProcess::Pointer, Process>(m,"AssignScalarVariableToConditionsProcess")
             .def(init<ModelPart&, Parameters >())
     ;
 
-    class_<AssignScalarFieldToConditionsProcess , Process>(m,"AssignScalarFieldToConditionsProcess")
+    class_<AssignScalarFieldToConditionsProcess, AssignScalarFieldToConditionsProcess::Pointer, Process>(m,"AssignScalarFieldToConditionsProcess")
             .def(init<ModelPart&, Parameters >())
     ;
 
@@ -268,15 +268,15 @@ void  AddProcessesToPython(pybind11::module& m)
     //typedef PointerVectorSet<Node<3>, IndexedObject> NodesContainerType;
     //typedef PointerVectorSet<Dof<double>, IndexedObject> DofsContainerType;
 
-    //class_<AddDofsNodalProcess<Variable<double> >, Process >(m,"AddDoubleDofsNodalProcess")
+    //class_<AddDofsNodalProcess<Variable<double> >, AddDofsNodalProcess<Variable<double> >::Pointer, Process>(m,"AddDoubleDofsNodalProcess")
     // .def(init<Variable<double>, NodesContainerType&, DofsContainerType&>())
     // ;
-    //class_<AddDofsNodalProcess<VariableComponent<Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> > > >, Process >(m,"AddArrayComponentDofsNodalProcess")
+    //class_<AddDofsNodalProcess<VariableComponent<Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> > > >, AddDofsNodalProcess<VariableComponent<Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3> > > >::Pointer, Process>(m,"AddArrayComponentDofsNodalProcess")
     // ;
 
     /* Simple Mortar mapper */
     // 2D 
-    class_<SimpleMortarMapperProcess<2, 2, Variable<double>, Historical>, Process>(m, "SimpleMortarMapperProcess2D2NDoubleHistorical")
+    class_<SimpleMortarMapperProcess<2, 2, Variable<double>, Historical>, SimpleMortarMapperProcess<2, 2, Variable<double>, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess2D2NDoubleHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -286,7 +286,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<2, 2, Variable<double>, Historical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, Historical>, Process>(m, "SimpleMortarMapperProcess2D2NVectorHistorical")
+    class_<SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, Historical>, SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess2D2NVectorHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -296,7 +296,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, Historical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<2, 2, Variable<double>, NonHistorical>, Process>(m, "SimpleMortarMapperProcess2D2NDoubleNonHistorical")
+    class_<SimpleMortarMapperProcess<2, 2, Variable<double>, NonHistorical>, SimpleMortarMapperProcess<2, 2, Variable<double>, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess2D2NDoubleNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Variable<double>&>())
@@ -305,7 +305,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<2, 2, Variable<double>, NonHistorical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, NonHistorical>, Process>(m, "SimpleMortarMapperProcess2D2NVectorNonHistorical")
+    class_<SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, NonHistorical>, SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess2D2NVectorNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -316,7 +316,7 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     // 3D - Triangle
-    class_<SimpleMortarMapperProcess<3, 3, Variable<double>, Historical>, Process>(m, "SimpleMortarMapperProcess3D3NDoubleHistorical")
+    class_<SimpleMortarMapperProcess<3, 3, Variable<double>, Historical>, SimpleMortarMapperProcess<3, 3, Variable<double>, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D3NDoubleHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -326,7 +326,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 3, Variable<double>, Historical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, Historical>, Process>(m, "SimpleMortarMapperProcess3D3NVectorHistorical")
+    class_<SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, Historical>, SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D3NVectorHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -336,7 +336,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, Historical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 3, Variable<double>, NonHistorical>, Process>(m, "SimpleMortarMapperProcess3D3NDoubleNonHistorical")
+    class_<SimpleMortarMapperProcess<3, 3, Variable<double>, NonHistorical>, SimpleMortarMapperProcess<3, 3, Variable<double>, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D3NDoubleNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -346,7 +346,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 3, Variable<double>, NonHistorical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, NonHistorical>, Process>(m, "SimpleMortarMapperProcess3D3NVectorNonHistorical")
+    class_<SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, NonHistorical>, SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D3NVectorNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -357,7 +357,7 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     // 3D - Quadrilateral
-    class_<SimpleMortarMapperProcess<3, 4, Variable<double>, Historical>, Process>(m, "SimpleMortarMapperProcess3D4NDoubleHistorical")
+    class_<SimpleMortarMapperProcess<3, 4, Variable<double>, Historical>, SimpleMortarMapperProcess<3, 4, Variable<double>, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D4NDoubleHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -367,7 +367,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 4, Variable<double>, Historical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, Historical>, Process>(m, "SimpleMortarMapperProcess3D4NVectorHistorical")
+    class_<SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, Historical>, SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D4NVectorHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -377,7 +377,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, Historical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 4, Variable<double>, NonHistorical>, Process>(m, "SimpleMortarMapperProcess3D4NDoubleNonHistorical")
+    class_<SimpleMortarMapperProcess<3, 4, Variable<double>, NonHistorical>, SimpleMortarMapperProcess<3, 4, Variable<double>, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D4NDoubleNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -387,7 +387,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 4, Variable<double>, NonHistorical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, NonHistorical>, Process>(m, "SimpleMortarMapperProcess3D4NVectorNonHistorical")
+    class_<SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, NonHistorical>, SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D4NVectorNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -398,7 +398,7 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
     
     // 2D 
-    class_<SimpleMortarMapperProcess<2, 2, Variable<double>, Historical, NonHistorical>, Process>(m, "SimpleMortarMapperProcess2D2NDoubleHistoricalToNonHistorical")
+    class_<SimpleMortarMapperProcess<2, 2, Variable<double>, Historical, NonHistorical>, SimpleMortarMapperProcess<2, 2, Variable<double>, Historical, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess2D2NDoubleHistoricalToNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -408,7 +408,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<2, 2, Variable<double>, Historical, NonHistorical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, Historical, NonHistorical>, Process>(m, "SimpleMortarMapperProcess2D2NVectorHistoricalToNonHistorical")
+    class_<SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, Historical, NonHistorical>, SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, Historical, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess2D2NVectorHistoricalToNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -418,7 +418,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, Historical, NonHistorical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<2, 2, Variable<double>, NonHistorical, Historical>, Process>(m, "SimpleMortarMapperProcess2D2NDoubleNonHistoricalToHistorical")
+    class_<SimpleMortarMapperProcess<2, 2, Variable<double>, NonHistorical, Historical>, SimpleMortarMapperProcess<2, 2, Variable<double>, NonHistorical, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess2D2NDoubleNonHistoricalToHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -428,7 +428,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<2, 2, Variable<double>, NonHistorical, Historical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, NonHistorical, Historical>, Process>(m, "SimpleMortarMapperProcess2D2NVectorNonHistoricalToHistorical")
+    class_<SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, NonHistorical, Historical>, SimpleMortarMapperProcess<2, 2, Variable<array_1d<double,3> >, NonHistorical, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess2D2NVectorNonHistoricalToHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -439,7 +439,7 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     // 3D - Triangle
-    class_<SimpleMortarMapperProcess<3, 3, Variable<double>, Historical, NonHistorical>, Process>(m, "SimpleMortarMapperProcess3D3NDoubleHistoricalToNonHistorical")
+    class_<SimpleMortarMapperProcess<3, 3, Variable<double>, Historical, NonHistorical>, SimpleMortarMapperProcess<3, 3, Variable<double>, Historical, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D3NDoubleHistoricalToNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -449,7 +449,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 3, Variable<double>, Historical, NonHistorical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, Historical, NonHistorical>, Process>(m, "SimpleMortarMapperProcess3D3NVectorHistoricalToNonHistorical")
+    class_<SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, Historical, NonHistorical>, SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, Historical, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D3NVectorHistoricalToNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -459,7 +459,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, Historical, NonHistorical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 3, Variable<double>, NonHistorical, Historical>, Process>(m, "SimpleMortarMapperProcess3D3NDoubleNonHistoricalToHistorical")
+    class_<SimpleMortarMapperProcess<3, 3, Variable<double>, NonHistorical, Historical>, SimpleMortarMapperProcess<3, 3, Variable<double>, NonHistorical, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D3NDoubleNonHistoricalToHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -469,7 +469,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 3, Variable<double>, NonHistorical, Historical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, NonHistorical, Historical>, Process>(m, "SimpleMortarMapperProcess3D3NVectorNonHistoricalToHistorical")
+    class_<SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, NonHistorical, Historical>, SimpleMortarMapperProcess<3, 3, Variable<array_1d<double,3> >, NonHistorical, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D3NVectorNonHistoricalToHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -480,7 +480,7 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     // 3D - Quadrilateral
-    class_<SimpleMortarMapperProcess<3, 4, Variable<double>, Historical, NonHistorical>, Process>(m, "SimpleMortarMapperProcess3D4NDoubleHistoricalToNonHistorical")
+    class_<SimpleMortarMapperProcess<3, 4, Variable<double>, Historical, NonHistorical>, SimpleMortarMapperProcess<3, 4, Variable<double>, Historical, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D4NDoubleHistoricalToNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -490,7 +490,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 4, Variable<double>, Historical, NonHistorical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, Historical, NonHistorical>, Process>(m, "SimpleMortarMapperProcess3D4NVectorHistoricalToNonHistorical")
+    class_<SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, Historical, NonHistorical>, SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, Historical, NonHistorical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D4NVectorHistoricalToNonHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -500,7 +500,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, Historical, NonHistorical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 4, Variable<double>, NonHistorical, Historical>, Process>(m, "SimpleMortarMapperProcess3D4NDoubleNonHistoricalToHistorical")
+    class_<SimpleMortarMapperProcess<3, 4, Variable<double>, NonHistorical, Historical>, SimpleMortarMapperProcess<3, 4, Variable<double>, NonHistorical, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D4NDoubleNonHistoricalToHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<double>&>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<double>&, Parameters, LinearSolverType::Pointer>())
@@ -510,7 +510,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 4, Variable<double>, NonHistorical, Historical>::Execute)
     ;
 
-    class_<SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, NonHistorical, Historical>, Process>(m, "SimpleMortarMapperProcess3D4NVectorNonHistoricalToHistorical")
+    class_<SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, NonHistorical, Historical>, SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, NonHistorical, Historical>::Pointer, Process>(m, "SimpleMortarMapperProcess3D4NVectorNonHistoricalToHistorical")
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters>())
     .def(init<ModelPart&, ModelPart&, Variable<array_1d<double,3> >&, Parameters, LinearSolverType::Pointer>())
@@ -520,7 +520,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def("Execute",&SimpleMortarMapperProcess<3, 4, Variable<array_1d<double,3> >, NonHistorical, Historical>::Execute)
     ;
 
-    class_<FastTransferBetweenModelPartsProcess, Process> FastTransferBetweenModelPartsProcess_Scope(m, "FastTransferBetweenModelPartsProcess");
+    class_<FastTransferBetweenModelPartsProcess, FastTransferBetweenModelPartsProcess::Pointer, Process> FastTransferBetweenModelPartsProcess_Scope(m, "FastTransferBetweenModelPartsProcess");
     
     FastTransferBetweenModelPartsProcess_Scope.def(init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered>());
     FastTransferBetweenModelPartsProcess_Scope.def(init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered, const Flags >());


### PR DESCRIPTION
This changes the handler of process from unique_ptr to shared_ptr. 
This allows to:
- Is possible to accept Process::Pointer a parameter in functions exposed to python
- Process are handled now like they were handled with boost.python.

@KratosMultiphysics/team-maintainers Please take 5 minutes to check codes run and review your application specific codes. Please take special care to review processes that we not directly derived from the class 'Process' since those were trickier to find and I may have missed some.

In the process of making the PR I noticed that some process are not exporting the Kratos pointer. I will note them here so you can handle this situation as you prefer (either remove them from the python interface or add the definition). The application were not ported anyway so there will be no problems compiling right now:

**Incompressible**:
- SaveFlagModelPartProcess
- SaveElementBySizeProcess
- SaveElementByFlagProcess
- ChooseElementProcess
- AssignHByDistanceProcess

**LagrangianMPM**:
- RecomputeNeighboursProcess
- Gauss_Coordinates_Update_Process (also the name of the class should be camelcase :D)
- ComputeMLSShapeFunctionsProcess
- ComputeLMEShapeFunctionsProcess