### PR TITLE
[StructuralMechanics] Making modelpart-adding optional

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/postprocess_eigenvalues_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/postprocess_eigenvalues_process.py
@@ -24,7 +24,7 @@ class PostProcessEigenvaluesProcess(KratosMultiphysics.Process):
                 "help"                         :"This process can be used in order to generate a postprocess files for eigenvalues problems. It uses the C++ class PostprocessEigenvaluesProcess",
                 "result_file_name"             : "Structure",
                 "result_file_format_use_ascii" : false,
-                "computing_model_part_name"    : "computing_domain",
+                "computing_model_part_name"    : "Structure.computing_domain",
                 "animation_steps"              :  20,
                 "list_of_result_variables"     : ["DISPLACEMENT"],
                 "label_type"                   : "frequency"

--- a/applications/StructuralMechanicsApplication/python_scripts/postprocess_eigenvalues_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/postprocess_eigenvalues_process.py
@@ -24,7 +24,7 @@ class PostProcessEigenvaluesProcess(KratosMultiphysics.Process):
                 "help"                         :"This process can be used in order to generate a postprocess files for eigenvalues problems. It uses the C++ class PostprocessEigenvaluesProcess",
                 "result_file_name"             : "Structure",
                 "result_file_format_use_ascii" : false,
-                "computing_model_part_name"    : "Structure.computing_domain",
+                "computing_model_part_name"    : "computing_domain",
                 "animation_steps"              :  20,
                 "list_of_result_variables"     : ["DISPLACEMENT"],
                 "label_type"                   : "frequency"

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -124,6 +124,8 @@ class MechanicalSolver(PythonSolver):
             self.solver_imports_model_part = False
         else:
             self.main_model_part = KratosMultiphysics.ModelPart(model_part_name) # Model.CreateodelPart()
+            if not self.settings["add_model_part_to_model"].GetBool(): # this will automatically be done once the Model is finished
+                self.model.AddModelPart(self.main_model_part)
             domain_size = self.settings["domain_size"].GetInt()
             if domain_size < 0:
                 raise Exception('Please specify a "domain_size" >= 0!')

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -49,6 +49,7 @@ class MechanicalSolver(PythonSolver):
         default_settings = KratosMultiphysics.Parameters("""
         {
             "model_part_name" : "",
+            "add_model_part_to_model" : true,
             "domain_size" : -1,
             "echo_level": 0,
             "buffer_size": 2,
@@ -210,8 +211,8 @@ class MechanicalSolver(PythonSolver):
             self._execute_after_reading()
             self._set_and_fill_buffer()
 
-        # This will be removed once the Model is fully supported! => It wont e necessary anymore
-        if not self.model.HasModelPart(self.main_model_part.Name):
+        # This will be removed once the Model is fully supported! => It wont be necessary anymore
+        if not self.model.HasModelPart(self.main_model_part.Name) and self.settings["add_model_part_to_model"].GetBool():
             self.model.AddModelPart(self.main_model_part)
 
         KratosMultiphysics.Logger.PrintInfo("::[MechanicalSolver]::", "ModelPart prepared for Solver.")
@@ -343,9 +344,9 @@ class MechanicalSolver(PythonSolver):
         import check_and_prepare_model_process_structural
         check_and_prepare_model_process_structural.CheckAndPrepareModelProcess(self.main_model_part, params).Execute()
 
-        # This will be removed once the Model is fully supported! => It wont e necessary anymore
+        # This will be removed once the Model is fully supported! => It wont be necessary anymore
         # NOTE: We do this here in case the model is empty, so the properties can be assigned
-        if not self.model.HasModelPart(self.main_model_part.Name):
+        if not self.model.HasModelPart(self.main_model_part.Name) and self.settings["add_model_part_to_model"].GetBool():
             self.model.AddModelPart(self.main_model_part)
 
         # Import constitutive laws.

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -49,7 +49,7 @@ class MechanicalSolver(PythonSolver):
         default_settings = KratosMultiphysics.Parameters("""
         {
             "model_part_name" : "",
-            "add_model_part_to_model" : true,
+            "add_model_part_to_model_before_reading" : false,
             "domain_size" : -1,
             "echo_level": 0,
             "buffer_size": 2,
@@ -124,7 +124,7 @@ class MechanicalSolver(PythonSolver):
             self.solver_imports_model_part = False
         else:
             self.main_model_part = KratosMultiphysics.ModelPart(model_part_name) # Model.CreateodelPart()
-            if not self.settings["add_model_part_to_model"].GetBool(): # this will automatically be done once the Model is finished
+            if self.settings["add_model_part_to_model_before_reading"].GetBool(): # this will be the default behavior once the Model is finished
                 self.model.AddModelPart(self.main_model_part)
             domain_size = self.settings["domain_size"].GetInt()
             if domain_size < 0:
@@ -213,8 +213,8 @@ class MechanicalSolver(PythonSolver):
             self._execute_after_reading()
             self._set_and_fill_buffer()
 
-        # This will be removed once the Model is fully supported! => It wont be necessary anymore
-        if not self.model.HasModelPart(self.main_model_part.Name) and self.settings["add_model_part_to_model"].GetBool():
+        # This will be removed once the Model is fully supported! => It wont e necessary anymore
+        if not self.model.HasModelPart(self.main_model_part.Name):
             self.model.AddModelPart(self.main_model_part)
 
         KratosMultiphysics.Logger.PrintInfo("::[MechanicalSolver]::", "ModelPart prepared for Solver.")
@@ -346,9 +346,9 @@ class MechanicalSolver(PythonSolver):
         import check_and_prepare_model_process_structural
         check_and_prepare_model_process_structural.CheckAndPrepareModelProcess(self.main_model_part, params).Execute()
 
-        # This will be removed once the Model is fully supported! => It wont be necessary anymore
+        # This will be removed once the Model is fully supported! => It wont e necessary anymore
         # NOTE: We do this here in case the model is empty, so the properties can be assigned
-        if not self.model.HasModelPart(self.main_model_part.Name) and self.settings["add_model_part_to_model"].GetBool():
+        if not self.model.HasModelPart(self.main_model_part.Name):
             self.model.AddModelPart(self.main_model_part)
 
         # Import constitutive laws.


### PR DESCRIPTION
This is needed if there are subsubmodelparts with the same name
This is currently not possible due to backwards-compatibility, but will be ok in the future / natively supported

