### PR TITLE
[Core] remove compiler warnings intel 858

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
@@ -41,23 +41,23 @@ EmbeddedSkinVisualizationProcess::EmbeddedSkinVisualizationProcess(
     const std::vector<Variable< array_1d<double, 3> > >& rVisualizationVectorVariables,
     const std::vector<VariableComponent<VectorComponentAdaptor< array_1d< double, 3> > > >& rVisualizationComponentVariables,
     const std::string& rShapeFunctions,
-    const bool ReformModelPartAtEachTimeStep) : 
-    Process(), 
-    mrModelPart(rModelPart), 
-    mrVisualizationModelPart(rVisualizationModelPart), 
+    const bool ReformModelPartAtEachTimeStep) :
+    Process(),
+    mrModelPart(rModelPart),
+    mrVisualizationModelPart(rVisualizationModelPart),
     mVisualizationScalarVariables(rVisualizationScalarVariables),
     mVisualizationVectorVariables(rVisualizationVectorVariables),
     mVisualizationComponentVariables(rVisualizationComponentVariables),
     mShapeFunctions(rShapeFunctions),
-    mReformModelPartAtEachTimeStep(ReformModelPartAtEachTimeStep){ 
+    mReformModelPartAtEachTimeStep(ReformModelPartAtEachTimeStep){
 }
 
 EmbeddedSkinVisualizationProcess::EmbeddedSkinVisualizationProcess(
     ModelPart& rModelPart,
     ModelPart& rVisualizationModelPart,
-    Parameters& rParameters) : 
-    Process(), 
-    mrModelPart(rModelPart), 
+    Parameters& rParameters) :
+    Process(),
+    mrModelPart(rModelPart),
     mrVisualizationModelPart(rVisualizationModelPart) {
 
     Parameters default_parameters( R"(
@@ -258,17 +258,17 @@ void EmbeddedSkinVisualizationProcess::CopyOriginNodalValues(){
         auto it_new_node = mrVisualizationModelPart.NodesBegin() + i_node;
 
         for (unsigned int i_var = 0; i_var < mVisualizationScalarVariables.size(); ++i_var){
-            it_new_node->FastGetSolutionStepValue(mVisualizationScalarVariables[i_var]) = 
+            it_new_node->FastGetSolutionStepValue(mVisualizationScalarVariables[i_var]) =
                 it_old_node->FastGetSolutionStepValue(mVisualizationScalarVariables[i_var]);
         }
 
         for (unsigned int i_var = 0; i_var < mVisualizationVectorVariables.size(); ++i_var){
-            it_new_node->FastGetSolutionStepValue(mVisualizationVectorVariables[i_var]) = 
+            it_new_node->FastGetSolutionStepValue(mVisualizationVectorVariables[i_var]) =
                 it_old_node->FastGetSolutionStepValue(mVisualizationVectorVariables[i_var]);
         }
 
         for (unsigned int i_var = 0; i_var < mVisualizationComponentVariables.size(); ++i_var){
-            it_new_node->FastGetSolutionStepValue(mVisualizationComponentVariables[i_var]) = 
+            it_new_node->FastGetSolutionStepValue(mVisualizationComponentVariables[i_var]) =
                 it_old_node->FastGetSolutionStepValue(mVisualizationComponentVariables[i_var]);
         }
     }
@@ -372,10 +372,10 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries(){
                         const double node_i_weight = edge_N_values(intersected_edge_id, node_i);
                         const double node_j_weight = edge_N_values(intersected_edge_id, node_j);
 
-                        auto new_node_info = std::make_tuple(p_node_i, p_node_j, node_i_weight, node_j_weight);                            
+                        auto new_node_info = std::make_tuple(p_node_i, p_node_j, node_i_weight, node_j_weight);
                         mCutNodesMap.insert(CutNodesMapType::value_type(p_new_node, new_node_info));
 
-                        // Link the new node global id. to its local index in the splitting util. Note that the side 
+                        // Link the new node global id. to its local index in the splitting util. Note that the side
                         // (positive or negative) is saved as well. This will be used when setting up the skin conditions.
                         std::pair<unsigned int, bool> aux_info(local_id,pos_side);
                         std::pair<std::pair<unsigned int,bool>, unsigned int> new_pair(aux_info, temp_node_id);
@@ -397,7 +397,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries(){
                 temp_elem_id++;
             }
 
-            // Get the interface geometries from the splitting pattern 
+            // Get the interface geometries from the splitting pattern
             const unsigned int n_pos_interface_geom = (p_split_utility->mPositiveInterfaces).size();
             const unsigned int n_neg_interface_geom = (p_split_utility->mNegativeInterfaces).size();
 
@@ -436,7 +436,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries(){
 
                 // Set the new condition geometry
                 Geometry< Node<3> >::Pointer p_new_geom = SetNewConditionGeometry(
-                    p_int_sub_geom_type, 
+                    p_int_sub_geom_type,
                     sub_int_geom_nodes_array);
 
                 // Set the new condition properties
@@ -516,7 +516,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries(){
     mrModelPart.GetCommunicator().Barrier();
 }
 
-const bool EmbeddedSkinVisualizationProcess::ElementIsPositive(
+bool EmbeddedSkinVisualizationProcess::ElementIsPositive(
     Geometry<Node<3>>::Pointer pGeometry,
     const Vector &rNodalDistances){
 
@@ -533,7 +533,7 @@ const bool EmbeddedSkinVisualizationProcess::ElementIsPositive(
     return is_positive;
 }
 
-const bool EmbeddedSkinVisualizationProcess::ElementIsSplit(
+bool EmbeddedSkinVisualizationProcess::ElementIsSplit(
     Geometry<Node<3>>::Pointer pGeometry,
     const Vector &rNodalDistances){
 
@@ -553,22 +553,22 @@ const bool EmbeddedSkinVisualizationProcess::ElementIsSplit(
 }
 
 const Vector EmbeddedSkinVisualizationProcess::SetDistancesVector(ModelPart::ElementIterator ItElem){
-    
+
     auto &r_geom = ItElem->GetGeometry();
     Vector nodal_distances(r_geom.PointsNumber());
 
-    if (mShapeFunctions == "standard"){ 
+    if (mShapeFunctions == "standard"){
         // Continuous nodal distance function case
         for (unsigned int i_node = 0; i_node < r_geom.PointsNumber(); ++i_node) {
             nodal_distances[i_node] = r_geom[i_node].FastGetSolutionStepValue(DISTANCE);
         }
-    } else if (mShapeFunctions == "ausas") { 
+    } else if (mShapeFunctions == "ausas") {
         // Discontinuous elemental distance function case
         nodal_distances = ItElem->GetValue(ELEMENTAL_DISTANCES);
     } else {
         KRATOS_ERROR << "Asking for a non-implemented modified shape functions type.";
     }
-    
+
     return nodal_distances;
 }
 
@@ -618,7 +618,7 @@ Geometry< Node<3> >::Pointer EmbeddedSkinVisualizationProcess::SetNewConditionGe
 }
 
 std::tuple< Properties::Pointer , Properties::Pointer > EmbeddedSkinVisualizationProcess::SetVisualizationProperties(){
-    // Set the properties for the new elements depending if the 
+    // Set the properties for the new elements depending if the
     // element is in the positive or negative side of the cut.
     // In this way, two layers will appear in GiD.
     unsigned int max_prop_id = 0;

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
@@ -62,13 +62,13 @@ namespace Kratos
  * @class EmbeddedSkinVisualizationProcess
  * @ingroup FluidDynamicsApplication
  * @brief This process saves the intersected elements in a different model part for its visualization.
- * @details For a given model part, this process checks if its elements are intersected. If they are, 
+ * @details For a given model part, this process checks if its elements are intersected. If they are,
  * calls the corresponding splitting utility to get the subgeometries that conform the splitting
  * pattern. Then, it saves that subgeometries in another model part for its visualization.
  * It has to be mentioned that all the origin model part nodes are kept. Then, the unique nodes
  * that are created are that ones in the intersection edge points.
- * Finally, the values in the visualization model part are computed using the corresponding 
- * modify shape functions utility. 
+ * Finally, the values in the visualization model part are computed using the corresponding
+ * modify shape functions utility.
  * @author Ruben Zorrilla
  */
 class KRATOS_API(FLUID_DYNAMICS_APPLICATION) EmbeddedSkinVisualizationProcess : public Process
@@ -94,10 +94,10 @@ public:
     /// Pointer definition of EmbeddedSkinVisualizationProcess
     KRATOS_CLASS_POINTER_DEFINITION(EmbeddedSkinVisualizationProcess);
 
-    typedef std::unordered_map< 
-        Node<3>::Pointer, 
-        std::tuple< const Node<3>::Pointer, const Node<3>::Pointer, const double, const double >, 
-        SharedPointerHasher<Node<3>::Pointer>, 
+    typedef std::unordered_map<
+        Node<3>::Pointer,
+        std::tuple< const Node<3>::Pointer, const Node<3>::Pointer, const double, const double >,
+        SharedPointerHasher<Node<3>::Pointer>,
         SharedPointerComparator<Node<3>::Pointer> > CutNodesMapType;
 
     ///@}
@@ -249,7 +249,7 @@ private:
      * @param rNodalDistances Vector containing the distance values
      * @return True if it is split and false if not
      */
-    const bool ElementIsSplit(
+    bool ElementIsSplit(
         Geometry<Node<3>>::Pointer pGeometry,
         const Vector &rNodalDistances);
 
@@ -259,12 +259,12 @@ private:
      * @param rNodalDistances Vector containing the distance values
      * @return True if it is split and false if not
      */
-    const bool ElementIsPositive(
+    bool ElementIsPositive(
         Geometry<Node<3>>::Pointer pGeometry,
         const Vector &rNodalDistances);
 
     /**
-     * Sets the distance values. If Ausas shape functions are used, 
+     * Sets the distance values. If Ausas shape functions are used,
      * it takes the ELEMENTAL_DISTANCES. Otherwise, the nodal ones
      * @param ItElem Element iterator
      * @return Vector containing the distance values
@@ -283,9 +283,9 @@ private:
         const Vector &rNodalDistances);
 
     /**
-     * Sets the new interface condition geometry 
+     * Sets the new interface condition geometry
      * @param rOriginGeometryType Interface subgeometry type
-     * @param rNewNodesArray Nodes that conform the new interface geometry 
+     * @param rNewNodesArray Nodes that conform the new interface geometry
      * @return A pointer to the new geometry
      */
     Geometry< Node<3> >::Pointer SetNewConditionGeometry(
@@ -293,7 +293,7 @@ private:
         const Condition::NodesArrayType &rNewNodesArray);
 
     /**
-     * Sets the visualization properties (one for the positive side 
+     * Sets the visualization properties (one for the positive side
      * and one for the negative)
      * @return Tuple containing two properties pointers
      */

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
@@ -112,7 +112,7 @@ public:
             return mXYDeriv;
         }
 
-        inline const double Determinant()const
+        inline double Determinant()const
         {
             return mDet;
         }

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.hpp
@@ -136,7 +136,7 @@ Southern California, 2012.
 				return mXYDeriv;
 			}
 
-			inline const double Determinant()const
+			inline double Determinant()const
 			{
 				return mDet;
 			}

--- a/applications/StructuralMechanicsApplication/custom_utilities/shell_cross_section.hpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shell_cross_section.hpp
@@ -85,12 +85,12 @@ public:
 
 	/** \brief SectionParameters
 	*
-	* SectionParameters is an accessibility class for shells using the 
+	* SectionParameters is an accessibility class for shells using the
 	* ShellCrossSection class. It allows one to set and get vectors and matrices
 	* associated with the shell cross section, such as strains, stresses and the
 	* constitutive matrix.
 	*
-	* An example application is taken from shell_thick_3D4N.cpp, before it's 
+	* An example application is taken from shell_thick_3D4N.cpp, before it's
 	* stiffness matrix gauss loop is entered:
 	*
 	* ShellCrossSection::SectionParameters parameters(geom, props, rCurrentProcessInfo);
@@ -267,7 +267,7 @@ public:
 		void SetStenbergShearStabilization(const double& StenbergShearStabilization)
 		{
 			mStenbergShearStabilization = StenbergShearStabilization;
-		};		
+		};
 
         /**
         * returns the reference or the value of a specified variable: returns the value of the parameter, only non const values can be modified
@@ -1100,7 +1100,7 @@ public:
     * Returns the total thickness of this cross section
     * @return the thickness
     */
-    inline const double GetThickness()const
+    inline double GetThickness()const
     {
         return mThickness;
     }
@@ -1112,7 +1112,7 @@ public:
     * The default value is Zero (i.e. the center of the cross section coincides with the shell mid-surface).
     * @return the offset
     */
-    inline const double GetOffset()const
+    inline double GetOffset()const
     {
         return mOffset;
     }
@@ -1133,7 +1133,7 @@ public:
     		mOffset = offset;
     	}
     }
-    
+
     /**
     * Stores the thicknesses of plies of this cross section.
     */
@@ -1147,7 +1147,7 @@ public:
     		++counter;
     	}
     }
-    
+
     /**
     * Setup to get the integrated constitutive matrices for each ply
     */
@@ -1157,7 +1157,7 @@ public:
 		// constitutive matrices for each ply!
     	mStorePlyConstitutiveMatrices = true;
     	mPlyConstitutiveMatrices = std::vector<Matrix>(this->NumberOfPlies());
-    
+
     	for (unsigned int ply = 0; ply < this->NumberOfPlies(); ++ply)
     	{
     		if (mBehavior == Thick)
@@ -1168,11 +1168,11 @@ public:
     		{
     			mPlyConstitutiveMatrices[ply].resize(6, 6, false);
     		}
-    
+
     		mPlyConstitutiveMatrices[ply].clear();
     	}
     }
-    
+
     /**
     * Get the integrated constitutive matrices for each ply
     */
@@ -1300,23 +1300,23 @@ public:
     {
         return mDrillingPenalty;
     }
-    
+
     /**
     * Checks if the shell is an orthotropic material
     * @return the true/false
     */
     static bool CheckIsOrthotropic(const Properties& rProps);
-    
+
     /**
     * Parses the shell orthotropic material data from properties
     */
     void ParseOrthotropicPropertyMatrix(const Properties::Pointer & pProps);
-    
+
     /**
     * Get orientation of laminae
     */
     void GetLaminaeOrientation(Vector& rOrientation_Vector);
-    
+
     /**
     * Get strengths of laminae
     */
@@ -1338,7 +1338,7 @@ private:
     	GeneralVariables& rVariables,
     	const ConstitutiveLaw::StressMeasure& rStressMeasure,
     	const unsigned int& plyNumber);
-    
+
     /**
     * Creates a deep copy of this cross section.
     * Note: all constitutive laws are properly cloned.
@@ -1374,7 +1374,7 @@ private:
     Vector mOOP_CondensedStrains_converged;
     bool mStorePlyConstitutiveMatrices = false;
     std::vector<Matrix> mPlyConstitutiveMatrices;
-    
+
     ///@}
 
     ///@name Serialization

--- a/applications/StructuralMechanicsApplication/custom_utilities/shellq4_local_coordinate_system.hpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shellq4_local_coordinate_system.hpp
@@ -308,7 +308,7 @@ namespace Kratos
 		}
 
 		template<int TComponent>
-		double Coord_ij(int Tid1, int Tid2)const {
+		inline double Coord_ij(int Tid1, int Tid2)const {
             KRATOS_ERROR_IF_NOT(TComponent >= 0 && TComponent < 3)
                 << "The component index should be 0-based, from 0 to 2" << std::endl;
 			double ci, cj;

--- a/applications/StructuralMechanicsApplication/custom_utilities/shellq4_local_coordinate_system.hpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shellq4_local_coordinate_system.hpp
@@ -195,22 +195,22 @@ namespace Kratos
 		inline const Vector3Type & P4()const { return mP[3]; }
 		inline const Vector3Type & Center()const { return mCenter; }
 
-		inline const RealType X1()const { return mP[0][0]; }
-		inline const RealType X2()const { return mP[1][0]; }
-		inline const RealType X3()const { return mP[2][0]; }
-		inline const RealType X4()const { return mP[3][0]; }
+		inline RealType X1()const { return mP[0][0]; }
+		inline RealType X2()const { return mP[1][0]; }
+		inline RealType X3()const { return mP[2][0]; }
+		inline RealType X4()const { return mP[3][0]; }
 
-		inline const RealType Y1()const { return mP[0][1]; }
-		inline const RealType Y2()const { return mP[1][1]; }
-		inline const RealType Y3()const { return mP[2][1]; }
-		inline const RealType Y4()const { return mP[3][1]; }
+		inline RealType Y1()const { return mP[0][1]; }
+		inline RealType Y2()const { return mP[1][1]; }
+		inline RealType Y3()const { return mP[2][1]; }
+		inline RealType Y4()const { return mP[3][1]; }
 
-		inline const RealType Z1()const { return mP[0][2]; }
-		inline const RealType Z2()const { return mP[1][2]; }
-		inline const RealType Z3()const { return mP[2][2]; }
-		inline const RealType Z4()const { return mP[3][2]; }
+		inline RealType Z1()const { return mP[0][2]; }
+		inline RealType Z2()const { return mP[1][2]; }
+		inline RealType Z3()const { return mP[2][2]; }
+		inline RealType Z4()const { return mP[3][2]; }
 
-		inline const RealType Area()const { return mArea; }
+		inline RealType Area()const { return mArea; }
 
 		inline const MatrixType & Orientation()const { return mOrientation; }
 
@@ -218,8 +218,8 @@ namespace Kratos
 		inline const ConstMatrixRowType Vy()const { return row( mOrientation, 1 ); }
 		inline const ConstMatrixRowType Vz()const { return row( mOrientation, 2 ); }
 
-		inline const double WarpageFactor()const { return this->Z1(); }
-		inline const bool IsWarped()const { return std::abs(this->WarpageFactor()) > 0.0; }
+		inline double WarpageFactor()const { return this->Z1(); }
+		inline bool IsWarped()const { return std::abs(this->WarpageFactor()) > 0.0; }
 
 		inline void ComputeTotalRotationMatrix( MatrixType & R )const
 		{
@@ -308,7 +308,7 @@ namespace Kratos
 		}
 
 		template<int TComponent>
-		inline const double Coord_ij(int Tid1, int Tid2)const {
+		double Coord_ij(int Tid1, int Tid2)const {
             KRATOS_ERROR_IF_NOT(TComponent >= 0 && TComponent < 3)
                 << "The component index should be 0-based, from 0 to 2" << std::endl;
 			double ci, cj;
@@ -331,11 +331,11 @@ namespace Kratos
 			return cj - ci;
 		}
 
-		inline const double Xij(int i, int j)const { return Coord_ij<0>(i,j); }
+		inline double Xij(int i, int j)const { return Coord_ij<0>(i,j); }
 
-		inline const double Yij(int i, int j)const { return Coord_ij<1>(i,j); }
+		inline double Yij(int i, int j)const { return Coord_ij<1>(i,j); }
 
-		inline const double Zij(int i, int j)const { return Coord_ij<2>(i,j); }
+		inline double Zij(int i, int j)const { return Coord_ij<2>(i,j); }
 
 	};
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/shellt3_local_coordinate_system.hpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shellt3_local_coordinate_system.hpp
@@ -193,46 +193,46 @@ public:
         return mCenter;
     }
 
-    inline const RealType X1()const
+    inline RealType X1()const
     {
         return mP[0][0];
     }
-    inline const RealType X2()const
+    inline RealType X2()const
     {
         return mP[1][0];
     }
-    inline const RealType X3()const
+    inline RealType X3()const
     {
         return mP[2][0];
     }
 
-    inline const RealType Y1()const
+    inline RealType Y1()const
     {
         return mP[0][1];
     }
-    inline const RealType Y2()const
+    inline RealType Y2()const
     {
         return mP[1][1];
     }
-    inline const RealType Y3()const
+    inline RealType Y3()const
     {
         return mP[2][1];
     }
 
-    inline const RealType Z1()const
+    inline RealType Z1()const
     {
         return mP[0][2];
     }
-    inline const RealType Z2()const
+    inline RealType Z2()const
     {
         return mP[1][2];
     }
-    inline const RealType Z3()const
+    inline RealType Z3()const
     {
         return mP[2][2];
     }
 
-    inline const RealType Area()const
+    inline RealType Area()const
     {
         return mArea;
     }

--- a/kratos/containers/vector_component_adaptor.h
+++ b/kratos/containers/vector_component_adaptor.h
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
-//                    
+//
 //
 
 
@@ -124,7 +124,7 @@ public:
         return *mpSourceVariable;
     }
 
-    const int GetComponentIndex() const {
+    int GetComponentIndex() const {
         return mComponentIndex;
     }
 
@@ -283,6 +283,6 @@ inline std::ostream& operator << (std::ostream& OStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_VECTOR_COMPONENT_ADAPTOR_H_INCLUDED  defined 
+#endif // KRATOS_VECTOR_COMPONENT_ADAPTOR_H_INCLUDED  defined
 
 

--- a/kratos/includes/properties.h
+++ b/kratos/includes/properties.h
@@ -236,7 +236,7 @@ public:
         mData.GetValue(rV) = rValue;
     }
 
-    bool const HasVariables()
+    bool HasVariables()
     {
         return !mData.IsEmpty();
     }
@@ -259,12 +259,12 @@ public:
 		mTables[Key(XVariable.Key(), YVariable.Key())] = rThisTable;
     }
 
-    bool const HasTables()
+    bool HasTables()
     {
         return !mTables.empty();
     }
 
-    bool const IsEmpty()
+    bool IsEmpty()
     {
         return !( HasVariables() || HasTables() );
     }


### PR DESCRIPTION
This PR removes some unnecessary `const` that cause many compiler warnings with the intel compiler ( see #1973 )

closes #1973