### PR TITLE
[Core] Added explicit to PointerVectorSet

### DIFF
--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -123,7 +123,7 @@ public:
     PointerVectorSet(const PointerVectorSet& rOther)
         :  mData(rOther.mData), mSortedPartSize(rOther.mSortedPartSize), mMaxBufferSize(rOther.mMaxBufferSize) {}
 
-    PointerVectorSet(const TContainerType& rContainer) :  mData(rContainer), mSortedPartSize(size_type()), mMaxBufferSize(1)
+    explicit PointerVectorSet(const TContainerType& rContainer) :  mData(rContainer), mSortedPartSize(size_type()), mMaxBufferSize(1)
     {
         Sort();
         std::unique(mData.begin(), mData.end(), EqualKeyTo());


### PR DESCRIPTION
This proposal adds the explicit specifier to the constructor of the PointerVectorSet.

This is the next step in #2527.