### PR TITLE
Core/fixing tests for amatrix

### DIFF
--- a/kratos/tests/utilities/test_discont_utils.cpp
+++ b/kratos/tests/utilities/test_discont_utils.cpp
@@ -144,7 +144,7 @@ namespace Kratos
 			KRATOS_CHECK_NEAR(edge_areas(2), 0.25, 1e-6);
 		}
 
-		KRATOS_TEST_CASE_IN_SUITE(TriangleVercitalDiscontUtils, KratosCoreFastSuite)
+		KRATOS_TEST_CASE_IN_SUITE(TriangleVerticalDiscontUtils, KratosCoreFastSuite)
 		{
 			// Generate a model part with the previous
 			ModelPart base_model_part("Triangle");

--- a/kratos/utilities/discont_utils.h
+++ b/kratos/utilities/discont_utils.h
@@ -1052,7 +1052,7 @@ private:
         return 0.5 * ((x1 - x0)*(y2 - y0)- (y1 - y0)*(x2 - x0));
     }
 
-    static inline void CalculateGeometryData(const BoundedMatrix<double, 3, 3 > & rCoordinates,
+    static inline void CalculateGeometryData(const BoundedMatrix<double, 3, 2 > & rCoordinates,
                                              BoundedMatrix<double,3,2>& rDN_DX,
                                              double& rArea)
     {
@@ -1081,7 +1081,7 @@ private:
         rArea = 0.5*detJ;
     }
 
-    static inline void CalculateGeometryData(BoundedMatrix<double, 4, 3 > & rCoordinates,
+    static inline void CalculateGeometryData(const BoundedMatrix<double, 4, 3 > & rCoordinates,
                                              BoundedMatrix<double,4,3>& rDN_DX,
                                              double& rVolume)
     {

--- a/kratos/utilities/discont_utils.h
+++ b/kratos/utilities/discont_utils.h
@@ -1117,7 +1117,7 @@ private:
         rVolume = detJ / 6.0;
     }
 
-    static inline void CalculatePosition(const BoundedMatrix<double, 3, 3 > & rCoordinates,
+    static inline void CalculatePosition(const BoundedMatrix<double, 3, 2 > & rCoordinates,
                                          const double xc,
                                          const double yc,
                                          const double zc,


### PR DESCRIPTION
Fixing a couple more tests when compiling in AMatrix mode. This one was a real bug (wrong size matrices in function signatures), which ublas for some reason did not notice.