### PR TITLE
Fixed a mistake in TotalLagrangian::CalculateSensitivityMatrix().

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.h
@@ -256,6 +256,7 @@ private:
                          ProcessInfo const& rCurrentProcessInfo);
 
     void CalculateShapeSensitivity(ShapeParameter Deriv,
+                                   Matrix& rDN_DX0,
                                    Matrix& rDN_DX0_Deriv,
                                    Matrix& rF_Deriv,
                                    double& rDetJ0_Deriv,

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_total_lagrangian_element_matrices.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_total_lagrangian_element_matrices.cpp
@@ -557,11 +557,13 @@ KRATOS_TEST_CASE_IN_SUITE(TotalLagrangian3D4_SensitivityMatrix, KratosStructural
         {
             const double delta = 0.00000001;
             p_elem->GetGeometry()[i].GetInitialPosition()[d] += delta;
+            p_elem->GetGeometry()[i].Coordinates()[d] += delta;
             get_res(R_perturb);
             p_elem->GetGeometry()[i].GetInitialPosition()[d] -= delta;
+            p_elem->GetGeometry()[i].Coordinates()[d] -= delta;
             semi_analytic_sensitivity_vector = (1.0 / delta) * (R_perturb - R);
             for (std::size_t k = 0; k < semi_analytic_sensitivity_vector.size(); ++k)
-                semi_analytic_sensitivity_matrix(k, i * ws_dim + d) =
+                semi_analytic_sensitivity_matrix(i * ws_dim + d, k) =
                     semi_analytic_sensitivity_vector(k);
         }
     for (std::size_t i = 0; i < sensitivity_matrix.size1(); ++i)


### PR DESCRIPTION
A partial contribution to the derivative, which is implicitly contained in the current configuration, was missing. Essentially we need to perturb both X() and X0() to get the correct behaviour with this element. Also to be consistent with the response function I needed to transpose the matrix.