### PR TITLE
[EigenSolversApplication] fix relative path for eigensolvers tests

### DIFF
--- a/applications/EigenSolversApplication/tests/test_eigen_direct_solver.py
+++ b/applications/EigenSolversApplication/tests/test_eigen_direct_solver.py
@@ -23,9 +23,7 @@ class TestEigenDirectSolver(KratosUnittest.TestCase):
 
         this_file_dir = os.path.dirname(os.path.realpath(__file__))
         base_dir = os.path.dirname(os.path.dirname(os.path.dirname(this_file_dir)))
-        matrix_file_path = os.path.join(base_dir, "kratos")
-        matrix_file_path = os.path.join(matrix_file_path, "tests")
-        matrix_file_path = os.path.join(matrix_file_path, "A.mm")
+        matrix_file_path = os.path.join(base_dir, "kratos", "tests", "A.mm")
 
         KratosMultiphysics.ReadMatrixMarketMatrix(matrix_file_path, a) # symmetric test matrix
 

--- a/applications/EigenSolversApplication/tests/test_eigen_direct_solver.py
+++ b/applications/EigenSolversApplication/tests/test_eigen_direct_solver.py
@@ -24,8 +24,8 @@ class TestEigenDirectSolver(KratosUnittest.TestCase):
         this_file_dir = os.path.dirname(os.path.realpath(__file__))
         base_dir = os.path.dirname(os.path.dirname(os.path.dirname(this_file_dir)))
         matrix_file_path = os.path.join(base_dir, "kratos")
-        matrix_file_path = os.path.join(matrix_file_path, "/tests")
-        matrix_file_path = os.path.join(matrix_file_path, "/A.mm")
+        matrix_file_path = os.path.join(matrix_file_path, "tests")
+        matrix_file_path = os.path.join(matrix_file_path, "A.mm")
 
         KratosMultiphysics.ReadMatrixMarketMatrix(matrix_file_path, a) # symmetric test matrix
 

--- a/applications/EigenSolversApplication/tests/test_eigen_direct_solver.py
+++ b/applications/EigenSolversApplication/tests/test_eigen_direct_solver.py
@@ -1,5 +1,6 @@
 
 from __future__ import print_function, absolute_import, division
+import os
 import KratosMultiphysics
 
 import KratosMultiphysics.EigenSolversApplication as EigenSolversApplication
@@ -15,14 +16,22 @@ class TestEigenDirectSolver(KratosUnittest.TestCase):
         space = KratosMultiphysics.UblasSparseSpace()
 
         settings = KratosMultiphysics.Parameters('{ "solver_type" : "' + solver_type + '" }')
-        
+
         solver = ConstructSolver(settings)
 
         a = KratosMultiphysics.CompressedMatrix()
-        
-        KratosMultiphysics.ReadMatrixMarketMatrix('../../../kratos/tests/A.mm', a) # symmetric test matrix
-        
+
+        this_file_dir = os.path.dirname(os.path.realpath(__file__))
+        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(this_file_dir)))
+        matrix_file_path = os.path.join(base_dir, "kratos")
+        matrix_file_path = os.path.join(matrix_file_path, "/tests")
+        matrix_file_path = os.path.join(matrix_file_path, "/A.mm")
+
+        KratosMultiphysics.ReadMatrixMarketMatrix(matrix_file_path, a) # symmetric test matrix
+
         dimension = a.Size1()
+
+        self.assertEqual(dimension, 900)
 
         b_exp = KratosMultiphysics.Vector(dimension) # [1, 2, ..., dimension-1, dimension]
 
@@ -41,7 +50,7 @@ class TestEigenDirectSolver(KratosUnittest.TestCase):
 
     def test_eigen_sparse_lu(self):
         self._execute_eigen_direct_solver_test('SparseLUSolver', 'eigen_sparse_lu')
-    
+
     def test_eigen_pardiso_lu(self):
         self._execute_eigen_direct_solver_test('PardisoLUSolver', 'eigen_pardiso_lu')
 


### PR DESCRIPTION
The "A.mm" file was not found because of the relative paths.

KratosMultiphysics.ReadMatrixMarketMatrix does not seem to give a helpful error in the tests...

closes #2819