### PR TITLE
Adding deprecation warnings for Flag bitwise AND operation

### DIFF
--- a/kratos/containers/flags.h
+++ b/kratos/containers/flags.h
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
-//                    
+//
 //
 
 #if !defined(KRATOS_FLAGS_H_INCLUDED )
@@ -242,7 +242,7 @@ public:
         mFlags &= ~(BlockType(1) << Position);
     }
 
- 
+
     void Clear()
     {
         mIsDefined = BlockType();
@@ -345,7 +345,7 @@ public:
         return results;
     }
 
-    friend Flags operator&(const Flags& Left, const Flags& Right )
+    KRATOS_DEPRECATED friend Flags operator&(const Flags& Left, const Flags& Right )
     {
         // This looks like copy paste error but the idea is to
         // define the & operator like the or one.
@@ -361,7 +361,7 @@ public:
         return *this;
     }
 
-    const Flags& operator&=(const Flags& Other )
+    KRATOS_DEPRECATED const Flags& operator&=(const Flags& Other )
     {
         // This looks like copy paste error but the idea is to
         // define the & operator like the or one.
@@ -499,6 +499,6 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_FLAGS_H_INCLUDED  defined 
+#endif // KRATOS_FLAGS_H_INCLUDED  defined
 
 

--- a/kratos/processes/tetrahedral_mesh_orientation_check.h
+++ b/kratos/processes/tetrahedral_mesh_orientation_check.h
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
-//                    
+//
 //
 
 #ifndef KRATOS_TETRAHEDRAL_MESH_ORIENTATION_CHECK_H
@@ -43,13 +43,13 @@ class TetrahedralMeshOrientationCheck: public Process
 public:
     ///@name Type Definitions
     ///@{
-    
+
     //DEFINITION OF FLAGS TO CONTROL THE BEHAVIOUR
     KRATOS_DEFINE_LOCAL_FLAG(ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS);
     KRATOS_DEFINE_LOCAL_FLAG(COMPUTE_NODAL_NORMALS);
     KRATOS_DEFINE_LOCAL_FLAG(COMPUTE_CONDITION_NORMALS);
     KRATOS_DEFINE_LOCAL_FLAG(MAKE_VOLUMES_POSITIVE);
-    
+
     /// Pointer definition of Process
     KRATOS_CLASS_POINTER_DEFINITION(TetrahedralMeshOrientationCheck);
 
@@ -67,7 +67,7 @@ public:
      */
     TetrahedralMeshOrientationCheck(ModelPart& rModelPart,
                                     bool ThrowErrors,
-                                    Flags options = NOT_COMPUTE_NODAL_NORMALS & NOT_COMPUTE_CONDITION_NORMALS & NOT_ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
+                                    Flags options = NOT_COMPUTE_NODAL_NORMALS | NOT_COMPUTE_CONDITION_NORMALS | NOT_ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
                                     ):
         Process(),
         mrModelPart(rModelPart),
@@ -76,9 +76,9 @@ public:
 
     {
     }
-    
+
     TetrahedralMeshOrientationCheck(ModelPart& rModelPart,
-                                    Flags options = NOT_COMPUTE_NODAL_NORMALS & NOT_COMPUTE_CONDITION_NORMALS & NOT_ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
+                                    Flags options = NOT_COMPUTE_NODAL_NORMALS | NOT_COMPUTE_CONDITION_NORMALS | NOT_ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
                                     ):
         Process(),
         mrModelPart(rModelPart),
@@ -111,19 +111,19 @@ public:
     void Execute() override
     {
         KRATOS_TRY;
-        
+
         if(mrOptions.Is(COMPUTE_NODAL_NORMALS))
         {
-            if(mrModelPart.NodesBegin()->SolutionStepsDataHas(NORMAL) == false) 
+            if(mrModelPart.NodesBegin()->SolutionStepsDataHas(NORMAL) == false)
                 KRATOS_THROW_ERROR(std::invalid_argument,"missing NORMAL variable on solution step data","");
             for(ModelPart::NodesContainerType::iterator itNode = mrModelPart.NodesBegin(); itNode != mrModelPart.NodesEnd(); itNode++)
             {
                 noalias(itNode->FastGetSolutionStepValue(NORMAL)) = ZeroVector(3);
             }
-            
+
         }
-        
-        
+
+
 
         //********************************************************
         //begin by orienting all of the elements in the volume
@@ -250,8 +250,8 @@ public:
                             FaceNormal3D(FaceNormal,rFaceGeom);
                         else if ( rFaceGeom.GetGeometryType()  == GeometryData::Kratos_Line2D2 )
                             FaceNormal2D(FaceNormal,rFaceGeom);
-                        
-                        
+
+
 
                         //do a dotproduct with the DenseVector that goes from
                         //"outer_node_index" to any of the nodes in aux;
@@ -266,10 +266,10 @@ public:
                         {
                             rFaceGeom(0).swap(rFaceGeom(1));
                             FaceNormal = -FaceNormal;
-      
+
                             CondSwitchCount++;
                         }
-                        
+
                         if(mrOptions.Is(COMPUTE_NODAL_NORMALS))
                         {
                             double factor = 1.0/static_cast<double>(rFaceGeom.size());
@@ -332,7 +332,7 @@ public:
                 rGeom(0).swap(rGeom(1));
         }
     }
-    
+
     void SwapNegativeElements()
     {
         for (ModelPart::ElementIterator itElem = mrModelPart.ElementsBegin(); itElem != mrModelPart.ElementsEnd(); itElem++)
@@ -395,7 +395,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    ModelPart& mrModelPart;    
+    ModelPart& mrModelPart;
     const bool mThrowErrors;
     Flags mrOptions;
 

--- a/kratos/python/add_containers_to_python.cpp
+++ b/kratos/python/add_containers_to_python.cpp
@@ -63,9 +63,9 @@ Flags FlagsOr(const Flags& Left, const Flags& Right )
 
 Flags FlagsAnd(const Flags& Left, const Flags& Right )
 {
-    KRATOS_WARNING("Kratos::Flags Python interface") << "Using deprecated flag &, which internally perfms a union (bitwise or)." << std::endl
+    KRATOS_WARNING("Kratos::Flags Python interface") << "Using deprecated flag & operation, which internally perfms a union (bitwise or)." << std::endl
                  << "Please use | instead, since this behaviour will be soon deprecated." << std::endl;
-    return (Left&Right);
+    return (Left|Right);
 }
 
 void FlagsSet1(Flags& ThisFlag, const Flags& OtherFlag )

--- a/kratos/python/add_containers_to_python.cpp
+++ b/kratos/python/add_containers_to_python.cpp
@@ -61,6 +61,13 @@ Flags FlagsOr(const Flags& Left, const Flags& Right )
     return (Left|Right);
 }
 
+Flags FlagsAnd(const Flags& Left, const Flags& Right )
+{
+    KRATOS_WARNING("Kratos::Flags Python interface") << "Using deprecated flag &, which internally perfms a union (bitwise or)." << std::endl
+                 << "Please use | instead, since this behaviour will be soon deprecated." << std::endl;
+    return (Left&Right);
+}
+
 void FlagsSet1(Flags& ThisFlag, const Flags& OtherFlag )
 {
     ThisFlag.Set(OtherFlag);
@@ -275,7 +282,7 @@ void  AddContainersToPython(pybind11::module& m)
     .def("Flip", &Flags::Flip)
     .def("Clear", &Flags::Clear)
     .def("__or__", FlagsOr)
-    .def("__and__", FlagsOr) // this is not an error, the and and or are considered both as add. Pooyan.
+    .def("__and__", FlagsAnd)
     .def("__repr__", &Flags::Info )
     ;
 


### PR DESCRIPTION
This is the first step in implementing #1277. The idea is to change the implementation of the `&` and `&=` operators of `Kratos::Flags` so that they perform a bitwise and (now they are performing a bitwise or) and then implement MPI synchronization of `Kratos::Flags` using the bitwise and/or operations.

This PR only contains deprecation warnings, so that any users of the current `&` implementation can switch it for calls to `|` instead in their code.