### PR TITLE
Fluid/feature python solver missing parameter errors

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_vmsmonolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_vmsmonolithic_solver.py
@@ -21,8 +21,8 @@ class AdjointVMSMonolithicSolver(AdjointFluidSolver):
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type" : "adjoint_vmsmonolithic_solver",
-            "model_part_name": "AdjointFluidModelPart",
-            "domain_size": 2,
+            "model_part_name": "",
+            "domain_size": -1,
             "scheme_settings" : {
                 "scheme_type" : "bossak"
             },
@@ -53,7 +53,7 @@ class AdjointVMSMonolithicSolver(AdjointFluidSolver):
 
     def __init__(self, model, custom_settings):
         super(AdjointVMSMonolithicSolver,self).__init__(model,custom_settings)
-        
+
         # There is only a single rank in OpenMP, we always print
         self._is_printing_rank = True
 
@@ -148,4 +148,4 @@ class AdjointVMSMonolithicSolver(AdjointFluidSolver):
             break
 
         KratosMultiphysics.VariableUtils().SetScalarVar(KratosMultiphysics.DENSITY, rho, self.main_model_part.Nodes)
-        KratosMultiphysics.VariableUtils().SetScalarVar(KratosMultiphysics.VISCOSITY, kin_viscosity, self.main_model_part.Nodes)        
+        KratosMultiphysics.VariableUtils().SetScalarVar(KratosMultiphysics.VISCOSITY, kin_viscosity, self.main_model_part.Nodes)

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis.py
@@ -15,12 +15,12 @@ class FluidDynamicsAnalysis(AnalysisStage):
     def __init__(self,model,parameters):
         # Deprecation warnings
         solver_settings = parameters["solver_settings"]
-        if not solver_settings.Has("domain_size"):
+        if not solver_settings.Has("domain_size") and parameters["problem_data"].Has("domain_size"):
             Kratos.Logger.PrintInfo("FluidDynamicsAnalysis", "Using the old way to pass the domain_size, this will be removed!")
             solver_settings.AddEmptyValue("domain_size")
             solver_settings["domain_size"].SetInt(parameters["problem_data"]["domain_size"].GetInt())
 
-        if not solver_settings.Has("model_part_name"):
+        if not solver_settings.Has("model_part_name") and parameters["problem_data"].Has("model_part_name"):
             Kratos.Logger.PrintInfo("FluidDynamicsAnalysis", "Using the old way to pass the model_part_name, this will be removed!")
             solver_settings.AddEmptyValue("model_part_name")
             solver_settings["model_part_name"].SetString(parameters["problem_data"]["model_part_name"].GetString())

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
@@ -34,7 +34,7 @@ class FluidSolver(PythonSolver):
         model_part_name = self.settings["model_part_name"].GetString()
 
         if model_part_name == "":
-            raise Exception('Please specify a model_part name!')
+            raise Exception('Please provide the model part name as the "model_part_name" (string) parameter!')
 
         if self.model.HasModelPart(model_part_name):
             self.main_model_part = self.model.GetModelPart(model_part_name)
@@ -42,6 +42,9 @@ class FluidSolver(PythonSolver):
             self.main_model_part = KratosMultiphysics.ModelPart(model_part_name)
 
         domain_size = self.settings["domain_size"].GetInt()
+        if domain_size == -1:
+            raise Exception('Please provide the domain size as the "domain_size" (int) parameter!')
+
         self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, domain_size)
 
     def AddVariables(self):

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_solver.py
@@ -19,8 +19,8 @@ class NavierStokesCompressibleSolver(FluidSolver):
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type": "compressible_solver_from_defaults",
-            "model_part_name": "FluidModelPart",
-            "domain_size": 2,
+            "model_part_name": "",
+            "domain_size": -1,
             "model_import_settings": {
                 "input_type": "mdpa",
                 "input_filename": "two_element_test"

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_ausas_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_ausas_solver.py
@@ -22,8 +22,8 @@ class NavierStokesEmbeddedAusasMonolithicSolver(navier_stokes_embedded_solver.Na
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type": "EmbeddedAusas",
-            "model_part_name": "FluidModelPart",
-            "domain_size": 2,
+            "model_part_name": "",
+            "domain_size": -1,
             "model_import_settings": {
                 "input_type": "mdpa",
                 "input_filename": "unknown_name"

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_fm_ale_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_fm_ale_solver.py
@@ -23,9 +23,9 @@ class NavierStokesEmbeddedFMALEMonolithicSolver(navier_stokes_embedded_solver.Na
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type": "embedded_solver_from_defaults",
-            "model_part_name": "FluidModelPart",
+            "model_part_name": "",
             "structure_model_part_name": "StructureModelPart",
-            "domain_size": 2,
+            "domain_size": -1,
             "model_import_settings": {
                 "input_type": "mdpa",
                 "input_filename": "unknown_name"

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_fm_ale_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_fm_ale_solver.py
@@ -24,7 +24,7 @@ class NavierStokesEmbeddedFMALEMonolithicSolver(navier_stokes_embedded_solver.Na
         {
             "solver_type": "embedded_solver_from_defaults",
             "model_part_name": "",
-            "structure_model_part_name": "StructureModelPart",
+            "structure_model_part_name": "",
             "domain_size": -1,
             "model_import_settings": {
                 "input_type": "mdpa",
@@ -65,6 +65,10 @@ class NavierStokesEmbeddedFMALEMonolithicSolver(navier_stokes_embedded_solver.Na
         }""")
 
         settings.ValidateAndAssignDefaults(default_settings)
+
+        if settings["structure_model_part_name"].GetString() == "":
+            raise Exception('Please provide the name of the fixed model part as the "structure_model_part_name" (string) parameter!')
+
         return settings
 
     def __init__(self, model, custom_settings):

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -22,8 +22,8 @@ class NavierStokesEmbeddedMonolithicSolver(FluidSolver):
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type": "embedded_solver_from_defaults",
-            "model_part_name": "FluidModelPart",
-            "domain_size": 2,
+            "model_part_name": "",
+            "domain_size": -1,
             "model_import_settings": {
                 "input_type": "mdpa",
                 "input_filename": "unknown_name"

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
@@ -22,8 +22,8 @@ class NavierStokesSolverFractionalStep(FluidSolver):
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type": "FractionalStep",
-            "model_part_name": "FluidModelPart",
-            "domain_size": 2,
+            "model_part_name": "",
+            "domain_size": -1,
             "model_import_settings": {
                     "input_type": "mdpa",
                     "input_filename": "unknown_name"

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
@@ -107,8 +107,8 @@ class NavierStokesSolverMonolithic(FluidSolver):
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type": "navier_stokes_solver_vmsmonolithic",
-            "model_part_name": "FluidModelPart",
-            "domain_size": 2,
+            "model_part_name": "",
+            "domain_size": -1,
             "model_import_settings": {
                 "input_type": "mdpa",
                 "input_filename": "unknown_name"

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_adjoint_vmsmonolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_adjoint_vmsmonolithic_solver.py
@@ -49,8 +49,8 @@ class AdjointVMSMonolithicMPISolver(AdjointVMSMonolithicSolver):
                 "automatic_time_step" : false,
                 "time_step"           : -0.1
             },
-            "domain_size": 2,
-            "model_part_name": "MainModelPart",
+            "domain_size": -1,
+            "model_part_name": "",
             "time_stepping": {
                 "automatic_time_step" : false,
                 "time_step"           : -0.1
@@ -59,7 +59,7 @@ class AdjointVMSMonolithicMPISolver(AdjointVMSMonolithicSolver):
 
         settings.ValidateAndAssignDefaults(default_settings)
         return settings
-    
+
     def __init__(self, model, custom_settings):
         super(AdjointVMSMonolithicSolver, self).__init__(model, custom_settings)
 

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_embedded_ausas_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_embedded_ausas_solver.py
@@ -23,8 +23,8 @@ class NavierStokesMPIEmbeddedAusasMonolithicSolver(trilinos_navier_stokes_embedd
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type": "EmbeddedAusas",
-            "model_part_name": "FluidModelPart",
-            "domain_size": 2,
+            "model_part_name": "",
+            "domain_size": -1,
             "model_import_settings": {
                 "input_type": "mdpa",
                 "input_filename": "unknown_name"

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_embedded_solver.py
@@ -26,8 +26,8 @@ class NavierStokesMPIEmbeddedMonolithicSolver(navier_stokes_embedded_solver.Navi
 
         default_settings = KratosMultiphysics.Parameters("""{
             "solver_type": "Embedded",
-            "model_part_name": "FluidModelPart",
-            "domain_size": 2,
+            "model_part_name": "",
+            "domain_size": -1,
             "model_import_settings": {
                 "input_type": "mdpa",
                 "input_filename": "unknown_name"

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_fractionalstep.py
@@ -26,8 +26,8 @@ class TrilinosNavierStokesSolverFractionalStep(navier_stokes_solver_fractionalst
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type": "FractionalStep",
-            "model_part_name": "FluidModelPart",
-            "domain_size": 2,
+            "model_part_name": "",
+            "domain_size": -1,
             "model_import_settings": {
                     "input_type": "mdpa",
                     "input_filename": "unknown_name"

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
@@ -26,8 +26,8 @@ class TrilinosNavierStokesSolverMonolithic(navier_stokes_solver_vmsmonolithic.Na
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type": "trilinos_navier_stokes_solver_vmsmonolithic",
-            "model_part_name": "FluidModelPart",
-            "domain_size": 2,
+            "model_part_name": "",
+            "domain_size": -1,
             "model_import_settings": {
                 "input_type": "mdpa",
                 "input_filename": "unknown_name"
@@ -147,7 +147,7 @@ class TrilinosNavierStokesSolverMonolithic(navier_stokes_solver_vmsmonolithic.Na
                                                                self.settings["absolute_velocity_tolerance"].GetDouble(),
                                                                self.settings["relative_pressure_tolerance"].GetDouble(),
                                                                self.settings["absolute_pressure_tolerance"].GetDouble())
-                                                               
+
         (self.conv_criteria).SetEchoLevel(self.settings["echo_level"].GetInt())
 
         ## Creating the Trilinos time scheme


### PR DESCRIPTION
Forcing the user to define the `model_part_name` and `domain_size`, since we cannot assume any reasonable defaults (at least now we get an error message).