### PR TITLE
[ParticleMechanicsApplication] Feature hexahedral element 3D8N

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
@@ -426,11 +426,19 @@ void UpdatedLagrangianQuadrilateral::CalculateKinematics(GeneralVariables& rVari
     1. By: noalias( rVariables.F ) = prod( rVariables.j, InvJ);
     2. By means of the gradient of nodal displacement: using this second expression quadratic convergence is not guarantee  
     
-    (NOTICE: Here, we are using method no. 1)
-    */
+    (NOTICE: Here, we are using method no. 2)*/
 
-    // Update Deformation gradient
-    noalias( rVariables.F ) = prod( rVariables.j, InvJ);
+    // METHOD 1: Update Deformation gradient: F [dx_n+1/dx_n] = [dx_n+1/d£] [d£/dx_n]
+    // noalias( rVariables.F ) = prod( rVariables.j, InvJ);
+    
+    // METHOD 2: Update Deformation gradient: F_ij = δ_ij + u_i,j
+    const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
+    Matrix I = identity_matrix<double>(dimension);
+    Matrix GradientDisp = ZeroMatrix(dimension, dimension);
+    rVariables.CurrentDisp = CalculateCurrentDisp(rVariables.CurrentDisp, rCurrentProcessInfo);
+    GradientDisp = prod(trans(rVariables.CurrentDisp),rVariables.DN_DX);
+    
+    noalias( rVariables.F ) = (I + GradientDisp);
 
     // Determinant of the previous Deformation Gradient F_n
     rVariables.detF0 = mDeterminantF0;

--- a/applications/ParticleMechanicsApplication/custom_python/particle_mechanics_python_application.cpp
+++ b/applications/ParticleMechanicsApplication/custom_python/particle_mechanics_python_application.cpp
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Ilaria Iaconeta
+//  Main authors:    Ilaria Iaconeta, Bodhinanda Chandra
 //
 //
 
@@ -28,15 +28,12 @@
 #include "custom_elements/updated_lagrangian.hpp"
 #include "custom_elements/updated_lagrangian_UP.hpp"
 #include "custom_elements/updated_lagrangian_quadrilateral.hpp"
-//#include "custom_elements/updated_lagrangian_UP_quadrilateral.hpp"
 
-//#include "custom_elements/total_lagrangian.hpp"
 #include "geometries/triangle_3d_3.h"
 #include "geometries/triangle_2d_3.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "geometries/tetrahedra_3d_4.h"
 #include "geometries/hexahedra_3d_8.h"
-
 
 #include "particle_mechanics_application.h"
 
@@ -50,50 +47,27 @@ using namespace pybind11;
 
 Element::Pointer CreateUpdatedLagragian2D3N()
 {
-    UpdatedLagrangian::Pointer NewElement(
-        new UpdatedLagrangian( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) ));
-    return NewElement;
-
+    return Kratos::make_shared<UpdatedLagrangian>( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) );
 }
 
 Element::Pointer CreateUpdatedLagragianUP2D3N()
 {
-    UpdatedLagrangianUP::Pointer NewElement(
-        new UpdatedLagrangianUP( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) ));
-    return NewElement;
-
+    return Kratos::make_shared<UpdatedLagrangianUP>( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) );
 }
 
 Element::Pointer CreateUpdatedLagragian3D4N()
 {
-    UpdatedLagrangian::Pointer NewElement(
-        new UpdatedLagrangian( 0, Element::GeometryType::Pointer( new Tetrahedra3D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ));
-    return NewElement;
-
+    return Kratos::make_shared<UpdatedLagrangian>( 0, Element::GeometryType::Pointer( new Tetrahedra3D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) );
 }
 Element::Pointer CreateUpdatedLagragian2D4N()
 {
-    UpdatedLagrangianQuadrilateral::Pointer NewElement(
-        new UpdatedLagrangianQuadrilateral( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ));
-    return NewElement;
+    return Kratos::make_shared<UpdatedLagrangianQuadrilateral>( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) );
 
 }
 Element::Pointer CreateUpdatedLagragian3D8N()
 {
-    UpdatedLagrangianQuadrilateral::Pointer NewElement(
-        new UpdatedLagrangianQuadrilateral( 0, Element::GeometryType::Pointer( new Hexahedra3D8 <Node<3> >( Element::GeometryType::PointsArrayType( 8 ) ) ) ));
-    return NewElement;
-
+    return Kratos::make_shared<UpdatedLagrangianQuadrilateral>( 0, Element::GeometryType::Pointer( new Hexahedra3D8 <Node<3> >( Element::GeometryType::PointsArrayType( 8 ) ) ) );
 }
-
-
-//Element::Pointer CreateUpdatedLagragianUP2D4N()
-//{
-//UpdatedLagrangianUPQuadrilateral::Pointer NewElement(
-//new UpdatedLagrangianUPQuadrilateral( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ));
-//return NewElement;
-
-//}
 
 
 PYBIND11_MODULE(KratosParticleMechanicsApplication, m)
@@ -114,10 +88,6 @@ PYBIND11_MODULE(KratosParticleMechanicsApplication, m)
     m.def("CreateUpdatedLagragian3D4N", &CreateUpdatedLagragian3D4N);
     m.def("CreateUpdatedLagragian2D4N", &CreateUpdatedLagragian2D4N);
     m.def("CreateUpdatedLagragian3D8N", &CreateUpdatedLagragian3D8N);
-//	def("CreateUpdatedLagragianUP2D4N", &CreateUpdatedLagragianUP2D4N);
-
-    //def("CreateTotalLagragian2D3N", &CreateTotalLagragian2D3N);
-    //def("CreateTotalLagragian3D4N", &CreateTotalLagragian3D4N);
 
     // Registering variables in python
     KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(m,  GAUSS_COORD )
@@ -136,7 +106,7 @@ PYBIND11_MODULE(KratosParticleMechanicsApplication, m)
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, MP_EQUIVALENT_PLASTIC_STRAIN);
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, MP_CONSTITUTIVE_PRESSURE);
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, MP_MATERIAL_ID);
-    //KRATOS_REGISTER_IN_PYTHON_VARIABLE(m, NODAL_MASS);
+
     KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(m, AUX_VELOCITY);
     KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(m, AUX_ACCELERATION);
 
@@ -167,12 +137,12 @@ PYBIND11_MODULE(KratosParticleMechanicsApplication, m)
     KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(m,  AUX_T_ACC )
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,  NODAL_LUMPED_MASS )
 
-    //nodal load variables
+    // Nodal load variables
     KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(m,  POINT_LOAD )
     KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(m,  LINE_LOAD )
     KRATOS_REGISTER_IN_PYTHON_3D_VARIABLE_WITH_COMPONENTS(m,  SURFACE_LOAD )
 
-    //condition load variables
+    // Condition load variables
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,POINT_LOADS_VECTOR )
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,LINE_LOADS_VECTOR )
     KRATOS_REGISTER_IN_PYTHON_VARIABLE(m,SURFACE_LOADS_VECTOR )

--- a/applications/ParticleMechanicsApplication/custom_python/particle_mechanics_python_application.cpp
+++ b/applications/ParticleMechanicsApplication/custom_python/particle_mechanics_python_application.cpp
@@ -35,6 +35,7 @@
 #include "geometries/triangle_2d_3.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "geometries/tetrahedra_3d_4.h"
+#include "geometries/hexahedra_3d_8.h"
 
 
 #include "particle_mechanics_application.h"
@@ -77,6 +78,13 @@ Element::Pointer CreateUpdatedLagragian2D4N()
     return NewElement;
 
 }
+Element::Pointer CreateUpdatedLagragian3D8N()
+{
+    UpdatedLagrangianQuadrilateral::Pointer NewElement(
+        new UpdatedLagrangianQuadrilateral( 0, Element::GeometryType::Pointer( new Hexahedra3D8 <Node<3> >( Element::GeometryType::PointsArrayType( 8 ) ) ) ));
+    return NewElement;
+
+}
 
 
 //Element::Pointer CreateUpdatedLagragianUP2D4N()
@@ -105,6 +113,7 @@ PYBIND11_MODULE(KratosParticleMechanicsApplication, m)
     m.def("CreateUpdatedLagragianUP2D3N", &CreateUpdatedLagragianUP2D3N);
     m.def("CreateUpdatedLagragian3D4N", &CreateUpdatedLagragian3D4N);
     m.def("CreateUpdatedLagragian2D4N", &CreateUpdatedLagragian2D4N);
+    m.def("CreateUpdatedLagragian3D8N", &CreateUpdatedLagragian3D8N);
 //	def("CreateUpdatedLagragianUP2D4N", &CreateUpdatedLagragianUP2D4N);
 
     //def("CreateTotalLagragian2D3N", &CreateTotalLagragian2D3N);

--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
@@ -759,12 +759,29 @@ public:
 			
 			auto elemItr = grid_model_part.Elements().begin() + i;
 			elemItr -> Reset(ACTIVE);
-            elemItr ->GetGeometry()[0].Reset(ACTIVE);
-            elemItr ->GetGeometry()[1].Reset(ACTIVE);
-            elemItr ->GetGeometry()[2].Reset(ACTIVE);
-            if (TDim ==3)
-            {
+            if (m_GeometryElement == "Triangle"){
+                elemItr ->GetGeometry()[0].Reset(ACTIVE);
+                elemItr ->GetGeometry()[1].Reset(ACTIVE);
+                elemItr ->GetGeometry()[2].Reset(ACTIVE);
+
+                if (TDim ==3)
+                {
+                    elemItr ->GetGeometry()[3].Reset(ACTIVE);
+                }
+            }
+            else if (m_GeometryElement == "Quadrilateral"){
+                elemItr ->GetGeometry()[0].Reset(ACTIVE);
+                elemItr ->GetGeometry()[1].Reset(ACTIVE);
+                elemItr ->GetGeometry()[2].Reset(ACTIVE);
                 elemItr ->GetGeometry()[3].Reset(ACTIVE);
+
+                if (TDim ==3)
+                {
+                    elemItr->GetGeometry()[4].Reset(ACTIVE);
+                    elemItr->GetGeometry()[5].Reset(ACTIVE);
+                    elemItr->GetGeometry()[6].Reset(ACTIVE);
+                    elemItr->GetGeometry()[7].Reset(ACTIVE);
+                }
             }
 		}
 
@@ -818,7 +835,7 @@ public:
                 }
 		    }
         }
-
+        
         //******************SEARCH FOR QUADRILATERALS************************
         else if(m_GeometryElement == "Quadrilateral")
         {

--- a/applications/ParticleMechanicsApplication/particle_mechanics_application.cpp
+++ b/applications/ParticleMechanicsApplication/particle_mechanics_application.cpp
@@ -67,15 +67,16 @@ namespace Kratos
         mUpdatedLagrangian3D4N( 0, Element::GeometryType::Pointer( new Tetrahedra3D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
         mUpdatedLagrangianUP2D3N( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3 ) ) ) ),
         //mUpdatedLagrangianUP3D4N( 0, Element::GeometryType::Pointer( new Tetrahedra3D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
-        mUpdatedLagrangian2D4N( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4) ) ) ),
+        mUpdatedLagrangian2D4N( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) ),
+        mUpdatedLagrangian3D8N( 0, Element::GeometryType::Pointer( new Hexahedra3D8 <Node<3> >( Element::GeometryType::PointsArrayType( 8 ) ) ) ),
         //mUpdatedLagrangianUP2D4N( 0, Element::GeometryType::Pointer( new Quadrilateral2D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4 ) ) ) )
         //mTotalLagrangian2D3N( 0, Element::GeometryType::Pointer( new Triangle2D3 <Node<3> >( Element::GeometryType::PointsArrayType( 3, Node<3>() ) ) ) ),
         //mTotalLagrangian3D4N( 0, Element::GeometryType::Pointer( new Tetrahedra3D4 <Node<3> >( Element::GeometryType::PointsArrayType( 4, Node<3>() ) ) ) )
         mMPMPointLoadCondition2D1N(0, Condition::GeometryType::Pointer(new Point2D<Node<3>>(Condition::GeometryType::PointsArrayType(1)))),
         mMPMPointLoadCondition3D1N(0, Condition::GeometryType::Pointer(new Point3D<Node<3>>(Condition::GeometryType::PointsArrayType(1)))),
         mMPMLineLoadCondition2D2N(0, Condition::GeometryType::Pointer(new Line2D2<Node<3>>(Condition::GeometryType::PointsArrayType(2)))),
-        mMPMSurfaceLoadCondition3D3N(0, Condition::GeometryType::Pointer(new Triangle3D3<Node<3>>(Condition::GeometryType::PointsArrayType(3))))
-
+        mMPMSurfaceLoadCondition3D3N(0, Condition::GeometryType::Pointer(new Triangle3D3<Node<3>>(Condition::GeometryType::PointsArrayType(3)))),
+        mMPMSurfaceLoadCondition3D4N(0, Condition::GeometryType::Pointer(new Quadrilateral3D4<Node<3>>(Condition::GeometryType::PointsArrayType(4))))
     {}
 
     void KratosParticleMechanicsApplication::Register()
@@ -85,7 +86,7 @@ namespace Kratos
         KRATOS_INFO("") << "           ____ __   ____ _____ _  ___ _   ____                 " << std::endl
                         << "     KRATOS  _ |  \\ |  _ |_   _| |/   | | | ___|               " << std::endl
                         << "          |   _| \\ \\|    | | | | |   (  |_| _|_               " << std::endl
-                        << "          |__|__/ \\_\\_|\\_\\ |_| |_|\\___|___|____| MECHANICS " << std::endl
+                        << "          |__|__/ \\_\\_|\\_\\ |_| |_|\\___|___|____|MECHANICS  " << std::endl
                         << "Initializing KratosParticleMechanicsApplication...              " << std::endl;
 
         //Registering elements
@@ -94,6 +95,7 @@ namespace Kratos
         KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianUP2D3N", mUpdatedLagrangianUP2D3N )
         //KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianUP3D4N", mUpdatedLagrangianUP3D4N )
         KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian2D4N", mUpdatedLagrangian2D4N )
+        KRATOS_REGISTER_ELEMENT( "UpdatedLagrangian3D8N", mUpdatedLagrangian3D8N )
         //KRATOS_REGISTER_ELEMENT( "UpdatedLagrangianUP2D4N", mUpdatedLagrangianUP2D4N )
 
         //Registering conditions
@@ -101,6 +103,7 @@ namespace Kratos
         KRATOS_REGISTER_CONDITION( "MPMPointLoadCondition3D1N", mMPMPointLoadCondition3D1N )
         KRATOS_REGISTER_CONDITION( "MPMLineLoadCondition2D2N", mMPMLineLoadCondition2D2N)
         KRATOS_REGISTER_CONDITION( "MPMSurfaceLoadCondition3D3N", mMPMSurfaceLoadCondition3D3N)
+        KRATOS_REGISTER_CONDITION( "MPMSurfaceLoadCondition3D4N", mMPMSurfaceLoadCondition3D4N)
 
         //element
         KRATOS_REGISTER_VARIABLE( COUNTER )

--- a/applications/ParticleMechanicsApplication/particle_mechanics_application.h
+++ b/applications/ParticleMechanicsApplication/particle_mechanics_application.h
@@ -210,6 +210,7 @@ private:
     const UpdatedLagrangianUP mUpdatedLagrangianUP2D3N;
     //const UpdatedLagrangianUP mUpdatedLagrangianUP3D4N;
     const UpdatedLagrangianQuadrilateral mUpdatedLagrangian2D4N;
+    const UpdatedLagrangianQuadrilateral mUpdatedLagrangian3D8N;
     //const UpdatedLagrangianUPQuadrilateral mUpdatedLagrangianUP2D4N;
     //const TotalLagrangian mTotalLagrangian2D3N;
     //const TotalLagrangian mTotalLagrangian3D4N;
@@ -219,6 +220,7 @@ private:
     const MPMPointLoadCondition mMPMPointLoadCondition3D1N;
     const MPMLineLoadCondition2D mMPMLineLoadCondition2D2N;
     const MPMSurfaceLoadCondition3D mMPMSurfaceLoadCondition3D3N;
+    const MPMSurfaceLoadCondition3D mMPMSurfaceLoadCondition3D4N;
 
     //constitutive laws
     const HyperElasticViscoplastic3DLaw                mHyperElasticViscoplastic3DLaw;

--- a/applications/ParticleMechanicsApplication/python_scripts/particle_mpm_solver.py
+++ b/applications/ParticleMechanicsApplication/python_scripts/particle_mpm_solver.py
@@ -202,7 +202,7 @@ class ParticleMPMSolver(object):
                 if (self.pressure_dofs):
                     raise Exception("Element for mixed U-P formulation in 3D for Hexahedral Element is not yet implemented.")
                 else:
-                    raise Exception("Element in 3D for Hexahedral Element is not yet implemented. Please use Tetrahedral instead.")
+                    self.new_element = KratosParticle.CreateUpdatedLagragian3D8N()
 
         # Initialize solver
         if(self.domain_size==2):

--- a/kratos/geometries/hexahedra_3d_8.h
+++ b/kratos/geometries/hexahedra_3d_8.h
@@ -12,6 +12,7 @@
 //                   Felix Nagel
 //  contributors:    Hoang Giang Bui
 //                   Josep Maria Carbonell
+//                   Bodhinanda Chandra
 //
 
 #if !defined(KRATOS_HEXAHEDRA_3D_8_H_INCLUDED )
@@ -585,6 +586,33 @@ public:
                                               this->pGetPoint( 7 ) ) ) );
         return faces;
     }
+
+
+    bool HasIntersection( const Point& rLowPoint, const Point& rHighPoint ) override
+    {
+        using Quadrilateral3D4Type = Quadrilateral3D4<TPointType>;
+        // Check if faces have intersection
+        if(Quadrilateral3D4Type(this->pGetPoint(0),this->pGetPoint(1), this->pGetPoint(2), this->pGetPoint(3)).HasIntersection(rLowPoint, rHighPoint))
+            return true;
+        if(Quadrilateral3D4Type(this->pGetPoint(4),this->pGetPoint(5), this->pGetPoint(6), this->pGetPoint(7)).HasIntersection(rLowPoint, rHighPoint))
+            return true;
+        if(Quadrilateral3D4Type(this->pGetPoint(0),this->pGetPoint(1), this->pGetPoint(5), this->pGetPoint(4)).HasIntersection(rLowPoint, rHighPoint))
+            return true;
+        if(Quadrilateral3D4Type(this->pGetPoint(3),this->pGetPoint(2), this->pGetPoint(6), this->pGetPoint(7)).HasIntersection(rLowPoint, rHighPoint))
+            return true;
+        if(Quadrilateral3D4Type(this->pGetPoint(0),this->pGetPoint(4), this->pGetPoint(7), this->pGetPoint(3)).HasIntersection(rLowPoint, rHighPoint))
+            return true;
+        if(Quadrilateral3D4Type(this->pGetPoint(1),this->pGetPoint(5), this->pGetPoint(6), this->pGetPoint(2)).HasIntersection(rLowPoint, rHighPoint))
+            return true;
+        
+        CoordinatesArrayType local_coordinates;
+        // if there are no faces intersecting the box then or the box is inside the hexahedron or it does not have intersection
+        if(IsInside(rLowPoint,local_coordinates))
+            return true;
+
+        return false;
+    }
+
 
     /**
      * Shape Function

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -12,6 +12,7 @@
 //                   Felix Nagel
 //  contributors:    Hoang Giang Bui
 //                   Josep Maria Carbonell
+//                   Bodhinanda Chandra
 //
 
 #if !defined(KRATOS_QUADRILATERAL_3D_4_H_INCLUDED )
@@ -23,6 +24,7 @@
 
 // Project includes
 #include "geometries/line_3d_2.h"
+#include "geometries/triangle_3d_3.h"
 #include "integration/quadrilateral_gauss_legendre_integration_points.h"
 #include "integration/quadrilateral_collocation_integration_points.h"
 
@@ -1054,7 +1056,31 @@ public:
         NodesInFaces(2,3)=2;
     }
 
-    
+    /** This method checks if an axis-aliged bounding box (AABB)
+    intersects the quadrilateral
+
+    @return bool if the quadrilateral overlaps the box
+    @param rLowPoint first corner of the box
+    @param rHighPoint second corner of the box
+    @see Triangle3D3::HasIntersection
+    */
+    bool HasIntersection( const Point& rLowPoint, const Point& rHighPoint ) override
+    {
+        Triangle3D3<PointType> triangle_0 (this->pGetPoint( 0 ),
+                                           this->pGetPoint( 1 ),
+                                           this->pGetPoint( 2 )
+        );
+        Triangle3D3<PointType> triangle_1 (this->pGetPoint( 2 ),
+                                           this->pGetPoint( 3 ),
+                                           this->pGetPoint( 0 )
+        );
+
+        if      ( triangle_0.HasIntersection(rLowPoint, rHighPoint) ) return true;
+        else if ( triangle_1.HasIntersection(rLowPoint, rHighPoint) ) return true;
+        else return false;
+    }
+
+
     /**
      * Returns all faces of the current geometry.
      * This is only implemented for 3D geometries, since 2D geometries


### PR DESCRIPTION
I extended the UL Quad element to Hexahedral. For the implementation to run, the PR #2386 is needed, else it will throw an error while accessing binbased_fast_point_locator.h's UpdateSearchDatabase() function.

I have validated it with a simple beam example as attached. The exact analytical value is approximately -0.0314
![snapshot](https://user-images.githubusercontent.com/37140224/41899787-44cc9506-7968-11e8-98a7-6127ba6fb92a.png)
