### PR TITLE
Core/print additional warning in amgcl solvers

### DIFF
--- a/kratos/linear_solvers/amgcl_ns_solver.h
+++ b/kratos/linear_solvers/amgcl_ns_solver.h
@@ -265,8 +265,7 @@ public:
         double resid;
         boost::tie(iters, resid) = solve(rB, rX);
 
-        if (mTol < resid)
-            KRATOS_WARNING("AMGCL NS Linear Solver")<<"Non converged linear solution. ["<< resid << " > "<< mTol << "]" << std::endl;
+        KRATOS_WARNING_IF("AMGCL NS Linear Solver", mTol < resid)<<"Non converged linear solution. ["<< resid << " > "<< mTol << "]" << std::endl;
 
         if(mverbosity > 1)
         {

--- a/kratos/linear_solvers/amgcl_ns_solver.h
+++ b/kratos/linear_solvers/amgcl_ns_solver.h
@@ -265,6 +265,9 @@ public:
         double resid;
         boost::tie(iters, resid) = solve(rB, rX);
 
+        if (mTol < resid)
+            KRATOS_WARNING("AMGCL NS Linear Solver")<<"Non converged linear solution. ["<< resid << " > "<< mTol << "]" << std::endl;
+
         if(mverbosity > 1)
         {
             std::cout << "Iterations: " << iters << std::endl

--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -522,6 +522,9 @@ public:
             ScalarSolve(rA,rX,rB, iters, resid);
         }
 
+        if (mTol < resid)
+            KRATOS_WARNING("AMGCL Linear Solver")<<"Non converged linear solution. ["<< resid << " > "<< mTol << "]" << std::endl;
+
 
         if(mverbosity > 1)
         {

--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -522,8 +522,7 @@ public:
             ScalarSolve(rA,rX,rB, iters, resid);
         }
 
-        if (mTol < resid)
-            KRATOS_WARNING("AMGCL Linear Solver")<<"Non converged linear solution. ["<< resid << " > "<< mTol << "]" << std::endl;
+        KRATOS_WARNING_IF("AMGCL Linear Solver", mTol < resid)<<"Non converged linear solution. ["<< resid << " > "<< mTol << "]" << std::endl;
 
 
         if(mverbosity > 1)


### PR DESCRIPTION
Adding a warning to the kratos logger to inform if the linear solver is not converged enough. This will be printed irrespective of the echo level of the solver.