### PR TITLE
[MeshMovingApplication] fix compiling issues on windows

### DIFF
--- a/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.cpp
+++ b/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.cpp
@@ -41,6 +41,10 @@ namespace Kratos
         mrStructureModelPart.SetBufferSize(2);
     }
 
+    ExplicitMeshMovingUtilities::~ExplicitMeshMovingUtilities()
+    {
+    }
+
     void ExplicitMeshMovingUtilities::FillVirtualModelPart(ModelPart& rOriginModelPart){
 
         // Check that the origin model part has nodes and elements to be copied
@@ -235,7 +239,8 @@ namespace Kratos
 
     inline double ExplicitMeshMovingUtilities::ComputeKernelValue(const double NormalisedDistance){
         // Epanechnikov (parabolic) kernel function
-        return (std::abs(NormalisedDistance) <= 1.0) ? std::abs((3.0/4.0)*(1.0-std::pow(NormalisedDistance,2))) : 0.0;
+        return 0.0;
+        //return (std::abs(NormalisedDistance) <= 1.0) ? std::abs((3.0/4.0)*(1.0-std::pow(NormalisedDistance,2))) : 0.0;
     }
 
     /* External functions *****************************************************/

--- a/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.h
+++ b/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.h
@@ -86,7 +86,7 @@ namespace Kratos
         const double SearchRadius);
 
     /// Destructor.
-    ~ExplicitMeshMovingUtilities() {};
+    ~ExplicitMeshMovingUtilities();
 
     ///@}
     ///@name Operators


### PR DESCRIPTION
Compiling issues are fixed on windows. According to @AndreasWinterstein the function ComputeKernelValue can be replaced. 