### PR TITLE
[Core] Fix norm in residual criteria and revert tests to original values

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_truss.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_truss.py
@@ -105,7 +105,7 @@ class TestTruss3D2N(KratosUnittest.TestCase):
         linear_solver = KratosMultiphysics.SkylineLUFactorizationSolver()
         builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver)
         scheme = KratosMultiphysics.ResidualBasedIncrementalUpdateStaticScheme()
-        convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-16,1e-24)
+        convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-8,1e-8)
         convergence_criterion.SetEchoLevel(0)
 
         max_iters = 1000
@@ -131,7 +131,7 @@ class TestTruss3D2N(KratosUnittest.TestCase):
         linear_solver = KratosMultiphysics.SkylineLUFactorizationSolver()
         builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver)
         scheme = KratosMultiphysics.ResidualBasedBossakDisplacementScheme(0.00)
-        convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-16,1e-24)
+        convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-8,1e-8)
         convergence_criterion.SetEchoLevel(0)
 
         max_iters = 1000

--- a/applications/trilinos_application/custom_strategies/convergencecriterias/trilinos_residual_criteria.h
+++ b/applications/trilinos_application/custom_strategies/convergencecriterias/trilinos_residual_criteria.h
@@ -122,6 +122,8 @@ protected:
         long int global_dof_num = 0;
         rB.Comm().SumAll(&local_dof_num,&global_dof_num,1);
         rDofNum = static_cast<typename BaseType::SizeType>(global_dof_num);
+
+        rResidualSolutionNorm = std::sqrt(rResidualSolutionNorm);
     }
 
     ///@}

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -298,7 +298,7 @@ protected:
         }
 
         rDofNum = dof_num;
-        rResidualSolutionNorm = residual_solution_norm;
+        rResidualSolutionNorm = std::sqrt(residual_solution_norm);
     }
 
     ///@}


### PR DESCRIPTION
This PR fixes a bug in the computation of the 2-norm (missing sqrt), introduced between commits  11377efe6a7f5cdf0de8d2fe33f77f21ee8692fb and ba897e37f633dbc14a7fe08206be23dc46e8ca11

Most importantly, it reverts tolerance values used in a Structural Mechanics test to the original values, so tests are passing again. The test failed after the modification of the computation of the norm, so the test was changed. I understand that with the modification in the routine, it was expected different results, so a change in the test might be needed. This is just a remainder to be VERY CAREFUL when modifying tests, as it completely defeats their purpose. 

```
--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_truss.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_truss.py
@@ -92,7 +92,7 @@ class TestTruss3D2N(KratosUnittest.TestCase):
         linear_solver = KratosMultiphysics.SkylineLUFactorizationSolver()
         builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver)
         scheme = KratosMultiphysics.ResidualBasedIncrementalUpdateStaticScheme()
-        convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-8,1e-8)
+        convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-16,1e-24)
         convergence_criterion.SetEchoLevel(0)

         max_iters = 1000
@@ -118,7 +118,7 @@ class TestTruss3D2N(KratosUnittest.TestCase):
         linear_solver = KratosMultiphysics.SkylineLUFactorizationSolver()
         builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver)
         scheme = KratosMultiphysics.ResidualBasedBossakDisplacementScheme(0.00)
-        convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-8,1e-8)
+        convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-16,1e-24)
         convergence_criterion.SetEchoLevel(0)
```
