### PR TITLE
[StructuralMechanics] fixing tests

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/sprism_test/patch_bending_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/sprism_test/patch_bending_test_parameters.json
@@ -24,6 +24,7 @@
         "line_search"                        : false,
         "compute_reactions"                  : true,
         "block_builder"                      : false,
+        "multi_point_constraints_used"       : false,
         "move_mesh_flag"                     : true,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,

--- a/applications/StructuralMechanicsApplication/tests/sprism_test/patch_membrane_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/sprism_test/patch_membrane_test_parameters.json
@@ -24,6 +24,7 @@
         "line_search"                        : false,
         "compute_reactions"                  : true,
         "block_builder"                      : false,
+        "multi_point_constraints_used"       : false,
         "move_mesh_flag"                     : true,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,


### PR DESCRIPTION
failing bcs the default changed, the EliminationB&S cannot be used with Constraints