### PR TITLE
[Hotfix][ExternalSolversApplication] Missing constructor GMRES solver

### DIFF
--- a/applications/ExternalSolversApplication/custom_python/add_linear_solvers_to_python.cpp
+++ b/applications/ExternalSolversApplication/custom_python/add_linear_solvers_to_python.cpp
@@ -111,6 +111,7 @@ void  AddLinearSolversToPython(pybind11::module& m)
     class_<GMRESSolverType,typename GMRESSolverType::Pointer, IterativeSolverType>
     (m, "GMRESSolver")
     .def(init<Parameters >())
+    .def(init<Parameters,  PreconditionerType::Pointer >())
     .def(init<double>())
     .def(init<double, unsigned int>())
     .def(init<double, unsigned int,  PreconditionerType::Pointer>())

--- a/applications/ExternalSolversApplication/external_includes/gmres_solver.h
+++ b/applications/ExternalSolversApplication/external_includes/gmres_solver.h
@@ -126,6 +126,8 @@ public:
     }
     
      GMRESSolver(Parameters settings):BaseType(settings) {}
+     
+     GMRESSolver(Parameters settings, typename TPreconditionerType::Pointer pNewPreconditioner):BaseType(settings, pNewPreconditioner) {}
 
     /// Copy constructor.
     GMRESSolver(const GMRESSolver& Other) : BaseType(Other) {}


### PR DESCRIPTION
Without this constructor is not possible to use the GMRES with new_linear_solver_factory 

Besides, maybe we should update the header of the file