### PR TITLE
Core/uniform def of resize and initialize

### DIFF
--- a/applications/MultiScaleApplication/custom_strategies/builder_and_solvers/static_general_builder_and_solver.h
+++ b/applications/MultiScaleApplication/custom_strategies/builder_and_solvers/static_general_builder_and_solver.h
@@ -681,9 +681,7 @@ public:
     void ResizeAndInitializeVectors( typename TSchemeType::Pointer pScheme,TSystemMatrixPointerType& pA,
                                     TSystemVectorPointerType& pDx,
                                     TSystemVectorPointerType& pb,
-                                    ElementsArrayType& rElements,
-                                    ConditionsArrayType& rConditions,
-                                    ProcessInfo& CurrentProcessInfo)
+                                    ModelPart& rModelPart)
     {
         KRATOS_TRY
         if (pA == NULL) //if the pointer is not initialized initialize it to an empty matrix
@@ -715,7 +713,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, false);
-            ConstructMatrixStructure(pScheme, A, rElements, rConditions, CurrentProcessInfo);
+            ConstructMatrixStructure(pScheme, A, rModelPart.Elements(), rModelPart.Conditions(), rModelPart.GetProcessInfo());
         }
         else
         {
@@ -723,7 +721,7 @@ public:
             {
                 KRATOS_WATCH( "it should not come here!!!!!!!! ... this is SLOW" )
                 A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, true);
-                ConstructMatrixStructure(pScheme, A, rElements, rConditions, CurrentProcessInfo);
+                ConstructMatrixStructure(pScheme, A, rModelPart.Elements(), rModelPart.Conditions(), rModelPart.GetProcessInfo());
             }
         }
         if (Dx.size() != BaseType::mEquationSystemSize)
@@ -799,15 +797,13 @@ public:
 protected:
 
     virtual void ConstructMatrixStructure( typename TSchemeType::Pointer pScheme,TSystemMatrixType& A,
-                                          ElementsContainerType& rElements,
-                                          ConditionsArrayType& rConditions,
-                                          ProcessInfo& CurrentProcessInfo)
+                                          ModelPart& rModelPart)
     {
         std::size_t equation_size = A.size1();
         std::vector<std::vector<std::size_t> > indices(equation_size);
 
         Element::EquationIdVectorType ids(3, 0);
-        for (typename ElementsContainerType::iterator i_element = rElements.begin(); i_element != rElements.end(); i_element++)
+        for (typename ElementsContainerType::iterator i_element = rModelPart.ElementsBegin(); i_element != rModelPart.ElementsEnd(); i_element++)
         {
 
             pScheme->EquationId( *(i_element.base()) , ids, CurrentProcessInfo);
@@ -824,7 +820,7 @@ protected:
 
         }
 
-        for (typename ConditionsArrayType::iterator i_condition = rConditions.begin(); i_condition != rConditions.end(); i_condition++)
+        for (typename ConditionsArrayType::iterator i_condition = rModelPart.ConditionsBegin(); i_condition != rModelPart.ConditionsEnd(); i_condition++)
         {
 
             pScheme->Condition_EquationId( *(i_condition.base()), ids, CurrentProcessInfo);

--- a/applications/MultiScaleApplication/custom_strategies/strategies/arc_length_diss_nrg_strategy.h
+++ b/applications/MultiScaleApplication/custom_strategies/strategies/arc_length_diss_nrg_strategy.h
@@ -779,9 +779,7 @@ protected:
 
         mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, 
 					mpA, mpDx, mpb, 
-					model.Elements(), 
-					model.Conditions(), 
-					model.GetProcessInfo());
+					model);
 
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;

--- a/applications/MultiScaleApplication/custom_strategies/strategies/arc_length_diss_nrg_strategy.h
+++ b/applications/MultiScaleApplication/custom_strategies/strategies/arc_length_diss_nrg_strategy.h
@@ -775,11 +775,11 @@ protected:
 
     void InitializeSolutionStep()
     {
-		ModelPart & model = BaseType::GetModelPart();
+		ModelPart & model_part = BaseType::GetModelPart();
 
         mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, 
 					mpA, mpDx, mpb, 
-					model);
+					model_part);
 
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;

--- a/applications/MultiScaleApplication/custom_strategies/strategies/arc_length_diss_nrg_strategy.h
+++ b/applications/MultiScaleApplication/custom_strategies/strategies/arc_length_diss_nrg_strategy.h
@@ -303,19 +303,19 @@ public:
 
 		mIsConverged = false;
 
-		ModelPart& model = BaseType::GetModelPart();
+		ModelPart& model_part = BaseType::GetModelPart();
 
 		if (!mInitializeWasPerformed) this->Initialize();
 
-		bool verbose_allowed = model.GetCommunicator().MyPID() == 0;
+		bool verbose_allowed = model_part.GetCommunicator().MyPID() == 0;
 		bool verbose         = this->GetEchoLevel() > 0 && verbose_allowed;
 
-		model.GetProcessInfo()[STRATEGY_SOLUTION_STEP_SOLVED] = 0;
+		model_part.GetProcessInfo()[STRATEGY_SOLUTION_STEP_SOLVED] = 0;
 
 		if (mpBuilderAndSolver->GetDofSetIsInitializedFlag() == false || mReformDofSetAtEachStep == true)
 		{
-			mpBuilderAndSolver->SetUpDofSet(mpScheme, model);
-			mpBuilderAndSolver->SetUpSystem(model);
+			mpBuilderAndSolver->SetUpDofSet(mpScheme, model_part);
+			mpBuilderAndSolver->SetUpSystem(model_part);
 		}
 
 		DofsArrayType& rDofSet = mpBuilderAndSolver->GetDofSet();
@@ -345,7 +345,7 @@ public:
 			// the RHS vector will contain only the external forces and 0 internal forces (balanced without external forces)
 			// Here we further assume that LAMBDA is set to 1
 			TSystemVectorType& mFhat = *mpFhat;
-			mpBuilderAndSolver->BuildRHS(mpScheme, model, mFhat);
+			mpBuilderAndSolver->BuildRHS(mpScheme, model_part, mFhat);
 			// check for a reference load
 			bool haveLoad = false;
 			for (unsigned int i=0; i<sys_size; i++) {
@@ -378,19 +378,19 @@ public:
 		
 		mIsConverged = false;
 
-		ModelPart& model = BaseType::GetModelPart();
+		ModelPart& model_part = BaseType::GetModelPart();
 
 		if (!mInitializeWasPerformed) this->Initialize();
 
-		bool verbose_allowed = model.GetCommunicator().MyPID() == 0;
+		bool verbose_allowed = model_part.GetCommunicator().MyPID() == 0;
 		bool verbose         = this->GetEchoLevel() > 0 && verbose_allowed;
 
-		model.GetProcessInfo()[STRATEGY_SOLUTION_STEP_SOLVED] = 0;
+		model_part.GetProcessInfo()[STRATEGY_SOLUTION_STEP_SOLVED] = 0;
 
 		if (mpBuilderAndSolver->GetDofSetIsInitializedFlag() == false || mReformDofSetAtEachStep == true)
 		{
-			mpBuilderAndSolver->SetUpDofSet(mpScheme, model);
-			mpBuilderAndSolver->SetUpSystem(model);
+			mpBuilderAndSolver->SetUpDofSet(mpScheme, model_part);
+			mpBuilderAndSolver->SetUpSystem(model_part);
 		}
 
 		DofsArrayType& rDofSet = mpBuilderAndSolver->GetDofSet();
@@ -437,12 +437,12 @@ public:
 			===============================================================================
 			*/
 
-			mpBuilderAndSolver->BuildRHS(mpScheme, model, mb);
+			mpBuilderAndSolver->BuildRHS(mpScheme, model_part, mb);
 			if(this->CheckIntegrationErrors() != 0.0)
 			{
 				if(verbose) this->PromptIntegrationErrors();
 				mIsConverged = false;
-				model.GetProcessInfo()[NL_ITERATION_NUMBER] = mMaxIterationNumber;
+				model_part.GetProcessInfo()[NL_ITERATION_NUMBER] = mMaxIterationNumber;
 			}
 			else
 			{
@@ -479,13 +479,13 @@ public:
 			*/
 
 			unsigned int iteration_number = 0;
-			model.GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
+			model_part.GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
 
 			// K,fint = assembleTangentStiffness( props, globdat )
 			TSparseSpace::SetToZero(mDx);
 			TSparseSpace::SetToZero(mA);
 			TSparseSpace::SetToZero(mb);
-			mpBuilderAndSolver->Build(mpScheme, model, mA, mb); // <<<<<<<<<<<<<<<<<<<<<<<<<<<< INT ERROR
+			mpBuilderAndSolver->Build(mpScheme, model_part, mA, mb); // <<<<<<<<<<<<<<<<<<<<<<<<<<<< INT ERROR
 			
 			while (true)
 			{
@@ -496,10 +496,10 @@ public:
 				*/
 
 				iteration_number++;
-				model.GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
+				model_part.GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
 
-				mpScheme->InitializeNonLinIteration(model, mA, mDx, mb);
-				mIsConverged = mpConvergenceCriteria->PreCriteria(model, rDofSet, mA, mDx, mb);
+				mpScheme->InitializeNonLinIteration(model_part, mA, mDx, mb);
+				mIsConverged = mpConvergenceCriteria->PreCriteria(model_part, rDofSet, mA, mDx, mb);
 
 				if(!mIsNrgControlled)
 				{
@@ -568,22 +568,22 @@ public:
 				noalias(u)  += mDx;
 				noalias(Du) += mDx;
 				rDofSet = mpBuilderAndSolver->GetDofSet();
-				mpScheme->Update(model, rDofSet, mA, mDx, resi);
+				mpScheme->Update(model_part, rDofSet, mA, mDx, resi);
 				if (BaseType::MoveMeshFlag()) BaseType::MoveMesh();
-				mpScheme->FinalizeNonLinIteration(model, mA, mDx, mb);
+				mpScheme->FinalizeNonLinIteration(model_part, mA, mDx, mb);
 				
 				
 				// K,fint = assembleTangentStiffness( props, globdat )
 				// error  = globdat.dofs.norm( globdat.lam*fhat-fint ) / globdat.dofs.norm( globdat.lam*fhat )
 				TSparseSpace::SetToZero(mb);
 				TSparseSpace::SetToZero(mA);
-				mpBuilderAndSolver->Build(mpScheme, model, mA, mb);
+				mpBuilderAndSolver->Build(mpScheme, model_part, mA, mb);
 				if(this->CheckIntegrationErrors() != 0.0)
 				{
 					if(verbose) this->PromptIntegrationErrors();
 					mIsConverged = false;
 					iteration_number = mMaxIterationNumber;
-					model.GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
+					model_part.GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
 					break;
 				}
 				noalias(resi) = lambda*mFhat + mb;
@@ -596,18 +596,18 @@ public:
 				===============================================================================
 				*/
 
-				model.GetProcessInfo()[ITERATION_CONVERGENCE_FLAG] = 0;
+				model_part.GetProcessInfo()[ITERATION_CONVERGENCE_FLAG] = 0;
 
-				mIsConverged = mpConvergenceCriteria->PostCriteria(model, rDofSet, mA, mDx, resi);
+				mIsConverged = mpConvergenceCriteria->PostCriteria(model_part, rDofSet, mA, mDx, resi);
 				if(iteration_number == 1)
 					mIsConverged = false;
 
-				if(model.GetProcessInfo()[ITERATION_CONVERGENCE_FLAG] != 0)
+				if(model_part.GetProcessInfo()[ITERATION_CONVERGENCE_FLAG] != 0)
 				{
 					if(verbose) this->PromptIntegrationErrors();
 					mIsConverged = false;
 					iteration_number = mMaxIterationNumber;
-					model.GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
+					model_part.GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
 					break;
 				}
 
@@ -616,13 +616,13 @@ public:
 
 			// refesh RHS (we DON'T do this in BuilderAndSolver to check for integration errors!!!!)
 			TSparseSpace::SetToZero(mb);
-			mpBuilderAndSolver->BuildRHS(mpScheme, model, mb);
+			mpBuilderAndSolver->BuildRHS(mpScheme, model_part, mb);
 			if(this->CheckIntegrationErrors() != 0.0)
 			{
 				if(verbose) this->PromptIntegrationErrors();
 				mIsConverged = false;
 				iteration_number = mMaxIterationNumber;
-				model.GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
+				model_part.GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
 			}
 			noalias(resi) = lambda*mFhat + mb;
 			
@@ -689,7 +689,7 @@ public:
 		===============================================================================
 		*/
 
-		model.GetProcessInfo()[STRATEGY_SOLUTION_STEP_SOLVED] = 1;
+		model_part.GetProcessInfo()[STRATEGY_SOLUTION_STEP_SOLVED] = 1;
 
 		if(mIsConverged)
 		{
@@ -755,16 +755,16 @@ protected:
 
     void Initialize()
     {
-		ModelPart & model = BaseType::GetModelPart();
+		ModelPart & model_part = BaseType::GetModelPart();
 
         if(!mpScheme->SchemeIsInitialized())
-			mpScheme->Initialize(model);
+			mpScheme->Initialize(model_part);
 
         if(!mpScheme->ElementsAreInitialized())
-			mpScheme->InitializeElements(model);
+			mpScheme->InitializeElements(model_part);
 
         if(!mpConvergenceCriteria->mConvergenceCriteriaIsInitialized)
-			mpConvergenceCriteria->Initialize(model);
+			mpConvergenceCriteria->Initialize(model_part);
 
 		BaseType::mStiffnessMatrixIsBuilt = false;
 
@@ -785,11 +785,11 @@ protected:
         TSystemVectorType& mDx = *mpDx;
         TSystemVectorType& mb = *mpb;
 
-        mpBuilderAndSolver->InitializeSolutionStep(model, mA, mDx, mb);
-        mpScheme->InitializeSolutionStep(model, mA, mDx, mb);
+        mpBuilderAndSolver->InitializeSolutionStep(model_part, mA, mDx, mb);
+        mpScheme->InitializeSolutionStep(model_part, mA, mDx, mb);
 
 		DofsArrayType& rDofSet = mpBuilderAndSolver->GetDofSet();
-		mpConvergenceCriteria->InitializeSolutionStep(model, rDofSet, mA, mDx, mb);
+		mpConvergenceCriteria->InitializeSolutionStep(model_part, rDofSet, mA, mDx, mb);
 		
         mSolutionStepIsInitialized = true;
 
@@ -798,16 +798,16 @@ protected:
 
 	void FinalizeSolutionStep(TSystemMatrixType& mA, TSystemVectorType& mDx, TSystemVectorType& mb)
 	{
-		ModelPart & model = BaseType::GetModelPart();
+		ModelPart & model_part = BaseType::GetModelPart();
 
 		if (mCalculateReactionsFlag) {
-            mpBuilderAndSolver->CalculateReactions(mpScheme, model, mA, mDx, mb);
+            mpBuilderAndSolver->CalculateReactions(mpScheme, model_part, mA, mDx, mb);
 		}
 
-        mpScheme->FinalizeSolutionStep(model, mA, mDx, mb);
+        mpScheme->FinalizeSolutionStep(model_part, mA, mDx, mb);
 		mpScheme->Clean();
 		
-        mpBuilderAndSolver->FinalizeSolutionStep(model, mA, mDx, mb);
+        mpBuilderAndSolver->FinalizeSolutionStep(model_part, mA, mDx, mb);
 
 		if(mReformDofSetAtEachStep) 
 			this->Clear();
@@ -817,11 +817,11 @@ protected:
 	
 	void AbortSolutionStep()
 	{
-		ModelPart & model = BaseType::GetModelPart();
+		ModelPart & model_part = BaseType::GetModelPart();
 
 		if(BaseType::MoveMeshFlag())
 		{
-			for (ModelPart::NodeIterator i = model.NodesBegin(); i != model.NodesEnd(); ++i)
+			for (ModelPart::NodeIterator i = model_part.NodesBegin(); i != model_part.NodesEnd(); ++i)
 			{
 				(i)->Coordinates() = (i)->GetInitialPosition() + (i)->FastGetSolutionStepValue(DISPLACEMENT, 1);
 			}
@@ -844,12 +844,12 @@ protected:
 
 	double CheckIntegrationErrors()
 	{
-		ModelPart & model = BaseType::GetModelPart();
+		ModelPart & model_part = BaseType::GetModelPart();
 		std::vector<double> error_codes;
-		for(ModelPart::ElementIterator elem_iter = model.ElementsBegin(); elem_iter != model.ElementsEnd(); elem_iter++)
+		for(ModelPart::ElementIterator elem_iter = model_part.ElementsBegin(); elem_iter != model_part.ElementsEnd(); elem_iter++)
 		{
 			Element& elem = *elem_iter;
-			elem.GetValueOnIntegrationPoints(CONSTITUTIVE_INTEGRATION_ERROR_CODE, error_codes, model.GetProcessInfo());
+			elem.GetValueOnIntegrationPoints(CONSTITUTIVE_INTEGRATION_ERROR_CODE, error_codes, model_part.GetProcessInfo());
 			for(size_t i = 0; i < error_codes.size(); i++)
 				if(error_codes[i] != 0.0)
 					return error_codes[i];
@@ -898,11 +898,11 @@ protected:
 
         BaseType::Check();
 
-		ModelPart & model = BaseType::GetModelPart();
+		ModelPart & model_part = BaseType::GetModelPart();
 
-        mpBuilderAndSolver->Check(model);
-        mpScheme->Check(model);
-        mpConvergenceCriteria->Check(model);
+        mpBuilderAndSolver->Check(model_part);
+        mpScheme->Check(model_part);
+        mpConvergenceCriteria->Check(model_part);
 
         KRATOS_CATCH("")
 		

--- a/applications/MultiScaleApplication/custom_strategies/strategies/arc_length_riks_strategy.h
+++ b/applications/MultiScaleApplication/custom_strategies/strategies/arc_length_riks_strategy.h
@@ -722,9 +722,7 @@ protected:
 
         mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, 
 					mpA, mpDx, mpb, 
-					model.Elements(), 
-					model.Conditions(), 
-					model.GetProcessInfo());
+					model);
 
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;

--- a/applications/MultiScaleApplication/custom_strategies/strategies/arc_length_strategy.h
+++ b/applications/MultiScaleApplication/custom_strategies/strategies/arc_length_strategy.h
@@ -612,9 +612,7 @@ protected:
 
         mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, 
 					mpA, mpDx, mpb, 
-					model.Elements(), 
-					model.Conditions(), 
-					model.GetProcessInfo());
+					model);
 
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;

--- a/applications/MultiScaleApplication/custom_strategies/strategies/displacement_control_strategy.h
+++ b/applications/MultiScaleApplication/custom_strategies/strategies/displacement_control_strategy.h
@@ -779,9 +779,7 @@ protected:
 
         mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, 
 					mpA, mpDx, mpb, 
-					model.Elements(), 
-					model.Conditions(), 
-					model.GetProcessInfo());
+					model);
 
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;

--- a/applications/MultiScaleApplication/custom_strategies/strategies/static_general_strategy.h
+++ b/applications/MultiScaleApplication/custom_strategies/strategies/static_general_strategy.h
@@ -1234,9 +1234,7 @@ protected:
 
         mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, 
 					mpA, mpDx, mpb, 
-					model.Elements(), 
-					model.Conditions(), 
-					model.GetProcessInfo());
+					model);
 
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;

--- a/applications/MultiScaleApplication/custom_strategies/strategies/static_general_strategy_krylov_newton.h
+++ b/applications/MultiScaleApplication/custom_strategies/strategies/static_general_strategy_krylov_newton.h
@@ -766,9 +766,7 @@ protected:
 
         mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, 
 					mpA, mpDx, mpb, 
-					model.Elements(), 
-					model.Conditions(), 
-					model.GetProcessInfo());
+					model);
 
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;

--- a/applications/PODApplication/custom_strategies/residualbased_elimination_builder_and_solver_pod.h
+++ b/applications/PODApplication/custom_strategies/residualbased_elimination_builder_and_solver_pod.h
@@ -869,9 +869,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& rModelPart
     )
     {
         KRATOS_TRY
@@ -904,7 +902,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,false);
-            ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+            ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
         }
         else
         {
@@ -912,7 +910,7 @@ public:
             {
                 KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
                 A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,true);
-                ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+                ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
             }
         }
         if(Dx.size() != BaseType::mEquationSystemSize)

--- a/applications/PODApplication/custom_strategies/residualbased_elimination_builder_and_solver_pod_WithPressure.h
+++ b/applications/PODApplication/custom_strategies/residualbased_elimination_builder_and_solver_pod_WithPressure.h
@@ -867,9 +867,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& rModelPart
     )
     {
         KRATOS_TRY
@@ -902,7 +900,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,false);
-            ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+            ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
         }
         else
         {
@@ -910,7 +908,7 @@ public:
             {
                 KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
                 A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,true);
-                ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+                ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
             }
         }
         if(Dx.size() != BaseType::mEquationSystemSize)

--- a/applications/PODApplication/custom_strategies/residualbased_elimination_builder_and_solver_standard.h
+++ b/applications/PODApplication/custom_strategies/residualbased_elimination_builder_and_solver_standard.h
@@ -764,9 +764,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& rModelPart
     )
     {
         KRATOS_TRY
@@ -799,7 +797,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,false);
-            ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+            ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
         }
         else
         {
@@ -807,7 +805,7 @@ public:
             {
                 KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
                 A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,true);
-                ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+                ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
             }
         }
         if(Dx.size() != BaseType::mEquationSystemSize)

--- a/applications/PODApplication/custom_strategies/residualbased_elimination_builder_and_solver_standard_biggerlocalM.h
+++ b/applications/PODApplication/custom_strategies/residualbased_elimination_builder_and_solver_standard_biggerlocalM.h
@@ -888,9 +888,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& rModelPart
     )
     {
         KRATOS_TRY
@@ -923,7 +921,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,false);
-            ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+            ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
         }
         else
         {
@@ -931,7 +929,7 @@ public:
             {
                 KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
                 A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,true);
-                ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+                ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
             }
         }
         if(Dx.size() != BaseType::mEquationSystemSize)

--- a/applications/PODApplication/custom_strategies/residualbased_elimination_builder_and_solver_standard_biggerlocalM_NoP.h
+++ b/applications/PODApplication/custom_strategies/residualbased_elimination_builder_and_solver_standard_biggerlocalM_NoP.h
@@ -888,9 +888,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& rModelPart
     )
     {
         KRATOS_TRY
@@ -923,7 +921,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,false);
-            ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+            ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
         }
         else
         {
@@ -931,7 +929,7 @@ public:
             {
                 KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
                 A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,true);
-                ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+                ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
             }
         }
         if(Dx.size() != BaseType::mEquationSystemSize)

--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_residual_based_newton_raphson_strategy.hpp
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_residual_based_newton_raphson_strategy.hpp
@@ -1117,7 +1117,7 @@ protected:
             //std::cout<<"in InitializeSolution Step of strategy"<<std::endl;
             //std::cout<<"ResizeAndInitializeVectors"<<std::endl;
             //setting up the Vectors involved to the correct size
-            pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA, mpDx, mpb, BaseType::GetModelPart().Elements(), BaseType::GetModelPart().Conditions(), BaseType::GetModelPart().GetProcessInfo());
+            pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA, mpDx, mpb, BaseType::GetModelPart());
 
             TSystemMatrixType& mA = *mpA;
             TSystemVectorType& mDx = *mpDx;

--- a/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/gauss_seidel_linear_strategy.h
+++ b/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/gauss_seidel_linear_strategy.h
@@ -570,7 +570,7 @@ private:
     	pBuilderAndSolver->SetUpSystem(BaseType::GetModelPart());
 
     	//setting up the Vectors involved to the correct size
-    	pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA, mpDx, mpb, BaseType::GetModelPart().Elements(), BaseType::GetModelPart().Conditions(), BaseType::GetModelPart().GetProcessInfo());
+    	pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA, mpDx, mpb, BaseType::GetModelPart());
         if (BaseType::GetEchoLevel() > 1 && rank == 0)
     	  std::cout << "System Construction Time : " << system_construction_time.elapsed() << std::endl;
 

--- a/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_ramm_arc_length_strategy.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_ramm_arc_length_strategy.hpp
@@ -99,8 +99,7 @@ public:
             }
             
             // Compute initial radius (mRadius_0)
-            mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, mpA, mpDx, mpb, BaseType::GetModelPart().Elements(),
-                                                            BaseType::GetModelPart().Conditions(), BaseType::GetModelPart().GetProcessInfo());
+            mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, mpA, mpDx, mpb, BaseType::GetModelPart());
             TSystemMatrixType& mA = *mpA;
             TSystemVectorType& mDx = *mpDx;
             TSystemVectorType& mb = *mpb;

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_builder_and_solver/residualbased_block_builder_and_solver_with_mpc.h
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_builder_and_solver/residualbased_block_builder_and_solver_with_mpc.h
@@ -325,14 +325,22 @@ protected:
 
     void ConstructMatrixStructure(
         typename TSchemeType::Pointer pScheme,
-        TSystemMatrixType &A,
-        ElementsContainerType &rElements,
-        ConditionsArrayType &rConditions,
-        ProcessInfo &CurrentProcessInfo
+        TSystemMatrixType& A,
+        ModelPart& rModelPart
         ) override
     {
         //filling with zero the matrix (creating the structure)
         Timer::Start("MatrixStructure");
+
+        // Getting the elements from the model
+        const int nelements = static_cast<int>(rModelPart.Elements().size());
+
+        // Getting the array of the conditions
+        const int nconditions = static_cast<int>(rModelPart.Conditions().size());
+
+        ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
+        ModelPart::ElementsContainerType::iterator el_begin = rModelPart.ElementsBegin();
+        ModelPart::ConditionsContainerType::iterator cond_begin = rModelPart.ConditionsBegin();
 
         const std::size_t equation_size = BaseType::mDofSet.size();
 
@@ -354,11 +362,10 @@ protected:
         }
         EquationIdVectorType ids(3, 0);
 
-        const int nelements = static_cast<int>(rElements.size());
 #pragma omp parallel for firstprivate(nelements, ids)
         for (int iii = 0; iii < nelements; iii++)
         {
-            typename ElementsContainerType::iterator i_element = rElements.begin() + iii;
+            typename ElementsContainerType::iterator i_element = el_begin + iii;
             (i_element)->EquationIdVector(ids, CurrentProcessInfo);
 
             // Modifying the equation IDs of this element to suit MPCs
@@ -377,11 +384,11 @@ protected:
 #endif
             }
         }
-        const int nconditions = static_cast<int>(rConditions.size());
+
 #pragma omp parallel for firstprivate(nconditions, ids)
         for (int iii = 0; iii < nconditions; iii++)
         {
-            typename ConditionsArrayType::iterator i_condition = rConditions.begin() + iii;
+            typename ConditionsArrayType::iterator i_condition = cond_begin + iii;
             (i_condition)->EquationIdVector(ids, CurrentProcessInfo);
             // Modifying the equation IDs of this element to suit MPCs
             this->Condition_ModifyEquationIdsForMPC(*(i_condition.base()), ids, CurrentProcessInfo);

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/eigensolver_strategy.hpp
@@ -339,13 +339,11 @@ public:
 
             // Mass matrix
             pBuilderAndSolver->ResizeAndInitializeVectors(
-                pScheme, pMassMatrix, pDx, pb, rModelPart.Elements(),
-                rModelPart.Conditions(), rModelPart.GetProcessInfo());
+                pScheme, pMassMatrix, pDx, pb, rModelPart);
 
             // Stiffness matrix
             pBuilderAndSolver->ResizeAndInitializeVectors(
-                pScheme, pStiffnessMatrix, pDx, pb, rModelPart.Elements(),
-                rModelPart.Conditions(), rModelPart.GetProcessInfo());
+                pScheme, pStiffnessMatrix, pDx, pb, rModelPart);
 
             KRATOS_INFO_IF("System Matrix Resize Time", BaseType::GetEchoLevel() > 0 && rank == 0)
                 << system_matrix_resize_time.ElapsedSeconds() << std::endl;

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/formfinding_updated_reference_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/formfinding_updated_reference_strategy.hpp
@@ -570,7 +570,7 @@ namespace Kratos
             {
                 //setting up the Vectors involved to the correct size
                 double system_matrix_resize_begin = OpenMPUtils::GetCurrentTime();
-                pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA, mpDx, mpb, BaseType::GetModelPart().Elements(), BaseType::GetModelPart().Conditions(), BaseType::GetModelPart().GetProcessInfo());
+                pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA, mpDx, mpb, BaseType::GetModelPart());
                 //pBuilderAndSolver->ResizeAndInitializeVectors(mpA, mpDx, mpb, BaseType::GetModelPart().Elements(), BaseType::GetModelPart().Conditions(), BaseType::GetModelPart().GetProcessInfo());
                 if (this->GetEchoLevel() > 0 && rank == 0)
                 {

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/harmonic_analysis_strategy.hpp
@@ -343,9 +343,7 @@ public:
                             temp_stiffness_matrix,
                             pDx,
                             pb,
-                            r_model_part.Elements(),
-                            r_model_part.Conditions(),
-                            r_model_part.GetProcessInfo());
+                            r_model_part);
 
                         //build stiffness matrix for submodelpart material
                         p_builder_and_solver->BuildLHS(p_scheme, sub_model_part, *temp_stiffness_matrix);

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/residual_based_arc_length_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/residual_based_arc_length_strategy.hpp
@@ -1271,7 +1271,7 @@ private:
         DofsArrayType& rDofSet = pBuilderAndSolver->GetDofSet();
 
         // Setting up the Vectors involved to the correct size with value cero
-        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart().Elements(),BaseType::GetModelPart().Conditions(),BaseType::GetModelPart().GetProcessInfo());
+        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart());
         InitializeAuxVectors(mpDelta_p);
         InitializeAuxVectors(mpDelta_pold);
         InitializeAuxVectors(mpX_old);

--- a/applications/ULFapplication/custom_strategies/builder_and_solvers/residualbased_elimination_quasiincompresible_builder_and_solver.h
+++ b/applications/ULFapplication/custom_strategies/builder_and_solvers/residualbased_elimination_quasiincompresible_builder_and_solver.h
@@ -330,9 +330,7 @@ public:
         TSystemVectorType& b,
         TSystemMatrixType& mMconsistent,
         TSystemVectorType& mMdiagInv,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& rModelPart
     )
     {
         KRATOS_TRY

--- a/applications/ULFapplication/custom_strategies/strategies/modified_linear_strategy.h
+++ b/applications/ULFapplication/custom_strategies/strategies/modified_linear_strategy.h
@@ -676,7 +676,7 @@ private:
 
             //setting up the Vectors involved to the correct size
             boost::timer system_matrix_resize_time;
-            pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart().Elements(),BaseType::GetModelPart().Conditions(),BaseType::GetModelPart().GetProcessInfo());
+            pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart());
             if(BaseType::GetEchoLevel()>0 && rank == 0)
                 std::cout << "system_matrix_resize_time : " << system_matrix_resize_time.elapsed() << std::endl;
         }

--- a/applications/ULFapplication/python_scripts/ulf_frac_strategy.py
+++ b/applications/ULFapplication/python_scripts/ulf_frac_strategy.py
@@ -271,7 +271,7 @@ class ULFFracStrategyPython:
             # reorder the list of degrees of freedom to identify fixity and system size
             self.builder_and_solver.SetUpSystem(self.model_part)
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.A, self.D, self.Dx, self.b, self.MPconsistent, self.MPinv, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo);
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.A, self.D, self.Dx, self.b, self.MPconsistent, self.MPinv, self.model_part);
             # auxiliary matrices (structure), needed SPECIFICALLY for the Quasi-Incompressible fluid
 
             self.builder_and_solver.ConstructMatrixStructure(self.A, self.model_part)

--- a/applications/ULFapplication/python_scripts/ulf_strategy_PGLASS.py
+++ b/applications/ULFapplication/python_scripts/ulf_strategy_PGLASS.py
@@ -173,7 +173,7 @@ class ULFStrategyPython:
             self.builder_and_solver.SetUpSystem(self.model_part)
 
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo);
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part);
 
             # updating references
             self.A = (self.pA).GetReference()

--- a/applications/ULFapplication/python_scripts/ulf_strategy_python.py
+++ b/applications/ULFapplication/python_scripts/ulf_strategy_python.py
@@ -173,7 +173,7 @@ class ULFStrategyPython:
             self.builder_and_solver.SetUpSystem(self.model_part)
 
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo);
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part);
 
             # updating references
             self.A = (self.pA).GetReference()

--- a/applications/ULFapplication/python_scripts/ulf_strategy_python_inc.py
+++ b/applications/ULFapplication/python_scripts/ulf_strategy_python_inc.py
@@ -183,7 +183,7 @@ class ULFStrategyPythonInc:
             # reorder the list of degrees of freedom to identify fixity and system size
             self.builder_and_solver.SetUpSystem(self.model_part)
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.A, self.D, self.Dx, self.b, self.MPconsistent, self.MPinv, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo);
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.A, self.D, self.Dx, self.b, self.MPconsistent, self.MPinv, self.model_part);
             # auxiliary matrices (structure), needed SPECIFICALLY for the Quasi-Incompressible fluid
 
             self.builder_and_solver.ConstructMatrixStructure(self.A, self.model_part)

--- a/applications/ULFapplication/python_scripts/ulf_strategy_python_inc_rigid.py
+++ b/applications/ULFapplication/python_scripts/ulf_strategy_python_inc_rigid.py
@@ -185,7 +185,7 @@ class ULFStrategyPythonInc:
             # reorder the list of degrees of freedom to identify fixity and system size
             self.builder_and_solver.SetUpSystem(self.model_part)
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.A, self.D, self.Dx, self.b, self.MPconsistent, self.MPinv, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo);
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.A, self.D, self.Dx, self.b, self.MPconsistent, self.MPinv, self.model_part);
             # auxiliary matrices (structure), needed SPECIFICALLY for the Quasi-Incompressible fluid
 
             self.builder_and_solver.ConstructMatrixStructure(self.A, self.model_part)

--- a/applications/incompressible_fluid_application/custom_strategies/builder_and_solvers/explicit_residualbased_builder.h
+++ b/applications/incompressible_fluid_application/custom_strategies/builder_and_solvers/explicit_residualbased_builder.h
@@ -488,12 +488,11 @@ public:
     //**************************************************************************
     //**************************************************************************
     void ResizeAndInitializeVectors( typename TSchemeType::Pointer pScheme,
+        typename TSchemeType::Pointer pScheme,
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& r_model_part
     )
     {
         KRATOS_TRY

--- a/applications/incompressible_fluid_application/custom_strategies/builder_and_solvers/pressure_splitting_builder_and_solver.h
+++ b/applications/incompressible_fluid_application/custom_strategies/builder_and_solvers/pressure_splitting_builder_and_solver.h
@@ -1025,9 +1025,8 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& rCurrentProcessInfo)
+        ModelPart& r_model_part
+        )
     {
         KRATOS_TRY;
 
@@ -1102,7 +1101,7 @@ public:
             D.resize(mPressFreeDofs, mVelFreeDofs, false);
             L.resize(mPressFreeDofs, mPressFreeDofs, false);
 
-            ConstructMatrixStructure(pScheme, S, D, G, L, rElements, rConditions, rCurrentProcessInfo);
+            ConstructMatrixStructure(pScheme, S, D, G, L, r_model_part);
 
             A.resize(mPressFreeDofs, mPressFreeDofs, false);
             IDiagS.resize(mVelFreeDofs);
@@ -1285,9 +1284,7 @@ protected:
         TSystemMatrixType& D,
         TSystemMatrixType& G,
         TSystemMatrixType& L,
-        const ElementsContainerType& rElements,
-        const ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo)
+        ModelPart& rModelPart)
     {
         std::vector< std::vector<std::size_t> > indicesS(mVelFreeDofs);
         std::vector< std::vector<std::size_t> > indicesG(mVelFreeDofs);
@@ -1298,8 +1295,8 @@ protected:
         ids.reserve(16); // 16 as initial capacity: 4 Dofs per node assumed
 
         // Identify and collect the indices of non-zero terms in each matrix
-        for (typename ElementsContainerType::const_iterator itElem = rElements.begin();
-                itElem != rElements.end(); itElem++)
+        for (typename ElementsContainerType::const_iterator itElem = rModelPart.ElementsBegin();
+                itElem != rModelPart.ElementsEnd(); itElem++)
         {
             pScheme->EquationId( *(itElem.base()) , ids, CurrentProcessInfo);
 
@@ -1333,8 +1330,8 @@ protected:
         }
 
         // Do the same for conditions
-        for (typename ConditionsArrayType::const_iterator itCond = rConditions.begin();
-                itCond != rConditions.end(); itCond++)
+        for (typename ConditionsArrayType::const_iterator itCond = rModelPart.ConditionsBegin();
+                itCond != rModelPart.ConditionsEnd(); itCond++)
         {            
             pScheme->Condition_EquationId( *(itCond.base()), ids, CurrentProcessInfo);
 

--- a/applications/incompressible_fluid_application/custom_strategies/builder_and_solvers/residualbased_elimination_discretelaplacian_builder_and_solver.h
+++ b/applications/incompressible_fluid_application/custom_strategies/builder_and_solvers/residualbased_elimination_discretelaplacian_builder_and_solver.h
@@ -294,9 +294,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& r_model_part
     )
     {
         KRATOS_TRY

--- a/applications/incompressible_fluid_application/custom_strategies/builder_and_solvers/residualbased_elimination_discretelaplacian_builder_and_solver_flexiblefsi.h
+++ b/applications/incompressible_fluid_application/custom_strategies/builder_and_solvers/residualbased_elimination_discretelaplacian_builder_and_solver_flexiblefsi.h
@@ -299,9 +299,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& r_model_part
     )
     {
         KRATOS_TRY

--- a/applications/incompressible_fluid_application/custom_strategies/strategies/newton_raphson_oss_strategy.h
+++ b/applications/incompressible_fluid_application/custom_strategies/strategies/newton_raphson_oss_strategy.h
@@ -844,7 +844,7 @@ private:
 
 
         //setting up the Vectors involved to the correct size
-        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart().Elements(),BaseType::GetModelPart().Conditions(),BaseType::GetModelPart().GetProcessInfo());
+        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart());
 
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;

--- a/applications/incompressible_fluid_application/custom_strategies/strategies/newton_raphson_strategy.h
+++ b/applications/incompressible_fluid_application/custom_strategies/strategies/newton_raphson_strategy.h
@@ -883,7 +883,7 @@ protected:
 
 
         //setting up the Vectors involved to the correct size
-        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart().Elements(),BaseType::GetModelPart().Conditions(),BaseType::GetModelPart().GetProcessInfo());
+        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart());
 
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;

--- a/applications/meshless_application/python_scripts/strategy_python.py
+++ b/applications/meshless_application/python_scripts/strategy_python.py
@@ -162,7 +162,7 @@ class SolvingStrategyPython:
             #reorder the list of degrees of freedom to identify fixity and system size                          
             self.builder_and_solver.SetUpSystem(self.model_part)
             #allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA,self.pDx,self.pb,self.model_part.Elements,self.model_part.Conditions,self.model_part.ProcessInfo);
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA,self.pDx,self.pb,self.model_part);
 
             #updating references
             self.A = (self.pA).GetReference()

--- a/applications/nurbs_application/python_scripts/strategy_python.py
+++ b/applications/nurbs_application/python_scripts/strategy_python.py
@@ -135,7 +135,7 @@ class SolvingStrategyPython:
             # allocate memory for the system and preallocate the structure of
             # the matrix
             self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, 
-                self.pA, self.pDx, self.pb, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo)
+                self.pA, self.pDx, self.pb, self.model_part)
 
             # updating references
             self.A = (self.pA).GetReference()

--- a/applications/pfem_2_application/python_scripts/strategy_python.py
+++ b/applications/pfem_2_application/python_scripts/strategy_python.py
@@ -136,7 +136,7 @@ class SolvingStrategyPython:
             #reorder the list of degrees of freedom to identify fixity and system size                                  
             self.builder_and_solver.SetUpSystem(self.model_part)
             #allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA,self.pDx,self.pb,self.model_part.Elements,self.model_part.Conditions,self.model_part.ProcessInfo);
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA,self.pDx,self.pb,self.model_part);
 
             #updating references
             self.A = (self.pA).GetReference()

--- a/applications/pfem_2_application/python_scripts/strategy_python_nonlinear.py
+++ b/applications/pfem_2_application/python_scripts/strategy_python_nonlinear.py
@@ -176,7 +176,7 @@ class SolvingStrategyPython:
             #reorder the list of degrees of freedom to identify fixity and system size	  			
             self.builder_and_solver.SetUpSystem(self.model_part)
             #allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA,self.pDx,self.pb,self.model_part.Elements,self.model_part.Conditions,self.model_part.ProcessInfo);
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA,self.pDx,self.pb,self.model_part);
 
             #updating references
             self.A = (self.pA).GetReference()

--- a/applications/structural_application/custom_strategies/builder_and_solvers/modal_analysis_builder_and_solver.h
+++ b/applications/structural_application/custom_strategies/builder_and_solvers/modal_analysis_builder_and_solver.h
@@ -680,9 +680,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& rModelPart
     )
     {
         KRATOS_TRY
@@ -714,7 +712,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,false);
-            ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+            ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
         }
         else
         {
@@ -722,7 +720,7 @@ public:
             {
                 KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
                 A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,true);
-                ConstructMatrixStructure(pScheme, A,rElements,rConditions,CurrentProcessInfo);
+                ConstructMatrixStructure(pScheme, A,rModelPart.Elements(),rModelPart.Conditions(),rModelPart.GetProcessInfo());
             }
         }
         if(Dx.size() != BaseType::mEquationSystemSize)

--- a/applications/structural_application/custom_strategies/builder_and_solvers/multiphase_builder_and_solver.h
+++ b/applications/structural_application/custom_strategies/builder_and_solvers/multiphase_builder_and_solver.h
@@ -902,9 +902,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& rCurrentProcessInfo
+        ModelPart& rModelPart
     )
     {
         KRATOS_WATCH("in ResizeAndInitializeVectors, line 885");
@@ -1024,8 +1022,8 @@ public:
             Kaa.resize( mAirPressureFreeDofs, mAirPressureFreeDofs, false );
 
 
-            ConstructMatrixStructure(pScheme,  Kuu, Kuw, Kua, Kwu, Kww, Kwa, Kau, Kaw, Kaa, rElements, rConditions, rCurrentProcessInfo );
-            ConstructMatrixStructure(pScheme,  A, rElements, rConditions, rCurrentProcessInfo );
+            ConstructMatrixStructure(pScheme,  Kuu, Kuw, Kua, Kwu, Kww, Kwa, Kau, Kaw, Kaa, rModelPart.Elements(), rModelPart.Conditions(), rModelPart.GetProcessInfo() );
+            ConstructMatrixStructure(pScheme,  A, rModelPart.Elements(), rModelPart.Conditions(), rModelPart.GetProcessInfo() );
             A.resize( BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, false );
             AllocateSystemMatrix( A );
             ConstructSystemMatrix( A );

--- a/applications/structural_application/custom_strategies/strategies/residualbased_arc_length_strategy.h
+++ b/applications/structural_application/custom_strategies/strategies/residualbased_arc_length_strategy.h
@@ -1192,7 +1192,7 @@ private:
         DofsArrayType& rDofSet = pBuilderAndSolver->GetDofSet();
 
         //setting up the Vectors involved to the correct size with value cero
-        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart().Elements(),BaseType::GetModelPart().Conditions(),BaseType::GetModelPart().GetProcessInfo());
+        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart());
         InitializeAuxVectors(mpDelta_p);
 	InitializeAuxVectors(mpDelta_pold);
 	InitializeAuxVectors(mpX_old);  

--- a/applications/structural_application/custom_strategies/strategies/residualbased_newton_raphson_line_search_strategy.h
+++ b/applications/structural_application/custom_strategies/strategies/residualbased_newton_raphson_line_search_strategy.h
@@ -203,7 +203,7 @@ public:
         TSystemVectorPointerType pDelta_p;
 
         // asignando tamaño
-        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, this->mpA, pX_old, pDelta_p, BaseType::GetModelPart().Elements(), BaseType::GetModelPart().Conditions(), BaseType::GetModelPart().GetProcessInfo());
+        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, this->mpA, pX_old, pDelta_p, BaseType::GetModelPart());
 
         TSystemVectorType& X_old = *pX_old;
         TSystemVectorType& Delta_p = *pDelta_p;

--- a/applications/structural_application/python_scripts/parallel_strategy_python.py
+++ b/applications/structural_application/python_scripts/parallel_strategy_python.py
@@ -127,7 +127,7 @@ class SolvingStrategyPython:
             self.builder_and_solver.SetUpSystem(self.model_part)
 
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo)
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part)
 
             # updating references
             self.A = (self.pA).GetReference()

--- a/applications/structural_application/python_scripts/strategy_python.py
+++ b/applications/structural_application/python_scripts/strategy_python.py
@@ -140,7 +140,7 @@ class SolvingStrategyPython:
             # reorder the list of degrees of freedom to identify fixity and system size
             self.builder_and_solver.SetUpSystem(self.model_part)
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo)
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part)
 
             # updating references
             self.A = (self.pA).GetReference()

--- a/applications/structural_application/python_scripts/strategy_python_UL.py
+++ b/applications/structural_application/python_scripts/strategy_python_UL.py
@@ -133,7 +133,7 @@ class SolvingStrategyPython:
             # reorder the list of degrees of freedom to identify fixity and system size
             self.builder_and_solver.SetUpSystem(self.model_part)
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.A, self.Dx, self.b, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo);
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.A, self.Dx, self.b, self.model_part);
 
         self.builder_and_solver.InitializeSolutionStep(self.model_part, self.A, self.Dx, self.b)
         self.scheme.InitializeSolutionStep(self.model_part, self.A, self.Dx, self.b)

--- a/applications/structural_application/python_scripts/strategy_python_contact.py
+++ b/applications/structural_application/python_scripts/strategy_python_contact.py
@@ -119,7 +119,7 @@ class SolvingStrategyPython:
             self.builder_and_solver.SetUpSystem(self.model_part)
 
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.A, self.Dx, self.b, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo)
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.A, self.Dx, self.b, self.model_part)
 
         self.builder_and_solver.InitializeSolutionStep(self.model_part, self.A, self.Dx, self.b)
         self.scheme.InitializeSolutionStep(self.model_part, self.A, self.Dx, self.b)

--- a/applications/structural_application/python_scripts/uzawa_contact_strategy.py
+++ b/applications/structural_application/python_scripts/uzawa_contact_strategy.py
@@ -272,7 +272,7 @@ class SolvingStrategyPython:
             #reorder the system dof id
             self.system_reorderer.Execute()
             #allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA,self.pDx,self.pb,self.model_part.Elements,self.model_part.Conditions,self.model_part.ProcessInfo)
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA,self.pDx,self.pb,self.model_part)
             #updating references
             self.A = (self.pA).GetReference()
             self.Dx = (self.pDx).GetReference()

--- a/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
+++ b/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
@@ -749,9 +749,7 @@ public:
       TSystemMatrixPointerType& pA,
       TSystemVectorPointerType& pDx,
       TSystemVectorPointerType& pb,
-      ElementsArrayType& rElements,
-      ConditionsArrayType& rConditions,
-      ProcessInfo& CurrentProcessInfo
+      ModelPart& rModelPart
     ) override
     {
         KRATOS_TRY
@@ -768,6 +766,8 @@ public:
             if(temp_size <1000) temp_size = 1000;
             int* temp = new int[temp_size]; //
 
+            auto rElements = rModelPart.Elements();
+            auto rConditions = rModelPart.Conditions();
 
             //generate map - use the "temp" array here
             for(unsigned int i=0; i!=number_of_local_dofs; i++)

--- a/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
+++ b/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
@@ -766,8 +766,8 @@ public:
             if(temp_size <1000) temp_size = 1000;
             int* temp = new int[temp_size]; //
 
-            auto rElements = rModelPart.Elements();
-            auto rConditions = rModelPart.Conditions();
+            auto& rElements = rModelPart.Elements();
+            auto& rConditions = rModelPart.Conditions();
 
             //generate map - use the "temp" array here
             for(unsigned int i=0; i!=number_of_local_dofs; i++)

--- a/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_elimination_builder_and_solver.h
+++ b/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_elimination_builder_and_solver.h
@@ -1110,8 +1110,8 @@ public:
                 temp[i] = mFirstMyId+i;
             Epetra_Map my_map(-1, number_of_local_dofs, temp, 0, mrComm);
 
-            auto rElements = rModelPart.Elements();
-            auto rConditions = rModelPart.Conditions();
+            auto& rElements = rModelPart.Elements();
+            auto& rConditions = rModelPart.Conditions();
 
             //create and fill the graph of the matrix --> the temp array is reused here with a different meaning
             Epetra_FECrsGraph Agraph(Copy, my_map, mguess_row_size);

--- a/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_elimination_builder_and_solver.h
+++ b/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_elimination_builder_and_solver.h
@@ -1086,9 +1086,7 @@ public:
       TSystemMatrixPointerType& pA,
       TSystemVectorPointerType& pDx,
       TSystemVectorPointerType& pb,
-      ElementsArrayType& rElements,
-      ConditionsArrayType& rConditions,
-      ProcessInfo& CurrentProcessInfo
+      ModelPart& rModelPart
     ) override
     {
         KRATOS_TRY
@@ -1112,6 +1110,8 @@ public:
                 temp[i] = mFirstMyId+i;
             Epetra_Map my_map(-1, number_of_local_dofs, temp, 0, mrComm);
 
+            auto rElements = rModelPart.Elements();
+            auto rConditions = rModelPart.Conditions();
 
             //create and fill the graph of the matrix --> the temp array is reused here with a different meaning
             Epetra_FECrsGraph Agraph(Copy, my_map, mguess_row_size);

--- a/applications/trilinos_application/python_scripts/trilinos_contact_strategy.py
+++ b/applications/trilinos_application/python_scripts/trilinos_contact_strategy.py
@@ -222,7 +222,7 @@ class SolvingStrategyPython:
             # reorder the list of degrees of freedom to identify fixity and system size
             self.builder_and_solver.SetUpSystem(self.model_part)
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo);
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part);
 
             # updating references
             self.A = (self.pA).GetReference()

--- a/applications/trilinos_application/python_scripts/trilinos_strategy_python.py
+++ b/applications/trilinos_application/python_scripts/trilinos_strategy_python.py
@@ -146,7 +146,7 @@ class SolvingStrategyPython:
             # reorder the list of degrees of freedom to identify fixity and system size
             self.builder_and_solver.SetUpSystem(self.model_part)
             # allocate memory for the system and preallocate the structure of the matrix
-            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part.Elements, self.model_part.Conditions, self.model_part.ProcessInfo)
+            self.builder_and_solver.ResizeAndInitializeVectors(self.scheme, self.pA, self.pDx, self.pb, self.model_part)
 
             # updating references
             self.A = (self.pA).GetReference()

--- a/kratos/solving_strategies/builder_and_solvers/builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/builder_and_solver.h
@@ -462,7 +462,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ModelPart& r_model_part
+        ModelPart& rModelPart
     )
     {
     }

--- a/kratos/solving_strategies/builder_and_solvers/builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/builder_and_solver.h
@@ -462,9 +462,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& r_model_part
     )
     {
     }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -726,7 +726,8 @@ public:
         {
             if (A.size1() != BaseType::mEquationSystemSize || A.size2() != BaseType::mEquationSystemSize)
             {
-                KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
+                //KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
+                KRATOS_ERROR <<"The equation system size has changed during the simulation. This is not permited."<<std::endl;
                 A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, true);
                 ConstructMatrixStructure(pScheme, A, rModelPart);
             }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -720,7 +720,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, false);
-            ConstructMatrixStructure(pScheme, A, rElements, rConditions);
+            ConstructMatrixStructure(pScheme, A, r_model_part);
         }
         else
         {
@@ -728,7 +728,7 @@ public:
             {
                 KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
                 A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, true);
-                ConstructMatrixStructure(pScheme, A, rElements, rConditions);
+                ConstructMatrixStructure(pScheme, A, r_model_part);
             }
         }
         if (Dx.size() != BaseType::mEquationSystemSize)
@@ -956,7 +956,7 @@ protected:
         const int nelements = static_cast<int>(rModelPart.Elements().size());
 
         // Getting the array of the conditions
-        const int nconditions = static_cast<int>(rModelPart.Conditions().size());        
+        const int nconditions = static_cast<int>(rModelPart.Conditions().size());
 
         ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
         ModelPart::ElementsContainerType::iterator el_begin = rModelPart.ElementsBegin();

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -720,7 +720,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, false);
-            ConstructMatrixStructure(pScheme, A, rElements, rConditions, CurrentProcessInfo);
+            ConstructMatrixStructure(pScheme, A, rElements, rConditions);
         }
         else
         {
@@ -728,7 +728,7 @@ public:
             {
                 KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
                 A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, true);
-                ConstructMatrixStructure(pScheme, A, rElements, rConditions, CurrentProcessInfo);
+                ConstructMatrixStructure(pScheme, A, rElements, rConditions);
             }
         }
         if (Dx.size() != BaseType::mEquationSystemSize)
@@ -947,12 +947,21 @@ protected:
     virtual void ConstructMatrixStructure(
         typename TSchemeType::Pointer pScheme,
         TSystemMatrixType& A,
-        ElementsContainerType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo)
+        ModelPart& r_model_part)
     {
         //filling with zero the matrix (creating the structure)
         Timer::Start("MatrixStructure");
+
+        // Getting the elements from the model
+        const int nelements = static_cast<int>(rModelPart.Elements().size());
+
+        // Getting the array of the conditions
+        const int nconditions = static_cast<int>(rModelPart.Conditions().size());        
+
+        ProcessInfo& CurrentProcessInfo = rModelPart.GetProcessInfo();
+        ModelPart::ElementsContainerType::iterator el_begin = rModelPart.ElementsBegin();
+        ModelPart::ConditionsContainerType::iterator cond_begin = rModelPart.ConditionsBegin();
+
 
         const std::size_t equation_size = BaseType::mEquationSystemSize;
 
@@ -975,11 +984,10 @@ protected:
 
         Element::EquationIdVectorType ids(3, 0);
 
-        const int nelements = static_cast<int>(rElements.size());
         #pragma omp parallel for firstprivate(nelements, ids)
         for(int iii=0; iii<nelements; iii++)
         {
-            typename ElementsContainerType::iterator i_element = rElements.begin() + iii;
+            typename ElementsContainerType::iterator i_element = el_begin + iii;
             pScheme->EquationId( *(i_element.base()) , ids, CurrentProcessInfo);
             for (std::size_t i = 0; i < ids.size(); i++)
             {
@@ -996,11 +1004,10 @@ protected:
 
         }
 
-        const int nconditions = static_cast<int>(rConditions.size());
         #pragma omp parallel for firstprivate(nconditions, ids)
         for (int iii = 0; iii<nconditions; iii++)
         {
-            typename ConditionsArrayType::iterator i_condition = rConditions.begin() + iii;
+            typename ConditionsArrayType::iterator i_condition = cond_begin + iii;
             pScheme->Condition_EquationId( *(i_condition.base()), ids, CurrentProcessInfo);
             for (std::size_t i = 0; i < ids.size(); i++)
             {

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -692,9 +692,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& r_model_part
     ) override
     {
         KRATOS_TRY

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -692,7 +692,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ModelPart& r_model_part
+        ModelPart& rModelPart
     ) override
     {
         KRATOS_TRY
@@ -720,7 +720,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, false);
-            ConstructMatrixStructure(pScheme, A, r_model_part);
+            ConstructMatrixStructure(pScheme, A, rModelPart);
         }
         else
         {
@@ -728,7 +728,7 @@ public:
             {
                 KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
                 A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, true);
-                ConstructMatrixStructure(pScheme, A, r_model_part);
+                ConstructMatrixStructure(pScheme, A, rModelPart);
             }
         }
         if (Dx.size() != BaseType::mEquationSystemSize)

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -947,7 +947,7 @@ protected:
     virtual void ConstructMatrixStructure(
         typename TSchemeType::Pointer pScheme,
         TSystemMatrixType& A,
-        ModelPart& r_model_part)
+        ModelPart& rModelPart)
     {
         //filling with zero the matrix (creating the structure)
         Timer::Start("MatrixStructure");

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
@@ -794,9 +794,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& r_model_part
     ) override
     {
         KRATOS_TRY

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
@@ -794,7 +794,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ModelPart& r_model_part
+        ModelPart& rModelPart
     ) override
     {
         KRATOS_TRY
@@ -827,7 +827,7 @@ public:
         if (A.size1() == 0 || BaseType::GetReshapeMatrixFlag() == true) //if the matrix is not initialized
         {
             A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, false);
-            ConstructMatrixStructure(pScheme, A, r_model_part);
+            ConstructMatrixStructure(pScheme, A, rModelPart);
         }
         else
         {
@@ -835,7 +835,7 @@ public:
             {
                 KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
                 A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, true);
-                ConstructMatrixStructure(pScheme, A, r_model_part);
+                ConstructMatrixStructure(pScheme, A, rModelPart);
             }
         }
         if (Dx.size() != BaseType::mEquationSystemSize)

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
@@ -1010,7 +1010,7 @@ protected:
    virtual void ConstructMatrixStructure(
         typename TSchemeType::Pointer pScheme,
         TSystemMatrixType& A,
-        ModelPart& r_model_part)
+        ModelPart& rModelPart)
    {
       //filling with zero the matrix (creating the structure)
       Timer::Start("MatrixStructure");

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver.h
@@ -833,7 +833,8 @@ public:
         {
             if (A.size1() != BaseType::mEquationSystemSize || A.size2() != BaseType::mEquationSystemSize)
             {
-                KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
+                //KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
+                KRATOS_ERROR <<"The equation system size has changed during the simulation. This is not permited."<<std::endl;
                 A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, true);
                 ConstructMatrixStructure(pScheme, A, rModelPart);
             }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
@@ -370,7 +370,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ModelPart& r_model_part
+        ModelPart& rModelPart
     ) override
     {
 #ifndef __SUNPRO_CC

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
@@ -373,9 +373,7 @@ public:
         ModelPart& rModelPart
     ) override
     {
-#ifndef __SUNPRO_CC
         KRATOS_TRY
-#endif
 
         if(pA == NULL) //if the pointer is not initialized initialize it to an empty matrix
         {
@@ -416,7 +414,8 @@ public:
         {
             if(A.size1() != BaseType::mEquationSystemSize || A.size2() != BaseType::mEquationSystemSize)
             {
-                KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
+                //KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
+                KRATOS_ERROR <<"The equation system size has changed during the simulation. This is not permited."<<std::endl;
                 A.resize(BaseType::mEquationSystemSize,BaseType::mEquationSystemSize,true);
 #ifdef _OPENMP
                 ParallelConstructGraph(A);

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_componentwise.h
@@ -370,9 +370,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& r_model_part
     ) override
     {
 #ifndef __SUNPRO_CC

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_slip.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_slip.h
@@ -448,7 +448,8 @@ public:
         {
             if (A.size1() != BaseType::mEquationSystemSize || A.size2() != BaseType::mEquationSystemSize)
             {
-                KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
+                //KRATOS_WATCH("it should not come here!!!!!!!! ... this is SLOW");
+                KRATOS_ERROR <<"The equation system size has changed during the simulation. This is not permited."<<std::endl;
                 A.resize(BaseType::mEquationSystemSize, BaseType::mEquationSystemSize, true);
                 ParallelConstructGraph(A);
             }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_slip.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_slip.h
@@ -407,9 +407,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ElementsArrayType& rElements,
-        ConditionsArrayType& rConditions,
-        ProcessInfo& CurrentProcessInfo
+        ModelPart& r_model_part
     )
     {
         KRATOS_TRY

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_slip.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_elimination_builder_and_solver_slip.h
@@ -407,7 +407,7 @@ public:
         TSystemMatrixPointerType& pA,
         TSystemVectorPointerType& pDx,
         TSystemVectorPointerType& pb,
-        ModelPart& r_model_part
+        ModelPart& rModelPart
     )
     {
         KRATOS_TRY

--- a/kratos/solving_strategies/strategies/adaptive_residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/adaptive_residualbased_newton_raphson_strategy.h
@@ -905,7 +905,7 @@ protected:
 
 
         //setting up the Vectors involved to the correct size
-        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart().Elements(),BaseType::GetModelPart().Conditions(),BaseType::GetModelPart().GetProcessInfo());
+        pBuilderAndSolver->ResizeAndInitializeVectors(pScheme, mpA,mpDx,mpb,BaseType::GetModelPart());
 
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;

--- a/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
@@ -475,9 +475,7 @@ public:
                 //setting up the Vectors involved to the correct size
                 BuiltinTimer system_matrix_resize_time;
                 p_builder_and_solver->ResizeAndInitializeVectors(p_scheme, mpA, mpDx, mpb,
-                                                                 BaseType::GetModelPart().Elements(),
-                                                                 BaseType::GetModelPart().Conditions(),
-                                                                 BaseType::GetModelPart().GetProcessInfo());
+                                                                 BaseType::GetModelPart());
                 KRATOS_INFO_IF("System Matrix Resize Time", BaseType::GetEchoLevel() > 0 && rank == 0)
                     << system_matrix_resize_time.ElapsedSeconds() << std::endl;
             }

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -546,9 +546,7 @@ class ResidualBasedNewtonRaphsonStrategy
                 //setting up the Vectors involved to the correct size
                 BuiltinTimer system_matrix_resize_time;
                 p_builder_and_solver->ResizeAndInitializeVectors(p_scheme, mpA, mpDx, mpb,
-                                                                 BaseType::GetModelPart().Elements(),
-                                                                 BaseType::GetModelPart().Conditions(),
-                                                                 BaseType::GetModelPart().GetProcessInfo());
+                                                                 BaseType::GetModelPart());
                 KRATOS_INFO_IF("System Matrix Resize Time", BaseType::GetEchoLevel() > 0 && rank == 0)
                     << system_matrix_resize_time.ElapsedSeconds() << std::endl;
             }


### PR DESCRIPTION
@KratosMultiphysics/technical-committee 

This PR changes the definition of the function 
```
    virtual void ResizeAndInitializeVectors(
        typename TSchemeType::Pointer pScheme,
        TSystemMatrixPointerType& pA,
        TSystemVectorPointerType& pDx,
        TSystemVectorPointerType& pb,
        ElementsArrayType& rElements,
        ConditionsArrayType& rConditions,
        ProcessInfo& CurrentProcessInfo
    )
    {
}
```
which is in the base builder and solver to 
```
    virtual void ResizeAndInitializeVectors(
        typename TSchemeType::Pointer pScheme,
        TSystemMatrixPointerType& pA,
        TSystemVectorPointerType& pDx,
        TSystemVectorPointerType& pb,
        ModelPart& r_model_part
    )
    {
    }
```


This is mainly for two reasons :

- Not only elements and conditions but also other entities (Eg : constraints) can also change the structure of the sparse matrix built in this function. 
- Also making the function more general. 

Apart from the corresponding changes in the core, the change is also propagated to the necessary applications. 


