### PR TITLE
Adding AMatrix library include files to external libraries

### DIFF
--- a/external_libraries/a_matrix/include/amatrix.h
+++ b/external_libraries/a_matrix/include/amatrix.h
@@ -1,0 +1,94 @@
+#include "matrix.h"
+
+namespace AMatrix {
+
+template <typename TDataType>
+using Matrix11 = Matrix<TDataType, 1, 1>;
+
+template <typename TDataType>
+using Matrix22 = Matrix<TDataType, 2, 2>;
+
+template <typename TDataType>
+using Matrix33 = Matrix<TDataType, 3, 3>;
+
+template <typename TDataType>
+using Matrix44 = Matrix<TDataType, 4, 4>;
+
+template <typename TDataType>
+using Matrix55 = Matrix<TDataType, 5, 5>;
+
+template <typename TDataType>
+using Matrix66 = Matrix<TDataType, 6, 6>;
+
+template <typename TDataType>
+using Matrix77 = Matrix<TDataType, 7, 7>;
+
+template <typename TDataType>
+using Matrix88 = Matrix<TDataType, 8, 8>;
+
+template <typename TDataType>
+using Matrix99 = Matrix<TDataType, 9, 9>;
+
+template <typename TDataType, std::size_t TSize>
+using Vector = Matrix<TDataType, TSize, 1>;
+
+template <typename TDataType>
+using Vector1 = Matrix<TDataType, 1, 1>;
+
+template <typename TDataType>
+using Vector2 = Matrix<TDataType, 2, 1>;
+
+template <typename TDataType>
+using Vector3 = Matrix<TDataType, 3, 1>;
+
+template <typename TDataType>
+using Vector4 = Matrix<TDataType, 4, 1>;
+
+template <typename TDataType>
+using Vector5 = Matrix<TDataType, 5, 1>;
+
+template <typename TDataType>
+using Vector6 = Matrix<TDataType, 6, 1>;
+
+template <typename TDataType>
+using Vector7 = Matrix<TDataType, 7, 1>;
+
+template <typename TDataType>
+using Vector8 = Matrix<TDataType, 8, 1>;
+
+template <typename TDataType>
+using Vector9 = Matrix<TDataType, 9, 1>;
+
+template <typename TDataType, std::size_t TSize>
+using RowVector = Matrix<TDataType, 1, TSize>;
+
+template <typename TDataType>
+using RowVector1 = Matrix<TDataType, 1, 1>;
+
+template <typename TDataType>
+using RowVector2 = Matrix<TDataType, 1, 2>;
+
+template <typename TDataType>
+using RowVector3 = Matrix<TDataType, 1, 3>;
+
+template <typename TDataType>
+using RowVector4 = Matrix<TDataType, 1, 4>;
+
+template <typename TDataType>
+using RowVector5 = Matrix<TDataType, 1, 5>;
+
+template <typename TDataType>
+using RowVector6 = Matrix<TDataType, 1, 6>;
+
+template <typename TDataType>
+using RowVector7 = Matrix<TDataType, 1, 7>;
+
+template <typename TDataType>
+using RowVector8 = Matrix<TDataType, 1, 8>;
+
+template <typename TDataType>
+using RowVector9 = Matrix<TDataType, 1, 9>;
+
+template <typename TDataType>
+using ZeroVector = ZeroMatrix<TDataType>;
+}

--- a/external_libraries/a_matrix/include/dense_storage.h
+++ b/external_libraries/a_matrix/include/dense_storage.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "matrix_expression.h"
+
+namespace AMatrix {
+
+template <typename TDataType, std::size_t TSize>
+class DenseStorage {
+    TDataType _data[TSize];
+
+   public:
+    DenseStorage() {}
+
+    explicit DenseStorage(std::size_t TheSize) {}
+
+    DenseStorage(DenseStorage const& Other) {
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other._data[i];
+    }
+
+    DenseStorage(DenseStorage&& Other) = default;
+
+    template <typename TExpressionType, std::size_t TCategory>
+    explicit DenseStorage(
+        MatrixExpression<TExpressionType, TCategory> const& Other)
+        : DenseStorage(Other.expression()) {}
+
+    template <typename TExpressionType>
+    explicit DenseStorage(
+        MatrixExpression<TExpressionType, row_major_access> const& Other) {
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other.expression()[i];
+    }
+
+    template <typename TOtherMatrixType>
+    explicit DenseStorage(TOtherMatrixType const& Other) {
+        auto i_data = _data;
+        for (std::size_t i = 0; i < Other.size1(); i++)
+            for (std::size_t j = 0; j < Other.size2(); j++)
+                *(i_data++) = Other(i, j);
+    }
+
+    explicit DenseStorage(std::initializer_list<TDataType> InitialValues) {
+        std::size_t position = 0;
+        for (auto& i : InitialValues) {
+            _data[position++] = i;
+        }
+    }
+
+    template <typename TExpressionType, std::size_t TCategory>
+    DenseStorage& operator=(
+        MatrixExpression<TExpressionType, TCategory> const& Other) {
+        auto i_data = _data;
+        for (std::size_t i = 0; i <  Other.expression().size1(); i++)
+            for (std::size_t j = 0; j <  Other.expression().size2(); j++)
+                *(i_data++) = Other.expression()(i, j);
+        return *this;
+    }
+
+    template <typename TExpressionType>
+    DenseStorage& operator=(
+        MatrixExpression<TExpressionType, row_major_access> const& Other) {
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other.expression()[i];
+        return *this;
+    }
+
+    template <typename TOtherMatrixType>
+    DenseStorage& operator=(TOtherMatrixType const& Other) {
+        auto i_data = _data;
+        for (std::size_t i = 0; i < Other.size1(); i++)
+            for (std::size_t j = 0; j < Other.size2(); j++)
+                *(i_data++) = Other(i, j);
+        return *this;
+    }
+
+    DenseStorage& operator=(DenseStorage const& Other) {
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other._data[i];
+        return *this;
+    }
+
+    DenseStorage& operator=(DenseStorage&& Other) = default;
+
+    TDataType& operator[](std::size_t i) { return at(i); }
+
+    TDataType const& operator[](std::size_t i) const { return at(i); }
+
+    TDataType& at(std::size_t i) { return _data[i]; }
+
+    TDataType const& at(std::size_t i) const { return _data[i]; }
+
+    static constexpr std::size_t size() { return TSize; }
+
+    TDataType* data() { return _data; }
+
+    TDataType const* data() const { return _data; }
+};
+
+} // namespace AMatrix

--- a/external_libraries/a_matrix/include/matrix.h
+++ b/external_libraries/a_matrix/include/matrix.h
@@ -1,0 +1,205 @@
+#pragma once
+
+// A matrix Library to be simple and fast
+#include <cmath>
+#include <limits>
+#include "matrix_storage.h"
+#include "matrix_iterator.h"
+
+namespace AMatrix {
+
+template <typename TDataType, std::size_t TSize1, std::size_t TSize2>
+class Matrix : public MatrixExpression<Matrix<TDataType, TSize1, TSize2>,
+                   row_major_access>,
+               public MatrixStorage<TDataType, TSize1, TSize2> {
+   public:
+    using data_type = TDataType;
+    using base_type = MatrixStorage<TDataType, TSize1, TSize2>;
+    using base_type::at;
+    using base_type::data;
+    using base_type::size;
+    using base_type::size1;
+    using base_type::size2;
+    
+    using iterator = RandomAccessIterator<TDataType>;
+    using const_iterator = RandomAccessIterator<const TDataType>;
+
+
+    Matrix() {}
+
+    explicit Matrix(std::size_t TheSize1, std::size_t TheSize2)
+        : base_type(TheSize1, TheSize2) {}
+
+    Matrix(Matrix const& Other) : base_type(Other) {}
+
+    Matrix(Matrix&& Other) : base_type(Other) {}
+
+    template <typename TExpressionType, std::size_t TCategory>
+    explicit Matrix(MatrixExpression<TExpressionType, TCategory> const& Other)
+        : base_type(Other) {}
+
+    template <typename TOtherMatrixType>
+    explicit Matrix(TOtherMatrixType const& Other) : base_type(Other) {}
+
+    explicit Matrix(std::initializer_list<TDataType> InitialValues)
+        : base_type(InitialValues) {}
+	 
+    template <typename TExpressionType, std::size_t TCategory>
+    Matrix& operator=(
+        MatrixExpression<TExpressionType, TCategory> const& Other) {
+        base_type::operator=(Other);
+        return *this;
+    }
+
+    template <typename TOtherMatrixType>
+    Matrix& operator=(TOtherMatrixType const& Other) {
+        base_type::operator=(Other);
+        return *this;
+    }
+
+    Matrix& operator=(Matrix const& Other) {
+        base_type::operator=(Other);
+        return *this;
+    }
+
+    Matrix& operator=(Matrix&& Other) {
+        base_type::operator=(Other);
+        return *this;
+    }
+
+    friend bool operator==(Matrix const& First, Matrix const& Second) {
+        for (std::size_t i = 0; i < First.size(); i++)
+            if (First.data()[i] != Second.data()[i])
+                return false;
+        return true;
+    }
+
+    template <typename TExpressionType, std::size_t TCategory>
+    Matrix& operator+=(
+        MatrixExpression<TExpressionType, TCategory> const& Other) {
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                at(i, j) += Other.expression()(i, j);
+
+        return *this;
+    }
+
+    template <typename TExpressionType>
+    Matrix& operator+=(
+        MatrixExpression<TExpressionType, row_major_access> const& Other) {
+        for (std::size_t i = 0; i < size(); i++)
+            at(i) += Other.expression()[i];
+
+        return *this;
+    }
+
+    template <typename TExpressionType, std::size_t TCategory>
+    Matrix& operator-=(
+        MatrixExpression<TExpressionType, TCategory> const& Other) {
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                at(i, j) -= Other.expression()(i, j);
+
+        return *this;
+    }
+
+    template <typename TExpressionType>
+    Matrix& operator-=(
+        MatrixExpression<TExpressionType, row_major_access> const& Other) {
+        for (std::size_t i = 0; i < size(); i++)
+            at(i) -= Other.expression()[i];
+
+        return *this;
+    }
+
+    Matrix& operator*=(data_type TheValue) {
+        for (std::size_t i = 0; i < size(); i++)
+            at(i) *= TheValue;
+
+        return *this;
+    }
+
+    Matrix& operator/=(data_type TheValue) {
+        auto inverse_of_value = 1.00 / TheValue;
+        for (std::size_t i = 0; i < size(); i++)
+            at(i) *= inverse_of_value;
+
+        return *this;
+    }
+
+    MatrixUnaryMinusExpression<Matrix> operator-() const {
+        return MatrixUnaryMinusExpression<Matrix>(*this);
+    }
+
+    void resize(std::size_t NewSize1, std::size_t NewSize2) {
+        base_type::resize(NewSize1, NewSize2);
+    }
+
+    void resize(std::size_t NewSize) { base_type::resize(NewSize); }
+
+    void swap(Matrix& Other){
+        base_type::swap(Other);
+    }
+
+    iterator begin() { return iterator(data()); }
+
+    iterator end() { return iterator(data() + size()); }
+
+    const_iterator begin() const { return const_iterator(data()); }
+
+    const_iterator end() const { return const_iterator(data() + size()); }
+
+    template <typename TExpressionType>
+    data_type dot(
+        MatrixExpression<TExpressionType, row_major_access> const& Other)
+        const {
+        data_type result = data_type();
+        for (std::size_t i = 0; i < size(); ++i) {
+            result += at(i) * Other.expression()[i];
+        }
+        return result;
+    }
+
+    data_type squared_norm() const { return dot(*this); }
+
+    data_type norm() const { return std::sqrt(dot(*this)); }
+
+    void normalize() {
+        auto the_norm = norm();
+        if (the_norm > std::numeric_limits<data_type>::epsilon()) {
+            const auto norm_inverse = 1.0 / the_norm;
+            for (std::size_t i = 0; i < size(); ++i) {
+                at(i) *= norm_inverse;
+            }
+        }
+    }
+
+    Matrix& noalias() { return *this; }
+
+    TransposeMatrix<Matrix<TDataType, TSize1, TSize2>> transpose() {
+        return TransposeMatrix<Matrix<TDataType, TSize1, TSize2>>(*this);
+    }
+};
+
+template <typename TDataType, std::size_t TSize1, std::size_t TSize2>
+bool operator!=(Matrix<TDataType, TSize1, TSize2> const& First,
+    Matrix<TDataType, TSize1, TSize2> const& Second) {
+    return !(First == Second);
+}
+
+/// output stream function
+template <typename TDataType, std::size_t TSize1, std::size_t TSize2>
+inline std::ostream& operator<<(std::ostream& rOStream,
+    Matrix<TDataType, TSize1, TSize2> const& TheMatrix) {
+    rOStream << '{';
+    for (std::size_t i = 0; i < TheMatrix.size1(); i++) {
+        for (std::size_t j = 0; j < TheMatrix.size2(); j++)
+            rOStream << TheMatrix(i, j) << ',';
+        rOStream << '\n';
+    }
+    rOStream << '}';
+
+    return rOStream;
+}
+
+}  // namespace AMatrix

--- a/external_libraries/a_matrix/include/matrix_expression.h
+++ b/external_libraries/a_matrix/include/matrix_expression.h
@@ -1,0 +1,755 @@
+#pragma once
+
+#include <iostream>
+
+namespace AMatrix {
+constexpr std::size_t dynamic = 0;
+constexpr std::size_t row_major_access = 1;
+constexpr std::size_t column_major_access = 2;
+constexpr std::size_t unordered_access = 3;
+
+template <std::size_t TCategory1, std::size_t TCategory2>
+class AccessTrait {
+   public:
+    static constexpr std::size_t category = unordered_access;
+};
+
+template <>
+class AccessTrait<row_major_access, row_major_access> {
+   public:
+    static constexpr std::size_t category = row_major_access;
+};
+
+template <typename TExpressionType, std::size_t TCategory = unordered_access>
+class MatrixExpression {
+   public:
+    static constexpr std::size_t category = TCategory;
+
+    // using value_type = TExpressionType::value_type;
+    MatrixExpression() {}
+
+    MatrixExpression(MatrixExpression const& Other) = default;
+
+    MatrixExpression(MatrixExpression&& Other) = default;
+
+    MatrixExpression& operator=(MatrixExpression const& Other) = default;
+
+    MatrixExpression& operator=(MatrixExpression&& Other) = default;
+
+    TExpressionType& expression() {
+        return *static_cast<TExpressionType*>(this);
+    }
+    TExpressionType const& expression() const {
+        return *static_cast<const TExpressionType* const>(this);
+    }
+
+    TExpressionType& noalias() { return expression(); }
+};
+
+template <typename TExpressionType>
+class TransposeMatrix
+    : public MatrixExpression<TransposeMatrix<TExpressionType>> {
+    TExpressionType const& _original_expression;
+
+   public:
+    using data_type = typename TExpressionType::data_type;
+    TransposeMatrix() = delete;
+
+    TransposeMatrix(TExpressionType const& Original)
+        : _original_expression(Original) {}
+
+    inline data_type operator()(std::size_t i, std::size_t j) const {
+        return _original_expression(j, i);
+    }
+
+    inline std::size_t size1() const { return _original_expression.size2(); }
+    inline std::size_t size2() const { return _original_expression.size1(); }
+};
+
+template <typename TExpressionType>
+class MatrixRow : public MatrixExpression<MatrixRow<TExpressionType>> {
+    TExpressionType& _original_expression;
+    std::size_t _row_index;
+
+   public:
+    using data_type = typename TExpressionType::data_type;
+    MatrixRow() = delete;
+
+    MatrixRow(TExpressionType& Original, std::size_t RowIndex)
+        : _original_expression(Original), _row_index(RowIndex) {}
+
+    template <typename TOtherExpressionType, std::size_t TCategory>
+    MatrixRow& operator=(
+        MatrixExpression<TOtherExpressionType, TCategory> const& Other) {
+        auto& other_expression = Other.expression();
+        for (std::size_t j = 0; j < size2(); j++)
+            _original_expression(_row_index, j) = Other.expression()(0, j);
+        return *this;
+    }
+
+    template <typename TOtherExpressionType>
+    MatrixRow& operator=(
+        MatrixExpression<TOtherExpressionType, row_major_access> const& Other) {
+        auto& other_expression = Other.expression();
+        for (std::size_t j = 0; j < size2(); j++)
+            _original_expression(_row_index, j) = Other.expression()[j];
+        return *this;
+    }
+
+    inline data_type const& operator()(std::size_t i, std::size_t j) const {
+        //assert(i == 0)
+        return _original_expression(_row_index, j);
+    }
+
+    inline data_type& operator()(std::size_t i, std::size_t j) {
+        //assert(i == 0)
+        return _original_expression(_row_index, j);
+    }
+
+    inline data_type const& operator[](std::size_t i) const {
+        return _original_expression(_row_index, i);
+    }
+
+    inline data_type& operator[](std::size_t i) {
+        return _original_expression(_row_index, i);
+    }
+
+    inline std::size_t size() const { return _original_expression.size2(); }
+    inline std::size_t size1() const { return 1; }
+    inline std::size_t size2() const { return _original_expression.size2(); }
+};
+
+template <typename TExpressionType>
+class MatrixColumn : public MatrixExpression<MatrixColumn<TExpressionType>> {
+    TExpressionType& _original_expression;
+    std::size_t _column_index;
+
+   public:
+    using data_type = typename TExpressionType::data_type;
+    MatrixColumn() = delete;
+
+    MatrixColumn(TExpressionType& Original, std::size_t ColumnIndex)
+        : _original_expression(Original), _column_index(ColumnIndex) {}
+
+    template <typename TOtherExpressionType, std::size_t TCategory>
+    MatrixColumn& operator=(
+        MatrixExpression<TOtherExpressionType, TCategory> const& Other) {
+        auto& other_expression = Other.expression();
+        for (std::size_t i = 0; i < size1(); i++)
+            _original_expression(i, _column_index) = Other.expression()(i, 0);
+        return *this;
+    }
+
+    template <typename TOtherExpressionType>
+    MatrixColumn& operator=(
+        MatrixExpression<TOtherExpressionType, row_major_access> const& Other) {
+        auto& other_expression = Other.expression();
+        for (std::size_t i = 0; i < size1(); i++)
+            _original_expression(i, _column_index) = Other.expression()[i];
+        return *this;
+    }
+
+    inline data_type const& operator()(std::size_t i, std::size_t j) const {
+        return _original_expression(i, _column_index);
+    }
+
+    inline data_type& operator()(std::size_t i, std::size_t j) {
+		//assert(j == 0)
+        return _original_expression(i, _column_index);
+    }
+
+    inline data_type const& operator[](std::size_t i) const {
+        //assert(j == 0)
+        return _original_expression(i, _column_index);
+    }
+
+    inline data_type& operator[](std::size_t i) {
+        return _original_expression(i, _column_index);
+    }
+
+    inline std::size_t size() const { return _original_expression.size1(); }
+    inline std::size_t size1() const { return _original_expression.size1(); }
+    inline std::size_t size2() const { return 1; }
+};
+
+template <typename TExpressionType>
+class SubMatrix : public MatrixExpression<SubMatrix<TExpressionType>> {
+    TExpressionType& _original_expression;
+    std::size_t _origin_index1;
+    std::size_t _origin_index2;
+    std::size_t _size1;
+    std::size_t _size2;
+
+   public:
+    using data_type = typename TExpressionType::data_type;
+    SubMatrix() = delete;
+
+    SubMatrix(TExpressionType& Original, std::size_t OriginIndex1,
+        std::size_t OriginIndex2, std::size_t TheSize1, std::size_t TheSize2)
+        : _original_expression(Original),
+          _origin_index1(OriginIndex1),
+          _origin_index2(OriginIndex2),
+          _size1(TheSize1),
+          _size2(TheSize2) {}
+
+    template <typename TOtherExpressionType, std::size_t TCategory>
+    SubMatrix& operator=(
+        MatrixExpression<TOtherExpressionType, TCategory> const& Other) {
+        auto& other_expression = Other.expression();
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                _original_expression(i + _origin_index1, j + _origin_index2) =
+                    Other.expression()(i, j);
+        return *this;
+    }
+
+    template <typename TOtherExpressionType>
+    SubMatrix& operator=(
+        MatrixExpression<TOtherExpressionType, row_major_access> const& Other) {
+        auto& other_expression = Other.expression();
+        std::size_t k = 0;
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                _original_expression(i + _origin_index1, j + _origin_index2) =
+                    Other.expression()[k++];
+        return *this;
+    }
+
+    inline data_type const& operator()(std::size_t i, std::size_t j) const {
+        return _original_expression(i + _origin_index1, j + _origin_index2);
+    }
+
+    inline data_type& operator()(std::size_t i, std::size_t j) {
+        return _original_expression(i + _origin_index1, j + _origin_index2);
+    }
+
+    inline std::size_t size() const { return _size1 * _size2; }
+    inline std::size_t size1() const { return _size1; }
+    inline std::size_t size2() const { return _size2; }
+};
+
+template <typename TExpressionType>
+class SubVector
+    : public MatrixExpression<SubVector<TExpressionType>, row_major_access> {
+    TExpressionType& _original_expression;
+    std::size_t _origin_index;
+    std::size_t _size;
+
+   public:
+    using data_type = typename TExpressionType::data_type;
+    SubVector() = delete;
+
+    SubVector(
+        TExpressionType& Original, std::size_t OriginIndex, std::size_t TheSize)
+        : _original_expression(Original),
+          _origin_index(OriginIndex),
+          _size(TheSize) {}
+
+    template <typename TOtherExpressionType>
+    SubVector& operator=(TOtherExpressionType const& Other) {
+        for (std::size_t i = 0; i < _size; i++)
+            _original_expression[i + _origin_index] = Other[i];
+
+        return *this;
+    }
+
+    template <typename TOtherExpressionType>
+    SubVector& operator+=(TOtherExpressionType const& Other) {
+        for (std::size_t i = 0; i < _size; i++)
+            _original_expression[i + _origin_index] += Other[i];
+
+        return *this;
+    }
+
+    template <typename TOtherExpressionType>
+    SubVector& operator-=(TOtherExpressionType const& Other) {
+        for (std::size_t i = 0; i < _size; i++)
+            _original_expression[i + _origin_index] -= Other[i];
+
+        return *this;
+    }
+
+    inline data_type operator()(std::size_t i, std::size_t j) const {
+		//assert(i == 0)
+        return _original_expression(0, j + _origin_index);
+    }
+
+    inline data_type& operator()(std::size_t i, std::size_t j) {
+        //assert(i == 0)
+        return _original_expression(0, j + _origin_index);
+    }
+
+    inline data_type const& operator[](std::size_t i) const {
+        return _original_expression[i + _origin_index];
+    }
+
+    inline data_type& operator[](std::size_t i) {
+        return _original_expression[i + _origin_index];
+    }
+
+    inline std::size_t size() const { return _size; }
+
+    inline std::size_t size1() const { return _size; }
+    inline std::size_t size2() const { return 1; }
+
+    data_type* data() { return &_original_expression[_origin_index]; }
+
+    data_type const* data() const { return &_original_expression[_origin_index]; }
+};
+
+template <typename TDataType>
+class ZeroMatrix
+    : public MatrixExpression<ZeroMatrix<TDataType>, row_major_access> {
+    std::size_t _size1;
+    std::size_t _size2;
+
+   public:
+    using data_type = TDataType;
+
+    ZeroMatrix() = delete;
+
+    ZeroMatrix(std::size_t Size) : _size1(Size), _size2(1) {}
+
+    ZeroMatrix(std::size_t Size1, std::size_t Size2)
+        : _size1(Size1), _size2(Size2) {}
+
+    inline TDataType operator()(std::size_t i, std::size_t j) const {
+        return TDataType();
+    }
+
+    inline TDataType operator[](std::size_t i) const { return TDataType(); }
+
+    inline std::size_t size1() const { return _size1; }
+    inline std::size_t size2() const { return _size2; }
+
+    inline std::size_t size() const { return _size1 * _size2; }
+};
+
+template <typename TDataType>
+class IdentityMatrix
+    : public MatrixExpression<IdentityMatrix<TDataType>, unordered_access> {
+    std::size_t _size;
+
+   public:
+    using data_type = TDataType;
+
+    IdentityMatrix() = delete;
+
+    IdentityMatrix(std::size_t Size) : _size(Size) {}
+
+    inline TDataType operator()(std::size_t i, std::size_t j) const {
+        return 1.00 * (i == j);
+    }
+
+    inline std::size_t size1() const { return _size; }
+    inline std::size_t size2() const { return _size; }
+    inline std::size_t size() const { return _size * _size; }
+};
+
+template <typename TExpression1Type, typename TExpression2Type>
+class MatrixSumExpression
+    : public MatrixExpression<
+          MatrixSumExpression<TExpression1Type, TExpression2Type>,
+          AccessTrait<TExpression1Type::category,
+              TExpression2Type::category>::category> {
+    TExpression1Type const& _first;
+    TExpression2Type const& _second;
+
+   public:
+    MatrixSumExpression(
+        TExpression1Type const& First, TExpression2Type const& Second)
+        : _first(First), _second(Second) {}
+    using data_type = typename TExpression1Type::data_type;
+
+    std::size_t size1() const { return _first.size1(); }
+
+    std::size_t size2() const { return _first.size2(); }
+
+    std::size_t size() const { return _first.size(); }
+
+    inline data_type operator()(std::size_t i, std::size_t j) const {
+        return _first(i, j) + _second(i, j);
+    }
+
+    inline data_type operator[](std::size_t i) const {
+        return _first[i] + _second[i];
+    }
+};
+
+template <typename TExpression1Type, typename TExpression2Type,
+    std::size_t TCategory1, std::size_t TCategory2>
+MatrixSumExpression<TExpression1Type, TExpression2Type> operator+(
+    MatrixExpression<TExpression1Type, TCategory1> const& First,
+    MatrixExpression<TExpression2Type, TCategory2> const& Second) {
+    return MatrixSumExpression<TExpression1Type, TExpression2Type>(
+        First.expression(), Second.expression());
+}
+
+template <typename TExpression1Type, typename TExpression2Type>
+class MatrixMinusExpression
+    : public MatrixExpression<
+          MatrixMinusExpression<TExpression1Type, TExpression2Type>,
+          AccessTrait<TExpression1Type::category,
+              TExpression2Type::category>::category> {
+    TExpression1Type const& _first;
+    TExpression2Type const& _second;
+
+   public:
+    MatrixMinusExpression(
+        TExpression1Type const& First, TExpression2Type const& Second)
+        : _first(First), _second(Second) {}
+    using data_type = typename TExpression1Type::data_type;
+
+    std::size_t size1() const { return _first.size1(); }
+
+    std::size_t size2() const { return _first.size2(); }
+
+    std::size_t size() const { return _first.size(); }
+
+    inline data_type operator()(std::size_t i, std::size_t j) const {
+        return _first(i, j) - _second(i, j);
+    }
+
+    inline data_type operator[](std::size_t i) const {
+        return _first[i] - _second[i];
+    }
+};
+
+template <typename TExpression1Type, typename TExpression2Type,
+    std::size_t TCategory1, std::size_t TCategory2>
+MatrixMinusExpression<TExpression1Type, TExpression2Type> operator-(
+    MatrixExpression<TExpression1Type, TCategory1> const& First,
+    MatrixExpression<TExpression2Type, TCategory2> const& Second) {
+    return MatrixMinusExpression<TExpression1Type, TExpression2Type>(
+        First.expression(), Second.expression());
+}
+
+template <typename TExpressionType>
+class MatrixUnaryMinusExpression
+    : public MatrixExpression<MatrixUnaryMinusExpression<TExpressionType>,
+          AccessTrait<TExpressionType::category, row_major_access>::category> {
+    TExpressionType const& _original_expression;
+
+   public:
+    using data_type = typename TExpressionType::data_type;
+
+    MatrixUnaryMinusExpression(TExpressionType const& TheExpression)
+        : _original_expression(TheExpression) {}
+    std::size_t size1() const { return _original_expression.size1(); }
+
+    std::size_t size2() const { return _original_expression.size2(); }
+
+    std::size_t size() const { return _original_expression.size(); }
+
+    inline data_type operator()(std::size_t i, std::size_t j) const {
+        return -_original_expression(i, j);
+    }
+
+    inline data_type operator[](std::size_t i) const {
+        return -_original_expression[i];
+    }
+};
+
+template <typename TExpressionType>
+class MatrixScalarProductExpression
+    : public MatrixExpression<MatrixScalarProductExpression<TExpressionType>,
+          AccessTrait<TExpressionType::category, row_major_access>::category> {
+    typename TExpressionType::data_type const& _first;
+    TExpressionType const& _second;
+
+   public:
+    using data_type = typename TExpressionType::data_type;
+
+    MatrixScalarProductExpression(
+        data_type const& First, TExpressionType const& Second)
+        : _first(First), _second(Second) {}
+    std::size_t size1() const { return _second.size1(); }
+
+    std::size_t size2() const { return _second.size2(); }
+
+    std::size_t size() const { return _second.size(); }
+
+    inline data_type operator()(std::size_t i, std::size_t j) const {
+        return _first * _second(i, j);
+    }
+
+    inline data_type operator[](std::size_t i) const {
+        return _first * _second[i];
+    }
+};
+
+template <typename TExpressionType, std::size_t TCategory>
+MatrixScalarProductExpression<TExpressionType> operator*(
+    typename TExpressionType::data_type const& First,
+    MatrixExpression<TExpressionType, TCategory> const& Second) {
+    return MatrixScalarProductExpression<TExpressionType>(
+        First, Second.expression());
+}
+
+template <typename TExpressionType, std::size_t TCategory>
+MatrixScalarProductExpression<TExpressionType> operator*(
+    MatrixExpression<TExpressionType, TCategory> const& First,
+    typename TExpressionType::data_type const& Second) {
+    return MatrixScalarProductExpression<TExpressionType>(
+        Second, First.expression());
+}
+
+template <typename TExpressionType>
+class MatrixScalarDivisionExpression
+    : public MatrixExpression<MatrixScalarDivisionExpression<TExpressionType>,
+          AccessTrait<TExpressionType::category, row_major_access>::category> {
+    TExpressionType const& _first;
+    typename TExpressionType::data_type const _inverse_of_second;
+
+   public:
+    using data_type = typename TExpressionType::data_type;
+
+    MatrixScalarDivisionExpression(
+        TExpressionType const& First, data_type const& Second)
+        : _first(First), _inverse_of_second(data_type(1) / Second) {}
+    std::size_t size1() const { return _first.size1(); }
+
+    std::size_t size2() const { return _first.size2(); }
+
+    std::size_t size() const { return _first.size(); }
+
+    inline data_type operator()(std::size_t i, std::size_t j) const {
+        return _first(i, j) * _inverse_of_second;
+    }
+
+    inline data_type operator[](std::size_t i) const {
+        return _first[i] * _inverse_of_second;
+    }
+};
+
+template <typename TExpressionType, std::size_t TCategory>
+MatrixScalarDivisionExpression<TExpressionType> operator/(
+    MatrixExpression<TExpressionType, TCategory> const& First,
+    typename TExpressionType::data_type const& Second) {
+    return MatrixScalarDivisionExpression<TExpressionType>(
+        First.expression(), Second);
+}
+
+template <typename TExpression1Type, typename TExpression2Type>
+class MatrixProductExpression
+    : public MatrixExpression<
+          MatrixProductExpression<TExpression1Type, TExpression2Type>,
+          unordered_access> {
+    TExpression1Type const& _first;
+    TExpression2Type const& _second;
+
+   public:
+    MatrixProductExpression(
+        TExpression1Type const& First, TExpression2Type const& Second)
+        : _first(First), _second(Second) {}
+    using data_type = typename TExpression1Type::data_type;
+
+    std::size_t size1() const { return _first.size1(); }
+
+    std::size_t size2() const { return _second.size2(); }
+
+    std::size_t size() const { return size1() * size2(); }
+
+    inline data_type operator()(std::size_t i, std::size_t j) const {
+        data_type result = data_type();
+        for (std::size_t k = 0; k < _first.size2(); k++)
+            result += _first(i, k) * _second(k, j);
+        return result;
+    }
+};
+
+template <typename TExpression1Type, typename TExpression2Type,
+    std::size_t TCategory1, std::size_t TCategory2>
+MatrixProductExpression<TExpression1Type, TExpression2Type> operator*(
+    MatrixExpression<TExpression1Type, TCategory1> const& First,
+    MatrixExpression<TExpression2Type, TCategory2> const& Second) {
+    return MatrixProductExpression<TExpression1Type, TExpression2Type>(
+        First.expression(), Second.expression());
+}
+
+template <typename TExpression1Type, typename TExpression2Type>
+class VectorOuterProductExpression
+    : public MatrixExpression<
+          VectorOuterProductExpression<TExpression1Type, TExpression2Type>,
+          unordered_access> {
+    TExpression1Type const& _first;
+    TExpression2Type const& _second;
+
+   public:
+    VectorOuterProductExpression(
+        TExpression1Type const& First, TExpression2Type const& Second)
+        : _first(First), _second(Second) {}
+    using data_type = typename TExpression1Type::data_type;
+
+    std::size_t size1() const { return _first.size(); }
+
+    std::size_t size2() const { return _second.size(); }
+
+    std::size_t size() const { return size() * size(); }
+
+    inline data_type operator()(std::size_t i, std::size_t j) const {
+        return _first[i] * _second[j];
+    }
+};
+
+template <typename TExpression1Type, typename TExpression2Type,
+    std::size_t TCategory1, std::size_t TCategory2>
+VectorOuterProductExpression<TExpression1Type, TExpression2Type> OuterProduct(
+    MatrixExpression<TExpression1Type, TCategory1> const& First,
+    MatrixExpression<TExpression2Type, TCategory2> const& Second) {
+    return VectorOuterProductExpression<TExpression1Type, TExpression2Type>(
+        First.expression(), Second.expression());
+}
+
+template <typename TMatrixType, typename TPermutationVectorType>
+class LUFactorization
+    : public MatrixExpression<
+          LUFactorization<TMatrixType, TPermutationVectorType>> {
+    TMatrixType& _matrix;
+    TPermutationVectorType _permutation_vector;
+    std::size_t number_of_pivoting;
+
+   public:
+    using data_type = typename TMatrixType::data_type;
+    LUFactorization() = delete;
+
+    LUFactorization(TMatrixType& Original) : _matrix(Original) {
+        perform_lu();
+    }
+
+    inline data_type const& operator()(std::size_t i, std::size_t j) const {
+        return _matrix(_permutation_vector[i], j);
+    }
+
+    inline std::size_t size1() const { return _matrix.size1(); }
+    inline std::size_t size2() const { return _matrix.size2(); }
+
+    /// The algorithm is based on wikipedia implemenation which
+    /// can be found in https://en.wikipedia.org/wiki/LU_decomposition
+    double determinant() {
+        const std::size_t size = size1();
+        double result = _matrix(_permutation_vector[0], 0);
+
+        for (std::size_t i = 1; i < size; i++)
+            result *= _matrix(_permutation_vector[i], i);
+
+        if ((number_of_pivoting) % 2 == 0)
+            return result;
+        else
+            return -result;
+    }
+
+    /// The algorithm is based on wikipedia implemenation which
+    /// can be found in https://en.wikipedia.org/wiki/LU_decomposition
+    TMatrixType inverse() {
+        const std::size_t size = size1();
+        TMatrixType result(size, size);
+
+        for (std::size_t j = 0; j < size; j++) {
+            for (std::size_t i = 0; i < size; i++) {
+                if (_permutation_vector[i] == j)
+                    result(i, j) = 1.0;
+                else
+                    result(i, j) = 0.0;
+
+                for (std::size_t k = 0; k < i; k++)
+                    result(i, j) -=
+                        _matrix(_permutation_vector[i], k) * result(k, j);
+            }
+
+            for (int i = size - 1; i >= 0; i--) {
+                for (std::size_t k = i + 1; k < size; k++)
+                    result(i, j) -=
+                        _matrix(_permutation_vector[i], k) * result(k, j);
+
+                result(i, j) /= _matrix(_permutation_vector[i], i);
+            }
+        }
+
+		return result;
+    }
+
+    /// The algorithm is based on wikipedia implemenation which
+    /// can be found in https://en.wikipedia.org/wiki/LU_decomposition
+    template <typename TVectorType>
+    TVectorType solve(TVectorType const& RHS) {
+        const std::size_t size = size1();
+        TVectorType result(size);
+
+        for (std::size_t i = 0; i < size; i++) {
+            result[i] = RHS[_permutation_vector[i]];
+
+            for (std::size_t k = 0; k < i; k++)
+                result[i] -= _matrix(_permutation_vector[i], k) * result[k];
+        }
+
+         for (int i = size - 1; i >= 0; i--) {
+            for (std::size_t k = i + 1; k < size; k++)
+                 result[i] -= _matrix(_permutation_vector[i], k) * result[k];
+
+            result[i] /= _matrix(_permutation_vector[i], i);
+        }
+
+        return result;
+    }
+
+
+   private:
+    /// The algorithm is based on wikipedia implemenation which
+    /// can be found in https://en.wikipedia.org/wiki/LU_decomposition
+    int perform_lu() {
+        constexpr double tolerance = std::numeric_limits<double>::epsilon();
+        std::size_t size1 = _matrix.size1();
+        number_of_pivoting = 0;
+
+        initialize_permutation_vector();
+
+        for (std::size_t i = 0; i < size1; i++) {
+            double max_pivot = 0.0;
+            std::size_t i_max = i;
+            double abs_max_pivot = 0.0;
+
+            for (std::size_t k = i; k < size1; k++)
+                if ((abs_max_pivot = fabs(_matrix(_permutation_vector[k], i))) >
+                    max_pivot) {
+                    max_pivot = abs_max_pivot;
+                    i_max = k;
+                }
+
+            if (max_pivot < tolerance)
+                return 0;  // Failed
+
+            if (i_max != i) {
+                //pivoting
+                std::size_t j = _permutation_vector[i];
+                _permutation_vector[i] = _permutation_vector[i_max];
+                _permutation_vector[i_max] = j;
+
+                //counting pivots to be used for determinant
+                number_of_pivoting++;
+            }
+
+            for (std::size_t j = i + 1; j < size1; j++) {
+                _matrix(_permutation_vector[j], i) /=
+                    _matrix(_permutation_vector[i], i);
+
+                for (std::size_t k = i + 1; k < size1; k++)
+                    _matrix(_permutation_vector[j], k) -=
+                        _matrix(_permutation_vector[j], i) *
+                        _matrix(_permutation_vector[i], k);
+            }
+        }
+
+        return 1;  // Success
+    }
+
+    void initialize_permutation_vector() {
+        std::size_t size = _matrix.size1();
+        _permutation_vector.resize(size);
+
+        for (std::size_t i = 0; i < size; i++)
+            _permutation_vector[i] = i;
+    }
+};
+
+}  // namespace AMatrix

--- a/external_libraries/a_matrix/include/matrix_iterator.h
+++ b/external_libraries/a_matrix/include/matrix_iterator.h
@@ -1,0 +1,115 @@
+#include <iterator>
+
+namespace AMatrix {
+
+template <typename TDataType>
+class RandomAccessIterator
+    : public std::iterator<std::random_access_iterator_tag, TDataType> {
+    TDataType* _p_data;
+
+   public:
+    using base_type = std::iterator<std::random_access_iterator_tag, TDataType>;
+    using typename base_type::difference_type;
+    RandomAccessIterator() = default;
+    RandomAccessIterator(RandomAccessIterator const& Other) = default;
+    RandomAccessIterator(RandomAccessIterator&& Other) = default;
+    RandomAccessIterator(TDataType* pData) : _p_data(pData) {}
+
+    template <typename TOtherDataType>
+    RandomAccessIterator(RandomAccessIterator<TOtherDataType> const& Other):
+        _p_data(Other.operator->()) {}
+
+    RandomAccessIterator& operator=(
+        RandomAccessIterator const& Other) = default;
+
+    bool operator==(const RandomAccessIterator& Other) const {
+        return _p_data == Other._p_data;
+    }
+
+    bool operator!=(const RandomAccessIterator& Other) const {
+        return _p_data != Other._p_data;
+    }
+
+    TDataType const& operator*() const { return *_p_data; }
+
+    TDataType& operator*() { return *_p_data; }
+
+    TDataType* const operator->() const { return _p_data; }
+
+    TDataType* operator->() { return _p_data; }
+
+    RandomAccessIterator& operator++() {
+        ++_p_data;
+        return *this;
+    }
+
+    RandomAccessIterator operator++(int) {
+        RandomAccessIterator temp(*this);
+        ++_p_data;
+        return temp;
+    }
+
+    RandomAccessIterator& operator--() {
+        --_p_data;
+        return *this;
+    }
+
+    RandomAccessIterator operator--(int) {
+        RandomAccessIterator temp(*this);
+        --_p_data;
+        return temp;
+    }
+
+    RandomAccessIterator& operator+=(difference_type Offset) {
+        _p_data += Offset;
+        return *this;
+    }
+
+    RandomAccessIterator& operator-=(difference_type Offset) {
+        _p_data -= Offset;
+        return *this;
+    }
+
+    friend RandomAccessIterator operator+(
+        RandomAccessIterator First, difference_type Second) {
+        First += Second;
+        return First;
+    }
+
+    friend RandomAccessIterator operator+(
+        difference_type First, RandomAccessIterator Second) {
+        Second += First;
+        return Second;
+    }
+
+    friend RandomAccessIterator operator-(
+        RandomAccessIterator First, difference_type Second) {
+        First -= Second;
+        return First;
+    }
+
+    friend difference_type operator-(
+        RandomAccessIterator const& First, RandomAccessIterator const& Second) {
+        return First._p_data - Second._p_data;
+    }
+
+    friend bool operator<(
+        RandomAccessIterator const& First, RandomAccessIterator const& Second) {
+        return First._p_data < Second._p_data;
+    }
+
+    friend bool operator>(
+        RandomAccessIterator const& First, RandomAccessIterator const& Second) {
+        return Second < First;
+    }
+    friend bool operator<=(
+        RandomAccessIterator const& First, RandomAccessIterator const& Second) {
+        return !(First > Second);
+    }
+    friend bool operator>=(
+        RandomAccessIterator const& First, RandomAccessIterator const& Second) {
+        return !(First < Second);
+    }
+};
+
+}  // namespace AMatrix

--- a/external_libraries/a_matrix/include/matrix_storage.h
+++ b/external_libraries/a_matrix/include/matrix_storage.h
@@ -1,0 +1,596 @@
+#pragma once
+
+#include "dense_storage.h"
+
+namespace AMatrix {
+
+template <typename TDataType, std::size_t TSize1, std::size_t TSize2>
+class MatrixStorage : public DenseStorage<TDataType, TSize1 * TSize2> {
+   public:
+    using base_type = DenseStorage<TDataType, TSize1 * TSize2>;
+    using base_type::at;
+    using base_type::data;
+    using base_type::size;
+
+    MatrixStorage() {}
+
+    explicit MatrixStorage(std::size_t TheSize1, std::size_t TheSize2) {}
+
+    MatrixStorage(MatrixStorage const& Other) : base_type(Other) {}
+
+    MatrixStorage(MatrixStorage&& Other) = default;
+
+    template <typename TExpressionType, std::size_t TCategory>
+    explicit MatrixStorage(
+        MatrixExpression<TExpressionType, TCategory> const& Other)
+        : base_type(Other) {}
+
+    template <typename TOtherMatrixType>
+    explicit MatrixStorage(TOtherMatrixType const& Other) : base_type(Other) {}
+
+    explicit MatrixStorage(std::initializer_list<TDataType> InitialValues)
+        : base_type(InitialValues) {}
+
+    template <typename TExpressionType, std::size_t TCategory>
+    MatrixStorage& operator=(
+        MatrixExpression<TExpressionType, TCategory> const& Other) {
+        base_type::operator=(Other);
+        return *this;
+    }
+
+    template <typename TOtherMatrixType>
+    MatrixStorage& operator=(TOtherMatrixType const& Other) {
+        base_type::operator=(Other);
+        return *this;
+    }
+
+    MatrixStorage& operator=(MatrixStorage const& Other) {
+        base_type::operator=(Other);
+        return *this;
+    }
+
+    MatrixStorage& operator=(MatrixStorage&& Other) = default;
+
+    TDataType& operator()(std::size_t i, std::size_t j) { return at(i, j); }
+
+    TDataType const& operator()(std::size_t i, std::size_t j) const {
+        return at(i, j);
+    }
+
+    TDataType& at(std::size_t i, std::size_t j) { return at(i * TSize2 + j); }
+
+    TDataType const& at(std::size_t i, std::size_t j) const {
+        return at(i * TSize2 + j);
+    }
+
+    static constexpr std::size_t size1() { return TSize1; }
+
+    static constexpr std::size_t size2() { return TSize2; }
+
+    void resize(std::size_t NewSize) {
+    }
+};
+
+template <typename TDataType>
+class MatrixStorage<TDataType, dynamic, dynamic> {
+    std::size_t _size1;
+    std::size_t _size2;
+    TDataType* _data;
+
+   public:
+    MatrixStorage() = delete;
+
+    MatrixStorage(std::size_t TheSize1, std::size_t TheSize2)
+        : _size1(TheSize1), _size2(TheSize2) {
+        _data = new TDataType[size()];
+    }
+
+    explicit MatrixStorage(std::size_t TheSize1, std::size_t TheSize2,
+        TDataType const& InitialValue)
+        : _size1(TheSize1), _size2(TheSize2) {
+        _data = new TDataType[size()];
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = InitialValue;
+    }
+
+    MatrixStorage(MatrixStorage const& Other)
+        : _size1(Other.size1()), _size2(Other.size2()) {
+        _data = new TDataType[size()];
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other._data[i];
+    }
+
+    MatrixStorage(MatrixStorage&& Other)
+        : _size1(Other.size1()), _size2(Other.size2()), _data(Other._data) {
+        Other._data = nullptr;
+    }
+
+    explicit MatrixStorage(std::initializer_list<TDataType> InitialValues)
+        : _size1(1), _size2(InitialValues.size()), _data(nullptr) {
+        if (_size2 == 0)
+            return;
+        _data = new TDataType[size()];
+        std::size_t position = 0;
+        for (auto& i : InitialValues) {
+            _data[position++] = i;
+        }
+    }
+
+    virtual ~MatrixStorage() {
+        if (_data)
+            delete[] _data;
+    }
+
+    template <typename TExpressionType, std::size_t TCategory>
+    explicit MatrixStorage(
+        MatrixExpression<TExpressionType, TCategory> const& Other)
+        : MatrixStorage(Other.expression()) {}
+
+    template <typename TExpressionType>
+    explicit MatrixStorage(
+        MatrixExpression<TExpressionType, row_major_access> const& Other)
+        : _size1(Other.expression().size1()),
+          _size2(Other.expression().size2()) {
+        _data = new TDataType[size()];
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other.expression()[i];
+    }
+
+    template <typename TOtherMatrixType>
+    explicit MatrixStorage(TOtherMatrixType const& Other)
+        : _size1(Other.size1()), _size2(Other.size2()) {
+        _data = new TDataType[size()];
+        auto i_data = _data;
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                *(i_data++) = Other(i, j);
+    }
+
+    template <typename TExpressionType, std::size_t TCategory>
+    MatrixStorage& operator=(
+        MatrixExpression<TExpressionType, TCategory> const& Other) {
+        auto& other_expression = Other.expression();
+        resize(other_expression.size1(), other_expression.size2());
+        auto i_data = _data;
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                *(i_data++) = other_expression(i, j);
+        return *this;
+    }
+
+    template <typename TExpressionType>
+    MatrixStorage& operator=(
+        MatrixExpression<TExpressionType, row_major_access> const& Other) {
+        auto the_expression = Other.expression();
+        resize(the_expression.size1(), the_expression.size2());
+        auto i_data = _data;
+        for (std::size_t i = 0; i < size(); i++)
+            *(i_data++) = the_expression[i];
+        return *this;
+    }
+
+    MatrixStorage& operator=(MatrixStorage const& Other) {
+        resize(Other.size1(), Other.size2());
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other._data[i];
+        return *this;
+    }
+
+    MatrixStorage& operator=(MatrixStorage&& Other) {
+        if (_data)
+            delete[] _data;
+
+        _size1 = Other.size1();
+        _size2 = Other.size2();
+        _data = Other._data;
+        Other._data = nullptr;
+
+        return *this;
+    }
+
+    TDataType& operator()(std::size_t i, std::size_t j) { return at(i, j); }
+
+    TDataType const& operator()(std::size_t i, std::size_t j) const {
+        return at(i, j);
+    }
+
+    TDataType& at(std::size_t i, std::size_t j) {
+        return _data[i * _size2 + j];
+    }
+
+    TDataType const& at(std::size_t i, std::size_t j) const {
+        return _data[i * _size2 + j];
+    }
+
+    TDataType& operator[](std::size_t i) { return at(i); }
+
+    TDataType const& operator[](std::size_t i) const { return at(i); }
+
+    TDataType& at(std::size_t i) { return _data[i]; }
+
+    TDataType const& at(std::size_t i) const { return _data[i]; }
+
+    std::size_t size1() const { return _size1; }
+
+    std::size_t size2() const { return _size2; }
+
+    std::size_t size() const { return _size1 * _size2; }
+
+    void resize(std::size_t NewSize1, std::size_t NewSize2) {
+        std::size_t new_size = NewSize1 * NewSize2;
+        if (size() != new_size) {
+            delete[] _data;
+            _data = new TDataType[new_size];
+        }
+        _size1 = NewSize1;
+        _size2 = NewSize2;
+    }
+
+    void swap(MatrixStorage& Other){
+        TDataType* p_temp = _data;
+        _data = Other._data;
+        Other._data = p_temp;
+    }
+
+    TDataType* data() { return _data; }
+
+    TDataType const* data() const { return _data; }
+};
+
+template <typename TDataType, std::size_t TSize1>
+class MatrixStorage<TDataType, TSize1, dynamic> {
+    std::size_t _size2;
+    TDataType* _data;
+
+   public:
+    MatrixStorage() = delete;
+
+    MatrixStorage(std::size_t TheSize1, std::size_t TheSize2)
+        : _size2(TheSize2) {
+        _data = new TDataType[size()];
+    }
+
+    explicit MatrixStorage(std::size_t TheSize1, std::size_t TheSize2,
+        TDataType const& InitialValue)
+        : _size2(TheSize2) {
+        _data = new TDataType[size()];
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = InitialValue;
+    }
+
+    MatrixStorage(MatrixStorage const& Other) : _size2(Other.size2()) {
+        _data = new TDataType[size()];
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other._data[i];
+    }
+
+    MatrixStorage(MatrixStorage&& Other)
+        : _size2(Other.size2()), _data(Other._data) {
+        Other._data = nullptr;
+    }
+
+    explicit MatrixStorage(std::initializer_list<TDataType> InitialValues)
+        : _size2(InitialValues.size() / TSize1), _data(nullptr) {
+        if (_size2 == 0)
+            return;
+        _data = new TDataType[size()];
+        std::size_t position = 0;
+        for (auto& i : InitialValues) {
+            _data[position++] = i;
+        }
+    }
+
+    virtual ~MatrixStorage() {
+        if (_data)
+            delete[] _data;
+    }
+
+    template <typename TExpressionType, std::size_t TCategory>
+    explicit MatrixStorage(
+        MatrixExpression<TExpressionType, TCategory> const& Other)
+        : MatrixStorage(Other.expression()) {}
+
+    template <typename TExpressionType>
+    explicit MatrixStorage(
+        MatrixExpression<TExpressionType, row_major_access> const& Other)
+        : _size2(Other.size2()) {
+        _data = new TDataType[size()];
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other[i];
+    }
+
+    template <typename TOtherMatrixType>
+    explicit MatrixStorage(TOtherMatrixType const& Other)
+        : _size2(Other.size2()) {
+        _data = new TDataType[size()];
+        auto i_data = _data;
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                *(i_data++) = Other(i, j);
+    }
+
+    template <typename TExpressionType, std::size_t TCategory>
+    MatrixStorage& operator=(
+        MatrixExpression<TExpressionType, TCategory> const& Other) {
+        auto& other_expression = Other.expression();
+        std::size_t new_size =
+            other_expression.size1() * other_expression.size2();
+        if (size() != new_size) {
+            delete[] _data;
+            _data = new TDataType[new_size];
+        }
+        _size2 = other_expression.size2();
+
+        auto i_data = _data;
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                *(i_data++) = Other.expression()(i, j);
+        return *this;
+    }
+
+    template <typename TOtherMatrixType>
+    MatrixStorage& operator=(TOtherMatrixType const& Other) {
+        std::size_t new_size = Other.size1() * Other.size2();
+        if (size() != new_size) {
+            delete[] _data;
+            _data = new TDataType[new_size];
+        }
+        _size2 = Other.size2();
+
+        auto i_data = _data;
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                *(i_data++) = Other(i, j);
+        return *this;
+    }
+
+    MatrixStorage& operator=(MatrixStorage const& Other) {
+        std::size_t new_size = Other.size1() * Other.size2();
+        if (size() != new_size) {
+            delete[] _data;
+            _data = new TDataType[new_size];
+        }
+        _size2 = Other.size2();
+
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other._data[i];
+        return *this;
+    }
+
+    MatrixStorage& operator=(MatrixStorage&& Other) {
+        if (_data)
+            delete[] _data;
+
+        _size2 = Other.size2();
+        _data = Other._data;
+        Other._data = nullptr;
+
+        return *this;
+    }
+
+    TDataType& operator()(std::size_t i, std::size_t j) { return at(i, j); }
+
+    TDataType const& operator()(std::size_t i, std::size_t j) const {
+        return at(i, j);
+    }
+
+    TDataType& at(std::size_t i, std::size_t j) {
+        return _data[i * _size2 + j];
+    }
+
+    TDataType const& at(std::size_t i, std::size_t j) const {
+        return _data[i * _size2 + j];
+    }
+
+    TDataType& operator[](std::size_t i) { return at(i); }
+
+    TDataType const& operator[](std::size_t i) const { return at(i); }
+
+    TDataType& at(std::size_t i) { return _data[i]; }
+
+    TDataType const& at(std::size_t i) const { return _data[i]; }
+
+    constexpr std::size_t size1() const { return TSize1; }
+
+    std::size_t size2() const { return _size2; }
+
+    std::size_t size() const { return TSize1 * _size2; }
+
+    void resize(std::size_t NewSize) {
+        if (size2() != NewSize) {
+            delete[] _data;
+            _data = new TDataType[TSize1 * NewSize];
+        }
+        _size2 = NewSize;
+    }
+
+    void swap(MatrixStorage& Other){
+        TDataType* p_temp = _data;
+        _data = Other._data;
+        Other._data = p_temp;
+    }
+
+    TDataType* data() { return _data; }
+
+    TDataType const* data() const { return _data; }
+};
+
+template <typename TDataType, std::size_t TSize2>
+class MatrixStorage<TDataType, dynamic, TSize2> {
+    std::size_t _size1;
+    TDataType* _data;
+
+   public:
+    MatrixStorage() : _size1(0), _data(nullptr) {}
+
+    MatrixStorage(std::size_t TheSize1, std::size_t TheSize2 = TSize2)
+        : _size1(TheSize1) {
+        _data = new TDataType[size()];
+    }
+
+    explicit MatrixStorage(std::size_t TheSize1, std::size_t TheSize2,
+        TDataType const& InitialValue)
+        : _size1(TheSize1) {
+        _data = new TDataType[size()];
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = InitialValue;
+    }
+
+    MatrixStorage(MatrixStorage const& Other) : _size1(Other.size1()) {
+        _data = new TDataType[size()];
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other._data[i];
+    }
+
+    MatrixStorage(MatrixStorage&& Other)
+        : _size1(Other.size1()), _data(Other._data) {
+        Other._data = nullptr;
+    }
+
+    explicit MatrixStorage(std::initializer_list<TDataType> InitialValues)
+        : _size1(InitialValues.size() / TSize2), _data(nullptr) {
+        if (_size1 == 0)
+            return;
+        _data = new TDataType[size()];
+        std::size_t position = 0;
+        for (auto& i : InitialValues) {
+            _data[position++] = i;
+        }
+    }
+
+    virtual ~MatrixStorage() {
+        if (_data)
+            delete[] _data;
+    }
+
+    template <typename TExpressionType, std::size_t TCategory>
+    explicit MatrixStorage(
+        MatrixExpression<TExpressionType, TCategory> const& Other)
+        : MatrixStorage(Other.expression()) {}
+
+    template <typename TExpressionType>
+    explicit MatrixStorage(
+        MatrixExpression<TExpressionType, row_major_access> const& Other)
+        : _size1(Other.expression().size1()) {
+        _data = new TDataType[size()];
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other.expression()[i];
+    }
+
+    template <typename TOtherMatrixType>
+    explicit MatrixStorage(TOtherMatrixType const& Other)
+        : _size1(Other.size1()) {
+        _data = new TDataType[size()];
+        auto i_data = _data;
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                *(i_data++) = Other(i, j);
+    }
+
+    template <typename TExpressionType, std::size_t TCategory>
+    MatrixStorage& operator=(
+        MatrixExpression<TExpressionType, TCategory> const& Other) {
+        auto& other_expression = Other.expression();
+        std::size_t new_size =
+            other_expression.size1() * other_expression.size2();
+        if (size() != new_size) {
+            delete[] _data;
+            _data = new TDataType[new_size];
+        }
+        _size1 = other_expression.size1();
+
+        auto i_data = _data;
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                *(i_data++) = Other.expression()(i, j);
+        return *this;
+    }
+
+    template <typename TOtherMatrixType>
+    MatrixStorage& operator=(TOtherMatrixType const& Other) {
+        std::size_t new_size = Other.size();
+        if (size() != new_size) {
+            delete[] _data;
+            _data = new TDataType[new_size];
+        }
+        _size1 = Other.size1();
+
+        auto i_data = _data;
+        for (std::size_t i = 0; i < size1(); i++)
+            for (std::size_t j = 0; j < size2(); j++)
+                *(i_data++) = Other(i, j);
+        return *this;
+    }
+
+    MatrixStorage& operator=(MatrixStorage const& Other) {
+        std::size_t new_size = Other.size1() * Other.size2();
+        if (size() != new_size) {
+            delete[] _data;
+            _data = new TDataType[new_size];
+        }
+        _size1 = Other.size1();
+
+        for (std::size_t i = 0; i < size(); i++)
+            _data[i] = Other._data[i];
+        return *this;
+    }
+
+    MatrixStorage& operator=(MatrixStorage&& Other) {
+        if (_data)
+            delete[] _data;
+
+        _size1 = Other.size1();
+        _data = Other._data;
+        Other._data = nullptr;
+
+        return *this;
+    }
+
+    TDataType& operator()(std::size_t i, std::size_t j) { return at(i, j); }
+
+    TDataType const& operator()(std::size_t i, std::size_t j) const {
+        return at(i, j);
+    }
+
+    TDataType& at(std::size_t i, std::size_t j) {
+        return _data[i * TSize2 + j];
+    }
+
+    TDataType const& at(std::size_t i, std::size_t j) const {
+        return _data[i * TSize2 + j];
+    }
+
+    TDataType& operator[](std::size_t i) { return at(i); }
+
+    TDataType const& operator[](std::size_t i) const { return at(i); }
+
+    TDataType& at(std::size_t i) { return _data[i]; }
+
+    TDataType const& at(std::size_t i) const { return _data[i]; }
+
+    std::size_t size1() const { return _size1; }
+
+    constexpr std::size_t size2() const { return TSize2; }
+
+    std::size_t size() const { return _size1 * TSize2; }
+
+    void resize(std::size_t NewSize) {
+        if (size1() != NewSize) {
+            delete[] _data;
+            _data = new TDataType[NewSize * TSize2];
+        }
+        _size1 = NewSize;
+    }
+
+    void swap(MatrixStorage& Other){
+        TDataType* p_temp = _data;
+        _data = Other._data;
+        Other._data = p_temp;
+    }
+
+    TDataType* data() { return _data; }
+
+    TDataType const* data() const { return _data; }
+};
+
+}  // namespace AMatrix


### PR DESCRIPTION
I have just uploaded the minimum header files required to compile Kratos with AMatrix. In future we may add the rest of the library including the tests and benchmarks.

Adding the difinition `-DAMATRIX_DIR=/path/to/kratos/external_libraries/a_matrix` to configure make CMake compile Kratos with AMatrix 