### PR TITLE
Setting shape functions values in the CL Parameters of small_displacement element

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1138,6 +1138,7 @@ void BaseSolidElement::CalculateConstitutiveVariables(
     )
 {
     // Here we essentially set the input parameters
+    rValues.SetShapeFunctionsValues(rThisKinematicVariables.N); // shape functions
     rValues.SetDeterminantF(rThisKinematicVariables.detF); // Assuming the determinant is computed somewhere else
     rValues.SetDeformationGradientF(rThisKinematicVariables.F); //F computed somewhere else
 

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -73,16 +73,16 @@ bool SmallDisplacement::UseElementProvidedStrain()
 /***********************************************************************************/
 /***********************************************************************************/
 
-void SmallDisplacement::CalculateAll( 
+void SmallDisplacement::CalculateAll(
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
     ProcessInfo& rCurrentProcessInfo,
     const bool CalculateStiffnessMatrixFlag,
-    const bool CalculateResidualVectorFlag 
+    const bool CalculateResidualVectorFlag
     )
 {
     KRATOS_TRY;
-    
+
     const unsigned int number_of_nodes = GetGeometry().size();
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
     const unsigned int strain_size = GetProperties().GetValue( CONSTITUTIVE_LAW )->GetStrainSize();
@@ -112,7 +112,7 @@ void SmallDisplacement::CalculateAll(
     const GeometryType::IntegrationMethod integration_method =
         GetGeometry().GetDefaultIntegrationMethod();
     const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(integration_method);
-    
+
     ConstitutiveLaw::Parameters Values(GetGeometry(),GetProperties(),rCurrentProcessInfo);
 
     // Set constitutive law flags:
@@ -120,24 +120,24 @@ void SmallDisplacement::CalculateAll(
     ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
     ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
     ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
-    
+
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter
-    
+
     for ( unsigned int point_number = 0; point_number < integration_points.size(); point_number++ ) {
         // Contribution to external forces
         const Vector body_force = this->GetBodyForce(integration_points, point_number);
-        
+
         // Compute element kinematics B, F, DN_DX ...
         CalculateKinematicVariables(this_kinematic_variables, point_number, integration_method);
-        
+
         // Compute material reponse
         CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
-        
-        // Calculating weights for integration on the reference configuration
-        double int_to_reference_weight = GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0); 
 
-        if ( dimension == 2 && GetProperties().Has( THICKNESS )) 
+        // Calculating weights for integration on the reference configuration
+        double int_to_reference_weight = GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);
+
+        if ( dimension == 2 && GetProperties().Has( THICKNESS ))
             int_to_reference_weight *= GetProperties()[THICKNESS];
 
         if ( CalculateStiffnessMatrixFlag == true ) { // Calculation of the matrix is required
@@ -149,7 +149,7 @@ void SmallDisplacement::CalculateAll(
             this->CalculateAndAddResidualVector(rRightHandSideVector, this_kinematic_variables, rCurrentProcessInfo, body_force, this_constitutive_variables.StressVector, int_to_reference_weight);
         }
     }
-    
+
     KRATOS_CATCH( "" )
 }
 
@@ -157,23 +157,23 @@ void SmallDisplacement::CalculateAll(
 /***********************************************************************************/
 
 void SmallDisplacement::CalculateKinematicVariables(
-    KinematicVariables& rThisKinematicVariables, 
+    KinematicVariables& rThisKinematicVariables,
     const unsigned int PointNumber,
     const GeometryType::IntegrationMethod& rIntegrationMethod
     )
-{        
+{
     const GeometryType::IntegrationPointsArrayType& r_integration_points =
         GetGeometry().IntegrationPoints(rIntegrationMethod);
     // Shape functions
     rThisKinematicVariables.N = GetGeometry().ShapeFunctionsValues(rThisKinematicVariables.N, r_integration_points[PointNumber].Coordinates());
-    
-    rThisKinematicVariables.detJ0 = CalculateDerivativesOnReferenceConfiguration(rThisKinematicVariables.J0, rThisKinematicVariables.InvJ0, rThisKinematicVariables.DN_DX, PointNumber, rIntegrationMethod); 
-    
+
+    rThisKinematicVariables.detJ0 = CalculateDerivativesOnReferenceConfiguration(rThisKinematicVariables.J0, rThisKinematicVariables.InvJ0, rThisKinematicVariables.DN_DX, PointNumber, rIntegrationMethod);
+
     KRATOS_ERROR_IF(rThisKinematicVariables.detJ0 < 0.0) << "WARNING:: ELEMENT ID: " << this->Id() << " INVERTED. DETJ0: " << rThisKinematicVariables.detJ0 << std::endl;
-    
+
     // Compute B
     CalculateB( rThisKinematicVariables.B, rThisKinematicVariables.DN_DX, r_integration_points, PointNumber );
-    
+
     // Compute equivalent F
     Vector displacements;
     GetValuesVector(displacements);
@@ -186,31 +186,32 @@ void SmallDisplacement::CalculateKinematicVariables(
 /***********************************************************************************/
 
 void SmallDisplacement::CalculateConstitutiveVariables(
-    KinematicVariables& rThisKinematicVariables, 
-    ConstitutiveVariables& rThisConstitutiveVariables, 
+    KinematicVariables& rThisKinematicVariables,
+    ConstitutiveVariables& rThisConstitutiveVariables,
     ConstitutiveLaw::Parameters& rValues,
     const unsigned int PointNumber,
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
     const ConstitutiveLaw::StressMeasure ThisStressMeasure
     )
-{        
+{
     // Displacements vector
     Vector displacements;
     GetValuesVector(displacements);
-    
+
     // Compute strain
     noalias(rThisConstitutiveVariables.StrainVector) = prod(rThisKinematicVariables.B, displacements);
 
     // Here we essentially set the input parameters
+    rValues.SetShapeFunctionsValues(rThisKinematicVariables.N); // shape functions
     rValues.SetDeterminantF(rThisKinematicVariables.detF); //assuming the determinant is computed somewhere else
     rValues.SetDeformationGradientF(rThisKinematicVariables.F); //F computed somewhere else
-    
+
     // Here we set the space on which the results shall be written
     rValues.SetConstitutiveMatrix(rThisConstitutiveVariables.D); //assuming the determinant is computed somewhere else
     rValues.SetStressVector(rThisConstitutiveVariables.StressVector); //F computed somewhere else
-    
-    // Actually do the computations in the ConstitutiveLaw    
-    mConstitutiveLawVector[PointNumber]->CalculateMaterialResponse(rValues, ThisStressMeasure); //here the calculations are actually done 
+
+    // Actually do the computations in the ConstitutiveLaw
+    mConstitutiveLawVector[PointNumber]->CalculateMaterialResponse(rValues, ThisStressMeasure); //here the calculations are actually done
 }
 
 /***********************************************************************************/
@@ -224,12 +225,12 @@ void SmallDisplacement::CalculateB(
     )
 {
     KRATOS_TRY;
-    
+
     const unsigned int number_of_nodes = GetGeometry().PointsNumber();
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
 
     rB.clear();
-    
+
     if(dimension == 2) {
         for ( unsigned int i = 0; i < number_of_nodes; ++i ) {
             rB( 0, i*2     ) = rDN_DX( i, 0 );
@@ -261,24 +262,24 @@ Matrix SmallDisplacement::ComputeEquivalentF(const Vector& rStrainTensor)
 {
     const unsigned int dim = GetGeometry().WorkingSpaceDimension();
     Matrix F(dim,dim);
-    
+
     if(dim == 2) {
-        F(0,0) = 1.0+rStrainTensor(0);  
-        F(0,1) = 0.5*rStrainTensor(2); 
-        F(1,0) = 0.5*rStrainTensor(2);   
+        F(0,0) = 1.0+rStrainTensor(0);
+        F(0,1) = 0.5*rStrainTensor(2);
+        F(1,0) = 0.5*rStrainTensor(2);
         F(1,1) = 1.0+rStrainTensor(1);
     } else {
-        F(0,0) = 1.0+rStrainTensor(0);     
-        F(0,1) = 0.5*rStrainTensor(3); 
+        F(0,0) = 1.0+rStrainTensor(0);
+        F(0,1) = 0.5*rStrainTensor(3);
         F(0,2) = 0.5*rStrainTensor(5);
-        F(1,0) = 0.5*rStrainTensor(3);   
-        F(1,1) = 1.0+rStrainTensor(1);   
+        F(1,0) = 0.5*rStrainTensor(3);
+        F(1,1) = 1.0+rStrainTensor(1);
         F(1,2) = 0.5*rStrainTensor(4);
-        F(2,0) = 0.5*rStrainTensor(5);   
-        F(2,1) = 0.5*rStrainTensor(4); 
+        F(2,0) = 0.5*rStrainTensor(5);
+        F(2,1) = 0.5*rStrainTensor(4);
         F(2,2) = 1.0+rStrainTensor(2);
     }
-    
+
     return F;
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -270,6 +270,7 @@ void SmallDisplacementBbar::CalculateConstitutiveVariables(
 
     // Here we essentially set the input parameters
     //rThisKinematicVariables.detF = MathUtils<double>::Det(rThisKinematicVariables.F); //TODO(marcelo): check if this line is necessary
+    rValues.SetShapeFunctionsValues(rThisKinematicVariables.N); // shape functions
     rValues.SetDeterminantF(rThisKinematicVariables.detF); //assuming the determinant is computed somewhere else
     rValues.SetDeformationGradientF(rThisKinematicVariables.F); //F computed somewhere else
 
@@ -423,7 +424,7 @@ void SmallDisplacementBbar::CalculateHydrostaticDeformationMatrix(KinematicVaria
     KRATOS_TRY
     const unsigned int number_of_nodes = GetGeometry().PointsNumber();
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
-    
+
     const GeometryType::IntegrationMethod integration_method =
         GetGeometry().GetDefaultIntegrationMethod();
     const GeometryType::IntegrationPointsArrayType& integration_points =


### PR DESCRIPTION
In order to interpolate nodal variables at each integration point inside the CL (e.g. TEMPERATURE), we need to set the Shape Function Values (N) in the element before calling the CalculateMaterialResponse method.