### PR TITLE
Core/hotfix solver ignore variables in mdpa

### DIFF
--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -89,7 +89,7 @@ public:
     ModelPartIO(std::string const& Filename, const Flags Options = IO::READ|IO::NOT_IGNORE_VARIABLES_ERROR);
 
     /// Constructor with stream.
-    ModelPartIO(Kratos::shared_ptr<std::iostream> Stream);
+    ModelPartIO(Kratos::shared_ptr<std::iostream> Stream, const Flags Options = IO::NOT_IGNORE_VARIABLES_ERROR);
 
 
     /// Constructor with filenames.

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -142,7 +142,7 @@ class PythonSolver(object):
         if (input_type == "mdpa"):
             import_flags = KratosMultiphysics.ModelPartIO.READ
             if model_part_import_settings.Has("ignore_variables_not_in_solution_step_data"):
-                if model_part_import_settings["ignore_variables_not_in_solution_step_data"].GetBool() == True:
+                if model_part_import_settings["ignore_variables_not_in_solution_step_data"].GetBool():
                     import_flags = KratosMultiphysics.ModelPartIO.IGNORE_VARIABLES_ERROR|KratosMultiphysics.ModelPartIO.READ
 
             # Import model part from mdpa file.

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -140,9 +140,17 @@ class PythonSolver(object):
         input_type = model_part_import_settings["input_type"].GetString()
 
         if (input_type == "mdpa"):
+            import_flags = KratosMultiphysics.ModelPartIO.READ
+            if model_part_import_settings.Has("ignore_variables_not_in_solution_step_data"):
+                print("have it")
+                if model_part_import_settings["ignore_variables_not_in_solution_step_data"].GetBool() == True:
+                    print("is true")
+                    import_flags = KratosMultiphysics.ModelPartIO.IGNORE_VARIABLES_ERROR|KratosMultiphysics.ModelPartIO.READ
+            print(import_flags.Is(KratosMultiphysics.ModelPartIO.IGNORE_VARIABLES_ERROR))
+            print(import_flags.Is(KratosMultiphysics.ModelPartIO.READ))
             # Import model part from mdpa file.
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Reading model part from file: " + os.path.join(problem_path, input_filename) + ".mdpa")
-            KratosMultiphysics.ModelPartIO(input_filename).ReadModelPart(model_part)
+            KratosMultiphysics.ModelPartIO(input_filename, import_flags).ReadModelPart(model_part)
             if (model_part_import_settings.Has("reorder") and model_part_import_settings["reorder"].GetBool()):
                 tmp = KratosMultiphysics.Parameters("{}")
                 KratosMultiphysics.ReorderAndOptimizeModelPartProcess(model_part, tmp).Execute()

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -142,12 +142,9 @@ class PythonSolver(object):
         if (input_type == "mdpa"):
             import_flags = KratosMultiphysics.ModelPartIO.READ
             if model_part_import_settings.Has("ignore_variables_not_in_solution_step_data"):
-                print("have it")
                 if model_part_import_settings["ignore_variables_not_in_solution_step_data"].GetBool() == True:
-                    print("is true")
                     import_flags = KratosMultiphysics.ModelPartIO.IGNORE_VARIABLES_ERROR|KratosMultiphysics.ModelPartIO.READ
-            print(import_flags.Is(KratosMultiphysics.ModelPartIO.IGNORE_VARIABLES_ERROR))
-            print(import_flags.Is(KratosMultiphysics.ModelPartIO.READ))
+
             # Import model part from mdpa file.
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Reading model part from file: " + os.path.join(problem_path, input_filename) + ".mdpa")
             KratosMultiphysics.ModelPartIO(input_filename, import_flags).ReadModelPart(model_part)

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -65,8 +65,9 @@ namespace Kratos
     }
 
     /// Constructor with stream
-    ModelPartIO::ModelPartIO(Kratos::shared_ptr<std::iostream> Stream)
+    ModelPartIO::ModelPartIO(Kratos::shared_ptr<std::iostream> Stream, const Flags Options)
       : mNumberOfLines(1)
+      , mOptions(Options)
     {
         // nullptr test can be confusing with Kratos::shared_ptr. Commented until we move to std::shared_ptr
         // if (Stream == nullptr)

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -1549,64 +1549,59 @@ namespace Kratos
         }
         else if(KratosComponents<Variable<int> >::Has(variable_name))
         {
-            bool has_been_added = rThisVariables.Has(KratosComponents<Variable<int> >::Get(variable_name)) ;
+            const bool has_been_added = rThisVariables.Has(KratosComponents<Variable<int> >::Get(variable_name)) ;
 			if( !has_been_added && mOptions.Is(IGNORE_VARIABLES_ERROR) ) {
                 KRATOS_WARNING("ModelPartIO") <<"WARNING: Skipping NodalData block. Variable "<<variable_name<<" has not been added to ModelPart '"<<rThisModelPart.Name()<<"'"<<std::endl<<std::endl;
                 SkipBlock("NodalData");
             }
-			else if (!has_been_added)
-				KRATOS_THROW_ERROR(std::invalid_argument,"The nodal solution step container deos not have this variable: ", variable_name)
-            else {
+			else {
+                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container deos not have this variable: " << variable_name << "." << std::endl;
                 ReadNodalScalarVariableData(rThisNodes, static_cast<Variable<int> const& >(KratosComponents<Variable<int> >::Get(variable_name)));
             }
         }
         else if(KratosComponents<Variable<double> >::Has(variable_name))
         {
-            bool has_been_added = rThisVariables.Has(KratosComponents<Variable<double> >::Get(variable_name)) ;
+            const bool has_been_added = rThisVariables.Has(KratosComponents<Variable<double> >::Get(variable_name)) ;
             if( !has_been_added && mOptions.Is(IGNORE_VARIABLES_ERROR) ) {
                 KRATOS_WARNING("ModelPartIO")<<"WARNING: Skipping NodalData block. Variable "<<variable_name<<" has not been added to ModelPart '"<<rThisModelPart.Name()<<"'"<<std::endl<<std::endl;
                 SkipBlock("NodalData");
             }
-			else if (!has_been_added)
-				KRATOS_THROW_ERROR(std::invalid_argument,"The nodal solution step container deos not have this variable: ", variable_name)
-            else {
+			else {
+                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container deos not have this variable: " << variable_name << "." << std::endl;
                 ReadNodalDofVariableData(rThisNodes, static_cast<Variable<double> const& >(KratosComponents<Variable<double> >::Get(variable_name)));
             }
         }
         else if(KratosComponents<array_1d_component_type>::Has(variable_name))
         {
-            bool has_been_added = rThisVariables.Has(KratosComponents<array_1d_component_type>::Get(variable_name)) ;
+            const bool has_been_added = rThisVariables.Has(KratosComponents<array_1d_component_type>::Get(variable_name)) ;
 			if( !has_been_added && mOptions.Is(IGNORE_VARIABLES_ERROR) ) {
                 KRATOS_WARNING("ModelPartIO") <<"WARNING: Skipping NodalData block. Variable "<<variable_name<<" has not been added to ModelPart '"<<rThisModelPart.Name()<<"'"<<std::endl<<std::endl;
                 SkipBlock("NodalData");
             }
-			else if (!has_been_added)
-				KRATOS_THROW_ERROR(std::invalid_argument,"The nodal solution step container deos not have this variable: ", variable_name)
-            else {
+			else {
+                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container deos not have this variable: " << variable_name << "." << std::endl;
                 ReadNodalDofVariableData(rThisNodes, static_cast<array_1d_component_type const& >(KratosComponents<array_1d_component_type>::Get(variable_name)));
             }
         }
         else if(KratosComponents<Variable<array_1d<double, 3> > >::Has(variable_name))
         {
-            bool has_been_added = rThisVariables.Has(KratosComponents<Variable<array_1d<double, 3> > >::Get(variable_name)) ;
+            const bool has_been_added = rThisVariables.Has(KratosComponents<Variable<array_1d<double, 3> > >::Get(variable_name)) ;
             if( !has_been_added && mOptions.Is(IGNORE_VARIABLES_ERROR) ) {
                 KRATOS_WARNING("ModelPartIO")<<"WARNING: Skipping NodalData block. Variable "<<variable_name<<" has not been added to ModelPart '"<<rThisModelPart.Name()<<"'"<<std::endl<<std::endl;
             }
-			else if (!has_been_added)
-				KRATOS_THROW_ERROR(std::invalid_argument,"The nodal solution step container deos not have this variable: ", variable_name)
-            else {
+			else {
+                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container deos not have this variable: " << variable_name << "." << std::endl;
                 ReadNodalVectorialVariableData(rThisNodes, static_cast<Variable<array_1d<double, 3> > const& >(KratosComponents<Variable<array_1d<double, 3> > >::Get(variable_name)), Vector(3));
             }
         }
         else if(KratosComponents<Variable<Quaternion<double> > >::Has(variable_name))
         {
-            bool has_been_added = rThisVariables.Has(KratosComponents<Variable<Quaternion<double> > >::Get(variable_name)) ;
+            const bool has_been_added = rThisVariables.Has(KratosComponents<Variable<Quaternion<double> > >::Get(variable_name)) ;
             if( !has_been_added && mOptions.Is(IGNORE_VARIABLES_ERROR) ) {
                 KRATOS_WARNING("ModelPartIO")<<"WARNING: Skipping NodalData block. Variable "<<variable_name<<" has not been added to ModelPart '"<<rThisModelPart.Name()<<"'"<<std::endl<<std::endl;
             }
-            else if (!has_been_added)
-                KRATOS_THROW_ERROR(std::invalid_argument,"The nodal solution step container deos not have this variable: ", variable_name)
             else {
+                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container deos not have this variable: " << variable_name << "." << std::endl;
                 ReadNodalVectorialVariableData(rThisNodes, static_cast<Variable<Quaternion<double> > const& >(KratosComponents<Variable<Quaternion<double> > >::Get(variable_name)), Vector(4));
             }
         }

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -1575,7 +1575,16 @@ namespace Kratos
         }
         else if(KratosComponents<array_1d_component_type>::Has(variable_name))
         {
-            ReadNodalDofVariableData(rThisNodes, static_cast<array_1d_component_type const& >(KratosComponents<array_1d_component_type>::Get(variable_name)));
+            bool has_been_added = rThisVariables.Has(KratosComponents<array_1d_component_type>::Get(variable_name)) ;
+			if( !has_been_added && mOptions.Is(IGNORE_VARIABLES_ERROR) ) {
+                KRATOS_WARNING("ModelPartIO") <<"WARNING: Skipping NodalData block. Variable "<<variable_name<<" has not been added to ModelPart '"<<rThisModelPart.Name()<<"'"<<std::endl<<std::endl;
+                SkipBlock("NodalData");
+            }
+			else if (!has_been_added)
+				KRATOS_THROW_ERROR(std::invalid_argument,"The nodal solution step container deos not have this variable: ", variable_name)
+            else {
+                ReadNodalDofVariableData(rThisNodes, static_cast<array_1d_component_type const& >(KratosComponents<array_1d_component_type>::Get(variable_name)));
+            }
         }
         else if(KratosComponents<Variable<array_1d<double, 3> > >::Has(variable_name))
         {

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -1573,7 +1573,7 @@ namespace Kratos
         }
         else if(KratosComponents<array_1d_component_type>::Has(variable_name))
         {
-            const bool has_been_added = rThisVariables.Has(KratosComponents<array_1d_component_type>::Get(variable_name)) ;
+            const bool has_been_added = rThisVariables.Has(KratosComponents<array_1d_component_type>::Get(variable_name).GetSourceVariable()) ;
 			if( !has_been_added && mOptions.Is(IGNORE_VARIABLES_ERROR) ) {
                 KRATOS_WARNING("ModelPartIO") <<"WARNING: Skipping NodalData block. Variable "<<variable_name<<" has not been added to ModelPart '"<<rThisModelPart.Name()<<"'"<<std::endl<<std::endl;
                 SkipBlock("NodalData");

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -1555,7 +1555,7 @@ namespace Kratos
                 SkipBlock("NodalData");
             }
 			else {
-                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container deos not have this variable: " << variable_name << "." << std::endl;
+                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container does not have this variable: " << variable_name << "." << std::endl;
                 ReadNodalScalarVariableData(rThisNodes, static_cast<Variable<int> const& >(KratosComponents<Variable<int> >::Get(variable_name)));
             }
         }
@@ -1567,7 +1567,7 @@ namespace Kratos
                 SkipBlock("NodalData");
             }
 			else {
-                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container deos not have this variable: " << variable_name << "." << std::endl;
+                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container does not have this variable: " << variable_name << "." << std::endl;
                 ReadNodalDofVariableData(rThisNodes, static_cast<Variable<double> const& >(KratosComponents<Variable<double> >::Get(variable_name)));
             }
         }
@@ -1579,7 +1579,7 @@ namespace Kratos
                 SkipBlock("NodalData");
             }
 			else {
-                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container deos not have this variable: " << variable_name << "." << std::endl;
+                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container does not have this variable: " << variable_name << "." << std::endl;
                 ReadNodalDofVariableData(rThisNodes, static_cast<array_1d_component_type const& >(KratosComponents<array_1d_component_type>::Get(variable_name)));
             }
         }
@@ -1590,7 +1590,7 @@ namespace Kratos
                 KRATOS_WARNING("ModelPartIO")<<"WARNING: Skipping NodalData block. Variable "<<variable_name<<" has not been added to ModelPart '"<<rThisModelPart.Name()<<"'"<<std::endl<<std::endl;
             }
 			else {
-                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container deos not have this variable: " << variable_name << "." << std::endl;
+                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container does not have this variable: " << variable_name << "." << std::endl;
                 ReadNodalVectorialVariableData(rThisNodes, static_cast<Variable<array_1d<double, 3> > const& >(KratosComponents<Variable<array_1d<double, 3> > >::Get(variable_name)), Vector(3));
             }
         }
@@ -1601,7 +1601,7 @@ namespace Kratos
                 KRATOS_WARNING("ModelPartIO")<<"WARNING: Skipping NodalData block. Variable "<<variable_name<<" has not been added to ModelPart '"<<rThisModelPart.Name()<<"'"<<std::endl<<std::endl;
             }
             else {
-                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container deos not have this variable: " << variable_name << "." << std::endl;
+                KRATOS_ERROR_IF_NOT(has_been_added) << "The nodal solution step container does not have this variable: " << variable_name << "." << std::endl;
                 ReadNodalVectorialVariableData(rThisNodes, static_cast<Variable<Quaternion<double> > const& >(KratosComponents<Variable<Quaternion<double> > >::Get(variable_name)), Vector(4));
             }
         }

--- a/kratos/tests/sources/test_model_part_io.cpp
+++ b/kratos/tests/sources/test_model_part_io.cpp
@@ -174,7 +174,7 @@ KRATOS_TEST_CASE_IN_SUITE(
 }
 
 KRATOS_TEST_CASE_IN_SUITE(ModelPartIOWriteModelPart, KratosCoreFastSuite) {
-    
+
     // Create a model part to write
     ModelPart main_model_part("MainModelPart");
     main_model_part.SetBufferSize(1);
@@ -204,7 +204,7 @@ KRATOS_TEST_CASE_IN_SUITE(ModelPartIOWriteModelPart, KratosCoreFastSuite) {
     main_model_part.GetMesh().GetElement(1).SetValue(TEMPERATURE, temperature);
     double displacement_x = 1.2;
     main_model_part.GetMesh().GetElement(1).SetValue(DISPLACEMENT_X, displacement_x);
-    
+
 
     std::vector<ModelPart::IndexType> cond_nodes_1 = {1,2};
     std::vector<ModelPart::IndexType> cond_nodes_2 = {3,4};
@@ -268,7 +268,7 @@ KRATOS_TEST_CASE_IN_SUITE(ModelPartIOWriteModelPart, KratosCoreFastSuite) {
     delete model_part_io_output;
 
     // Remove the generated files
-    std::string aux_string_mdpa = output_file_name + ".mdpa"; 
+    std::string aux_string_mdpa = output_file_name + ".mdpa";
     std::string aux_string_time = output_file_name + ".time";
     const char *mdpa_to_remove = aux_string_mdpa.c_str();
     const char *time_to_remove = aux_string_time.c_str();
@@ -279,6 +279,94 @@ KRATOS_TEST_CASE_IN_SUITE(ModelPartIOWriteModelPart, KratosCoreFastSuite) {
     if (remove(time_to_remove) != 0) {
         KRATOS_ERROR << error_msg + ".time";
     }
+}
+
+
+KRATOS_TEST_CASE_IN_SUITE(ModelPartIOVariableNotInSolutionStepData, KratosCoreFastSuite) {
+    Kratos::shared_ptr<std::iostream> p_input(new std::stringstream(
+        R"input(
+			    Begin Properties  0
+                End Properties
+
+				Begin Nodes
+				       1        0.0        0.0         0.0
+				       2        1.0        0.0         0.0
+				       3        1.0        1.0         0.0
+				       4        0.0        1.0         0.0
+				End Nodes
+
+				Begin Elements Element2D3N
+				  1 0 1 2 4
+				  2 0 3 4 2
+				End Elements
+
+				Begin NodalData DISPLACEMENT_X
+				1 1 100.0
+				End NodalData
+
+				Begin NodalData DISPLACEMENT_Y
+				1 1 100.0
+				End NodalData
+
+				Begin NodalData PRESSURE
+				2 0 50.0
+				End NodalData
+
+				Begin NodalData TEMPERATURE
+				4 0 33.0
+				End NodalData
+
+				Begin NodalData FORCE_Y
+				3    0    5.0
+				End NodalData
+			)input"));
+
+    Kernel kernel;
+    KratosApplication application(std::string("Kratos"));
+    application.Register();
+    kernel.Initialize();
+
+    // 1. Reading without IGNORE flag -> Error
+    ModelPartIO default_model_part_io(p_input);
+
+    ModelPart model_part_0("ErrorForce");
+    model_part_0.AddNodalSolutionStepVariable(DISPLACEMENT);
+    model_part_0.AddNodalSolutionStepVariable(PRESSURE);
+    model_part_0.AddNodalSolutionStepVariable(TEMPERATURE);
+
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        default_model_part_io.ReadModelPart(model_part_0),
+        "The nodal solution step container does not have this variable: FORCE_Y");
+
+    ModelPart model_part_1("ErrorTemperature");
+    model_part_1.AddNodalSolutionStepVariable(DISPLACEMENT);
+    model_part_1.AddNodalSolutionStepVariable(FORCE);
+    model_part_1.AddNodalSolutionStepVariable(PRESSURE);
+
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        default_model_part_io.ReadModelPart(model_part_1),
+        "The nodal solution step container does not have this variable: TEMPERATURE");
+
+    // 2. Reading with IGNORE flag -> Not set
+    ModelPartIO ignore_model_part_io(p_input,ModelPartIO::READ|ModelPartIO::IGNORE_VARIABLES_ERROR);
+
+    ModelPart model_part_2("IgnoreForce");
+    model_part_0.AddNodalSolutionStepVariable(DISPLACEMENT);
+    model_part_0.AddNodalSolutionStepVariable(PRESSURE);
+    model_part_0.AddNodalSolutionStepVariable(TEMPERATURE);
+
+    ignore_model_part_io.ReadModelPart(model_part_2);
+    KRATOS_CHECK_EQUAL(model_part_2.NumberOfNodes(), 4);
+    KRATOS_CHECK_EQUAL(model_part_2.NodesBegin()->Has(FORCE), false);
+
+    ModelPart model_part_3("IgnoreTemperature");
+    model_part_1.AddNodalSolutionStepVariable(DISPLACEMENT);
+    model_part_1.AddNodalSolutionStepVariable(FORCE);
+    model_part_1.AddNodalSolutionStepVariable(PRESSURE);
+
+    ignore_model_part_io.ReadModelPart(model_part_3);
+    KRATOS_CHECK_EQUAL(model_part_3.NumberOfNodes(), 4);
+    KRATOS_CHECK_EQUAL(model_part_3.NodesBegin()->Has(TEMPERATURE), false);
 }
 
 }  // namespace Testing.


### PR DESCRIPTION
Adding a json option to ignore variables while reading mdpa files if they have not been added to the model part's solution step data (default behavior is to throw an error). We need this in optimization to use the same model part in the primal and dual problems.

In doing so, we have found a bug in model_part_io.cpp, which was not checking for this flag in reading vector component variables. This is also fixed in this PR.