### PR TITLE
[StructuralMechanics] removing unneeded const

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/truss_constitutive_law.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/truss_constitutive_law.cpp
@@ -148,7 +148,7 @@ void TrussConstitutiveLaw::CalculateMaterialResponse(
 //************************************************************************************
 //************************************************************************************
 
-const double TrussConstitutiveLaw::CalculateStressElastic(
+double TrussConstitutiveLaw::CalculateStressElastic(
     ConstitutiveLaw::Parameters& rParameterValues) const
 {
     Vector current_strain = ZeroVector(1);

--- a/applications/StructuralMechanicsApplication/custom_constitutive/truss_constitutive_law.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/truss_constitutive_law.h
@@ -136,7 +136,7 @@ public:
 
     //this functions calculates the current stress based on an element given (set)
     //strain
-    const double CalculateStressElastic(ConstitutiveLaw::Parameters& rParameterValues) const;
+    double CalculateStressElastic(ConstitutiveLaw::Parameters& rParameterValues) const;
 
 protected:
 

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
@@ -578,7 +578,7 @@ void AdjointFiniteDifferencingBaseElement::CalculateStressDesignVariableDerivati
 }
 
 // private
-const double AdjointFiniteDifferencingBaseElement::GetPerturbationSize(const Variable<double>& rDesignVariable)
+double AdjointFiniteDifferencingBaseElement::GetPerturbationSize(const Variable<double>& rDesignVariable)
 {
     const double correction_factor = this->GetPerturbationSizeModificationFactor(rDesignVariable);
     const double delta = this->GetValue(PERTURBATION_SIZE) * correction_factor;
@@ -586,7 +586,7 @@ const double AdjointFiniteDifferencingBaseElement::GetPerturbationSize(const Var
     return delta;
 }
 
-const double AdjointFiniteDifferencingBaseElement::GetPerturbationSize(const Variable<array_1d<double,3>>& rDesignVariable)
+double AdjointFiniteDifferencingBaseElement::GetPerturbationSize(const Variable<array_1d<double,3>>& rDesignVariable)
 {
     const double correction_factor = this->GetPerturbationSizeModificationFactor(rDesignVariable);
     const double delta = this->GetValue(PERTURBATION_SIZE) * correction_factor;

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.h
@@ -437,12 +437,12 @@ private:
     /**
      * Get the perturbation size for a scalar variable
      */
-    const double GetPerturbationSize(const Variable<double>& rDesignVariable);
+    double GetPerturbationSize(const Variable<double>& rDesignVariable);
 
     /**
      * Get the perturbation size for a vector variable
      */
-    const double GetPerturbationSize(const Variable<array_1d<double,3>>& rDesignVariable);
+    double GetPerturbationSize(const Variable<array_1d<double,3>>& rDesignVariable);
 
     /**
      * Get the perturbation size modification factor for a scalar variable.


### PR DESCRIPTION
Removing a compiler warning with the Intel-Compiler
The const in this place is meaningless

see #2158 

FYI @MFusseder @KlausBSautter 