### PR TITLE
Breaking circular include in gid_io.h.

### DIFF
--- a/kratos/includes/gid_gauss_point_container.h
+++ b/kratos/includes/gid_gauss_point_container.h
@@ -1,10 +1,10 @@
-//    |  /           | 
-//    ' /   __| _` | __|  _ \   __| 
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ \.
-//   _|\_\_|  \__,_|\__|\___/ ____/ 
-//                   Multi-Physics  
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
@@ -27,7 +27,6 @@
 
 // Project includes
 #include "includes/define.h"
-#include "includes/gid_io.h"
 #include "geometries/geometry_data.h"
 
 #define tet10_a 0.108103018168070
@@ -91,7 +90,7 @@ public:
         else return false;
         KRATOS_CATCH("")
     }
-    
+
 
 //            virtual void PrintResults( Variable<array_1d<double,3> > rVariable, ModelPart& rModelPart,
 //                                        double SolutionTag, unsigned int ValueIndex )
@@ -150,7 +149,7 @@ public:
                             int index = mIndexContainer[i];
                             GiD_fWriteScalar( ResultFile, it->Id(), ValuesOnIntPoint[index] );
                         }
-                    }           
+                    }
                 }
             }
             if( mMeshConditions.size() != 0 )
@@ -167,7 +166,7 @@ public:
                             int index = mIndexContainer[i];
                             GiD_fWriteScalar( ResultFile, it->Id(), ValuesOnIntPoint[index] );
                         }
-                    }                
+                    }
                 }
             }
             GiD_fEndResult(ResultFile);
@@ -197,7 +196,7 @@ public:
                             int index = mIndexContainer[i];
                             GiD_fWriteScalar( ResultFile, it->Id(), double(ValuesOnIntPoint[index]) );
                         }
-                    }             
+                    }
                 }
             }
             if( mMeshConditions.size() != 0 )
@@ -214,7 +213,7 @@ public:
                             int index = mIndexContainer[i];
                             GiD_fWriteScalar( ResultFile, it->Id(), double(ValuesOnIntPoint[index]) );
                         }
-                    }               
+                    }
                 }
             }
             GiD_fEndResult(ResultFile);
@@ -247,7 +246,7 @@ public:
                                 GiD_fWriteVector( ResultFile, it->Id(), ValuesOnIntPoint[index][0],
                                                  ValuesOnIntPoint[index][1], ValuesOnIntPoint[index][2] );
                         }
-                    }               
+                    }
                 }
             }
             if( mMeshConditions.size() != 0 )
@@ -298,7 +297,7 @@ public:
                                                ValuesOnIntPoint[index][3], ValuesOnIntPoint[index][4],
                                                ValuesOnIntPoint[index][5] );
                         }
-                    }             
+                    }
                 }
             }
             if( mMeshConditions.size() != 0 )
@@ -318,7 +317,7 @@ public:
                                                ValuesOnIntPoint[index][3], ValuesOnIntPoint[index][4],
                                                ValuesOnIntPoint[index][5] );
                         }
-                    }                   
+                    }
                 }
             }
             GiD_fEndResult(ResultFile);
@@ -377,7 +376,7 @@ public:
                                 GiD_fWrite3DMatrix( ResultFile, it->Id(), values[0], values[1], values[2],
                                     values[3], values[4], values[5] );
                         }
-                    }                 
+                    }
                 }
             }
             GiD_fEndResult(ResultFile);
@@ -764,7 +763,7 @@ public:
             }
         }
     }
-    
+
 
 protected:
 
@@ -780,5 +779,5 @@ protected:
 };//class GidGaussPointsContainer
 }// namespace Kratos.
 
-#endif // KRATOS_GID_GAUSS_POINT_CONTAINER_H_INCLUDED defined 
+#endif // KRATOS_GID_GAUSS_POINT_CONTAINER_H_INCLUDED defined
 

--- a/kratos/includes/gid_mesh_container.h
+++ b/kratos/includes/gid_mesh_container.h
@@ -1,10 +1,10 @@
-//    |  /           | 
-//    ' /   __| _` | __|  _ \   __| 
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ \.
-//   _|\_\_|  \__,_|\__|\___/ ____/ 
-//                   Multi-Physics  
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
@@ -34,7 +34,6 @@
 #include "gidpost/source/gidpost.h"
 // Project includes
 #include "includes/define.h"
-#include "includes/gid_io.h"
 #include "geometries/geometry_data.h"
 #include "includes/deprecated_variables.h"
 
@@ -187,7 +186,7 @@ public:
                             nodes_id[2] = (it)->GetGeometry() [2].Id();
                         }
                         nodes_id[ (it)->GetGeometry().size()]= (it)->GetProperties().Id()+1;
-                        
+
                         bool element_is_active = true;
                         if ((it)->IsDefined(ACTIVE))
                             element_is_active = (it)->Is(ACTIVE);
@@ -195,7 +194,7 @@ public:
                         if (element_is_active)
                             if ((it)->GetProperties().Id()==current_layer)
                                 GiD_fWriteElementMat ( MeshFile, (it)->Id(), nodes_id);
-                        
+
                     }
                     delete [] nodes_id;
                     GiD_fEndElements(MeshFile);
@@ -289,7 +288,7 @@ public:
                             nodes_id[19] = (it)->GetGeometry() [15].Id();
                         }
                         nodes_id[ (it)->GetGeometry().size()]= (it)->GetProperties().Id()+1;
-                        
+
                         bool element_is_active = true;
                         if ((it)->IsDefined(ACTIVE))
                             element_is_active = (it)->Is(ACTIVE);


### PR DESCRIPTION
These two files are included from gid_io.h and were also including it. I'm removing these apparently unnecessary includes of gid_io.h to break the loop. (sorry for the whitespace noise in the diff, there are only two actual changes: one include removed on each file).

Thanks to @philbucher, who detected the issue.