### PR TITLE
Adding gid-post files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,12 @@ kratos/includes/kratos_version.h
 *.a
 *.lib
 
+# GiD post files
+*.post.res
+*.post.msh
+*.post.bin
+*.post.lst
+
 # Output of tests of meshing application (MMG)
 *.sol
 *.mesh


### PR DESCRIPTION
I am suggesting to add the GiD-post files to gitignore

E.g. when one is debugging tests with output it is handy not to have these files messing up the git-stuff