### PR TITLE
Removing unused omp include.

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
@@ -14,7 +14,6 @@
 #define KRATOS_SPR_ERROR_PROCESS
 
 // System includes
-#include <omp.h>
 
 // External includes
 

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
@@ -16,7 +16,7 @@
 // System includes
 #ifdef _OPENMP
 #include <omp.h>
-#else
+#endif
 
 // External includes
 

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
@@ -14,6 +14,9 @@
 #define KRATOS_SPR_ERROR_PROCESS
 
 // System includes
+#ifdef _OPENMP
+#include <omp.h>
+#else
 
 // External includes
 


### PR DESCRIPTION
The explicit inclusion of omp in this file does not allow me to compile without omp support. Since there are no specific omp calls in that file, I removed the include and everything seems to work... Is it OK to change it?