### PR TITLE
Structural/fix eigenfrequency sensitivities shells

### DIFF
--- a/applications/ShapeOptimizationApplication/tests/algorithm_penalized_projection_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_penalized_projection_test/parameters.json
@@ -21,8 +21,7 @@
                 },
                 "model_import_settings"    : {
                     "input_type"       : "use_input_model_part",
-                    "input_filename"   : "3D_Shell",
-                    "input_file_label" : 0
+                    "input_filename"   : "3D_Shell"
                 },
                 "gradient_mode"          : "finite_differencing",
                 "step_size"              : 1e-6,

--- a/applications/ShapeOptimizationApplication/tests/algorithm_steepest_descent_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_steepest_descent_test/parameters.json
@@ -21,8 +21,7 @@
                 },
                 "model_import_settings"    : {
                     "input_type"       : "use_input_model_part",
-                    "input_filename"   : "structure",
-                    "input_file_label" : 0
+                    "input_filename"   : "structure"
                 },
                 "gradient_mode"          : "finite_differencing",
                 "step_size"              : 1e-6,

--- a/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/parameters.json
@@ -21,8 +21,7 @@
                 },
                 "model_import_settings"    : {
                     "input_type"       : "use_input_model_part",
-                    "input_filename"   : "3D_Shell",
-                    "input_file_label" : 0
+                    "input_filename"   : "3D_Shell"
                 },
                 "gradient_mode"          : "finite_differencing",
                 "step_size"              : 1e-6,

--- a/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/eigenfrequency_response_function_utility.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/eigenfrequency_response_function_utility.h
@@ -332,8 +332,6 @@ protected:
     // --------------------------------------------------------------------------
     void DetermineEigenvectorOfElement(ModelPart::ElementType& rElement, const int& eigenfrequency_id, Vector& rEigenvectorOfElement, ProcessInfo& CurrentProcessInfo)
     {
-        const std::size_t num_nodes = rElement.GetGeometry().size();
-
         std::vector<std::size_t> eq_ids;
         rElement.EquationIdVector(eq_ids, CurrentProcessInfo);
 

--- a/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/eigenfrequency_response_function_utility.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/eigenfrequency_response_function_utility.h
@@ -324,13 +324,13 @@ protected:
     }
 
     // --------------------------------------------------------------------------
-    double GetEigenvalue(const int& eigenfrequency_id)
+    double GetEigenvalue(const int eigenfrequency_id)
     {
         return (mrModelPart.GetProcessInfo()[EIGENVALUE_VECTOR])[eigenfrequency_id-1];
     }
 
     // --------------------------------------------------------------------------
-    void DetermineEigenvectorOfElement(ModelPart::ElementType& rElement, const int& eigenfrequency_id, Vector& rEigenvectorOfElement, ProcessInfo& CurrentProcessInfo)
+    void DetermineEigenvectorOfElement(ModelPart::ElementType& rElement, const int eigenfrequency_id, Vector& rEigenvectorOfElement, ProcessInfo& CurrentProcessInfo)
     {
         std::vector<std::size_t> eq_ids;
         rElement.EquationIdVector(eq_ids, CurrentProcessInfo);
@@ -340,16 +340,17 @@ protected:
             rEigenvectorOfElement.resize(eq_ids.size(), false);
         }
 
+        // sort the values of the eigenvector into the rEigenvectorOfElement according to the dof ordering at the element
         for (auto& r_node_i : rElement.GetGeometry())
         {
-            const ModelPart::NodeType::DofsContainerType& r_node_dofs = r_node_i.GetDofs();
+            const auto& r_node_dofs = r_node_i.GetDofs();
 
             const Matrix& rNodeEigenvectors = r_node_i.GetValue(EIGENVECTOR_MATRIX);
             for (std::size_t dof_index = 0; dof_index < r_node_dofs.size(); dof_index++)
             {
-                auto it_dof = std::begin(r_node_dofs) + dof_index;
-                const std::size_t elem_dof_index = std::distance(eq_ids.begin(), std::find(eq_ids.begin(), eq_ids.end(), it_dof->EquationId()));
-                rEigenvectorOfElement(elem_dof_index) = rNodeEigenvectors((eigenfrequency_id-1), dof_index);
+                const auto& current_dof = std::begin(r_node_dofs) + dof_index;
+                const std::size_t dof_index_at_element = std::distance(eq_ids.begin(), std::find(eq_ids.begin(), eq_ids.end(), current_dof->EquationId()));
+                rEigenvectorOfElement(dof_index_at_element) = rNodeEigenvectors((eigenfrequency_id-1), dof_index);
             }
         }
     }

--- a/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/eigenfrequency_response_function_utility.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/eigenfrequency_response_function_utility.h
@@ -262,7 +262,7 @@ protected:
         for(std::size_t i = 0; i < num_of_traced_eigenfrequencies; i++)
         {
             traced_eigenvalues[i] = GetEigenvalue(mTracedEigenfrequencyIds[i]);
-            gradient_prefactors[i] = 1 / (4 * Globals::Pi * std::sqrt(traced_eigenvalues[i]));
+            gradient_prefactors[i] = 1.0 / (4.0 * Globals::Pi * std::sqrt(traced_eigenvalues[i]));
         }
 
         // Element-wise computation of gradients
@@ -284,7 +284,7 @@ protected:
             // Predetermine the necessary eigenvectors
             std::vector<Vector> eigenvectors_of_element(num_of_traced_eigenfrequencies,Vector(0));
             for(std::size_t i = 0; i < num_of_traced_eigenfrequencies; i++)
-                DetermineEigenvectorOfElement(elem_i, mTracedEigenfrequencyIds[i], num_dofs_element, eigenvectors_of_element[i]);
+                DetermineEigenvectorOfElement(elem_i, mTracedEigenfrequencyIds[i], eigenvectors_of_element[i], CurrentProcessInfo);
 
             // Computation of derivative of state equation w.r.t. node coordinates
             for(auto& node_i : elem_i.GetGeometry())
@@ -296,6 +296,7 @@ protected:
                 for(std::size_t coord_dir_i = 0; coord_dir_i < domain_size; coord_dir_i++)
                 {
                     node_i.GetInitialPosition()[coord_dir_i] += mDelta;
+                    node_i.Coordinates()[coord_dir_i] += mDelta;
 
                     elem_i.CalculateMassMatrix(perturbed_mass_matrix, CurrentProcessInfo);
                     noalias(perturbed_mass_matrix) = (perturbed_mass_matrix - mass_matrix_org) / mDelta;
@@ -314,7 +315,8 @@ protected:
                         gradient_contribution[coord_dir_i] += gradient_prefactors[i] * inner_prod(eigenvectors_of_element[i] , aux_vector) * mWeightingFactors[i];
                     }
 
-                   node_i.GetInitialPosition()[coord_dir_i] -= mDelta;
+                    node_i.GetInitialPosition()[coord_dir_i] -= mDelta;
+                    node_i.Coordinates()[coord_dir_i] -= mDelta;
                 }
                 noalias(node_i.FastGetSolutionStepValue(SHAPE_SENSITIVITY)) += gradient_contribution;
             }
@@ -322,25 +324,35 @@ protected:
     }
 
     // --------------------------------------------------------------------------
-    double GetEigenvalue(int eigenfrequency_id)
+    double GetEigenvalue(const int& eigenfrequency_id)
     {
         return (mrModelPart.GetProcessInfo()[EIGENVALUE_VECTOR])[eigenfrequency_id-1];
     }
 
     // --------------------------------------------------------------------------
-    void DetermineEigenvectorOfElement(ModelPart::ElementType& traced_element, int eigenfrequency_id, int size_of_eigenvector, Vector& rEigenvectorOfElement)
+    void DetermineEigenvectorOfElement(ModelPart::ElementType& rElement, const int& eigenfrequency_id, Vector& rEigenvectorOfElement, ProcessInfo& CurrentProcessInfo)
     {
-        rEigenvectorOfElement.resize(size_of_eigenvector,false);
+        const std::size_t num_nodes = rElement.GetGeometry().size();
 
-        const std::size_t num_nodes = traced_element.GetGeometry().size();
-        const std::size_t num_node_dofs = size_of_eigenvector/num_nodes;
+        std::vector<std::size_t> eq_ids;
+        rElement.EquationIdVector(eq_ids, CurrentProcessInfo);
 
-        for (std::size_t node_index=0; node_index<num_nodes; node_index++)
+        if (rEigenvectorOfElement.size() != eq_ids.size())
         {
-            Matrix& rNodeEigenvectors = traced_element.GetGeometry()[node_index].GetValue(EIGENVECTOR_MATRIX);
+            rEigenvectorOfElement.resize(eq_ids.size(), false);
+        }
 
-            for (std::size_t dof_index = 0; dof_index < num_node_dofs; dof_index++)
-                rEigenvectorOfElement(dof_index+num_node_dofs*node_index) = rNodeEigenvectors((eigenfrequency_id-1),dof_index);
+        for (auto& r_node_i : rElement.GetGeometry())
+        {
+            const ModelPart::NodeType::DofsContainerType& r_node_dofs = r_node_i.GetDofs();
+
+            const Matrix& rNodeEigenvectors = r_node_i.GetValue(EIGENVECTOR_MATRIX);
+            for (std::size_t dof_index = 0; dof_index < r_node_dofs.size(); dof_index++)
+            {
+                auto it_dof = std::begin(r_node_dofs) + dof_index;
+                const std::size_t elem_dof_index = std::distance(eq_ids.begin(), std::find(eq_ids.begin(), eq_ids.end(), it_dof->EquationId()));
+                rEigenvectorOfElement(elem_dof_index) = rNodeEigenvectors((eigenfrequency_id-1), dof_index);
+            }
         }
     }
 

--- a/applications/StructuralMechanicsApplication/tests/response_function_tests/eigenfrequency_primal_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/response_function_tests/eigenfrequency_primal_parameters.json
@@ -1,0 +1,97 @@
+{
+    "problem_data"             : {
+        "problem_name"    : "rectangular_plate_structure",
+        "parallel_type"   : "OpenMP",
+        "start_time"      : 0.0,
+        "end_time"        : 1.0,
+        "echo_level"      : 0
+    },
+    "solver_settings"          : {
+        "solver_type"                        : "eigen_value",
+        "scheme_type"                        : "dynamic",
+        "echo_level"                         : 0,
+        "model_part_name" : "rectangular_plate_structure",
+        "domain_size"     : 3,
+        "time_stepping" : {
+            "time_step"       : 1.1
+        },
+        "model_import_settings"              : {
+            "input_type"     : "mdpa",
+            "input_filename" : "eigenfrequency_structure"
+        },
+        "material_import_settings"           : {
+            "materials_filename" : "StructuralMaterials.json"
+        },
+        "eigensolver_settings":{
+            "solver_type": "eigen_eigensystem",
+            "number_of_eigenvalues": 2,
+            "max_iteration": 1000,
+            "tolerance": 1e-8,
+            "echo_level": 1
+        },
+        "problem_domain_sub_model_part_list" : ["Parts_AREAS"],
+        "processes_sub_model_part_list"      : ["support"],
+        "rotation_dofs"                      : true
+    },
+    "constraints_process_list" : [{
+        "python_module" : "assign_vector_variable_process",
+        "kratos_module" : "KratosMultiphysics",
+        "help"          : "This process fixes the selected components of a given vector variable",
+        "process_name"  : "AssignVectorVariableProcess",
+        "Parameters"    : {
+            "mesh_id"         : 0,
+            "model_part_name" : "rectangular_plate_structure.support",
+            "variable_name"   : "DISPLACEMENT",
+            "constrained"     : [true,true,true],
+            "value"           : [0.0,0.0,0.0],
+            "interval"        : [0.0,"End"]
+        }
+    },{
+        "python_module" : "assign_vector_variable_process",
+        "kratos_module" : "KratosMultiphysics",
+        "help"          : "This process fixes the selected components of a given vector variable",
+        "process_name"  : "AssignVectorVariableProcess",
+        "Parameters"    : {
+            "mesh_id"         : 0,
+            "model_part_name" : "rectangular_plate_structure.support",
+            "variable_name"   : "ROTATION",
+            "constrained"     : [true,true,true],
+            "value"           : [0.0,0.0,0.0],
+            "interval"        : [0.0,"End"]
+        }
+    }],
+    "contact_process_list"     : [],
+    "loads_process_list"       : [],
+    "output_configuration"     : {
+        "result_file_configuration" : {
+            "gidpost_flags"       : {
+                "GiDPostMode"           : "GiD_PostBinary",
+                "WriteDeformedMeshFlag" : "WriteDeformed",
+                "WriteConditionsFlag"   : "WriteConditions",
+                "MultiFileFlag"         : "SingleFile"
+            },
+            "file_label"          : "step",
+            "output_control_type" : "step",
+            "output_frequency"    : 1,
+            "body_output"         : true,
+            "node_output"         : false,
+            "skin_output"         : false,
+            "plane_output"        : [],
+            "nodal_results"       : ["DISPLACEMENT","SHAPE_SENSITIVITY"],
+            "gauss_point_results" : []
+        },
+        "point_data_configuration"  : []
+    },
+    "list_other_processes": [
+    ],
+    "restart_options"          : {
+        "SaveRestart"      : false,
+        "RestartFrequency" : 0,
+        "LoadRestart"      : false,
+        "Restart_Step"     : 0
+    },
+    "constraints_data"         : {
+        "incremental_load"         : false,
+        "incremental_displacement" : false
+    }
+}

--- a/applications/StructuralMechanicsApplication/tests/response_function_tests/eigenfrequency_primal_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/response_function_tests/eigenfrequency_primal_parameters.json
@@ -24,7 +24,8 @@
         },
         "eigensolver_settings":{
             "solver_type": "eigen_eigensystem",
-            "number_of_eigenvalues": 2,
+            "number_of_eigenvalues": 1,
+            "normalize_eigenvectors": true,
             "max_iteration": 1000,
             "tolerance": 1e-8,
             "echo_level": 1

--- a/applications/StructuralMechanicsApplication/tests/response_function_tests/eigenfrequency_primal_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/response_function_tests/eigenfrequency_primal_parameters.json
@@ -28,7 +28,7 @@
             "normalize_eigenvectors": true,
             "max_iteration": 1000,
             "tolerance": 1e-8,
-            "echo_level": 1
+            "echo_level": 0
         },
         "problem_domain_sub_model_part_list" : ["Parts_AREAS"],
         "processes_sub_model_part_list"      : ["support"],

--- a/applications/StructuralMechanicsApplication/tests/response_function_tests/eigenfrequency_response_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/response_function_tests/eigenfrequency_response_parameters.json
@@ -1,0 +1,22 @@
+{
+    "problem_data"             : {
+        "problem_name"    : "rectangular_plate_structure",
+        "model_part_name" : "rectangular_plate_structure",
+        "domain_size"     : 3,
+        "time_step"       : 1.0,
+        "start_time"      : 0.0,
+        "end_time"        : 1.0,
+        "parallel_type"   : "OpenMP",
+        "echo_level"      : 0
+    },
+    "kratos_response_settings":{
+        "response_type"          : "eigenfrequency",
+        "primal_settings"        : "eigenfrequency_primal_parameters.json",
+        "gradient_mode"          : "semi_analytic",
+        "step_size"              : 1e-8,
+        "traced_eigenfrequencies"  : [1],
+        "weighting_method"       : "linear_scaling",
+        "weighting_factors"      : [1.0],
+        "consider_discretization": true
+    }
+}

--- a/applications/StructuralMechanicsApplication/tests/response_function_tests/eigenfrequency_structure.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/response_function_tests/eigenfrequency_structure.mdpa
@@ -1,0 +1,153 @@
+Begin ModelPartData
+//  VARIABLE_NAME value
+End ModelPartData
+
+Begin Properties 0
+End Properties
+
+Begin Nodes
+    1   1.0000000000   0.0000000000   0.0000000000
+    2   1.0000000000   0.2500000000   0.0000000000
+    3   0.7500000000   0.0000000000   0.0000000000
+    4   0.7490696209   0.3576388889   0.0000000000
+    5   0.5000000000   0.0000000000   0.0000000000
+    6   1.0000000000   0.5000000000   0.0000000000
+    7   0.5000000000   0.2500000000   0.0000000000
+    8   0.7444177252   0.6458333333   0.0000000000
+    9   0.5000000000   0.5000000000   0.0000000000
+   10   1.0000000000   0.7500000000   0.0000000000
+   11   0.2500000000   0.0000000000   0.0000000000
+   12   0.2490696209   0.3576388889   0.0000000000
+   13   0.5000000000   0.7500000000   0.0000000000
+   14   0.2444177252   0.6458333333   0.0000000000
+   15   0.0000000000   0.0000000000   0.0000000000
+   16   1.0000000000   1.0000000000   0.0000000000
+   17   0.0000000000   0.2500000000   0.0000000000
+   18   0.7500000000   1.0000000000   0.0000000000
+   19   0.5000000000   1.0000000000   0.0000000000
+   20   0.0000000000   0.5000000000   0.0000000000
+   21   0.0000000000   0.7500000000   0.0000000000
+   22   0.2500000000   1.0000000000   0.0000000000
+   23   0.0000000000   1.0000000000   0.0000000000
+End Nodes
+
+Begin Elements ShellThinElement3D3N
+         1          0         23         21         22
+         2          0         15         11         17
+         3          0          9         13         14
+         4          0         20         17         12
+         5          0         12         17         11
+         6          0         20         12         14
+         7          0          5          7         11
+         8          0         19         22         13
+         9          0         21         20         14
+        10          0          7          9         12
+        11          0         14         13         22
+        12          0          9         14         12
+        13          0         21         14         22
+        14          0          7         12         11
+        15          0         19         13         18
+        16          0          5          3          7
+        17          0          6         10          8
+        18          0          9          7          4
+        19          0          4          7          3
+        20          0          9          4          8
+        21          0          1          2          3
+        22          0         16         18         10
+        23          0         13          9          8
+        24          0          2          6          4
+        25          0          8         10         18
+        26          0          6          8          4
+        27          0         13          8         18
+        28          0          2          4          3
+End Elements
+
+Begin Conditions PointLoadCondition3D1N
+    29 0 19
+End Conditions
+
+Begin SubModelPart Parts_AREAS
+    Begin SubModelPartNodes
+         1
+         2
+         3
+         4
+         5
+         6
+         7
+         8
+         9
+        10
+        11
+        12
+        13
+        14
+        15
+        16
+        17
+        18
+        19
+        20
+        21
+        22
+        23
+    End SubModelPartNodes
+    Begin SubModelPartElements
+         1
+         2
+         3
+         4
+         5
+         6
+         7
+         8
+         9
+        10
+        11
+        12
+        13
+        14
+        15
+        16
+        17
+        18
+        19
+        20
+        21
+        22
+        23
+        24
+        25
+        26
+        27
+        28
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+
+Begin SubModelPart support
+    Begin SubModelPartNodes
+         1
+         3
+         5
+        11
+        15
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+
+Begin SubModelPart load_point
+    Begin SubModelPartNodes
+        19
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+         29
+    End SubModelPartConditions
+End SubModelPart
+

--- a/applications/StructuralMechanicsApplication/tests/structural_response_function_test_factory.py
+++ b/applications/StructuralMechanicsApplication/tests/structural_response_function_test_factory.py
@@ -16,6 +16,12 @@ try:
 except ImportError:
     has_hdf5_application = False
 
+try:
+    from KratosMultiphysics.EigenSolversApplication import *
+    has_eigensolvers_application = True
+except ImportError:
+    has_eigensolvers_application = False
+
 # This utility will control the execution scope in case we need to access files or we depend
 # on specific relative locations of the files.
 
@@ -149,6 +155,19 @@ class TestStrainEnergyResponseFunction(StructuralResponseFunctionTestFactory):
         self.assertAlmostEqual(self.gradient[nodeId][1],  0.0017745756664132117, 9)
         self.assertAlmostEqual(self.gradient[nodeId][2], -1.5466215093998671e-07, 9)
 
+@KratosUnittest.skipUnless(has_eigensolvers_application,"Missing required application: EigenSolversApplication")
+class TestAdjointEigenfrequencyResponseFunction(StructuralResponseFunctionTestFactory):
+    file_name = "eigenfrequency_response"
+
+    def test_execution(self):
+        self._calculate_response_and_gradient()
+
+        self.assertAlmostEqual(self.value, 0.014123803835107267)
+
+        self.assertAlmostEqual(self.gradient[19][0], -2.629125898327006e-09)
+        self.assertAlmostEqual(self.gradient[19][1], -0.0070165270383214864)
+        self.assertAlmostEqual(self.gradient[19][2], 1.0549911195848093e-08)
+
 
 if __name__ == "__main__":
     suites = KratosUnittest.KratosSuites
@@ -158,6 +177,7 @@ if __name__ == "__main__":
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestAdjointStressResponseFunction]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestMassResponseFunction]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestStrainEnergyResponseFunction]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestAdjointEigenfrequencyResponseFunction]))
     allSuite = suites['all']
     allSuite.addTests(smallSuite)
     KratosUnittest.runTests(suites)

--- a/applications/StructuralMechanicsApplication/tests/structural_response_function_test_factory.py
+++ b/applications/StructuralMechanicsApplication/tests/structural_response_function_test_factory.py
@@ -156,7 +156,7 @@ class TestStrainEnergyResponseFunction(StructuralResponseFunctionTestFactory):
         self.assertAlmostEqual(self.gradient[nodeId][2], -1.5466215093998671e-07, 9)
 
 @KratosUnittest.skipUnless(has_eigensolvers_application,"Missing required application: EigenSolversApplication")
-class TestAdjointEigenfrequencyResponseFunction(StructuralResponseFunctionTestFactory):
+class TestEigenfrequencyResponseFunction(StructuralResponseFunctionTestFactory):
     file_name = "eigenfrequency_response"
 
     def test_execution(self):
@@ -177,7 +177,7 @@ if __name__ == "__main__":
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestAdjointStressResponseFunction]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestMassResponseFunction]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestStrainEnergyResponseFunction]))
-    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestAdjointEigenfrequencyResponseFunction]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestEigenfrequencyResponseFunction]))
     allSuite = suites['all']
     allSuite.addTests(smallSuite)
     KratosUnittest.runTests(suites)

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -183,6 +183,7 @@ from structural_response_function_test_factory import TestAdjointDisplacementRes
 from structural_response_function_test_factory import TestAdjointStressResponseFunction as TTestAdjointStressResponseFunction
 from structural_response_function_test_factory import TestMassResponseFunction as TTestMassResponseFunction
 from structural_response_function_test_factory import TestStrainEnergyResponseFunction as TTestStrainEnergyResponseFunction
+from structural_response_function_test_factory import TestEigenfrequencyResponseFunction as TTestEigenfrequencyResponseFunction
 
 def AssembleTestSuites():
     ''' Populates the test suites to run.
@@ -328,6 +329,7 @@ def AssembleTestSuites():
 
     nightSuite.addTest(TTestMassResponseFunction('test_execution'))
     nightSuite.addTest(TTestStrainEnergyResponseFunction('test_execution'))
+    nightSuite.addTest(TTestEigenfrequencyResponseFunction('test_execution'))
     nightSuite.addTest(TTestAdjointStrainEnergyResponseFunction('test_execution'))
     nightSuite.addTest(TTestAdjointDisplacementResponseFunction('test_execution'))
     nightSuite.addTest(TTestAdjointStressResponseFunction('test_execution'))


### PR DESCRIPTION
Fixes the eigenfrequency sensitivities for shells: Previously, the DOF ordering was not considered when creating an "eigenvector of elements size" from the nodal value `EIGENVECTOR_MATRIX`. 

A test is added.

closes #2556