### PR TITLE
[StructuralMechanicsApplication] Clean up and reducing code duplication in hyperelastic Kirchoff laws

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.cpp
@@ -16,59 +16,64 @@
 // External includes
 
 // Project includes
+#include "includes/checks.h"
 #include "includes/properties.h"
 #include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h"
-
 #include "structural_mechanics_application_variables.h"
 
 namespace Kratos
 {
 //******************************CONSTRUCTOR*******************************************
-//************************************************************************************
+/***********************************************************************************/
 HyperElasticIsotropicKirchhoff3D::HyperElasticIsotropicKirchhoff3D()
-    : ConstitutiveLaw() {
+    : ConstitutiveLaw() 
+{
 }
 
 //******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
+/***********************************************************************************/
 
 HyperElasticIsotropicKirchhoff3D::HyperElasticIsotropicKirchhoff3D(const HyperElasticIsotropicKirchhoff3D& rOther)
-    : ConstitutiveLaw(rOther) {
+    : ConstitutiveLaw(rOther) 
+{
 }
 
 //********************************CLONE***********************************************
-//************************************************************************************
+/***********************************************************************************/
 
-ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoff3D::Clone() const {
-    HyperElasticIsotropicKirchhoff3D::Pointer p_clone(new HyperElasticIsotropicKirchhoff3D(*this));
-    return p_clone;
+ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoff3D::Clone() const 
+{
+    return Kratos::make_shared<HyperElasticIsotropicKirchhoff3D>(*this);
 }
 
 //*******************************DESTRUCTOR*******************************************
-//************************************************************************************
+/***********************************************************************************/
 
-HyperElasticIsotropicKirchhoff3D::~HyperElasticIsotropicKirchhoff3D() {
+HyperElasticIsotropicKirchhoff3D::~HyperElasticIsotropicKirchhoff3D() 
+{
 };
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponsePK1 (ConstitutiveLaw::Parameters& rValues) {
-
-    CalculateMaterialResponsePK2(rValues);
+void HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponsePK1 (ConstitutiveLaw::Parameters& rValues) 
+{
+    this->CalculateMaterialResponsePK2(rValues);
 
     Vector& stress_vector                = rValues.GetStressVector();
     const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
-    const double& determinant_f          = rValues.GetDeterminantF();
+    const double determinant_f           = rValues.GetDeterminantF();
 
-    TransformStresses(stress_vector, deformation_gradient_f, determinant_f, StressMeasure_PK2, StressMeasure_PK1);
+    this->TransformStresses(stress_vector, deformation_gradient_f, determinant_f, StressMeasure_PK2, StressMeasure_PK1);
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-void  HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) {
+void  HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) 
+{
     KRATOS_TRY;
+    
     // Get Values to compute the constitutive law:
     Flags &Options=rValues.GetOptions();
 
@@ -76,16 +81,16 @@ void  HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponsePK2(Constitutiv
     Vector& strain_vector                 = rValues.GetStrainVector();
 
     // The material properties
-    const double& young_modulus = material_properties[YOUNG_MODULUS];
-    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+    const double young_modulus = material_properties[YOUNG_MODULUS];
+    const double poisson_coefficient = material_properties[POISSON_RATIO];
 
     if(Options.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
-        CalculateGreenLagrangianStrain(rValues, strain_vector);
+        this->CalculateGreenLagrangianStrain(rValues, strain_vector);
     }
 
     if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
-        Matrix& ConstitutiveMatrix = rValues.GetConstitutiveMatrix();
-        CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
+        Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
+        this->CalculateConstitutiveMatrixPK2( constitutive_matrix, young_modulus, poisson_coefficient);
     }
 
     if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
@@ -94,17 +99,18 @@ void  HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponsePK2(Constitutiv
             Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
             noalias(stress_vector) = prod(constitutive_matrix, strain_vector);
         } else {
-            CalculatePK2Stress( strain_vector, stress_vector, young_modulus, poisson_coefficient );
+            this->CalculatePK2Stress( strain_vector, stress_vector, young_modulus, poisson_coefficient );
         }
     }
+    
     KRATOS_CATCH("");
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponseKirchhoff (ConstitutiveLaw::Parameters& rValues) {
-
+void HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponseKirchhoff (ConstitutiveLaw::Parameters& rValues) 
+{
     // Get Values to compute the constitutive law:
     Flags &Options=rValues.GetOptions();
 
@@ -113,113 +119,114 @@ void HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponseKirchhoff (Const
     Vector& stress_vector                 = rValues.GetStressVector();
 
     // The material properties
-    const double& young_modulus = material_properties[YOUNG_MODULUS];
-    const double& poisson_coefficient = material_properties[POISSON_RATIO];
+    const double young_modulus = material_properties[YOUNG_MODULUS];
+    const double poisson_coefficient = material_properties[POISSON_RATIO];
 
      // The deformation gradient
     const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
 
     if(Options.Is( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
-        CalculateAlmansiStrain(rValues, strain_vector);
+        this->CalculateAlmansiStrain(rValues, strain_vector);
     }
 
     if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
         Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
-        CalculateConstitutiveMatrixKirchhoff(constitutive_matrix, deformation_gradient_f ,young_modulus, poisson_coefficient);
+        this->CalculateConstitutiveMatrixKirchhoff(constitutive_matrix, deformation_gradient_f ,young_modulus, poisson_coefficient);
     }
 
     if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
-        if (rValues.IsSetDeformationGradientF() == true) {
-               CalculateGreenLagrangianStrain(rValues, strain_vector);
+        if (rValues.IsSetDeformationGradientF()) {
+            this->CalculateGreenLagrangianStrain(rValues, strain_vector);
         }
 
-        CalculateKirchhoffStress(strain_vector, stress_vector, deformation_gradient_f ,young_modulus, poisson_coefficient);
+        this->CalculateKirchhoffStress(strain_vector, stress_vector, deformation_gradient_f ,young_modulus, poisson_coefficient);
     }
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponseCauchy (ConstitutiveLaw::Parameters& rValues) {
-
-    CalculateMaterialResponseKirchhoff(rValues);
+void HyperElasticIsotropicKirchhoff3D::CalculateMaterialResponseCauchy (ConstitutiveLaw::Parameters& rValues) 
+{
+    this->CalculateMaterialResponseKirchhoff(rValues);
 
     Vector& stress_vector       = rValues.GetStressVector();
     Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
-    const double& determinant_f = rValues.GetDeterminantF();
+    const double determinant_f = rValues.GetDeterminantF();
 
     // Set to Cauchy Stress:
     stress_vector       /= determinant_f;
     constitutive_matrix /= determinant_f;
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues) {
+void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues) 
+{
 //     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
 //     this->CalculateMaterialResponsePK1(rValues);
 //     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) {
+void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) 
+{
 //     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
 //     this->CalculateMaterialResponsePK2(rValues);
 //     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) {
+void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) 
+{
 //     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
 //     this->CalculateMaterialResponseCauchy(rValues);
 //     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues) {
+void HyperElasticIsotropicKirchhoff3D::FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues) 
+{
 //     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
 //     this->CalculateMaterialResponseKirchhoff(rValues);
 //     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
 }
 
-//************************************************************************************
-//************************************************************************************
-
+/***********************************************************************************/
+/***********************************************************************************/
 
 double& HyperElasticIsotropicKirchhoff3D::CalculateValue(
     ConstitutiveLaw::Parameters& rParameterValues,
     const Variable<double>& rThisVariable,
-    double& rValue) {
-    
+    double& rValue
+    ) 
+{
     const Properties& material_properties  = rParameterValues.GetMaterialProperties();
     Vector& strain_vector                  = rParameterValues.GetStrainVector();
 
     // The material properties
-    const double& young_modulus = material_properties[YOUNG_MODULUS];
-    const double& poisson_coefficient = material_properties[POISSON_RATIO];
-
+    const double young_modulus = material_properties[YOUNG_MODULUS];
+    const double poisson_coefficient = material_properties[POISSON_RATIO];
 
     // The LAME parameters
     const double lame_lambda = (young_modulus * poisson_coefficient)/((1.0 + poisson_coefficient)*(1.0 - 2.0 * poisson_coefficient));
     const double lame_mu = young_modulus/(2.0 * (1.0 + poisson_coefficient));
 
     // We compute the right Cauchy-Green tensor (C):
-
     if (rThisVariable == STRAIN_ENERGY) {
-
         CalculateGreenLagrangianStrain(rParameterValues,strain_vector);
-        Matrix E_tensor=MathUtils<double>::StrainVectorToTensor(strain_vector);
-        Matrix E_tensor_sq=prod(E_tensor,E_tensor);
+        const Matrix E_tensor=MathUtils<double>::StrainVectorToTensor(strain_vector);
+        const Matrix E_tensor_sq=prod(E_tensor,E_tensor);
         double E_trace = 0.0;
         double E_trace_sq = 0.0;
-        for (unsigned int i = 0; i < E_tensor.size1();i++) {
+        for (IndexType i = 0; i < E_tensor.size1();i++) {
             E_trace     += E_tensor (i,i);
             E_trace_sq  += E_tensor_sq(i,i);
         }
@@ -231,9 +238,10 @@ double& HyperElasticIsotropicKirchhoff3D::CalculateValue(
 }
 
 //*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
-//************************************************************************************
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoff3D::GetLawFeatures(Features& rFeatures) {
+void HyperElasticIsotropicKirchhoff3D::GetLawFeatures(Features& rFeatures) 
+{
     //Set the type of law
     rFeatures.mOptions.Set( THREE_DIMENSIONAL_LAW );
     rFeatures.mOptions.Set( FINITE_STRAINS );
@@ -250,91 +258,89 @@ void HyperElasticIsotropicKirchhoff3D::GetLawFeatures(Features& rFeatures) {
     rFeatures.mSpaceDimension = WorkingSpaceDimension();
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
 int HyperElasticIsotropicKirchhoff3D::Check(
-    const Properties& rmaterial_properties,
+    const Properties& rMaterialProperties,
     const GeometryType& rElementGeometry,
-    const ProcessInfo& rCurrentProcessInfo) {
+    const ProcessInfo& rCurrentProcessInfo
+    ) 
+{
+    KRATOS_CHECK_VARIABLE_KEY(YOUNG_MODULUS);
+    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] <= 0.0) << "YOUNG_MODULUS is invalid value " << std::endl;
 
-    if(YOUNG_MODULUS.Key() == 0 || rmaterial_properties[YOUNG_MODULUS] <= 0.0) {
-        KRATOS_ERROR << "YOUNG_MODULUS has Key zero or invalid value " << std::endl;
-    }
+    KRATOS_CHECK_VARIABLE_KEY(POISSON_RATIO);
+    const double nu = rMaterialProperties[POISSON_RATIO];
+    const bool check = static_cast<bool>((nu >0.499 && nu<0.501) || (nu < -0.999 && nu > -1.01));
+    KRATOS_ERROR_IF(check) << "POISSON_RATIO is invalid value " << std::endl;
 
-    const double& nu = rmaterial_properties[POISSON_RATIO];
-    const bool check = bool( (nu > 0.499 && nu < 0.501 ) || (nu < -0.999 && nu > -1.01 ) );
-
-    if(POISSON_RATIO.Key() == 0 || check==true) {
-        KRATOS_ERROR << "POISSON_RATIO has Key zero invalid value " << std::endl;
-    }
-
-    if(DENSITY.Key() == 0 || rmaterial_properties[DENSITY] < 0.0) {
-        KRATOS_ERROR << "DENSITY has Key zero or invalid value " << std::endl;
-    }
+    KRATOS_CHECK_VARIABLE_KEY(DENSITY);
+    KRATOS_ERROR_IF(rMaterialProperties[DENSITY] < 0.0) << "DENSITY is invalid value " << std::endl;
 
     return 0;
 }
 
-//************************************************************************************
-//************************************************************************************
-//CalculateConstitutiveMatrixPK2( constitutive_matrix, inverse_C_tensor, determinant_f, lame_lambda, lame_mu );
+/***********************************************************************************/
+/***********************************************************************************/
 
-//CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
 void HyperElasticIsotropicKirchhoff3D::CalculateConstitutiveMatrixPK2(
-    Matrix& ConstitutiveMatrix,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
-    
-    ConstitutiveMatrix.clear();
-    ConstitutiveMatrix = ZeroMatrix(6,6);
+    Matrix& rConstitutiveMatrix,
+    const double YoungModulus,
+    const double PoissonCoefficient
+    ) 
+{
+    rConstitutiveMatrix.clear();
+    rConstitutiveMatrix = ZeroMatrix(6,6);
     const double c1 = YoungModulus / (( 1.00 + PoissonCoefficient ) * ( 1 - 2 * PoissonCoefficient ) );
     const double c2 = c1 * ( 1 - PoissonCoefficient );
     const double c3 = c1 * PoissonCoefficient;
     const double c4 = c1 * 0.5 * ( 1 - 2 * PoissonCoefficient );
 
-    ConstitutiveMatrix( 0, 0 ) = c2;
-    ConstitutiveMatrix( 0, 1 ) = c3;
-    ConstitutiveMatrix( 0, 2 ) = c3;
-    ConstitutiveMatrix( 1, 0 ) = c3;
-    ConstitutiveMatrix( 1, 1 ) = c2;
-    ConstitutiveMatrix( 1, 2 ) = c3;
-    ConstitutiveMatrix( 2, 0 ) = c3;
-    ConstitutiveMatrix( 2, 1 ) = c3;
-    ConstitutiveMatrix( 2, 2 ) = c2;
-    ConstitutiveMatrix( 3, 3 ) = c4;
-    ConstitutiveMatrix( 4, 4 ) = c4;
-    ConstitutiveMatrix( 5, 5 ) = c4;
+    rConstitutiveMatrix( 0, 0 ) = c2;
+    rConstitutiveMatrix( 0, 1 ) = c3;
+    rConstitutiveMatrix( 0, 2 ) = c3;
+    rConstitutiveMatrix( 1, 0 ) = c3;
+    rConstitutiveMatrix( 1, 1 ) = c2;
+    rConstitutiveMatrix( 1, 2 ) = c3;
+    rConstitutiveMatrix( 2, 0 ) = c3;
+    rConstitutiveMatrix( 2, 1 ) = c3;
+    rConstitutiveMatrix( 2, 2 ) = c2;
+    rConstitutiveMatrix( 3, 3 ) = c4;
+    rConstitutiveMatrix( 4, 4 ) = c4;
+    rConstitutiveMatrix( 5, 5 ) = c4;
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoff3D::CalculateConstitutiveMatrixKirchhoff(
-    Matrix& ConstitutiveMatrix,
-    const Matrix& DeformationGradientF,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
-
-    ConstitutiveMatrix.clear();
-
-    CalculateConstitutiveMatrixPK2(ConstitutiveMatrix, YoungModulus, PoissonCoefficient);
-    PushForwardConstitutiveMatrix (ConstitutiveMatrix,DeformationGradientF );
-
+void HyperElasticIsotropicKirchhoff3D::CalculateKirchhoffStress(
+    const Vector& rStrainVector,
+    Vector& rStressVector,
+    const Matrix& rDeformationGradientF,
+    const double YoungModulus,
+    const double PoissonCoefficient
+    ) 
+{
+    CalculatePK2Stress( rStrainVector, rStressVector, YoungModulus, PoissonCoefficient );
+    Matrix stress_matrix = MathUtils<double>::StressVectorToTensor( rStressVector );
+    ContraVariantPushForward (stress_matrix,rDeformationGradientF); //Kirchhoff
+    rStressVector = MathUtils<double>::StressTensorToVector( stress_matrix, rStressVector.size() );
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
 void HyperElasticIsotropicKirchhoff3D::CalculatePK2Stress(
     const Vector& rStrainVector,
     Vector& rStressVector,
-    const double& YoungModulus,
-    const double& PoissonCoefficient ) {
-
+    const double YoungModulus,
+    const double PoissonCoefficient 
+    ) 
+{
     const double lame_lambda = (YoungModulus * PoissonCoefficient)/((1.0 + PoissonCoefficient)*(1.0 - 2.0 * PoissonCoefficient));
     const double lame_mu = YoungModulus/(2.0 * (1.0 + PoissonCoefficient));
-    Matrix E_tensor=MathUtils<double>::StrainVectorToTensor(rStrainVector);
+    const Matrix E_tensor=MathUtils<double>::StrainVectorToTensor(rStrainVector);
     double E_trace = 0.0;
     for (unsigned int i = 0; i < E_tensor.size1();i++) {
       E_trace += E_tensor (i,i);
@@ -343,33 +349,30 @@ void HyperElasticIsotropicKirchhoff3D::CalculatePK2Stress(
     Matrix stress_matrix = lame_lambda*E_trace*IdentityMatrix(dimension, dimension) + 2.0 * lame_mu * E_tensor;
     rStressVector = MathUtils<double>::StressTensorToVector( stress_matrix, rStressVector.size() );
 
-    // Other possibility
-    //SizeType SizeSystem = GetStrainSize();
-    //Matrix ConstMatrixPK2(SizeSystem,SizeSystem);
-    //CalculateConstitutiveMatrixPK2(ConstMatrixPK2, YoungModulus, PoissonCoefficient);
-    //rStressVector = prod(ConstMatrixPK2,rStrainVector);
-
+//     // Other possibility
+//     SizeType size_system = GetStrainSize();
+//     Matrix constitutive_matrix_pk2(size_system,size_system);
+//     CalculateConstitutiveMatrixPK2(constitutive_matrix_pk2, YoungModulus, PoissonCoefficient);
+//     noalias(rStressVector) = prod(constitutive_matrix_pk2,rStrainVector);
 }
 
+/***********************************************************************************/
+/***********************************************************************************/
 
-//************************************************************************************
-//************************************************************************************
-void HyperElasticIsotropicKirchhoff3D::CalculateKirchhoffStress(
-    const Vector& rStrainVector,
-    Vector& rStressVector,
+void HyperElasticIsotropicKirchhoff3D::CalculateConstitutiveMatrixKirchhoff(
+    Matrix& ConstitutiveMatrix,
     const Matrix& DeformationGradientF,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
+    const double YoungModulus,
+    const double PoissonCoefficient) {
 
-    CalculatePK2Stress( rStrainVector, rStressVector, YoungModulus, PoissonCoefficient );
-    Matrix StressMatrix = MathUtils<double>::StressVectorToTensor( rStressVector );
-    ContraVariantPushForward (StressMatrix,DeformationGradientF); //Kirchhoff
-    rStressVector = MathUtils<double>::StressTensorToVector( StressMatrix, rStressVector.size() );
+    ConstitutiveMatrix.clear();
 
+    this->CalculateConstitutiveMatrixPK2(ConstitutiveMatrix, YoungModulus, PoissonCoefficient);
+    PushForwardConstitutiveMatrix (ConstitutiveMatrix,DeformationGradientF );
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
 void HyperElasticIsotropicKirchhoff3D::CalculateGreenLagrangianStrain(
     ConstitutiveLaw::Parameters& rValues,
@@ -389,8 +392,8 @@ void HyperElasticIsotropicKirchhoff3D::CalculateGreenLagrangianStrain(
     rStrainVector[5] = C_tensor( 0, 2 ); // xz
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
 void HyperElasticIsotropicKirchhoff3D::CalculateAlmansiStrain(
     ConstitutiveLaw::Parameters& rValues,

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h
@@ -40,20 +40,33 @@ namespace Kratos
 ///@}
 ///@name Kratos Classes
 ///@{
-class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) HyperElasticIsotropicKirchhoff3D : public ConstitutiveLaw
+/**
+ * @class HyperElasticIsotropicKirchhoff3D
+ * @ingroup StructuralMechanicsApplication
+ * @brief This law defines an hyperelastic material according to the Saint-Venant–Kirchhoff formulation for 3D cases
+ * @details The simplest hyperelastic material model is the Saint Venant–Kirchhoff model which is just an extension of the linear elastic material model to the nonlinear regime. 
+ * More info https://en.wikipedia.org/wiki/Hyperelastic_material#Saint_Venant%E2%80%93Kirchhoff_model
+ * @author Malik Ali Dawi
+ * @author Ruben Zorrilla
+ */
+class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) HyperElasticIsotropicKirchhoff3D 
+    : public ConstitutiveLaw
 {
 public:
 
     ///@name Type Definitions
     ///@{
-
+    
+    /// The definition of the process info
     typedef ProcessInfo      ProcessInfoType;
+    
+    /// The definition of the base class
     typedef ConstitutiveLaw         BaseType;
+    
+    /// The definition of the size type
     typedef std::size_t             SizeType;
 
-    /**
-     * Counted pointer of HyperElasticIsotropicKirchhoff3D
-     */
+    /// Pointer definition of HyperElasticIsotropicKirchhoff3D
     KRATOS_CLASS_POINTER_DEFINITION( HyperElasticIsotropicKirchhoff3D );
 
     ///@name Lyfe Cycle
@@ -105,71 +118,63 @@ public:
     };
 
     /**
-     * Computes the material response:
-     * PK1 stresses and algorithmic ConstitutiveMatrix
+     * @brief Computes the material response: PK1 stresses and algorithmic ConstitutiveMatrix
      * @param rValues: The Internalvalues of the law
      * @see   Parameters
      */
     void CalculateMaterialResponsePK1 (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
-     * Computes the material response:
-     * PK2 stresses and algorithmic ConstitutiveMatrix
+     * @brief Computes the material response: PK2 stresses and algorithmic ConstitutiveMatrix
      * @param rValues: The Internalvalues of the law
      * @see   Parameters
      */
     void CalculateMaterialResponsePK2 (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
-     * Computes the material response:
-     * Kirchhoff stresses and algorithmic ConstitutiveMatrix
+     * @brief Computes the material response: Kirchhoff stresses and algorithmic ConstitutiveMatrix
      * @param rValues: The Internalvalues of the law
      * @see   Parameters
      */
     void CalculateMaterialResponseKirchhoff (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
-     * Computes the material response:
-     * Cauchy stresses and algorithmic ConstitutiveMatrix
+     * @brief Computes the material response: Cauchy stresses and algorithmic ConstitutiveMatrix
      * @param rValues: The Internalvalues of the law
      * @see   Parameters
      */
     void CalculateMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
+      * @brief Updates the material response: Cauchy stresses and Internal Variables
       * @param rValues: The Internalvalues of the law
       * @see   Parameters
       */
     void FinalizeMaterialResponsePK1 (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
+      * @brief Updates the material response: Cauchy stresses and Internal Variables
       * @param rValues: The Internalvalues of the law
       * @see   Parameters
       */
     void FinalizeMaterialResponsePK2 (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
+      * @brief Updates the material response: Cauchy stresses and Internal Variables
       * @param rValues: The Internalvalues of the law
       * @see   Parameters
       */
     void FinalizeMaterialResponseKirchhoff (ConstitutiveLaw::Parameters & rValues)  override;
 
     /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
+      * @brief Updates the material response: Cauchy stresses and Internal Variables
       * @param rValues: The Internalvalues of the law
       * @see   Parameters
       */
     void FinalizeMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
-     * calculates the value of a specified variable
+     * @brief It calculates the value of a specified variable
      * @param rParameterValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
@@ -178,7 +183,8 @@ public:
     double& CalculateValue(
         ConstitutiveLaw::Parameters& rParameterValues,
         const Variable<double>& rThisVariable, 
-        double& rValue) override;
+        double& rValue
+        ) override;
 
     /**
      * This function provides the place to perform checks on the completeness of the input.
@@ -192,7 +198,8 @@ public:
     int Check(
         const Properties& rMaterialProperties,
         const GeometryType& rElementGeometry,
-        const ProcessInfo& rCurrentProcessInfo) override;
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
 
 protected:
 
@@ -206,11 +213,89 @@ protected:
     ///@}
     ///@name Protected Operators
     ///@{
-
+    
     ///@}
     ///@name Protected Operations
     ///@{
 
+    /**
+     * It calculates the constitutive matrix C (PK2)
+     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param InverseCTensor: The inverse right Cauchy-Green tensor
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Second Lame parameter
+     */
+    virtual void CalculateConstitutiveMatrixPK2(
+        Matrix& ConstitutiveMatrix,
+        const double YoungModulus,
+        const double PoissonCoefficient
+        );
+
+    /**
+     * It calculates the constitutive matrix C (Kirchoff)
+     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Second Lame parameter
+     */
+    virtual void CalculateConstitutiveMatrixKirchhoff(
+        Matrix& ConstitutiveMatrix,
+        const Matrix& DeformationGradientF,
+        const double YoungModulus,
+        const double PoissonCoefficient
+        );
+
+    /**
+     * It calculates the PK2 stress vector
+     * @param InvCTensor: The inverse of the right Cauchy-Green tensor
+     * @param rStressVector: The stress vector in Voigt notation
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Second Lame parameter
+     */
+    virtual void CalculatePK2Stress(
+        const Vector& rStrainVector,
+        Vector& rStressVector,
+        const double YoungModulus,
+        const double PoissonCoefficient);
+
+    /**
+     * It calculates the Kirchoff stress vector
+     * @param BTensor: The left Cauchy-Green tensor
+     * @param rStressVector: The stress vector in Voigt notation
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    virtual void CalculateKirchhoffStress(
+        const Vector& rStrainVector,
+        Vector& rStressVector,
+        const Matrix& DeformationGradientF,
+        const double YoungModulus,
+        const double PoissonCoefficient
+        );
+
+    /**
+     * It calculates the strain vector
+     * @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    virtual void CalculateGreenLagrangianStrain(
+        ConstitutiveLaw::Parameters& rValues,
+        Vector& rStrainVector
+        );
+
+    /**
+     * Calculates the Almansi strains
+     * @param @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    virtual void CalculateAlmansiStrain(
+        ConstitutiveLaw::Parameters& rValues,
+        Vector& rStrainVector
+        );
+    
     ///@}
 
 private:
@@ -225,79 +310,6 @@ private:
     ///@}
     ///@name Private Operators
     ///@{
-
-    /**
-     * It calculates the constitutive matrix C (PK2)
-     * @param ConstitutiveMatrix: The constitutive matrix
-     * @param InverseCTensor: The inverse right Cauchy-Green tensor
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Second Lame parameter
-     */
-    virtual void CalculateConstitutiveMatrixPK2(
-        Matrix& ConstitutiveMatrix,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the constitutive matrix C (Kirchoff)
-     * @param ConstitutiveMatrix: The constitutive matrix
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Second Lame parameter
-     */
-    virtual void CalculateConstitutiveMatrixKirchhoff(
-        Matrix& ConstitutiveMatrix,
-        const Matrix& DeformationGradientF,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the PK2 stress vector
-     * @param InvCTensor: The inverse of the right Cauchy-Green tensor
-     * @param rStressVector: The stress vector in Voigt notation
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Second Lame parameter
-     */
-    virtual void CalculatePK2Stress(
-        const Vector& rStrainVector,
-        Vector& rStressVector,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the Kirchoff stress vector
-     * @param BTensor: The left Cauchy-Green tensor
-     * @param rStressVector: The stress vector in Voigt notation
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
-     */
-    virtual void CalculateKirchhoffStress(
-        const Vector& rStrainVector,
-        Vector& rStressVector,
-        const Matrix& DeformationGradientF,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the strain vector
-     * @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
-     */
-    virtual void CalculateGreenLagrangianStrain(
-        ConstitutiveLaw::Parameters& rValues,
-        Vector& rStrainVector);
-
-    /**
-     * Calculates the Almansi strains
-     * @param @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
-     */
-    virtual void CalculateAlmansiStrain(
-        ConstitutiveLaw::Parameters& rValues,
-        Vector& rStrainVector);
 
     ///@}
     ///@name Private Operations

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h
@@ -119,56 +119,56 @@ public:
 
     /**
      * @brief Computes the material response: PK1 stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
+     * @param rValues The Internalvalues of the law
      * @see   Parameters
      */
     void CalculateMaterialResponsePK1 (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
      * @brief Computes the material response: PK2 stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
+     * @param rValues The Internalvalues of the law
      * @see   Parameters
      */
     void CalculateMaterialResponsePK2 (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
      * @brief Computes the material response: Kirchhoff stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
+     * @param rValues The Internalvalues of the law
      * @see   Parameters
      */
     void CalculateMaterialResponseKirchhoff (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
      * @brief Computes the material response: Cauchy stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
+     * @param rValues The Internalvalues of the law
      * @see   Parameters
      */
     void CalculateMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
       * @brief Updates the material response: Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
+      * @param rValues The Internalvalues of the law
       * @see   Parameters
       */
     void FinalizeMaterialResponsePK1 (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
       * @brief Updates the material response: Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
+      * @param rValues The Internalvalues of the law
       * @see   Parameters
       */
     void FinalizeMaterialResponsePK2 (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
       * @brief Updates the material response: Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
+      * @param rValues The Internalvalues of the law
       * @see   Parameters
       */
     void FinalizeMaterialResponseKirchhoff (ConstitutiveLaw::Parameters & rValues)  override;
 
     /**
       * @brief Updates the material response: Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
+      * @param rValues The Internalvalues of the law
       * @see   Parameters
       */
     void FinalizeMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
@@ -213,13 +213,13 @@ public:
         ) override;
 
     /**
-     * This function provides the place to perform checks on the completeness of the input.
-     * It is designed to be called only once (or anyway, not often) typically at the beginning
+     * @brief This function provides the place to perform checks on the completeness of the input.
+     * @details It is designed to be called only once (or anyway, not often) typically at the beginning
      * of the calculations, so to verify that nothing is missing from the input
      * or that no common error is found.
-     * @param rMaterialProperties: The properties of the material
-     * @param rElementGeometry: The geometry of the element
-     * @param rCurrentProcessInfo: The current process info instance
+     * @param rMaterialProperties The properties of the material
+     * @param rElementGeometry The geometry of the element
+     * @param rCurrentProcessInfo The current process info instance
      */
     int Check(
         const Properties& rMaterialProperties,
@@ -245,38 +245,35 @@ protected:
     ///@{
 
     /**
-     * It calculates the constitutive matrix C (PK2)
-     * @param ConstitutiveMatrix: The constitutive matrix
-     * @param InverseCTensor: The inverse right Cauchy-Green tensor
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Second Lame parameter
+     * @brief It calculates the constitutive matrix C (PK2)
+     * @param rConstitutiveMatrix The constitutive matrix
+     * @param YoungModulus The young modulus
+     * @param PoissonCoefficient The Poisson coefficient
      */
     virtual void CalculateConstitutiveMatrixPK2(
-        Matrix& ConstitutiveMatrix,
+        Matrix& rConstitutiveMatrix,
         const double YoungModulus,
         const double PoissonCoefficient
         );
 
     /**
-     * It calculates the constitutive matrix C (Kirchoff)
-     * @param ConstitutiveMatrix: The constitutive matrix
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Second Lame parameter
+     * @brief It calculates the constitutive matrix C (Kirchoff)
+     * @param rConstitutiveMatrix The constitutive matrix
+     * @param rDeformationGradientF The deformation gradient
+     * @param YoungModulus The young modulus
+     * @param PoissonCoefficient The Poisson coefficient
      */
     virtual void CalculateConstitutiveMatrixKirchhoff(
-        Matrix& ConstitutiveMatrix,
-        const Matrix& DeformationGradientF,
+        Matrix& rConstitutiveMatrix,
+        const Matrix& rDeformationGradientF,
         const double YoungModulus,
         const double PoissonCoefficient
         );
 
     /**
-     * It calculates the PK2 stress vector
-     * @param InvCTensor: The inverse of the right Cauchy-Green tensor
-     * @param rStressVector: The stress vector in Voigt notation
-     * @param DeterminantF: The determinant of the deformation gradient
+     * @brief It calculates the PK2 stress vector
+     * @param rStrainVector The strain vector in Voigt notation
+     * @param rStressVector The stress vector in Voigt notation
      * @param LameLambda: First Lame parameter
      * @param LameMu: Second Lame parameter
      */
@@ -284,28 +281,29 @@ protected:
         const Vector& rStrainVector,
         Vector& rStressVector,
         const double YoungModulus,
-        const double PoissonCoefficient);
+        const double PoissonCoefficient
+        );
 
     /**
-     * It calculates the Kirchoff stress vector
-     * @param BTensor: The left Cauchy-Green tensor
-     * @param rStressVector: The stress vector in Voigt notation
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
+     * @brief It calculates the Kirchoff stress vector
+     * @param rStrainVector The strain vector in Voigt notation
+     * @param rStressVector The stress vector in Voigt notation
+     * @param rDeformationGradientF The deformation gradient
+     * @param YoungModulus The young modulus
+     * @param PoissonCoefficient The Poisson coefficient
      */
     virtual void CalculateKirchhoffStress(
         const Vector& rStrainVector,
         Vector& rStressVector,
-        const Matrix& DeformationGradientF,
+        const Matrix& rDeformationGradientF,
         const double YoungModulus,
         const double PoissonCoefficient
         );
 
     /**
-     * It calculates the strain vector
-     * @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
+     * @brief It calculates the strain vector
+     * @param rValues The Internalvalues of the law
+     * @param rStrainVector The strain vector in Voigt notation
      */
     virtual void CalculateGreenLagrangianStrain(
         ConstitutiveLaw::Parameters& rValues,
@@ -313,9 +311,9 @@ protected:
         );
 
     /**
-     * Calculates the Almansi strains
-     * @param @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
+     * @brief Calculates the Almansi strains
+     * @param rValues The Internalvalues of the law
+     * @param rStrainVector The strain vector in Voigt notation
      */
     virtual void CalculateAlmansiStrain(
         ConstitutiveLaw::Parameters& rValues,

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h
@@ -174,7 +174,7 @@ public:
     void FinalizeMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
 
     /**
-     * @brief It calculates the value of a specified variable
+     * @brief It calculates the value of a specified variable (double)
      * @param rParameterValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
@@ -184,6 +184,32 @@ public:
         ConstitutiveLaw::Parameters& rParameterValues,
         const Variable<double>& rThisVariable, 
         double& rValue
+        ) override;
+
+    /**
+     * @brief It calculates the value of a specified variable (Vector)
+     * @param rParameterValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @param rValue output: the value of the specified variable
+     */
+    Vector& CalculateValue(
+        ConstitutiveLaw::Parameters& rParameterValues,
+        const Variable<Vector>& rThisVariable, 
+        Vector& rValue
+        ) override;
+
+    /**
+     * @brief It calculates the value of a specified variable (Matrix)
+     * @param rParameterValues the needed parameters for the CL calculation
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @param rValue output: the value of the specified variable
+     */
+    Matrix& CalculateValue(
+        ConstitutiveLaw::Parameters& rParameterValues,
+        const Variable<Matrix>& rThisVariable, 
+        Matrix& rValue
         ) override;
 
     /**

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
@@ -85,8 +85,8 @@ void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateConstitutiveMatrixPK2
 {
     rConstitutiveMatrix.clear();
     rConstitutiveMatrix = ZeroMatrix(3,3);
-    const double c0 = YoungModulus / ((1.00 + PoissonCoefficient)*(1-2*PoissonCoefficient));
-    const double c1 = (1.00 - PoissonCoefficient)*c0;
+    const double c0 = YoungModulus / ((1.0 + PoissonCoefficient)*(1.0-2.0*PoissonCoefficient));
+    const double c1 = (1.0 - PoissonCoefficient)*c0;
     const double c2 = c0 * PoissonCoefficient;
     const double c3 = (0.5 - PoissonCoefficient)*c0;
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
@@ -23,7 +23,7 @@
 
 namespace Kratos
 {
-//******************************CONSTRUCTOR*******************************************
+/******************************CONSTRUCTOR******************************************/
 /***********************************************************************************/
 HyperElasticIsotropicKirchhoffPlaneStrain2D::HyperElasticIsotropicKirchhoffPlaneStrain2D()
     : BaseType() 
@@ -38,7 +38,7 @@ HyperElasticIsotropicKirchhoffPlaneStrain2D::HyperElasticIsotropicKirchhoffPlane
 {
 }
 
-//********************************CLONE***********************************************
+/********************************CLONE**********************************************/
 /***********************************************************************************/
 
 ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoffPlaneStrain2D::Clone() const 
@@ -46,14 +46,14 @@ ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoffPlaneStrain2D::Clone() co
     return Kratos::make_shared<HyperElasticIsotropicKirchhoffPlaneStrain2D>(*this);
 }
 
-//*******************************DESTRUCTOR*******************************************
+/*******************************DESTRUCTOR******************************************/
 /***********************************************************************************/
 
 HyperElasticIsotropicKirchhoffPlaneStrain2D::~HyperElasticIsotropicKirchhoffPlaneStrain2D() 
 {
 };
 
-//*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
+/*************************CONSTITUTIVE LAW GENERAL FEATURES ************************/
 /***********************************************************************************/
 
 void HyperElasticIsotropicKirchhoffPlaneStrain2D::GetLawFeatures(Features& rFeatures) 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.cpp
@@ -24,221 +24,42 @@
 namespace Kratos
 {
 //******************************CONSTRUCTOR*******************************************
-//************************************************************************************
+/***********************************************************************************/
 HyperElasticIsotropicKirchhoffPlaneStrain2D::HyperElasticIsotropicKirchhoffPlaneStrain2D()
-    : ConstitutiveLaw() {
+    : BaseType() 
+{
 }
 
 //******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
+/***********************************************************************************/
 
 HyperElasticIsotropicKirchhoffPlaneStrain2D::HyperElasticIsotropicKirchhoffPlaneStrain2D(const HyperElasticIsotropicKirchhoffPlaneStrain2D& rOther)
-    : ConstitutiveLaw(rOther) {
+    : BaseType(rOther)
+{
 }
 
 //********************************CLONE***********************************************
-//************************************************************************************
+/***********************************************************************************/
 
-ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoffPlaneStrain2D::Clone() const {
-    HyperElasticIsotropicKirchhoffPlaneStrain2D::Pointer p_clone(new HyperElasticIsotropicKirchhoffPlaneStrain2D(*this));
-    return p_clone;
+ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoffPlaneStrain2D::Clone() const 
+{
+    return Kratos::make_shared<HyperElasticIsotropicKirchhoffPlaneStrain2D>(*this);
 }
 
 //*******************************DESTRUCTOR*******************************************
-//************************************************************************************
+/***********************************************************************************/
 
-HyperElasticIsotropicKirchhoffPlaneStrain2D::~HyperElasticIsotropicKirchhoffPlaneStrain2D() {
+HyperElasticIsotropicKirchhoffPlaneStrain2D::~HyperElasticIsotropicKirchhoffPlaneStrain2D() 
+{
 };
 
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateMaterialResponsePK1 (ConstitutiveLaw::Parameters& rValues) {
-
-    CalculateMaterialResponsePK2(rValues);
-
-    Vector& stress_vector                = rValues.GetStressVector();
-    const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
-    const double& determinant_f          = rValues.GetDeterminantF();
-
-    TransformStresses(stress_vector, deformation_gradient_f, determinant_f, StressMeasure_PK2, StressMeasure_PK1);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void  HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) {
-    KRATOS_TRY;
-    // Get Values to compute the constitutive law:
-    Flags &Options=rValues.GetOptions();
-
-    const Properties& material_properties  = rValues.GetMaterialProperties();
-    Vector& strain_vector                  = rValues.GetStrainVector();
-
-    // The material properties
-    const double& young_modulus = material_properties[YOUNG_MODULUS];
-    const double& poisson_coefficient = material_properties[POISSON_RATIO];
-
-
-    if(Options.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
-        CalculateGreenLagrangianStrain(rValues, strain_vector);
-    }
-
-    if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
-        Matrix& ConstitutiveMatrix = rValues.GetConstitutiveMatrix();
-        CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
-    }
-
-    if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
-        Vector& stress_vector = rValues.GetStressVector();
-        if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
-            Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
-            noalias(stress_vector) = prod(constitutive_matrix, strain_vector);
-        } else {
-            CalculatePK2Stress( strain_vector, stress_vector, young_modulus, poisson_coefficient );
-        }
-    }
-    KRATOS_CATCH("");
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateMaterialResponseKirchhoff (ConstitutiveLaw::Parameters& rValues) {
-
-    // Get Values to compute the constitutive law:
-    Flags &Options=rValues.GetOptions();
-
-    const Properties& material_properties  = rValues.GetMaterialProperties();
-    Vector& strain_vector                  = rValues.GetStrainVector();
-    Vector& stress_vector                  = rValues.GetStressVector();
-
-    // The material properties
-    const double& young_modulus = material_properties[YOUNG_MODULUS];
-    const double& poisson_coefficient = material_properties[POISSON_RATIO];
-
-
-    // The deformation gradient
-    const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
-
-    if(Options.Is( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
-        CalculateAlmansiStrain(rValues, strain_vector);
-    }
-
-    if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
-        Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
-        CalculateConstitutiveMatrixKirchhoff(constitutive_matrix, deformation_gradient_f ,young_modulus, poisson_coefficient);
-    }
-
-    if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
-        if (rValues.IsSetDeformationGradientF() == true) {
-               CalculateGreenLagrangianStrain(rValues, strain_vector);
-        }
-        CalculateKirchhoffStress(strain_vector, stress_vector, deformation_gradient_f ,young_modulus, poisson_coefficient);
-    }
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateMaterialResponseCauchy (ConstitutiveLaw::Parameters& rValues) {
-
-    CalculateMaterialResponseKirchhoff(rValues);
-
-    Vector& stress_vector       = rValues.GetStressVector();
-    Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
-    const double& determinant_f = rValues.GetDeterminantF();
-
-    // Set to Cauchy Stress:
-    stress_vector       /= determinant_f;
-    constitutive_matrix /= determinant_f;
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
-{
-//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-//     this->CalculateMaterialResponsePK1(rValues);
-//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
-{
-//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-//     this->CalculateMaterialResponsePK2(rValues);
-//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
-{
-//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-//     this->CalculateMaterialResponseCauchy(rValues);
-//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
-{
-//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-//     this->CalculateMaterialResponseKirchhoff(rValues);
-//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-
-double& HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateValue(
-    ConstitutiveLaw::Parameters& rParameterValues,
-    const Variable<double>& rThisVariable,
-    double& rValue) {
-
-    const Properties& material_properties  = rParameterValues.GetMaterialProperties();
-    Vector& strain_vector                  = rParameterValues.GetStrainVector();
-
-    // The material properties
-    const double& young_modulus = material_properties[YOUNG_MODULUS];
-    const double& poisson_coefficient = material_properties[POISSON_RATIO];
-
-    // The LAME parameters
-    const double lame_lambda = (young_modulus * poisson_coefficient)/((1.0 + poisson_coefficient)*(1.0 - 2.0 * poisson_coefficient));
-    const double lame_mu = young_modulus/(2.0 * (1.0 + poisson_coefficient));
-
-    // We compute the right Cauchy-Green tensor (C):
-    if (rThisVariable == STRAIN_ENERGY) {
-        CalculateGreenLagrangianStrain(rParameterValues,strain_vector);
-        Matrix E_tensor=MathUtils<double>::StrainVectorToTensor(strain_vector);
-        Matrix E_tensor_sq=prod(E_tensor,E_tensor);
-        double E_trace = 0.0;
-        double E_trace_sq = 0.0;
-        for (unsigned int i = 0; i < E_tensor.size1();i++) {
-            E_trace     += E_tensor (i,i);
-            E_trace_sq  += E_tensor_sq(i,i);
-        }
-
-        rValue = 0.5 * lame_lambda * E_trace * E_trace  + 0.5 *lame_mu *E_trace_sq ;
-    }
-
-    return( rValue );
-}
-
 //*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
-//************************************************************************************
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::GetLawFeatures(Features& rFeatures) {
-
+void HyperElasticIsotropicKirchhoffPlaneStrain2D::GetLawFeatures(Features& rFeatures) 
+{
     //Set the type of law
-    rFeatures.mOptions.Set( THREE_DIMENSIONAL_LAW );
+    rFeatures.mOptions.Set( PLANE_STRAIN_LAW );
     rFeatures.mOptions.Set( FINITE_STRAINS );
     rFeatures.mOptions.Set( ISOTROPIC );
 
@@ -253,109 +74,37 @@ void HyperElasticIsotropicKirchhoffPlaneStrain2D::GetLawFeatures(Features& rFeat
     rFeatures.mSpaceDimension = WorkingSpaceDimension();
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-int HyperElasticIsotropicKirchhoffPlaneStrain2D::Check(
-    const Properties& rmaterial_properties,
-    const GeometryType& rElementGeometry,
-    const ProcessInfo& rCurrentProcessInfo) {
-
-    if(YOUNG_MODULUS.Key() == 0 || rmaterial_properties[YOUNG_MODULUS] <= 0.0) {
-        KRATOS_ERROR << "YOUNG_MODULUS has Key zero or invalid value " << std::endl;
-    }
-
-    const double& nu = rmaterial_properties[POISSON_RATIO];
-    const bool check = bool( (nu >0.499 && nu<0.501 ) || (nu < -0.999 && nu > -1.01 ) );
-
-    if(POISSON_RATIO.Key() == 0 || check==true) {
-        KRATOS_ERROR << "POISSON_RATIO has Key zero invalid value " << std::endl;
-    }
-
-    if(DENSITY.Key() == 0 || rmaterial_properties[DENSITY] < 0.0) {
-        KRATOS_ERROR << "DENSITY has Key zero or invalid value " << std::endl;
-    }
-
-    return 0;
-}
-
-//************************************************************************************
-//************************************************************************************
-//CalculateConstitutiveMatrixPK2( constitutive_matrix, inverse_C_tensor, determinant_f, lame_lambda, lame_mu );
-
-//CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
 void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateConstitutiveMatrixPK2(
-    Matrix& ConstitutiveMatrix,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
-
-    ConstitutiveMatrix.clear();
-    ConstitutiveMatrix = ZeroMatrix(3,3);
+    Matrix& rConstitutiveMatrix,
+    const double YoungModulus,
+    const double PoissonCoefficient
+    ) 
+{
+    rConstitutiveMatrix.clear();
+    rConstitutiveMatrix = ZeroMatrix(3,3);
     const double c0 = YoungModulus / ((1.00 + PoissonCoefficient)*(1-2*PoissonCoefficient));
     const double c1 = (1.00 - PoissonCoefficient)*c0;
     const double c2 = c0 * PoissonCoefficient;
     const double c3 = (0.5 - PoissonCoefficient)*c0;
 
-    ConstitutiveMatrix(0,0) = c1;
-    ConstitutiveMatrix(0,1) = c2;
-    ConstitutiveMatrix(1,0) = c2;
-    ConstitutiveMatrix(1,1) = c1;
-    ConstitutiveMatrix(2,2) = c3;
+    rConstitutiveMatrix(0,0) = c1;
+    rConstitutiveMatrix(0,1) = c2;
+    rConstitutiveMatrix(1,0) = c2;
+    rConstitutiveMatrix(1,1) = c1;
+    rConstitutiveMatrix(2,2) = c3;
 }
 
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateConstitutiveMatrixKirchhoff(
-    Matrix& ConstitutiveMatrix,
-    const Matrix& DeformationGradientF,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
-
-    ConstitutiveMatrix.clear();
-
-    CalculateConstitutiveMatrixPK2(ConstitutiveMatrix, YoungModulus, PoissonCoefficient);
-    PushForwardConstitutiveMatrix (ConstitutiveMatrix, DeformationGradientF );
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculatePK2Stress(
-    const Vector& rStrainVector,
-    Vector& rStressVector,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
-
-    SizeType SizeSystem = GetStrainSize();
-    Matrix ConstMatrixPK2(SizeSystem,SizeSystem);
-    CalculateConstitutiveMatrixPK2(ConstMatrixPK2, YoungModulus, PoissonCoefficient);
-    rStressVector = prod(ConstMatrixPK2,rStrainVector);
-}
-
-
-//************************************************************************************
-//************************************************************************************
-void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateKirchhoffStress(
-    const Vector& rStrainVector,
-    Vector& rStressVector,
-    const Matrix& DeformationGradientF,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
-
-    CalculatePK2Stress( rStrainVector, rStressVector, YoungModulus, PoissonCoefficient );
-    Matrix StressMatrix = MathUtils<double>::StressVectorToTensor( rStressVector );
-    ContraVariantPushForward (StressMatrix,DeformationGradientF); //Kirchhoff
-    rStressVector = MathUtils<double>::StressTensorToVector( StressMatrix, rStressVector.size() );
-}
-
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
 void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateGreenLagrangianStrain(
     ConstitutiveLaw::Parameters& rValues,
-    Vector& rStrainVector) {
-
+    Vector& rStrainVector
+    ) 
+{
     //1.-Compute total deformation gradient
     const Matrix& F = rValues.GetDeformationGradientF();
 
@@ -367,13 +116,14 @@ void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateGreenLagrangianStrain
     rStrainVector[2] = C_tensor( 0, 1 ); // xy
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
 void HyperElasticIsotropicKirchhoffPlaneStrain2D::CalculateAlmansiStrain(
     ConstitutiveLaw::Parameters& rValues,
-    Vector& rStrainVector) {
-
+    Vector& rStrainVector
+    ) 
+{
     //1.-Compute total deformation gradient
     const Matrix& F = rValues.GetDeformationGradientF();
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h
@@ -147,14 +147,14 @@ protected:
 
     /**
      * @brief It calculates the constitutive matrix C (PK2)
-     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param rConstitutiveMatrix: The constitutive matrix
      * @param InverseCTensor: The inverse right Cauchy-Green tensor
      * @param DeterminantF: The determinant of the deformation gradient
      * @param LameLambda: First Lame parameter
      * @param LameMu: Seconf Lame parameter
      */
     void CalculateConstitutiveMatrixPK2(
-        Matrix& ConstitutiveMatrix,
+        Matrix& rConstitutiveMatrix,
         const double YoungModulus,
         const double PoissonCoefficient
         ) override;

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h
@@ -147,11 +147,9 @@ protected:
 
     /**
      * @brief It calculates the constitutive matrix C (PK2)
-     * @param rConstitutiveMatrix: The constitutive matrix
-     * @param InverseCTensor: The inverse right Cauchy-Green tensor
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
+     * @param rConstitutiveMatrix The constitutive matrix
+     * @param YoungModulus The Young modulus
+     * @param PoissonCoefficient The Poisson coefficient
      */
     void CalculateConstitutiveMatrixPK2(
         Matrix& rConstitutiveMatrix,
@@ -161,8 +159,8 @@ protected:
 
     /**
      * @brief It calculates the strain vector
-     * @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
+     * @param rValues The Internalvalues of the law
+     * @param rStrainVector The strain vector in Voigt notation
      */
     void CalculateGreenLagrangianStrain(
         ConstitutiveLaw::Parameters& rValues,
@@ -171,8 +169,8 @@ protected:
 
     /**
      * @brief Calculates the Almansi strains
-     * @param @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
+     * @param rValues The Internalvalues of the law
+     * @param rStrainVector The strain vector in Voigt notation
      */
     void CalculateAlmansiStrain(
         ConstitutiveLaw::Parameters& rValues,

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h
@@ -18,7 +18,7 @@
 // External includes
 
 // Project includes
-#include "includes/constitutive_law.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h"
 
 namespace Kratos
 {
@@ -40,39 +40,56 @@ namespace Kratos
 ///@}
 ///@name Kratos Classes
 ///@{
-class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) HyperElasticIsotropicKirchhoffPlaneStrain2D : public ConstitutiveLaw
+/**
+ * @class HyperElasticIsotropicKirchhoffPlaneStrain2D
+ * @ingroup StructuralMechanicsApplication
+ * @brief This law defines an hyperelastic material according to the Saint-Venant–Kirchhoff formulation for 2D-plane strain cases
+ * @details The simplest hyperelastic material model is the Saint Venant–Kirchhoff model which is just an extension of the linear elastic material model to the nonlinear regime. 
+ * More info https://en.wikipedia.org/wiki/Hyperelastic_material#Saint_Venant%E2%80%93Kirchhoff_model
+ * @author Malik Ali Dawi
+ * @author Ruben Zorrilla
+ */
+class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) HyperElasticIsotropicKirchhoffPlaneStrain2D 
+    : public HyperElasticIsotropicKirchhoff3D
 {
 public:
 
     ///@name Type Definitions
     ///@{
 
-    typedef ProcessInfo      ProcessInfoType;
-    typedef ConstitutiveLaw         BaseType;
-    typedef std::size_t             SizeType;
+    /// The definition of the process info
+    typedef ProcessInfo               ProcessInfoType;
+    
+    /// The definition of the CL base  class
+    typedef ConstitutiveLaw                CLBaseType;
+    
+    /// The definition of the base class
+    typedef HyperElasticIsotropicKirchhoff3D BaseType;
+    
+    /// The definition of the size type
+    typedef std::size_t                      SizeType;
+    
+    /// The definition of the index type
+    typedef std::size_t                      IndexType;
 
-    /**
-     * Counted pointer of HyperElasticIsotropicKirchhoffPlaneStrain2D
-     */
+    /// Pointer definition of HyperElasticIsotropicKirchhoffPlaneStrain2D
     KRATOS_CLASS_POINTER_DEFINITION( HyperElasticIsotropicKirchhoffPlaneStrain2D );
 
     ///@name Lyfe Cycle
     ///@{
 
     /**
-     * Default constructor.
+     * @brief Default constructor.
      */
     HyperElasticIsotropicKirchhoffPlaneStrain2D();
 
-    ConstitutiveLaw::Pointer Clone() const override;
-
     /**
-     * Copy constructor.
+     * @brief Copy constructor.
      */
     HyperElasticIsotropicKirchhoffPlaneStrain2D (const HyperElasticIsotropicKirchhoffPlaneStrain2D& rOther);
 
     /**
-     * Destructor.
+     * @brief Destructor.
      */
     ~HyperElasticIsotropicKirchhoffPlaneStrain2D() override;
 
@@ -85,111 +102,31 @@ public:
     ///@{
 
     /**
+     * @brief Clone operator 
+     */
+    ConstitutiveLaw::Pointer Clone() const override;
+    
+    /**
      * This function is designed to be called once to check compatibility with element
      * @param rFeatures: The Features of the law
      */
     void GetLawFeatures(Features& rFeatures) override;
 
     /**
-     * Dimension of the law:
+     * @brief Dimension of the law:
      */
-    SizeType WorkingSpaceDimension() override {
+    SizeType WorkingSpaceDimension() override 
+    {
         return 2;
     };
 
     /**
-     * Voigt tensor size:
+     * @brief Voigt tensor size:
      */
-    SizeType GetStrainSize() override {
+    SizeType GetStrainSize() override 
+    {
         return 3;
     };
-
-    /**
-     * Computes the material response:
-     * PK1 stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
-     * @see   Parameters
-     */
-    void CalculateMaterialResponsePK1 (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-     * Computes the material response:
-     * PK2 stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
-     * @see   Parameters
-     */
-    void CalculateMaterialResponsePK2 (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-     * Computes the material response:
-     * Kirchhoff stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
-     * @see   Parameters
-     */
-    void CalculateMaterialResponseKirchhoff (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-     * Computes the material response:
-     * Cauchy stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
-     * @see   Parameters
-     */
-    void CalculateMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
-      * @see   Parameters
-      */
-    void FinalizeMaterialResponsePK1 (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
-      * @see   Parameters
-      */
-    void FinalizeMaterialResponsePK2 (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
-      * @see   Parameters
-      */
-    void FinalizeMaterialResponseKirchhoff (ConstitutiveLaw::Parameters & rValues)  override;
-
-    /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
-      * @see   Parameters
-      */
-    void FinalizeMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-     * calculates the value of a specified variable
-     * @param rParameterValues the needed parameters for the CL calculation
-     * @param rThisVariable the variable to be returned
-     * @param rValue a reference to the returned value
-     * @param rValue output: the value of the specified variable
-     */
-    double& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues, const Variable<double>& rThisVariable, double& rValue) override;
-
-    /**
-     * This function provides the place to perform checks on the completeness of the input.
-     * It is designed to be called only once (or anyway, not often) typically at the beginning
-     * of the calculations, so to verify that nothing is missing from the input
-     * or that no common error is found.
-     * @param rMaterialProperties: The properties of the material
-     * @param rElementGeometry: The geometry of the element
-     * @param rCurrentProcessInfo: The current process info instance
-     */
-    int Check(
-        const Properties& rMaterialProperties,
-        const GeometryType& rElementGeometry,
-        const ProcessInfo& rCurrentProcessInfo) override;
 
 protected:
 
@@ -208,6 +145,40 @@ protected:
     ///@name Protected Operations
     ///@{
 
+    /**
+     * @brief It calculates the constitutive matrix C (PK2)
+     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param InverseCTensor: The inverse right Cauchy-Green tensor
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    void CalculateConstitutiveMatrixPK2(
+        Matrix& ConstitutiveMatrix,
+        const double YoungModulus,
+        const double PoissonCoefficient
+        ) override;
+
+    /**
+     * @brief It calculates the strain vector
+     * @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    void CalculateGreenLagrangianStrain(
+        ConstitutiveLaw::Parameters& rValues,
+        Vector& rStrainVector
+        ) override;
+
+    /**
+     * @brief Calculates the Almansi strains
+     * @param @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    void CalculateAlmansiStrain(
+        ConstitutiveLaw::Parameters& rValues,
+        Vector& rStrainVector
+        ) override;
+    
     ///@}
 
 private:
@@ -222,79 +193,6 @@ private:
     ///@}
     ///@name Private Operators
     ///@{
-
-    /**
-     * It calculates the constitutive matrix C (PK2)
-     * @param ConstitutiveMatrix: The constitutive matrix
-     * @param InverseCTensor: The inverse right Cauchy-Green tensor
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
-     */
-    virtual void CalculateConstitutiveMatrixPK2(
-        Matrix& ConstitutiveMatrix,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the constitutive matrix C (Kirchoff)
-     * @param ConstitutiveMatrix: The constitutive matrix
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
-     */
-    virtual void CalculateConstitutiveMatrixKirchhoff(
-        Matrix& ConstitutiveMatrix,
-        const Matrix& DeformationGradientF,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the PK2 stress vector
-     * @param InvCTensor: The inverse of the right Cauchy-Green tensor
-     * @param rStressVector: The stress vector in Voigt notation
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
-     */
-    virtual void CalculatePK2Stress(
-        const Vector& rStrainVector,
-        Vector& rStressVector,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the Kirchoff stress vector
-     * @param BTensor: The left Cauchy-Green tensor
-     * @param rStressVector: The stress vector in Voigt notation
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
-     */
-    virtual void CalculateKirchhoffStress(
-        const Vector& rStrainVector,
-        Vector& rStressVector,
-        const Matrix& DeformationGradientF,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the strain vector
-     * @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
-     */
-    virtual void CalculateGreenLagrangianStrain(
-        ConstitutiveLaw::Parameters& rValues,
-        Vector& rStrainVector);
-
-    /**
-     * Calculates the Almansi strains
-     * @param @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
-     */
-    virtual void CalculateAlmansiStrain(
-        ConstitutiveLaw::Parameters& rValues,
-        Vector& rStrainVector);
 
     ///@}
     ///@name Private Operations
@@ -311,12 +209,14 @@ private:
     ///@{
     friend class Serializer;
 
-    void save(Serializer& rSerializer) const override {
-        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw )
+    void save(Serializer& rSerializer) const override 
+    {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType )
     }
 
-    void load(Serializer& rSerializer) override {
-        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw)
+    void load(Serializer& rSerializer) override 
+    {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType)
     }
 
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_strain_2d.h
@@ -107,8 +107,8 @@ public:
     ConstitutiveLaw::Pointer Clone() const override;
     
     /**
-     * This function is designed to be called once to check compatibility with element
-     * @param rFeatures: The Features of the law
+     * @brief This function is designed to be called once to check compatibility with element
+     * @param rFeatures The Features of the law
      */
     void GetLawFeatures(Features& rFeatures) override;
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
@@ -105,7 +105,6 @@ void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateGreenLagrangianStrain
     Vector& rStrainVector
     ) 
 {
-
     //1.-Compute total deformation gradient
     const Matrix& F = rValues.GetDeformationGradientF();
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
@@ -24,212 +24,40 @@
 namespace Kratos
 {
 //******************************CONSTRUCTOR*******************************************
-//************************************************************************************
+/***********************************************************************************/
 HyperElasticIsotropicKirchhoffPlaneStress2D::HyperElasticIsotropicKirchhoffPlaneStress2D()
-    : ConstitutiveLaw() {
+    : BaseType() 
+{
 }
 
 //******************************COPY CONSTRUCTOR**************************************
-//************************************************************************************
+/***********************************************************************************/
 
 HyperElasticIsotropicKirchhoffPlaneStress2D::HyperElasticIsotropicKirchhoffPlaneStress2D(const HyperElasticIsotropicKirchhoffPlaneStress2D& rOther)
-    : ConstitutiveLaw(rOther) {
+    : BaseType(rOther)
+{
 }
 
 //********************************CLONE***********************************************
-//************************************************************************************
+/***********************************************************************************/
 
-ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoffPlaneStress2D::Clone() const {
-    HyperElasticIsotropicKirchhoffPlaneStress2D::Pointer p_clone(new HyperElasticIsotropicKirchhoffPlaneStress2D(*this));
-    return p_clone;
+ConstitutiveLaw::Pointer HyperElasticIsotropicKirchhoffPlaneStress2D::Clone() const 
+{
+    return Kratos::make_shared<HyperElasticIsotropicKirchhoffPlaneStress2D>(*this);
 }
 
 //*******************************DESTRUCTOR*******************************************
-//************************************************************************************
+/***********************************************************************************/
 
-HyperElasticIsotropicKirchhoffPlaneStress2D::~HyperElasticIsotropicKirchhoffPlaneStress2D() {
+HyperElasticIsotropicKirchhoffPlaneStress2D::~HyperElasticIsotropicKirchhoffPlaneStress2D() 
+{
 };
 
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateMaterialResponsePK1 (ConstitutiveLaw::Parameters& rValues) {
-
-    CalculateMaterialResponsePK2(rValues);
-
-    Vector& stress_vector                = rValues.GetStressVector();
-    const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
-    const double& determinant_f          = rValues.GetDeterminantF();
-
-    TransformStresses(stress_vector, deformation_gradient_f, determinant_f, StressMeasure_PK2, StressMeasure_PK1);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void  HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) {
-    KRATOS_TRY;
-    // Get Values to compute the constitutive law:
-    Flags &Options=rValues.GetOptions();
-
-    const Properties& material_properties  = rValues.GetMaterialProperties();
-    Vector& strain_vector                  = rValues.GetStrainVector();
-
-    // The material properties
-    const double& young_modulus = material_properties[YOUNG_MODULUS];
-    const double& poisson_coefficient = material_properties[POISSON_RATIO];
-
-    if(Options.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
-        CalculateGreenLagrangianStrain(rValues, strain_vector);
-    }
-
-    if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
-        Matrix& ConstitutiveMatrix = rValues.GetConstitutiveMatrix();
-        CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
-    }
-
-    if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
-        Vector& stress_vector = rValues.GetStressVector();
-        if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) )  {
-            Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
-            noalias(stress_vector) = prod(constitutive_matrix, strain_vector);
-        } else {
-            CalculatePK2Stress( strain_vector, stress_vector, young_modulus, poisson_coefficient );
-        }
-    }
-    KRATOS_CATCH("");
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateMaterialResponseKirchhoff (ConstitutiveLaw::Parameters& rValues) {
-
-    // Get Values to compute the constitutive law:
-    Flags &Options=rValues.GetOptions();
-
-    const Properties& material_properties  = rValues.GetMaterialProperties();
-    Vector& strain_vector                  = rValues.GetStrainVector();
-    Vector& stress_vector                  = rValues.GetStressVector();
-
-    // The material properties
-    const double& young_modulus = material_properties[YOUNG_MODULUS];
-    const double& poisson_coefficient = material_properties[POISSON_RATIO];
-
-    // The deformation gradient
-    const Matrix& deformation_gradient_f = rValues.GetDeformationGradientF();
-
-    if(Options.Is( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
-        CalculateAlmansiStrain(rValues, strain_vector);
-    }
-
-    if( Options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
-        Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
-        CalculateConstitutiveMatrixKirchhoff(constitutive_matrix, deformation_gradient_f ,young_modulus, poisson_coefficient);
-    }
-
-    if( Options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
-        if (rValues.IsSetDeformationGradientF() == true) {
-               CalculateGreenLagrangianStrain(rValues, strain_vector);
-        }
-        CalculateKirchhoffStress(strain_vector, stress_vector, deformation_gradient_f ,young_modulus, poisson_coefficient);
-    }
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateMaterialResponseCauchy (ConstitutiveLaw::Parameters& rValues) {
-
-    CalculateMaterialResponseKirchhoff(rValues);
-
-    Vector& stress_vector       = rValues.GetStressVector();
-    Matrix& constitutive_matrix = rValues.GetConstitutiveMatrix();
-    const double& determinant_f = rValues.GetDeterminantF();
-
-    // Set to Cauchy Stress:
-    stress_vector       /= determinant_f;
-    constitutive_matrix /= determinant_f;
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStress2D::FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues) {
-//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-//     this->CalculateMaterialResponsePK1(rValues);
-//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStress2D::FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) {
-//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-//     this->CalculateMaterialResponsePK2(rValues);
-//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStress2D::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) {
-//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-//     this->CalculateMaterialResponseCauchy(rValues);
-//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStress2D::FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues) {
-//     rValues.Set(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-//     this->CalculateMaterialResponseKirchhoff(rValues);
-//     rValues.Reset(ConstitutiveLaw::FINALIZE_MATERIAL_RESPONSE);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-
-double& HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateValue(
-    ConstitutiveLaw::Parameters& rParameterValues,
-    const Variable<double>& rThisVariable,
-    double& rValue) {
-
-    const Properties& material_properties  = rParameterValues.GetMaterialProperties();
-    Vector& strain_vector                  = rParameterValues.GetStrainVector();
-
-    // The material properties
-    const double& young_modulus = material_properties[YOUNG_MODULUS];
-    const double& poisson_coefficient = material_properties[POISSON_RATIO];
-
-    // The LAME parameters
-    const double lame_lambda = (young_modulus * poisson_coefficient)/((1.0 + poisson_coefficient)*(1.0 - 2.0 * poisson_coefficient));
-    const double lame_mu = young_modulus/(2.0 * (1.0 + poisson_coefficient));
-
-    // We compute the right Cauchy-Green tensor (C):
-    if (rThisVariable == STRAIN_ENERGY) {
-        CalculateGreenLagrangianStrain(rParameterValues,strain_vector);
-        Matrix E_tensor=MathUtils<double>::StrainVectorToTensor(strain_vector);
-        Matrix E_tensor_sq=prod(E_tensor,E_tensor);
-        double E_trace = 0.0;
-        double E_trace_sq = 0.0;
-        for (unsigned int i = 0; i < E_tensor.size1();i++) {
-            E_trace     += E_tensor (i,i);
-            E_trace_sq  += E_tensor_sq(i,i);
-        }
-
-        rValue = 0.5 * lame_lambda * E_trace * E_trace  + 0.5 *lame_mu *E_trace_sq ;
-    }
-
-    return( rValue );
-}
-
 //*************************CONSTITUTIVE LAW GENERAL FEATURES *************************
-//************************************************************************************
+/***********************************************************************************/
 
-void HyperElasticIsotropicKirchhoffPlaneStress2D::GetLawFeatures(Features& rFeatures) {
+void HyperElasticIsotropicKirchhoffPlaneStress2D::GetLawFeatures(Features& rFeatures) 
+{
 
     //Set the type of law
     rFeatures.mOptions.Set( THREE_DIMENSIONAL_LAW );
@@ -247,109 +75,36 @@ void HyperElasticIsotropicKirchhoffPlaneStress2D::GetLawFeatures(Features& rFeat
     rFeatures.mSpaceDimension = WorkingSpaceDimension();
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
-int HyperElasticIsotropicKirchhoffPlaneStress2D::Check(
-    const Properties& rmaterial_properties,
-    const GeometryType& rElementGeometry,
-    const ProcessInfo& rCurrentProcessInfo) {
-
-    if(YOUNG_MODULUS.Key() == 0 || rmaterial_properties[YOUNG_MODULUS] <= 0.0) {
-        KRATOS_ERROR << "YOUNG_MODULUS has Key zero or invalid value " << std::endl;
-    }
-
-    const double& nu = rmaterial_properties[POISSON_RATIO];
-    const bool check = bool( (nu >0.499 && nu<0.501 ) || (nu < -0.999 && nu > -1.01 ) );
-
-    if(POISSON_RATIO.Key() == 0 || check==true) {
-        KRATOS_ERROR << "POISSON_RATIO has Key zero invalid value " << std::endl;
-    }
-
-    if(DENSITY.Key() == 0 || rmaterial_properties[DENSITY] < 0.0) {
-        KRATOS_ERROR << "DENSITY has Key zero or invalid value " << std::endl;
-    }
-
-    return 0;
-}
-
-//************************************************************************************
-//************************************************************************************
-//CalculateConstitutiveMatrixPK2( constitutive_matrix, inverse_C_tensor, determinant_f, lame_lambda, lame_mu );
-
-//CalculateConstitutiveMatrixPK2( ConstitutiveMatrix, young_modulus, poisson_coefficient);
 void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateConstitutiveMatrixPK2(
-    Matrix& ConstitutiveMatrix,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
+    Matrix& rConstitutiveMatrix,
+    const double YoungModulus,
+    const double PoissonCoefficient) {
 
-    ConstitutiveMatrix.clear();
-    ConstitutiveMatrix = ZeroMatrix(3,3);
+    rConstitutiveMatrix.clear();
+    rConstitutiveMatrix = ZeroMatrix(3,3);
 
-    double c1 = YoungModulus / (1.00 - PoissonCoefficient*PoissonCoefficient);
+    double c1 = YoungModulus / (1.0 - PoissonCoefficient*PoissonCoefficient);
     double c2 = c1 * PoissonCoefficient;
     double c3 = 0.5*YoungModulus / (1 + PoissonCoefficient);
 
-    ConstitutiveMatrix(0,0) = c1;
-    ConstitutiveMatrix(0,1) = c2;
-    ConstitutiveMatrix(1,0) = c2;
-    ConstitutiveMatrix(1,1) = c1;
-    ConstitutiveMatrix(2,2) = c3;
+    rConstitutiveMatrix(0,0) = c1;
+    rConstitutiveMatrix(0,1) = c2;
+    rConstitutiveMatrix(1,0) = c2;
+    rConstitutiveMatrix(1,1) = c1;
+    rConstitutiveMatrix(2,2) = c3;
 }
 
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateConstitutiveMatrixKirchhoff(
-    Matrix& ConstitutiveMatrix,
-    const Matrix& DeformationGradientF,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
-
-    ConstitutiveMatrix.clear();
-
-    CalculateConstitutiveMatrixPK2(ConstitutiveMatrix, YoungModulus, PoissonCoefficient);
-    PushForwardConstitutiveMatrix (ConstitutiveMatrix,DeformationGradientF );
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculatePK2Stress(
-    const Vector& rStrainVector,
-    Vector& rStressVector,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
-
-    SizeType SizeSystem = GetStrainSize();
-    Matrix ConstMatrixPK2(SizeSystem,SizeSystem);
-    CalculateConstitutiveMatrixPK2(ConstMatrixPK2, YoungModulus, PoissonCoefficient);
-    rStressVector = prod(ConstMatrixPK2,rStrainVector);
-
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateKirchhoffStress(
-    const Vector& rStrainVector,
-    Vector& rStressVector,
-    const Matrix& DeformationGradientF,
-    const double& YoungModulus,
-    const double& PoissonCoefficient) {
-
-    CalculatePK2Stress( rStrainVector, rStressVector, YoungModulus, PoissonCoefficient );
-    Matrix StressMatrix = MathUtils<double>::StressVectorToTensor( rStressVector );
-    ContraVariantPushForward (StressMatrix,DeformationGradientF); //Kirchhoff
-    rStressVector = MathUtils<double>::StressTensorToVector( StressMatrix, rStressVector.size() );
-}
-
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
 void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateGreenLagrangianStrain(
     ConstitutiveLaw::Parameters& rValues,
-    Vector& rStrainVector) {
+    Vector& rStrainVector
+    ) 
+{
 
     //1.-Compute total deformation gradient
     const Matrix& F = rValues.GetDeformationGradientF();
@@ -362,12 +117,14 @@ void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateGreenLagrangianStrain
     rStrainVector[2] = C_tensor( 0, 1 ); // xy
 }
 
-//************************************************************************************
-//************************************************************************************
+/***********************************************************************************/
+/***********************************************************************************/
 
 void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateAlmansiStrain(
     ConstitutiveLaw::Parameters& rValues,
-    Vector& rStrainVector) {
+    Vector& rStrainVector
+    ) 
+{
 
     //1.-Compute total deformation gradient
     const Matrix& F = rValues.GetDeformationGradientF();

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
@@ -60,7 +60,7 @@ void HyperElasticIsotropicKirchhoffPlaneStress2D::GetLawFeatures(Features& rFeat
 {
 
     //Set the type of law
-    rFeatures.mOptions.Set( THREE_DIMENSIONAL_LAW );
+    rFeatures.mOptions.Set( PLANE_STRESS_LAW );
     rFeatures.mOptions.Set( FINITE_STRAINS );
     rFeatures.mOptions.Set( ISOTROPIC );
 
@@ -81,8 +81,9 @@ void HyperElasticIsotropicKirchhoffPlaneStress2D::GetLawFeatures(Features& rFeat
 void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateConstitutiveMatrixPK2(
     Matrix& rConstitutiveMatrix,
     const double YoungModulus,
-    const double PoissonCoefficient) {
-
+    const double PoissonCoefficient
+    ) 
+{
     rConstitutiveMatrix.clear();
     rConstitutiveMatrix = ZeroMatrix(3,3);
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h
@@ -107,8 +107,8 @@ public:
     ConstitutiveLaw::Pointer Clone() const override;
     
     /**
-     * This function is designed to be called once to check compatibility with element
-     * @param rFeatures: The Features of the law
+     * @brief This function is designed to be called once to check compatibility with element
+     * @param rFeatures The Features of the law
      */
     void GetLawFeatures(Features& rFeatures) override;
 
@@ -147,22 +147,20 @@ protected:
 
     /**
      * @brief It calculates the constitutive matrix C (PK2)
-     * @param ConstitutiveMatrix: The constitutive matrix
-     * @param InverseCTensor: The inverse right Cauchy-Green tensor
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
+     * @param rConstitutiveMatrix The constitutive matrix
+     * @param YoungModulus The Young modulus
+     * @param PoissonCoefficient The Poisson coefficient
      */
     void CalculateConstitutiveMatrixPK2(
-        Matrix& ConstitutiveMatrix,
+        Matrix& rConstitutiveMatrix,
         const double YoungModulus,
         const double PoissonCoefficient
         ) override;
 
     /**
      * @brief It calculates the strain vector
-     * @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
+     * @param rValues The Internalvalues of the law
+     * @param rStrainVector The strain vector in Voigt notation
      */
     void CalculateGreenLagrangianStrain(
         ConstitutiveLaw::Parameters& rValues,
@@ -171,14 +169,14 @@ protected:
 
     /**
      * @brief Calculates the Almansi strains
-     * @param @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
+     * @param rValues The Internalvalues of the law
+     * @param rStrainVector The strain vector in Voigt notation
      */
     void CalculateAlmansiStrain(
         ConstitutiveLaw::Parameters& rValues,
         Vector& rStrainVector
         ) override;
-    
+        
     ///@}
 
 private:

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h
@@ -18,7 +18,7 @@
 // External includes
 
 // Project includes
-#include "includes/constitutive_law.h"
+#include "custom_constitutive/hyper_elastic_isotropic_kirchhoff_3d.h"
 
 namespace Kratos
 {
@@ -40,39 +40,56 @@ namespace Kratos
 ///@}
 ///@name Kratos Classes
 ///@{
-class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) HyperElasticIsotropicKirchhoffPlaneStress2D : public ConstitutiveLaw
+/**
+ * @class HyperElasticIsotropicKirchhoffPlaneStress2D
+ * @ingroup StructuralMechanicsApplication
+ * @brief This law defines an hyperelastic material according to the Saint-Venant–Kirchhoff formulation for 2D-plane stress cases
+ * @details The simplest hyperelastic material model is the Saint Venant–Kirchhoff model which is just an extension of the linear elastic material model to the nonlinear regime. 
+ * More info https://en.wikipedia.org/wiki/Hyperelastic_material#Saint_Venant%E2%80%93Kirchhoff_model
+ * @author Malik Ali Dawi
+ * @author Ruben Zorrilla
+ */
+class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) HyperElasticIsotropicKirchhoffPlaneStress2D 
+    : public HyperElasticIsotropicKirchhoff3D
 {
 public:
 
     ///@name Type Definitions
     ///@{
 
-    typedef ProcessInfo      ProcessInfoType;
-    typedef ConstitutiveLaw         BaseType;
-    typedef std::size_t             SizeType;
+    /// The definition of the process info
+    typedef ProcessInfo               ProcessInfoType;
+    
+    /// The definition of the CL base  class
+    typedef ConstitutiveLaw                CLBaseType;
+    
+    /// The definition of the base class
+    typedef HyperElasticIsotropicKirchhoff3D BaseType;
+    
+    /// The definition of the size type
+    typedef std::size_t                      SizeType;
+    
+    /// The definition of the index type
+    typedef std::size_t                      IndexType;
 
-    /**
-     * Counted pointer of HyperElasticIsotropicKirchhoffPlaneStress2D
-     */
+    /// Pointer definition of HyperElasticIsotropicKirchhoffPlaneStress2D
     KRATOS_CLASS_POINTER_DEFINITION( HyperElasticIsotropicKirchhoffPlaneStress2D );
 
     ///@name Lyfe Cycle
     ///@{
 
     /**
-     * Default constructor.
+     * @brief Default constructor.
      */
     HyperElasticIsotropicKirchhoffPlaneStress2D();
 
-    ConstitutiveLaw::Pointer Clone() const override;
-
     /**
-     * Copy constructor.
+     * @brief Copy constructor.
      */
     HyperElasticIsotropicKirchhoffPlaneStress2D (const HyperElasticIsotropicKirchhoffPlaneStress2D& rOther);
 
     /**
-     * Destructor.
+     * @brief Destructor.
      */
     ~HyperElasticIsotropicKirchhoffPlaneStress2D() override;
 
@@ -85,111 +102,31 @@ public:
     ///@{
 
     /**
+     * @brief Clone operator 
+     */
+    ConstitutiveLaw::Pointer Clone() const override;
+    
+    /**
      * This function is designed to be called once to check compatibility with element
      * @param rFeatures: The Features of the law
      */
     void GetLawFeatures(Features& rFeatures) override;
 
     /**
-     * Dimension of the law:
+     * @brief Dimension of the law:
      */
-    SizeType WorkingSpaceDimension() override {
+    SizeType WorkingSpaceDimension() override 
+    {
         return 2;
     };
 
     /**
-     * Voigt tensor size:
+     * @brief Voigt tensor size:
      */
-    SizeType GetStrainSize() override {
+    SizeType GetStrainSize() override 
+    {
         return 3;
     };
-
-    /**
-     * Computes the material response:
-     * PK1 stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
-     * @see   Parameters
-     */
-    void CalculateMaterialResponsePK1 (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-     * Computes the material response:
-     * PK2 stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
-     * @see   Parameters
-     */
-    void CalculateMaterialResponsePK2 (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-     * Computes the material response:
-     * Kirchhoff stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
-     * @see   Parameters
-     */
-    void CalculateMaterialResponseKirchhoff (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-     * Computes the material response:
-     * Cauchy stresses and algorithmic ConstitutiveMatrix
-     * @param rValues: The Internalvalues of the law
-     * @see   Parameters
-     */
-    void CalculateMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
-      * @see   Parameters
-      */
-    void FinalizeMaterialResponsePK1 (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
-      * @see   Parameters
-      */
-    void FinalizeMaterialResponsePK2 (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
-      * @see   Parameters
-      */
-    void FinalizeMaterialResponseKirchhoff (ConstitutiveLaw::Parameters & rValues)  override;
-
-    /**
-      * Updates the material response:
-      * Cauchy stresses and Internal Variables
-      * @param rValues: The Internalvalues of the law
-      * @see   Parameters
-      */
-    void FinalizeMaterialResponseCauchy (ConstitutiveLaw::Parameters & rValues) override;
-
-    /**
-     * calculates the value of a specified variable
-     * @param rParameterValues the needed parameters for the CL calculation
-     * @param rThisVariable the variable to be returned
-     * @param rValue a reference to the returned value
-     * @param rValue output: the value of the specified variable
-     */
-    double& CalculateValue(ConstitutiveLaw::Parameters& rParameterValues, const Variable<double>& rThisVariable, double& rValue) override;
-
-    /**
-     * This function provides the place to perform checks on the completeness of the input.
-     * It is designed to be called only once (or anyway, not often) typically at the beginning
-     * of the calculations, so to verify that nothing is missing from the input
-     * or that no common error is found.
-     * @param rMaterialProperties: The properties of the material
-     * @param rElementGeometry: The geometry of the element
-     * @param rCurrentProcessInfo: The current process info instance
-     */
-    int Check(
-        const Properties& rMaterialProperties,
-        const GeometryType& rElementGeometry,
-        const ProcessInfo& rCurrentProcessInfo) override;
 
 protected:
 
@@ -208,6 +145,40 @@ protected:
     ///@name Protected Operations
     ///@{
 
+    /**
+     * @brief It calculates the constitutive matrix C (PK2)
+     * @param ConstitutiveMatrix: The constitutive matrix
+     * @param InverseCTensor: The inverse right Cauchy-Green tensor
+     * @param DeterminantF: The determinant of the deformation gradient
+     * @param LameLambda: First Lame parameter
+     * @param LameMu: Seconf Lame parameter
+     */
+    void CalculateConstitutiveMatrixPK2(
+        Matrix& ConstitutiveMatrix,
+        const double YoungModulus,
+        const double PoissonCoefficient
+        ) override;
+
+    /**
+     * @brief It calculates the strain vector
+     * @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    void CalculateGreenLagrangianStrain(
+        ConstitutiveLaw::Parameters& rValues,
+        Vector& rStrainVector
+        ) override;
+
+    /**
+     * @brief Calculates the Almansi strains
+     * @param @param rValues: The Internalvalues of the law
+     * @param rStrainVector: The strain vector in Voigt notation
+     */
+    void CalculateAlmansiStrain(
+        ConstitutiveLaw::Parameters& rValues,
+        Vector& rStrainVector
+        ) override;
+    
     ///@}
 
 private:
@@ -222,79 +193,6 @@ private:
     ///@}
     ///@name Private Operators
     ///@{
-
-    /**
-     * It calculates the constitutive matrix C (PK2)
-     * @param ConstitutiveMatrix: The constitutive matrix
-     * @param InverseCTensor: The inverse right Cauchy-Green tensor
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
-     */
-    virtual void CalculateConstitutiveMatrixPK2(
-        Matrix& ConstitutiveMatrix,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the constitutive matrix C (Kirchoff)
-     * @param ConstitutiveMatrix: The constitutive matrix
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
-     */
-    virtual void CalculateConstitutiveMatrixKirchhoff(
-        Matrix& ConstitutiveMatrix,
-        const Matrix& DeformationGradientF,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the PK2 stress vector
-     * @param InvCTensor: The inverse of the right Cauchy-Green tensor
-     * @param rStressVector: The stress vector in Voigt notation
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
-     */
-    virtual void CalculatePK2Stress(
-        const Vector& rStrainVector,
-        Vector& rStressVector,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the Kirchoff stress vector
-     * @param BTensor: The left Cauchy-Green tensor
-     * @param rStressVector: The stress vector in Voigt notation
-     * @param DeterminantF: The determinant of the deformation gradient
-     * @param LameLambda: First Lame parameter
-     * @param LameMu: Seconf Lame parameter
-     */
-    virtual void CalculateKirchhoffStress(
-        const Vector& rStrainVector,
-        Vector& rStressVector,
-        const Matrix& DeformationGradientF,
-        const double& YoungModulus,
-        const double& PoissonCoefficient);
-
-    /**
-     * It calculates the strain vector
-     * @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
-     */
-    virtual void CalculateGreenLagrangianStrain(
-        ConstitutiveLaw::Parameters& rValues,
-        Vector& rStrainVector);
-
-    /**
-     * Calculates the Almansi strains
-     * @param @param rValues: The Internalvalues of the law
-     * @param rStrainVector: The strain vector in Voigt notation
-     */
-    virtual void CalculateAlmansiStrain(
-        ConstitutiveLaw::Parameters& rValues,
-        Vector& rStrainVector);
 
     ///@}
     ///@name Private Operations
@@ -311,11 +209,13 @@ private:
     ///@{
     friend class Serializer;
 
-    void save(Serializer& rSerializer) const override {
+    void save(Serializer& rSerializer) const override 
+    {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw )
     }
 
-    void load(Serializer& rSerializer) override {
+    void load(Serializer& rSerializer) override 
+    {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw)
     }
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h
@@ -211,12 +211,12 @@ private:
 
     void save(Serializer& rSerializer) const override 
     {
-        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, ConstitutiveLaw )
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType )
     }
 
     void load(Serializer& rSerializer) override 
     {
-        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, ConstitutiveLaw)
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType)
     }
 
 


### PR DESCRIPTION
In order to prepare the hyperelastic CL for the creating the large deformation plasticity laws I cleaned up, reduced duplicated code and added missing methods to the Kirchoff hyperelastic laws

In a future PR I will add the Neo-Hookean laws