### PR TITLE
Fluid json has changed

### DIFF
--- a/applications/FSIapplication/python_scripts/fsi_analysis.py
+++ b/applications/FSIapplication/python_scripts/fsi_analysis.py
@@ -157,10 +157,10 @@ class FSIAnalysis(AnalysisStage):
         # Fluid domain processes
         # Note 1: gravity is constructed first. Outlet process might need its information.
         # Note 2: initial conditions are constructed before BCs. Otherwise, they may overwrite the BCs information.
-        self._list_of_processes =  factory.ConstructListOfProcesses( self.project_parameters["fluid_solver_settings"]["gravity"] )
-        self._list_of_processes += factory.ConstructListOfProcesses( self.project_parameters["fluid_solver_settings"]["initial_conditions_process_list"] )
-        self._list_of_processes += factory.ConstructListOfProcesses( self.project_parameters["fluid_solver_settings"]["boundary_conditions_process_list"] )
-        self._list_of_processes += factory.ConstructListOfProcesses( self.project_parameters["fluid_solver_settings"]["auxiliar_process_list"] )
+        self._list_of_processes =  factory.ConstructListOfProcesses( self.project_parameters["fluid_solver_settings"]["processes"]["gravity"] )
+        self._list_of_processes += factory.ConstructListOfProcesses( self.project_parameters["fluid_solver_settings"]["processes"]["initial_conditions_process_list"] )
+        self._list_of_processes += factory.ConstructListOfProcesses( self.project_parameters["fluid_solver_settings"]["processes"]["boundary_conditions_process_list"] )
+        self._list_of_processes += factory.ConstructListOfProcesses( self.project_parameters["fluid_solver_settings"]["processes"]["auxiliar_process_list"] )
 
         # Structure domain processes
         self._list_of_processes += factory.ConstructListOfProcesses( self.project_parameters["structure_solver_settings"]["constraints_process_list"] )


### PR DESCRIPTION
[FSI].[Fluid] Now ProjectParameters.json processes are inside an object, since KratosMultiphysics/GiDInterface#438 , resulting:

```json
"processes"            : {
        "initial_conditions_process_list"  : [],
        "boundary_conditions_process_list" : [{
            "python_module" : "apply_inlet_process",
            "kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
            "Parameters"    : {
                "model_part_name" : "AutomaticInlet2D_Inlet",
                "variable_name"   : "VELOCITY",
                "modulus"         : "6*y*(1-y)*sin(pi*t*0.5)",
                "direction"       : "automatic_inwards_normal",
                "interval"        : [0,1]
            }
        },{
            "python_module" : "apply_inlet_process",
            "kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
            "Parameters"    : {
                "model_part_name" : "AutomaticInlet2D_Inlet",
                "variable_name"   : "VELOCITY",
                "modulus"         : "6*y*(1-y)",
                "direction"       : "automatic_inwards_normal",
                "interval"        : [1,"End"]
            }
        }],
        "gravity"                          : [{
            "python_module" : "assign_vector_by_direction_process",
            "kratos_module" : "KratosMultiphysics",
            "process_name"  : "AssignVectorByDirectionProcess",
            "Parameters"    : {
                "model_part_name" : "Parts_Fluid",
                "variable_name"   : "BODY_FORCE",
                "modulus"         : 0.0,
                "constrained"     : false,
                "direction"       : [0.0,-1.0,0.0]
            }
        }],
        "auxiliar_process_list"            : []
    }

```

Notice I've changed it manually in the fsi script. Maybe you should try to let the Fluid app scripts make the read of the fluid part

Caution, if you had tests, this may break them