### PR TITLE
write conditions on elements of boundary surfaces

### DIFF
--- a/applications/DEM_application/custom_problemtype/DEMpack/scripts/initptype.tcl
+++ b/applications/DEM_application/custom_problemtype/DEMpack/scripts/initptype.tcl
@@ -161,6 +161,7 @@ proc kipt::BeforeMeshGeneration {elementsize} {
 	::wkcf::CleanAutomaticConditionGroupGiD $entitytype $groupid
 	# Find boundaries
 	set bsurfacelist [::wkcf::FindBoundariesOfNonSphericElements $entitytype]
+	set allsurfacelist [::wkcf::FindAllSurfacesOfNonSphericElements $entitytype]
 	#
 	::wkcf::AssignGeometricalEntitiesToSkinSphere3D
 	# Get the surface type list
@@ -182,7 +183,7 @@ proc kipt::BeforeMeshGeneration {elementsize} {
 	::wkcf::AssignConditionToGroupGID $entitytype $bsurfacelist $groupid
 
 	# Special case of DEM
-	::wkcf::AssignSpecialBoundaries $ndime $bsurfacelist
+	::wkcf::AssignSpecialBoundaries $ndime $allsurfacelist
 	::wkcf::ForceTheMeshingOfDEMFEMWallGroups
 	::wkcf::ForceTheMeshingOfDEMInletGroups
     }

--- a/applications/DEM_application/custom_problemtype/DEMpack/scripts/libs/wkcf/wkcfdem.tcl
+++ b/applications/DEM_application/custom_problemtype/DEMpack/scripts/libs/wkcf/wkcfdem.tcl
@@ -179,12 +179,14 @@ proc ::wkcf::AssignSpecialBoundaries {ndime entitylist} {
 	    set endlinelist [list]
 	    foreach surfid $entitylist {
 		set surfprop [GiD_Geometry get surface $surfid]
-		# set surfacetype [lindex $surfprop 0]
+		set surfacetype [lindex $surfprop 0]
 		set nline [lindex $surfprop 2]
 		set lineprop [list]
-		#if {$surfacetype eq "nurbssurface"} {
+		if {$surfacetype eq "nurbssurface"} {
 		    set lineprop [lrange $surfprop 9 [expr {9+$nline-1}]]
-		    #}
+		} else {
+			set lineprop [lrange $surfprop 3 [expr {3+$nline-1}]]
+		}
 		foreach lprop $lineprop {
 		    lassign $lprop lineid orientation
 		    lappend endlinelist $lineid
@@ -675,7 +677,7 @@ proc ::wkcf::WriteMatTestData {fileid} {
     set cxpath "DEM//c.DEM-MaterialTest//i.DEM-ConfinementPressure"
     set ConfPress [::xmlutils::setXml $cxpath "dv"]
     puts $fileid "\"ConfinementPressure\"              : $ConfPress,"
-    
+
     set basexpath "DEM//c.DEM-MaterialTest//c.DEM-TopLayerGroup"
     set topgroup [::xmlutils::setXmlContainerIds $basexpath]
     if {[llength $topgroup]} {
@@ -686,7 +688,7 @@ proc ::wkcf::WriteMatTestData {fileid} {
         set LVelt [::xmlutils::setXml $cxpath "dv"]
     }
     }
-    
+
     set basexpath "DEM//c.DEM-MaterialTest//c.DEM-BotLayerGroup"
     set botgroup [::xmlutils::setXmlContainerIds $basexpath]
     if {[llength $botgroup]} {
@@ -697,10 +699,10 @@ proc ::wkcf::WriteMatTestData {fileid} {
         set LVelb [::xmlutils::setXml $cxpath "dv"]
     }
     }
-    
+
     if {$TestTypeOn eq "No"} {set LVelt 0.0}
     if {$TestTypeOn eq "No"} {set LVelb 0.0}
-    puts $fileid "\"LoadingVelocity\"              : [expr ($LVelt-$LVelb)],"    
+    puts $fileid "\"LoadingVelocity\"              : [expr ($LVelt-$LVelb)],"
     set cxpath "DEM//c.DEM-MaterialTest//i.DEM-MeshType"
     set mt [::xmlutils::setXml $cxpath "dv"]
     puts $fileid "\"MeshType\"                        : \"$mt\","

--- a/applications/DEM_application/custom_problemtype/DEMpack/scripts/libs/wkcf/wkcfutils.tcl
+++ b/applications/DEM_application/custom_problemtype/DEMpack/scripts/libs/wkcf/wkcfutils.tcl
@@ -1959,7 +1959,7 @@ proc ::wkcf::FindBoundaries {entity} {
     return $boundarylist
 }
 
-proc ::wkcf::FindBoundaries_no_spheric_elems {entity} {
+proc ::wkcf::FindBoundariesOfNonSphericElements {entity} {
     # ABSTRACT: Return a list containing all boundaries entities
     # Arguments
     # entity => Entity to be processed
@@ -1996,7 +1996,7 @@ proc ::wkcf::FindBoundaries_no_spheric_elems {entity} {
     return $boundarylist
 }
 
-proc ::wkcf::FindBoundariesOfNonSphericElements {entity} {
+proc ::wkcf::FindAllSurfacesOfNonSphericElements {entity} {
     # ABSTRACT: Return a list containing all boundaries entities
     # Arguments
     # entity => surface


### PR DESCRIPTION
Added a procedure that searches all the surfaces in the model (belonging to a volume or not). These surfaces are necessary for the ExcludeBoundary option for inlets in GUI. This proc is also compatible with non-nurb surfaces.
This fixes the incompatibility with swimming application when applying conditions.
