### PR TITLE
[StructuralMechanicsApplication] Clean up *.json and *.mdpa to reduce verbosity on tests

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/cl_test/IsotropicDamageSimoJu/PlaneStress_FourPointShear_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/cl_test/IsotropicDamageSimoJu/PlaneStress_FourPointShear_test_parameters.json
@@ -32,7 +32,7 @@
     },
     "constraints_process_list" : [{
         "python_module" : "assign_vector_by_direction_to_condition_process",
-        "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module" : "StructuralMechanicsApplication",
         "help"          : "This process fixes the selected components of a given vector variable",
         "process_name"  : "AssignVectorComponentsToNodesProcess",
         "Parameters"    : {
@@ -43,7 +43,7 @@
         }
     },{
         "python_module" : "assign_vector_by_direction_to_condition_process",
-        "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module" : "StructuralMechanicsApplication",
         "help"          : "This process fixes the selected components of a given vector variable",
         "process_name"  : "AssignVectorComponentsToNodesProcess",
         "Parameters"    : {
@@ -55,7 +55,7 @@
     }],
     "loads_process_list"       : [{
         "python_module" : "assign_vector_by_direction_to_condition_process",
-        "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module" : "StructuralMechanicsApplication",
         "process_name"  : "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
             "mesh_id"         : 0,
@@ -66,7 +66,7 @@
         }
     },{
         "python_module": "assign_vector_by_direction_to_condition_process",
-        "kratos_module": "KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module": "StructuralMechanicsApplication",
         "process_name": "AssignVectorByDirectionToConditionProcess",
         "Parameters"    : {
             "mesh_id"         : 0,

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_3D3N_Thin_Circle_test.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_3D3N_Thin_Circle_test.mdpa
@@ -11,10 +11,6 @@ End Properties
 Begin Properties 3
 End Properties
 Begin Properties 4
-    THICKNESS   1.00000E-02 
-    DENSITY   7.85000E+03 
-    YOUNG_MODULUS   2.06900E+11 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_3D3N_Thin_Circle_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_3D3N_Thin_Circle_test_materials.json
@@ -5,13 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.DENSITY": 7.85000E+03,
-                            "KratosMultiphysics.YOUNG_MODULUS": 2.06900E+11,
-                            "KratosMultiphysics.POISSON_RATIO": 3.00000E-001,
-                            "KratosMultiphysics.THICKNESS": 1.00000E-02
+                            "DENSITY": 7.85000E+03,
+                            "YOUNG_MODULUS": 2.06900E+11,
+                            "POISSON_RATIO": 3.00000E-001,
+                            "THICKNESS": 1.00000E-02
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_3D3N_Thin_Circle_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_3D3N_Thin_Circle_test_parameters.json
@@ -62,7 +62,7 @@
     }],
     "loads_process_list"       : [],
     "list_other_processes" :[{
-        "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module" : "StructuralMechanicsApplication",
         "python_module" : "check_eigenvalues_process",
         "help"          : "First eigenfrequencies of a circular plate according to Leissa, A. (1993). Vibration of plates.",
         "process_name"  : "CheckEigenvaluesProcess",

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_Q4_Thick_2x2_Plate.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_Q4_Thick_2x2_Plate.mdpa
@@ -11,10 +11,6 @@ End Properties
 Begin Properties 3
 End Properties
 Begin Properties 4
-    THICKNESS   1.00000E-01 
-    DENSITY   7.85000E+03 
-    YOUNG_MODULUS   1.00000E+07 
-    POISSON_RATIO   2.90000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_Q4_Thick_2x2_Plate_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_Q4_Thick_2x2_Plate_test_materials.json
@@ -5,13 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.DENSITY": 7.85000E+03,
-                            "KratosMultiphysics.YOUNG_MODULUS": 1.00000E+07,
-                            "KratosMultiphysics.POISSON_RATIO": 2.90000E-01,
-                            "KratosMultiphysics.THICKNESS": 1.00000E-01
+                            "DENSITY": 7.85000E+03,
+                            "YOUNG_MODULUS": 1.00000E+07,
+                            "POISSON_RATIO": 2.90000E-01,
+                            "THICKNESS": 1.00000E-01
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_Q4_Thick_2x2_Plate_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_Q4_Thick_2x2_Plate_test_parameters.json
@@ -50,7 +50,7 @@
     }],
     "loads_process_list"       : [],
     "list_other_processes" :[{
-        "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module" : "StructuralMechanicsApplication",
         "python_module" : "check_eigenvalues_process",
         "help"          : "",
         "process_name"  : "CheckEigenvaluesProcess",

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_TL_3D8N_Cube.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_TL_3D8N_Cube.mdpa
@@ -3,9 +3,6 @@ Begin ModelPartData
 End ModelPartData
 
 Begin Properties 2
-    DENSITY   7.85000E+03 
-    YOUNG_MODULUS   2.00000E+06 
-    POISSON_RATIO   2.90000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_TL_3D8N_Cube_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_TL_3D8N_Cube_test_materials.json
@@ -5,12 +5,12 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElastic3DLaw"
+                            "name": "LinearElastic3DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.DENSITY": 7.85000E+03  ,
-                            "KratosMultiphysics.YOUNG_MODULUS": 2.00000E+06  ,
-                            "KratosMultiphysics.POISSON_RATIO": 2.90000E-01 
+                            "DENSITY": 7.85000E+03  ,
+                            "YOUNG_MODULUS": 2.00000E+06  ,
+                            "POISSON_RATIO": 2.90000E-01 
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_TL_3D8N_Cube_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_TL_3D8N_Cube_test_parameters.json
@@ -50,7 +50,7 @@
     }],
     "loads_process_list"       : [],
     "list_other_processes" :[{
-        "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module" : "StructuralMechanicsApplication",
         "python_module" : "check_eigenvalues_process",
         "help"          : "",
         "process_name"  : "CheckEigenvaluesProcess",

--- a/applications/StructuralMechanicsApplication/tests/formfinding_test/Fofi_4Point_Tent_Cable.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/formfinding_test/Fofi_4Point_Tent_Cable.mdpa
@@ -5,16 +5,9 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    THICKNESS  1.00000E+000 
-    DENSITY  7.85000E+003 
-    YOUNG_MODULUS  2.06900E+011 
-    POISSON_RATIO  2.90000E-001 
 End Properties
 
 Begin Properties 2
-    DENSITY  7.85000E+003 
-    YOUNG_MODULUS  2.06900E+011 
-    POISSON_RATIO  2.90000E-001 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/formfinding_test/Fofi_4Point_Tent_Cable_test_material.json
+++ b/applications/StructuralMechanicsApplication/tests/formfinding_test/Fofi_4Point_Tent_Cable_test_material.json
@@ -10,6 +10,7 @@
                     "Variables": {
                             "YOUNG_MODULUS": 0.0 ,
                             "POISSON_RATIO": 0.0,
+                            "DENSITY"      : 7850.0,
                             "THICKNESS": 1.00000E-1,
                             "PRESTRESS_VECTOR": [100.0,100.0,0.0]
                     },
@@ -26,6 +27,7 @@
                     },
                     "Variables": {
                             "YOUNG_MODULUS": 0.0000001,
+                            "DENSITY"      : 7850.0,
                             "TRUSS_PRESTRESS_PK2": 2.0e3,
                             "CROSS_AREA": 0.07
                     },

--- a/applications/StructuralMechanicsApplication/tests/formfinding_test/Fofi_4Point_Tent_noCable.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/formfinding_test/Fofi_4Point_Tent_noCable.mdpa
@@ -5,10 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 4
-    THICKNESS  1.00000E+000 
-    DENSITY  1.00000E+000 
-    YOUNG_MODULUS  0.00000E+000 
-    POISSON_RATIO  0.00000E+000 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/formfinding_test/Fofi_4Point_Tent_noCable_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/formfinding_test/Fofi_4Point_Tent_noCable_test_parameters.json
@@ -89,7 +89,7 @@
     "_formfinding_IO_process" :[
         {
             "python_module"   : "formfinding_IO_process",
-            "kratos_module"   : "KratosMultiphysics.StructuralMechanicsApplication",
+            "kratos_module"   : "StructuralMechanicsApplication",
             "help"                  : "This process writes the mesh resulting from the formfinding in a .mdpa-file",
             "process_name"          : "FormfindingIOProcess",
             "Parameters"            : {

--- a/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_eigenproblem_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_eigenproblem_parameters.json
@@ -73,7 +73,7 @@
     }],
     "list_other_processes"  : [{
         "python_module" : "eigen_solution_output_process",
-        "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module" : "StructuralMechanicsApplication",
         "help"          : "",
         "process_name"  : "",
         "Parameters" : {

--- a/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_materials.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.0125,

--- a/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_parameters.json
@@ -63,7 +63,7 @@
         }
     }],
     "list_other_processes"  : [{
-        "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module" : "StructuralMechanicsApplication",
         "python_module" : "eigen_solution_input_process",
         "help"          : "",
         "process_name"  : "",
@@ -91,7 +91,7 @@
         "relative_tolerance" : 1e-6
         }
     },{
-        "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module" : "StructuralMechanicsApplication",
         "python_module" : "check_eigenvalues_process",
         "help" : "",
         "process_name" : "CheckEigenvaluesProcess",

--- a/applications/StructuralMechanicsApplication/tests/membrane_test/Membrane_Q4_PointLoad_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/membrane_test/Membrane_Q4_PointLoad_test_materials.json
@@ -5,7 +5,7 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
                             "YOUNG_MODULUS": 1.00000E+002 ,

--- a/applications/StructuralMechanicsApplication/tests/membrane_test/Membrane_Q4_Truss_PointLoad_test_material.json
+++ b/applications/StructuralMechanicsApplication/tests/membrane_test/Membrane_Q4_Truss_PointLoad_test_material.json
@@ -5,7 +5,7 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
                             "YOUNG_MODULUS": 1.00000E+002 ,

--- a/applications/StructuralMechanicsApplication/tests/mesh_moving_test/simple_mesh_moving_test.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/mesh_moving_test/simple_mesh_moving_test.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   7.85000E+03 
-    YOUNG_MODULUS   1.00000E+07 
-    POISSON_RATIO   0.00000E-00 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/mesh_moving_test/simple_mesh_moving_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/mesh_moving_test/simple_mesh_moving_test_materials.json
@@ -5,12 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStrain2DLaw"
+                            "name": "LinearElasticPlaneStrain2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 1.00000E+03,
-                            "KratosMultiphysics.POISSON_RATIO": 3.00000E-01,
-                            "KratosMultiphysics.THICKNESS": 1.00000
+                            "YOUNG_MODULUS": 1.00000E+03,
+                            "POISSON_RATIO": 3.00000E-01,
+                            "THICKNESS"    : 1.00000,
+                            "DENSITY"      : 1.00000
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/patch_test/materials_2D.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/materials_2D.json
@@ -5,12 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStrain2DLaw"
+                            "name": "LinearElasticPlaneStrain2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 1.00000E+03,
-                            "KratosMultiphysics.POISSON_RATIO": 3.00000E-01,
-                            "KratosMultiphysics.THICKNESS": 1.00000
+                            "YOUNG_MODULUS": 1.00000E+03,
+                            "POISSON_RATIO": 3.00000E-01,
+                            "THICKNESS"    : 1.00000,
+                            "DENSITY"      : 1.0e0
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/patch_test/materials_3D.json
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/materials_3D.json
@@ -5,11 +5,12 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElastic3DLaw"
+                            "name": "LinearElastic3DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 1.00000E+03,
-                            "KratosMultiphysics.POISSON_RATIO": 3.00000E-01
+                            "YOUNG_MODULUS": 1.00000E+03,
+                            "POISSON_RATIO": 3.00000E-01,
+                            "DENSITY"      : 1.0e0
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_shear_qua.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_shear_qua.mdpa
@@ -5,10 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
-    THICKNESS       1.00000
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_shear_tri.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_shear_tri.mdpa
@@ -5,10 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
-    THICKNESS       1.00000
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_tension_qua.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_tension_qua.mdpa
@@ -5,10 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
-    THICKNESS       1.00000
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_tension_tri.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_2D_tension_tri.mdpa
@@ -5,10 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
-    THICKNESS       1.00000
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_shear_hexa.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_shear_hexa.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_shear_tetra.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_shear_tetra.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_tension_hexa.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_tension_hexa.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_tension_tetra.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/small_disp/patch_test_3D_tension_tetra.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_shear_qua.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_shear_qua.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_shear_tri.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_shear_tri.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_tension_qua.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_tension_qua.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_tension_tri.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_2D_tension_tri.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_shear_hexa.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_shear_hexa.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_shear_tetra.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_shear_tetra.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_tension_hexa.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_tension_hexa.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_tension_tetra.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/total_lagrangian/patch_test_3D_tension_tetra.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_shear_qua.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_shear_qua.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_shear_tri.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_shear_tri.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_tension_qua.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_tension_qua.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_tension_tri.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_2D_tension_tri.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 1
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_shear_hexa.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_shear_hexa.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_shear_tetra.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_shear_tetra.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_tension_hexa.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_tension_hexa.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_tension_tetra.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/patch_test/updated_lagrangian/patch_test_3D_tension_tetra.mdpa
@@ -5,9 +5,6 @@ End ModelPartData
 Begin Properties 0
 End Properties
 Begin Properties 2
-    DENSITY   1.00000E+03 
-    YOUNG_MODULUS   1.00000E+03 
-    POISSON_RATIO   3.00000E-01 
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/pendulus_test/pendulus_material.json
+++ b/applications/StructuralMechanicsApplication/tests/pendulus_test/pendulus_material.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.HyperElasticPlaneStrain2DLaw"
+                "name" : "HyperElasticPlaneStrain2DLaw"
             },
             "Variables"        : {
                 "DENSITY"       : 7850.0,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__BendingRollUp.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__BendingRollUp.mdpa
@@ -11,12 +11,6 @@ End Properties
 Begin Properties 3
 End Properties
 Begin Properties 4 // GUI property identifier: Property1
-// GUI material identifier: Steel_AISI1059
- DENSITY 0
- YOUNG_MODULUS 200.0e9
- POISSON_RATIO 0.0
- THICKNESS 0.025
- BODY_FORCE [3] (0.0, 0.0, 0.0)
 End Properties
 
 Begin Nodes // GUI group identifier: Group0

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__BendingRollUp_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__BendingRollUp_test_materials.json
@@ -5,12 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 200.0e9,
-                            "KratosMultiphysics.POISSON_RATIO": 0.0,
-                            "KratosMultiphysics.THICKNESS": 0.025
+                            "YOUNG_MODULUS": 200.0e9,
+                            "POISSON_RATIO": 0.0,
+                            "DENSITY"      : 7850.0,
+                            "THICKNESS": 0.025
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__DrillingRollUp.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__DrillingRollUp.mdpa
@@ -11,12 +11,6 @@ End Properties
 Begin Properties 3
 End Properties
 Begin Properties 4 // GUI property identifier: Property1
-// GUI material identifier: Steel_AISI1059
- DENSITY 0
- YOUNG_MODULUS 200.0e9
- POISSON_RATIO 0.0
- THICKNESS 0.25
- BODY_FORCE [3] (0.0, 0.0, 0.0)
 End Properties
 
 Begin Nodes // GUI group identifier: Group0

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__DrillingRollUp_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick__DrillingRollUp_test_materials.json
@@ -5,12 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 200.0e9,
-                            "KratosMultiphysics.POISSON_RATIO": 0.0,
-                            "KratosMultiphysics.THICKNESS": 0.25
+                            "YOUNG_MODULUS": 200.0e9,
+                            "POISSON_RATIO": 0.0,
+                            "DENSITY"      : 7850.0,
+                            "THICKNESS": 0.25
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick_orthotropic_laminate_linear_static_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thick_orthotropic_laminate_linear_static_test_materials.json
@@ -4,12 +4,12 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticOrthotropic2DLaw"
+                "name" : "LinearElasticOrthotropic2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 1.0,
                 "DENSITY"       : 7850.0,
-				"KratosMultiphysics.StructuralMechanicsApplication.SHELL_ORTHOTROPIC_LAYERS" : [[0.5,0.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6],[0.5,90.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6]]
+				"SHELL_ORTHOTROPIC_LAYERS" : [[0.5,0.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6],[0.5,90.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6]]
 			},
             "Tables"           : {}
         }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_linear_dynamic_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_linear_dynamic_test_materials.json
@@ -5,13 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 1e6,
-                            "KratosMultiphysics.POISSON_RATIO": 0.0,
-                            "KratosMultiphysics.THICKNESS": 0.1,
-                            "KratosMultiphysics.DENSITY": 7.85e3
+                            "YOUNG_MODULUS": 1e6,
+                            "POISSON_RATIO": 0.0,
+                            "THICKNESS": 0.1,
+                            "DENSITY": 7.85e3
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_linear_static_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_linear_static_test_materials.json
@@ -5,13 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 4.32e8,
-                            "KratosMultiphysics.POISSON_RATIO": 0.0,
-                            "KratosMultiphysics.THICKNESS": 0.25,
-                            "KratosMultiphysics.DENSITY": 3.6e2
+                            "YOUNG_MODULUS": 4.32e8,
+                            "POISSON_RATIO": 0.0,
+                            "THICKNESS": 0.25,
+                            "DENSITY": 3.6e2
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_nonlinear_dynamic_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_nonlinear_dynamic_test_materials.json
@@ -5,13 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 1e9,
-                            "KratosMultiphysics.POISSON_RATIO": 0.3,
-                            "KratosMultiphysics.THICKNESS": 0.1,
-                            "KratosMultiphysics.DENSITY": 7.85e3
+                            "YOUNG_MODULUS": 1e9,
+                            "POISSON_RATIO": 0.3,
+                            "THICKNESS": 0.1,
+                            "DENSITY": 7.85e3
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_nonlinear_static_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_nonlinear_static_test_materials.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.0127,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_orthotropic_laminate_linear_static_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_Q4_Thin_orthotropic_laminate_linear_static_test_materials.json
@@ -4,12 +4,12 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticOrthotropic2DLaw"
+                "name" : "LinearElasticOrthotropic2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 1.0,
                 "DENSITY"       : 7850.0,
-				"KratosMultiphysics.StructuralMechanicsApplication.SHELL_ORTHOTROPIC_LAYERS" : [[0.5,0.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6],[0.5,90.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6]]
+				"SHELL_ORTHOTROPIC_LAYERS" : [[0.5,0.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6],[0.5,90.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6]]
 			},
             "Tables"           : {}
         }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Isotropic_Scordelis.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Isotropic_Scordelis.mdpa
@@ -11,12 +11,6 @@ End Properties
 Begin Properties 3
 End Properties
 Begin Properties 4 // GUI property identifier: Property1
-// GUI material identifier: Steel_AISI1059
- DENSITY 1
- YOUNG_MODULUS 4.32e8
- POISSON_RATIO 0.0
- THICKNESS 0.25
- BODY_FORCE [3] (0.0, 0.0, 0.0)
 End Properties
 
 Begin Nodes // GUI group identifier: shell

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Isotropic_Scordelis_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Isotropic_Scordelis_test_materials.json
@@ -5,12 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 4.32e8,
-                            "KratosMultiphysics.POISSON_RATIO": 0.0,
-                            "KratosMultiphysics.THICKNESS": 0.25
+                            "YOUNG_MODULUS": 4.32e8,
+                            "POISSON_RATIO": 0.0,
+                            "DENSITY"      : 1.0,
+                            "THICKNESS": 0.25
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_linear_dynamic_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_linear_dynamic_test_materials.json
@@ -5,13 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 1e6,
-                            "KratosMultiphysics.POISSON_RATIO": 0.0,
-                            "KratosMultiphysics.THICKNESS": 0.1,
-                            "KratosMultiphysics.DENSITY": 7.85e3
+                            "YOUNG_MODULUS": 1e6,
+                            "POISSON_RATIO": 0.0,
+                            "THICKNESS": 0.1,
+                            "DENSITY": 7.85e3
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_linear_static_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_linear_static_test_materials.json
@@ -5,13 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 4.32e8,
-                            "KratosMultiphysics.POISSON_RATIO": 0.0,
-                            "KratosMultiphysics.THICKNESS": 0.25,
-                            "KratosMultiphysics.DENSITY": 3.6e2
+                            "YOUNG_MODULUS": 4.32e8,
+                            "POISSON_RATIO": 0.0,
+                            "THICKNESS": 0.25,
+                            "DENSITY": 3.6e2
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_nonlinear_dynamic_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_nonlinear_dynamic_test_materials.json
@@ -5,13 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 1e9,
-                            "KratosMultiphysics.POISSON_RATIO": 0.3,
-                            "KratosMultiphysics.THICKNESS": 0.1,
-                            "KratosMultiphysics.DENSITY": 7.85e3
+                            "YOUNG_MODULUS": 1e9,
+                            "POISSON_RATIO": 0.3,
+                            "THICKNESS": 0.1,
+                            "DENSITY": 7.85e3
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_nonlinear_static_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_nonlinear_static_test_materials.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.0127,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_orthotropic_laminate_linear_static_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thick_orthotropic_laminate_linear_static_test_materials.json
@@ -4,12 +4,12 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticOrthotropic2DLaw"
+                "name" : "LinearElasticOrthotropic2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 1.0,
                 "DENSITY"       : 7850.0,
-				"KratosMultiphysics.StructuralMechanicsApplication.SHELL_ORTHOTROPIC_LAYERS" : [[0.5,0.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6],[0.5,90.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6]]
+				"SHELL_ORTHOTROPIC_LAYERS" : [[0.5,0.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6],[0.5,90.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6]]
 			},
             "Tables"           : {}
         }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin__BendingRollUp.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin__BendingRollUp.mdpa
@@ -11,12 +11,6 @@ End Properties
 Begin Properties 3
 End Properties
 Begin Properties 4 // GUI property identifier: Property1
-// GUI material identifier: Steel_AISI1059
- DENSITY 0
- YOUNG_MODULUS 200.0e9
- POISSON_RATIO 0.0
- THICKNESS 0.025
- BODY_FORCE [3] (0.0, 0.0, 0.0)
 End Properties
 
 Begin Nodes // GUI group identifier: Group0

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin__BendingRollUp_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin__BendingRollUp_test_materials.json
@@ -5,12 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 200.0e9,
-                            "KratosMultiphysics.POISSON_RATIO": 0.0,
-                            "KratosMultiphysics.THICKNESS": 0.025
+                            "YOUNG_MODULUS": 200.0e9,
+                            "POISSON_RATIO": 0.0,
+                            "DENSITY"      : 7850.0,
+                            "THICKNESS": 0.025
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin__DrillingRollUp.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin__DrillingRollUp.mdpa
@@ -11,12 +11,6 @@ End Properties
 Begin Properties 3
 End Properties
 Begin Properties 4 // GUI property identifier: Property1
-// GUI material identifier: Steel_AISI1059
- DENSITY 0
- YOUNG_MODULUS 200.0e9
- POISSON_RATIO 0.0
- THICKNESS 0.25
- BODY_FORCE [3] (0.0, 0.0, 0.0)
 End Properties
 
 Begin Nodes // GUI group identifier: Group0

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin__DrillingRollUp_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin__DrillingRollUp_test_materials.json
@@ -5,12 +5,13 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                            "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 200.0e9,
-                            "KratosMultiphysics.POISSON_RATIO": 0.0,
-                            "KratosMultiphysics.THICKNESS": 0.25
+                            "YOUNG_MODULUS": 200.0e9,
+                            "POISSON_RATIO": 0.0,
+                            "DENSITY"      : 7850.0,
+                            "THICKNESS": 0.25
                     },
                     "Tables": {}
             }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin_orthotropic_laminate_linear_static_test_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3_Thin_orthotropic_laminate_linear_static_test_materials.json
@@ -4,12 +4,12 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticOrthotropic2DLaw"
+                "name" : "LinearElasticOrthotropic2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 1.0,
                 "DENSITY"       : 7850.0,
-				"KratosMultiphysics.StructuralMechanicsApplication.SHELL_ORTHOTROPIC_LAYERS" : [[0.5,0.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6],[0.5,90.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6]]
+				"SHELL_ORTHOTROPIC_LAYERS" : [[0.5,0.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6],[0.5,90.0,7850,7.5E+6,2E+6,0.25,1.25E+6,0.625E+6,0.625E+6]]
 			},
             "Tables"           : {}
         }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_linear_static_clamped_cylinder_orthotropic_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_linear_static_clamped_cylinder_orthotropic_materials.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticOrthotropic2DLaw"
+                "name" : "LinearElasticOrthotropic2DLaw"
             },
             "Variables"        : {
                 "SHELL_ORTHOTROPIC_LAYERS" : [
@@ -19,7 +19,7 @@
         "properties_id"   : 2,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticOrthotropic2DLaw"
+                "name" : "LinearElasticOrthotropic2DLaw"
             },
             "Variables"        : {
                 "SHELL_ORTHOTROPIC_LAYERS" : [
@@ -34,7 +34,7 @@
         "properties_id"   : 3,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticOrthotropic2DLaw"
+                "name" : "LinearElasticOrthotropic2DLaw"
             },
             "Variables"        : {
                 "SHELL_ORTHOTROPIC_LAYERS" : [
@@ -49,7 +49,7 @@
         "properties_id"   : 4,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticOrthotropic2DLaw"
+                "name" : "LinearElasticOrthotropic2DLaw"
             },
             "Variables"        : {
                 "SHELL_ORTHOTROPIC_LAYERS" : [

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_linear_static_pinched_hemisphere_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_linear_static_pinched_hemisphere_materials.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.04,
@@ -19,7 +19,7 @@
         "properties_id"   : 2,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.04,
@@ -34,7 +34,7 @@
         "properties_id"   : 3,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.04,
@@ -49,7 +49,7 @@
         "properties_id"   : 4,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.04,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_linear_static_scordelis_lo_roof_isotropic_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_linear_static_scordelis_lo_roof_isotropic_materials.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.25,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_linear_static_scordelis_lo_roof_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_linear_static_scordelis_lo_roof_materials.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.25,
@@ -19,7 +19,7 @@
         "properties_id"   : 2,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.25,
@@ -34,7 +34,7 @@
         "properties_id"   : 3,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.25,
@@ -49,7 +49,7 @@
         "properties_id"   : 4,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.25,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_nonlinear_dynamic_oscillating_plate_lumped_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_nonlinear_dynamic_oscillating_plate_lumped_materials.json
@@ -4,14 +4,14 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
                 "DENSITY"       : 7850.0,
                 "YOUNG_MODULUS" : 1000000.0,
                 "POISSON_RATIO" : 0.0,
-                "KratosMultiphysics.StructuralMechanicsApplication.USE_LUMPED_MASS_MATRIX" : true
+                "USE_LUMPED_MASS_MATRIX" : true
             },
             "Tables"           : {}
         }
@@ -20,14 +20,14 @@
         "properties_id"   : 2,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
                 "DENSITY"       : 7850.0,
                 "YOUNG_MODULUS" : 1000000.0,
                 "POISSON_RATIO" : 0.0,
-                "KratosMultiphysics.StructuralMechanicsApplication.USE_LUMPED_MASS_MATRIX" : true
+                "USE_LUMPED_MASS_MATRIX" : true
             },
             "Tables"           : {}
         }
@@ -36,14 +36,14 @@
         "properties_id"   : 3,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
                 "DENSITY"       : 7850.0,
                 "YOUNG_MODULUS" : 1000000.0,
                 "POISSON_RATIO" : 0.0,
-                "KratosMultiphysics.StructuralMechanicsApplication.USE_LUMPED_MASS_MATRIX" : true
+                "USE_LUMPED_MASS_MATRIX" : true
             },
             "Tables"           : {}
         }
@@ -52,14 +52,14 @@
         "properties_id"   : 4,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
                 "DENSITY"       : 7850.0,
                 "YOUNG_MODULUS" : 1000000.0,
                 "POISSON_RATIO" : 0.0,
-                "KratosMultiphysics.StructuralMechanicsApplication.USE_LUMPED_MASS_MATRIX" : true
+                "USE_LUMPED_MASS_MATRIX" : true
             },
             "Tables"           : {}
         }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_nonlinear_dynamic_oscillating_plate_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_nonlinear_dynamic_oscillating_plate_materials.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
@@ -19,7 +19,7 @@
         "properties_id"   : 2,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
@@ -34,7 +34,7 @@
         "properties_id"   : 3,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
@@ -49,7 +49,7 @@
         "properties_id"   : 4,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_nonlinear_dynamic_pendulus_lumped_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_nonlinear_dynamic_pendulus_lumped_materials.json
@@ -4,14 +4,14 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
                 "DENSITY"       : 7850.0,
                 "YOUNG_MODULUS" : 1000000000.0,
                 "POISSON_RATIO" : 0.0,
-                "KratosMultiphysics.StructuralMechanicsApplication.USE_LUMPED_MASS_MATRIX" : true
+                "USE_LUMPED_MASS_MATRIX" : true
             },
             "Tables"           : {}
         }
@@ -20,14 +20,14 @@
         "properties_id"   : 2,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
                 "DENSITY"       : 7850.0,
                 "YOUNG_MODULUS" : 1000000000.0,
                 "POISSON_RATIO" : 0.0,
-                "KratosMultiphysics.StructuralMechanicsApplication.USE_LUMPED_MASS_MATRIX" : true
+                "USE_LUMPED_MASS_MATRIX" : true
             },
             "Tables"           : {}
         }
@@ -36,14 +36,14 @@
         "properties_id"   : 3,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
                 "DENSITY"       : 7850.0,
                 "YOUNG_MODULUS" : 1000000000.0,
                 "POISSON_RATIO" : 0.0,
-                "KratosMultiphysics.StructuralMechanicsApplication.USE_LUMPED_MASS_MATRIX" : true
+                "USE_LUMPED_MASS_MATRIX" : true
             },
             "Tables"           : {}
         }
@@ -52,14 +52,14 @@
         "properties_id"   : 4,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
                 "DENSITY"       : 7850.0,
                 "YOUNG_MODULUS" : 1000000000.0,
                 "POISSON_RATIO" : 0.0,
-                "KratosMultiphysics.StructuralMechanicsApplication.USE_LUMPED_MASS_MATRIX" : true
+                "USE_LUMPED_MASS_MATRIX" : true
             },
             "Tables"           : {}
         }

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_nonlinear_dynamic_pendulus_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_nonlinear_dynamic_pendulus_materials.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
@@ -19,7 +19,7 @@
         "properties_id"   : 2,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
@@ -34,7 +34,7 @@
         "properties_id"   : 3,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,
@@ -49,7 +49,7 @@
         "properties_id"   : 4,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 0.1,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_nonlinear_static_hinged_cyl_roof_snapthrough_materials.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_nonlinear_static_hinged_cyl_roof_snapthrough_materials.json
@@ -4,7 +4,7 @@
         "properties_id"   : 1,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 12.7,
@@ -19,7 +19,7 @@
         "properties_id"   : 2,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 12.7,
@@ -34,7 +34,7 @@
         "properties_id"   : 3,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 12.7,
@@ -49,7 +49,7 @@
         "properties_id"   : 4,
         "Material"        : {
             "constitutive_law" : {
-                "name" : "KratosMultiphysics.StructuralMechanicsApplication.LinearElasticPlaneStress2DLaw"
+                "name" : "LinearElasticPlaneStress2DLaw"
             },
             "Variables"        : {
                 "THICKNESS"     : 12.7,

--- a/applications/StructuralMechanicsApplication/tests/sprism_test/pan_test.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/sprism_test/pan_test.mdpa
@@ -9,13 +9,6 @@ Begin Properties  1
 End Properties
 
 Begin Properties  2
-CONSTITUTIVE_LAW_NAME  Elastic3DLaw
-YOUNG_MODULUS                3102750000.0
-POISSON_RATIO                0.3
-DENSITY                      1000.0
-NINT_TRANS                   3
-EAS_IMP                      1
-QUAD_ON                      1
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/sprism_test/pan_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/sprism_test/pan_test_parameters.json
@@ -132,7 +132,7 @@
     ],
     "list_other_processes" : [{
         "python_module"  :"sprism_process", 
-        "kratos_module":"KratosMultiphysics.StructuralMechanicsApplication", 
+        "kratos_module":"StructuralMechanicsApplication", 
         "help"                 : "", 
         "process_name"         : "SPRISMProcess",
         "Parameters":{

--- a/applications/StructuralMechanicsApplication/tests/sprism_test/patch_bending_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/sprism_test/patch_bending_test_parameters.json
@@ -68,7 +68,7 @@
     "loads_process_list" : [],
     "list_other_processes" : [{
         "python_module"  :"sprism_process",
-        "kratos_module":"KratosMultiphysics.StructuralMechanicsApplication",
+        "kratos_module":"StructuralMechanicsApplication",
         "help"                 : "",
         "process_name"         : "SPRISMProcess",
         "Parameters":{

--- a/applications/StructuralMechanicsApplication/tests/sprism_test/patch_membrane_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/sprism_test/patch_membrane_test_parameters.json
@@ -81,7 +81,7 @@
     "list_other_processes" : [
     {
         "python_module"  :"sprism_process", 
-        "kratos_module":"KratosMultiphysics.StructuralMechanicsApplication", 
+        "kratos_module":"StructuralMechanicsApplication", 
         "help"                 : "", 
         "process_name"         : "SPRISMProcess",
         "Parameters":{

--- a/applications/StructuralMechanicsApplication/tests/sprism_test/patch_test.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/sprism_test/patch_test.mdpa
@@ -3,9 +3,6 @@ Begin ModelPartData
 End ModelPartData
 
 Begin Properties  2
-YOUNG_MODULUS          1.00000e+12
-POISSON_RATIO          2.50000e-01
-DENSITY        1.00000e+00
 End Properties
 
 Begin Nodes

--- a/applications/StructuralMechanicsApplication/tests/sprism_test/patch_test_material.json
+++ b/applications/StructuralMechanicsApplication/tests/sprism_test/patch_test_material.json
@@ -5,11 +5,12 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "KratosMultiphysics.StructuralMechanicsApplication.LinearElastic3DLaw"
+                            "name": "LinearElastic3DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.YOUNG_MODULUS": 1.00000e+12,
-                            "KratosMultiphysics.POISSON_RATIO": 2.50000e-01
+                            "YOUNG_MODULUS": 1.00000e+12,
+                            "POISSON_RATIO": 2.50000e-01,
+                            "DENSITY"      : 1.0e0
                     },
                     "Tables": {}
             }

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -357,7 +357,7 @@ public:
             BaseType::mpLinearSystemSolver->Solve(A, Dx, b);
         } else {
             TSparseSpace::SetToZero(Dx);
-            KRATOS_WARNING_IF("ResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() > 0) << "ATTENTION! setting the RHS to zero!" << std::endl;
+            KRATOS_WARNING("ResidualBasedBlockBuilderAndSolver") << "ATTENTION! setting the RHS to zero!" << std::endl;
         }
 
         // Prints informations about the current time

--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -348,22 +348,19 @@ public:
         else
             norm_b = 0.00;
 
-        if (norm_b != 0.00)
-        {
+        if (norm_b != 0.00) {
             //provide physical data as needed
             if(BaseType::mpLinearSystemSolver->AdditionalPhysicalDataIsNeeded() )
                 BaseType::mpLinearSystemSolver->ProvideAdditionalData(A, Dx, b, BaseType::mDofSet, rModelPart);
 
             //do solve
             BaseType::mpLinearSystemSolver->Solve(A, Dx, b);
-        }
-        else
-        {
+        } else {
             TSparseSpace::SetToZero(Dx);
-            KRATOS_WARNING("ResidualBasedBlockBuilderAndSolver") << "ATTENTION! setting the RHS to zero!" << std::endl;
+            KRATOS_WARNING_IF("ResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() > 0) << "ATTENTION! setting the RHS to zero!" << std::endl;
         }
 
-        //prints informations about the current time
+        // Prints informations about the current time
         KRATOS_INFO_IF("ResidualBasedBlockBuilderAndSolver", this->GetEchoLevel() > 1) << *(BaseType::mpLinearSystemSolver) << std::endl;
 
         KRATOS_CATCH("")


### PR DESCRIPTION
This PR clean the materials.json and the mdpa in order to reduce verbosity when running tests (due to duplicated definition of materials or because combined names that are deprecated right now)