### PR TITLE
Node[Curve/Surface]Geometry3D

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "applications/PfemApplication/external_modules/tetgen"]
 	path = applications/PfemApplication/external_modules/tetgen
 	url = https://github.com/PFEM/tetgen.git
+[submodule "external_libraries/ANurbs"]
+	path = external_libraries/ANurbs
+	url = https://github.com/oberbichler/ANurbs.git

--- a/applications/NurbsBrepApplication/CMakeLists.txt
+++ b/applications/NurbsBrepApplication/CMakeLists.txt
@@ -5,7 +5,10 @@ message("**** configuring KratosNurbBrepApplication ****")
 ################### PYBIND11
 include(pybind11Tools)
 
-include_directories( ${CMAKE_SOURCE_DIR}/kratos )
+include_directories(
+  ${CMAKE_SOURCE_DIR}/kratos
+  ${CMAKE_SOURCE_DIR}/external_libraries/ANurbs/include
+)
 
 file(GLOB KRATOS_NURBS_BREP_APPLICATION_BREP_SOURCES
                                                 "${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/*.h"

--- a/applications/NurbsBrepApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/NurbsBrepApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -97,39 +97,39 @@ namespace Python
 
             pybind11::class_<Type, Pointer>(m, "NodeCurveGeometry3D")
                 .def(pybind11::init<int, int>(),
-                    "degree"_a,
-                    "nbNodes"_a)
+                    "Degree"_a,
+                    "NbNodes"_a)
                 .def("Knot", &Type::Knot,
-                    "index"_a)
+                    "Index"_a)
                 .def("SetKnot", &Type::SetKnot,
-                    "index"_a,
-                    "value"_a)
+                    "Index"_a,
+                    "Value"_a)
                 .def("Knots", &Type::Knots)
                 .def("Node", &Type::Node,
-                    "index"_a)
+                    "Index"_a)
                 .def("SetNode", &Type::SetNode,
-                    "index"_a,
-                    "value"_a)
+                    "Index"_a,
+                    "Value"_a)
                 .def("Pole", &Type::Pole,
-                    "index"_a)
+                    "Index"_a)
                 .def("SetPole", &Type::SetPole,
-                    "index"_a,
-                    "value"_a)
+                    "Index"_a,
+                    "Value"_a)
                 .def("Weight", &Type::Weight,
-                    "index"_a)
+                    "Index"_a)
                 .def("SetWeight", &Type::SetWeight,
-                    "index"_a,
-                    "value"_a)
+                    "Index"_a,
+                    "Value"_a)
                 .def("PointAt", &Type::PointAt,
-                    "t"_a)
+                    "T"_a)
                 .def("Spans", &Type::Spans)
                 .def("ValueAt", &Type::ValueAt<double>,
-                    "variable"_a,
-                    "t"_a)
+                    "Variable"_a,
+                    "T"_a)
                 .def("ValueAt2", &Type::ValueAt2<double>,
-                    "variable"_a,
-                    "t"_a,
-                    "order"_a)
+                    "Variable"_a,
+                    "T"_a,
+                    "Order"_a)
             ;
         }
 
@@ -140,40 +140,40 @@ namespace Python
 
             pybind11::class_<Type, Pointer>(m, "NodeSurfaceGeometry3D")
                 .def(pybind11::init<int, int, int, int>(),
-                    "degreeU"_a,
-                    "degreeV"_a,
-                    "nbNodesU"_a,
-                    "nbNodesV"_a)
+                    "DegreeU"_a,
+                    "DegreeV"_a,
+                    "NbNodesU"_a,
+                    "NbNodesV"_a)
                 .def("SetKnotU", &Type::SetKnotU,
-                    "index"_a,
-                    "value"_a)
+                    "Index"_a,
+                    "Value"_a)
                 .def("SetKnotV", &Type::SetKnotV,
-                    "index"_a,
-                    "value"_a)
+                    "Index"_a,
+                    "Value"_a)
                 .def("Node", &Type::Node,
-                    "indexU"_a,
-                    "indexV"_a)
+                    "IndexU"_a,
+                    "IndexV"_a)
                 .def("SetNode", &Type::SetNode,
-                    "indexU"_a,
-                    "indexV"_a,
-                    "value"_a)
+                    "IndexU"_a,
+                    "IndexV"_a,
+                    "Value"_a)
                 .def("Pole", &Type::Pole,
-                    "indexU"_a,
-                    "indexV"_a)
+                    "IndexU"_a,
+                    "IndexV"_a)
                 .def("SetPole", &Type::SetPole,
-                    "indexU"_a,
-                    "indexV"_a,
-                    "value"_a)
+                    "IndexU"_a,
+                    "IndexV"_a,
+                    "Value"_a)
                 .def("Weight", &Type::Weight,
-                    "indexU"_a,
-                    "indexV"_a)
+                    "IndexU"_a,
+                    "IndexV"_a)
                 .def("SetWeight", &Type::SetWeight,
-                    "indexU"_a,
-                    "indexV"_a,
-                    "value"_a)
+                    "IndexU"_a,
+                    "IndexV"_a,
+                    "Value"_a)
                 .def("PointAt", &Type::PointAt,
-                    "u"_a,
-                    "v"_a)
+                    "U"_a,
+                    "V"_a)
             ;
         }
     }

--- a/applications/NurbsBrepApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/NurbsBrepApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -120,13 +120,16 @@ namespace Python
                 .def("SetWeight", &Type::SetWeight,
                     "Index"_a,
                     "Value"_a)
+                .def("Spans", &Type::Spans)
                 .def("PointAt", &Type::PointAt,
                     "T"_a)
-                .def("Spans", &Type::Spans)
+                .def("DerivativesAt", &Type::DerivativesAt,
+                    "T"_a,
+                    "Order"_a)
                 .def("ValueAt", &Type::ValueAt<double>,
                     "Variable"_a,
                     "T"_a)
-                .def("ValueAt2", &Type::ValueAt2<double>,
+                .def("ValueAt", &Type::ValueAt2<double>,
                     "Variable"_a,
                     "T"_a,
                     "Order"_a)
@@ -174,6 +177,19 @@ namespace Python
                 .def("PointAt", &Type::PointAt,
                     "U"_a,
                     "V"_a)
+                .def("DerivativesAt", &Type::DerivativesAt,
+                    "U"_a,
+                    "V"_a,
+                    "Order"_a)
+                .def("ValueAt", &Type::ValueAt<double>,
+                    "Variable"_a,
+                    "U"_a,
+                    "V"_a)
+                .def("ValueAt", &Type::ValueAt2<double>,
+                    "Variable"_a,
+                    "U"_a,
+                    "V"_a,
+                    "Order"_a)
             ;
         }
     }

--- a/applications/NurbsBrepApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/NurbsBrepApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -9,11 +9,13 @@
 //
 //  Main authors:    Tobias Teschemacher
 //                   Riccardo Rossi
+//                   Thomas Oberbichler
 //
 
 // System includes
 
 // External includes
+#include <ANurbs/Core>
 
 // Project includes
 #include "includes/define_python.h"
@@ -27,39 +29,154 @@
 #include "custom_utilities/NurbsBrepModeler.h"
 #include "custom_utilities/BrepModelGeometryReader.h"
 
+#include "custom_utilities/geometries/NodeCurveGeometry3D.h"
+#include "custom_utilities/geometries/NodeSurfaceGeometry3D.h"
+
 namespace Kratos
 {
 
 namespace Python
 {
 
-	void  AddCustomUtilitiesToPython(pybind11::module& m)
-	{
-		using namespace pybind11;
+    void  AddCustomUtilitiesToPython(pybind11::module& m)
+    {
+        using namespace pybind11;
+        using namespace pybind11::literals;
+
+        typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
+        typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
+        typedef LinearSolver<SparseSpaceType, LocalSpaceType > LinearSolverType;
 
 
-		typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
-		typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
-		typedef LinearSolver<SparseSpaceType, LocalSpaceType > LinearSolverType;
+        class_<NurbsBrepModeler, typename NurbsBrepModeler::Pointer>(m, "NurbsBrepModeler")
+            .def(init<ModelPart::Pointer>())
+            .def("LoadGeometry", &NurbsBrepModeler::LoadGeometry)
+            .def("CreateIntegrationDomain", &NurbsBrepModeler::CreateIntegrationDomain)
+            .def("ApplyGeometryRefinement", &NurbsBrepModeler::ApplyGeometryRefinement)
+            .def("ComputeArea", &NurbsBrepModeler::ComputeArea)
+            .def("MapNode", &NurbsBrepModeler::MapNode)
+            .def("GetInterfaceConditions", &NurbsBrepModeler::GetInterfaceConditions)
+            ;
+
+        class_<BrepModelGeometryReader, typename BrepModelGeometryReader::Pointer>(m, "BrepModelGeometryReader")
+            .def(init<Parameters&>())
+            .def("ReadGeometry", &BrepModelGeometryReader::ReadGeometry)
+            .def("WriteGaussPoints", &BrepModelGeometryReader::WriteGaussPoints)
+            .def("WriteGaussPointsJson", &BrepModelGeometryReader::WriteGaussPointsJson)
+            ;
 
 
-		class_<NurbsBrepModeler, typename NurbsBrepModeler::Pointer>(m, "NurbsBrepModeler")
-			.def(init<ModelPart::Pointer>())
-			.def("LoadGeometry", &NurbsBrepModeler::LoadGeometry)
-			.def("CreateIntegrationDomain", &NurbsBrepModeler::CreateIntegrationDomain)
-			.def("ApplyGeometryRefinement", &NurbsBrepModeler::ApplyGeometryRefinement)
-			.def("ComputeArea", &NurbsBrepModeler::ComputeArea)
-			.def("MapNode", &NurbsBrepModeler::MapNode)
-			.def("GetInterfaceConditions", &NurbsBrepModeler::GetInterfaceConditions)
-			;
+        // --- register geometries
 
-		class_<BrepModelGeometryReader, typename BrepModelGeometryReader::Pointer>(m, "BrepModelGeometryReader")
-			.def(init<Parameters&>())
-			.def("ReadGeometry", &BrepModelGeometryReader::ReadGeometry)
-			.def("WriteGaussPoints", &BrepModelGeometryReader::WriteGaussPoints)
-			.def("WriteGaussPointsJson", &BrepModelGeometryReader::WriteGaussPointsJson)
-			;
-	}
+        // register Point3d
+        {
+            using Type = ANurbs::Point3D;
+
+            pybind11::class_<Type>(m, "Point3D")
+                .def_property_readonly("X", &Type::X)
+                .def_property_readonly("Y", &Type::Y)
+                .def_property_readonly("Z", &Type::Z)
+            ;
+        }
+
+        // register Interval
+        {
+            using Type = ANurbs::Interval<double>;
+
+            pybind11::class_<Type>(m, "Interval")
+                .def(pybind11::init<double, double>())
+                .def_property_readonly("T0", &Type::T0)
+                .def_property_readonly("T1", &Type::T1)
+            ;
+        }
+
+        // register NodalCurveGeometry
+        {
+            using Type = NodeCurveGeometry3D;
+            using Pointer = std::shared_ptr<Type>;
+
+            pybind11::class_<Type, Pointer>(m, "NodeCurveGeometry3D")
+                .def(pybind11::init<int, int>(),
+                    "degree"_a,
+                    "nbNodes"_a)
+                .def("Knot", &Type::Knot,
+                    "index"_a)
+                .def("SetKnot", &Type::SetKnot,
+                    "index"_a,
+                    "value"_a)
+                .def("Knots", &Type::Knots)
+                .def("Node", &Type::Node,
+                    "index"_a)
+                .def("SetNode", &Type::SetNode,
+                    "index"_a,
+                    "value"_a)
+                .def("Pole", &Type::Pole,
+                    "index"_a)
+                .def("SetPole", &Type::SetPole,
+                    "index"_a,
+                    "value"_a)
+                .def("Weight", &Type::Weight,
+                    "index"_a)
+                .def("SetWeight", &Type::SetWeight,
+                    "index"_a,
+                    "value"_a)
+                .def("PointAt", &Type::PointAt,
+                    "t"_a)
+                .def("Spans", &Type::Spans)
+                .def("ValueAt", &Type::ValueAt<double>,
+                    "variable"_a,
+                    "t"_a)
+                .def("ValueAt2", &Type::ValueAt2<double>,
+                    "variable"_a,
+                    "t"_a,
+                    "order"_a)
+            ;
+        }
+
+        // register NodalSurfaceGeometry
+        {
+            using Type = NodeSurfaceGeometry3D;
+            using Pointer = std::shared_ptr<Type>;
+
+            pybind11::class_<Type, Pointer>(m, "NodeSurfaceGeometry3D")
+                .def(pybind11::init<int, int, int, int>(),
+                    "degreeU"_a,
+                    "degreeV"_a,
+                    "nbNodesU"_a,
+                    "nbNodesV"_a)
+                .def("SetKnotU", &Type::SetKnotU,
+                    "index"_a,
+                    "value"_a)
+                .def("SetKnotV", &Type::SetKnotV,
+                    "index"_a,
+                    "value"_a)
+                .def("Node", &Type::Node,
+                    "indexU"_a,
+                    "indexV"_a)
+                .def("SetNode", &Type::SetNode,
+                    "indexU"_a,
+                    "indexV"_a,
+                    "value"_a)
+                .def("Pole", &Type::Pole,
+                    "indexU"_a,
+                    "indexV"_a)
+                .def("SetPole", &Type::SetPole,
+                    "indexU"_a,
+                    "indexV"_a,
+                    "value"_a)
+                .def("Weight", &Type::Weight,
+                    "indexU"_a,
+                    "indexV"_a)
+                .def("SetWeight", &Type::SetWeight,
+                    "indexU"_a,
+                    "indexV"_a,
+                    "value"_a)
+                .def("PointAt", &Type::PointAt,
+                    "u"_a,
+                    "v"_a)
+            ;
+        }
+    }
 
 }  // namespace Python.
 

--- a/applications/NurbsBrepApplication/custom_utilities/geometries/NodeCurveGeometry3D.h
+++ b/applications/NurbsBrepApplication/custom_utilities/geometries/NodeCurveGeometry3D.h
@@ -35,9 +35,9 @@ protected:
 public:
     NodeCurveGeometry3D(
         const int Degree,
-        const int NbNodes)
-        : CurveGeometryBaseType(Degree, NbNodes)
-        , mNodes(NbNodes)
+        const int NumberOfNodes)
+        : CurveGeometryBaseType(Degree, NumberOfNodes)
+        , mNodes(NumberOfNodes)
     {
     }
 

--- a/applications/NurbsBrepApplication/custom_utilities/geometries/NodeCurveGeometry3D.h
+++ b/applications/NurbsBrepApplication/custom_utilities/geometries/NodeCurveGeometry3D.h
@@ -24,7 +24,8 @@ protected:
     using typename NodePointer = typename Node<3>::Pointer;
 
 public:
-    using CurveGeometryBaseType = ANurbs::CurveGeometryBase<double, ANurbs::Point3D>;
+    using CurveGeometryBaseType = ANurbs::CurveGeometryBase<double,
+        ANurbs::Point3D>;
     using typename CurveGeometryBaseType::KnotsType;
     using typename CurveGeometryBaseType::ScalarType;
     using typename CurveGeometryBaseType::VectorType;

--- a/applications/NurbsBrepApplication/custom_utilities/geometries/NodeCurveGeometry3D.h
+++ b/applications/NurbsBrepApplication/custom_utilities/geometries/NodeCurveGeometry3D.h
@@ -1,0 +1,136 @@
+/*
+//  KRATOS _____________ 
+//        /  _/ ____/   |
+//        / // / __/ /| |
+//      _/ // /_/ / ___ |
+//     /___/\____/_/  |_| StructuralMechanicsApplication
+//
+//  Author: Thomas Oberbichler
+*/
+
+#pragma once
+
+#include <ANurbs/Core>
+
+
+namespace Kratos {
+
+using NodalCurveControlPoints = std::vector<typename Node<3>::Pointer>;
+
+class NodeCurveGeometry3D
+: public ANurbs::CurveGeometryBase<double, ANurbs::Point3D>
+{
+protected:
+    using typename NodePointer = typename Node<3>::Pointer;
+
+public:
+    using CurveGeometryBaseType = ANurbs::CurveGeometryBase<double, ANurbs::Point3D>;
+    using typename CurveGeometryBaseType::KnotsType;
+    using typename CurveGeometryBaseType::ScalarType;
+    using typename CurveGeometryBaseType::VectorType;
+
+protected:
+    std::vector<NodePointer> m_nodes;
+
+public:
+    NodeCurveGeometry3D(
+        const int& degree,
+        const int& nbNodes)
+        : CurveGeometryBaseType(degree, nbNodes)
+        , m_nodes(nbNodes)
+    {
+    }
+
+    NodePointer
+    Node(
+        const int& index
+    ) const
+    {
+        return m_nodes[index];
+    }
+
+    void
+    SetNode(
+        const int& index,
+        NodePointer value
+    )
+    {
+        m_nodes[index] = value;
+    }
+
+    VectorType
+    Pole(
+        const int& index) const override
+    {
+        auto node = Node(index);
+
+        VectorType pole;
+        pole[0] = node->X();
+        pole[1] = node->Y();
+        pole[2] = node->Z();
+
+        return pole;
+    }
+
+    void
+    SetPole(
+        const int& index,
+        const VectorType& value) override
+    {
+        auto node = Node(index);
+
+        node->X() = value.X();
+        node->Y() = value.Y();
+        node->Z() = value.Z();
+    }
+
+    bool
+    IsRational() const override
+    {
+        return true;
+    }
+
+    ScalarType
+    Weight(
+        const int& index) const override
+    {
+        auto node = Node(index);
+
+        return node->GetValue(Kratos::INTEGRATION_WEIGHT); // FIXME use WEIGHT
+    }
+
+    void
+    SetWeight(
+        const int& index,
+        const ScalarType& value) override
+    {
+        auto node = Node(index);
+
+        node->SetValue(Kratos::INTEGRATION_WEIGHT, value); // FIXME use WEIGHT
+    }
+    
+    template <typename TDataType>
+    TDataType
+    ValueAt(
+        const Variable<TDataType>& variable,
+        const double& t)
+    {
+        return EvaluateAt<TDataType>([&](int i) -> TDataType {
+            return Node(i)->GetValue(variable);
+        }, t);
+    }
+    
+    template <typename TDataType>
+    std::vector<TDataType>
+    ValueAt2( // FIXME use pybind overloading
+        const Variable<TDataType>& variable,
+        const double& t,
+        const int& order)
+    {
+        return EvaluateAt<TDataType>([&](int i) -> TDataType {
+            return Node(i)->GetValue(variable);
+        }, t, order);
+    }
+};
+
+} // namespace Kratos

--- a/applications/NurbsBrepApplication/custom_utilities/geometries/NodeCurveGeometry3D.h
+++ b/applications/NurbsBrepApplication/custom_utilities/geometries/NodeCurveGeometry3D.h
@@ -30,39 +30,39 @@ public:
     using typename CurveGeometryBaseType::VectorType;
 
 protected:
-    std::vector<NodePointer> m_nodes;
+    std::vector<NodePointer> mNodes;
 
 public:
     NodeCurveGeometry3D(
-        const int& degree,
-        const int& nbNodes)
-        : CurveGeometryBaseType(degree, nbNodes)
-        , m_nodes(nbNodes)
+        const int& Degree,
+        const int& NbNodes)
+        : CurveGeometryBaseType(Degree, NbNodes)
+        , mNodes(NbNodes)
     {
     }
 
     NodePointer
     Node(
-        const int& index
+        const int& Index
     ) const
     {
-        return m_nodes[index];
+        return mNodes[Index];
     }
 
     void
     SetNode(
-        const int& index,
-        NodePointer value
+        const int& Index,
+        NodePointer Value
     )
     {
-        m_nodes[index] = value;
+        mNodes[Index] = Value;
     }
 
     VectorType
     Pole(
-        const int& index) const override
+        const int& Index) const override
     {
-        auto node = Node(index);
+        auto node = Node(Index);
 
         VectorType pole;
         pole[0] = node->X();
@@ -74,14 +74,14 @@ public:
 
     void
     SetPole(
-        const int& index,
-        const VectorType& value) override
+        const int& Index,
+        const VectorType& Value) override
     {
-        auto node = Node(index);
+        auto node = Node(Index);
 
-        node->X() = value.X();
-        node->Y() = value.Y();
-        node->Z() = value.Z();
+        node->X() = Value.X();
+        node->Y() = Value.Y();
+        node->Z() = Value.Z();
     }
 
     bool
@@ -92,44 +92,44 @@ public:
 
     ScalarType
     Weight(
-        const int& index) const override
+        const int& Index) const override
     {
-        auto node = Node(index);
+        auto node = Node(Index);
 
         return node->GetValue(Kratos::INTEGRATION_WEIGHT); // FIXME use WEIGHT
     }
 
     void
     SetWeight(
-        const int& index,
-        const ScalarType& value) override
+        const int& Index,
+        const ScalarType& Value) override
     {
-        auto node = Node(index);
+        auto node = Node(Index);
 
-        node->SetValue(Kratos::INTEGRATION_WEIGHT, value); // FIXME use WEIGHT
+        node->SetValue(Kratos::INTEGRATION_WEIGHT, Value); // FIXME use WEIGHT
     }
     
     template <typename TDataType>
     TDataType
     ValueAt(
-        const Variable<TDataType>& variable,
-        const double& t)
+        const Variable<TDataType>& Variable,
+        const double& T)
     {
         return EvaluateAt<TDataType>([&](int i) -> TDataType {
-            return Node(i)->GetValue(variable);
-        }, t);
+            return Node(i)->GetValue(Variable);
+        }, T);
     }
     
     template <typename TDataType>
     std::vector<TDataType>
     ValueAt2( // FIXME use pybind overloading
-        const Variable<TDataType>& variable,
-        const double& t,
-        const int& order)
+        const Variable<TDataType>& Variable,
+        const double& T,
+        const int& Order)
     {
         return EvaluateAt<TDataType>([&](int i) -> TDataType {
-            return Node(i)->GetValue(variable);
-        }, t, order);
+            return Node(i)->GetValue(Variable);
+        }, T, Order);
     }
 };
 

--- a/applications/NurbsBrepApplication/custom_utilities/geometries/NodeCurveGeometry3D.h
+++ b/applications/NurbsBrepApplication/custom_utilities/geometries/NodeCurveGeometry3D.h
@@ -34,8 +34,8 @@ protected:
 
 public:
     NodeCurveGeometry3D(
-        const int& Degree,
-        const int& NbNodes)
+        const int Degree,
+        const int NbNodes)
         : CurveGeometryBaseType(Degree, NbNodes)
         , mNodes(NbNodes)
     {
@@ -43,7 +43,7 @@ public:
 
     NodePointer
     Node(
-        const int& Index
+        const int Index
     ) const
     {
         return mNodes[Index];
@@ -51,7 +51,7 @@ public:
 
     void
     SetNode(
-        const int& Index,
+        const int Index,
         NodePointer Value
     )
     {
@@ -60,7 +60,7 @@ public:
 
     VectorType
     Pole(
-        const int& Index) const override
+        const int Index) const override
     {
         auto node = Node(Index);
 
@@ -74,7 +74,7 @@ public:
 
     void
     SetPole(
-        const int& Index,
+        const int Index,
         const VectorType& Value) override
     {
         auto node = Node(Index);
@@ -92,7 +92,7 @@ public:
 
     ScalarType
     Weight(
-        const int& Index) const override
+        const int Index) const override
     {
         auto node = Node(Index);
 
@@ -101,8 +101,8 @@ public:
 
     void
     SetWeight(
-        const int& Index,
-        const ScalarType& Value) override
+        const int Index,
+        const ScalarType Value) override
     {
         auto node = Node(Index);
 
@@ -125,7 +125,7 @@ public:
     ValueAt2( // FIXME use pybind overloading
         const Variable<TDataType>& Variable,
         const double& T,
-        const int& Order)
+        const int Order)
     {
         return EvaluateAt<TDataType>([&](int i) -> TDataType {
             return Node(i)->GetValue(Variable);

--- a/applications/NurbsBrepApplication/custom_utilities/geometries/NodeSurfaceGeometry3D.h
+++ b/applications/NurbsBrepApplication/custom_utilities/geometries/NodeSurfaceGeometry3D.h
@@ -32,10 +32,10 @@ protected:
 
 public:
     NodeSurfaceGeometry3D(
-        const int& DegreeU,
-        const int& DegreeV,
-        const int& NbNodesU,
-        const int& NbNodesV)
+        const int DegreeU,
+        const int DegreeV,
+        const int NbNodesU,
+        const int NbNodesV)
         : SurfaceGeometryBaseType(DegreeU, DegreeV, NbNodesU, NbNodesV)
         , mNodes(NbNodesU, NbNodesV)
     {
@@ -43,16 +43,16 @@ public:
 
     NodePointer
     Node(
-        const int& IndexU,
-        const int& IndexV) const
+        const int IndexU,
+        const int IndexV) const
     {
         return mNodes(IndexU, IndexV);
     }
 
     void
     SetNode(
-        const int& IndexU,
-        const int& IndexV,
+        const int IndexU,
+        const int IndexV,
         NodePointer Value)
     {
         mNodes(IndexU, IndexV) = Value;
@@ -60,8 +60,8 @@ public:
 
     VectorType
     Pole(
-        const int& IndexU,
-        const int& IndexV) const override
+        const int IndexU,
+        const int IndexV) const override
     {
         auto node = Node(IndexU, IndexV);
 
@@ -75,8 +75,8 @@ public:
 
     void
     SetPole(
-        const int& IndexU,
-        const int& IndexV,
+        const int IndexU,
+        const int IndexV,
         const VectorType& Value) override
     {
         auto node = Node(IndexU, IndexV);
@@ -94,8 +94,8 @@ public:
 
     ScalarType
     Weight(
-        const int& IndexU,
-        const int& IndexV) const override
+        const int IndexU,
+        const int IndexV) const override
     {
         auto node = Node(IndexU, IndexV);
 
@@ -104,9 +104,9 @@ public:
 
     void
     SetWeight(
-        const int& IndexU,
-        const int& IndexV,
-        const ScalarType& Value) override
+        const int IndexU,
+        const int IndexV,
+        const ScalarType Value) override
     {
         auto node = Node(IndexU, IndexV);
 
@@ -117,8 +117,8 @@ public:
     TDataType
     ValueAt(
         const Variable<TDataType>& Variable,
-        const double& U,
-        const double& V)
+        const double U,
+        const double V)
     {
         return EvaluateAt<TDataType>([&](int i, int j) -> TDataType {
             return Node(i, j)->GetValue(Variable);
@@ -129,9 +129,9 @@ public:
     std::vector<TDataType>
     ValueAt2( // FIXME use pybind overloading
         const Variable<TDataType>& Variable,
-        const double& U,
-        const double& V,
-        const int& Order)
+        const double U,
+        const double V,
+        const int Order)
     {
         return EvaluateAt<TDataType>([&](int i, int j) -> TDataType {
             return Node(i, j)->GetValue(Variable);

--- a/applications/NurbsBrepApplication/custom_utilities/geometries/NodeSurfaceGeometry3D.h
+++ b/applications/NurbsBrepApplication/custom_utilities/geometries/NodeSurfaceGeometry3D.h
@@ -1,0 +1,140 @@
+/*
+//  KRATOS _____________ 
+//        /  _/ ____/   |
+//        / // / __/ /| |
+//      _/ // /_/ / ___ |
+//     /___/\____/_/  |_| StructuralMechanicsApplication
+//
+//  Author: Thomas Oberbichler
+*/
+
+#pragma once
+
+#include <ANurbs/Core>
+
+
+namespace Kratos {
+
+class NodeSurfaceGeometry3D
+    : public ANurbs::SurfaceGeometryBase<double, ANurbs::Point3D>
+{
+protected:
+    using typename NodePointer = typename Node<3>::Pointer;
+
+public:
+    using SurfaceGeometryBaseType = SurfaceGeometryBase<double, ANurbs::Point3D>;
+    using typename SurfaceGeometryBaseType::KnotsType;
+    using typename SurfaceGeometryBaseType::ScalarType;
+    using typename SurfaceGeometryBaseType::VectorType;
+
+protected:
+    ANurbs::Grid<NodePointer> m_nodes;
+
+public:
+    NodeSurfaceGeometry3D(
+        const int& degreeU,
+        const int& degreeV,
+        const int& nbNodesU,
+        const int& nbNodesV)
+        : SurfaceGeometryBaseType(degreeU, degreeV, nbNodesU, nbNodesV)
+        , m_nodes(nbNodesU, nbNodesV)
+    {
+    }
+
+    NodePointer
+    Node(
+        const int& indexU,
+        const int& indexV) const
+    {
+        return m_nodes(indexU, indexV);
+    }
+
+    void
+    SetNode(
+        const int& indexU,
+        const int& indexV,
+        NodePointer value)
+    {
+        m_nodes(indexU, indexV) = value;
+    }
+
+    VectorType
+    Pole(
+        const int& indexU,
+        const int& indexV) const override
+    {
+        auto node = Node(indexU, indexV);
+
+        VectorType pole;
+        pole[0] = node->X();
+        pole[1] = node->Y();
+        pole[2] = node->Z();
+
+        return pole;
+    }
+
+    void
+    SetPole(
+        const int& indexU,
+        const int& indexV,
+        const VectorType& value) override
+    {
+        auto node = Node(indexU, indexV);
+
+        node->X() = value.X();
+        node->Y() = value.Y();
+        node->Z() = value.Z();
+    }
+
+    bool
+    IsRational() const override
+    {
+        return true;
+    }
+
+    ScalarType
+    Weight(
+        const int& indexU,
+        const int& indexV) const override
+    {
+        auto node = Node(indexU, indexV);
+
+        return node->GetValue(Kratos::INTEGRATION_WEIGHT); // FIXME use WEIGHT
+    }
+
+    void
+    SetWeight(
+        const int& indexU,
+        const int& indexV,
+        const ScalarType& value) override
+    {
+        auto node = Node(indexU, indexV);
+
+        node->SetValue(Kratos::INTEGRATION_WEIGHT, value); // FIXME use WEIGHT
+    }
+    
+    template <typename TDataType>
+    TDataType
+    ValueAt(
+        const Variable<TDataType>& variable,
+        const double& t)
+    {
+        return EvaluateAt<TDataType>([&](int i) -> TDataType {
+            return Node(i)->GetValue(variable);
+        }, t);
+    }
+    
+    template <typename TDataType>
+    std::vector<TDataType>
+    ValueAt2( // FIXME use pybind overloading
+        const Variable<TDataType>& variable,
+        const double& t,
+        const int& order)
+    {
+        return EvaluateAt<TDataType>([&](int i) -> TDataType {
+            return Node(i)->GetValue(variable);
+        }, t, order);
+    }
+};
+
+} // namespace Kratos

--- a/applications/NurbsBrepApplication/custom_utilities/geometries/NodeSurfaceGeometry3D.h
+++ b/applications/NurbsBrepApplication/custom_utilities/geometries/NodeSurfaceGeometry3D.h
@@ -28,42 +28,42 @@ public:
     using typename SurfaceGeometryBaseType::VectorType;
 
 protected:
-    ANurbs::Grid<NodePointer> m_nodes;
+    ANurbs::Grid<NodePointer> mNodes;
 
 public:
     NodeSurfaceGeometry3D(
-        const int& degreeU,
-        const int& degreeV,
-        const int& nbNodesU,
-        const int& nbNodesV)
-        : SurfaceGeometryBaseType(degreeU, degreeV, nbNodesU, nbNodesV)
-        , m_nodes(nbNodesU, nbNodesV)
+        const int& DegreeU,
+        const int& DegreeV,
+        const int& NbNodesU,
+        const int& NbNodesV)
+        : SurfaceGeometryBaseType(DegreeU, DegreeV, NbNodesU, NbNodesV)
+        , mNodes(NbNodesU, NbNodesV)
     {
     }
 
     NodePointer
     Node(
-        const int& indexU,
-        const int& indexV) const
+        const int& IndexU,
+        const int& IndexV) const
     {
-        return m_nodes(indexU, indexV);
+        return mNodes(IndexU, IndexV);
     }
 
     void
     SetNode(
-        const int& indexU,
-        const int& indexV,
-        NodePointer value)
+        const int& IndexU,
+        const int& IndexV,
+        NodePointer Value)
     {
-        m_nodes(indexU, indexV) = value;
+        mNodes(IndexU, IndexV) = Value;
     }
 
     VectorType
     Pole(
-        const int& indexU,
-        const int& indexV) const override
+        const int& IndexU,
+        const int& IndexV) const override
     {
-        auto node = Node(indexU, indexV);
+        auto node = Node(IndexU, IndexV);
 
         VectorType pole;
         pole[0] = node->X();
@@ -75,15 +75,15 @@ public:
 
     void
     SetPole(
-        const int& indexU,
-        const int& indexV,
-        const VectorType& value) override
+        const int& IndexU,
+        const int& IndexV,
+        const VectorType& Value) override
     {
-        auto node = Node(indexU, indexV);
+        auto node = Node(IndexU, IndexV);
 
-        node->X() = value.X();
-        node->Y() = value.Y();
-        node->Z() = value.Z();
+        node->X() = Value.X();
+        node->Y() = Value.Y();
+        node->Z() = Value.Z();
     }
 
     bool
@@ -94,46 +94,46 @@ public:
 
     ScalarType
     Weight(
-        const int& indexU,
-        const int& indexV) const override
+        const int& IndexU,
+        const int& IndexV) const override
     {
-        auto node = Node(indexU, indexV);
+        auto node = Node(IndexU, IndexV);
 
         return node->GetValue(Kratos::INTEGRATION_WEIGHT); // FIXME use WEIGHT
     }
 
     void
     SetWeight(
-        const int& indexU,
-        const int& indexV,
-        const ScalarType& value) override
+        const int& IndexU,
+        const int& IndexV,
+        const ScalarType& Value) override
     {
-        auto node = Node(indexU, indexV);
+        auto node = Node(IndexU, IndexV);
 
-        node->SetValue(Kratos::INTEGRATION_WEIGHT, value); // FIXME use WEIGHT
+        node->SetValue(Kratos::INTEGRATION_WEIGHT, Value); // FIXME use WEIGHT
     }
     
     template <typename TDataType>
     TDataType
     ValueAt(
-        const Variable<TDataType>& variable,
-        const double& t)
+        const Variable<TDataType>& Variable,
+        const double& T)
     {
         return EvaluateAt<TDataType>([&](int i) -> TDataType {
-            return Node(i)->GetValue(variable);
-        }, t);
+            return Node(i)->GetValue(Variable);
+        }, T);
     }
     
     template <typename TDataType>
     std::vector<TDataType>
     ValueAt2( // FIXME use pybind overloading
-        const Variable<TDataType>& variable,
-        const double& t,
-        const int& order)
+        const Variable<TDataType>& Variable,
+        const double& T,
+        const int& Order)
     {
         return EvaluateAt<TDataType>([&](int i) -> TDataType {
-            return Node(i)->GetValue(variable);
-        }, t, order);
+            return Node(i)->GetValue(Variable);
+        }, T, Order);
     }
 };
 

--- a/applications/NurbsBrepApplication/custom_utilities/geometries/NodeSurfaceGeometry3D.h
+++ b/applications/NurbsBrepApplication/custom_utilities/geometries/NodeSurfaceGeometry3D.h
@@ -117,23 +117,25 @@ public:
     TDataType
     ValueAt(
         const Variable<TDataType>& Variable,
-        const double& T)
+        const double& U,
+        const double& V)
     {
-        return EvaluateAt<TDataType>([&](int i) -> TDataType {
-            return Node(i)->GetValue(Variable);
-        }, T);
+        return EvaluateAt<TDataType>([&](int i, int j) -> TDataType {
+            return Node(i, j)->GetValue(Variable);
+        }, U, V);
     }
     
     template <typename TDataType>
     std::vector<TDataType>
     ValueAt2( // FIXME use pybind overloading
         const Variable<TDataType>& Variable,
-        const double& T,
+        const double& U,
+        const double& V,
         const int& Order)
     {
-        return EvaluateAt<TDataType>([&](int i) -> TDataType {
-            return Node(i)->GetValue(Variable);
-        }, T, Order);
+        return EvaluateAt<TDataType>([&](int i, int j) -> TDataType {
+            return Node(i, j)->GetValue(Variable);
+        }, U, V, Order);
     }
 };
 

--- a/applications/NurbsBrepApplication/custom_utilities/geometries/NodeSurfaceGeometry3D.h
+++ b/applications/NurbsBrepApplication/custom_utilities/geometries/NodeSurfaceGeometry3D.h
@@ -22,7 +22,8 @@ protected:
     using typename NodePointer = typename Node<3>::Pointer;
 
 public:
-    using SurfaceGeometryBaseType = SurfaceGeometryBase<double, ANurbs::Point3D>;
+    using SurfaceGeometryBaseType = SurfaceGeometryBase<double,
+        ANurbs::Point3D>;
     using typename SurfaceGeometryBaseType::KnotsType;
     using typename SurfaceGeometryBaseType::ScalarType;
     using typename SurfaceGeometryBaseType::VectorType;
@@ -34,10 +35,11 @@ public:
     NodeSurfaceGeometry3D(
         const int DegreeU,
         const int DegreeV,
-        const int NbNodesU,
-        const int NbNodesV)
-        : SurfaceGeometryBaseType(DegreeU, DegreeV, NbNodesU, NbNodesV)
-        , mNodes(NbNodesU, NbNodesV)
+        const int NumberOfNodesU,
+        const int NumberOfNodesV)
+        : SurfaceGeometryBaseType(DegreeU, DegreeV, NumberOfNodesU,
+            NumberOfNodesV)
+        , mNodes(NumberOfNodesU, NumberOfNodesV)
     {
     }
 


### PR DESCRIPTION
Exemplary usage of `ANurbs` to define a `Node[Curve/Surface]Geometry3D` (let me know if you have a better name for this classes...).

The geometry is related to the current configuration of the corresponding `Kratos::Node<3>`s.

The functions `[curve/surface].ValueAt(variable, ...)` allows to get the value of a Kratos variable at a specific curve/surface parameter.