### PR TITLE
[Hotfix][Meshing application] Missing comma in mmg_process.py

### DIFF
--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -53,7 +53,7 @@ class MmgProcess(KratosMultiphysics.Process):
                 },
                 "set_target_number_of_elements"       : false,
                 "target_number_of_elements"           : 1000,
-                "perform_nodal_h_averaging"           : false
+                "perform_nodal_h_averaging"           : false,
                 "max_iterations"                      : 3
             },
             "framework"                            : "Eulerian",


### PR DESCRIPTION
That make it the tests to fail when checking the default parameters