### PR TITLE
Fixes in the trilinos convergence criteria.

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_struct_pinched_cylinder_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_struct_pinched_cylinder_parameters.json
@@ -20,7 +20,7 @@
         "material_import_settings"           : {
             "materials_filename" : "shell_test/Shell_linear_static_pinched_cylinder_materials.json"
         },
-        "multi_point_constraints_used" : false,
+        "multi_point_constraints_used"       : false,
         "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,

--- a/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_struct_pinched_cylinder_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/shell_test/Shell_T3andQ4_linear_static_struct_pinched_cylinder_parameters.json
@@ -20,6 +20,7 @@
         "material_import_settings"           : {
             "materials_filename" : "shell_test/Shell_linear_static_pinched_cylinder_materials.json"
         },
+        "multi_point_constraints_used" : false,
         "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,

--- a/applications/trilinos_application/custom_python/add_trilinos_convergence_criterias_to_python.cpp
+++ b/applications/trilinos_application/custom_python/add_trilinos_convergence_criterias_to_python.cpp
@@ -47,6 +47,7 @@
 //#include "solving_strategies/convergencecriterias/displacement_criteria.h"
 //
 #include "custom_strategies/convergencecriterias/trilinos_displacement_criteria.h"
+#include "custom_strategies/convergencecriterias/trilinos_residual_criteria.h"
 #include "custom_strategies/convergencecriterias/trilinos_up_criteria.h"
 
 //teuchos parameter list
@@ -101,8 +102,8 @@ void  AddConvergenceCriterias(pybind11::module& m)
             (m,"TrilinosUPCriteria")
             .def(init< double, double, double, double >());
 
-    class_< ResidualCriteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >,
-            typename ResidualCriteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >::Pointer,
+    class_< TrilinosResidualCriteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >,
+            typename TrilinosResidualCriteria<TrilinosSparseSpaceType, TrilinosLocalSpaceType >::Pointer,
             TrilinosConvergenceCriteria >
             (m,"TrilinosResidualCriteria")
             .def(init< TrilinosSparseSpaceType::DataType, TrilinosSparseSpaceType::DataType >());

--- a/applications/trilinos_application/custom_strategies/convergencecriterias/trilinos_displacement_criteria.h
+++ b/applications/trilinos_application/custom_strategies/convergencecriterias/trilinos_displacement_criteria.h
@@ -278,9 +278,11 @@ private:
         TDataType local_ReferenceDispNorm = TDataType();
         TDataType temp;
 
+        const double rank = rModelPart.GetCommunicator().MyPID(); // double because I want to compare with PARTITION_INDEX
+
         for(typename DofsArrayType::iterator i_dof = rDofSet.begin() ; i_dof != rDofSet.end() ; ++i_dof)
         {
-            if(i_dof->IsFree())
+            if(i_dof->IsFree() && (i_dof->GetSolutionStepValue(PARTITION_INDEX) == rank))
             {
                 temp = i_dof->GetSolutionStepValue();
                 local_ReferenceDispNorm += temp*temp;

--- a/applications/trilinos_application/custom_strategies/convergencecriterias/trilinos_displacement_criteria.h
+++ b/applications/trilinos_application/custom_strategies/convergencecriterias/trilinos_displacement_criteria.h
@@ -276,16 +276,16 @@ private:
     TDataType CalculateReferenceNorm(DofsArrayType& rDofSet, ModelPart& rModelPart)
     {
         TDataType local_ReferenceDispNorm = TDataType();
-        TDataType temp;
+        TDataType value;
 
         const double rank = rModelPart.GetCommunicator().MyPID(); // double because I want to compare with PARTITION_INDEX
 
-        for(typename DofsArrayType::iterator i_dof = rDofSet.begin() ; i_dof != rDofSet.end() ; ++i_dof)
+        for(auto it_dof = rDofSet.begin() ; it_dof != rDofSet.end() ; ++it_dof)
         {
-            if(i_dof->IsFree() && (i_dof->GetSolutionStepValue(PARTITION_INDEX) == rank))
+            if(it_dof->IsFree() && (it_dof->GetSolutionStepValue(PARTITION_INDEX) == rank))
             {
-                temp = i_dof->GetSolutionStepValue();
-                local_ReferenceDispNorm += temp*temp;
+                value = it_dof->GetSolutionStepValue();
+                local_ReferenceDispNorm += value*value;
             }
         }
 

--- a/applications/trilinos_application/custom_strategies/convergencecriterias/trilinos_residual_criteria.h
+++ b/applications/trilinos_application/custom_strategies/convergencecriterias/trilinos_residual_criteria.h
@@ -1,0 +1,149 @@
+//  KRATOS  _____     _ _ _
+//         |_   _| __(_) (_)_ __   ___  ___
+//           | || '__| | | | '_ \ / _ \/ __|
+//           | || |  | | | | | | | (_) \__
+//           |_||_|  |_|_|_|_| |_|\___/|___/ APPLICATION
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Jordi Cotela
+//
+
+#if !defined(KRATOS_TRILINOS_RESIDUAL_CRITERIA_H_INCLUDED)
+#define  KRATOS_TRILINOS_RESIDUAL_CRITERIA_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+#include "solving_strategies/convergencecriterias/residual_criteria.h"
+
+namespace Kratos
+{
+///@addtogroup TrilinosApplication
+///@{
+
+///@name Kratos Classes
+///@{
+
+/// MPI version of the ResidualCriteria.
+/** Implements a convergence criteria based on the norm of the (free rows of) the RHS vector.
+ *  @see ResidualCriteria
+ */
+template< class TSparseSpace, class TDenseSpace >
+class TrilinosResidualCriteria : public ResidualCriteria< TSparseSpace, TDenseSpace >
+{
+public:
+
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of TrilinosResidualCriteria
+    KRATOS_CLASS_POINTER_DEFINITION(TrilinosResidualCriteria);
+
+    typedef ResidualCriteria< TSparseSpace, TDenseSpace > BaseType;
+
+    typedef typename BaseType::TDataType TDataType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Constructor
+    explicit TrilinosResidualCriteria(TDataType NewRatioTolerance,TDataType AlwaysConvergedNorm):
+        ResidualCriteria<TSparseSpace,TDenseSpace>(NewRatioTolerance, AlwaysConvergedNorm)
+    {}
+
+    /// Copy constructor
+    explicit TrilinosResidualCriteria(const TrilinosResidualCriteria& rOther):
+        ResidualCriteria<TSparseSpace,TDenseSpace>(rOther)
+    {}
+
+    /// Destructor.
+    ~TrilinosResidualCriteria() override {}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Deleted assignment operator.
+    TrilinosResidualCriteria& operator=(TrilinosResidualCriteria const& rOther) = delete;
+
+    ///@}
+
+protected:
+
+    ///@name Protected Operations
+    ///@{
+
+    /**
+     * @brief This method computes the norm of the residual
+     * @details It checks if the dof is fixed
+     * @param rResidualSolutionNorm The norm of the residual
+     * @param rDofNum The number of DoFs
+     * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
+     * @param b RHS vector (residual + reactions)
+     */
+    void CalculateResidualNorm(
+        TDataType& rResidualSolutionNorm,
+        typename BaseType::SizeType& rDofNum,
+        typename BaseType::DofsArrayType& rDofSet,
+        const typename BaseType::TSystemVectorType& rB) override
+    {
+        // Initialize
+        TDataType residual_solution_norm = TDataType();
+        long int local_dof_num = 0;
+
+        const double rank = rB.Comm().MyPID(); // To compare with PARTITION_INDEX, which is a double variable
+
+        // Loop over Dofs
+        #pragma omp parallel for reduction(+:residual_solution_norm,local_dof_num)
+        for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
+            auto it_dof = rDofSet.begin() + i;
+
+            typename BaseType::IndexType dof_id;
+            TDataType residual_dof_value;
+
+            if (it_dof->IsFree() && (it_dof->GetSolutionStepValue(PARTITION_INDEX) == rank)) {
+                dof_id = it_dof->EquationId();
+                residual_dof_value = TSparseSpace::GetValue(rB,dof_id);
+                residual_solution_norm += residual_dof_value * residual_dof_value;
+                local_dof_num++;
+            }
+        }
+
+        // Combine local contributions
+        // Note that I'm not merging the two calls because one adds doubles and the other ints (JC)
+        rB.Comm().SumAll(&residual_solution_norm,&rResidualSolutionNorm,1);
+        // SizeType is long unsigned int in linux, but EpetraComm does not support unsigned types
+        long int global_dof_num = 0;
+        rB.Comm().SumAll(&local_dof_num,&global_dof_num,1);
+        rDofNum = static_cast<typename BaseType::SizeType>(global_dof_num);
+    }
+
+    ///@}
+
+private:
+
+    ///@name Member Variables
+    ///@{
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+
+}; // Class TrilinosResidualCriteria
+
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_TRILINOS_RESIDUAL_CRITERIA_H_INCLUDED  defined

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -262,6 +262,44 @@ protected:
     ///@name Protected Operations
     ///@{
 
+    /**
+     * @brief This method computes the norm of the residual
+     * @details It checks if the dof is fixed
+     * @param rResidualSolutionNorm The norm of the residual
+     * @param rDofNum The number of DoFs
+     * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
+     * @param b RHS vector (residual + reactions)
+     */
+    virtual void CalculateResidualNorm(
+        TDataType& rResidualSolutionNorm,
+        SizeType& rDofNum,
+        DofsArrayType& rDofSet,
+        const TSystemVectorType& b
+        )
+    {
+        // Initialize
+        TDataType residual_solution_norm = TDataType();
+        SizeType dof_num = 0;
+
+        // Loop over Dofs
+        #pragma omp parallel for reduction(+:residual_solution_norm,dof_num)
+        for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
+            auto it_dof = rDofSet.begin() + i;
+
+            IndexType dof_id;
+            TDataType residual_dof_value;
+
+            if (it_dof->IsFree()) {
+                dof_id = it_dof->EquationId();
+                residual_dof_value = TSparseSpace::GetValue(b,dof_id);
+                residual_solution_norm += residual_dof_value * residual_dof_value;
+                dof_num++;
+            }
+        }
+
+        rDofNum = dof_num;
+        rResidualSolutionNorm = residual_solution_norm;
+    }
 
     ///@}
     ///@name Protected  Access
@@ -311,45 +349,6 @@ private:
     ///@}
     ///@name Private Operations
     ///@{
-
-    /**
-     * @brief This method computes the norm of the residual
-     * @details It checks if the dof is fixed
-     * @param rResidualSolutionNorm The norm of the residual
-     * @param rDofNum The number of DoFs
-     * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
-     * @param b RHS vector (residual + reactions)
-     */
-    void CalculateResidualNorm(
-        TDataType& rResidualSolutionNorm,
-        SizeType& rDofNum,
-        DofsArrayType& rDofSet,
-        const TSystemVectorType& b
-        )
-    {
-        // Initialize
-        TDataType residual_solution_norm = TDataType();
-        SizeType dof_num = 0;
-
-        // Loop over Dofs
-        #pragma omp parallel for reduction(+:residual_solution_norm,dof_num)
-        for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
-            auto it_dof = rDofSet.begin() + i;
-
-            IndexType dof_id;
-            TDataType residual_dof_value;
-
-            if (it_dof->IsFree()) {
-                dof_id = it_dof->EquationId();
-                residual_dof_value = TSparseSpace::GetValue(b,dof_id);
-                residual_solution_norm += residual_dof_value * residual_dof_value;
-                dof_num++;
-            }
-        }
-
-        rDofNum = dof_num;
-        rResidualSolutionNorm = residual_solution_norm;
-    }
 
     ///@}
     ///@name Private  Access


### PR DESCRIPTION
Essentially implementing the trilinos version of ResidualCriteria, which was not working in MPI after recent changes. In the process, I noticed a problem with the TrilinosDisplacementCriteria, which is fixed here too.

Tests are not working but they were already failing after the modifications in ResidualCriteria. @philbucher will provide a new set of result values.

@philbucher I have not yet added the function to check if DoF are local in the spaces, I'm not sure they belong there (spaces deal with vectors, not with DoF). We can discuss where to put these functions in your convergence criteria branch.

This closes #2654.