### PR TITLE
[ParticleMechanics] Volume and density preservation in non-isochoric flow rule

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_constitutive/hencky_plastic_3d_law.hpp
+++ b/applications/ParticleMechanicsApplication/custom_constitutive/hencky_plastic_3d_law.hpp
@@ -233,7 +233,7 @@ protected:
     ///@}
     ///@name Protected member Variables
     ///@{
-    double mPlasticRegion;
+    unsigned int mPlasticRegion;
     Matrix mPlasticDeformationGradient;
     Matrix mElasticLeftCauchyGreen;
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -195,7 +195,7 @@ void UpdatedLagrangian::InitializeGeneralVariables (GeneralVariables& rVariables
     rVariables.F.resize( dimension, dimension );
 
     rVariables.F0.resize( dimension, dimension );
-
+    
     rVariables.FT.resize( dimension, dimension );
 
     rVariables.ConstitutiveMatrix.resize( voigtsize, voigtsize );
@@ -345,6 +345,10 @@ void UpdatedLagrangian::CalculateElementalSystem( LocalSystemComponents& rLocalS
     The function below will call CalculateMaterialResponseCauchy() by default and then (may)
     call CalculateMaterialResponseKirchhoff() in the constitutive_law.*/
     mConstitutiveLawVector->CalculateMaterialResponse(Values, Variables.StressMeasure);
+
+    // Update the total determinant of deformation gradient after return mapping
+    // This is necessary for non-isochoric return mapping
+    Variables.detFT = Values.GetDeterminantF();
 
     /* NOTE:
     The material points will have constant mass as defined at the beginning.

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
@@ -371,6 +371,10 @@ void UpdatedLagrangianQuadrilateral::CalculateElementalSystem( LocalSystemCompon
         this->SetValue(PREVIOUS_MP_ALMANSI_STRAIN_VECTOR, Variables.StrainVector);
     }
 
+    // Update the total determinant of deformation gradient after return mapping
+    // This is necessary for non-isochoric return mapping
+    Variables.detFT = Values.GetDeterminantF();
+
     /* NOTE:
     The material points will have constant mass as defined at the beginning.
     However, the density and volume (integration weight) are changing every time step.*/


### PR DESCRIPTION
I modified the computation of detFT after the return mapping is done to get an accurate update of volume and density as discussed with @antonialarese.