### PR TITLE
Modifying constructor arguments to sidestep pybind limitations.

### DIFF
--- a/applications/FluidDynamicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/FluidDynamicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -87,8 +87,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
             (m,"ResidualBasedPredictorCorrectorVelocityBossakSchemeTurbulent")
             .def(init<double,double,unsigned int,Process::Pointer >() )
             .def(init<double,double,unsigned int >())// constructor without a turbulence model
-            .def(init<double,double,unsigned int,const Kratos::Variable<int>&>())// constructor without a turbulence model for periodic boundary conditions
-            .def(init<double,double,unsigned int,Kratos::Variable<double>&>())// constructor with a non-default flag for slip conditions
+            .def(init<double,unsigned int,const Kratos::Variable<int>&>())// constructor without a turbulence model for periodic boundary conditions
             ;
 
     typedef ResidualBasedSimpleSteadyScheme< SparseSpaceType, LocalSpaceType > ResidualBasedSimpleSteadySchemeType;
@@ -122,7 +121,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
 		.def(init<unsigned int >())// constructor without a turbulence model
 		.def(init<unsigned int, Kratos::Variable<double>&>())// constructor with a non-default flag for slip conditions
 		;
-            
+
     class_< GearScheme< SparseSpaceType, LocalSpaceType >,
             typename GearScheme< SparseSpaceType, LocalSpaceType >::Pointer,
             BaseSchemeType >

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/residualbased_predictorcorrector_velocity_bossak_scheme_turbulent.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/residualbased_predictorcorrector_velocity_bossak_scheme_turbulent.h
@@ -140,7 +140,6 @@ namespace Kratos {
          */
         ResidualBasedPredictorCorrectorVelocityBossakSchemeTurbulent(
             double NewAlphaBossak,
-            double MoveMeshStrategy,
             unsigned int DomainSize,
             const Variable<int>& rPeriodicIdVar)
         :
@@ -152,7 +151,7 @@ namespace Kratos {
             mAlphaBossak = NewAlphaBossak;
             mBetaNewmark = 0.25 * pow((1.00 - mAlphaBossak), 2);
             mGammaNewmark = 0.5 - mAlphaBossak;
-            mMeshVelocity = MoveMeshStrategy;
+            mMeshVelocity = 0.0;
 
 
             //Allocate auxiliary memory

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
@@ -259,7 +259,6 @@ class NavierStokesSolverMonolithic(FluidSolver):
                 if self.settings["consider_periodic_conditions"].GetBool() == True:
                     self.time_scheme = KratosCFD.ResidualBasedPredictorCorrectorVelocityBossakSchemeTurbulent(
                                         self.settings["alpha"].GetDouble(),
-                                        self.settings["move_mesh_strategy"].GetInt(),
                                         self.computing_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE],
                                         KratosCFD.PATCH_INDEX)
                 else:

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
@@ -147,14 +147,13 @@ class TrilinosNavierStokesSolverMonolithic(navier_stokes_solver_vmsmonolithic.Na
                                                                self.settings["absolute_velocity_tolerance"].GetDouble(),
                                                                self.settings["relative_pressure_tolerance"].GetDouble(),
                                                                self.settings["absolute_pressure_tolerance"].GetDouble())
-                                                               
+
         (self.conv_criteria).SetEchoLevel(self.settings["echo_level"].GetInt())
 
         ## Creating the Trilinos time scheme
         if (self.settings["turbulence_model"].GetString() == "None"):
             if self.settings["consider_periodic_conditions"].GetBool() == True:
                 self.time_scheme = KratosTrilinos.TrilinosPredictorCorrectorVelocityBossakSchemeTurbulent(self.settings["alpha"].GetDouble(),
-                                                                                                          self.settings["move_mesh_strategy"].GetInt(),
                                                                                                           self.computing_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE],
                                                                                                           KratosCFD.PATCH_INDEX)
             else:

--- a/applications/trilinos_application/custom_python/add_trilinos_schemes_to_python.cpp
+++ b/applications/trilinos_application/custom_python/add_trilinos_schemes_to_python.cpp
@@ -197,7 +197,7 @@ void  AddSchemes(pybind11::module& m)
         (m,"TrilinosPredictorCorrectorVelocityBossakSchemeTurbulent")
         .def(init<double, double, unsigned int, Process::Pointer >())
         .def(init<double,double,unsigned int >())
-        .def(init<double,double,unsigned int, const Variable<int>&>())
+        .def(init<double,unsigned int, const Variable<int>&>())
         ;
 
     class_ <


### PR DESCRIPTION
I am rearranging the constructor arguments of the fluid bossak scheme to sidestep a limitation with the way pybind treats function overloading (it cannot properly choose between two alternative constructors).

This closes #2008.