### PR TITLE
Fixing C size_t problems in pybind11 namespace

### DIFF
--- a/external_libraries/pybind11/detail/common.h
+++ b/external_libraries/pybind11/detail/common.h
@@ -295,7 +295,7 @@ extern "C" {
 NAMESPACE_BEGIN(PYBIND11_NAMESPACE)
 
 using ssize_t = Py_ssize_t;
-using size_t  = std::size_t;
+using std::size_t;
 
 /// Approach used to cast a previously unknown C++ instance into a Python object
 enum class return_value_policy : uint8_t {


### PR DESCRIPTION
This replaces #2264 as is a more generic temporal solution.
The real problem is that we should not use  `using namespace pybind11` but make a namespace alias as recommended in the doc like `using pb = pybind11` or whatever, but we need to change that incrementally