### PR TITLE
[StructuralMechanicsApplication] Improve adjoint elements

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
@@ -222,6 +222,8 @@ int AdjointFiniteDifferencingBaseElement::Check(const ProcessInfo& rCurrentProce
 {
     KRATOS_TRY
 
+    int return_value = Element::Check(rCurrentProcessInfo);
+
     KRATOS_ERROR_IF_NOT(mpPrimalElement) << "Primal element pointer is nullptr!" << std::endl;
 
     GeometryType& r_geom = GetGeometry();
@@ -264,7 +266,7 @@ int AdjointFiniteDifferencingBaseElement::Check(const ProcessInfo& rCurrentProce
         }
     }
 
-    return 0;
+    return return_value;
 
     KRATOS_CATCH("")
 }
@@ -615,7 +617,10 @@ double AdjointFiniteDifferencingBaseElement::GetPerturbationSizeModificationFact
 
     if(rDesignVariable == SHAPE)
     {
-        KRATOS_ERROR << "GetPerturbationSizeModificationFactor NOT_IMPLEMENTED" << std::endl;
+        const double domain_size = mpPrimalElement->GetGeometry().DomainSize();
+        KRATOS_DEBUG_ERROR_IF(domain_size <= std::numeric_limits<double>::epsilon())
+            << "Pertubation size for shape derivatives of element" << this->Id() << "~ 0" << std::endl;
+        return domain_size;
     }
     else
         return 1.0;

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
@@ -621,7 +621,7 @@ double AdjointFiniteDifferencingBaseElement::GetPerturbationSizeModificationFact
     if(rDesignVariable == SHAPE)
     {
         const double domain_size = mpPrimalElement->GetGeometry().DomainSize();
-        KRATOS_DEBUG_ERROR_IF(domain_size <= std::numeric_limits<double>::epsilon())
+        KRATOS_DEBUG_ERROR_IF(domain_size <= 0.0)
             << "Pertubation size for shape derivatives of element" << this->Id() << "~ 0" << std::endl;
         return domain_size;
     }

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
@@ -616,13 +616,13 @@ double AdjointFiniteDifferencingBaseElement::GetPerturbationSizeModificationFact
     KRATOS_TRY;
 
     // For shape derivatives the size of the element (length, area, ...) is used as default perturbation size modification factor.
-    // Later on this value is multiplied with an user defined factor. This product is then used as final perturbation size for computing
+    // Later on this value is multiplied with a user defined factor. This product is then used as final perturbation size for computing
     // derivatives with finite differences.
     if(rDesignVariable == SHAPE)
     {
         const double domain_size = mpPrimalElement->GetGeometry().DomainSize();
         KRATOS_DEBUG_ERROR_IF(domain_size <= 0.0)
-            << "Pertubation size for shape derivatives of element" << this->Id() << "~ 0" << std::endl;
+            << "Pertubation size for shape derivatives of element" << this->Id() << "<= 0.0" << std::endl;
         return domain_size;
     }
     else

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.cpp
@@ -615,6 +615,9 @@ double AdjointFiniteDifferencingBaseElement::GetPerturbationSizeModificationFact
 {
     KRATOS_TRY;
 
+    // For shape derivatives the size of the element (length, area, ...) is used as default perturbation size modification factor.
+    // Later on this value is multiplied with an user defined factor. This product is then used as final perturbation size for computing
+    // derivatives with finite differences.
     if(rDesignVariable == SHAPE)
     {
         const double domain_size = mpPrimalElement->GetGeometry().DomainSize();

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_cr_beam_element_3D2N.cpp
@@ -116,6 +116,8 @@ int AdjointFiniteDifferenceCrBeamElement::Check(const ProcessInfo& rCurrentProce
 {
     KRATOS_TRY
 
+    int return_value = AdjointFiniteDifferencingBaseElement::Check(rCurrentProcessInfo);
+
     KRATOS_ERROR_IF_NOT(mpPrimalElement) << "Primal element pointer is nullptr!" << std::endl;
 
     //TODO: Check() of primal element should be called, but is not possible because of DOF check!
@@ -168,25 +170,7 @@ int AdjointFiniteDifferenceCrBeamElement::Check(const ProcessInfo& rCurrentProce
     KRATOS_ERROR_IF_NOT( this->GetProperties().Has(I33) )
     << "I33 not provided for this element" << this->Id() << std::endl;
 
-    return 0;
-
-    KRATOS_CATCH("")
-}
-
-double AdjointFiniteDifferenceCrBeamElement::GetPerturbationSizeModificationFactor(const Variable<array_1d<double,3>>& rDesignVariable)
-{
-    KRATOS_TRY;
-
-    if(rDesignVariable == SHAPE)
-    {
-        double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
-        double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
-        double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-        double L = std::sqrt(dx*dx + dy*dy + dz*dz);
-        return L;
-    }
-    else
-        return 1.0;
+    return return_value;
 
     KRATOS_CATCH("")
 }

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_cr_beam_element_3D2N.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_cr_beam_element_3D2N.h
@@ -41,8 +41,6 @@ protected:
 
 
 private:
-    double GetPerturbationSizeModificationFactor(const Variable<array_1d<double,3>>& rDesignVariable) override;
-
     friend class Serializer;
     void save(Serializer& rSerializer) const override;
     void load(Serializer& rSerializer) override;

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_shell_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_shell_element.cpp
@@ -193,6 +193,8 @@ int AdjointFiniteDifferencingShellElement::Check(const ProcessInfo& rCurrentProc
 {
     KRATOS_TRY
 
+    int return_value = AdjointFiniteDifferencingBaseElement::Check(rCurrentProcessInfo);
+
     KRATOS_ERROR_IF_NOT(mpPrimalElement) << "Primal element pointer is nullptr!" << std::endl;
 
     //TODO: Check() of primal element should be called, but is not possible because of DOF check!
@@ -203,7 +205,7 @@ int AdjointFiniteDifferencingShellElement::Check(const ProcessInfo& rCurrentProc
     KRATOS_ERROR_IF(GetGeometry().Area() < std::numeric_limits<double>::epsilon()*1000)
         << "Element #" << Id() << " has an Area of zero!" << std::endl;
 
-    return 0;
+    return return_value;
 
     KRATOS_CATCH("")
 }

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_3D2N.cpp
@@ -178,18 +178,6 @@ void AdjointFiniteDifferenceTrussElement::CheckProperties(const ProcessInfo& rCu
     cl->Check(r_properties ,this->GetGeometry(),rCurrentProcessInfo);
 }
 
-double AdjointFiniteDifferenceTrussElement::GetPerturbationSizeModificationFactor(const Variable<array_1d<double,3>>& rDesignVariable)
-{
-    KRATOS_TRY;
-
-    if(rDesignVariable == SHAPE)
-        return this->CalculateReferenceLength();
-    else
-        return 1.0;
-
-    KRATOS_CATCH("")
-}
-
 double AdjointFiniteDifferenceTrussElement::CalculateReferenceLength()
 {
   KRATOS_TRY;

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_3D2N.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_3D2N.h
@@ -58,8 +58,6 @@ private:
 
     void CheckProperties(const ProcessInfo& rCurrentProcessInfo);
 
-    double GetPerturbationSizeModificationFactor(const Variable<array_1d<double,3>>& rDesignVariable) override;
-
     double CalculateReferenceLength();
 
     double CalculateCurrentLength();

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_linear_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_linear_3D2N.cpp
@@ -94,23 +94,6 @@ void AdjointFiniteDifferenceTrussElementLinear::CalculateStressDisplacementDeriv
     KRATOS_CATCH("")
 }
 
-double AdjointFiniteDifferenceTrussElementLinear::GetPerturbationSizeModificationFactor(const Variable<array_1d<double,3>>& rDesignVariable)
-{
-    KRATOS_TRY;
-
-    if(rDesignVariable == SHAPE)
-    {
-        const double L = this->GetGeometry().DomainSize();
-        KRATOS_DEBUG_ERROR_IF(L <= std::numeric_limits<double>::epsilon())
-            << "Pertubation size for shape derivatives of element" << this->Id() << "~ 0" << std::endl;
-        return L;
-    }
-    else
-        return 1.0;
-
-    KRATOS_CATCH("")
-}
-
 void AdjointFiniteDifferenceTrussElementLinear::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, AdjointFiniteDifferenceTrussElement);

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_linear_3D2N.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_linear_3D2N.h
@@ -46,8 +46,6 @@ public:
 
 
 private:
-    double GetPerturbationSizeModificationFactor(const Variable<array_1d<double,3>>& rDesignVariable) override;
-
     friend class Serializer;
     void save(Serializer& rSerializer) const override;
     void load(Serializer& rSerializer) override;


### PR DESCRIPTION
Some improvements of the adjoint elements:

- call  ```Check``` of the respective base element

- usage of ```DomainSize``` within the adjoint finite differencing base element to get perturbation measure for shape derivatives 