### PR TITLE
Fix pybind LTO selection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,10 +194,10 @@ endif(USE_COTIRE MATCHES ON)
 include(pybind11Tools)
 
 # Reset pybind11 config and remove -LTO on FullDebug to speedup linking time,
-if(CMAKE_CONFIGURATION_TYPES MATCHES FullDebug)
+if(CMAKE_BUILD_TYPE MATCHES FullDebug)
     set(PYBIND11_LTO_CXX_FLAGS "" CACHE INTERNAL "")
     set(PYBIND11_LTO_LINKER_FLAGS "" CACHE INTERNAL "")
-endif(CMAKE_CONFIGURATION_TYPES MATCHES FullDebug)
+endif(CMAKE_BUILD_TYPE MATCHES FullDebug)
 
 ######################################################################################
 ######################################################################################


### PR DESCRIPTION
While (once more) debugging Kratos with the Intel compiler I found the following

I am quite sure it should be as I propose, currently it always removes the LTO-flags / never adds them in the first place

EDIT I saw that @RiccardoRossi suggested this in the first place in #2416 
Could you please also have a look after your vacation?