### PR TITLE
[Core] Geometrical Projection Utilities

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_mortar_contact_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/ALM_mortar_contact_condition.cpp
@@ -22,6 +22,7 @@
 #include "custom_conditions/ALM_mortar_contact_condition.h"
 
 /* Utilities */
+#include "utilities/geometrical_projection_utilities.h"
 #include "utilities/math_utils.h"
 
 namespace Kratos 
@@ -574,7 +575,7 @@ void AugmentedLagrangianMethodMortarContactCondition<TDim,TNumNodes,TFrictional,
     
     GeometryType::CoordinatesArrayType slave_gp_global;
     this->GetGeometry( ).GlobalCoordinates( slave_gp_global, LocalPoint );
-    MortarUtilities::FastProjectDirection( master_geometry, slave_gp_global, projected_gp_global, NormalMaster, -gp_normal ); // The opposite direction
+    GeometricalProjectionUtilities::FastProjectDirection( master_geometry, slave_gp_global, projected_gp_global, NormalMaster, -gp_normal ); // The opposite direction
     
     GeometryType::CoordinatesArrayType projected_gp_local;
     

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
@@ -10,15 +10,14 @@
 //
 
 // System includes
+#include <algorithm>
 
 // External includes
 
 // Project includes
+#include "utilities/geometrical_projection_utilities.h"
 /* Mortar includes */
 #include "custom_conditions/mesh_tying_mortar_condition.h"
-
-/* Additional includes */
-#include <algorithm>
 
 namespace Kratos 
 {
@@ -507,7 +506,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem,TTensor>::MasterShapeFunctionVa
     
     GeometryType::CoordinatesArrayType slave_gp_global;
     this->GetGeometry( ).GlobalCoordinates( slave_gp_global, LocalPoint );
-    MortarUtilities::FastProjectDirection( master_geometry, slave_gp_global, projected_gp_global, NormalMaster, -gp_normal ); // The opposite direction
+    GeometricalProjectionUtilities::FastProjectDirection( master_geometry, slave_gp_global, projected_gp_global, NormalMaster, -gp_normal ); // The opposite direction
     
     GeometryType::CoordinatesArrayType projected_gp_local;
     

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.h
@@ -24,6 +24,7 @@
 #include "includes/mortar_classes.h"
 
 /* Utilities */
+#include "utilities/geometrical_projection_utilities.h"
 #include "utilities/mortar_utilities.h"
 #include "utilities/math_utils.h"
 
@@ -423,10 +424,10 @@ public:
 
                 // The coordinates should be in the projected plane
                 double distance;
-                const array_1d<double, 3> xs1 = MortarUtilities::FastProject(slave_center, SlaveGeometry[belong_index_slave_start], Normal, distance).Coordinates(); // Start coordinates of the first segment
-                const array_1d<double, 3> xe1 = MortarUtilities::FastProject(slave_center, SlaveGeometry[belong_index_slave_end], Normal, distance).Coordinates(); // End coordinates of the first segment
-                const array_1d<double, 3> xs2 = MortarUtilities::FastProject(slave_center, MasterGeometry[belong_index_master_start], Normal, distance).Coordinates(); // Start coordinates of the second segment
-                const array_1d<double, 3> xe2 = MortarUtilities::FastProject(slave_center, MasterGeometry[belong_index_master_end], Normal, distance).Coordinates(); // End coordinates of the second segment
+                const array_1d<double, 3> xs1 = GeometricalProjectionUtilities::FastProject(slave_center, SlaveGeometry[belong_index_slave_start], Normal, distance).Coordinates(); // Start coordinates of the first segment
+                const array_1d<double, 3> xe1 = GeometricalProjectionUtilities::FastProject(slave_center, SlaveGeometry[belong_index_slave_end], Normal, distance).Coordinates(); // End coordinates of the first segment
+                const array_1d<double, 3> xs2 = GeometricalProjectionUtilities::FastProject(slave_center, MasterGeometry[belong_index_master_start], Normal, distance).Coordinates(); // Start coordinates of the second segment
+                const array_1d<double, 3> xe2 = GeometricalProjectionUtilities::FastProject(slave_center, MasterGeometry[belong_index_master_end], Normal, distance).Coordinates(); // End coordinates of the second segment
 
                 // We define the array containing the indexes of the vertexes
                 array_1d<IndexType, 4> belong_indexes;
@@ -644,8 +645,8 @@ public:
 
             for (IndexType i_mortar_node = 0; i_mortar_node < TNumNodes; ++i_mortar_node) {
                 // Projecting points in opposite geometry, defining mortar nodes
-                MortarUtilities::FastProjectDirection( SlaveGeometry,  MasterGeometry[i_mortar_node], projected_in_slave[i_mortar_node],  SlaveNormal, MasterNormal );
-                MortarUtilities::FastProjectDirection( MasterGeometry, SlaveGeometry[i_mortar_node],  projected_in_master[i_mortar_node], MasterNormal, SlaveNormal );
+                GeometricalProjectionUtilities::FastProjectDirection( SlaveGeometry,  MasterGeometry[i_mortar_node], projected_in_slave[i_mortar_node],  SlaveNormal, MasterNormal );
+                GeometricalProjectionUtilities::FastProjectDirection( MasterGeometry, SlaveGeometry[i_mortar_node],  projected_in_master[i_mortar_node], MasterNormal, SlaveNormal );
             }
 
             for ( IndexType i_node = 0; i_node < TNumNodes; ++i_node) {
@@ -967,7 +968,7 @@ public:
 
                     GeometryType::CoordinatesArrayType slave_gp_global;
                     SlaveGeometry.GlobalCoordinates( slave_gp_global, local_point_parent );
-                    MortarUtilities::FastProjectDirection( MasterGeometry, slave_gp_global, projected_gp_global, SlaveNormal, -gp_normal ); // The opposite direction
+                    GeometricalProjectionUtilities::FastProjectDirection( MasterGeometry, slave_gp_global, projected_gp_global, SlaveNormal, -gp_normal ); // The opposite direction
 
                     GeometryType::CoordinatesArrayType projected_gp_local;
                     MasterGeometry.PointLocalCoordinates( projected_gp_local, projected_gp_global.Coordinates( ) ) ;

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/tree_contact_search.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/tree_contact_search.cpp
@@ -15,6 +15,7 @@
 // External includes
 
 // Project includes
+#include "utilities/geometrical_projection_utilities.h"
 #include "utilities/mortar_utilities.h"
 #include "utilities/variable_utils.h"
 
@@ -846,9 +847,9 @@ inline void TreeContactSearch<TDim, TNumNodes>::AddPotentialPairing(
                     double aux_distance = 0.0;
                     const array_1d<double, 3> normal = geom_slave[i_node].GetValue(NORMAL);
                     if (norm_2(normal) < tolerance)
-                        aux_distance = MortarUtilities::FastProjectDirection(geom_master, geom_slave[i_node], projected_point, normal_master, normal_slave);
+                        aux_distance = GeometricalProjectionUtilities::FastProjectDirection(geom_master, geom_slave[i_node], projected_point, normal_master, normal_slave);
                     else
-                        aux_distance = MortarUtilities::FastProjectDirection(geom_master, geom_slave[i_node], projected_point, normal_master, normal);
+                        aux_distance = GeometricalProjectionUtilities::FastProjectDirection(geom_master, geom_slave[i_node], projected_point, normal_master, normal);
 
                     array_1d<double, 3> result;
                     if (aux_distance <= geom_slave[i_node].FastGetSolutionStepValue(NODAL_H) * active_check_factor &&  geom_master.IsInside(projected_point, result, tolerance)) { // NOTE: This can be problematic (It depends the way IsInside() and the local_pointCoordinates() are implemented)
@@ -866,7 +867,7 @@ inline void TreeContactSearch<TDim, TNumNodes>::AddPotentialPairing(
                         }
                     }
 
-                    aux_distance = MortarUtilities::FastProjectDirection(geom_master, geom_slave[i_node], projected_point, normal_master, -normal_master);
+                    aux_distance = GeometricalProjectionUtilities::FastProjectDirection(geom_master, geom_slave[i_node], projected_point, normal_master, -normal_master);
                     if (aux_distance <= geom_slave[i_node].FastGetSolutionStepValue(NODAL_H) * active_check_factor &&  geom_master.IsInside(projected_point, result, tolerance)) { // NOTE: This can be problematic (It depends the way IsInside() and the local_pointCoordinates() are implemented)
                         at_least_one_node_potential_contact = true;
                         geom_slave[i_node].Set(ACTIVE, true);

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition.cpp
@@ -10,15 +10,14 @@
 //
 
 // System includes
+#include <algorithm>
 
 // External includes
 
 // Project includes
+#include "utilities/geometrical_projection_utilities.h"
 /* Mortar includes */
 #include "custom_conditions/mesh_tying_mortar_condition.h"
-
-/* Additional includes */
-#include <algorithm>
 
 namespace Kratos 
 {
@@ -507,7 +506,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem,TTensor>::MasterShapeFunctionVa
     
     GeometryType::CoordinatesArrayType slave_gp_global;
     this->GetGeometry( ).GlobalCoordinates( slave_gp_global, LocalPoint );
-    MortarUtilities::FastProjectDirection( master_geometry, slave_gp_global, projected_gp_global, NormalMaster, -gp_normal ); // The opposite direction
+    GeometricalProjectionUtilities::FastProjectDirection( master_geometry, slave_gp_global, projected_gp_global, NormalMaster, -gp_normal ); // The opposite direction
     
     GeometryType::CoordinatesArrayType projected_gp_local;
     

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition_template.cpp
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition_template.cpp
@@ -10,15 +10,14 @@
 //
 
 // System includes
+#include <algorithm>
 
 // External includes
 
 // Project includes
+#include "custom_conditions/mesh_tying_mortar_condition.h"
 /* Mortar includes */
 #include "custom_conditions/mesh_tying_mortar_condition.h"
-
-/* Additional includes */
-#include <algorithm>
 
 namespace Kratos 
 {
@@ -507,7 +506,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem,TTensor>::MasterShapeFunctionVa
     
     GeometryType::CoordinatesArrayType slave_gp_global;
     this->GetGeometry( ).GlobalCoordinates( slave_gp_global, LocalPoint );
-    MortarUtilities::FastProjectDirection( master_geometry, slave_gp_global, projected_gp_global, NormalMaster, -gp_normal ); // The opposite direction
+    GeometricalProjectionUtilities::FastProjectDirection( master_geometry, slave_gp_global, projected_gp_global, NormalMaster, -gp_normal ); // The opposite direction
     
     GeometryType::CoordinatesArrayType projected_gp_local;
     

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_derivatives.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_derivatives.cpp
@@ -20,6 +20,7 @@
 #include "includes/model_part.h"
 
 /* Utilities */
+#include "utilities/geometrical_projection_utilities.h"
 #include "utilities/mortar_utilities.h"
 #include "utilities/exact_mortar_segmentation_utility.h"
 #include "custom_utilities/derivatives_utilities.h"
@@ -241,7 +242,7 @@ namespace Kratos
 
                                     GeometryType::CoordinatesArrayType slave_gp_global;
                                     slave_geometry_0.GlobalCoordinates( slave_gp_global, local_point_parent );
-                                    MortarUtilities::FastProjectDirection( master_geometry_0, slave_gp_global, projected_gp_global, normal_master_0, -gp_normal ); // The opposite direction
+                                    GeometricalProjectionUtilities::FastProjectDirection( master_geometry_0, slave_gp_global, projected_gp_global, normal_master_0, -gp_normal ); // The opposite direction
 
                                     GeometryType::CoordinatesArrayType projected_gp_local;
 
@@ -267,7 +268,7 @@ namespace Kratos
                                     gp_normal = MortarUtilities::GaussPointUnitNormal(rVariables.NSlave, slave_geometry_1);
 
                                     slave_geometry_1.GlobalCoordinates( slave_gp_global, local_point_parent );
-                                    MortarUtilities::FastProjectDirection( master_geometry_1, slave_gp_global, projected_gp_global, normal_master_1, -gp_normal ); // The opposite direction
+                                    GeometricalProjectionUtilities::FastProjectDirection( master_geometry_1, slave_gp_global, projected_gp_global, normal_master_1, -gp_normal ); // The opposite direction
 
                                     master_geometry_1.PointLocalCoordinates( projected_gp_local, projected_gp_global.Coordinates( ) ) ;
 

--- a/kratos/processes/simple_mortar_mapper_process.cpp
+++ b/kratos/processes/simple_mortar_mapper_process.cpp
@@ -18,6 +18,7 @@
 #include "processes/simple_mortar_mapper_process.h"
 
 /* Custom utilities */
+#include "utilities/geometrical_projection_utilities.h"
 #include "utilities/mortar_utilities.h"
 #include "utilities/math_utils.h"
 
@@ -289,7 +290,7 @@ void SimpleMortarMapperProcess<TDim, TNumNodes, TVarType, THistOrigin, THistDest
 
                 GeometryType::CoordinatesArrayType slave_gp_global;
                 SlaveGeometry.GlobalCoordinates( slave_gp_global, local_point_parent );
-                MortarUtilities::FastProjectDirection( MasterGeometry, gp_global, projected_gp_global, MasterNormal, -gp_normal ); // The opposite direction
+                GeometricalProjectionUtilities::FastProjectDirection( MasterGeometry, gp_global, projected_gp_global, MasterNormal, -gp_normal ); // The opposite direction
 
                 GeometryType::CoordinatesArrayType projected_gp_local;
 

--- a/kratos/tests/utilities/run_tests_projection.py
+++ b/kratos/tests/utilities/run_tests_projection.py
@@ -1,4 +1,0 @@
-from KratosMultiphysics import *
-
-Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
-Tester.RunTestCases("*GeometricalProjectionUtilities*")

--- a/kratos/tests/utilities/run_tests_projection.py
+++ b/kratos/tests/utilities/run_tests_projection.py
@@ -1,0 +1,4 @@
+from KratosMultiphysics import *
+
+Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
+Tester.RunTestCases("*GeometricalProjectionUtilities*")

--- a/kratos/tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/utilities/test_geometrical_projection_utilities.cpp
@@ -8,6 +8,7 @@
 //  			 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher
+//                   Vicente Mataix Ferrandiz
 //
 //
 
@@ -50,12 +51,12 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirection, Kr
     array_1d<double,3> normal_vector;
 
     dir_vector[0] = 0.0;
-    dir_vector[0] = 0.0;
-    dir_vector[0] = 1.0;
+    dir_vector[1] = 0.0;
+    dir_vector[2] = -1.0;
 
     normal_vector[0] = 0.0;
-    normal_vector[0] = 0.0;
-    normal_vector[0] = 1.0;
+    normal_vector[1] = 0.0;
+    normal_vector[2] = 1.0;
 
     Point projected_point;
 
@@ -85,8 +86,8 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProject, KratosCoreF
     array_1d<double,3> normal_vector;
 
     normal_vector[0] = 0.0;
-    normal_vector[0] = 0.0;
-    normal_vector[0] = 1.0;
+    normal_vector[1] = 0.0;
+    normal_vector[2] = 1.0;
 
     double proj_distance;
 

--- a/kratos/tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/utilities/test_geometrical_projection_utilities.cpp
@@ -45,7 +45,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirection, Kr
     const double x_coord = 0.325;
     const double y_coord = 0.147;
 
-    Point point_to_proj(x_coord, y_coord, expected_proj_dist);
+    const Point point_to_proj(x_coord, y_coord, expected_proj_dist);
 
     array_1d<double,3> dir_vector;
     array_1d<double,3> normal_vector;
@@ -75,13 +75,13 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirection, Kr
 
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProject, KratosCoreFastSuite)
 {
-    double expected_proj_dist = 1.258;
+    const double expected_proj_dist = 1.258;
 
     const double x_coord = 0.325;
     const double y_coord = 0.147;
 
-    Point point_in_plane(-1.274, 10.478, 0.0);
-    Point point_to_proj(x_coord, y_coord, expected_proj_dist);
+    const Point point_in_plane(-1.274, 10.478, 0.0);
+    const Point point_to_proj(x_coord, y_coord, expected_proj_dist);
 
     array_1d<double,3> normal_vector;
 

--- a/kratos/tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/utilities/test_geometrical_projection_utilities.cpp
@@ -13,7 +13,7 @@
 
 // Project includes
 #include "testing/testing.h"
-#include "utilities/geometrical_projection_utilities.h"
+#include "utilities/mortar_utilities.h"
 
 #include "geometries/triangle_2d_3.h"
 
@@ -22,8 +22,8 @@ namespace Kratos
 namespace Testing
 {
 
-using NodeType = typename GeometricalProjectionUtilities::NodeType;
-using GeometryType = typename GeometricalProjectionUtilities::GeometryType;
+using NodeType = typename MortarUtilities::NodeType;
+using GeometryType = typename MortarUtilities::GeometryType;
 
 GeometryType::Pointer CreateTriangle2D3NForTest()
 {
@@ -59,7 +59,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilities_FastProjectDirection, K
 
     Point projected_point;
 
-    double proj_distance = GeometricalProjectionUtilities::FastProjectDirection(
+    double proj_distance = MortarUtilities::FastProjectDirection(
         *p_geom,
         point_to_proj,
         projected_point,
@@ -90,7 +90,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilities_FastProject, KratosCore
 
     double proj_distance;
 
-    Point projected_point = GeometricalProjectionUtilities::FastProject(
+    Point projected_point = MortarUtilities::FastProject(
         point_in_plane,
         point_to_proj,
         normal_vector,

--- a/kratos/tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/utilities/test_geometrical_projection_utilities.cpp
@@ -13,17 +13,17 @@
 
 // Project includes
 #include "testing/testing.h"
-#include "utilities/mortar_utilities.h"
+#include "utilities/geometrical_projection_utilities.h"
 
-#include "geometries/triangle_2d_3.h"
+#include "geometries/triangle_3d_3.h"
 
 namespace Kratos
 {
 namespace Testing
 {
 
-using NodeType = typename MortarUtilities::NodeType;
-using GeometryType = typename MortarUtilities::GeometryType;
+using NodeType = typename GeometricalProjectionUtilities::NodeType;
+using GeometryType = typename GeometricalProjectionUtilities::GeometryType;
 
 GeometryType::Pointer CreateTriangle2D3NForTest()
 {
@@ -32,10 +32,10 @@ GeometryType::Pointer CreateTriangle2D3NForTest()
     points.push_back(Kratos::make_shared<NodeType>(1.1, 0.03, 0.0));
     points.push_back(Kratos::make_shared<NodeType>(1.08, 1.0, 0.0));
 
-    return GeometryType::Pointer(new Triangle2D3<NodeType>(points));
+    return GeometryType::Pointer(new Triangle3D3<NodeType>(points));
 }
 
-KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilities_FastProjectDirection, KratosCoreFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirection, KratosCoreFastSuite)
 {
     GeometryType::Pointer p_geom = CreateTriangle2D3NForTest();
 
@@ -59,7 +59,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilities_FastProjectDirection, K
 
     Point projected_point;
 
-    double proj_distance = MortarUtilities::FastProjectDirection(
+    double proj_distance = GeometricalProjectionUtilities::FastProjectDirection(
         *p_geom,
         point_to_proj,
         projected_point,
@@ -72,7 +72,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilities_FastProjectDirection, K
     KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Z(), 0.0);
 }
 
-KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilities_FastProject, KratosCoreFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProject, KratosCoreFastSuite)
 {
     double expected_proj_dist = 1.258;
 
@@ -90,7 +90,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilities_FastProject, KratosCore
 
     double proj_distance;
 
-    Point projected_point = MortarUtilities::FastProject(
+    Point projected_point = GeometricalProjectionUtilities::FastProject(
         point_in_plane,
         point_to_proj,
         normal_vector,

--- a/kratos/tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/utilities/test_geometrical_projection_utilities.cpp
@@ -1,0 +1,106 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:     BSD License
+//  			 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher
+//
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "utilities/geometrical_projection_utilities.h"
+
+#include "geometries/triangle_2d_3.h"
+
+namespace Kratos
+{
+namespace Testing
+{
+
+using NodeType = typename GeometricalProjectionUtilities::NodeType;
+using GeometryType = typename GeometricalProjectionUtilities::GeometryType;
+
+GeometryType::Pointer CreateTriangle2D3NForTest()
+{
+    GeometryType::PointsArrayType points;
+    points.push_back(Kratos::make_shared<NodeType>(0.04, 0.02, 0.0));
+    points.push_back(Kratos::make_shared<NodeType>(1.1, 0.03, 0.0));
+    points.push_back(Kratos::make_shared<NodeType>(1.08, 1.0, 0.0));
+
+    return GeometryType::Pointer(new Triangle2D3<NodeType>(points));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilities_FastProjectDirection, KratosCoreFastSuite)
+{
+    GeometryType::Pointer p_geom = CreateTriangle2D3NForTest();
+
+    double expected_proj_dist = 1.258;
+
+    const double x_coord = 0.325;
+    const double y_coord = 0.147;
+
+    Point point_to_proj(x_coord, y_coord, expected_proj_dist);
+
+    array_1d<double,3> dir_vector;
+    array_1d<double,3> normal_vector;
+
+    dir_vector[0] = 0.0;
+    dir_vector[0] = 0.0;
+    dir_vector[0] = 1.0;
+
+    normal_vector[0] = 0.0;
+    normal_vector[0] = 0.0;
+    normal_vector[0] = 1.0;
+
+    Point projected_point;
+
+    double proj_distance = GeometricalProjectionUtilities::FastProjectDirection(
+        *p_geom,
+        point_to_proj,
+        projected_point,
+        normal_vector,
+        dir_vector);
+
+    KRATOS_CHECK_DOUBLE_EQUAL(expected_proj_dist, proj_distance);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.X(), x_coord);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Y(), y_coord);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Z(), 0.0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilities_FastProject, KratosCoreFastSuite)
+{
+    double expected_proj_dist = 1.258;
+
+    const double x_coord = 0.325;
+    const double y_coord = 0.147;
+
+    Point point_in_plane(-1.274, 10.478, 0.0);
+    Point point_to_proj(x_coord, y_coord, expected_proj_dist);
+
+    array_1d<double,3> normal_vector;
+
+    normal_vector[0] = 0.0;
+    normal_vector[0] = 0.0;
+    normal_vector[0] = 1.0;
+
+    double proj_distance;
+
+    Point projected_point = GeometricalProjectionUtilities::FastProject(
+        point_in_plane,
+        point_to_proj,
+        normal_vector,
+        proj_distance);
+
+    KRATOS_CHECK_DOUBLE_EQUAL(expected_proj_dist, proj_distance);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.X(), x_coord);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Y(), y_coord);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Z(), 0.0);
+}
+
+} // namespace Testing.
+} // namespace Kratos.

--- a/kratos/utilities/exact_mortar_segmentation_utility.cpp
+++ b/kratos/utilities/exact_mortar_segmentation_utility.cpp
@@ -16,6 +16,7 @@
 // External includes
 
 // Project includes
+#include "utilities/geometrical_projection_utilities.h"
 #include "utilities/exact_mortar_segmentation_utility.h"
 
 namespace Kratos {
@@ -42,7 +43,7 @@ bool ExactMortarIntegrationUtility<2, 2, false>::GetExactIntegration(
     for (IndexType i_slave = 0; i_slave < 2; ++i_slave) {
         const array_1d<double, 3>& normal = OriginalSlaveGeometry[i_slave].FastGetSolutionStepValue(NORMAL);
 
-        const double distance = MortarUtilities::FastProjectDirection(OriginalMasterGeometry, OriginalSlaveGeometry[i_slave].Coordinates(), projected_gp_global, MasterNormal, -normal ); // The opposite direction
+        const double distance = GeometricalProjectionUtilities::FastProjectDirection(OriginalMasterGeometry, OriginalSlaveGeometry[i_slave].Coordinates(), projected_gp_global, MasterNormal, -normal ); // The opposite direction
 
         if (distance > mDistanceThreshold) {
             ConditionsPointsSlave.clear();
@@ -68,7 +69,7 @@ bool ExactMortarIntegrationUtility<2, 2, false>::GetExactIntegration(
         for (IndexType i_master = 0; i_master < 2; ++i_master) {
             projected_gp_local[0] = (i_master == 0) ? -1.0 : 1.0;
             double delta_xi = (i_master == 0) ? 0.5 : -0.5;
-            const bool is_inside = MortarUtilities::ProjectIterativeLine2D(OriginalSlaveGeometry, OriginalMasterGeometry[i_master].Coordinates(), projected_gp_local, SlaveNormal, tolerance, delta_xi);
+            const bool is_inside = GeometricalProjectionUtilities::ProjectIterativeLine2D(OriginalSlaveGeometry, OriginalMasterGeometry[i_master].Coordinates(), projected_gp_local, SlaveNormal, tolerance, delta_xi);
 
             if (is_inside)
                 auxiliar_xi.push_back(projected_gp_local[0]);
@@ -160,7 +161,7 @@ bool ExactMortarIntegrationUtility<3, 3, false>::GetExactIntegration(
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
         points_array_slave[i_node] = Kratos::make_shared<PointType>(aux_point);
 
-        aux_point = MortarUtilities::FastProject( slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance);
+        aux_point = GeometricalProjectionUtilities::FastProject( slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
         points_array_master[i_node] = Kratos::make_shared<PointType>(aux_point);
 
@@ -241,12 +242,12 @@ bool ExactMortarIntegrationUtility<3, 4, false>::GetExactIntegration(
         PointType aux_point;
         double distance_slave, distance_master;
 
-        aux_point = MortarUtilities::FastProject(slave_center, OriginalSlaveGeometry[i_node], SlaveNormal, distance_slave);
+        aux_point = GeometricalProjectionUtilities::FastProject(slave_center, OriginalSlaveGeometry[i_node], SlaveNormal, distance_slave);
         points_array_slave_not_rotated[i_node] = Kratos::make_shared<PointType>(aux_point);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
         points_array_slave[i_node] = Kratos::make_shared<PointType>(aux_point);
 
-        aux_point = MortarUtilities::FastProject( slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance_master);
+        aux_point = GeometricalProjectionUtilities::FastProject( slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance_master);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
         points_array_master[i_node] = Kratos::make_shared<PointType>(aux_point);
 
@@ -320,7 +321,7 @@ bool ExactMortarIntegrationUtility<2, 2, true>::GetExactIntegration(
     for (unsigned int i_slave = 0; i_slave < 2; ++i_slave) {
         const array_1d<double, 3>& normal = OriginalSlaveGeometry[i_slave].FastGetSolutionStepValue(NORMAL);
 
-        const double distance = MortarUtilities::FastProjectDirection(OriginalMasterGeometry, OriginalSlaveGeometry[i_slave].Coordinates(), projected_gp_global, MasterNormal, -normal ); // The opposite direction
+        const double distance = GeometricalProjectionUtilities::FastProjectDirection(OriginalMasterGeometry, OriginalSlaveGeometry[i_slave].Coordinates(), projected_gp_global, MasterNormal, -normal ); // The opposite direction
 
         if (distance > mDistanceThreshold) {
             ConditionsPointsSlave.clear();
@@ -349,7 +350,7 @@ bool ExactMortarIntegrationUtility<2, 2, true>::GetExactIntegration(
         for (IndexType i_master = 0; i_master < 2; ++i_master) {
             projected_gp_local[0] = (i_master == 0) ? -1.0 : 1.0;
             double delta_xi = (i_master == 0) ? 0.5 : -0.5;
-            const bool is_inside = MortarUtilities::ProjectIterativeLine2D(OriginalSlaveGeometry,  OriginalMasterGeometry[i_master].Coordinates(), projected_gp_local, SlaveNormal, tolerance, delta_xi);
+            const bool is_inside = GeometricalProjectionUtilities::ProjectIterativeLine2D(OriginalSlaveGeometry,  OriginalMasterGeometry[i_master].Coordinates(), projected_gp_local, SlaveNormal, tolerance, delta_xi);
 
             if (is_inside) {
                 auxiliar_xi.push_back(projected_gp_local[0]);
@@ -453,7 +454,7 @@ bool ExactMortarIntegrationUtility<3, 3, true>::GetExactIntegration(
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
         points_array_slave[i_node] = Kratos::make_shared<PointType>(aux_point);
 
-        aux_point = MortarUtilities::FastProject(slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance);
+        aux_point = GeometricalProjectionUtilities::FastProject(slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
         points_array_master[i_node] = Kratos::make_shared<PointType>(aux_point);
     }
@@ -529,12 +530,12 @@ bool ExactMortarIntegrationUtility<3, 4, true>::GetExactIntegration(
         PointType aux_point;
         double distance_slave, distance_master;
 
-        aux_point = MortarUtilities::FastProject(slave_center, OriginalSlaveGeometry[i_node], SlaveNormal, distance_slave);
+        aux_point = GeometricalProjectionUtilities::FastProject(slave_center, OriginalSlaveGeometry[i_node], SlaveNormal, distance_slave);
         points_array_slave_not_rotated[i_node] = Kratos::make_shared<PointType>(aux_point);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
         points_array_slave[i_node] = Kratos::make_shared<PointType>(aux_point);
 
-        aux_point = MortarUtilities::FastProject(slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance_master);
+        aux_point = GeometricalProjectionUtilities::FastProject(slave_center, OriginalMasterGeometry[i_node], SlaveNormal, distance_master);
         MortarUtilities::RotatePoint(aux_point, slave_center, slave_tangent_xi, slave_tangent_eta, false);
         points_array_master[i_node] = Kratos::make_shared<PointType>(aux_point);
 

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -129,14 +129,14 @@ public:
         if( norm_2( rVector ) < zero_tolerance && norm_2( rNormal ) > zero_tolerance ) {
             distance = inner_prod(vector_points, rNormal)/norm_2(rNormal);
 
-            rPointProjected.Coordinates() = rPointDestiny.Coordinates() + rVector * distance;
+            noalias(rPointProjected.Coordinates()) = rPointDestiny.Coordinates() + rVector * distance;
             KRATOS_WARNING("Warning: Zero projection vector.") << " Projection using the condition vector instead." << std::endl;
         } else if (std::abs(inner_prod(rVector, rNormal) ) > zero_tolerance) {
             distance = inner_prod(vector_points, rNormal)/inner_prod(rVector, rNormal);
 
-            rPointProjected.Coordinates() = rPointDestiny.Coordinates() + rVector * distance;
+            noalias(rPointProjected.Coordinates()) = rPointDestiny.Coordinates() + rVector * distance;
         } else {
-            rPointProjected.Coordinates() = rPointDestiny.Coordinates();
+            noalias(rPointProjected.Coordinates()) = rPointDestiny.Coordinates();
             KRATOS_WARNING("Warning: The line and the plane are coplanar.")  << " Something wrong happened " << std::endl;
         }
 

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -18,8 +18,10 @@
 // External includes
 
 // Project includes
-#include "utilities/math_utils.h"
-#include "includes/model_part.h"
+#include "geometries/geometry.h"
+#include "includes/checks.h"
+#include "includes/node.h"
+#include "includes/variables.h"
 
 namespace Kratos
 {
@@ -29,11 +31,11 @@ namespace Kratos
 ///@}
 ///@name Type Definitions
 ///@{
-    
+
 ///@}
 ///@name  Enum's
 ///@{
-    
+
 ///@}
 ///@name  Functions
 ///@{
@@ -55,7 +57,7 @@ class GeometricalProjectionUtilities
 public:
     ///@name Type Definitions
     ///@{
-    
+
     /// Pointer definition of GeometricalProjectionUtilities
     KRATOS_CLASS_POINTER_DEFINITION( GeometricalProjectionUtilities );
 
@@ -73,7 +75,7 @@ public:
 
     /// Size type definition
     typedef std::size_t                                          SizeType;
-    
+
     ///@}
     ///@name Life Cycle
     ///@{
@@ -93,27 +95,27 @@ public:
     ///@}
     ///@name Friends
     ///@{
-    
+
     ///@}
     ///@name Operations
     ///@{
 
     /**
      * @brief Project a point over a line/plane following an arbitrary direction
-     * @param Geom The geometry where to be projected
-     * @param PointDestiny The point to be projected
-     * @param PointProjected The point pojected over the plane
-     * @param Normal The normal of the geometry
-     * @param Vector The direction to project
+     * @param rGeom The geometry where to be projected
+     * @param rPointDestiny The point to be projected
+     * @param rPointProjected The point pojected over the plane
+     * @param rNormal The normal of the geometry
+     * @param rVector The direction to project
      * @return Distance The distance between surfaces
      */
 
     static inline double FastProjectDirection(
-        const GeometryType& Geom,
-        const PointType& PointDestiny,
-        PointType& PointProjected,
-        const array_1d<double,3>& Normal,
-        const array_1d<double,3>& Vector
+        const GeometryType& rGeom,
+        const PointType& rPointDestiny,
+        PointType& rPointProjected,
+        const array_1d<double,3>& rNormal,
+        const array_1d<double,3>& rVector
         )
     {
         // Zero tolerance
@@ -121,133 +123,136 @@ public:
 
         // We define the distance
         double distance = 0.0;
-        
-        const array_1d<double,3> vector_points = Geom[0].Coordinates() - PointDestiny.Coordinates();
 
-        if( norm_2( Vector ) < zero_tolerance && norm_2( Normal ) > zero_tolerance ) {
-            distance = inner_prod(vector_points, Normal)/norm_2(Normal);
+        const array_1d<double,3> vector_points = rGeom[0].Coordinates() - rPointDestiny.Coordinates();
 
-            PointProjected.Coordinates() = PointDestiny.Coordinates() + Vector * distance;
+        if( norm_2( rVector ) < zero_tolerance && norm_2( rNormal ) > zero_tolerance ) {
+            distance = inner_prod(vector_points, rNormal)/norm_2(rNormal);
+
+            rPointProjected.Coordinates() = rPointDestiny.Coordinates() + rVector * distance;
             KRATOS_WARNING("Warning: Zero projection vector.") << " Projection using the condition vector instead." << std::endl;
-        } else if (std::abs(inner_prod(Vector, Normal) ) > zero_tolerance) {
-            distance = inner_prod(vector_points, Normal)/inner_prod(Vector, Normal); 
+        } else if (std::abs(inner_prod(rVector, rNormal) ) > zero_tolerance) {
+            distance = inner_prod(vector_points, rNormal)/inner_prod(rVector, rNormal);
 
-            PointProjected.Coordinates() = PointDestiny.Coordinates() + Vector * distance;
+            rPointProjected.Coordinates() = rPointDestiny.Coordinates() + rVector * distance;
         } else {
-            PointProjected.Coordinates() = PointDestiny.Coordinates();
+            rPointProjected.Coordinates() = rPointDestiny.Coordinates();
             KRATOS_WARNING("Warning: The line and the plane are coplanar.")  << " Something wrong happened " << std::endl;
         }
-        
+
         return distance;
     }
-    
+
     /**
      * @brief Project a point over a plane (avoiding some steps)
-     * @param PointOrigin A point in the plane
-     * @param PointDestiny The point to be projected
-     * @param Normal The normal of the plane
-     * @param Distance The distance to the projection
+     * @param rPointOrigin A point in the plane
+     * @param rPointDestiny The point to be projected
+     * @param rNormal The normal of the plane
+     * @param rDistance The distance to the projection
      * @return PointProjected The point pojected over the plane
      */
-    
+
     static inline PointType FastProject(
-        const PointType& PointOrigin,
-        const PointType& PointDestiny,
-        const array_1d<double,3>& Normal,
-        double& Distance
+        const PointType& rPointOrigin,
+        const PointType& rPointDestiny,
+        const array_1d<double,3>& rNormal,
+        double& rDistance
         )
     {
-        const array_1d<double,3> vector_points = PointDestiny.Coordinates() - PointOrigin.Coordinates();
+        const array_1d<double,3> vector_points = rPointDestiny.Coordinates() - rPointOrigin.Coordinates();
 
-        Distance = inner_prod(vector_points, Normal); 
-        
+        rDistance = inner_prod(vector_points, rNormal);
+
         PointType point_projected;
-        noalias(point_projected.Coordinates()) = PointDestiny.Coordinates() - Normal * Distance;
-        
+        noalias(point_projected.Coordinates()) = rPointDestiny.Coordinates() - rNormal * rDistance;
+
         return point_projected;
     }
-    
+
     /**
      * @brief Projects iteratively to get the coordinate
-     * @param GeomOrigin The origin geometry
-     * @param PointDestiny The destination point
-     * @param ResultingPoint The distance between the point and the plane
+     * @param rGeomOrigin The origin geometry
+     * @param rPointDestiny The destination point
+     * @param rResultingPoint The distance between the point and the plane
      * @return Inside True is inside, false not
      */
-    
+
     static inline bool ProjectIterativeLine2D(
-        GeometryType& GeomOrigin,
-        const GeometryType::CoordinatesArrayType& PointDestiny,
-        GeometryType::CoordinatesArrayType& ResultingPoint,
-        const array_1d<double, 3>& Normal,
+        GeometryType& rGeomOrigin,
+        const GeometryType::CoordinatesArrayType& rPointDestiny,
+        GeometryType::CoordinatesArrayType& rResultingPoint,
+        const array_1d<double, 3>& rNormal,
         const double Tolerance = 1.0e-8,
         double DeltaXi = 0.5
         )
     {
-//         ResultingPoint.clear();
-        
+//         rResultingPoint.clear();
+
         double old_delta_xi = 0.0;
 
         array_1d<double, 3> current_global_coords;
 
+        KRATOS_DEBUG_CHECK_VARIABLE_IN_NODAL_DATA(NORMAL, rGeomOrigin[0])
+        KRATOS_DEBUG_CHECK_VARIABLE_IN_NODAL_DATA(NORMAL, rGeomOrigin[1])
+
         array_1d<array_1d<double, 3>, 2> normals;
-        normals[0] = GeomOrigin[0].FastGetSolutionStepValue(NORMAL);
-        normals[1] = GeomOrigin[1].FastGetSolutionStepValue(NORMAL);
-        
+        normals[0] = rGeomOrigin[0].FastGetSolutionStepValue(NORMAL);
+        normals[1] = rGeomOrigin[1].FastGetSolutionStepValue(NORMAL);
+
         BoundedMatrix<double,2,2> X;
         BoundedMatrix<double,2,1> DN;
         for(unsigned int i=0; i<2;++i) {
-            X(0,i) = GeomOrigin[i].X();
-            X(1,i) = GeomOrigin[i].Y();
+            X(0,i) = rGeomOrigin[i].X();
+            X(1,i) = rGeomOrigin[i].Y();
         }
 
         Matrix J = ZeroMatrix( 1, 1 );
-        
+
         //Newton iteration:
 
         const unsigned int max_iter = 20;
 
         for ( unsigned int k = 0; k < max_iter; ++k ) {
             array_1d<double, 2> N_origin;
-            N_origin[0] = 0.5 * ( 1.0 - ResultingPoint[0]);
-            N_origin[1] = 0.5 * ( 1.0 + ResultingPoint[0]);
-            
+            N_origin[0] = 0.5 * ( 1.0 - rResultingPoint[0]);
+            N_origin[1] = 0.5 * ( 1.0 + rResultingPoint[0]);
+
             array_1d<double,3> normal_xi = N_origin[0] * normals[0] + N_origin[1] * normals[1];
-            normal_xi = normal_xi/norm_2(normal_xi); 
-            
+            normal_xi = normal_xi/norm_2(normal_xi);
+
             current_global_coords = ZeroVector(3);
             for( IndexType i_node = 0; i_node < 2; ++i_node )
-                current_global_coords += N_origin[i_node] * GeomOrigin[i_node].Coordinates(); 
-            
-            const array_1d<double,3> VectorPoints = GeomOrigin.Center() - PointDestiny;
-            const double distance = inner_prod(VectorPoints, Normal)/inner_prod(-normal_xi, Normal); 
-            const array_1d<double, 3> current_destiny_global_coords = PointDestiny - normal_xi * distance;
-            
+                current_global_coords += N_origin[i_node] * rGeomOrigin[i_node].Coordinates();
+
+            const array_1d<double,3> VectorPoints = rGeomOrigin.Center() - rPointDestiny;
+            const double distance = inner_prod(VectorPoints, rNormal)/inner_prod(-normal_xi, rNormal);
+            const array_1d<double, 3> current_destiny_global_coords = rPointDestiny - normal_xi * distance;
+
             // Derivatives of shape functions
             Matrix ShapeFunctionsGradients;
-            ShapeFunctionsGradients = GeomOrigin.ShapeFunctionsLocalGradients(ShapeFunctionsGradients, ResultingPoint );
+            ShapeFunctionsGradients = rGeomOrigin.ShapeFunctionsLocalGradients(ShapeFunctionsGradients, rResultingPoint );
             noalias(DN) = prod(X,ShapeFunctionsGradients);
 
             noalias(J) = prod(trans(DN),DN); // TODO: Add the non linearity concerning the normal
             Vector RHS = prod(trans(DN),subrange(current_destiny_global_coords - current_global_coords,0,2));
-            
+
             old_delta_xi = DeltaXi;
             DeltaXi = RHS[0]/J(0, 0);
-            
-            ResultingPoint[0] += DeltaXi;
-            
-            if (ResultingPoint[0] <= -1.0)
-                ResultingPoint[0] = -1.0;
-            else if (ResultingPoint[0] >= 1.0)
-                ResultingPoint[0] = 1.0;
-            
+
+            rResultingPoint[0] += DeltaXi;
+
+            if (rResultingPoint[0] <= -1.0)
+                rResultingPoint[0] = -1.0;
+            else if (rResultingPoint[0] >= 1.0)
+                rResultingPoint[0] = 1.0;
+
             if ( std::abs(DeltaXi - old_delta_xi) < Tolerance )
                 return true;
         }
-        
+
         return false;
     }
-    
+
 private:
 };// class GeometricalProjectionUtilities
 

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -1,0 +1,255 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+#if !defined(KRATOS_GEOMETRICAL_PROJECTION_UTILITIES)
+#define KRATOS_GEOMETRICAL_PROJECTION_UTILITIES
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "utilities/math_utils.h"
+#include "includes/model_part.h"
+
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+    
+///@}
+///@name  Enum's
+///@{
+    
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/**
+ * @class GeometricalProjectionUtilities
+ * @ingroup KratosCore
+ * @brief This is a class that provides auxiliar utilities for projections
+ * @details This is a class that provides auxiliar utilities for the projections. Check the documentation for more details
+ * @author Vicente Mataix Ferrandiz
+ * Contact: vmataix@cimne.upc.edu
+ */
+class GeometricalProjectionUtilities
+{
+public:
+    ///@name Type Definitions
+    ///@{
+    
+    /// Pointer definition of GeometricalProjectionUtilities
+    KRATOS_CLASS_POINTER_DEFINITION( GeometricalProjectionUtilities );
+
+    // Some geometrical definitions
+    typedef Node<3>                                              NodeType;
+    typedef Point                                               PointType;
+    typedef PointType::CoordinatesArrayType          CoordinatesArrayType;
+
+    /// Definition of geometries
+    typedef Geometry<NodeType>                               GeometryType;
+    typedef Geometry<PointType>                         GeometryPointType;
+
+    /// Index type definition
+    typedef std::size_t                                         IndexType;
+
+    /// Size type definition
+    typedef std::size_t                                          SizeType;
+    
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    ///@}
+    ///@name Friends
+    ///@{
+    
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Project a point over a line/plane following an arbitrary direction
+     * @param Geom The geometry where to be projected
+     * @param PointDestiny The point to be projected
+     * @param PointProjected The point pojected over the plane
+     * @param Normal The normal of the geometry
+     * @param Vector The direction to project
+     * @return Distance The distance between surfaces
+     */
+
+    static inline double FastProjectDirection(
+        const GeometryType& Geom,
+        const PointType& PointDestiny,
+        PointType& PointProjected,
+        const array_1d<double,3>& Normal,
+        const array_1d<double,3>& Vector
+        )
+    {
+        // Zero tolerance
+        const double zero_tolerance = std::numeric_limits<double>::epsilon();
+
+        // We define the distance
+        double distance = 0.0;
+        
+        const array_1d<double,3> vector_points = Geom[0].Coordinates() - PointDestiny.Coordinates();
+
+        if( norm_2( Vector ) < zero_tolerance && norm_2( Normal ) > zero_tolerance ) {
+            distance = inner_prod(vector_points, Normal)/norm_2(Normal);
+
+            PointProjected.Coordinates() = PointDestiny.Coordinates() + Vector * distance;
+            KRATOS_WARNING("Warning: Zero projection vector.") << " Projection using the condition vector instead." << std::endl;
+        } else if (std::abs(inner_prod(Vector, Normal) ) > zero_tolerance) {
+            distance = inner_prod(vector_points, Normal)/inner_prod(Vector, Normal); 
+
+            PointProjected.Coordinates() = PointDestiny.Coordinates() + Vector * distance;
+        } else {
+            PointProjected.Coordinates() = PointDestiny.Coordinates();
+            KRATOS_WARNING("Warning: The line and the plane are coplanar.")  << " Something wrong happened " << std::endl;
+        }
+        
+        return distance;
+    }
+    
+    /**
+     * @brief Project a point over a plane (avoiding some steps)
+     * @param PointOrigin A point in the plane
+     * @param PointDestiny The point to be projected
+     * @param Normal The normal of the plane
+     * @param Distance The distance to the projection
+     * @return PointProjected The point pojected over the plane
+     */
+    
+    static inline PointType FastProject(
+        const PointType& PointOrigin,
+        const PointType& PointDestiny,
+        const array_1d<double,3>& Normal,
+        double& Distance
+        )
+    {
+        const array_1d<double,3> vector_points = PointDestiny.Coordinates() - PointOrigin.Coordinates();
+
+        Distance = inner_prod(vector_points, Normal); 
+        
+        PointType point_projected;
+        noalias(point_projected.Coordinates()) = PointDestiny.Coordinates() - Normal * Distance;
+        
+        return point_projected;
+    }
+    
+    /**
+     * @brief Projects iteratively to get the coordinate
+     * @param GeomOrigin The origin geometry
+     * @param PointDestiny The destination point
+     * @param ResultingPoint The distance between the point and the plane
+     * @return Inside True is inside, false not
+     */
+    
+    static inline bool ProjectIterativeLine2D(
+        GeometryType& GeomOrigin,
+        const GeometryType::CoordinatesArrayType& PointDestiny,
+        GeometryType::CoordinatesArrayType& ResultingPoint,
+        const array_1d<double, 3>& Normal,
+        const double Tolerance = 1.0e-8,
+        double DeltaXi = 0.5
+        )
+    {
+//         ResultingPoint.clear();
+        
+        double old_delta_xi = 0.0;
+
+        array_1d<double, 3> current_global_coords;
+
+        array_1d<array_1d<double, 3>, 2> normals;
+        normals[0] = GeomOrigin[0].FastGetSolutionStepValue(NORMAL);
+        normals[1] = GeomOrigin[1].FastGetSolutionStepValue(NORMAL);
+        
+        BoundedMatrix<double,2,2> X;
+        BoundedMatrix<double,2,1> DN;
+        for(unsigned int i=0; i<2;++i) {
+            X(0,i) = GeomOrigin[i].X();
+            X(1,i) = GeomOrigin[i].Y();
+        }
+
+        Matrix J = ZeroMatrix( 1, 1 );
+        
+        //Newton iteration:
+
+        const unsigned int max_iter = 20;
+
+        for ( unsigned int k = 0; k < max_iter; ++k ) {
+            array_1d<double, 2> N_origin;
+            N_origin[0] = 0.5 * ( 1.0 - ResultingPoint[0]);
+            N_origin[1] = 0.5 * ( 1.0 + ResultingPoint[0]);
+            
+            array_1d<double,3> normal_xi = N_origin[0] * normals[0] + N_origin[1] * normals[1];
+            normal_xi = normal_xi/norm_2(normal_xi); 
+            
+            current_global_coords = ZeroVector(3);
+            for( IndexType i_node = 0; i_node < 2; ++i_node )
+                current_global_coords += N_origin[i_node] * GeomOrigin[i_node].Coordinates(); 
+            
+            const array_1d<double,3> VectorPoints = GeomOrigin.Center() - PointDestiny;
+            const double distance = inner_prod(VectorPoints, Normal)/inner_prod(-normal_xi, Normal); 
+            const array_1d<double, 3> current_destiny_global_coords = PointDestiny - normal_xi * distance;
+            
+            // Derivatives of shape functions
+            Matrix ShapeFunctionsGradients;
+            ShapeFunctionsGradients = GeomOrigin.ShapeFunctionsLocalGradients(ShapeFunctionsGradients, ResultingPoint );
+            noalias(DN) = prod(X,ShapeFunctionsGradients);
+
+            noalias(J) = prod(trans(DN),DN); // TODO: Add the non linearity concerning the normal
+            Vector RHS = prod(trans(DN),subrange(current_destiny_global_coords - current_global_coords,0,2));
+            
+            old_delta_xi = DeltaXi;
+            DeltaXi = RHS[0]/J(0, 0);
+            
+            ResultingPoint[0] += DeltaXi;
+            
+            if (ResultingPoint[0] <= -1.0)
+                ResultingPoint[0] = -1.0;
+            else if (ResultingPoint[0] >= 1.0)
+                ResultingPoint[0] = 1.0;
+            
+            if ( std::abs(DeltaXi - old_delta_xi) < Tolerance )
+                return true;
+        }
+        
+        return false;
+    }
+    
+private:
+};// class GeometricalProjectionUtilities
+
+}
+#endif /* KRATOS_GEOMETRICAL_PROJECTION_UTILITIES defined */

--- a/kratos/utilities/mortar_utilities.h
+++ b/kratos/utilities/mortar_utilities.h
@@ -128,7 +128,7 @@ public:
      * @return Distance The distance between surfaces
      */
 
-    static inline double FastProjectDirection(
+    KRATOS_DEPRECATED_MESSAGE("Method moved to geometrical_projection_utilities.h. Please update your declaration") static inline double FastProjectDirection(
         const GeometryType& Geom,
         const PointType& PointDestiny,
         PointType& PointProjected,
@@ -170,7 +170,7 @@ public:
      * @return PointProjected The point pojected over the plane
      */
     
-    static inline PointType FastProject(
+    KRATOS_DEPRECATED_MESSAGE("Method moved to geometrical_projection_utilities.h. Please update your declaration") static inline PointType FastProject(
         const PointType& PointOrigin,
         const PointType& PointDestiny,
         const array_1d<double,3>& Normal,
@@ -195,7 +195,7 @@ public:
      * @return Inside True is inside, false not
      */
     
-    static inline bool ProjectIterativeLine2D(
+    KRATOS_DEPRECATED_MESSAGE("Method moved to geometrical_projection_utilities.h. Please update your declaration") static inline bool ProjectIterativeLine2D(
         GeometryType& GeomOrigin,
         const GeometryType::CoordinatesArrayType& PointDestiny,
         GeometryType::CoordinatesArrayType& ResultingPoint,


### PR DESCRIPTION
Hi @loumalouomega 
I would like to use the projections functions from `MortarUtilities` for mapping

I made a small test for it but unfortunately the results are not as expected, the projection gives wrong results.

The case is a simple projection onto a plane triangle

Can you please take a look?

**Outlook:** I would like to move the projection-related functions to a separate class, because `mortar_utilities.h` is a quite heavy include
Plus this makes it easier to extend the functionalities related to projections
=> I have done this locally but I would like to first have a test for it to not break stuff