### PR TITLE
Bugfix: Calling process constructor in ComputeDragProcess.

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/compute_drag_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/compute_drag_process.py
@@ -2,17 +2,18 @@ import KratosMultiphysics
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
 
-def Factory(settings, Model):
+def Factory(settings, model):
     if(type(settings) != KratosMultiphysics.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
 
-    return ComputeDragProcess(Model, settings["Parameters"])
+    return ComputeDragProcess(model, settings["Parameters"])
 
 
 class ComputeDragProcess(KratosMultiphysics.Process):
-    def __init__(self, Model, settings ):
+    def __init__(self, model, settings ):
         """ Auxiliary class to output total flow forces over obstacles in fluid dynamics problems.
         """
+        super(ComputeDragProcess,self).__init__()
 
         default_settings = KratosMultiphysics.Parameters("""
             {
@@ -37,7 +38,7 @@ class ComputeDragProcess(KratosMultiphysics.Process):
 
         self.format = settings["print_format"].GetString()
 
-        self.model_part = Model[settings["model_part_name"].GetString()]
+        self.model_part = model[settings["model_part_name"].GetString()]
         self.interval = KratosMultiphysics.Vector(2)
         self.interval[0] = settings["interval"][0].GetDouble()
         self.interval[1] = settings["interval"][1].GetDouble()


### PR DESCRIPTION
Now that processes derive from the C++ Process class, the ComputeDragProcess is producing segfaults when calling process functions not reimplemented in python. I don't fully understand the issue, but it seems to be caused by never calling the base class constructor. This PR fixes that.

@philbucher this is the "unrelated" change that sneaked into #2347.