### PR TITLE
[Core] Added element reordering to model part optimization

### DIFF
--- a/kratos/processes/reorder_and_optimize_modelpart_process.cpp
+++ b/kratos/processes/reorder_and_optimize_modelpart_process.cpp
@@ -13,6 +13,7 @@
 
 // System includes
 #include <vector>
+#include <algorithm>
 // External includes
 
 // Project includes
@@ -42,8 +43,8 @@ namespace Kratos
             KRATOS_TRY
 
 
-            //reorder nodes,#include "spaces/ublas_space.h"elements and conditions so that their Id start in 1 and is consecutive
-            #pragma omp parallel for
+        //reorder nodes,#include "spaces/ublas_space.h"elements and conditions so that their Id start in 1 and is consecutive
+#pragma omp parallel for
             for(int i=0; i<static_cast<int>(mrModelPart.Nodes().size()); ++i)
                 (mrModelPart.NodesBegin() + i)->SetId(i+1);
             mrModelPart.Nodes().Sort();
@@ -231,25 +232,47 @@ namespace Kratos
             
             //reorder
             mrModelPart.Nodes().Sort();
+
+            ReorderElements();
         }
-        
 
-        
-        
-	std::string ReorderAndOptimizeModelPartProcess::Info() const {
-		return "ReorderAndOptimizeModelPartProcess";
-	}
+        void ReorderAndOptimizeModelPartProcess::ReorderElements()
+        {
+            // Expects element ids are ordered 1 ... Elements().size().
+            std::vector<std::size_t> element_ids(mrModelPart.NumberOfElements());
+            std::vector<std::size_t> node_ids(mrModelPart.NumberOfElements());
+            #pragma omp parallel for
+            for(int i=0; i < static_cast<int>(element_ids.size()); ++i)
+            {
+                auto it = mrModelPart.ElementsBegin() + i;
+                element_ids.at(it->Id() - 1) = it->Id();
+                std::size_t node_id = it->GetGeometry()[0].Id();
+                for (const auto& r_node : it->GetGeometry().Points())
+                    node_id = std::min(node_id, r_node.Id());
+                node_ids.at(it->Id() - 1) = node_id;
+            }
+            std::sort(element_ids.begin(), element_ids.end(),
+                      [&node_ids](const std::size_t& i, const std::size_t& j) {
+                          return node_ids[i - 1] < node_ids[j - 1];
+                      });
+            #pragma omp parallel for
+            for(int i=0; i < static_cast<int>(element_ids.size()); ++i)
+                (mrModelPart.ElementsBegin() + element_ids[i] - 1)->SetId(i + 1);
+            mrModelPart.Elements().Sort();
+        }
 
-	void ReorderAndOptimizeModelPartProcess::PrintInfo(std::ostream& rOStream) const {
-		rOStream << Info();
-	}
+        std::string ReorderAndOptimizeModelPartProcess::Info() const
+        {
+            return "ReorderAndOptimizeModelPartProcess";
+        }
 
-	void ReorderAndOptimizeModelPartProcess::PrintData(std::ostream& rOStream) const {
+        void ReorderAndOptimizeModelPartProcess::PrintInfo(std::ostream& rOStream) const
+        {
+            rOStream << Info();
+        }
 
-	}
-
-        
-
-
+        void ReorderAndOptimizeModelPartProcess::PrintData(std::ostream& rOStream) const
+        {
+        }
 
 }  // namespace Kratos.

--- a/kratos/processes/reorder_and_optimize_modelpart_process.cpp
+++ b/kratos/processes/reorder_and_optimize_modelpart_process.cpp
@@ -169,6 +169,7 @@ namespace Kratos
                 pelem = mrModelPart.Elements()(pelem->Id());
 
             }
+            subpart.Elements().Sort();
 
             #pragma omp parallel for
             for(int i=0; i<static_cast<int>(subpart.Conditions().size()); ++i)

--- a/kratos/processes/reorder_and_optimize_modelpart_process.h
+++ b/kratos/processes/reorder_and_optimize_modelpart_process.h
@@ -128,6 +128,7 @@ protected:
     ///@{
     void ActualizeSubModelPart(ModelPart& subpart);
     void OptimizeOrdering();
+    void ReorderElements();
 
     ///@}
     ///@name Private  Access


### PR DESCRIPTION
The process was reordering nodes, but not elements. I added element reordering so that repeated node accesses are closer in the build loop. I tried a small test, but performance gains were negligible. Below are examples of sparsity patterns from a model part after this modification.

![after_element_reordering](https://user-images.githubusercontent.com/22290001/41926090-a2cdf900-796e-11e8-927b-9c595522c64a.png)

Before the modification, the sparsity pattern was following:

![before_element_reordering](https://user-images.githubusercontent.com/22290001/41926108-b2965ecc-796e-11e8-8d7b-96b8837a251b.png)

