### PR TITLE
Update amgcl; fix compile issue with amgcl and boost.property_tree

### DIFF
--- a/applications/trilinos_application/external_includes/amgcl_mpi_schur_complement_solver.h
+++ b/applications/trilinos_application/external_includes/amgcl_mpi_schur_complement_solver.h
@@ -35,7 +35,7 @@
 #include "Epetra_LinearProblem.h"
 //#include "Teuchos_ParameterList.hpp"
 
-#include <boost/property_tree/ptree.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <amgcl/amg.hpp>

--- a/applications/trilinos_application/external_includes/amgcl_mpi_solver.h
+++ b/applications/trilinos_application/external_includes/amgcl_mpi_solver.h
@@ -35,7 +35,7 @@
 //#include "Teuchos_ParameterList.hpp"
 
 
-#include <boost/property_tree/ptree.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <amgcl/amg.hpp>

--- a/external_libraries/amgcl/backend/block_crs.hpp
+++ b/external_libraries/amgcl/backend/block_crs.hpp
@@ -159,7 +159,7 @@ struct block_crs {
 
         params(size_t block_size = 4) : block_size(block_size) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, block_size)
         {

--- a/external_libraries/amgcl/backend/builtin.hpp
+++ b/external_libraries/amgcl/backend/builtin.hpp
@@ -702,7 +702,7 @@ spectral_radius(const Matrix &A, int power_iters = 0) {
                     if (scale && c == i) dia = v;
                 }
 
-                if (scale) s *= math::norm(math::inverse(dia)); 
+                if (scale) s *= math::norm(math::inverse(dia));
 
                 emax = std::max(emax, s);
             }
@@ -925,6 +925,25 @@ struct cols_impl< crs<V, C, P> > {
 };
 
 template < typename V, typename C, typename P >
+struct bytes_impl< crs<V, C, P> > {
+    static size_t get(const crs<V, C, P> &A) {
+        return sizeof(P) * (A.nrows + 1) + sizeof(C) * A.nnz + sizeof(V) * A.nnz;
+    }
+};
+
+template < class Vec >
+struct bytes_impl<
+    Vec,
+    typename std::enable_if< is_builtin_vector<Vec>::value >::type
+    >
+{
+    static size_t get(const Vec &x) {
+        typedef typename backend::value_type<Vec>::type V;
+        return x.size() * sizeof(V);
+    }
+};
+
+template < typename V, typename C, typename P >
 struct ptr_data_impl< crs<V, C, P> > {
     typedef const P* type;
     static type get(const crs<V, C, P> &A) {
@@ -1030,7 +1049,7 @@ struct inner_product_impl<
         return_type sum[1];
 #endif
 
-        
+
 #pragma omp parallel
         {
 #ifdef _OPENMP

--- a/external_libraries/amgcl/backend/hpx.hpp
+++ b/external_libraries/amgcl/backend/hpx.hpp
@@ -222,6 +222,7 @@ struct HPX {
 
         params() : grain_size(4096) {}
 
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, grain_size)
         {
@@ -231,6 +232,7 @@ struct HPX {
         void get(boost::property_tree::ptree &p, const std::string &path) const {
             AMGCL_PARAMS_EXPORT_VALUE(p, path, grain_size);
         }
+#endif
     };
 
     typedef hpx_matrix<value_type>         matrix;

--- a/external_libraries/amgcl/backend/interface.hpp
+++ b/external_libraries/amgcl/backend/interface.hpp
@@ -93,6 +93,15 @@ struct cols_impl {
     typedef typename Matrix::COLS_NOT_IMPLEMENTED type;
 };
 
+/// Implementation for function returning number of bytes allocated for a matrix/vector.
+/** \note Used in bytes() */
+template <class T, class Enable = void>
+struct bytes_impl {
+    static size_t get(const T&) {
+        return 0;
+    }
+};
+
 template <class Matrix, class Enable = void>
 struct ptr_data_impl {
     typedef typename Matrix::PTR_DATA_NOT_IMPLEMENTED type;
@@ -213,6 +222,11 @@ size_t cols(const Matrix &matrix) {
     return cols_impl<Matrix>::get(matrix);
 }
 
+/// Returns number of bytes allocated for the container (matrix / vector)
+template <class T>
+size_t bytes(const T &t) {
+    return bytes_impl<T>::get(t);
+}
 template <class Matrix>
 typename ptr_data_impl<Matrix>::type
 ptr_data(const Matrix &matrix) {

--- a/external_libraries/amgcl/coarsening/aggregation.hpp
+++ b/external_libraries/amgcl/coarsening/aggregation.hpp
@@ -96,7 +96,7 @@ struct aggregation {
 
         params() : over_interp(1.5f) { }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_CHILD(p, aggr),
               AMGCL_PARAMS_IMPORT_CHILD(p, nullspace),

--- a/external_libraries/amgcl/coarsening/plain_aggregates.hpp
+++ b/external_libraries/amgcl/coarsening/plain_aggregates.hpp
@@ -74,7 +74,7 @@ struct plain_aggregates {
 
         params() : eps_strong(0.08f) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, eps_strong)
         {

--- a/external_libraries/amgcl/coarsening/pointwise_aggregates.hpp
+++ b/external_libraries/amgcl/coarsening/pointwise_aggregates.hpp
@@ -61,7 +61,7 @@ class pointwise_aggregates {
 
             params() : block_size(1) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : plain_aggregates::params(p),
                   AMGCL_PARAMS_IMPORT_VALUE(p, block_size)

--- a/external_libraries/amgcl/coarsening/ruge_stuben.hpp
+++ b/external_libraries/amgcl/coarsening/ruge_stuben.hpp
@@ -81,7 +81,7 @@ struct ruge_stuben {
 
         params() : eps_strong(0.25f), do_trunc(true), eps_trunc(0.2f) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, eps_strong),
               AMGCL_PARAMS_IMPORT_VALUE(p, do_trunc),

--- a/external_libraries/amgcl/coarsening/runtime.hpp
+++ b/external_libraries/amgcl/coarsening/runtime.hpp
@@ -33,16 +33,20 @@ THE SOFTWARE.
 
 #include <iostream>
 #include <stdexcept>
-
 #include <type_traits>
+
+#ifdef AMGCL_NO_BOOST
+#  error Runtime interface relies on Boost.PropertyTree!
+#endif
+
 #include <boost/property_tree/ptree.hpp>
 
+#include <amgcl/util.hpp>
 #include <amgcl/backend/interface.hpp>
 #include <amgcl/coarsening/ruge_stuben.hpp>
 #include <amgcl/coarsening/aggregation.hpp>
 #include <amgcl/coarsening/smoothed_aggregation.hpp>
 #include <amgcl/coarsening/smoothed_aggr_emin.hpp>
-#include <amgcl/util.hpp>
 
 namespace amgcl {
 namespace runtime {

--- a/external_libraries/amgcl/coarsening/smoothed_aggr_emin.hpp
+++ b/external_libraries/amgcl/coarsening/smoothed_aggr_emin.hpp
@@ -65,7 +65,7 @@ struct smoothed_aggr_emin {
 
         params() {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_CHILD(p, aggr),
               AMGCL_PARAMS_IMPORT_CHILD(p, nullspace)

--- a/external_libraries/amgcl/coarsening/smoothed_aggregation.hpp
+++ b/external_libraries/amgcl/coarsening/smoothed_aggregation.hpp
@@ -103,7 +103,7 @@ struct smoothed_aggregation {
 
         params() : relax(1.0f), estimate_spectral_radius(false), power_iters(0) { }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_CHILD(p, aggr),
               AMGCL_PARAMS_IMPORT_CHILD(p, nullspace),

--- a/external_libraries/amgcl/coarsening/tentative_prolongation.hpp
+++ b/external_libraries/amgcl/coarsening/tentative_prolongation.hpp
@@ -73,7 +73,7 @@ struct nullspace_params {
 
     nullspace_params() : cols(0) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
     nullspace_params(const boost::property_tree::ptree &p)
         : cols(p.get("cols", nullspace_params().cols))
     {

--- a/external_libraries/amgcl/detail/qr.hpp
+++ b/external_libraries/amgcl/detail/qr.hpp
@@ -319,6 +319,10 @@ class QR {
             solve(rows, cols, row_stride, col_stride, A, b, x, computed);
         }
 
+        size_t bytes() {
+            return sizeof(value_type) * (tau.size() + f.size() + q.size());
+        }
+
     private:
         typedef typename math::scalar_of<value_type>::type scalar_type;
 
@@ -559,6 +563,10 @@ class QR<value_type, typename std::enable_if<math::is_static_matrix<value_type>:
             int row_stride = (order == row_major ? cols : 1);
             int col_stride = (order == row_major ? 1 : rows);
             solve(rows, cols, row_stride, col_stride, A, f, x, computed);
+        }
+
+        size_t bytes() const {
+            return base.bytes() + sizeof(scalar_type) * buf.size();
         }
 
     private:

--- a/external_libraries/amgcl/make_solver.hpp
+++ b/external_libraries/amgcl/make_solver.hpp
@@ -69,7 +69,7 @@ class make_solver {
 
             params() {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, precond),
                   AMGCL_PARAMS_IMPORT_CHILD(p, solver)
@@ -191,7 +191,7 @@ class make_solver {
             return P.system_matrix();
         }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         /// Stores the parameters used during construction into the property tree \p p.
         void get_params(boost::property_tree::ptree &p) const {
             prm.get(p);
@@ -203,8 +203,14 @@ class make_solver {
             return n;
         }
 
+        size_t bytes() const {
+            return backend::bytes(S) + backend::bytes(P);
+        }
+
         friend std::ostream& operator<<(std::ostream &os, const make_solver &p) {
-            return os << p.S << std::endl << p.P;
+            return os
+                << "Solver\n======\n" << p.S << std::endl
+                << "Preconditioner\n==============\n" << p.P;
         }
     private:
         size_t           n;
@@ -377,7 +383,16 @@ class make_scaling_solver {
         std::shared_ptr<vector> t;
 };
 
+namespace backend {
 
+template <class P, class S>
+struct bytes_impl< make_solver<P, S> > {
+    static size_t get(const make_solver<P, S> &s) {
+        return s.bytes();
+    }
+};
+
+} // namespace backend
 } // namespace amgcl
 
 #endif

--- a/external_libraries/amgcl/mpi/amg.hpp
+++ b/external_libraries/amgcl/mpi/amg.hpp
@@ -113,7 +113,7 @@ class amg {
                 npre(1), npost(1), ncycle(1), pre_cycles(1)
             {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, coarsening),
                   AMGCL_PARAMS_IMPORT_CHILD(p, relax),

--- a/external_libraries/amgcl/mpi/coarsening/aggregation.hpp
+++ b/external_libraries/amgcl/mpi/coarsening/aggregation.hpp
@@ -73,7 +73,7 @@ struct aggregation {
 
         params() : over_interp(1.5f) { }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_CHILD(p, aggr),
               AMGCL_PARAMS_IMPORT_VALUE(p, over_interp)

--- a/external_libraries/amgcl/mpi/coarsening/pmis.hpp
+++ b/external_libraries/amgcl/mpi/coarsening/pmis.hpp
@@ -63,7 +63,7 @@ struct pmis {
 
         params() : eps_strong(0.08), block_size(1) { }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, eps_strong),
               AMGCL_PARAMS_IMPORT_VALUE(p, block_size)

--- a/external_libraries/amgcl/mpi/coarsening/runtime.hpp
+++ b/external_libraries/amgcl/mpi/coarsening/runtime.hpp
@@ -31,6 +31,10 @@ THE SOFTWARE.
  * \brief  Runtime wrapper for distributed coarsening schemes.
  */
 
+#ifdef AMGCL_NO_BOOST
+#  error Runtime interface relies on Boost.PropertyTree!
+#endif
+
 #include <boost/property_tree/ptree.hpp>
 
 #include <amgcl/util.hpp>

--- a/external_libraries/amgcl/mpi/coarsening/smoothed_aggregation.hpp
+++ b/external_libraries/amgcl/mpi/coarsening/smoothed_aggregation.hpp
@@ -72,7 +72,7 @@ struct smoothed_aggregation {
             : relax(1.0f), estimate_spectral_radius(false), power_iters(0)
         { }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_CHILD(p, aggr),
               AMGCL_PARAMS_IMPORT_VALUE(p, relax),

--- a/external_libraries/amgcl/mpi/direct_solver/pastix.hpp
+++ b/external_libraries/amgcl/mpi/direct_solver/pastix.hpp
@@ -74,7 +74,7 @@ class pastix : public solver_base< value_type, pastix<value_type, Distrib> > {
                 : max_rows_per_process(50000)
             {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, max_rows_per_process)
             {

--- a/external_libraries/amgcl/mpi/direct_solver/runtime.hpp
+++ b/external_libraries/amgcl/mpi/direct_solver/runtime.hpp
@@ -31,6 +31,10 @@ THE SOFTWARE.
  * \brief  Runtime wrapper for distributed direct solvers.
  */
 
+#ifdef AMGCL_NO_BOOST
+#  error Runtime interface relies on Boost.PropertyTree!
+#endif
+
 #include <boost/property_tree/ptree.hpp>
 
 #include <amgcl/util.hpp>

--- a/external_libraries/amgcl/mpi/distributed_matrix.hpp
+++ b/external_libraries/amgcl/mpi/distributed_matrix.hpp
@@ -1102,7 +1102,7 @@ spectral_radius(const mpi::distributed_matrix<Backend> &A, int power_iters = 0)
                 for(ptrdiff_t j = A_rem.ptr[i], e = A_rem.ptr[i+1]; j < e; ++j)
                     s += math::norm(A_rem.val[j]);
 
-                if (scale) s *= math::norm(math::inverse(dia)); 
+                if (scale) s *= math::norm(math::inverse(dia));
 
                 emax = std::max(emax, s);
             }

--- a/external_libraries/amgcl/mpi/make_solver.hpp
+++ b/external_libraries/amgcl/mpi/make_solver.hpp
@@ -66,7 +66,7 @@ class make_solver {
 
             params() {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, precond),
                   AMGCL_PARAMS_IMPORT_CHILD(p, solver)
@@ -148,7 +148,7 @@ class make_solver {
             return P.system_matrix();
         }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         void get_params(boost::property_tree::ptree &p) const {
             prm.get(p);
         }

--- a/external_libraries/amgcl/mpi/partition/merge.hpp
+++ b/external_libraries/amgcl/mpi/partition/merge.hpp
@@ -57,7 +57,7 @@ struct merge {
             enable(false), min_per_proc(10000), shrink_ratio(8)
         {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, enable),
               AMGCL_PARAMS_IMPORT_VALUE(p, min_per_proc),

--- a/external_libraries/amgcl/mpi/partition/parmetis.hpp
+++ b/external_libraries/amgcl/mpi/partition/parmetis.hpp
@@ -59,7 +59,7 @@ struct parmetis {
             enable(false), min_per_proc(10000), shrink_ratio(8)
         {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, enable),
               AMGCL_PARAMS_IMPORT_VALUE(p, min_per_proc),

--- a/external_libraries/amgcl/mpi/partition/ptscotch.hpp
+++ b/external_libraries/amgcl/mpi/partition/ptscotch.hpp
@@ -59,7 +59,7 @@ struct ptscotch {
             enable(false), min_per_proc(10000), shrink_ratio(8)
         {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, enable),
               AMGCL_PARAMS_IMPORT_VALUE(p, min_per_proc),

--- a/external_libraries/amgcl/mpi/partition/runtime.hpp
+++ b/external_libraries/amgcl/mpi/partition/runtime.hpp
@@ -32,14 +32,18 @@ THE SOFTWARE.
  */
 
 #include <memory>
+
+#ifdef AMGCL_NO_BOOST
+#  error Runtime interface relies on Boost.PropertyTree!
+#endif
+
 #include <boost/property_tree/ptree.hpp>
 
+#include <amgcl/util.hpp>
 #include <amgcl/mpi/partition/merge.hpp>
-
 #ifdef AMGCL_HAVE_SCOTCH
 #  include <amgcl/mpi/partition/ptscotch.hpp>
 #endif
-
 #ifdef AMGCL_HAVE_PARMETIS
 #  include <amgcl/mpi/partition/parmetis.hpp>
 #endif

--- a/external_libraries/amgcl/mpi/relaxation/runtime.hpp
+++ b/external_libraries/amgcl/mpi/relaxation/runtime.hpp
@@ -33,8 +33,13 @@ THE SOFTWARE.
 
 #include <memory>
 
+#ifdef AMGCL_NO_BOOST
+#  error Runtime interface relies on Boost.PropertyTree!
+#endif
+
 #include <boost/property_tree/ptree.hpp>
 
+#include <amgcl/util.hpp>
 #include <amgcl/backend/interface.hpp>
 #include <amgcl/value_type/interface.hpp>
 #include <amgcl/relaxation/runtime.hpp>

--- a/external_libraries/amgcl/mpi/schur_pressure_correction.hpp
+++ b/external_libraries/amgcl/mpi/schur_pressure_correction.hpp
@@ -81,7 +81,7 @@ class schur_pressure_correction {
 
             params() : approx_schur(true) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, usolver),
                   AMGCL_PARAMS_IMPORT_CHILD(p, psolver),

--- a/external_libraries/amgcl/mpi/subdomain_deflation.hpp
+++ b/external_libraries/amgcl/mpi/subdomain_deflation.hpp
@@ -129,7 +129,7 @@ class subdomain_deflation {
 
             params() {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, local),
                   AMGCL_PARAMS_IMPORT_CHILD(p, isolver),

--- a/external_libraries/amgcl/preconditioner/cpr.hpp
+++ b/external_libraries/amgcl/preconditioner/cpr.hpp
@@ -71,7 +71,7 @@ class cpr {
 
             params() : block_size(2), active_rows(0) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, pprecond),
                   AMGCL_PARAMS_IMPORT_CHILD(p, sprecond),

--- a/external_libraries/amgcl/preconditioner/cpr_drs.hpp
+++ b/external_libraries/amgcl/preconditioner/cpr_drs.hpp
@@ -77,7 +77,7 @@ class cpr_drs {
 
             params() : block_size(2), active_rows(0), eps_dd(0.2), eps_ps(0.02) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, pprecond),
                   AMGCL_PARAMS_IMPORT_CHILD(p, sprecond),

--- a/external_libraries/amgcl/preconditioner/runtime.hpp
+++ b/external_libraries/amgcl/preconditioner/runtime.hpp
@@ -31,7 +31,13 @@ THE SOFTWARE.
  * \brief  Runtime-configurable wrappers around amgcl classes.
  */
 
+#ifdef AMGCL_NO_BOOST
+#  error Runtime interface relies on Boost.PropertyTree!
+#endif
+
 #include <boost/property_tree/ptree.hpp>
+
+#include <amgcl/util.hpp>
 #include <amgcl/solver/runtime.hpp>
 #include <amgcl/coarsening/runtime.hpp>
 #include <amgcl/relaxation/runtime.hpp>

--- a/external_libraries/amgcl/preconditioner/schur_pressure_correction.hpp
+++ b/external_libraries/amgcl/preconditioner/schur_pressure_correction.hpp
@@ -121,7 +121,7 @@ class schur_pressure_correction {
 
             params() : approx_schur(true) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_CHILD(p, usolver),
                   AMGCL_PARAMS_IMPORT_CHILD(p, psolver),

--- a/external_libraries/amgcl/relaxation/as_preconditioner.hpp
+++ b/external_libraries/amgcl/relaxation/as_preconditioner.hpp
@@ -87,23 +87,31 @@ class as_preconditioner {
         std::shared_ptr<matrix> system_matrix_ptr() const {
             return A;
         }
+
+        size_t bytes() const {
+            size_t b = 0;
+
+            if (A) b += backend::bytes(*A);
+            if (S) b += backend::bytes(*S);
+
+            return b;
+        }
     private:
         params prm;
 
         std::shared_ptr<matrix>   A;
         std::shared_ptr<smoother> S;
-        std::shared_ptr<vector> tmp;
 
         void init(std::shared_ptr<build_matrix> M, const backend_params &bprm) {
             A = Backend::copy_matrix(M, bprm);
             S = std::make_shared<smoother>(*M, prm, bprm);
-            tmp = Backend::create_vector(backend::rows(*M), bprm);
         }
 
         friend std::ostream& operator<<(std::ostream &os, const as_preconditioner &p) {
             os << "Relaxation as preconditioner" << std::endl;
             os << "  unknowns: " << backend::rows(p.system_matrix()) << std::endl;
             os << "  nonzeros: " << backend::nonzeros(p.system_matrix()) << std::endl;
+            os << "  memory:   " << human_readable_memory(p.bytes()) << std::endl;
 
             return os;
         }

--- a/external_libraries/amgcl/relaxation/chebyshev.hpp
+++ b/external_libraries/amgcl/relaxation/chebyshev.hpp
@@ -68,7 +68,7 @@ class chebyshev {
 
             params() : degree(5), lower(1.0f / 30), power_iters(0) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, degree),
                   AMGCL_PARAMS_IMPORT_VALUE(p, lower),
@@ -170,6 +170,13 @@ class chebyshev {
             solve(A, rhs, x);
         }
 
+        size_t bytes() const {
+            return
+                backend::bytes(C) +
+                backend::bytes(*p) +
+                backend::bytes(*q);
+        }
+
     private:
         std::vector<scalar_type> C;
         mutable std::shared_ptr<vector> p, q;
@@ -191,8 +198,17 @@ class chebyshev {
 };
 
 } // namespace relaxation
+
+namespace backend {
+
+template <class Backend>
+struct bytes_impl< relaxation::chebyshev<Backend> > {
+    static size_t get(const relaxation::chebyshev<Backend> &R) {
+        return R.bytes();
+    }
+};
+
+} // namespace backend
 } // namespace amgcl
-
-
 
 #endif

--- a/external_libraries/amgcl/relaxation/cusparse_ilu0.hpp
+++ b/external_libraries/amgcl/relaxation/cusparse_ilu0.hpp
@@ -54,7 +54,7 @@ struct ilu0< backend::cuda<real> > {
 
         params() : damping(1) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, damping)
         {
@@ -251,6 +251,16 @@ struct ilu0< backend::cuda<real> > {
     {
         backend::copy(rhs, x);
         solve(x);
+    }
+
+    size_t bytes() const {
+        // This is incomplete, as cusparse structs are opaque.
+        return
+            backend::bytes(ptr) +
+            backend::bytes(col) +
+            backend::bytes(val) +
+            backend::bytes(y) +
+            backend::bytes(buf);
     }
 
     private:

--- a/external_libraries/amgcl/relaxation/damped_jacobi.hpp
+++ b/external_libraries/amgcl/relaxation/damped_jacobi.hpp
@@ -62,7 +62,7 @@ struct damped_jacobi {
 
         params(scalar_type damping = 0.72) : damping(damping) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, damping)
         {
@@ -134,6 +134,17 @@ struct damped_jacobi {
 };
 
 } // namespace relaxation
+
+namespace backend {
+
+template <class Backend>
+struct bytes_impl< relaxation::damped_jacobi<Backend> > {
+    static size_t get(const relaxation::damped_jacobi<Backend> &R) {
+        return backend::bytes(*R.dia);
+    }
+};
+
+} // namespace backend
 } // namespace amgcl
 
 #endif

--- a/external_libraries/amgcl/relaxation/ilu0.hpp
+++ b/external_libraries/amgcl/relaxation/ilu0.hpp
@@ -67,7 +67,7 @@ struct ilu0 {
 
         params() : damping(1) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, damping)
             , AMGCL_PARAMS_IMPORT_CHILD(p, solve)
@@ -206,14 +206,27 @@ struct ilu0 {
         ilu->solve(x);
     }
 
+    size_t bytes() const {
+        return ilu->bytes();
+    }
+
     private:
         std::shared_ptr<ilu_solve> ilu;
 
 };
 
 } // namespace relaxation
+
+namespace backend {
+
+template <class Backend>
+struct bytes_impl< relaxation::ilu0<Backend> > {
+    static size_t get(const relaxation::ilu0<Backend> &R) {
+        return R.bytes();
+    }
+};
+
+} // namespace backend
 } // namespace amgcl
-
-
 
 #endif

--- a/external_libraries/amgcl/relaxation/iluk.hpp
+++ b/external_libraries/amgcl/relaxation/iluk.hpp
@@ -69,7 +69,7 @@ struct iluk {
 
         params() : k(1), damping(1) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, k)
             , AMGCL_PARAMS_IMPORT_VALUE(p, damping)
@@ -182,6 +182,10 @@ struct iluk {
         ilu->solve(x);
     }
 
+    size_t bytes() const {
+        return ilu->bytes();
+    }
+
     private:
         std::shared_ptr<ilu_solve> ilu;
 
@@ -269,6 +273,17 @@ struct iluk {
 };
 
 } // namespace relaxation
+
+namespace backend {
+
+template <class Backend>
+struct bytes_impl< relaxation::iluk<Backend> > {
+    static size_t get(const relaxation::iluk<Backend> &R) {
+        return R.bytes();
+    }
+};
+
+} // namespace backend
 } // namespace amgcl
 
 #endif

--- a/external_libraries/amgcl/relaxation/ilut.hpp
+++ b/external_libraries/amgcl/relaxation/ilut.hpp
@@ -79,7 +79,7 @@ struct ilut {
 
         params() : p(2), tau(1e-2f), damping(1) {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
         params(const boost::property_tree::ptree &p)
             : AMGCL_PARAMS_IMPORT_VALUE(p, p)
             , AMGCL_PARAMS_IMPORT_VALUE(p, tau)
@@ -205,6 +205,10 @@ struct ilut {
     {
         backend::copy(rhs, x);
         ilu->solve(x);
+    }
+
+    size_t bytes() const {
+        return ilu->bytes();
     }
 
     private:
@@ -375,6 +379,17 @@ struct ilut {
 };
 
 } // namespace relaxation
+
+namespace backend {
+
+template <class Backend>
+struct bytes_impl< relaxation::ilut<Backend> > {
+    static size_t get(const relaxation::ilut<Backend> &R) {
+        return R.bytes();
+    }
+};
+
+} // namespace backend
 } // namespace amgcl
 
 #endif

--- a/external_libraries/amgcl/relaxation/spai0.hpp
+++ b/external_libraries/amgcl/relaxation/spai0.hpp
@@ -109,11 +109,21 @@ struct spai0 {
         backend::vmul(math::identity<scalar_type>(), *M, rhs, math::zero<scalar_type>(), x);
     }
 
-    private:
-        std::shared_ptr<matrix_diagonal> M;
+    std::shared_ptr<matrix_diagonal> M;
 };
 
 } // namespace relaxation
+
+namespace backend {
+
+template <class Backend>
+struct bytes_impl< relaxation::spai0<Backend> > {
+    static size_t get(const relaxation::spai0<Backend> &R) {
+        return backend::bytes(*R.M);
+    }
+};
+
+} // namespace backend
 } // namespace amgcl
 
 #endif

--- a/external_libraries/amgcl/relaxation/spai1.hpp
+++ b/external_libraries/amgcl/relaxation/spai1.hpp
@@ -148,11 +148,21 @@ struct spai1 {
         backend::spmv(math::identity<scalar_type>(), *M, rhs, math::zero<scalar_type>(), x);
     }
 
-    private:
-        std::shared_ptr<typename Backend::matrix> M;
+    std::shared_ptr<typename Backend::matrix> M;
 };
 
 } // namespace relaxation
+
+namespace backend {
+
+template <class Backend>
+struct bytes_impl< relaxation::spai1<Backend> > {
+    static size_t get(const relaxation::spai1<Backend> &R) {
+        return backend::bytes(*R.M);
+    }
+};
+
+} // namespace backend
 } // namespace amgcl
 
 

--- a/external_libraries/amgcl/solver/bicgstab.hpp
+++ b/external_libraries/amgcl/solver/bicgstab.hpp
@@ -85,7 +85,7 @@ class bicgstab {
                   abstol(std::numeric_limits<scalar_type>::min())
             {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, pside),
                   AMGCL_PARAMS_IMPORT_VALUE(p, maxiter),
@@ -228,8 +228,23 @@ class bicgstab {
             return (*this)(P.system_matrix(), P, rhs, x);
         }
 
+        size_t bytes() const {
+            return
+                backend::bytes(*r) +
+                backend::bytes(*p) +
+                backend::bytes(*v) +
+                backend::bytes(*s) +
+                backend::bytes(*t) +
+                backend::bytes(*rh) +
+                backend::bytes(*T);
+        }
+
         friend std::ostream& operator<<(std::ostream &os, const bicgstab &s) {
-            return os << "bicgstab: " << s.n << " unknowns";
+            return os
+                << "Type:             BiCGStab"
+                << "\nUnknowns:         " << s.n
+                << "\nMemory footprint: " << human_readable_memory(s.bytes())
+                << std::endl;
         }
     public:
         params prm;
@@ -254,6 +269,16 @@ class bicgstab {
 };
 
 } // namespace solver
+
+namespace backend {
+template <class B, class I>
+struct bytes_impl< solver::bicgstab<B, I> > {
+    static size_t get(const solver::bicgstab<B, I> &S) {
+        return S.bytes();
+    }
+};
+
+} // namespace backend
 } // namespace amgcl
 
 

--- a/external_libraries/amgcl/solver/bicgstabl.hpp
+++ b/external_libraries/amgcl/solver/bicgstabl.hpp
@@ -36,7 +36,7 @@ The code is ported from PETSC BCGSL [1] and is based on [2].
 [2] Fokkema, Diederik R. Enhanced implementation of BiCGstab (l) for solving
     linear systems of equations. Universiteit Utrecht. Mathematisch Instituut,
     1996.
- 
+
 The original code came with the following license:
 
 \verbatim
@@ -131,7 +131,7 @@ class bicgstabl {
             {
             }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, L),
                   AMGCL_PARAMS_IMPORT_VALUE(p, delta),
@@ -415,9 +415,34 @@ done:
             return (*this)(P.system_matrix(), P, rhs, x);
         }
 
+        size_t bytes() const {
+            size_t b = 0;
+
+            b += backend::bytes(*Rt);
+            b += backend::bytes(*X);
+            b += backend::bytes(*B);
+            b += backend::bytes(*T);
+
+            for(const auto &v : R) b += backend::bytes(*v);
+            for(const auto &v : U) b += backend::bytes(*v);
+
+            b += MZa.size() * sizeof(coef_type);
+            b += MZb.size() * sizeof(coef_type);
+
+            b += backend::bytes(Y0);
+            b += backend::bytes(YL);
+
+            b += qr.bytes();
+
+            return b;
+        }
 
         friend std::ostream& operator<<(std::ostream &os, const bicgstabl &s) {
-            return os << "bicgstab(" << s.prm.L << "): " << s.n << " unknowns";
+            return os
+                << "Type:             BiCGStab(" << s.prm.L << ")"
+                << "\nUnknowns:         " << s.n
+                << "\nMemory footprint: " << human_readable_memory(s.bytes())
+                << std::endl;
         }
     public:
         params prm;

--- a/external_libraries/amgcl/solver/cg.hpp
+++ b/external_libraries/amgcl/solver/cg.hpp
@@ -92,7 +92,7 @@ class cg {
                   abstol(std::numeric_limits<scalar_type>::min())
             {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, maxiter),
                   AMGCL_PARAMS_IMPORT_VALUE(p, tol),
@@ -194,8 +194,20 @@ class cg {
             return (*this)(P.system_matrix(), P, rhs, x);
         }
 
+        size_t bytes() const {
+            return
+                backend::bytes(*r) +
+                backend::bytes(*s) +
+                backend::bytes(*p) +
+                backend::bytes(*q);
+        }
+
         friend std::ostream& operator<<(std::ostream &os, const cg &s) {
-            return os << "cg: " << s.n << " unknowns";
+            return os
+                << "Type:             CG"
+                << "\nUnknowns:         " << s.n
+                << "\nMemory footprint: " << human_readable_memory(s.bytes())
+                << std::endl;
         }
     public:
         params prm;

--- a/external_libraries/amgcl/solver/fgmres.hpp
+++ b/external_libraries/amgcl/solver/fgmres.hpp
@@ -84,7 +84,7 @@ class fgmres {
                   abstol(std::numeric_limits<scalar_type>::min())
             { }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, M),
                   AMGCL_PARAMS_IMPORT_VALUE(p, maxiter),
@@ -235,9 +235,27 @@ class fgmres {
             return (*this)(P.system_matrix(), P, rhs, x);
         }
 
+        size_t bytes() const {
+            size_t b = 0;
+
+            b += H.size() * sizeof(coef_type);
+            b += backend::bytes(s);
+            b += backend::bytes(cs);
+            b += backend::bytes(sn);
+            b += backend::bytes(*r);
+
+            for(const auto &x : v) b += backend::bytes(*x);
+            for(const auto &x : z) b += backend::bytes(*x);
+
+            return b;
+        }
 
         friend std::ostream& operator<<(std::ostream &os, const fgmres &s) {
-            return os << "fgmres(" << s.prm.M << "): " << s.n << " unknowns";
+            return os
+                << "Type:             FGMRES(" << s.prm.M << ")"
+                << "\nUnknowns:         " << s.n
+                << "\nMemory footprint: " << human_readable_memory(s.bytes())
+                << std::endl;
         }
     private:
         size_t n;

--- a/external_libraries/amgcl/solver/gmres.hpp
+++ b/external_libraries/amgcl/solver/gmres.hpp
@@ -90,7 +90,7 @@ class gmres {
                   abstol(std::numeric_limits<scalar_type>::min())
             { }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, M),
                   AMGCL_PARAMS_IMPORT_VALUE(p, pside),
@@ -255,13 +255,29 @@ class gmres {
             return (*this)(P.system_matrix(), P, rhs, x);
         }
 
-
         friend std::ostream& operator<<(std::ostream &os, const gmres &s) {
-            return os << "gmres(" << s.prm.M << "): " << s.n << " unknowns";
+            return os
+                << "Type:             GMRES(" << s.prm.M << ")"
+                << "\nUnknowns:         " << s.n
+                << "\nMemory footprint: " << human_readable_memory(s.bytes())
+                << std::endl;
         }
     public:
         params prm;
 
+        size_t bytes() const {
+            size_t b = 0;
+
+            b += H.size() * sizeof(coef_type);
+            b += backend::bytes(s);
+            b += backend::bytes(cs);
+            b += backend::bytes(sn);
+            b += backend::bytes(*r);
+
+            for(const auto &x : v) b += backend::bytes(*x);
+
+            return b;
+        }
     private:
         size_t n;
 

--- a/external_libraries/amgcl/solver/idrs.hpp
+++ b/external_libraries/amgcl/solver/idrs.hpp
@@ -103,7 +103,7 @@ class idrs {
              * Determines the residual replacement strategy.
              *    If |r| > 1E3 |b| TOL/EPS) (EPS is the machine precision)
              *    the recursively computed residual is replaced by the true residual
-             *    once |r| < |b| (to reduce the effect of large intermediate residuals 
+             *    once |r| < |b| (to reduce the effect of large intermediate residuals
              *    on the final accuracy).
              * Default: No residual replacement.
              */
@@ -124,7 +124,7 @@ class idrs {
                   abstol(std::numeric_limits<scalar_type>::min())
             { }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, s),
                   AMGCL_PARAMS_IMPORT_VALUE(p, omega),
@@ -418,8 +418,34 @@ class idrs {
             return (*this)(P.system_matrix(), P, rhs, x);
         }
 
+        size_t bytes() const {
+            size_t b = 0;
+
+            b += M.size() * sizeof(coef_type);
+
+            b += backend::bytes(f);
+            b += backend::bytes(c);
+
+            b += backend::bytes(*r);
+            b += backend::bytes(*v);
+            b += backend::bytes(*t);
+
+            if (x_s) b += backend::bytes(*x_s);
+            if (r_s) b += backend::bytes(*r_s);
+
+            for(const auto &v : P) b += backend::bytes(*v);
+            for(const auto &v : G) b += backend::bytes(*v);
+            for(const auto &v : U) b += backend::bytes(*v);
+
+            return b;
+        }
+
         friend std::ostream& operator<<(std::ostream &os, const idrs &s) {
-            return os << "IDR(" << s.prm.s << "): " << s.n << " unknowns";
+            return os
+                << "Type:             IDR(" << s.prm.s << ")"
+                << "\nUnknowns:         " << s.n
+                << "\nMemory footprint: " << human_readable_memory(s.bytes())
+                << std::endl;
         }
 
     private:

--- a/external_libraries/amgcl/solver/lgmres.hpp
+++ b/external_libraries/amgcl/solver/lgmres.hpp
@@ -146,7 +146,7 @@ class lgmres {
                   abstol(std::numeric_limits<scalar_type>::min())
             { }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, M),
                   AMGCL_PARAMS_IMPORT_VALUE(p, K),
@@ -401,9 +401,33 @@ class lgmres {
             return (*this)(P.system_matrix(), P, rhs, x);
         }
 
+        size_t bytes() const {
+            size_t b = 0;
+
+            b += H.size() * sizeof(coef_type);
+            b += H0.size() * sizeof(coef_type);
+
+            b += backend::bytes(s);
+            b += backend::bytes(cs);
+            b += backend::bytes(sn);
+            b += backend::bytes(y);
+
+            b += backend::bytes(*r);
+
+            for(const auto &v : vs) b += backend::bytes(*v);
+
+            for(const auto &v : outer_v_data)  b += backend::bytes(*v);
+            for(const auto &v : outer_Av_data) b += backend::bytes(*v);
+
+            return b;
+        }
 
         friend std::ostream& operator<<(std::ostream &os, const lgmres &s) {
-            return os << "lgmres(" << s.prm.M << "," << s.prm.K << "): " << s.n << " unknowns";
+            return os
+                << "Type:             LGMRES(" << s.prm.M << "," << s.prm.K << ")"
+                << "\nUnknowns:         " << s.n
+                << "\nMemory footprint: " << human_readable_memory(s.bytes())
+                << std::endl;
         }
     private:
         size_t n;

--- a/external_libraries/amgcl/solver/runtime.hpp
+++ b/external_libraries/amgcl/solver/runtime.hpp
@@ -33,10 +33,15 @@ THE SOFTWARE.
 
 #include <iostream>
 #include <stdexcept>
-
 #include <type_traits>
+
+#ifdef AMGCL_NO_BOOST
+#  error Runtime interface relies on Boost.PropertyTree!
+#endif
+
 #include <boost/property_tree/ptree.hpp>
 
+#include <amgcl/util.hpp>
 #include <amgcl/solver/cg.hpp>
 #include <amgcl/solver/bicgstab.hpp>
 #include <amgcl/solver/bicgstabl.hpp>
@@ -210,6 +215,28 @@ struct wrapper {
 #define AMGCL_RUNTIME_SOLVER(type) \
             case type: \
                 return os << *static_cast<amgcl::solver::type<Backend, InnerProduct>*>(w.handle)
+
+            AMGCL_RUNTIME_SOLVER(cg);
+            AMGCL_RUNTIME_SOLVER(bicgstab);
+            AMGCL_RUNTIME_SOLVER(bicgstabl);
+            AMGCL_RUNTIME_SOLVER(gmres);
+            AMGCL_RUNTIME_SOLVER(lgmres);
+            AMGCL_RUNTIME_SOLVER(fgmres);
+            AMGCL_RUNTIME_SOLVER(idrs);
+
+#undef AMGCL_RUNTIME_SOLVER
+
+            default:
+                throw std::invalid_argument("Unsupported solver type");
+        }
+    }
+
+    size_t bytes() const {
+        switch(s) {
+
+#define AMGCL_RUNTIME_SOLVER(type) \
+            case type: \
+                return backend::bytes(*static_cast<amgcl::solver::type<Backend, InnerProduct>*>(handle))
 
             AMGCL_RUNTIME_SOLVER(cg);
             AMGCL_RUNTIME_SOLVER(bicgstab);

--- a/external_libraries/amgcl/solver/skyline_lu.hpp
+++ b/external_libraries/amgcl/solver/skyline_lu.hpp
@@ -197,6 +197,15 @@ class skyline_lu {
 
             for(int i = 0; i < n; ++i) x[perm[i]] = y[i];
         }
+
+        size_t bytes() const {
+            return
+                backend::bytes(perm) +
+                backend::bytes(ptr) +
+                backend::bytes(L) +
+                backend::bytes(U) +
+                backend::bytes(D);
+        }
     private:
         int n;
         std::vector<int> perm;
@@ -299,6 +308,17 @@ class skyline_lu {
 };
 
 } // namespace solver
+
+namespace backend {
+
+template <typename V, class O>
+struct bytes_impl< solver::skyline_lu<V, O> > {
+    static size_t get(const solver::skyline_lu<V, O> &S) {
+        return S.bytes();
+    }
+};
+
+} // namespace backend
 } // namespace amgcl
 
 

--- a/external_libraries/amgcl/util.hpp
+++ b/external_libraries/amgcl/util.hpp
@@ -40,7 +40,9 @@ THE SOFTWARE.
 #include <stdexcept>
 #include <cstddef>
 
-#ifdef BOOST_VERSION
+// If asked explicitly, or if boost is available, enable
+// using boost::propert_tree::ptree as amgcl parameters:
+#ifndef AMGCL_NO_BOOST
 #  include <boost/property_tree/ptree.hpp>
 #endif
 
@@ -89,7 +91,7 @@ void precondition(const Condition &condition, const Message &message) {
 #endif
 }
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
 
 #define AMGCL_PARAMS_IMPORT_VALUE(p, name)                                     \
     name( p.get(#name, params().name) )
@@ -166,7 +168,7 @@ inline void put(boost::property_tree::ptree &p, const std::string &param) {
 
 namespace detail {
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
 inline const boost::property_tree::ptree& empty_ptree() {
     static const boost::property_tree::ptree p;
     return p;
@@ -176,7 +178,7 @@ inline const boost::property_tree::ptree& empty_ptree() {
 struct empty_params {
     empty_params() {}
 
-#ifdef BOOST_VERSION
+#ifndef AMGCL_NO_BOOST
     empty_params(const boost::property_tree::ptree &p) {
         for(const auto &v : p) {
             AMGCL_PARAM_UNKNOWN(v.first);
@@ -304,6 +306,19 @@ T eps(size_t n) {
 
 template <class T> struct is_complex : std::false_type {};
 template <class T> struct is_complex< std::complex<T> > : std::true_type {};
+
+inline std::string human_readable_memory(size_t bytes) {
+    static const char *suffix[] = {"B", "K", "M", "G", "T"};
+
+    int i = 0;
+    double m = bytes;
+    for(; i < 4 && m >= 1024; ++i, m /= 1024);
+
+    std::ostringstream s;
+    s << std::fixed << std::setprecision(2) << m << " " << suffix[i];
+    return s.str();
+}
+
 } // namespace amgcl
 
 namespace std {

--- a/kratos/linear_solvers/amgcl_ns_solver.h
+++ b/kratos/linear_solvers/amgcl_ns_solver.h
@@ -25,19 +25,16 @@
 #endif
 
 // External includes
-#include "boost/smart_ptr.hpp"
 #include <iostream>
+#include <utility>
 
 #include "includes/ublas_interface.h"
 
 // Project includes
 #include "includes/define.h"
 #include "linear_solvers/iterative_solver.h"
-#include <utility>
 
-#include <boost/utility/enable_if.hpp>
-#include <boost/type_traits/is_arithmetic.hpp>
-#include <boost/property_tree/ptree.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <amgcl/adapter/crs_tuple.hpp>

--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -25,9 +25,9 @@
 #endif
 
 // External includes
-#include "boost/smart_ptr.hpp"
 #include <iostream>
 #include <fstream>
+#include <utility>
 
 #include "includes/ublas_interface.h"
 
@@ -35,9 +35,8 @@
 #include "includes/define.h"
 #include "includes/kratos_parameters.h"
 #include "linear_solvers/iterative_solver.h"
-#include<utility>
 
-#include <boost/property_tree/ptree.hpp>
+#include <boost/range/iterator_range.hpp>
 #include <boost/property_tree/json_parser.hpp>
 
 #include <amgcl/adapter/crs_tuple.hpp>


### PR DESCRIPTION
The issue was described in #2570.

The fix was applied at amgcl upstream (https://github.com/ddemidov/amgcl/commit/f22a189380a38cb466f6d2cc3382eb3ec69b6cd6), this just bumps amgcl version and cleans up Kratos wrappers.

The amgcl update includes memory profiling feature requested by @pooyan-dadvand (`amgcl::backend::bytes(solver)` where solver is an amgcl solver object should return number of bytes allocated by amgcl).