### PR TITLE
[MeshMoving] minor internal renamings to avoid confusion

### DIFF
--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_ballvertex.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_ballvertex.py
@@ -44,13 +44,13 @@ class MeshSolverBallvertex(mesh_solver_base.MeshSolverBase):
                                                       number_of_avg_elems,
                                                       number_of_avg_nodes)
         neighbour_search.Execute()
-        solver = self.get_mesh_motion_solver()
+        solver = self.get_mesh_motion_solving_strategy()
         if self.settings["reform_dofs_each_step"].GetBool() == False:
             solver.ConstructSystem(self.model_part)
         print("::[MeshSolverBallvertex]:: Finished initialization.")
 
     def Solve(self):
-        solver = self.get_mesh_motion_solver()
+        solver = self.get_mesh_motion_solving_strategy()
         linear_solver = self.get_linear_solver()
         if self.settings["reform_dofs_each_step"].GetBool() == True:
             (self.neighbour_search).Execute()
@@ -73,7 +73,7 @@ class MeshSolverBallvertex(mesh_solver_base.MeshSolverBase):
         linear_solver = ScalingSolver(DeflatedCGSolver(1e-6, 3000, True, 1000), True)
         return linear_solver
 
-    def _create_mesh_motion_solver(self):
+    def _create_mesh_motion_solving_strategy(self):
         domain_size = self.model_part.ProcessInfo[DOMAIN_SIZE]
         if(domain_size == 2):
             solver = BallVertexMeshMoving2D()

--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
@@ -22,8 +22,8 @@ class MeshSolverBase(object):
 
     This class defines the user interface to mesh motion solvers.
 
-    Derived classes must override the function _create_mesh_motion_solver()
-    to customize the mesh motion algorithm. The mesh motion solver and linear
+    Derived classes must override the function _create_mesh_motion_solving_strategy()
+    to customize the mesh motion algorithm. The mesh motion solving strategy and linear
     solver should always be retrieved using the getter functions. Only the
     member variables listed below should be accessed directly.
 
@@ -84,33 +84,33 @@ class MeshSolverBase(object):
 
 
     def Initialize(self):
-        self.get_mesh_motion_solver().Initialize()
+        self.get_mesh_motion_solving_strategy().Initialize()
         #self.neighbour_search.Execute()
         self.print_on_rank_zero("::[MeshSolverBase]:: Finished initialization.")
 
     def InitializeSolutionStep(self):
-        self.get_mesh_motion_solver().InitializeSolutionStep()
+        self.get_mesh_motion_solving_strategy().InitializeSolutionStep()
 
     def FinalizeSolutionStep(self):
-        self.get_mesh_motion_solver().FinalizeSolutionStep()
+        self.get_mesh_motion_solving_strategy().FinalizeSolutionStep()
 
     def SetEchoLevel(self, level):
-        self.get_mesh_motion_solver().SetEchoLevel(level)
+        self.get_mesh_motion_solving_strategy().SetEchoLevel(level)
 
     def GetEchoLevel(self):
-        self.get_mesh_motion_solver().GetEchoLevel()
+        self.get_mesh_motion_solving_strategy().GetEchoLevel()
 
     def Solve(self):
-        self.get_mesh_motion_solver().Solve()
+        self.get_mesh_motion_solving_strategy().Solve()
 
     def Clear(self):
-        self.get_mesh_motion_solver().Clear()
+        self.get_mesh_motion_solving_strategy().Clear()
 
     def Check(self):
-        self.get_mesh_motion_solver().Check()
+        self.get_mesh_motion_solving_strategy().Check()
 
     def MoveMesh(self):
-        self.get_mesh_motion_solver().MoveMesh()
+        self.get_mesh_motion_solving_strategy().MoveMesh()
 
     def ImportModelPart(self):
         """ Legacy function, use ReadModelPart and PrepareModelPartForSolver instead """
@@ -153,10 +153,10 @@ class MeshSolverBase(object):
             self._linear_solver = self._create_linear_solver()
         return self._linear_solver
 
-    def get_mesh_motion_solver(self):
-        if not hasattr(self, '_mesh_motion_solver'):
-            self._mesh_motion_solver = self._create_mesh_motion_solver()
-        return self._mesh_motion_solver
+    def get_mesh_motion_solving_strategy(self):
+        if not hasattr(self, '_mesh_motion_solving_strategy'):
+            self._mesh_motion_solving_strategy = self._create_mesh_motion_solving_strategy()
+        return self._mesh_motion_solving_strategy
 
     @classmethod
     def print_on_rank_zero(self, *args):
@@ -170,12 +170,12 @@ class MeshSolverBase(object):
         linear_solver = linear_solver_factory.ConstructSolver(self.settings["mesh_motion_linear_solver_settings"])
         return linear_solver
 
-    def _create_mesh_motion_solver(self):
-        """Create the mesh motion solver.
+    def _create_mesh_motion_solving_strategy(self):
+        """Create the mesh motion solving strategy.
 
-        The mesh motion solver must provide the functions defined in SolutionStrategy.
+        The mesh motion solving strategy must provide the functions defined in SolutionStrategy.
         """
-        raise Exception("Mesh motion solver must be created by the derived class.")
+        raise Exception("Mesh motion solving strategy must be created by the derived class.")
 
 
     def _set_and_fill_buffer(self):

--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_laplacian.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_laplacian.py
@@ -22,21 +22,21 @@ class MeshSolverLaplacian(mesh_solver_base.MeshSolverBase):
         super(MeshSolverLaplacian, self).__init__(mesh_model_part, custom_settings)
         print("::[MeshSolverLaplacian]:: Construction finished")
 
-    def _create_mesh_motion_solver(self):
+    def _create_mesh_motion_solving_strategy(self):
         linear_solver = self.get_linear_solver()
         time_order = self.settings["time_order"].GetInt()
         reform_dofs_each_step = self.settings["reform_dofs_each_step"].GetBool()
         compute_reactions = self.settings["compute_reactions"].GetBool()
         calculate_mesh_velocities = self.settings["calculate_mesh_velocities"].GetBool()
         echo_level = self.settings["echo_level"].GetInt()
-        solver = KratosMeshMoving.LaplacianMeshMovingStrategy(self.mesh_model_part,
+        solving_strategy = KratosMeshMoving.LaplacianMeshMovingStrategy(self.mesh_model_part,
                                                             linear_solver,
                                                             time_order,
                                                             reform_dofs_each_step,
                                                             compute_reactions,
                                                              calculate_mesh_velocities,
                                                             echo_level)
-        return solver
+        return solving_strategy
 
 
 

--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_structural_similarity.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_structural_similarity.py
@@ -22,18 +22,18 @@ class MeshSolverStructuralSimilarity(mesh_solver_base.MeshSolverBase):
         super(MeshSolverStructuralSimilarity, self).__init__(mesh_model_part, custom_settings)
         print("::[MeshSolverStructuralSimilarity]:: Construction finished")
 
-    def _create_mesh_motion_solver(self):
+    def _create_mesh_motion_solving_strategy(self):
         linear_solver = self.get_linear_solver()
         time_order = self.settings["time_order"].GetInt()
         reform_dofs_each_step = self.settings["reform_dofs_each_step"].GetBool()
         compute_reactions = self.settings["compute_reactions"].GetBool()
         calculate_mesh_velocities = self.settings["calculate_mesh_velocities"].GetBool()
         echo_level = self.settings["echo_level"].GetInt()
-        solver = KratosMeshMoving.StructuralMeshMovingStrategy(self.mesh_model_part,
+        solving_strategy = KratosMeshMoving.StructuralMeshMovingStrategy(self.mesh_model_part,
                                                              linear_solver,
                                                              time_order,
                                                              reform_dofs_each_step,
                                                              compute_reactions,
                                                              calculate_mesh_velocities,
                                                              echo_level)
-        return solver
+        return solving_strategy

--- a/applications/MeshMovingApplication/python_scripts/trilinos_mesh_solver_base.py
+++ b/applications/MeshMovingApplication/python_scripts/trilinos_mesh_solver_base.py
@@ -59,5 +59,5 @@ class TrilinosMeshSolverBase(mesh_solver_base.MeshSolverBase):
         linear_solver = trilinos_linear_solver_factory.ConstructSolver(self.settings["mesh_motion_linear_solver_settings"])
         return linear_solver
 
-    def _create_mesh_motion_solver(self):
+    def _create_mesh_motion_solving_strategy(self):
         raise Exception("Mesh motion solver must be created by the derived class.")

--- a/applications/MeshMovingApplication/python_scripts/trilinos_mesh_solver_laplacian.py
+++ b/applications/MeshMovingApplication/python_scripts/trilinos_mesh_solver_laplacian.py
@@ -24,7 +24,7 @@ class TrilinosMeshSolverComponentwise(trilinos_mesh_solver_base.TrilinosMeshSolv
 
     #### Private functions ####
 
-    def _create_mesh_motion_solver(self):
+    def _create_mesh_motion_solving_strategy(self):
         linear_solver = self.get_linear_solver()
         time_order = self.settings["time_order"].GetInt()
         reform_dofs_each_step = self.settings["reform_dofs_each_step"].GetBool()
@@ -32,7 +32,7 @@ class TrilinosMeshSolverComponentwise(trilinos_mesh_solver_base.TrilinosMeshSolv
         calculate_mesh_velocities = self.settings["calculate_mesh_velocities"].GetBool()
         echo_level = self.settings["echo_level"].GetInt()
         communicator = self.get_communicator()
-        solver = TrilinosApplication.TrilinosLaplacianMeshMovingStrategy(
+        solving_strategy = TrilinosApplication.TrilinosLaplacianMeshMovingStrategy(
             communicator,
             self.mesh_model_part,
             linear_solver,
@@ -41,4 +41,4 @@ class TrilinosMeshSolverComponentwise(trilinos_mesh_solver_base.TrilinosMeshSolv
             compute_reactions,
             calculate_mesh_velocities,
             echo_level)
-        return solver
+        return solving_strategy

--- a/applications/MeshMovingApplication/python_scripts/trilinos_mesh_solver_structural_similarity.py
+++ b/applications/MeshMovingApplication/python_scripts/trilinos_mesh_solver_structural_similarity.py
@@ -24,7 +24,7 @@ class TrilinosMeshSolverStructuralSimilarity(trilinos_mesh_solver_base.TrilinosM
 
     #### Private functions ####
 
-    def _create_mesh_motion_solver(self):
+    def _create_mesh_motion_solving_strategy(self):
         linear_solver = self.get_linear_solver()
         communicator = self.get_communicator()
         time_order = self.settings["time_order"].GetInt()
@@ -32,7 +32,7 @@ class TrilinosMeshSolverStructuralSimilarity(trilinos_mesh_solver_base.TrilinosM
         compute_reactions = self.settings["compute_reactions"].GetBool()
         calculate_mesh_velocities = self.settings["calculate_mesh_velocities"].GetBool()
         echo_level = self.settings["echo_level"].GetInt()
-        solver = TrilinosApplication.TrilinosStructuralMeshMovingStrategy(
+        solving_strategy = TrilinosApplication.TrilinosStructuralMeshMovingStrategy(
             communicator,
             self.mesh_model_part,
             linear_solver,
@@ -41,4 +41,4 @@ class TrilinosMeshSolverStructuralSimilarity(trilinos_mesh_solver_base.TrilinosM
             compute_reactions,
             calculate_mesh_velocities,
             echo_level)
-        return solver
+        return solving_strategy


### PR DESCRIPTION
This PR renames the mesh_solver (which is actually a solving_strategy) to mesh_solving_strategy

It is the same what I did in Structural a while ago, this should avoid confusion (bcs the (Python)-MeshSolver currently has a member mesh-solver)

In light of recent discussions this PR ONLY renames, nothing else changes

More cleanup (like deriving the solvers from the PythonSolver in the core) is coming soon

Tests are running