### PR TITLE
Improve adjoint sensitivity analysis

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_conditions/adjoint_semi_analytic_base_condition.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_conditions/adjoint_semi_analytic_base_condition.h
@@ -69,7 +69,7 @@ public:
 
     AdjointSemiAnalyticBaseCondition(
         Condition::Pointer pPrimalCondition
-        ): Condition( pPrimalCondition->Id(), pPrimalCondition->pGetGeometry() ),
+        ): Condition( pPrimalCondition->Id(), pPrimalCondition->pGetGeometry(), pPrimalCondition->pGetProperties() ),
            mpPrimalCondition(pPrimalCondition)
         {
         }

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
@@ -405,7 +405,6 @@ void AdjointFiniteDifferencingBaseElement::CalculateStressDisplacementDerivative
     
     const SizeType num_nodes = mpPrimalElement->GetGeometry().PointsNumber();
     const SizeType dimension = mpPrimalElement->GetGeometry().WorkingSpaceDimension();
-    //const SizeType num_dofs_per_node = dimension; // TODO generalize
     const SizeType num_dofs_per_node = (mHasRotationDofs) ?  2 * dimension : dimension;
     const SizeType num_dofs = num_nodes * num_dofs_per_node;
     Vector initial_state_variables;
@@ -431,10 +430,9 @@ void AdjointFiniteDifferencingBaseElement::CalculateStressDisplacementDerivative
         primal_solution_variable_list.push_back(ROTATION_Z);
     }
 
-
     // TODO Find a better way of doing this check
     KRATOS_ERROR_IF(rCurrentProcessInfo.Has(NL_ITERATION_NUMBER))
-        << "Stress displacement derivative computation is currently only available for linear cases !" << std::endl;
+        << "This stress displacement derivative computation is only usable for linear cases!" << std::endl;
 
     for (IndexType i = 0; i < num_nodes; ++i)
     {

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
@@ -348,7 +348,8 @@ void AdjointFiniteDifferencingBaseElement::CalculateSensitivityMatrix(const Vari
 
         const SizeType number_of_nodes = mpPrimalElement->GetGeometry().PointsNumber();
         const SizeType dimension = rCurrentProcessInfo.GetValue(DOMAIN_SIZE);
-        const SizeType local_size = number_of_nodes * dimension * 2;
+        const SizeType num_dofs_per_node = (mHasRotationDofs) ?  2 * dimension : dimension;
+        const SizeType local_size = number_of_nodes * num_dofs_per_node;
 
         if ( (rOutput.size1() != dimension * number_of_nodes) || (rOutput.size2() != local_size ) )
             rOutput.resize(dimension * number_of_nodes, local_size);

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
@@ -24,8 +24,15 @@ namespace Kratos
 {
 
 AdjointFiniteDifferencingBaseElement::AdjointFiniteDifferencingBaseElement(Element::Pointer pPrimalElement)
-                    : Element(pPrimalElement->Id(), pPrimalElement->pGetGeometry(), pPrimalElement->pGetProperties()),
-                        mpPrimalElement(pPrimalElement)
+                    : Element(pPrimalElement->Id(), pPrimalElement->pGetGeometry(), pPrimalElement->pGetProperties())
+                    , mpPrimalElement(pPrimalElement)
+{
+}
+
+AdjointFiniteDifferencingBaseElement::AdjointFiniteDifferencingBaseElement(Element::Pointer pPrimalElement, bool HasRotationDofs)
+                    : Element(pPrimalElement->Id(), pPrimalElement->pGetGeometry(), pPrimalElement->pGetProperties())
+                    , mpPrimalElement(pPrimalElement)
+                    , mHasRotationDofs(HasRotationDofs)
 {
 }
 
@@ -39,7 +46,7 @@ void AdjointFiniteDifferencingBaseElement::EquationIdVector(EquationIdVectorType
 
     const SizeType number_of_nodes = geom.PointsNumber();
     const SizeType dimension = geom.WorkingSpaceDimension();
-    const SizeType num_dofs_per_node = dimension * 2;
+    const SizeType num_dofs_per_node = (mHasRotationDofs) ?  2 * dimension : dimension;
     const SizeType num_dofs = number_of_nodes * num_dofs_per_node;
 
     if(rResult.size() != num_dofs)
@@ -54,9 +61,12 @@ void AdjointFiniteDifferencingBaseElement::EquationIdVector(EquationIdVectorType
         rResult[index + 1] = iNode.GetDof(ADJOINT_DISPLACEMENT_Y).EquationId();
         rResult[index + 2] = iNode.GetDof(ADJOINT_DISPLACEMENT_Z).EquationId();
 
-        rResult[index + 3] = iNode.GetDof(ADJOINT_ROTATION_X).EquationId();
-        rResult[index + 4] = iNode.GetDof(ADJOINT_ROTATION_Y).EquationId();
-        rResult[index + 5] = iNode.GetDof(ADJOINT_ROTATION_Z).EquationId();
+        if(mHasRotationDofs)
+        {
+            rResult[index + 3] = iNode.GetDof(ADJOINT_ROTATION_X).EquationId();
+            rResult[index + 4] = iNode.GetDof(ADJOINT_ROTATION_Y).EquationId();
+            rResult[index + 5] = iNode.GetDof(ADJOINT_ROTATION_Z).EquationId();
+        }
     }
     KRATOS_CATCH("")
 }
@@ -70,7 +80,7 @@ void AdjointFiniteDifferencingBaseElement::GetDofList(DofsVectorType& rElemental
 
     const SizeType number_of_nodes = geom.PointsNumber();
     const SizeType dimension =  geom.WorkingSpaceDimension();
-    const SizeType num_dofs_per_node = dimension * 2;
+    const SizeType num_dofs_per_node = (mHasRotationDofs) ?  2 * dimension : dimension;
     const SizeType num_dofs = number_of_nodes * num_dofs_per_node;
 
     if (rElementalDofList.size() != num_dofs)
@@ -82,10 +92,13 @@ void AdjointFiniteDifferencingBaseElement::GetDofList(DofsVectorType& rElemental
         rElementalDofList[index    ] = GetGeometry()[i].pGetDof(ADJOINT_DISPLACEMENT_X);
         rElementalDofList[index + 1] = GetGeometry()[i].pGetDof(ADJOINT_DISPLACEMENT_Y);
         rElementalDofList[index + 2] = GetGeometry()[i].pGetDof(ADJOINT_DISPLACEMENT_Z);
-
-        rElementalDofList[index + 3] = GetGeometry()[i].pGetDof(ADJOINT_ROTATION_X);
-        rElementalDofList[index + 4] = GetGeometry()[i].pGetDof(ADJOINT_ROTATION_Y);
-        rElementalDofList[index + 5] = GetGeometry()[i].pGetDof(ADJOINT_ROTATION_Z);
+        
+        if(mHasRotationDofs)
+        {
+            rElementalDofList[index + 3] = GetGeometry()[i].pGetDof(ADJOINT_ROTATION_X);
+            rElementalDofList[index + 4] = GetGeometry()[i].pGetDof(ADJOINT_ROTATION_Y);
+            rElementalDofList[index + 5] = GetGeometry()[i].pGetDof(ADJOINT_ROTATION_Z);
+        }
     }
     KRATOS_CATCH("")
 }
@@ -98,7 +111,7 @@ void AdjointFiniteDifferencingBaseElement::GetValuesVector(Vector& rValues, int 
 
     const SizeType number_of_nodes = geom.PointsNumber();
     const SizeType dimension =  geom.WorkingSpaceDimension();
-    const SizeType num_dofs_per_node = dimension * 2;
+    const SizeType num_dofs_per_node = (mHasRotationDofs) ?  2 * dimension : dimension;
     const SizeType num_dofs = number_of_nodes * num_dofs_per_node;
 
     if(rValues.size() != num_dofs)
@@ -108,16 +121,19 @@ void AdjointFiniteDifferencingBaseElement::GetValuesVector(Vector& rValues, int 
     {
         const NodeType & iNode = geom[i];
         const array_1d<double,3>& disp = iNode.FastGetSolutionStepValue(ADJOINT_DISPLACEMENT, Step);
-        const array_1d<double,3>& rot = iNode.FastGetSolutionStepValue(ADJOINT_ROTATION, Step);
 
         const IndexType index = i * num_dofs_per_node;
         rValues[index]     = disp[0];
         rValues[index + 1] = disp[1];
         rValues[index + 2] = disp[2];
 
-        rValues[index + 3] = rot[0];
-        rValues[index + 4] = rot[1];
-        rValues[index + 5] = rot[2];
+        if(mHasRotationDofs)
+        {
+            const array_1d<double,3>& rot = iNode.FastGetSolutionStepValue(ADJOINT_ROTATION, Step);
+            rValues[index + 3] = rot[0];
+            rValues[index + 4] = rot[1];
+            rValues[index + 5] = rot[2];
+        }
     }
     KRATOS_CATCH("")
 }
@@ -212,13 +228,17 @@ int AdjointFiniteDifferencingBaseElement::Check(const ProcessInfo& rCurrentProce
 
     // verify that the variables are correctly initialized
     KRATOS_CHECK_VARIABLE_KEY(DISPLACEMENT);
-    KRATOS_CHECK_VARIABLE_KEY(ROTATION);
     KRATOS_CHECK_VARIABLE_KEY(VELOCITY);
     KRATOS_CHECK_VARIABLE_KEY(ACCELERATION);
     KRATOS_CHECK_VARIABLE_KEY(DENSITY);
     KRATOS_CHECK_VARIABLE_KEY(CONSTITUTIVE_LAW);
     KRATOS_CHECK_VARIABLE_KEY(ADJOINT_DISPLACEMENT);
-    KRATOS_CHECK_VARIABLE_KEY(ADJOINT_ROTATION);
+
+    if(mHasRotationDofs)
+    {
+        KRATOS_CHECK_VARIABLE_KEY(ROTATION);
+        KRATOS_CHECK_VARIABLE_KEY(ADJOINT_ROTATION);
+    }
 
     // TODO generic way of doing these checks without checking the dofs..
 
@@ -228,16 +248,20 @@ int AdjointFiniteDifferencingBaseElement::Check(const ProcessInfo& rCurrentProce
         auto& r_node = r_geom[i];
 
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT, r_node);
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ROTATION, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ADJOINT_DISPLACEMENT, r_node);
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ADJOINT_ROTATION, r_node);
-
+        
         KRATOS_CHECK_DOF_IN_NODE(ADJOINT_DISPLACEMENT_X, r_node);
         KRATOS_CHECK_DOF_IN_NODE(ADJOINT_DISPLACEMENT_Y, r_node);
         KRATOS_CHECK_DOF_IN_NODE(ADJOINT_DISPLACEMENT_Z, r_node);
-        KRATOS_CHECK_DOF_IN_NODE(ADJOINT_ROTATION_X, r_node);
-        KRATOS_CHECK_DOF_IN_NODE(ADJOINT_ROTATION_Y, r_node);
-        KRATOS_CHECK_DOF_IN_NODE(ADJOINT_ROTATION_Z, r_node);
+
+        if(mHasRotationDofs)
+        {
+            KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ROTATION, r_node);
+            KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ADJOINT_ROTATION, r_node);
+            KRATOS_CHECK_DOF_IN_NODE(ADJOINT_ROTATION_X, r_node);
+            KRATOS_CHECK_DOF_IN_NODE(ADJOINT_ROTATION_Y, r_node);
+            KRATOS_CHECK_DOF_IN_NODE(ADJOINT_ROTATION_Z, r_node);
+        }
     }
 
     return 0;
@@ -378,10 +402,11 @@ void AdjointFiniteDifferencingBaseElement::CalculateStressDisplacementDerivative
                                             Matrix& rOutput, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
-
+    
     const SizeType num_nodes = mpPrimalElement->GetGeometry().PointsNumber();
     const SizeType dimension = mpPrimalElement->GetGeometry().WorkingSpaceDimension();
-    const SizeType num_dofs_per_node = dimension * 2; // TODO generalize
+    //const SizeType num_dofs_per_node = dimension; // TODO generalize
+    const SizeType num_dofs_per_node = (mHasRotationDofs) ?  2 * dimension : dimension;
     const SizeType num_dofs = num_nodes * num_dofs_per_node;
     Vector initial_state_variables;
     Vector stress_derivatives_vector;
@@ -398,9 +423,14 @@ void AdjointFiniteDifferencingBaseElement::CalculateStressDisplacementDerivative
     primal_solution_variable_list.push_back(DISPLACEMENT_X);
     primal_solution_variable_list.push_back(DISPLACEMENT_Y);
     primal_solution_variable_list.push_back(DISPLACEMENT_Z);
-    primal_solution_variable_list.push_back(ROTATION_X);
-    primal_solution_variable_list.push_back(ROTATION_Y);
-    primal_solution_variable_list.push_back(ROTATION_Z);
+
+    if(mHasRotationDofs)
+    {
+        primal_solution_variable_list.push_back(ROTATION_X);
+        primal_solution_variable_list.push_back(ROTATION_Y);
+        primal_solution_variable_list.push_back(ROTATION_Z);
+    }
+
 
     // TODO Find a better way of doing this check
     KRATOS_ERROR_IF(rCurrentProcessInfo.Has(NL_ITERATION_NUMBER))

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.h
@@ -69,6 +69,8 @@ public:
 
     AdjointFiniteDifferencingBaseElement(Element::Pointer pPrimalElement);
 
+    AdjointFiniteDifferencingBaseElement(Element::Pointer pPrimalElement, bool HasRotationDofs);
+
     ~AdjointFiniteDifferencingBaseElement() override;
 
     ///@}
@@ -419,6 +421,7 @@ protected:
      * pointer to the primal element
      */
     Element::Pointer mpPrimalElement;
+    bool mHasRotationDofs = false;
 
     ///@}
 

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_cr_beam_element_3D2N.cpp
@@ -20,7 +20,7 @@ namespace Kratos
 {
 
 AdjointFiniteDifferenceCrBeamElement::AdjointFiniteDifferenceCrBeamElement(Element::Pointer pPrimalElement)
-    : AdjointFiniteDifferencingBaseElement(pPrimalElement)
+    : AdjointFiniteDifferencingBaseElement(pPrimalElement, true)
 {
 }
 

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_shell_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_shell_element.cpp
@@ -24,7 +24,7 @@ namespace Kratos
 {
 
 AdjointFiniteDifferencingShellElement::AdjointFiniteDifferencingShellElement(Element::Pointer pPrimalElement)
-                    : AdjointFiniteDifferencingBaseElement(pPrimalElement) {}
+                    : AdjointFiniteDifferencingBaseElement(pPrimalElement, true) {}
 
 AdjointFiniteDifferencingShellElement::~AdjointFiniteDifferencingShellElement() {}
 


### PR DESCRIPTION
This pull request contains some improvements of the adjoint elements and conditions:

- a member variable ```mHasRotationDofs``` was added to the adjoint element base class in order to tell the adjoint element if the primal element has also rotational-Dofs

- The constructor of the adjoint condition base class was modified