### PR TITLE
Fix hdf5application filename

### DIFF
--- a/applications/HDF5Application/python_scripts/hdf5_io.py
+++ b/applications/HDF5Application/python_scripts/hdf5_io.py
@@ -121,6 +121,16 @@ class PrimalBossakInput(IOObject):
         primal_io = KratosHDF5.HDF5NodalSolutionStepBossakIO(self.settings, hdf5_file)
         primal_io.ReadNodalResults(model_part.Nodes, model_part.GetCommunicator())
 
+class ElementResultsInput(IOObject):
+    """Provides the interface for reading element results from a file."""
+
+    def __init__(self, settings):
+        default_settings = KratosMultiphysics.Parameters(hdf5_defaults.temporal_default_settings)
+        self.settings = settings.Clone()
+        self.settings.ValidateAndAssignDefaults(default_settings)
+
+    def Execute(self, model_part, hdf5_file):
+        KratosHDF5.HDF5ElementSolutionStepDataIO(self.settings, hdf5_file).ReadElementResults(model_part.Elements)
 
 class PartitionedModelPartOutput(IOObject):
     """Provides the interface for writing a partitioned model part to a file."""
@@ -137,17 +147,18 @@ class PartitionedModelPartOutput(IOObject):
 class StaticOutputProcess(KratosMultiphysics.Process):
     """A process for writing static simulation results."""
 
-    def __init__(self, model_part, hdf5_file_factory):
+    def __init__(self, model_part, hdf5_file_factory, file_name):
         KratosMultiphysics.Process.__init__(self)
         self._model_part = model_part
         self._hdf5_file_factory = hdf5_file_factory
         self._list_of_outputs = []
+        self._file_name = file_name
 
     def AddOutput(self, output):
         self._list_of_outputs.append(output)
 
     def Execute(self):
-        hdf5_file = self._hdf5_file_factory.Open(self._model_part.Name + ".h5")
+        hdf5_file = self._hdf5_file_factory.Open(self._file_name + ".h5")
         for output in self._list_of_outputs:
             output.Execute(self._model_part, hdf5_file)
 
@@ -165,13 +176,15 @@ class TemporalOutputProcess(KratosMultiphysics.Process):
             {
                 "output_time_frequency": 1.0,
                 "output_step_frequency": 0,
-                "time_tag_precision": 4
+                "time_tag_precision": 4,
+                "file_name": "%s"
             }
-            """)
+            """ % model_part.Name)
         settings.ValidateAndAssignDefaults(default_settings)
         self._model_part = model_part
         self._hdf5_file_factory = hdf5_file_factory
-        self._initial_output = StaticOutputProcess(model_part, hdf5_file_factory)
+        self._time_step_file_name = settings["file_name"].GetString() + "-" + self._model_part.Name
+        self._initial_output = StaticOutputProcess(model_part, hdf5_file_factory, self._time_step_file_name)
         for output in list_of_initial_outputs:
             self._initial_output.AddOutput(output)
         self._output_time_frequency = settings["output_time_frequency"].GetDouble()
@@ -204,7 +217,7 @@ class TemporalOutputProcess(KratosMultiphysics.Process):
     def _get_current_file_name(self):
         fmt = "{:." + str(self._time_tag_precision) + "f}"
         time_tag = "-" + fmt.format(self._model_part.ProcessInfo[KratosMultiphysics.TIME])
-        return self._model_part.Name + time_tag + ".h5"
+        return self._time_step_file_name + time_tag + ".h5"
 
 
 class TemporalInputProcess(KratosMultiphysics.Process):
@@ -214,12 +227,14 @@ class TemporalInputProcess(KratosMultiphysics.Process):
         KratosMultiphysics.Process.__init__(self)
         default_settings = KratosMultiphysics.Parameters("""
             {
-                "time_tag_precision": 4
+                "time_tag_precision": 4,
+                "file_name": "%s"
             }
-            """)
+            """ % model_part.Name)
         settings.ValidateAndAssignDefaults(default_settings)
         self._model_part = model_part
         self._hdf5_file_factory = hdf5_file_factory
+        self._time_step_file_name = settings["file_name"].GetString() + "-" + self._model_part.Name
         self._time_tag_precision = settings["time_tag_precision"].GetInt()
         self._list_of_inputs = []
 
@@ -234,4 +249,4 @@ class TemporalInputProcess(KratosMultiphysics.Process):
     def _get_current_file_name(self):
         fmt = "{:." + str(self._time_tag_precision) + "f}"
         time_tag = "-" + fmt.format(self._model_part.ProcessInfo[KratosMultiphysics.TIME])
-        return self._model_part.Name + time_tag + ".h5"
+        return self._time_step_file_name + time_tag + ".h5"

--- a/applications/HDF5Application/python_scripts/partitioned_single_mesh_primal_input_process.py
+++ b/applications/HDF5Application/python_scripts/partitioned_single_mesh_primal_input_process.py
@@ -11,7 +11,9 @@ def Factory(settings, Model):
                 "model_part_name" : "MainModelPart",
                 "file_settings" : {},
                 "nodal_results_settings" : {},
-                "time_tag_precision" : 4
+                "element_results_settings" : {},
+                "time_tag_precision" : 4,
+                "file_name": "DEFAULT_NAME"
             }
             """)
     settings = settings["Parameters"].Clone()
@@ -19,10 +21,17 @@ def Factory(settings, Model):
     model_part = Model[settings["model_part_name"].GetString()]
     hdf5_file_factory = hdf5_io.HDF5ParallelFileFactory(settings["file_settings"])
     nodal_results_input = hdf5_io.PrimalBossakInput(settings["nodal_results_settings"])
+    element_results_input = hdf5_io.ElementResultsInput(settings["element_results_settings"])
     input_time_settings = KratosMultiphysics.Parameters("""{}""")
     input_time_settings.AddEmptyValue("time_tag_precision")
     input_time_settings["time_tag_precision"].SetInt(settings["time_tag_precision"].GetInt())
+    input_time_settings.AddEmptyValue("file_name")
+    if settings["file_name"].GetString()=="DEFAULT_NAME":
+        input_time_settings["file_name"].SetString(model_part.Name)
+    else:
+        input_time_settings["file_name"].SetString(settings["file_name"].GetString())
     temporal_input_process = hdf5_io.TemporalInputProcess(
         model_part, hdf5_file_factory, input_time_settings)
     temporal_input_process.AddInput(nodal_results_input)
+    temporal_input_process.AddInput(element_results_input)
     return temporal_input_process

--- a/applications/HDF5Application/python_scripts/single_mesh_primal_input_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_primal_input_process.py
@@ -11,7 +11,9 @@ def Factory(settings, Model):
                 "model_part_name" : "MainModelPart",
                 "file_settings" : {},
                 "nodal_results_settings" : {},
-                "time_tag_precision" : 4
+                "element_results_settings" : {},
+                "time_tag_precision" : 4,
+                "file_name": "DEFAULT_NAME"
             }
             """)
     settings = settings["Parameters"].Clone()
@@ -19,10 +21,17 @@ def Factory(settings, Model):
     model_part = Model[settings["model_part_name"].GetString()]
     hdf5_file_factory = hdf5_io.HDF5SerialFileFactory(settings["file_settings"])
     nodal_results_input = hdf5_io.PrimalBossakInput(settings["nodal_results_settings"])
+    element_results_input = hdf5_io.ElementResultsInput(settings["element_results_settings"])
     input_time_settings = KratosMultiphysics.Parameters("""{}""")
     input_time_settings.AddEmptyValue("time_tag_precision")
+    input_time_settings.AddEmptyValue("file_name")
+    if settings["file_name"].GetString()=="DEFAULT_NAME":
+        input_time_settings["file_name"].SetString(model_part.Name)
+    else:
+        input_time_settings["file_name"].SetString(settings["file_name"].GetString())
     input_time_settings["time_tag_precision"].SetInt(settings["time_tag_precision"].GetInt())
     temporal_input_process = hdf5_io.TemporalInputProcess(
         model_part, hdf5_file_factory, input_time_settings)
     temporal_input_process.AddInput(nodal_results_input)
+    temporal_input_process.AddInput(element_results_input)
     return temporal_input_process


### PR DESCRIPTION
This is a small PR adding followings

- Added missing ElementResultsInput class to fill element temporal results from hdf files
- Added a prefix for hdf5 output and input file names

This PR uses the existing structure of the settings, with an optional additional "file_name" setting in both input and output processes.