### PR TITLE
Removing the order dependent check

### DIFF
--- a/kratos/tests/sources/test_model_part.cpp
+++ b/kratos/tests/sources/test_model_part.cpp
@@ -31,10 +31,10 @@ namespace Kratos {
 			for(auto i_SubModelPart = model_part.SubModelPartsBegin() ; i_SubModelPart != model_part.SubModelPartsEnd() ; i_SubModelPart++){
 				i_SubModelPart->CreateNewNode(id++, 0.00,0.00,0.00);
 			}
+
 			KRATOS_CHECK_EQUAL(model_part.NumberOfNodes(), 4);
 			KRATOS_CHECK_EQUAL(model_part.GetSubModelPart("Inlet1").NumberOfNodes(), 1);
 			KRATOS_CHECK_EQUAL(model_part.GetSubModelPart("Outlet").NumberOfNodes(), 1);
-			KRATOS_CHECK_EQUAL(model_part.GetSubModelPart("Outlet").GetNode(2).Id(), 2);
 		}
 
 		KRATOS_TEST_CASE_IN_SUITE(ModelPartAddNodalSolutionStepVariable, KratosCoreFastSuite)


### PR DESCRIPTION
This PR fixes #2191 by removing the order dependent check from the test. The failure was caused by changing the `SubModelPartsContainerType` in commit 2fed1a8 which changes the order of iteration.