### PR TITLE
[StructuralMechanics] Rename shell GP functions

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.h
@@ -143,6 +143,59 @@ public:
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
 	                            ProcessInfo& rCurrentProcessInfo) override;
 
+    // GetValueOnIntegrationPoints are TEMPORARY until they are removed!!!
+    // They will be removed from the derived elements; i.e. the implementation
+    // should be in CalculateOnIntegrationPoints!
+    // Adding these functions here is bcs GiD calls GetValueOnIntegrationPoints
+    void GetValueOnIntegrationPoints(const Variable<bool>& rVariable,
+					     std::vector<bool>& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<int>& rVariable,
+					     std::vector<int>& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+					     std::vector<double>& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
+					     std::vector<array_1d<double, 3 > >& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
+					     std::vector<array_1d<double, 6 > >& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+					     std::vector<Vector>& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
+    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+					     std::vector<Matrix>& rValues,
+					     const ProcessInfo& rCurrentProcessInfo) override
+    {
+        CalculateOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    }
+
     /**
     * This method provides the place to perform checks on the completeness of the input
     * and the compatibility with the problem options as well as the contitutive laws selected

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
@@ -555,12 +555,6 @@ void ShellThickElement3D3N::GetValueOnIntegrationPoints(const Variable<array_1d<
     if (TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
-void ShellThickElement3D3N::GetValueOnIntegrationPoints(const Variable<array_1d<double, 6> >& rVariable,
-    std::vector<array_1d<double, 6> >& rValues,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-}
-
 void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo & rCurrentProcessInfo)
 {
     GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
@@ -586,13 +580,6 @@ void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<Matrix>&
 
 void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable,
     std::vector<array_1d<double, 3> >& rValues,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-    GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 6> >& rVariable,
-    std::vector<array_1d<double, 6> >& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
     GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
@@ -368,7 +368,7 @@ void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<double>&
         else
         {
             KRATOS_ERROR <<
-                "Error: ELEMENT ShellThinElement3D4N, METHOD GetValueOnIntegrationPoints(double)"
+                "Error: ELEMENT ShellThinElement3D4N, METHOD CalculateOnIntegrationPoints(double)"
                 << std::endl;
         }
 
@@ -545,14 +545,14 @@ void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<Matrix>&
     std::vector<Matrix>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    if (TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(rVariable, rValues, rCurrentProcessInfo)) return;
+    if (TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
 void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable,
     std::vector<array_1d<double, 3> >& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    if (TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
+    if (TryCalculateOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
 void ShellThickElement3D3N::Calculate(const Variable<Matrix>& rVariable, Matrix & Output, const ProcessInfo & rCurrentProcessInfo)
@@ -1881,7 +1881,7 @@ void ShellThickElement3D3N::CalculateAll(MatrixType& rLeftHandSideMatrix,
     KRATOS_CATCH("")
 }
 
-bool ShellThickElement3D3N::TryGetValueOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double, 3> >& rVariable,
+bool ShellThickElement3D3N::TryCalculateOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double, 3> >& rVariable,
     std::vector<array_1d<double, 3> >& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1944,7 +1944,7 @@ bool ShellThickElement3D3N::TryGetValueOnIntegrationPoints_MaterialOrientation(c
     return true;
 }
 
-bool ShellThickElement3D3N::TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
+bool ShellThickElement3D3N::TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
     std::vector<Matrix>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
@@ -283,7 +283,7 @@ void ShellThickElement3D3N::CalculateMassMatrix(MatrixType& rMassMatrix, Process
 //
 // =====================================================================================
 
-void ShellThickElement3D3N::GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
     std::vector<double>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -472,7 +472,7 @@ void ShellThickElement3D3N::GetValueOnIntegrationPoints(const Variable<double>& 
     OPT_INTERPOLATE_RESULTS_TO_STANDARD_GAUSS_POINTS(rValues);
 }
 
-void ShellThickElement3D3N::GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
     std::vector<Vector>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -541,48 +541,18 @@ void ShellThickElement3D3N::GetValueOnIntegrationPoints(const Variable<Vector>& 
     }
 }
 
-void ShellThickElement3D3N::GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
     std::vector<Matrix>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
     if (TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
-void ShellThickElement3D3N::GetValueOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable,
-    std::vector<array_1d<double, 3> >& rValues,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-    if (TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
-}
-
-void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo & rCurrentProcessInfo)
-{
-    GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
-    std::vector<Vector>& rOutput,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-    KRATOS_TRY;
-
-    GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
-
-    KRATOS_CATCH("");
-}
-
-void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
-    std::vector<Matrix>& rValues,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-    GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
 void ShellThickElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable,
     std::vector<array_1d<double, 3> >& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
+    if (TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
 void ShellThickElement3D3N::Calculate(const Variable<Matrix>& rVariable, Matrix & Output, const ProcessInfo & rCurrentProcessInfo)

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.hpp
@@ -156,15 +156,6 @@ namespace Kratos
 
         void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
-        // Results calculation on integration points
-        void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-        void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-        void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-        void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable, std::vector<array_1d<double, 3> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
         // More results calculation on integration points to interface with python
         void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.hpp
@@ -157,8 +157,6 @@ namespace Kratos
         void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
         // Results calculation on integration points
-
-
         void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
         void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
@@ -166,8 +164,6 @@ namespace Kratos
         void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
         void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable, std::vector<array_1d<double, 3> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-        void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6> >& rVariable, std::vector<array_1d<double, 6> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
         // More results calculation on integration points to interface with python
         void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
@@ -181,10 +177,6 @@ namespace Kratos
 
         void CalculateOnIntegrationPoints(const Variable<array_1d<double,
             3> >& rVariable, std::vector<array_1d<double, 3> >& rValues,
-            const ProcessInfo& rCurrentProcessInfo) override;
-
-        void CalculateOnIntegrationPoints(const Variable<array_1d<double,
-            6> >& rVariable, std::vector<array_1d<double, 6> >& rValues,
             const ProcessInfo& rCurrentProcessInfo) override;
 
         // Calculate functions

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.hpp
@@ -342,11 +342,11 @@ namespace Kratos
             const bool CalculateStiffnessMatrixFlag,
             const bool CalculateResidualVectorFlag) override;
 
-        bool TryGetValueOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double, 3> >& rVariable,
+        bool TryCalculateOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double, 3> >& rVariable,
             std::vector<array_1d<double, 3> >& rValues,
             const ProcessInfo& rCurrentProcessInfo);
 
-        bool TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
+        bool TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
             std::vector<Matrix>& rValues,
             const ProcessInfo& rCurrentProcessInfo);
 

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
@@ -906,14 +906,14 @@ void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<Matrix>&
 	}
 
 
-    if(TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(rVariable, rValues, rCurrentProcessInfo)) return;
+    if(TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
 void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable,
         std::vector<array_1d<double,3> >& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
-    if(TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
+    if(TryCalculateOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
 void ShellThickElement3D4N::Calculate(const Variable<Matrix>& rVariable, Matrix & Output, const ProcessInfo & rCurrentProcessInfo)
@@ -1687,7 +1687,7 @@ void ShellThickElement3D4N::AddBodyForces(const array_1d<double,4> & dA, VectorT
     }
 }
 
-bool ShellThickElement3D4N::TryGetValueOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double,3> >& rVariable,
+bool ShellThickElement3D4N::TryCalculateOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double,3> >& rVariable,
         std::vector<array_1d<double,3> >& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1753,7 +1753,7 @@ bool ShellThickElement3D4N::TryGetValueOnIntegrationPoints_MaterialOrientation(c
     return true;
 }
 
-bool ShellThickElement3D4N::TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
+bool ShellThickElement3D4N::TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
         std::vector<Matrix>& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
@@ -496,7 +496,7 @@ void ShellThickElement3D4N::CalculateMassMatrix(MatrixType& rMassMatrix, Process
 //
 // =====================================================================================
 
-void ShellThickElement3D4N::GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
         std::vector<double>& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
@@ -796,7 +796,7 @@ void ShellThickElement3D4N::GetValueOnIntegrationPoints(const Variable<double>& 
 	}
 }
 
-void ShellThickElement3D4N::GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
         std::vector<Vector>& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
@@ -882,7 +882,7 @@ void ShellThickElement3D4N::GetValueOnIntegrationPoints(const Variable<Vector>& 
 	}
 }
 
-void ShellThickElement3D4N::GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
         std::vector<Matrix>& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
@@ -909,37 +909,11 @@ void ShellThickElement3D4N::GetValueOnIntegrationPoints(const Variable<Matrix>& 
     if(TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
-void ShellThickElement3D4N::GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable,
+void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable,
         std::vector<array_1d<double,3> >& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
     if(TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
-}
-
-void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo & rCurrentProcessInfo)
-{
-	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
-	std::vector<Vector>& rOutput,
-	const ProcessInfo& rCurrentProcessInfo)
-{
-	GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
-}
-
-void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
-	std::vector<Matrix>& rValues,
-	const ProcessInfo& rCurrentProcessInfo)
-{
-	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable,
-	std::vector<array_1d<double, 3> >& rValues,
-	const ProcessInfo& rCurrentProcessInfo)
-{
-	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
 }
 
 void ShellThickElement3D4N::Calculate(const Variable<Matrix>& rVariable, Matrix & Output, const ProcessInfo & rCurrentProcessInfo)

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
@@ -916,12 +916,6 @@ void ShellThickElement3D4N::GetValueOnIntegrationPoints(const Variable<array_1d<
     if(TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
-void ShellThickElement3D4N::GetValueOnIntegrationPoints(const Variable<array_1d<double,6> >& rVariable,
-        std::vector<array_1d<double,6> >& rValues,
-        const ProcessInfo& rCurrentProcessInfo)
-{
-}
-
 void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo & rCurrentProcessInfo)
 {
 	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
@@ -943,13 +937,6 @@ void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<Matrix>&
 
 void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable,
 	std::vector<array_1d<double, 3> >& rValues,
-	const ProcessInfo& rCurrentProcessInfo)
-{
-	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThickElement3D4N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 6> >& rVariable,
-	std::vector<array_1d<double, 6> >& rValues,
 	const ProcessInfo& rCurrentProcessInfo)
 {
 	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
@@ -339,7 +339,6 @@ public:
     void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
     // Results calculation on integration points
-
     void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
@@ -347,8 +346,6 @@ public:
     void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable, std::vector<array_1d<double,3> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<array_1d<double,6> >& rVariable, std::vector<array_1d<double,6> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     // More results calculation on integration points to interface with python
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
@@ -362,10 +359,6 @@ public:
 
     void CalculateOnIntegrationPoints(const Variable<array_1d<double,
         3> >& rVariable, std::vector<array_1d<double, 3> >& rValues,
-        const ProcessInfo& rCurrentProcessInfo) override;
-
-    void CalculateOnIntegrationPoints(const Variable<array_1d<double,
-        6> >& rVariable, std::vector<array_1d<double, 6> >& rValues,
         const ProcessInfo& rCurrentProcessInfo) override;
 
     // Calculate functions

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
@@ -418,11 +418,11 @@ private:
 
     void AddBodyForces(const array_1d<double,4> & dA, VectorType& rRightHandSideVector);
 
-    bool TryGetValueOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double,3> >& rVariable,
+    bool TryCalculateOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double,3> >& rVariable,
             std::vector<array_1d<double,3> >& rValues,
             const ProcessInfo& rCurrentProcessInfo);
 
-    bool TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
+    bool TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
             std::vector<Matrix>& rValues,
             const ProcessInfo& rCurrentProcessInfo);
 

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
@@ -338,15 +338,6 @@ public:
 
     void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
-    // Results calculation on integration points
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable, std::vector<array_1d<double,3> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
     // More results calculation on integration points to interface with python
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
         std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
@@ -200,7 +200,7 @@ void ShellThinElement3D3N::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessI
 //
 // =====================================================================================
 
-void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<double>& rVariable,
         std::vector<double>& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
@@ -362,7 +362,7 @@ void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<double>& r
     OPT_INTERPOLATE_RESULTS_TO_STANDARD_GAUSS_POINTS(rValues);
 }
 
-void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
+void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
         std::vector<Vector>& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
@@ -428,7 +428,7 @@ void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<Vector>& r
 	}
 }
 
-void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
+void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
         std::vector<Matrix>& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
@@ -454,37 +454,11 @@ void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<Matrix>& r
     if(TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
-void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable,
+void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable,
         std::vector<array_1d<double,3> >& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
     if(TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
-}
-
-void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo & rCurrentProcessInfo)
-{
-	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
-	std::vector<Vector>& rOutput,
-	const ProcessInfo& rCurrentProcessInfo)
-{
-	GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
-}
-
-void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
-	std::vector<Matrix>& rValues,
-	const ProcessInfo& rCurrentProcessInfo)
-{
-	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable,
-	std::vector<array_1d<double, 3> >& rValues,
-	const ProcessInfo& rCurrentProcessInfo)
-{
-	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
 }
 
 void ShellThinElement3D3N::Calculate(const Variable<Matrix>& rVariable, Matrix & Output, const ProcessInfo & rCurrentProcessInfo)

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
@@ -461,12 +461,6 @@ void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<array_1d<d
     if(TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
-void ShellThinElement3D3N::GetValueOnIntegrationPoints(const Variable<array_1d<double,6> >& rVariable,
-        std::vector<array_1d<double,6> >& rValues,
-        const ProcessInfo& rCurrentProcessInfo)
-{
-}
-
 void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo & rCurrentProcessInfo)
 {
 	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
@@ -488,13 +482,6 @@ void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<Matrix>& 
 
 void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable,
 	std::vector<array_1d<double, 3> >& rValues,
-	const ProcessInfo& rCurrentProcessInfo)
-{
-	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 6> >& rVariable,
-	std::vector<array_1d<double, 6> >& rValues,
 	const ProcessInfo& rCurrentProcessInfo)
 {
 	GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
@@ -451,14 +451,14 @@ void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<Matrix>& 
 		}
 	}
 
-    if(TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(rVariable, rValues, rCurrentProcessInfo)) return;
+    if(TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
 void ShellThinElement3D3N::CalculateOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable,
         std::vector<array_1d<double,3> >& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
-    if(TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
+    if(TryCalculateOnIntegrationPoints_MaterialOrientation(rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
 void ShellThinElement3D3N::Calculate(const Variable<Matrix>& rVariable, Matrix & Output, const ProcessInfo & rCurrentProcessInfo)
@@ -1503,7 +1503,7 @@ void ShellThinElement3D3N::CalculateAll(MatrixType& rLeftHandSideMatrix,
     AddBodyForces(data, rRightHandSideVector);
 }
 
-bool ShellThinElement3D3N::TryGetValueOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double,3> >& rVariable,
+bool ShellThinElement3D3N::TryCalculateOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double,3> >& rVariable,
         std::vector<array_1d<double,3> >& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {
@@ -1564,7 +1564,7 @@ bool ShellThinElement3D3N::TryGetValueOnIntegrationPoints_MaterialOrientation(co
     return true;
 }
 
-bool ShellThinElement3D3N::TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
+bool ShellThinElement3D3N::TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
         std::vector<Matrix>& rValues,
         const ProcessInfo& rCurrentProcessInfo)
 {

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.hpp
@@ -147,7 +147,6 @@ public:
     void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
     // Results calculation on integration points
-
     void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
@@ -155,8 +154,6 @@ public:
     void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable, std::vector<array_1d<double,3> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<array_1d<double,6> >& rVariable, std::vector<array_1d<double,6> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
 
 	// More results calculation on integration points to interface with python
@@ -172,10 +169,6 @@ public:
 	void CalculateOnIntegrationPoints(const Variable<array_1d<double,
 		3> >& rVariable, std::vector<array_1d<double, 3> >& rValues,
 		const ProcessInfo& rCurrentProcessInfo) override;
-
-	void CalculateOnIntegrationPoints(const Variable<array_1d<double,
-		6> >& rVariable, std::vector<array_1d<double, 6> >& rValues,
-        const ProcessInfo& rCurrentProcessInfo) override;
 
     // Calculate functions
     void Calculate(const Variable<Matrix >& rVariable,

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.hpp
@@ -324,11 +324,11 @@ private:
         const bool CalculateStiffnessMatrixFlag,
         const bool CalculateResidualVectorFlag) override;
 
-    bool TryGetValueOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double,3> >& rVariable,
+    bool TryCalculateOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double,3> >& rVariable,
             std::vector<array_1d<double,3> >& rValues,
             const ProcessInfo& rCurrentProcessInfo);
 
-    bool TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
+    bool TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
             std::vector<Matrix>& rValues,
             const ProcessInfo& rCurrentProcessInfo);
 

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.hpp
@@ -146,16 +146,6 @@ public:
 
     void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
 
-    // Results calculation on integration points
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<array_1d<double,3> >& rVariable, std::vector<array_1d<double,3> >& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-
 	// More results calculation on integration points to interface with python
 	void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
 		std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
@@ -698,13 +698,6 @@ void ShellThinElement3D4N::GetValueOnIntegrationPoints
         rValues, rCurrentProcessInfo)) return;
 }
 
-void ShellThinElement3D4N::GetValueOnIntegrationPoints
-(const Variable<array_1d<double, 6> >& rVariable,
-    std::vector<array_1d<double, 6> >& rValues,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-}
-
 void ShellThinElement3D4N::CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo & rCurrentProcessInfo)
 {
     GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
@@ -726,13 +719,6 @@ void ShellThinElement3D4N::CalculateOnIntegrationPoints(const Variable<Matrix>& 
 
 void ShellThinElement3D4N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable,
     std::vector<array_1d<double, 3> >& rValues,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-    GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThinElement3D4N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 6> >& rVariable,
-    std::vector<array_1d<double, 6> >& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
     GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
@@ -472,7 +472,7 @@ void ShellThinElement3D4N::CalculateOnIntegrationPoints(
             else
             {
                 KRATOS_ERROR <<
-                    "Error: ELEMENT ShellThinElement3D4N, METHOD GetValueOnIntegrationPoints(double)"
+                    "Error: ELEMENT ShellThinElement3D4N, METHOD CalculateOnIntegrationPoints(double)"
                     << std::endl;
             }
 
@@ -685,7 +685,7 @@ void ShellThinElement3D4N::CalculateOnIntegrationPoints(
     std::vector<Matrix>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    if (TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(
+    if (TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(
         rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
@@ -694,7 +694,7 @@ void ShellThinElement3D4N::CalculateOnIntegrationPoints(
     std::vector<array_1d<double, 3> >& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    if (TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable,
+    if (TryCalculateOnIntegrationPoints_MaterialOrientation(rVariable,
         rValues, rCurrentProcessInfo)) return;
 }
 
@@ -2128,7 +2128,7 @@ void ShellThinElement3D4N::CalculateAll(MatrixType& rLeftHandSideMatrix,
     AddBodyForces(data, rRightHandSideVector);
 }
 
-bool ShellThinElement3D4N::TryGetValueOnIntegrationPoints_MaterialOrientation
+bool ShellThinElement3D4N::TryCalculateOnIntegrationPoints_MaterialOrientation
 (const Variable<array_1d<double, 3> >& rVariable,
     std::vector<array_1d<double, 3> >& rValues,
     const ProcessInfo& rCurrentProcessInfo)
@@ -2194,7 +2194,7 @@ bool ShellThinElement3D4N::TryGetValueOnIntegrationPoints_MaterialOrientation
 }
 
 bool ShellThinElement3D4N::
-    TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses
+    TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses
     (const Variable<Matrix>& rVariable,
         std::vector<Matrix>& rValues,
         const ProcessInfo& rCurrentProcessInfo)

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
@@ -359,8 +359,8 @@ void ShellThinElement3D4N::AddBodyForces(CalculationData& data,
 //
 // =========================================================================
 
-void ShellThinElement3D4N::GetValueOnIntegrationPoints
-(const Variable<double>& rVariable,
+void ShellThinElement3D4N::CalculateOnIntegrationPoints(
+    const Variable<double>& rVariable,
     std::vector<double>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -610,8 +610,8 @@ void ShellThinElement3D4N::GetValueOnIntegrationPoints
     KRATOS_CATCH("");
 }
 
-void ShellThinElement3D4N::GetValueOnIntegrationPoints
-(const Variable<Vector>& rVariable,
+void ShellThinElement3D4N::CalculateOnIntegrationPoints(
+    const Variable<Vector>& rVariable,
     std::vector<Vector>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
@@ -680,48 +680,22 @@ void ShellThinElement3D4N::GetValueOnIntegrationPoints
     }
 }
 
-void ShellThinElement3D4N::GetValueOnIntegrationPoints
-(const Variable<Matrix>& rVariable,
+void ShellThinElement3D4N::CalculateOnIntegrationPoints(
+    const Variable<Matrix>& rVariable,
     std::vector<Matrix>& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
-    if (TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses
-    (rVariable, rValues, rCurrentProcessInfo)) return;
+    if (TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(
+        rVariable, rValues, rCurrentProcessInfo)) return;
 }
 
-void ShellThinElement3D4N::GetValueOnIntegrationPoints
-(const Variable<array_1d<double, 3> >& rVariable,
+void ShellThinElement3D4N::CalculateOnIntegrationPoints(
+    const Variable<array_1d<double, 3> >& rVariable,
     std::vector<array_1d<double, 3> >& rValues,
     const ProcessInfo& rCurrentProcessInfo)
 {
     if (TryGetValueOnIntegrationPoints_MaterialOrientation(rVariable,
         rValues, rCurrentProcessInfo)) return;
-}
-
-void ShellThinElement3D4N::CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo & rCurrentProcessInfo)
-{
-    GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThinElement3D4N::CalculateOnIntegrationPoints(const Variable<Vector>& rVariable,
-    std::vector<Vector>& rValues,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-    GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThinElement3D4N::CalculateOnIntegrationPoints(const Variable<Matrix>& rVariable,
-    std::vector<Matrix>& rValues,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-    GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
-}
-
-void ShellThinElement3D4N::CalculateOnIntegrationPoints(const Variable<array_1d<double, 3> >& rVariable,
-    std::vector<array_1d<double, 3> >& rValues,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-    GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
 }
 
 void ShellThinElement3D4N::Calculate(const Variable<Matrix>& rVariable, Matrix & Output, const ProcessInfo & rCurrentProcessInfo)

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.hpp
@@ -400,11 +400,11 @@ private:
         const bool CalculateStiffnessMatrixFlag,
         const bool CalculateResidualVectorFlag) override;
 
-    bool TryGetValueOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double, 3> >& rVariable,
+    bool TryCalculateOnIntegrationPoints_MaterialOrientation(const Variable<array_1d<double, 3> >& rVariable,
         std::vector<array_1d<double, 3> >& rValues,
         const ProcessInfo& rCurrentProcessInfo);
 
-    bool TryGetValueOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
+    bool TryCalculateOnIntegrationPoints_GeneralizedStrainsOrStresses(const Variable<Matrix>& rVariable,
         std::vector<Matrix>& rValues,
         const ProcessInfo& rCurrentProcessInfo);
 

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.hpp
@@ -225,10 +225,6 @@ public:
         3> >& rVariable, std::vector<array_1d<double, 3> >& rValues,
         const ProcessInfo& rCurrentProcessInfo) override;
 
-    void GetValueOnIntegrationPoints(const Variable<array_1d<double,
-        6> >& rVariable, std::vector<array_1d<double, 6> >& rValues,
-        const ProcessInfo& rCurrentProcessInfo) override;
-
     // More results calculation on integration points to interface with python
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
         std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
@@ -241,10 +237,6 @@ public:
 
     void CalculateOnIntegrationPoints(const Variable<array_1d<double,
         3> >& rVariable, std::vector<array_1d<double, 3> >& rValues,
-        const ProcessInfo& rCurrentProcessInfo) override;
-
-    void CalculateOnIntegrationPoints(const Variable<array_1d<double,
-        6> >& rVariable, std::vector<array_1d<double, 6> >& rValues,
         const ProcessInfo& rCurrentProcessInfo) override;
 
     // Calculate functions

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.hpp
@@ -211,20 +211,6 @@ public:
     void CalculateMassMatrix(MatrixType& rMassMatrix,
         ProcessInfo& rCurrentProcessInfo) override;
 
-    // Results calculation on integration points
-    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
-        std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
-        std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
-        std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-
-    void GetValueOnIntegrationPoints(const Variable<array_1d<double,
-        3> >& rVariable, std::vector<array_1d<double, 3> >& rValues,
-        const ProcessInfo& rCurrentProcessInfo) override;
-
     // More results calculation on integration points to interface with python
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
         std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_shell_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_shell_element.cpp
@@ -169,9 +169,9 @@ void AdjointFiniteDifferencingShellElement::Calculate(const Variable<Vector >& r
         }
 
         if(stress_is_moment)
-            mpPrimalElement->GetValueOnIntegrationPoints(SHELL_MOMENT_GLOBAL, stress_vector, rCurrentProcessInfo);
+            mpPrimalElement->CalculateOnIntegrationPoints(SHELL_MOMENT_GLOBAL, stress_vector, rCurrentProcessInfo);
         else
-            mpPrimalElement->GetValueOnIntegrationPoints(SHELL_FORCE_GLOBAL, stress_vector, rCurrentProcessInfo);
+            mpPrimalElement->CalculateOnIntegrationPoints(SHELL_FORCE_GLOBAL, stress_vector, rCurrentProcessInfo);
 
         rOutput.resize(num_gps);
         for(IndexType i = 0; i < num_gps; i++)


### PR DESCRIPTION
Following #2759 and as preparation for #2194 

@armingeiser @MFusseder I corrected the calls in the AdjointShellElement