### PR TITLE
[Fluid] Reducing tolerance of cylinder test reference file checking

### DIFF
--- a/applications/FluidDynamicsApplication/tests/CylinderTest/cylinder_fluid_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/CylinderTest/cylinder_fluid_parameters.json
@@ -144,7 +144,7 @@
             "reference_file_name" : "cylinder_test_probe1_ref.dat",
             "comparison_type"     : "dat_file",
             "remove_output_file"    : true,
-            "decimal_places"      : 7
+            "decimal_places"      : 5
         }
     },{
         "python_module"   : "compare_two_files_check_process",
@@ -156,7 +156,7 @@
             "reference_file_name" : "cylinder_test_probe2_ref.dat",
             "comparison_type"     : "dat_file",
             "remove_output_file"    : true,
-	        "decimal_places"      : 7
+	        "decimal_places"      : 5
         }
     },{
         "python_module"   : "compare_two_files_check_process",
@@ -168,7 +168,7 @@
             "reference_file_name" : "NoSlip2D_cylinder_drag_ref.dat",
             "comparison_type"     : "dat_file",
             "remove_output_file"    : true,
-	        "decimal_places"      : 7
+	        "decimal_places"      : 5
         }
     }]
 }


### PR DESCRIPTION
Reducing tolerance of few CompareTwoFilesCheckProcess since, some occasions high tolerance fails these tests due to numerical errors. [#2786]