### PR TITLE
[TrilinosImportModelPartUtility] add option to skip reading modelpart

### DIFF
--- a/applications/trilinos_application/python_scripts/trilinos_import_model_part_utility.py
+++ b/applications/trilinos_application/python_scripts/trilinos_import_model_part_utility.py
@@ -88,6 +88,9 @@ class TrilinosImportModelPartUtility():
 
             RestartUtility(self.main_model_part, restart_settings).LoadRestart()
 
+        elif input_type == "use_input_model_part":
+            pass
+
         else:
             raise Exception("Other input options are not yet implemented.")
 


### PR DESCRIPTION
to make it consistent with the serial version => see [here](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/python_scripts/python_solver.py#L160-L161)