### PR TITLE
[Core] Adding lifecycle operations to Parameters

### DIFF
--- a/kratos/python/add_kratos_parameters_to_python.cpp
+++ b/kratos/python/add_kratos_parameters_to_python.cpp
@@ -64,7 +64,7 @@ void  AddKratosParametersToPython(pybind11::module& m)
 
     class_<Parameters, Parameters::Pointer >(m,"Parameters")
     .def(init<>())
-    .def(init<const std::string&>()) //init<rapidjson::Value& >())
+    .def(init<const std::string&>())
     .def(init<Parameters const&>())
     .def("WriteJsonString", &Parameters::WriteJsonString)
     .def("PrettyPrintJsonString", &Parameters::PrettyPrintJsonString)

--- a/kratos/python/add_kratos_parameters_to_python.cpp
+++ b/kratos/python/add_kratos_parameters_to_python.cpp
@@ -63,7 +63,8 @@ void  AddKratosParametersToPython(pybind11::module& m)
 
 
     class_<Parameters, Parameters::Pointer >(m,"Parameters")
-    .def(init<const std::string>()) //init<rapidjson::Value& >())
+    .def(init<>())
+    .def(init<const std::string&>()) //init<rapidjson::Value& >())
     .def(init<Parameters const&>())
     .def("WriteJsonString", &Parameters::WriteJsonString)
     .def("PrettyPrintJsonString", &Parameters::PrettyPrintJsonString)

--- a/kratos/tests/sources/test_parameters.cpp
+++ b/kratos/tests/sources/test_parameters.cpp
@@ -55,5 +55,46 @@ namespace Kratos {
 
 
 		}
-	}
+
+        KRATOS_TEST_CASE_IN_SUITE(Parameters_Constructor1, KratosCoreFastSuite)
+        {
+            Parameters p;
+            KRATOS_CHECK_EQUAL(p.WriteJsonString(), "{}");
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Parameters_Swap1, KratosCoreFastSuite)
+        {
+            Parameters p1{R"({"foo": 1.0})"};
+            Parameters p2{R"({"bar": false})"};
+            p1.swap(p2);
+            KRATOS_CHECK(p1.Has("bar"));
+            KRATOS_CHECK(p1["bar"].GetBool() == false);
+            KRATOS_CHECK(p2.Has("foo"));
+            KRATOS_CHECK(p2["foo"].GetDouble() == 1.0);
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Parameters_Reset1, KratosCoreFastSuite)
+        {
+            Parameters p{R"({"foo": {"bar": 1.0}})"};
+            p.Reset();
+            KRATOS_CHECK_EQUAL(p.WriteJsonString(), "{}");
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Parameters_MoveConstructor1, KratosCoreFastSuite)
+        {
+            Parameters p1{R"({"foo": {"bar": 1.0}})"};
+            Parameters p2{std::move(p1)};
+            KRATOS_CHECK_EQUAL(p1.WriteJsonString(), "{}");
+            KRATOS_CHECK_EQUAL(p2.WriteJsonString(), R"({"foo":{"bar":1.0}})");
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(Parameters_MoveAssignment1, KratosCoreFastSuite)
+        {
+            Parameters p1{R"({"foo": {"bar": 1.0}})"};
+            Parameters p2{};
+            p2 = std::move(p1);
+            KRATOS_CHECK_EQUAL(p1.WriteJsonString(), "{}");
+            KRATOS_CHECK_EQUAL(p2.WriteJsonString(), R"({"foo":{"bar":1.0}})");
+        }
+    }
 }  // namespace Kratos.

--- a/kratos/utilities/python_function_callback_utility.h
+++ b/kratos/utilities/python_function_callback_utility.h
@@ -47,7 +47,7 @@ class PythonGenericFunctionUtility
 public:
     KRATOS_CLASS_POINTER_DEFINITION(PythonGenericFunctionUtility);
 
-    PythonGenericFunctionUtility(  const std::string& function_body,  Parameters local_system = Parameters({}) )
+    PythonGenericFunctionUtility(  const std::string& function_body,  Parameters local_system = Parameters{} )
     {
         //compile the function starting from the string function body
         try


### PR DESCRIPTION
This proposal includes the following changes.

- Default constructor, which constructs an empty, valid json string.
- Move ctor and assignment.
- Reset and swap.
- Tests for the added functions.

Additionally, string parameters passed by `const string` are replaced by `const string&`.