### PR TITLE
Fixing print macros

### DIFF
--- a/kratos/input_output/logger.h
+++ b/kratos/input_output/logger.h
@@ -250,18 +250,18 @@ namespace Kratos
 
 #define KRATOS_WARNING(label) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::WARNING
 #define KRATOS_WARNING_IF(label, conditional) if(conditional) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::WARNING
-#define KRATOS_WARNING_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == __COUNT__) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::WARNING
+#define KRATOS_WARNING_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == 0) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::WARNING
 #define KRATOS_WARNING_FIRST_N(label, logger_count) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES < logger_count) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::WARNING
 
 #define KRATOS_DETAIL(label) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::DETAIL
 #define KRATOS_DETAIL_IF(label, conditional) if(conditional) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::DETAIL
-#define KRATOS_DETAIL_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == __COUNT__) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::DETAIL
+#define KRATOS_DETAIL_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == 0) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::DETAIL
 #define KRATOS_DETAIL_FIRST_N(label, logger_count) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES < logger_count) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::DETAIL
 
 #ifdef KRATOS_DEBUG
 #define KRATOS_TRACE(label) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::TRACE
 #define KRATOS_TRACE_IF(label, conditional) if(conditional) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::TRACE
-#define KRATOS_TRACE_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == __COUNT__) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::TRACE
+#define KRATOS_TRACE_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == 0) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::TRACE
 #define KRATOS_TRACE_FIRST_N(label, logger_count) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES < logger_count) Logger(label) << KRATOS_CODE_LOCATION << Logger::Severity::TRACE
 #else
 #define KRATOS_TRACE(label) if(false) KRATOS_WARNING(label)

--- a/kratos/tests/input_output/test_logger.cpp
+++ b/kratos/tests/input_output/test_logger.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics 
 //
-//  License:		 BSD License 
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License 
+//                     Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   
@@ -19,84 +19,84 @@
 
 
 namespace Kratos {
-	namespace Testing {
+    namespace Testing {
 
-		KRATOS_TEST_CASE_IN_SUITE(LoggerMessageStream, KratosCoreFastSuite)
-		{
-			LoggerMessage message("label");
+        KRATOS_TEST_CASE_IN_SUITE(LoggerMessageStream, KratosCoreFastSuite)
+        {
+            LoggerMessage message("label");
 
-			message << "Test message with number " << 12 << 'e' << "00";
+            message << "Test message with number " << 12 << 'e' << "00";
 
-			KRATOS_CHECK_C_STRING_EQUAL(message.GetLabel().c_str(), "label");
-			KRATOS_CHECK_C_STRING_EQUAL(message.GetMessage().c_str(), "Test message with number 12e00");
-			KRATOS_CHECK_EQUAL(message.GetSeverity(), LoggerMessage::Severity::INFO);
+            KRATOS_CHECK_C_STRING_EQUAL(message.GetLabel().c_str(), "label");
+            KRATOS_CHECK_C_STRING_EQUAL(message.GetMessage().c_str(), "Test message with number 12e00");
+            KRATOS_CHECK_EQUAL(message.GetSeverity(), LoggerMessage::Severity::INFO);
             KRATOS_CHECK_EQUAL(message.GetCategory(), LoggerMessage::Category::STATUS);
             KRATOS_CHECK_EQUAL(message.GetLocation().GetFileName(), "Unknown");
             KRATOS_CHECK_EQUAL(message.GetLocation().GetFunctionName(), "Unknown");
             KRATOS_CHECK_EQUAL(message.GetLocation().GetLineNumber(), -1);
 
-			message << LoggerMessage::Severity::DETAIL 
+            message << LoggerMessage::Severity::DETAIL 
                 << LoggerMessage::Category::CRITICAL 
                 << KRATOS_CODE_LOCATION << std::endl;
 
-			KRATOS_CHECK_C_STRING_EQUAL(message.GetMessage().c_str(), "Test message with number 12e00\n");
-			KRATOS_CHECK_EQUAL(message.GetSeverity(), LoggerMessage::Severity::DETAIL);
+            KRATOS_CHECK_C_STRING_EQUAL(message.GetMessage().c_str(), "Test message with number 12e00\n");
+            KRATOS_CHECK_EQUAL(message.GetSeverity(), LoggerMessage::Severity::DETAIL);
             KRATOS_CHECK_EQUAL(message.GetCategory(), LoggerMessage::Category::CRITICAL);
             KRATOS_CHECK_NOT_EQUAL(message.GetLocation().GetFileName().find("test_logger.cpp"), std::string::npos);
             KRATOS_CHECK_EQUAL(message.GetLocation().GetFunctionName(), KRATOS_CURRENT_FUNCTION);
             KRATOS_CHECK_EQUAL(message.GetLocation().GetLineNumber(), 40);
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(LoggerOutput, KratosCoreFastSuite)
-		{
-			std::stringstream buffer;
-			LoggerOutput output(buffer);
-
-			LoggerMessage message("label");
-			message << "Test message with number " << 12 << 'e' << "00";
-
-			output.WriteMessage(message);
-			KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "label: Test message with number 12e00");
-		}
-
-		KRATOS_TEST_CASE_IN_SUITE(LoggerStream, KratosCoreFastSuite)
-		{
-			static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
-			Logger::AddOutput(p_output);
-
-			Logger("TestLabel") << "Test message with number " << 12 << 'e' << "00";
-
-			KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestLabel: Test message with number 12e00");
-
-			Logger("TestDetail") << Logger::Severity::DETAIL << "This log has detailed severity and will not be printed in output " 
-				<< Logger::Category::CRITICAL << std::endl;
-
-			// The message has DETAIL severity and should not be written
-			KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestLabel: Test message with number 12e00");
         }
 
-		KRATOS_TEST_CASE_IN_SUITE(CheckPoint, KratosCoreFastSuite)
-		{
-			std::stringstream buffer;
-			LoggerOutput output(buffer);
+        KRATOS_TEST_CASE_IN_SUITE(LoggerOutput, KratosCoreFastSuite)
+        {
+            std::stringstream buffer;
+            LoggerOutput output(buffer);
 
-			KRATOS_CHECK_POINT("TestCheckPoint") << "The value in check point is " << 3.14;
+            LoggerMessage message("label");
+            message << "Test message with number " << 12 << 'e' << "00";
+
+            output.WriteMessage(message);
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "label: Test message with number 12e00");
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(LoggerStream, KratosCoreFastSuite)
+        {
+            static std::stringstream buffer;
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            Logger::AddOutput(p_output);
+
+            Logger("TestLabel") << "Test message with number " << 12 << 'e' << "00";
+
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestLabel: Test message with number 12e00");
+
+            Logger("TestDetail") << Logger::Severity::DETAIL << "This log has detailed severity and will not be printed in output " 
+                << Logger::Category::CRITICAL << std::endl;
+
+            // The message has DETAIL severity and should not be written
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestLabel: Test message with number 12e00");
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(CheckPoint, KratosCoreFastSuite)
+        {
+            std::stringstream buffer;
+            LoggerOutput output(buffer);
+
+            KRATOS_CHECK_POINT("TestCheckPoint") << "The value in check point is " << 3.14;
 
 #if defined(KRATOS_ENABLE_CHECK_POINT)
-			KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestCheckPoint: The value in check point is 3.14");
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestCheckPoint: The value in check point is 3.14");
 #else
-			KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), ""); // should print noting
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), ""); // should print noting
 #endif
-		}
+        }
 
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamInfo, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
-			Logger::AddOutput(p_output);
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            Logger::AddOutput(p_output);
 
-			KRATOS_INFO("TestInfo") << "Test info message";
+            KRATOS_INFO("TestInfo") << "Test info message";
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestInfo: Test info message");
         }
@@ -104,8 +104,8 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamInfoIf, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
-			Logger::AddOutput(p_output);
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            Logger::AddOutput(p_output);
 
             KRATOS_INFO_IF("TestInfo", true) << "Test info message";
             KRATOS_INFO_IF("TestInfo", false) << "This should not appear";
@@ -116,10 +116,10 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamInfoOnce, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
-			Logger::AddOutput(p_output);
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            Logger::AddOutput(p_output);
 
-			for(std::size_t i = 0; i < 10; i++) {
+            for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_INFO_ONCE("TestInfo") << "Test info message - " << i;
             }
 
@@ -129,8 +129,8 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamInfoFirst, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
-			Logger::AddOutput(p_output);
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            Logger::AddOutput(p_output);
 
             for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_INFO_FIRST_N("TestInfo", 4) << ".";
@@ -142,10 +142,10 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamWarning, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
-			Logger::AddOutput(p_output);
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            Logger::AddOutput(p_output);
 
-			KRATOS_WARNING("TestWarning") << "Test warning message";
+            KRATOS_WARNING("TestWarning") << "Test warning message";
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestWarning: Test warning message");
         }
@@ -153,8 +153,8 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamWarningIf, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
-			Logger::AddOutput(p_output);
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            Logger::AddOutput(p_output);
 
             KRATOS_WARNING_IF("TestWarning", true) << "Test warning message";
             KRATOS_WARNING_IF("TestWarning", false) << "This should not appear";
@@ -165,10 +165,10 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamWarningOnce, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
-			Logger::AddOutput(p_output);
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            Logger::AddOutput(p_output);
 
-			for(std::size_t i = 0; i < 10; i++) {
+            for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_WARNING_ONCE("TestWarning") << "Test warning message - " << i;
             }
 
@@ -178,8 +178,8 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamWarningFirst, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
-			Logger::AddOutput(p_output);
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            Logger::AddOutput(p_output);
 
             for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_WARNING_FIRST_N("TestWarning", 4) << ".";
@@ -193,9 +193,9 @@ namespace Kratos {
             static std::stringstream buffer;
             LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
             p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
-			Logger::AddOutput(p_output);
+            Logger::AddOutput(p_output);
             
-			KRATOS_DETAIL("TestDetail") << "Test detail message";
+            KRATOS_DETAIL("TestDetail") << "Test detail message";
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestDetail: Test detail message");
         }
@@ -205,7 +205,7 @@ namespace Kratos {
             static std::stringstream buffer;
             LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
             p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
-			Logger::AddOutput(p_output);
+            Logger::AddOutput(p_output);
 
             KRATOS_DETAIL_IF("TestDetail", true) << "Test detail message";
             KRATOS_DETAIL_IF("TestDetail", false) << "This should not appear";
@@ -218,9 +218,9 @@ namespace Kratos {
             static std::stringstream buffer;
             LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
             p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
-			Logger::AddOutput(p_output);
+            Logger::AddOutput(p_output);
 
-			for(std::size_t i = 0; i < 10; i++) {
+            for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_DETAIL_ONCE("TestDetail") << "Test detail message - " << i;
             }
 
@@ -232,7 +232,7 @@ namespace Kratos {
             static std::stringstream buffer;
             LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
             p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
-			Logger::AddOutput(p_output);
+            Logger::AddOutput(p_output);
 
             for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_DETAIL_FIRST_N("TestDetail", 4) << ".";
@@ -241,33 +241,33 @@ namespace Kratos {
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestDetail: .TestDetail: .TestDetail: .TestDetail: .");
         }
 
-		KRATOS_TEST_CASE_IN_SUITE(LoggerTableOutput, KratosCoreFastSuite)
-		{
-			static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerTableOutput(buffer, {"Time Step    ", "Iteration Number        ", "Convergence        ", "Is converged"}));
-			Logger::AddOutput(p_output);
+        KRATOS_TEST_CASE_IN_SUITE(LoggerTableOutput, KratosCoreFastSuite)
+        {
+            static std::stringstream buffer;
+            LoggerOutput::Pointer p_output(new LoggerTableOutput(buffer, {"Time Step    ", "Iteration Number        ", "Convergence        ", "Is converged"}));
+            Logger::AddOutput(p_output);
             p_output->WriteHeader();
             std::stringstream reference_output;
             reference_output << "Time Step     Iteration Number         Convergence         Is converged " << std::endl;
 
-			KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), reference_output.str().c_str());
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), reference_output.str().c_str());
 
             std::size_t time_step = 1;
-			Logger("Time Step") << time_step << std::endl;
+            Logger("Time Step") << time_step << std::endl;
             reference_output << "1             ";
 
-			KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), reference_output.str().c_str());
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), reference_output.str().c_str());
 
-			Logger("Label") << "This log has a lable which is not in the output columns and will not be printed in output " << std::endl;
+            Logger("Label") << "This log has a lable which is not in the output columns and will not be printed in output " << std::endl;
 
-			KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), reference_output.str().c_str());
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), reference_output.str().c_str());
 
             double convergence = 0.00;
             for(time_step = 2;time_step < 4; time_step++){
                 Logger("Time Step") << time_step << std::endl;
                 for(int iteration_number = 1 ; iteration_number < 3; iteration_number++){
                         convergence = 0.3 / (iteration_number * time_step);
-                    	Logger("Iteration Number") << iteration_number << std::endl;
+                        Logger("Iteration Number") << iteration_number << std::endl;
                         Logger("Convergence") << convergence << std::endl;
                 }
                 if(convergence < 0.06) {
@@ -284,14 +284,14 @@ namespace Kratos {
             reference_output << std::endl << "3             1                        0.1                 ";
             reference_output << std::endl << "              2                        0.05                Yes          ";
             
-			KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), reference_output.str().c_str());
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), reference_output.str().c_str());
             
             std::cout << std::endl;
             std::cout << buffer.str() << std::endl;
 
         }
 
-	}   // namespace Testing
+    }   // namespace Testing
 }  // namespace Kratos.
 
 

--- a/kratos/tests/input_output/test_logger.cpp
+++ b/kratos/tests/input_output/test_logger.cpp
@@ -191,10 +191,11 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamDetail, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
 			Logger::AddOutput(p_output);
-
-			KRATOS_WARNING("TestDetail") << "Test detail message";
+            
+			KRATOS_DETAIL("TestDetail") << "Test detail message";
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestDetail: Test detail message");
         }
@@ -202,11 +203,12 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamDetailIf, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
 			Logger::AddOutput(p_output);
 
-            KRATOS_WARNING_IF("TestDetail", true) << "Test detail message";
-            KRATOS_WARNING_IF("TestDetail", false) << "This should not appear";
+            KRATOS_DETAIL_IF("TestDetail", true) << "Test detail message";
+            KRATOS_DETAIL_IF("TestDetail", false) << "This should not appear";
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestDetail: Test detail message");
         }
@@ -214,11 +216,12 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamDetailOnce, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
 			Logger::AddOutput(p_output);
 
 			for(std::size_t i = 0; i < 10; i++) {
-                KRATOS_WARNING_ONCE("TestDetail") << "Test detail message - " << i;
+                KRATOS_DETAIL_ONCE("TestDetail") << "Test detail message - " << i;
             }
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestDetail: Test detail message - 0");
@@ -227,11 +230,12 @@ namespace Kratos {
         KRATOS_TEST_CASE_IN_SUITE(LoggerStreamDetailFirst, KratosCoreFastSuite)
         {
             static std::stringstream buffer;
-			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
 			Logger::AddOutput(p_output);
 
             for(std::size_t i = 0; i < 10; i++) {
-                KRATOS_WARNING_FIRST_N("TestDetail", 4) << ".";
+                KRATOS_DETAIL_FIRST_N("TestDetail", 4) << ".";
             }
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestDetail: .TestDetail: .TestDetail: .TestDetail: .");

--- a/kratos/tests/input_output/test_logger.cpp
+++ b/kratos/tests/input_output/test_logger.cpp
@@ -188,6 +188,54 @@ namespace Kratos {
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestWarning: .TestWarning: .TestWarning: .TestWarning: .");
         }
 
+        KRATOS_TEST_CASE_IN_SUITE(LoggerStreamDetail, KratosCoreFastSuite)
+        {
+            static std::stringstream buffer;
+			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+			Logger::AddOutput(p_output);
+
+			KRATOS_WARNING("TestDetail") << "Test detail message";
+
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestDetail: Test detail message");
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(LoggerStreamDetailIf, KratosCoreFastSuite)
+        {
+            static std::stringstream buffer;
+			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+			Logger::AddOutput(p_output);
+
+            KRATOS_WARNING_IF("TestDetail", true) << "Test detail message";
+            KRATOS_WARNING_IF("TestDetail", false) << "This should not appear";
+
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestDetail: Test detail message");
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(LoggerStreamDetailOnce, KratosCoreFastSuite)
+        {
+            static std::stringstream buffer;
+			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+			Logger::AddOutput(p_output);
+
+			for(std::size_t i = 0; i < 10; i++) {
+                KRATOS_WARNING_ONCE("TestDetail") << "Test detail message - " << i;
+            }
+
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestDetail: Test detail message - 0");
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(LoggerStreamDetailFirst, KratosCoreFastSuite)
+        {
+            static std::stringstream buffer;
+			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+			Logger::AddOutput(p_output);
+
+            for(std::size_t i = 0; i < 10; i++) {
+                KRATOS_WARNING_FIRST_N("TestDetail", 4) << ".";
+            }
+
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestDetail: .TestDetail: .TestDetail: .TestDetail: .");
+        }
 
 		KRATOS_TEST_CASE_IN_SUITE(LoggerTableOutput, KratosCoreFastSuite)
 		{

--- a/kratos/tests/input_output/test_logger.cpp
+++ b/kratos/tests/input_output/test_logger.cpp
@@ -145,7 +145,7 @@ namespace Kratos {
 			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
 			Logger::AddOutput(p_output);
 
-			KRATOS_INFO("TestWarning") << "Test warning message";
+			KRATOS_WARNING("TestWarning") << "Test warning message";
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestWarning: Test warning message");
         }
@@ -156,8 +156,8 @@ namespace Kratos {
 			LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
 			Logger::AddOutput(p_output);
 
-            KRATOS_INFO_IF("TestWarning", true) << "Test warning message";
-            KRATOS_INFO_IF("TestWarning", false) << "This should not appear";
+            KRATOS_WARNING_IF("TestWarning", true) << "Test warning message";
+            KRATOS_WARNING_IF("TestWarning", false) << "This should not appear";
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestWarning: Test warning message");
         }
@@ -169,7 +169,7 @@ namespace Kratos {
 			Logger::AddOutput(p_output);
 
 			for(std::size_t i = 0; i < 10; i++) {
-                KRATOS_INFO_ONCE("TestWarning") << "Test warning message - " << i;
+                KRATOS_WARNING_ONCE("TestWarning") << "Test warning message - " << i;
             }
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestWarning: Test warning message - 0");
@@ -182,7 +182,7 @@ namespace Kratos {
 			Logger::AddOutput(p_output);
 
             for(std::size_t i = 0; i < 10; i++) {
-                KRATOS_INFO_FIRST_N("TestWarning", 4) << ".";
+                KRATOS_WARNING_FIRST_N("TestWarning", 4) << ".";
             }
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), "TestWarning: .TestWarning: .TestWarning: .TestWarning: .");


### PR DESCRIPTION
Fixes #2800, the tests for warning level, the detail and future trace macros and adds tests for the detail level.