### PR TITLE
[Core] Clean up constraints classes. Making member variables of linear constraint protected

### DIFF
--- a/kratos/includes/linear_master_slave_constraint.h
+++ b/kratos/includes/linear_master_slave_constraint.h
@@ -223,10 +223,10 @@ public:
     LinearMasterSlaveConstraint& operator=(const LinearMasterSlaveConstraint& rOther)
     {
         BaseType::operator=( rOther );
-        mSlaveDofsVector = mSlaveDofsVector;
-        mMasterDofsVector = mMasterDofsVector;
-        mRelationMatrix = mRelationMatrix;
-        mConstantVector = mConstantVector;
+        mSlaveDofsVector = rOther.mSlaveDofsVector;
+        mMasterDofsVector = rOther.mMasterDofsVector;
+        mRelationMatrix = rOther.mRelationMatrix;
+        mConstantVector = rOther.mConstantVector;
         return *this;
     }
 

--- a/kratos/includes/linear_master_slave_constraint.h
+++ b/kratos/includes/linear_master_slave_constraint.h
@@ -313,6 +313,22 @@ public:
     }
 
     /**
+     * @brief It creates a new constraint pointer and clones the previous constraint data
+     * @param NewId the ID of the new constraint
+     * @return a Pointer to the new constraint
+     */
+    MasterSlaveConstraint::Pointer Clone (IndexType NewId) const override
+    {
+        KRATOS_TRY
+
+        MasterSlaveConstraint::Pointer p_constraint = Kratos::make_shared<LinearMasterSlaveConstraint>(*this);
+        p_constraint->SetData(this->GetData());
+        return p_constraint;
+
+        KRATOS_CATCH("");
+    }
+
+    /**
      * @brief Determines the constrant's slvae and master list of DOFs
      * @param rSlaveDofList The list of slave DOFs
      * @param rMasterDofList The list of slave DOFs

--- a/kratos/includes/linear_master_slave_constraint.h
+++ b/kratos/includes/linear_master_slave_constraint.h
@@ -9,81 +9,149 @@
 //
 //  Main authors:    Aditya Ghantasala
 //
-//
 
 #if !defined(LINEAR_MASTER_SLAVE_CONSTRAINT_H)
 #define LINEAR_MASTER_SLAVE_CONSTRAINT_H
+
 // System includes
 
-// project includes
+// External includes
+
+// Project includes
 #include "includes/define.h"
 #include "includes/master_slave_constraint.h"
 
 namespace Kratos
 {
-  /** @class LinearMasterSlaveConstraint
-    * @ingroup KratosCore
-    * @brief
-    *
-    * This class allows to add a master-slave constraint which is of the form
-    *
-    * SlaveDofVector = T * MasterDofVector + ConstantVector.
-    *
-    * or
-    *
-    * SlaveDof = weight * MasterDof + Constant
-    *
-    * the data T and ConstantVector (or the equivalent scalars) are not stored in the base class, since they can be eventually evaluated runtime.
-    */
-class LinearMasterSlaveConstraint :  public MasterSlaveConstraint
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/**
+ * @class LinearMasterSlaveConstraint
+ * @ingroup KratosCore
+ * @brief This class allows to add a master-slave constraint which is of the form
+ * SlaveDofVector = T * MasterDofVector + ConstantVector.
+ *
+ * or
+ *
+ * SlaveDof = weight * MasterDof + Constant
+ * @details The data T and ConstantVector (or the equivalent scalars) are not stored in the base class, since they can be eventually evaluated runtime.
+ * @author Aditya Ghantasala
+ */
+class LinearMasterSlaveConstraint
+    :  public MasterSlaveConstraint
 {
 public:
+    ///@name Type Definitions
+    ///@{
+
+    /// The definition of the base class, we take the rest of the definitions from the base class
+    typedef MasterSlaveConstraint BaseType;
+
+    /// The index type definition
+    typedef BaseType::IndexType IndexType;
+
+    /// The DoF type definition
+    typedef BaseType::DofType DofType;
+
+    /// The DoF pointer vector type definition
+    typedef BaseType::DofPointerVectorType DofPointerVectorType;
+
+    /// The node type definition
+    typedef BaseType::NodeType NodeType;
+
+    /// The equation Id vector type definition
+    typedef BaseType::EquationIdVectorType EquationIdVectorType;
+
+    /// The matrix type definition
+    typedef BaseType::MatrixType MatrixType;
+
+    /// The vector type definition
+    typedef BaseType::VectorType VectorType;
+
+    /// The variable type definition (double)
+    typedef BaseType::VariableType VariableType;
+
+    /// The component variable type definition
+    typedef BaseType::VariableComponentType VariableComponentType;
+
     /// Pointer definition of DataValueContainer
     KRATOS_CLASS_POINTER_DEFINITION(LinearMasterSlaveConstraint);
-    typedef IndexedObject BaseType;
-    typedef std::size_t IndexType;
-    typedef Dof<double> DofType;
-    typedef std::vector< DofType::Pointer > DofPointerVectorType;
-    typedef Node<3> NodeType;
-    typedef std::vector<std::size_t> EquationIdVectorType;
 
-    typedef Matrix MatrixType;
-    typedef Vector VectorType;
-    typedef Kratos::Variable<double> VariableType;
-    typedef Kratos::VariableComponent<Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3>>> VariableComponentType;
+    ///@}
+    ///@name  Enum's
+    ///@{
+
+    ///@}
     ///@name Life Cycle
     ///@{
 
+    /**
+     * @brief The default constructor
+     * @param IndexType The Id of the new created constraint
+     */
     explicit LinearMasterSlaveConstraint(IndexType Id = 0)
-        :
-        MasterSlaveConstraint(Id)
+        : BaseType(Id)
     {
     }
 
-    /*
-    * Constructor by passing a vector of Master and slave dofs and corresponding Matrix and constant vector
-    */
-    LinearMasterSlaveConstraint(IndexType Id,
-                                DofPointerVectorType& rMasterDofsVector,
-                                DofPointerVectorType& rSlaveDofsVector,
-                                const MatrixType& rRelationMatrix,
-                                const VectorType& rConstantVector)
-        : MasterSlaveConstraint(Id), mSlaveDofsVector(rSlaveDofsVector), mMasterDofsVector(rMasterDofsVector),
-                                    mRelationMatrix(rRelationMatrix), mConstantVector(rConstantVector)
+    /**
+     * @brief Constructor by passing a vector of Master and slave dofs and corresponding Matrix and constant vector
+     * @param IndexType The Id of the new created constraint
+     * @param rMasterDofsVector The vector containing the DoF of the master side
+     * @param rSlaveDofsVector The vector containing the DoF of the slave side
+     * @param rRelationMatrix The relation matrix between the master/slave DoF
+     * @param rConstantVector The vector containing the additional kinematic relationship
+     */
+    LinearMasterSlaveConstraint(
+        IndexType Id,
+        DofPointerVectorType& rMasterDofsVector,
+        DofPointerVectorType& rSlaveDofsVector,
+        const MatrixType& rRelationMatrix,
+        const VectorType& rConstantVector
+        ) : BaseType(Id),
+            mSlaveDofsVector(rSlaveDofsVector),
+            mMasterDofsVector(rMasterDofsVector),
+            mRelationMatrix(rRelationMatrix),
+            mConstantVector(rConstantVector)
     {
     }
 
-    /*
-    * Constructor by passing a single Master and slave dofs and corresponding weight and constant for a variable component
-    */
-    LinearMasterSlaveConstraint(IndexType Id,
-                                NodeType& rMasterNode,
-                                const VariableType& rMasterVariable,
-                                NodeType& rSlaveNode,
-                                const VariableType& rSlaveVariable,
-                                const double Weight,
-                                const double Constant)
-        : MasterSlaveConstraint(Id)
+    /**
+     * @brief Constructor by passing a single Master and slave dofs and corresponding weight and constant for a variable component
+     * @param IndexType The Id of the new created constraint
+     * @param rMasterNode The node of master side
+     * @param rMasterVariable The variable of the master DoF
+     * @param rSlaveNode The node of slave side
+     * @param rSlaveVariable The variable of the slave DoF
+     * @param Weight The relation between the master/slave DoF
+     * @param Constant The additional kinematic relationship
+     */
+    LinearMasterSlaveConstraint(
+        IndexType Id,
+        NodeType& rMasterNode,
+        const VariableType& rMasterVariable,
+        NodeType& rSlaveNode,
+        const VariableType& rSlaveVariable,
+        const double Weight,
+        const double Constant
+        ) : MasterSlaveConstraint(Id)
     {
         // Resizing the memeber variables
         mRelationMatrix.resize(1,1,false);
@@ -100,17 +168,25 @@ public:
         rSlaveNode.Set(SLAVE);
     }
 
-    /*
-    * Constructor by passing a single Master and slave dofs and corresponding weight and constant for a variable component
-    */
-    LinearMasterSlaveConstraint(IndexType Id,
-                                NodeType& rMasterNode,
-                                const VariableComponentType& rMasterVariable,
-                                NodeType& rSlaveNode,
-                                const VariableComponentType& rSlaveVariable,
-                                const double Weight,
-                                const double Constant)
-        : MasterSlaveConstraint(Id)
+    /**
+     * @brief Constructor by passing a single Master and slave dofs and corresponding weight and constant for a variable component
+     * @param IndexType The Id of the new created constraint
+     * @param rMasterNode The node of master side
+     * @param rMasterVariable The variable of the master DoF
+     * @param rSlaveNode The node of slave side
+     * @param rSlaveVariable The variable of the slave DoF
+     * @param Weight The relation between the master/slave DoF
+     * @param Constant The additional kinematic relationship
+     */
+    LinearMasterSlaveConstraint(
+        IndexType Id,
+        NodeType& rMasterNode,
+        const VariableComponentType& rMasterVariable,
+        NodeType& rSlaveNode,
+        const VariableComponentType& rSlaveVariable,
+        const double Weight,
+        const double Constant
+        ) : MasterSlaveConstraint(Id)
     {
         // Resizing the memeber variables
         mRelationMatrix.resize(1,1,false);
@@ -135,83 +211,134 @@ public:
 
     /// Copy Constructor
     LinearMasterSlaveConstraint(const LinearMasterSlaveConstraint& rOther)
+        : BaseType(rOther),
+          mSlaveDofsVector(rOther.mSlaveDofsVector),
+          mMasterDofsVector(rOther.mMasterDofsVector),
+          mRelationMatrix(rOther.mRelationMatrix),
+          mConstantVector(rOther.mConstantVector)
     {
-        this->SetId(rOther.Id());
-        // this->Flags = rOther.Flags;
-        this->mSlaveDofsVector = rOther.mSlaveDofsVector;
-        this->mMasterDofsVector = rOther.mMasterDofsVector;
-        this->mRelationMatrix = rOther.mRelationMatrix;
-        this->mConstantVector = rOther.mConstantVector;
     }
 
     /// Assignment operator
     LinearMasterSlaveConstraint& operator=(const LinearMasterSlaveConstraint& rOther)
     {
-        this->SetId(rOther.Id());
-        // this->Flags = rOther.Flags;
-        this->mSlaveDofsVector = rOther.mSlaveDofsVector;
-        this->mMasterDofsVector = rOther.mMasterDofsVector;
-        this->mRelationMatrix = rOther.mRelationMatrix;
-        this->mConstantVector = rOther.mConstantVector;
-
+        BaseType::operator=( rOther );
+        mSlaveDofsVector = mSlaveDofsVector;
+        mMasterDofsVector = mMasterDofsVector;
+        mRelationMatrix = mRelationMatrix;
+        mConstantVector = mConstantVector;
         return *this;
     }
 
-    MasterSlaveConstraint::Pointer Create(IndexType Id,
-                                          DofPointerVectorType& MasterDofsVector,
-                                          DofPointerVectorType& SlaveDofsVector,
-                                          const MatrixType& RelationMatrix,
-                                          const VectorType& ConstantVector) const override
-    {
-        KRATOS_TRY
-        auto new_pointer = Kratos::make_shared<LinearMasterSlaveConstraint>(Id, MasterDofsVector, SlaveDofsVector, RelationMatrix, ConstantVector);
-        return new_pointer;
-        KRATOS_CATCH("");
-    }
-
-    MasterSlaveConstraint::Pointer Create(IndexType Id,
-                                          NodeType& rMasterNode,
-                                          const VariableType& rMasterVariable,
-                                          NodeType& rSlaveNode,
-                                          const VariableType& rSlaveVariable,
-                                          const double Weight,
-                                          const double Constant) const override
-    {
-        KRATOS_TRY
-        return Kratos::make_shared<LinearMasterSlaveConstraint>(Id, rMasterNode, rMasterVariable, rSlaveNode, rSlaveVariable, Weight, Constant);
-        KRATOS_CATCH("");
-    }
-
-    MasterSlaveConstraint::Pointer Create(IndexType Id,
-                                          NodeType& rMasterNode,
-                                          const VariableComponentType& rMasterVariable,
-                                          NodeType& rSlaveNode,
-                                          const VariableComponentType& rSlaveVariable,
-                                          const double Weight,
-                                          const double Constant) const override
-    {
-        KRATOS_TRY
-        return Kratos::make_shared<LinearMasterSlaveConstraint>(Id, rMasterNode, rMasterVariable, rSlaveNode, rSlaveVariable, Weight, Constant);
-        KRATOS_CATCH("");
-    }
-
-
     ///@}
-
-    ///@name Access
+    ///@name Operators
     ///@{
 
-    virtual void GetDofList(DofPointerVectorType& rSlaveDofsVector,
-                            DofPointerVectorType& rMasterDofsVector,
-                            ProcessInfo& rCurrentProcessInfo) override
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Create method by passing a single Master and slave dofs and corresponding weight and constant for a variable component
+     * @param IndexType The Id of the new created constraint
+     * @param rMasterDofsVector The DoFs of master side
+     * @param rSlaveDofsVector The DoFs of master side
+     * @param rRelationMatrix The relation matrix between the master/slave DoF
+     * @param rConstantVector The vector containing the additional kinematic relationship
+     * @return A Pointer to the new constraint
+     */
+    MasterSlaveConstraint::Pointer Create(
+        IndexType Id,
+        DofPointerVectorType& rMasterDofsVector,
+        DofPointerVectorType& rSlaveDofsVector,
+        const MatrixType& rRelationMatrix,
+        const VectorType& rConstantVector
+        ) const override
+    {
+        KRATOS_TRY
+        return Kratos::make_shared<LinearMasterSlaveConstraint>(Id, rMasterDofsVector, rSlaveDofsVector, rRelationMatrix, rConstantVector);
+        KRATOS_CATCH("");
+    }
+
+    /**
+     * @brief Create method by passing a single Master and slave dofs and corresponding weight and constant for a variable component
+     * @param IndexType The Id of the new created constraint
+     * @param rMasterNode The node of master side
+     * @param rMasterVariable The variable of the master DoF
+     * @param rSlaveNode The node of slave side
+     * @param rSlaveVariable The variable of the slave DoF
+     * @param Weight The relation between the master/slave DoF
+     * @param Constant The additional kinematic relationship
+     * @return A Pointer to the new constraint
+     */
+    MasterSlaveConstraint::Pointer Create(
+        IndexType Id,
+        NodeType& rMasterNode,
+        const VariableType& rMasterVariable,
+        NodeType& rSlaveNode,
+        const VariableType& rSlaveVariable,
+        const double Weight,
+        const double Constant
+        ) const override
+    {
+        KRATOS_TRY
+        return Kratos::make_shared<LinearMasterSlaveConstraint>(Id, rMasterNode, rMasterVariable, rSlaveNode, rSlaveVariable, Weight, Constant);
+        KRATOS_CATCH("");
+    }
+
+    /**
+     * @brief Create method by passing a single Master and slave dofs and corresponding weight and constant for a variable component
+     * @param IndexType The Id of the new created constraint
+     * @param rMasterNode The node of master side
+     * @param rMasterVariable The variable of the master DoF
+     * @param rSlaveNode The node of slave side
+     * @param rSlaveVariable The variable of the slave DoF
+     * @param Weight The relation between the master/slave DoF
+     * @param Constant The additional kinematic relationship
+     * @return A Pointer to the new constraint
+     */
+    MasterSlaveConstraint::Pointer Create(
+        IndexType Id,
+        NodeType& rMasterNode,
+        const VariableComponentType& rMasterVariable,
+        NodeType& rSlaveNode,
+        const VariableComponentType& rSlaveVariable,
+        const double Weight,
+        const double Constant
+        ) const override
+    {
+        KRATOS_TRY
+        return Kratos::make_shared<LinearMasterSlaveConstraint>(Id, rMasterNode, rMasterVariable, rSlaveNode, rSlaveVariable, Weight, Constant);
+        KRATOS_CATCH("");
+    }
+
+    /**
+     * @brief Determines the constrant's slvae and master list of DOFs
+     * @param rSlaveDofList The list of slave DOFs
+     * @param rMasterDofList The list of slave DOFs
+     * @param rCurrentProcessInfo The current process info instance
+     */
+    void GetDofList(
+        DofPointerVectorType& rSlaveDofsVector,
+        DofPointerVectorType& rMasterDofsVector,
+        ProcessInfo& rCurrentProcessInfo
+        ) override
     {
         rSlaveDofsVector = mSlaveDofsVector;
         rMasterDofsVector = mMasterDofsVector;
     }
 
-    void EquationIdVector(EquationIdVectorType& rSlaveEquationIds,
-                          EquationIdVectorType& rMasterEquationIds,
-                          ProcessInfo& rCurrentProcessInfo) override
+    /**
+     * @brief This determines the master equation IDs connected to this constraint
+     * @param rSlaveEquationIds The vector of slave equation ids.
+     * @param rMasterEquationIds The vector of master equation ids.
+     * @param rCurrentProcessInfo The current process info instance
+     */
+    void EquationIdVector(
+        EquationIdVectorType& rSlaveEquationIds,
+        EquationIdVectorType& rMasterEquationIds,
+        ProcessInfo& rCurrentProcessInfo
+        ) override
     {
         if (rSlaveEquationIds.size() != mSlaveDofsVector.size())
             rSlaveEquationIds.resize(mSlaveDofsVector.size());
@@ -219,48 +346,97 @@ public:
         if (rMasterEquationIds.size() != mMasterDofsVector.size())
             rMasterEquationIds.resize(mMasterDofsVector.size());
 
-        for(unsigned int i=0; i<rSlaveEquationIds.size(); ++i)
+        for(IndexType i=0; i<rSlaveEquationIds.size(); ++i)
             rSlaveEquationIds[i] = mSlaveDofsVector[i]->EquationId();
 
-        for(unsigned int i=0; i<rMasterEquationIds.size(); ++i)
+        for(IndexType i=0; i<rMasterEquationIds.size(); ++i)
             rMasterEquationIds[i] = mMasterDofsVector[i]->EquationId();
     }
 
-    void CalculateLocalSystem(MatrixType& rTransformationMatrix,
-                              VectorType& rConstantVector,
-                              ProcessInfo& rCurrentProcessInfo) override
+    /**
+     * @brief This is called during the assembling process in order
+     * @details To calculate the relation between the master and slave.
+     * @param rTransformationMatrix the matrix which relates the master and slave degree of freedom
+     * @param rConstant The constant vector (one entry for each slave)
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void CalculateLocalSystem(
+        MatrixType& rTransformationMatrix,
+        VectorType& rConstantVector,
+        ProcessInfo& rCurrentProcessInfo
+        ) override
     {
-      rTransformationMatrix = mRelationMatrix;
-      rConstantVector = mConstantVector;
+        rTransformationMatrix = mRelationMatrix;
+        rConstantVector = mConstantVector;
     }
-
-    std::string GetInfo() const override
-    {
-        return "Linear User Provded Master Slave Constraint class !";
-    }
-
-    ///@
-
-    ///@name Static Operations
-    ///
-    //@{
 
     ///@}
+    ///@name Input and output
+    ///@{
+
+    /**
+     * @brief Returns the string containing a detailed description of this object.
+     * @return the string with informations
+     */
+    std::string GetInfo() const override
+    {
+        return "Linear User Provided Master Slave Constraint class !";
+    }
+
+    /**
+     * @brief This method prints the current Constraint Id
+     * @param rOStream The buffer where the information is given
+     */
     void PrintInfo(std::ostream &rOStream) const override
     {
         rOStream << " LinearMasterSlaveConstraint Id  : " << this->Id() << std::endl;
-        rOStream << " Number of Slaves          : " << this->mSlaveDofsVector.size() << std::endl;
-        rOStream << " Number of Masters         : " << this->mMasterDofsVector.size() << std::endl;
+        rOStream << " Number of Slaves          : " << mSlaveDofsVector.size() << std::endl;
+        rOStream << " Number of Masters         : " << mMasterDofsVector.size() << std::endl;
     }
 
+    ///@}
+protected:
+    ///@name Protected static Member Variables
+    ///@{
 
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+    DofPointerVectorType mSlaveDofsVector;  /// The DoFs of slave side
+    DofPointerVectorType mMasterDofsVector; /// The DoFs of master side
+    MatrixType mRelationMatrix;             /// The relation matrix between the master/slave DoF
+    VectorType mConstantVector;             /// The vector containing the additional kinematic relationship
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+    ///@}
 
 private:
+    ///@name Static Member Variables
+    ///@{
+
     ///@}
-    DofPointerVectorType mSlaveDofsVector;
-    DofPointerVectorType mMasterDofsVector;
-    MatrixType mRelationMatrix;
-    VectorType mConstantVector;
+    ///@name Member Variables
+    ///@{
 
     ///@name Serialization
     ///@{

--- a/kratos/includes/master_slave_constraint.h
+++ b/kratos/includes/master_slave_constraint.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                     Kratos default license: kratos/license.txt
 //
 //  Main authors:    Aditya Ghantasala
 //
@@ -27,55 +27,104 @@
 #include "includes/process_info.h"
 namespace Kratos
 {
-/** * @class MasterSlaveConstraint
-    * @ingroup KratosCore
-    * @brief
-	* A class that implements the interface for different master-slave constraints to be applied on a system.
-    * This is the part that is seen by the user from the python level. Objects of this class are
-    * first class citizens of the modelpart.
-    *
-    * This class allows to add a master-slave constraint which is of the form
-    *
-    * SlaveDofVector = T * MasterDofVector + ConstantVector. (Processing of this is currently not implemented.)
-    *
-    * or
-    *
-    * SlaveDof = weight * MasterDof + Constant
-    *
-    * This class's object will provide its slave, master details and relation matrix between them.
-    *
-    * One can add two MasterSlaveConstraint objects with same slave but different masters and weights.
-    * Consider user adds : SlaveDof = weight1 * MasterDof1 + Constant1
-    *              and   : SlaveDof = weight2 * MasterDof2 + Constant2
-    *
-    * These are later consolidated in the builder and solver to make
-    *                    : SlaveDof = weight1 * MasterDof1 + weight2 * MasterDof2 + Constant1+Constant2
-    *       and then converted to :
-    *                    : SlaveEqID = weight1 * MasterEqId1 + weight2 * MasterEqId2 + Constant1+Constant2
-    * This unique equation is used later on to modify the equation system.
-    */
-class MasterSlaveConstraint :  public IndexedObject, public Flags
-{
+///@name Kratos Globals
+///@{
 
-  public:
-    /// Pointer definition of MasterSlaveConstraint
-    KRATOS_CLASS_POINTER_DEFINITION(MasterSlaveConstraint);
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+/**
+ * @class MasterSlaveConstraint
+ * @ingroup KratosCore
+ * @brief A class that implements the interface for different master-slave constraints to be applied on a system.
+ * @details This is the part that is seen by the user from the python level. Objects of this class are
+ * first class citizens of the modelpart.
+ *
+ * This class allows to add a master-slave constraint which is of the form
+ *
+ * SlaveDofVector = T * MasterDofVector + ConstantVector. (Processing of this is currently not implemented.)
+ *
+ * or
+ *
+ * SlaveDof = weight * MasterDof + Constant
+ *
+ * This class's object will provide its slave, master details and relation matrix between them.
+ *
+ * One can add two MasterSlaveConstraint objects with same slave but different masters and weights.
+ * Consider user adds : SlaveDof = weight1 * MasterDof1 + Constant1
+ *              and   : SlaveDof = weight2 * MasterDof2 + Constant2
+ *
+ * These are later consolidated in the builder and solver to make
+ *                    : SlaveDof = weight1 * MasterDof1 + weight2 * MasterDof2 + Constant1+Constant2
+ *       and then converted to :
+ *                    : SlaveEqID = weight1 * MasterEqId1 + weight2 * MasterEqId2 + Constant1+Constant2
+ * This unique equation is used later on to modify the equation system.
+ * @author Aditya Ghantasala
+ */
+class MasterSlaveConstraint
+    :  public IndexedObject, public Flags
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// The definition of the base class
     typedef IndexedObject BaseType;
+
+    /// The index type definition
     typedef std::size_t IndexType;
+
+    /// The DoF type definition
     typedef Dof<double> DofType;
+
+    /// The DoF pointer vector type definition
     typedef std::vector< DofType::Pointer > DofPointerVectorType;
+
+    /// The node type definition
     typedef Node<3> NodeType;
+
+    /// The equation Id vector type definition
     typedef std::vector<std::size_t> EquationIdVectorType;
 
+    /// The matrix type definition
     typedef Matrix MatrixType;
+
+    /// The vector type definition
     typedef Vector VectorType;
+
+    /// The variable type definition (double)
     typedef Kratos::Variable<double> VariableType;
+
+    /// The component variable type definition
     typedef Kratos::VariableComponent<Kratos::VectorComponentAdaptor<Kratos::array_1d<double, 3>>> VariableComponentType;
+
+    /// Pointer definition of MasterSlaveConstraint
+    KRATOS_CLASS_POINTER_DEFINITION(MasterSlaveConstraint);
+
+    ///@}
+    ///@name  Enum's
+    ///@{
+
+    ///@}
     ///@name Life Cycle
     ///@{
 
-
-    /// Empty Constructor
+    /**
+     * @brief The default constructor
+     * @param IndexType The Id of the new created constraint
+     */
     explicit MasterSlaveConstraint(IndexType Id = 0) : IndexedObject(Id), Flags()
     {
     }
@@ -86,20 +135,44 @@ class MasterSlaveConstraint :  public IndexedObject, public Flags
 
     }
 
+    /// Copy Constructor
+    MasterSlaveConstraint(const MasterSlaveConstraint& rOther)
+        : BaseType(rOther),
+          mData(rOther.mData)
+    {
+    }
+
+    /// Assignment operator
+    MasterSlaveConstraint& operator=(const MasterSlaveConstraint& rOther)
+    {
+        BaseType::operator=( rOther );
+        return *this;
+    }
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    ///@}
+    ///@name Operations
+    ///@{
+
     /**
-     * creates a new constraint pointer
+     * @brief Creates a new constraint pointer
      * @param Id the ID of the new constraint
      * @param MasterDofsVector the vector of master degree of freedoms.
      * @param SlaveDofsVector the vector of slave degree of freedoms.
      * @param RelationMatrix The matrix of weights relating the master DOFs and Slave DOFs
      * @param ConstantVector The vector of the constants, one entry for each of the slave.
-     * @return a Pointer to the new constraint
+     * @return A Pointer to the new constraint
      */
-    virtual MasterSlaveConstraint::Pointer Create(IndexType Id,
-                                                  DofPointerVectorType& MasterDofsVector,
-                                                  DofPointerVectorType& SlaveDofsVector,
-                                                  const MatrixType& RelationMatrix,
-                                                  const VectorType& ConstantVector) const
+    virtual MasterSlaveConstraint::Pointer Create(
+        IndexType Id,
+        DofPointerVectorType& MasterDofsVector,
+        DofPointerVectorType& SlaveDofsVector,
+        const MatrixType& RelationMatrix,
+        const VectorType& ConstantVector
+        ) const
     {
         KRATOS_TRY
 
@@ -117,15 +190,17 @@ class MasterSlaveConstraint :  public IndexedObject, public Flags
      * @param rSlaveVariable the scalar variable which is on the slave node. (DOF)
      * @param Weight The weight with which the master and slave are related s = w*m + c
      * @param Constant The constant in the master slave relation
-     * @return a Pointer to the new constraint
+     * @return A Pointer to the new constraint
      */
-    virtual MasterSlaveConstraint::Pointer Create(IndexType Id,
-                                                  NodeType& rMasterNode,
-                                                  const VariableType& rMasterVariable,
-                                                  NodeType& rSlaveNode,
-                                                  const VariableType& rSlaveVariable,
-                                                  const double Weight,
-                                                  const double Constant) const
+    virtual MasterSlaveConstraint::Pointer Create(
+        IndexType Id,
+        NodeType& rMasterNode,
+        const VariableType& rMasterVariable,
+        NodeType& rSlaveNode,
+        const VariableType& rSlaveVariable,
+        const double Weight,
+        const double Constant
+        ) const
     {
         KRATOS_TRY
 
@@ -135,7 +210,7 @@ class MasterSlaveConstraint :  public IndexedObject, public Flags
     }
 
     /**
-     * creates a new constraint pointer
+     * @brief Creates a new constraint pointer
      * @param Id the ID of the new constraint
      * @param rMasterNode Node which is the master of for this constraint.
      * @param rMasterVariable the component of vector variable which is on the master node. (DOF)
@@ -143,15 +218,17 @@ class MasterSlaveConstraint :  public IndexedObject, public Flags
      * @param rSlaveVariable the component of vector variable which is on the slave node. (DOF)
      * @param Weight The weight with which the master and slave are related s = w*m + c
      * @param Constant The constant in the master slave relation
-     * @return a Pointer to the new constraint
+     * @return A Pointer to the new constraint
      */
-    virtual MasterSlaveConstraint::Pointer Create(IndexType Id,
-                                                  NodeType& rMasterNode,
-                                                  const VariableComponentType& rMasterVariable,
-                                                  NodeType& rSlaveNode,
-                                                  const VariableComponentType& rSlaveVariable,
-                                                  const double Weight,
-                                                  const double Constant) const
+    virtual MasterSlaveConstraint::Pointer Create(
+        IndexType Id,
+        NodeType& rMasterNode,
+        const VariableComponentType& rMasterVariable,
+        NodeType& rSlaveNode,
+        const VariableComponentType& rSlaveVariable,
+        const double Weight,
+        const double Constant
+        ) const
     {
         KRATOS_TRY
 
@@ -160,30 +237,24 @@ class MasterSlaveConstraint :  public IndexedObject, public Flags
         KRATOS_CATCH("");
     }
 
-
-    ///@}
-
-    ///@name Access
-    ///@{
-
     /**
-	* Clears the maps contents
-	*/
+     * @brief Clears the maps contents
+     */
     virtual void Clear()
     {
     }
 
     /**
-     * is called to initialize the constraint
-     * if the constraint needs to perform any operation before any calculation is done
+     * @brief It is called to initialize the constraint
+     * @details If the constraint needs to perform any operation before any calculation is done
      */
     virtual void Initialize()
     {
     }
 
     /**
-     * is called to finalize the constraint
-     * if the constraint needs to perform any operation before any calculation is done
+     * @brief It is called to finalize the constraint
+     * @details If the constraint needs to perform any operation before any calculation is done
      */
     virtual void Finalize()
     {
@@ -191,56 +262,59 @@ class MasterSlaveConstraint :  public IndexedObject, public Flags
     }
 
     /**
-     * this is called in the beginning of each solution step
+     * @brief This is called in the beginning of each solution step
      */
     virtual void InitializeSolutionStep()
     {
     }
 
-
     /**
-     * this is called for non-linear analysis at the beginning of the iteration process
+     * @brief This is called for non-linear analysis at the beginning of the iteration process
      */
     virtual void InitializeNonLinearIteration()
     {
     }
 
     /**
-     * this is called for non-linear analysis at the end of the iteration process
+     * @brief This is called for non-linear analysis at the end of the iteration process
      */
     virtual void FinalizeNonLinearIteration()
     {
     }
 
     /**
-     * this is called at the end of each solution step
+     * @brief This is called at the end of each solution step
      */
     virtual void FinalizeSolutionStep()
     {
     }
 
     /**
-     * determines the constrant's slvae and master list of DOFs
-     * @param rSlaveDofList the list of slave DOFs
-     * @param rMasterDofList the list of slave DOFs
-     * @param rCurrentProcessInfo the current process info instance
+     * @brief Determines the constrant's slvae and master list of DOFs
+     * @param rSlaveDofList The list of slave DOFs
+     * @param rMasterDofList The list of slave DOFs
+     * @param rCurrentProcessInfo The current process info instance
      */
-    virtual void GetDofList(DofPointerVectorType& rSlaveDofList,
-                            DofPointerVectorType& rMasterDofList,
-                            ProcessInfo& rCurrentProcessInfo)
+    virtual void GetDofList(
+        DofPointerVectorType& rSlaveDofList,
+        DofPointerVectorType& rMasterDofList,
+        ProcessInfo& rCurrentProcessInfo
+        )
     {
         KRATOS_ERROR << "Create not implemented in MasterSlaveConstraintBaseClass" << std::endl;
     }
 
     /**
-     * this determines the master equation IDs connected to this constraint
-     * @param rSlaveEquationIds the vector of slave equation ids.
-     * @param rMasterEquationIds the vector of master equation ids.
-     * @param rCurrentProcessInfo the current process info instance
+     * @brief This determines the master equation IDs connected to this constraint
+     * @param rSlaveEquationIds The vector of slave equation ids.
+     * @param rMasterEquationIds The vector of master equation ids.
+     * @param rCurrentProcessInfo The current process info instance
      */
-    virtual void EquationIdVector(EquationIdVectorType& rSlaveEquationIds,
-                                  EquationIdVectorType& rMasterEquationIds,
-                                  ProcessInfo& rCurrentProcessInfo)
+    virtual void EquationIdVector(
+        EquationIdVectorType& rSlaveEquationIds,
+        EquationIdVectorType& rMasterEquationIds,
+        ProcessInfo& rCurrentProcessInfo
+        )
     {
         if (rSlaveEquationIds.size() != 0)
             rSlaveEquationIds.resize(0);
@@ -250,51 +324,56 @@ class MasterSlaveConstraint :  public IndexedObject, public Flags
     }
 
     /**
-     * this is called during the assembling process in order
-     * to calculate the relation between the master and slave.
-     * matrix and the right hand side
+     * @brief This is called during the assembling process in order
+     * @details To calculate the relation between the master and slave.
      * @param rTransformationMatrix the matrix which relates the master and slave degree of freedom
      * @param rConstant The constant vector (one entry for each slave)
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void CalculateLocalSystem(MatrixType& rTransformationMatrix,
-                                      VectorType& rConstantVector,
-                                      ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateLocalSystem(
+        MatrixType& rTransformationMatrix,
+        VectorType& rConstantVector,
+        ProcessInfo& rCurrentProcessInfo
+        )
     {
-      if (rTransformationMatrix.size1() != 0)
-      {
-    	rTransformationMatrix.resize(0, 0, false);
-      }
+        if (rTransformationMatrix.size1() != 0) {
+            rTransformationMatrix.resize(0, 0, false);
+        }
 
-      if (rConstantVector.size() != 0)
-      {
-    	rConstantVector.resize(0, false);
-      }
+        if (rConstantVector.size() != 0) {
+            rConstantVector.resize(0, false);
+        }
     }
 
+    ///@}
+    ///@name Input and output
+    ///@{
+
     /**
-	* Returns the string containing a detailed description of this object.
-	* @return the string with informations
-	*/
+     * @brief Returns the string containing a detailed description of this object.
+     * @return the string with informations
+     */
     virtual std::string GetInfo() const
     {
         return " Constraint base class !";
     }
 
-    ///@
-
-    ///@name Static Operations
-    ///
-    //@{
-
-    ///@}
+    /**
+     * @brief This method prints the current Constraint Id
+     * @param rOStream The buffer where the information is given
+     */
     virtual void PrintInfo(std::ostream &rOStream) const override
     {
-        rOStream << " MasterSlaveConstraint Id  : " <<this->Id()<<std::endl;
+        rOStream << " MasterSlaveConstraint Id  : " << this->Id() << std::endl;
     }
 
+    ///@}
+    ///@name Access
+    ///@{
+
     /**
-     * Check if the Data exists with Has(..) methods:
+     * @brief Check if the Data exists with Has(..) methods:
+     * @param rThisVariable The variable to be check
      */
     template<class TDataType> bool Has(const Variable<TDataType>& rThisVariable) const
     {
@@ -302,36 +381,72 @@ class MasterSlaveConstraint :  public IndexedObject, public Flags
     }
 
     /**
-     * Set Data with SetValue and the Variable to set:
+     * @brief Set Data with SetValue and the Variable to set
+     * @param rThisVariable The variable to be set
+     * @param rValue The value to be set
      */
     template<class TVariableType> void SetValue(
         const TVariableType& rThisVariable,
-        typename TVariableType::Type const& rValue)
+        typename TVariableType::Type const& rValue
+        )
     {
         mData.SetValue(rThisVariable, rValue);
     }
 
     /**
-     * Get Data with GetValue and the Variable to get:
+     * @brief Get Data with GetValue and the Variable to get
+     * @param rThisVariable The variable to get
      */
-    template<class TVariableType> typename TVariableType::Type& GetValue(
-        const TVariableType& rThisVariable)
+    template<class TVariableType> typename TVariableType::Type& GetValue(const TVariableType& rThisVariable)
     {
         return mData.GetValue(rThisVariable);
     }
 
+protected:
+    ///@name Protected static Member Variables
+    ///@{
 
-  private:
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
     ///@}
 
-    /**
-     * pointer to the data related to this constraint
-     */
-    DataValueContainer mData;
-    ///@}
+private:
+    ///@name Static Member Variables
+    ///@{
 
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    DataValueContainer mData; /// Pointer to the data related to this constraint
+
+    ///@}
     ///@name Serialization
     ///@{
+
     friend class Serializer;
 
     virtual void save(Serializer &rSerializer) const override

--- a/kratos/includes/master_slave_constraint.h
+++ b/kratos/includes/master_slave_constraint.h
@@ -146,6 +146,7 @@ public:
     MasterSlaveConstraint& operator=(const MasterSlaveConstraint& rOther)
     {
         BaseType::operator=( rOther );
+        mData = rOther.mData;
         return *this;
     }
 

--- a/kratos/includes/master_slave_constraint.h
+++ b/kratos/includes/master_slave_constraint.h
@@ -238,6 +238,19 @@ public:
     }
 
     /**
+     * @brief It creates a new constraint pointer and clones the previous constraint data
+     * @param NewId the ID of the new constraint
+     * @return a Pointer to the new constraint
+     */
+    virtual Pointer Clone (IndexType NewId) const
+    {
+        KRATOS_TRY
+        KRATOS_ERROR << "Clone not implemented in MasterSlaveConstraintBaseClass" << std::endl;
+        return nullptr;
+        KRATOS_CATCH("");
+    }
+
+    /**
      * @brief Clears the maps contents
      */
     virtual void Clear()
@@ -370,6 +383,33 @@ public:
     ///@}
     ///@name Access
     ///@{
+
+    /**
+     * @brief This method returns the data container of the constraint
+     * @return The data container mData
+     */
+    DataValueContainer& Data()
+    {
+        return mData;
+    }
+
+    /**
+     * @brief This method returns the data container of the constraint (constant)
+     * @return The data container mData
+     */
+    DataValueContainer const& GetData() const
+    {
+        return mData;
+    }
+
+    /**
+     * @brief This method sets the data container of the constraint
+     * @param rThisData The data container to set on mData
+     */
+    void SetData(DataValueContainer const& rThisData)
+    {
+        mData = rThisData;
+    }
 
     /**
      * @brief Check if the Data exists with Has(..) methods:


### PR DESCRIPTION
the original poupose of this PR was to move the member variables of the linear_master_slave_constraint to protected, in order to derive new constraints classes. I decided additionally to clean up and extend documentation