### PR TITLE
[core] Fix for std::vector operator <<

### DIFF
--- a/kratos/tests/utilities/test_stl_io.cpp
+++ b/kratos/tests/utilities/test_stl_io.cpp
@@ -22,27 +22,23 @@ namespace Testing {
 
 KRATOS_TEST_CASE_IN_SUITE(StdVectorOutputStream, KratosCoreFastSuite)
 {
+    using Kratos::operator<<; // needed bcs it is inside the namespace "Testing"
+
     std::vector<int> int_vector {1,5,-63,581,6};
     std::vector<double> double_vector {4.335, 8.639, -888.47, 9874.0};
     std::vector<std::string> string_vector {"val_1", "custom", "again_test"};
 
-    std::cout << int_vector;
+    std::stringstream ss_int;
+    ss_int << int_vector;
+    KRATOS_CHECK_EQUAL(ss_int.str(), "[1, 5, -63, 581, 6]");
 
-    // std::stringstream ss;
-    // ss << out.rdbuf();
-    // std::string myString = ss.str();
+    std::stringstream ss_double;
+    ss_double << double_vector;
+    KRATOS_CHECK_EQUAL(ss_double.str(), "[4.335, 8.639, -888.47, 9874]");
 
-    // std::ostream ss_int;
-    // ss_int << int_vector;
-    // KRATOS_CHECK_EQUAL(ss_int.rdbuf().str(), "label");
-
-    // std::stringstream ss_double;
-    // ss_double << double_vector;
-    // KRATOS_CHECK_EQUAL(ss_double.str(), "label");
-
-    // std::stringstream ss_string;
-    // ss_string << string_vector;
-    // KRATOS_CHECK_EQUAL(ss_string.str(), "label");
+    std::stringstream ss_string;
+    ss_string << string_vector;
+    KRATOS_CHECK_EQUAL(ss_string.str(), "[val_1, custom, again_test]");
 }
 
 }   // namespace Testing

--- a/kratos/tests/utilities/test_stl_io.cpp
+++ b/kratos/tests/utilities/test_stl_io.cpp
@@ -1,0 +1,51 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher
+//
+//
+
+
+// Project includes
+#include "testing/testing.h"
+#include "utilities/stl_io.h"
+
+
+namespace Kratos {
+namespace Testing {
+
+KRATOS_TEST_CASE_IN_SUITE(StdVectorOutputStream, KratosCoreFastSuite)
+{
+    std::vector<int> int_vector {1,5,-63,581,6};
+    std::vector<double> double_vector {4.335, 8.639, -888.47, 9874.0};
+    std::vector<std::string> string_vector {"val_1", "custom", "again_test"};
+
+    std::cout << int_vector;
+
+    // std::stringstream ss;
+    // ss << out.rdbuf();
+    // std::string myString = ss.str();
+
+    // std::ostream ss_int;
+    // ss_int << int_vector;
+    // KRATOS_CHECK_EQUAL(ss_int.rdbuf().str(), "label");
+
+    // std::stringstream ss_double;
+    // ss_double << double_vector;
+    // KRATOS_CHECK_EQUAL(ss_double.str(), "label");
+
+    // std::stringstream ss_string;
+    // ss_string << string_vector;
+    // KRATOS_CHECK_EQUAL(ss_string.str(), "label");
+}
+
+}   // namespace Testing
+}  // namespace Kratos.
+
+

--- a/kratos/utilities/stl_io.h
+++ b/kratos/utilities/stl_io.h
@@ -31,11 +31,12 @@ namespace Kratos {
 template<class T>
 std::ostream& operator<<(std::ostream& os, const std::vector<T> & data) {
 
+    std::size_t vector_size = data.size();
+
     os << "[";
-    const int vector_size = static_cast<int>(data.size());
-    if(vector_size) os << data[0];
+    if(vector_size>0) os << data[0];
     if(vector_size>1) {
-        for(int i = 1; i < vector_size; i++) {
+        for(std::size_t i = 1; i < vector_size; i++) {
             os<<", "<<data[i];
         }
     }

--- a/kratos/utilities/stl_io.h
+++ b/kratos/utilities/stl_io.h
@@ -31,9 +31,15 @@ namespace Kratos {
 template<class T>
 std::ostream& operator<<(std::ostream& os, const std::vector<T> & data) {
 
-    std::cout << "[";
-    std::copy(data.begin(), data.end(), std::ostream_iterator<T>(std::cout, ", "));
-    std::cout << "]";
+    os << "[";
+    const int vector_size = static_cast<int>(data.size());
+    if(vector_size) os << data[0];
+    if(vector_size>1) {
+        for(int i = 1; i < vector_size; i++) {
+            os<<", "<<data[i];
+        }
+    }
+    os << "]";
 
     return os;
 }

--- a/kratos/utilities/stl_io.h
+++ b/kratos/utilities/stl_io.h
@@ -15,34 +15,26 @@
 #define  KRATOS_KRATOS_STL_IO_H_INCLUDED
 
 // System includes
-#include <algorithm>
-#include <iterator>
-#include <iostream>
-#include <vector>
 
 // Project includes
 #include "includes/define.h"
 
-// Std::vecotr << operator
-
 namespace Kratos {
 
-// Std::vector << operator
 template<class T>
-std::ostream& operator<<(std::ostream& os, const std::vector<T> & data) {
+std::ostream& operator<<(std::ostream& rOStream, const std::vector<T>& rVec) {
 
-    std::size_t vector_size = data.size();
+    std::size_t vector_size = rVec.size();
 
-    os << "[";
-    if(vector_size>0) os << data[0];
+    rOStream << "[";
+    if(vector_size>0) rOStream << rVec[0];
     if(vector_size>1) {
-        for(std::size_t i = 1; i < vector_size; i++) {
-            os<<", "<<data[i];
-        }
+        for(std::size_t i = 1; i < vector_size; i++)
+            rOStream<<", "<<rVec[i];
     }
-    os << "]";
+    rOStream << "]";
 
-    return os;
+    return rOStream;
 }
 
 } //namespace Kratos

--- a/kratos/utilities/stl_io.h
+++ b/kratos/utilities/stl_io.h
@@ -2,13 +2,13 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Carlos A. Roig
-//                    
+//
 //
 
 #if !defined(KRATOS_KRATOS_STL_IO_H_INCLUDED )
@@ -24,14 +24,21 @@
 #include "includes/define.h"
 
 // Std::vecotr << operator
+
+namespace Kratos {
+
+// Std::vector << operator
 template<class T>
 std::ostream& operator<<(std::ostream& os, const std::vector<T> & data) {
 
     std::cout << "[";
     std::copy(data.begin(), data.end(), std::ostream_iterator<T>(std::cout, ", "));
-    std::cout << "[";
-    
+    std::cout << "]";
+
     return os;
 }
+
+} //namespace Kratos
+
 
 #endif // KRATOS_KRATOS_STL_IO_H_INCLUDED  defined

--- a/kratos/utilities/stl_io.h
+++ b/kratos/utilities/stl_io.h
@@ -15,6 +15,8 @@
 #define  KRATOS_KRATOS_STL_IO_H_INCLUDED
 
 // System includes
+#include <iostream>
+#include <vector>
 
 // Project includes
 #include "includes/define.h"


### PR DESCRIPTION
A namespace was missing.
Bug noted by @philbucher in #849.