### PR TITLE
Fix variable name for project parameters file

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_analysis.py
@@ -222,7 +222,7 @@ if __name__ == "__main__":
     else: # using default name
         project_parameters_file_name = "ProjectParameters.json"
 
-    with open(parameter_file_name,'r') as parameter_file:
+    with open(project_parameters_file_name,'r') as parameter_file:
         parameters = KratosMultiphysics.Parameters(parameter_file.read())
 
     model = KratosMultiphysics.Model()


### PR DESCRIPTION
Small fix to the variable name for the project parameters file, in main of structural_mechanics_analysis. I couldn't find a test for this script to test it though.

