### PR TITLE
[convection-diffussion] Adding variables.h to avoid compiler error

### DIFF
--- a/applications/convection_diffusion_application/custom_conditions/flux_condition.cpp
+++ b/applications/convection_diffusion_application/custom_conditions/flux_condition.cpp
@@ -12,6 +12,7 @@
 
 #include "flux_condition.h"
 #include "includes/convection_diffusion_settings.h"
+#include "includes/variables.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
Avoids the  error: ‘NORMAL’ was not declared in this scope