### PR TITLE
[EigenApp] Including Eigen as System-Header

### DIFF
--- a/applications/EigenSolversApplication/CMakeLists.txt
+++ b/applications/EigenSolversApplication/CMakeLists.txt
@@ -28,7 +28,7 @@ add_definitions( -DEIGEN_DEFAULT_TO_ROW_MAJOR -DEIGEN_MPL2_ONLY )
 
 include_directories(
 	${CMAKE_SOURCE_DIR}/kratos
-	${EIGEN_ROOT}
+        SYSTEM ${EIGEN_ROOT} # Including as System to suppress compile-warnings from it
 )
 
 if( USE_EIGEN_MKL MATCHES ON )


### PR DESCRIPTION
With newer compilers (GCC7) Eigen throws very many compiler warnings (sth with ints treated as bools or so)

Including it as system suppresses those warnings

The same was done with Trilinos and MPI