### PR TITLE
Test/enabling test hdf5

### DIFF
--- a/scripts/build/nightly/configure_clang.sh
+++ b/scripts/build/nightly/configure_clang.sh
@@ -15,6 +15,7 @@ cmake .. \
 -DMESH_MOVING_APPLICATION=ON                                                                            \
 -DADJOINT_FLUID_APPLICATION=OFF                                                                 \
 -DCONVECTION_DIFFUSION_APPLICATION=ON                                                           \
+-DHDF5_APPLICATION=ON                                                                           \
 -DDAM_APPLICATION=ON                                                                            \
 -DDEM_APPLICATION=ON                                                                            \
 -DEMPIRE_APPLICATION=ON                                                                         \

--- a/scripts/build/nightly/configure_gcc.sh
+++ b/scripts/build/nightly/configure_gcc.sh
@@ -15,6 +15,7 @@ cmake .. \
 -DMESH_MOVING_APPLICATION=ON                                                                            \
 -DADJOINT_FLUID_APPLICATION=OFF                                                                 \
 -DCONVECTION_DIFFUSION_APPLICATION=ON                                                           \
+-DHDF5_APPLICATION=ON                                                                           \
 -DDAM_APPLICATION=ON                                                                            \
 -DDEM_APPLICATION=ON                                                                            \
 -DEMPIRE_APPLICATION=ON                                                                         \

--- a/scripts/build/nightly_build.sh
+++ b/scripts/build/nightly_build.sh
@@ -19,7 +19,7 @@ export PYTHONPATH=$PYTHONPATH:/home/ubuntu/Kratos
 sleep 300 # 5 minutes
 
 # Install packages needed by the hdf5 app
-sudo apt-get install -y python3-h5py libhdf5-openmpi-dev
+sudo apt-get install -y python3-h5py libhdf5-dev
 
 # Install packaged nedded by the mailing
 sudo apt-get install -y libio-socket-ssl-perl  libdigest-hmac-perl  libterm-readkey-perl libmime-lite-perl libfile-libmagic-perl libio-socket-inet6-perl

--- a/scripts/build/nightly_build.sh
+++ b/scripts/build/nightly_build.sh
@@ -18,6 +18,12 @@ export PYTHONPATH=$PYTHONPATH:/home/ubuntu/Kratos
 ## Step0: Let it rest some time so the unassisted updated can finish
 sleep 300 # 5 minutes
 
+# Install packages needed by the hdf5 app
+sudo apt-get install -y python3-h5py libhdf5-openmpi-dev
+
+# Install packaged nedded by the mailing
+sudo apt-get install -y libio-socket-ssl-perl  libdigest-hmac-perl  libterm-readkey-perl libmime-lite-perl libfile-libmagic-perl libio-socket-inet6-perl
+
 ## Step1: Prepare
 cd ${HOME}
 wget http://www.logix.cz/michal/devel/smtp-cli/smtp-cli
@@ -75,11 +81,6 @@ cat ${LOG_DIR}/unittest_gcc.log >> ${MAIL_GCC};
 # echo "Benchmarking: \n" >> ${MAIL_GCC}
 # echo "============= \n" >> ${MAIL_GCC}
 # cat ${LOG_DIR}/benchmarking_gcc.log >> ${MAIL_GCC};
-
-#### Ugly Fix ####
-# Apparently, this needs to go here because someone didn't had anything else to do apart from adding autoupdates in ubuntu 16....
-sudo apt-get install -y libio-socket-ssl-perl  libdigest-hmac-perl  libterm-readkey-perl libmime-lite-perl libfile-libmagic-perl libio-socket-inet6-perl
-##################
 
 cd ${HOME}
 tar -zcvf /tmp/logs_gcc.tar.gz ${LOG_DIR}/*


### PR DESCRIPTION
This should close #2687.

I am not sure about the order change in the apt-get instruction since the unasisted upgrades from ubuntu are still happening but should be safe with the 5 min sleep. 