### PR TITLE
[StructuralMechanics] update to plasticity and damage CLs

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.cpp
@@ -76,6 +76,21 @@ bool LinearIsotropicDamage3D::Has(const Variable<double>& rThisVariable)
 //************************************************************************************
 //************************************************************************************
 
+bool& LinearIsotropicDamage3D::GetValue(
+    const Variable<bool>& rThisVariable,
+    bool& rValue
+    )
+{
+    if(rThisVariable == INELASTIC_FLAG){
+        rValue = mInelasticFlag;
+    }
+
+    return rValue;
+}
+
+//************************************************************************************
+//************************************************************************************
+
 void LinearIsotropicDamage3D::InitializeMaterial(
     const Properties& rMaterialProperties,
     const GeometryType& rElementGeometry,
@@ -175,21 +190,6 @@ void LinearIsotropicDamage3D::CalculateMaterialResponseCauchy(Parameters& rValue
             stress_vector *= (1. - damage_variable);
         }
     }
-}
-
-//************************************************************************************
-//************************************************************************************
-
-bool& LinearIsotropicDamage3D::CalculateValue(
-    ConstitutiveLaw::Parameters& rParameterValues,
-    const Variable<bool>& rThisVariable,
-    bool& rValue
-    )
-{
-    if(rThisVariable == INELASTIC_FLAG){
-        rValue = mInelasticFlag;
-    }
-    return(rValue);
 }
 
 //************************************************************************************

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.h
@@ -132,13 +132,6 @@ public:
     bool Has(const Variable<bool>& rThisVariable) override;
 
     /**
-     * @brief Returns whether this constitutive Law has specified variable (double)
-     * @param rThisVariable the variable to be checked for
-     * @return true if the variable is defined in the constitutive law
-     */
-    bool Has(const Variable<double>& rThisVariable) override;
-
-    /**
      * @brief Returns the value of a specified variable (bool)
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.h
@@ -125,7 +125,7 @@ public:
     };
 
     /**
-     * @brief Returns whether this constitutive Law has specified variable (double)
+     * @brief Returns whether this constitutive Law has specified variable (bool)
      * @param rThisVariable the variable to be checked for
      * @return true if the variable is defined in the constitutive law
      */
@@ -137,6 +137,17 @@ public:
      * @return true if the variable is defined in the constitutive law
      */
     bool Has(const Variable<double>& rThisVariable) override;
+
+    /**
+     * @brief Returns the value of a specified variable (bool)
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @return rValue output: the value of the specified variable
+     */
+    bool& GetValue(
+        const Variable<bool>& rThisVariable,
+        bool& rValue
+        ) override;
 
     /**
      * @brief This is to be called at the very beginning of the calculation
@@ -224,17 +235,6 @@ public:
      * @param rValue a reference to the returned value
      * @return rValue output: the value of the specified variable
      */
-
-    /**
-     * @brief calculates the value of a specified variable
-     * @param rParameterValues the needed parameters for the CL calculation
-     * @param rThisVariable the variable to be returned
-     * @param rValue a reference to the returned value
-     * @return rValue output: the value of the specified variable
-     */
-    bool& CalculateValue(Parameters& rParameterValues,
-                           const Variable<bool>& rThisVariable,
-                           bool& rValue) override;
 
     /**
      * @brief calculates the value of a specified variable

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.cpp
@@ -93,6 +93,21 @@ void LinearJ2Plasticity3D::SetValue(
 //************************************************************************************
 //************************************************************************************
 
+bool& LinearJ2Plasticity3D::GetValue(
+    const Variable<bool>& rThisVariable,
+    bool& rValue
+    )
+{
+    if(rThisVariable == INELASTIC_FLAG){
+        rValue = mInelasticFlag;
+    }
+
+    return rValue;
+}
+
+//************************************************************************************
+//************************************************************************************
+
 double& LinearJ2Plasticity3D::GetValue(
     const Variable<double>& rThisVariable,
     double& rValue
@@ -261,21 +276,6 @@ void LinearJ2Plasticity3D::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
                                    rMaterialProperties, tangent_tensor);
         }
     }
-}
-
-//************************************************************************************
-//************************************************************************************
-
-bool& LinearJ2Plasticity3D::CalculateValue(
-    ConstitutiveLaw::Parameters& rParameterValues,
-    const Variable<bool>& rThisVariable,
-    bool& rValue
-    )
-{
-    if(rThisVariable == INELASTIC_FLAG){
-        rValue = mInelasticFlag;
-    }
-    return(rValue);
 }
 
 //************************************************************************************

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.cpp
@@ -63,36 +63,6 @@ bool LinearJ2Plasticity3D::Has(const Variable<bool>& rThisVariable)
 //************************************************************************************
 //************************************************************************************
 
-bool LinearJ2Plasticity3D::Has(const Variable<double>& rThisVariable)
-{
-    if(rThisVariable == STRAIN_ENERGY){
-        return true;
-    }
-    if(rThisVariable == PLASTIC_STRAIN){
-        return true;
-    }
-    return false;
-}
-
-
-
-//************************************************************************************
-//************************************************************************************
-
-void LinearJ2Plasticity3D::SetValue(
-    const Variable<double>& rThisVariable,
-    const double& rValue,
-    const ProcessInfo& rCurrentProcessInfo
-    )
-{
-    if(rThisVariable == PLASTIC_STRAIN){
-        mAccumulatedPlasticStrain = rValue;
-    }
-}
-
-//************************************************************************************
-//************************************************************************************
-
 bool& LinearJ2Plasticity3D::GetValue(
     const Variable<bool>& rThisVariable,
     bool& rValue
@@ -108,21 +78,6 @@ bool& LinearJ2Plasticity3D::GetValue(
 //************************************************************************************
 //************************************************************************************
 
-double& LinearJ2Plasticity3D::GetValue(
-    const Variable<double>& rThisVariable,
-    double& rValue
-    )
-{
-    if(rThisVariable == PLASTIC_STRAIN){
-        rValue = mAccumulatedPlasticStrain;
-    }
-
-    return rValue;
-}
-
-//************************************************************************************
-//************************************************************************************
-
 void LinearJ2Plasticity3D::InitializeMaterial(
     const Properties& rMaterialProperties,
     const GeometryType& rElementGeometry,
@@ -130,8 +85,9 @@ void LinearJ2Plasticity3D::InitializeMaterial(
     )
 {
     mPlasticStrainOld = ZeroVector(this->GetStrainSize());
-    mPlasticStrain = mPlasticStrainOld;
+    mPlasticStrain = ZeroVector(this->GetStrainSize());
     mAccumulatedPlasticStrainOld = 0.0;
+    mAccumulatedPlasticStrain = 0.0;
 }
 
 //************************************************************************************
@@ -176,105 +132,94 @@ void LinearJ2Plasticity3D::CalculateMaterialResponseKirchhoff(ConstitutiveLaw::P
 
 void LinearJ2Plasticity3D::CalculateMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
 {
-    Flags &Options = rValues.GetOptions();
-
     const Properties& rMaterialProperties = rValues.GetMaterialProperties();
     Vector& strain_vector = rValues.GetStrainVector();
     Vector& stress_vector = rValues.GetStressVector();
 
-    if (Options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
-        Matrix& ConstitutiveMatrix = rValues.GetConstitutiveMatrix();
-        CalculateElasticMatrix(ConstitutiveMatrix, rMaterialProperties);
+    if (rValues.GetProcessInfo().Has(INITIAL_STRAIN)) {
+        noalias(strain_vector) += rValues.GetProcessInfo()[INITIAL_STRAIN];
     }
+    Matrix elastic_tensor;
+    Matrix& tangent_tensor = rValues.GetConstitutiveMatrix();
+    const double hardening_modulus = rMaterialProperties[ISOTROPIC_HARDENING_MODULUS];
+    const double delta_k = rMaterialProperties[INFINITY_HARDENING_MODULUS];
+    const double hardening_exponent = rMaterialProperties[HARDENING_EXPONENT];
+    const double E = rMaterialProperties[YOUNG_MODULUS];
+    const double poisson_ratio = rMaterialProperties[POISSON_RATIO];
+    const double mu = E / (2. + 2. * poisson_ratio);
+    const double volumetric_modulus = E / (3. * (1. - 2. * poisson_ratio));
+    const double sqrt_two_thirds = std::sqrt(2.0 / 3.0); // =0.8164965809277260
+    double trial_yield_function;
 
-    if (Options.Is(ConstitutiveLaw::COMPUTE_STRESS)) {
-        if (rValues.GetProcessInfo().Has(INITIAL_STRAIN)) {
-            noalias(strain_vector) += rValues.GetProcessInfo()[INITIAL_STRAIN];
+    mPlasticStrain = mPlasticStrainOld;
+    mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld;
+
+    elastic_tensor.resize(6, 6, false);
+    CalculateElasticMatrix(elastic_tensor, rMaterialProperties);
+    Vector yield_tensionrial(6);
+    noalias(yield_tensionrial) = prod(elastic_tensor, strain_vector - mPlasticStrainOld);
+
+    // stress_trial_dev = sigma - 1/3 tr(sigma) * I
+    Vector stress_trial_dev = yield_tensionrial;
+
+    const double trace = 1.0 / 3.0 * (yield_tensionrial(0) + yield_tensionrial(1) + yield_tensionrial(2));
+    stress_trial_dev(0) -= trace;
+    stress_trial_dev(1) -= trace;
+    stress_trial_dev(2) -= trace;
+    const double norm_dev_stress = std::sqrt(stress_trial_dev(0) * stress_trial_dev(0) +
+                                       stress_trial_dev(1) * stress_trial_dev(1) +
+                                       stress_trial_dev(2) * stress_trial_dev(2) +
+                                       2. * stress_trial_dev(3) * stress_trial_dev(3) +
+                                       2. * stress_trial_dev(4) * stress_trial_dev(4) +
+                                       2. * stress_trial_dev(5) * stress_trial_dev(5));
+    trial_yield_function = this->YieldFunction(norm_dev_stress, rMaterialProperties);
+
+    if (trial_yield_function <= 0.) {
+        // ELASTIC
+        mInelasticFlag = false;
+        stress_vector = yield_tensionrial;
+        tangent_tensor = elastic_tensor;
+    } else {
+        // INELASTIC
+        mInelasticFlag = true;
+        double dgamma = 0;
+        Vector yield_function_normal_vector = stress_trial_dev / norm_dev_stress;
+        if (delta_k != 0.0 && hardening_exponent != 0.0) {
+            // Exponential softening
+            dgamma = GetDeltaGamma(norm_dev_stress, rMaterialProperties);
         }
-        Matrix elastic_tensor;
-        Matrix& tangent_tensor = rValues.GetConstitutiveMatrix();
-        const double hardening_modulus = rMaterialProperties[ISOTROPIC_HARDENING_MODULUS];
-        const double delta_k = rMaterialProperties[INFINITY_HARDENING_MODULUS];
-        const double hardening_exponent = rMaterialProperties[HARDENING_EXPONENT];
-        const double E = rMaterialProperties[YOUNG_MODULUS];
-        const double poisson_ratio = rMaterialProperties[POISSON_RATIO];
-        const double mu = E / (2. + 2. * poisson_ratio);
-        const double volumetric_modulus = E / (3. * (1. - 2. * poisson_ratio));
-        const double sqrt_two_thirds = std::sqrt(2.0 / 3.0); // =0.8164965809277260
-        double trial_yield_function;
-
-        mPlasticStrain = mPlasticStrainOld;
-        mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld;
-
-        elastic_tensor.resize(6, 6, false);
-        CalculateElasticMatrix(elastic_tensor, rMaterialProperties);
-        Vector yield_tensionrial(6);
-        noalias(yield_tensionrial) = prod(elastic_tensor, strain_vector - mPlasticStrainOld);
-
-        // stress_trial_dev = sigma - 1/3 tr(sigma) * I
-        Vector stress_trial_dev = yield_tensionrial;
-
-        const double trace = 1.0 / 3.0 * (yield_tensionrial(0) + yield_tensionrial(1) + yield_tensionrial(2));
-        stress_trial_dev(0) -= trace;
-        stress_trial_dev(1) -= trace;
-        stress_trial_dev(2) -= trace;
-        const double norm_dev_stress = std::sqrt(stress_trial_dev(0) * stress_trial_dev(0) +
-                                           stress_trial_dev(1) * stress_trial_dev(1) +
-                                           stress_trial_dev(2) * stress_trial_dev(2) +
-                                           2. * stress_trial_dev(3) * stress_trial_dev(3) +
-                                           2. * stress_trial_dev(4) * stress_trial_dev(4) +
-                                           2. * stress_trial_dev(5) * stress_trial_dev(5));
-        trial_yield_function = this->YieldFunction(norm_dev_stress, rMaterialProperties);
-
-        if (trial_yield_function <= 0.) {
-            // ELASTIC
-            mInelasticFlag = false;
-            stress_vector = yield_tensionrial;
-            tangent_tensor = elastic_tensor;
-        } else {
-            // INELASTIC
-            mInelasticFlag = true;
-            double dgamma = 0;
-            Vector yield_function_normal_vector = stress_trial_dev / norm_dev_stress;
-            if (delta_k != 0.0 && hardening_exponent != 0.0) {
-                // Exponential softening
-                dgamma = GetDeltaGamma(norm_dev_stress, rMaterialProperties);
-            }
-            else {
-                // Linear softening
-                dgamma = trial_yield_function /
-                         (2. * mu * (1. + (hardening_modulus / (3. * mu))));
-            }
-
-            stress_vector(0) =
-                volumetric_modulus * (strain_vector(0) + strain_vector(1) + strain_vector(2)) +
-                stress_trial_dev(0) - 2. * mu * dgamma * yield_function_normal_vector(0);
-            stress_vector(1) =
-                volumetric_modulus * (strain_vector(0) + strain_vector(1) + strain_vector(2)) +
-                stress_trial_dev(1) - 2. * mu * dgamma * yield_function_normal_vector(1);
-            stress_vector(2) =
-                volumetric_modulus * (strain_vector(0) + strain_vector(1) + strain_vector(2)) +
-                stress_trial_dev(2) - 2. * mu * dgamma * yield_function_normal_vector(2);
-            stress_vector(3) =
-                stress_trial_dev(3) - 2. * mu * dgamma * yield_function_normal_vector(3);
-            stress_vector(4) =
-                stress_trial_dev(4) - 2. * mu * dgamma * yield_function_normal_vector(4);
-            stress_vector(5) =
-                stress_trial_dev(5) - 2. * mu * dgamma * yield_function_normal_vector(5);
-
-            mPlasticStrain(0) = mPlasticStrainOld(0) + dgamma * yield_function_normal_vector(0);
-            mPlasticStrain(1) = mPlasticStrainOld(1) + dgamma * yield_function_normal_vector(1);
-            mPlasticStrain(2) = mPlasticStrainOld(2) + dgamma * yield_function_normal_vector(2);
-            mPlasticStrain(3) = mPlasticStrainOld(3) + dgamma * yield_function_normal_vector(3) * 2;
-            mPlasticStrain(4) = mPlasticStrainOld(4) + dgamma * yield_function_normal_vector(4) * 2;
-            mPlasticStrain(5) = mPlasticStrainOld(5) + dgamma * yield_function_normal_vector(5) * 2;
-            mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld + sqrt_two_thirds * dgamma;
-
-            // Update derivative of the hardening-softening modulus
-
-            CalculateTangentTensor(dgamma, norm_dev_stress, yield_function_normal_vector,
-                                   rMaterialProperties, tangent_tensor);
+        else {
+            // Linear softening
+            dgamma = trial_yield_function /
+                     (2. * mu * (1. + (hardening_modulus / (3. * mu))));
         }
+
+        stress_vector(0) =
+            volumetric_modulus * (strain_vector(0) + strain_vector(1) + strain_vector(2)) +
+            stress_trial_dev(0) - 2. * mu * dgamma * yield_function_normal_vector(0);
+        stress_vector(1) =
+            volumetric_modulus * (strain_vector(0) + strain_vector(1) + strain_vector(2)) +
+            stress_trial_dev(1) - 2. * mu * dgamma * yield_function_normal_vector(1);
+        stress_vector(2) =
+            volumetric_modulus * (strain_vector(0) + strain_vector(1) + strain_vector(2)) +
+            stress_trial_dev(2) - 2. * mu * dgamma * yield_function_normal_vector(2);
+        stress_vector(3) =
+            stress_trial_dev(3) - 2. * mu * dgamma * yield_function_normal_vector(3);
+        stress_vector(4) =
+            stress_trial_dev(4) - 2. * mu * dgamma * yield_function_normal_vector(4);
+        stress_vector(5) =
+            stress_trial_dev(5) - 2. * mu * dgamma * yield_function_normal_vector(5);
+
+        mPlasticStrain(0) = mPlasticStrainOld(0) + dgamma * yield_function_normal_vector(0);
+        mPlasticStrain(1) = mPlasticStrainOld(1) + dgamma * yield_function_normal_vector(1);
+        mPlasticStrain(2) = mPlasticStrainOld(2) + dgamma * yield_function_normal_vector(2);
+        mPlasticStrain(3) = mPlasticStrainOld(3) + dgamma * yield_function_normal_vector(3) * 2;
+        mPlasticStrain(4) = mPlasticStrainOld(4) + dgamma * yield_function_normal_vector(4) * 2;
+        mPlasticStrain(5) = mPlasticStrainOld(5) + dgamma * yield_function_normal_vector(5) * 2;
+        mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld + sqrt_two_thirds * dgamma;
+
+        CalculateTangentTensor(dgamma, norm_dev_stress, yield_function_normal_vector,
+                               rMaterialProperties, tangent_tensor);
     }
 }
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
@@ -139,25 +139,6 @@ public:
     bool Has(const Variable<bool>& rThisVariable) override;
 
     /**
-     * @brief Returns whether this constitutive Law has specified variable (double)
-     * @param rThisVariable the variable to be checked for
-     * @return true if the variable is defined in the constitutive law
-     */
-    bool Has(const Variable<double>& rThisVariable) override;
-
-    /**
-     * @brief Sets the value of a specified variable (double)
-     * @param rThisVariable The variable to be returned
-     * @param rValue New value of the specified variable
-     * @param rCurrentProcessInfo the process info
-     */
-    void SetValue(
-        const Variable<double>& rThisVariable,
-        const double& rValue,
-        const ProcessInfo& rCurrentProcessInfo
-        ) override;
-
-    /**
      * @brief Returns the value of a specified variable (bool)
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
@@ -166,17 +147,6 @@ public:
     bool& GetValue(
         const Variable<bool>& rThisVariable,
         bool& rValue
-        ) override;
-
-    /**
-     * @brief Returns the value of a specified variable (double)
-     * @param rThisVariable the variable to be returned
-     * @param rValue a reference to the returned value
-     * @return rValue output: the value of the specified variable
-     */
-    double& GetValue(
-        const Variable<double>& rThisVariable,
-        double& rValue
         ) override;
 
     /**

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
@@ -132,7 +132,7 @@ public:
     };
 
     /**
-     * @brief Returns whether this constitutive Law has specified variable (double)
+     * @brief Returns whether this constitutive Law has specified variable (bool)
      * @param rThisVariable the variable to be checked for
      * @return true if the variable is defined in the constitutive law
      */
@@ -155,6 +155,17 @@ public:
         const Variable<double>& rThisVariable,
         const double& rValue,
         const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    /**
+     * @brief Returns the value of a specified variable (bool)
+     * @param rThisVariable the variable to be returned
+     * @param rValue a reference to the returned value
+     * @return rValue output: the value of the specified variable
+     */
+    bool& GetValue(
+        const Variable<bool>& rThisVariable,
+        bool& rValue
         ) override;
 
     /**
@@ -246,17 +257,6 @@ public:
      * @see Parameters
      */
     void FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) override;
-
-    /**
-     * @brief calculates the value of a specified variable
-     * @param rParameterValues the needed parameters for the CL calculation
-     * @param rThisVariable the variable to be returned
-     * @param rValue a reference to the returned value
-     * @return rValue output: the value of the specified variable
-     */
-    bool& CalculateValue(Parameters& rParameterValues,
-                           const Variable<bool>& rThisVariable,
-                           bool& rValue) override;
 
     /**
      * @brief calculates the value of a specified variable


### PR DESCRIPTION
This PR introduced some fixes to the Plasticity and the Damage CLs.

-Use CalculateValue (which passes Parameters) instead of GetValue for double variables. For this, it was necessary that the Has function to NOT return True for the variable. The base solid element is programmed in a way that if the constitutive law returns Has==True for a variable, the base element calls GetValue. In case Has==False, it calls CalculateValue, passing parameters. I am not sure the rationally behind this behavior, it should be more intuitive.

-Option to only calculate the constitutive tensor was removed, as it was computing the elastic CT instead of the tanget CT.