### PR TITLE
[StructuralMechanics] Adding GetValueOnIntegrationPoints-wrappers in base-shell-element

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.h
@@ -143,6 +143,59 @@ public:
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
 	                            ProcessInfo& rCurrentProcessInfo) override;
 
+    // GetValueOnIntegrationPoints are TEMPORARY until they are removed!!!
+    // They will be removed from the derived elements; i.e. the implementation
+    // should be in CalculateOnIntegrationPoints!
+    // Adding these functions here is bcs GiD calls GetValueOnIntegrationPoints
+    void GetValueOnIntegrationPoints(const Variable<bool>& rVariable,
+					     std::vector<bool>& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<int>& rVariable,
+					     std::vector<int>& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+					     std::vector<double>& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+					     std::vector<array_1d<double, 3 > >& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+					     std::vector<array_1d<double, 6 > >& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+					     std::vector<Vector>& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+					     std::vector<Matrix>& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
     /**
     * This method provides the place to perform checks on the completeness of the input
     * and the compatibility with the problem options as well as the contitutive laws selected


### PR DESCRIPTION
this will be removed again in #2194 , this is a temp solution such that I can properly implement the correct functions (`CalculateOnIntegrationPoints`)