### PR TITLE
[MeshMoving] Explicit FM-ALE fix iterator (reference instead of copy)

### DIFF
--- a/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.cpp
+++ b/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.cpp
@@ -66,7 +66,7 @@ namespace Kratos
 
         // Copy the origin model part elements
         auto &r_elems = rOriginModelPart.Elements();
-        for(auto elem : r_elems){
+        for(auto &elem : r_elems){
             // Set the array of virtual nodes to create the element from the original ids.
             PointsArrayType nodes_array;
             auto &r_orig_geom = elem.GetGeometry();


### PR DESCRIPTION
The new MeshElement raised this potential source of errors. @philbucher and @loumalouomega thanks again!

(this fixes #2950)