### PR TITLE
Fixed failing MPI tests

### DIFF
--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/mpi_cylinder_test_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/mpi_cylinder_test_adjoint_parameters.json
@@ -22,7 +22,7 @@
             "file_label"          : "time",
             "output_control_type" : "step",
             "output_frequency"    : 1.0,
-            "body_output"         : true,
+            "body_output"         : false,
             "node_output"         : false,
             "skin_output"         : false,
             "plane_output"        : [],
@@ -147,7 +147,8 @@
             "model_part_name"  : "Parts_Fluid",
             "output_file_settings": {
                 "file_name"  : "mpi_cylinder_test_adjoint_probe1.dat",
-                "folder_name": "AdjointVMSSensitivity2DTest"
+                "folder_name": "AdjointVMSSensitivity2DTest",
+                "write_buffer_size" : 1
             },
             "output_variables" : ["ADJOINT_VELOCITY_X", "ADJOINT_VELOCITY_Y"]
         }
@@ -161,7 +162,8 @@
             "model_part_name"  : "Parts_Fluid",
             "output_file_settings": {
                 "file_name"  : "mpi_cylinder_test_adjoint_probe2.dat",
-                "folder_name": "AdjointVMSSensitivity2DTest"
+                "folder_name": "AdjointVMSSensitivity2DTest",
+                "write_buffer_size" : 1
             },
             "output_variables" : ["ADJOINT_PRESSURE"]
         }
@@ -175,42 +177,46 @@
             "model_part_name"  : "Parts_Fluid",
             "output_file_settings": {
                 "file_name"  : "mpi_cylinder_test_adjoint_probe3.dat",
-                "folder_name": "AdjointVMSSensitivity2DTest"
+                "folder_name": "AdjointVMSSensitivity2DTest",
+                "write_buffer_size" : 1
             },
             "output_variables" : ["SHAPE_SENSITIVITY_X", "SHAPE_SENSITIVITY_Y"]
         }
     },{
-        "python_module"   : "compare_two_files_check_process",
+        "python_module"   : "compare_two_files_check_process_mpi",
         "kratos_module"   : "KratosMultiphysics",
         "help"            : "",
-        "process_name"    : "CompareTwoFilesCheckProcess",
+        "process_name"    : "CompareTwoFilesCheckProcessMPI",
         "Parameters" :{
             "output_file_name"    : "AdjointVMSSensitivity2DTest/mpi_cylinder_test_adjoint_probe1.dat",
             "reference_file_name" : "AdjointVMSSensitivity2DTest/cylinder_test_adjoint_probe1_ref.dat",
             "comparison_type"     : "dat_file",
-            "decimal_places"      : 2
+            "decimal_places"      : 2,
+            "remove_output_file"  : false
         }
     },{
-        "python_module"   : "compare_two_files_check_process",
+        "python_module"   : "compare_two_files_check_process_mpi",
         "kratos_module"   : "KratosMultiphysics",
         "help"            : "",
-        "process_name"    : "CompareTwoFilesCheckProcess",
+        "process_name"    : "CompareTwoFilesCheckProcessMPI",
         "Parameters" :{
             "output_file_name"    : "AdjointVMSSensitivity2DTest/mpi_cylinder_test_adjoint_probe2.dat",
             "reference_file_name" : "AdjointVMSSensitivity2DTest/cylinder_test_adjoint_probe2_ref.dat",
             "comparison_type"     : "dat_file",
-	        "decimal_places"      : 1
+            "decimal_places"      : 1,
+            "remove_output_file"  : false
         }
     },{
-        "python_module"   : "compare_two_files_check_process",
+        "python_module"   : "compare_two_files_check_process_mpi",
         "kratos_module"   : "KratosMultiphysics",
         "help"            : "",
-        "process_name"    : "CompareTwoFilesCheckProcess",
+        "process_name"    : "CompareTwoFilesCheckProcessMPI",
         "Parameters" :{
             "output_file_name"    : "AdjointVMSSensitivity2DTest/mpi_cylinder_test_adjoint_probe3.dat",
             "reference_file_name" : "AdjointVMSSensitivity2DTest/cylinder_test_adjoint_probe3_ref.dat",
             "comparison_type"     : "dat_file",
-	        "decimal_places"      : 7
+            "decimal_places"      : 7,
+            "remove_output_file"  : false
         }
     }]
 }

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/mpi_cylinder_test_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/mpi_cylinder_test_parameters.json
@@ -22,7 +22,7 @@
             "file_label"          : "time",
             "output_control_type" : "step",
             "output_frequency"    : 1.0,
-            "body_output"         : true,
+            "body_output"         : false,
             "node_output"         : false,
             "skin_output"         : false,
             "plane_output"        : [],
@@ -147,7 +147,8 @@
             "model_part_name"  : "Parts_Fluid",
             "output_file_settings": {
                 "file_name"  : "mpi_cylinder_test_probe1.dat",
-                "folder_name": "AdjointVMSSensitivity2DTest"
+                "folder_name": "AdjointVMSSensitivity2DTest",
+                "write_buffer_size" : 1
             },
             "output_variables" : [
                 "VELOCITY_X",
@@ -164,7 +165,8 @@
             "model_part_name"  : "Parts_Fluid",
             "output_file_settings": {
                 "file_name"  : "mpi_cylinder_test_probe2.dat",
-                "folder_name": "AdjointVMSSensitivity2DTest"
+                "folder_name": "AdjointVMSSensitivity2DTest",
+                "write_buffer_size" : 1
             },
             "output_variables" : [
                 "VELOCITY_X",
@@ -172,26 +174,28 @@
                 "PRESSURE"]
         }
     },{
-        "python_module"   : "compare_two_files_check_process",
+        "python_module"   : "compare_two_files_check_process_mpi",
         "kratos_module"   : "KratosMultiphysics",
         "help"            : "",
-        "process_name"    : "CompareTwoFilesCheckProcess",
+        "process_name"    : "CompareTwoFilesCheckProcessMPI",
         "Parameters" :{
             "output_file_name"    : "AdjointVMSSensitivity2DTest/mpi_cylinder_test_probe1.dat",
             "reference_file_name" : "AdjointVMSSensitivity2DTest/cylinder_test_probe1_ref.dat",
             "comparison_type"     : "dat_file",
-            "decimal_places"      : 6
+            "decimal_places"      : 6,
+            "remove_output_file"  : false
         }
     },{
-        "python_module"   : "compare_two_files_check_process",
+        "python_module"   : "compare_two_files_check_process_mpi",
         "kratos_module"   : "KratosMultiphysics",
         "help"            : "",
-        "process_name"    : "CompareTwoFilesCheckProcess",
+        "process_name"    : "CompareTwoFilesCheckProcessMPI",
         "Parameters" :{
             "output_file_name"    : "AdjointVMSSensitivity2DTest/mpi_cylinder_test_probe2.dat",
             "reference_file_name" : "AdjointVMSSensitivity2DTest/cylinder_test_probe2_ref.dat",
             "comparison_type"     : "dat_file",
-	        "decimal_places"      : 6
+            "decimal_places"      : 6,
+            "remove_output_file"  : false
         }
     }]
 }

--- a/kratos/python_scripts/compare_two_files_check_process_mpi.py
+++ b/kratos/python_scripts/compare_two_files_check_process_mpi.py
@@ -10,8 +10,6 @@ def Factory(settings, Model):
 
 class CompareTwoFilesCheckProcessMPI(CompareTwoFilesCheckProcess):
     """Inserts MPI barrier before check to ensure results files are present."""
-    def __init__(self, model, params):
-        super(CompareTwoFilesCheckProcessMPI, self).__init__(model, params)
 
     def ExecuteFinalize(self):
         KratosMPI.mpi.world.barrier()

--- a/kratos/python_scripts/compare_two_files_check_process_mpi.py
+++ b/kratos/python_scripts/compare_two_files_check_process_mpi.py
@@ -1,0 +1,18 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
+import KratosMultiphysics
+import KratosMultiphysics.mpi as KratosMPI
+from compare_two_files_check_process import CompareTwoFilesCheckProcess
+
+def Factory(settings, Model):
+    if(type(settings) != KratosMultiphysics.Parameters):
+        raise Exception("Expected input shall be a Parameters object, encapsulating a json string")
+    return CompareTwoFilesCheckProcessMPI(Model, settings["Parameters"])
+
+class CompareTwoFilesCheckProcessMPI(CompareTwoFilesCheckProcess):
+    """Inserts MPI barrier before check to ensure results files are present."""
+    def __init__(self, model, params):
+        super(CompareTwoFilesCheckProcessMPI, self).__init__(model, params)
+
+    def ExecuteFinalize(self):
+        KratosMPI.mpi.world.barrier()
+        super(CompareTwoFilesCheckProcessMPI, self).ExecuteFinalize()


### PR DESCRIPTION
MPI tests were failing for three reasons:

- CompareOutputProcess was changed such that it removes the output file by default (in mpi this is done by each process, which causes a failure after the first process executes).
- PointOutputProcess and the TimeBasedAsciiFileWriterUtility were changed causing the flush frequency to change.
- A barrier was missing in the CompareOutputProcess such that one process might try to compare before the other process writes the output.

The proposed changes are:

- Add a new CompareOutputProcessMPI which inserts a barrier before the comparison in the base class.
- Fix the json parameters for the MPI tests.