### PR TITLE
Update macOS name and availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ _KRATOS Multiphysics_ ("Kratos") is a framework for building parallel, multi-dis
 
 
 # Main Features
-**Kratos** is __multiplatform__ and available for __Windows, Linux__ (several distros) and can be compiled in __OSX__.
+**Kratos** is __multiplatform__ and available for __Windows, Linux__ (several distros) and __macOS__.
 
 **Kratos** is __OpenMP__ and __MPI__ parallel and scalable up to thousands of cores.
 


### PR DESCRIPTION
Since Kratos 6.0 release, macOS version is distributed the same way as Windows and Linux