### PR TITLE
[Structural ] Typo in PrepareModelPart function name

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
@@ -48,7 +48,7 @@ class TrilinosMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
         self.trilinos_model_part_importer.ImportModelPart()
         self.print_on_rank_zero("::[TrilinosMechanicalSolver]:: ", "Finished importing model part.")
 
-    def PrepareModel(self):
+    def PrepareModelPart(self):
         super(TrilinosMechanicalSolver, self).PrepareModelPart()
         # Construct the mpi-communicator
         self.trilinos_model_part_importer.CreateCommunicators()


### PR DESCRIPTION
The serial communicator was always created because of this :sweat_smile: 