### PR TITLE
[Core] removing misleading comment in Element and Condition

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -869,18 +869,6 @@ public:
         KRATOS_CATCH("")
     }
 
-    //METHODS TO BE CLEANED: DEPRECATED start
-
-
-    //NOTE: They will be deleted in December, 2015
-
-
-    /**
-     * CONDITIONS inherited from this class must implement this methods
-     * if they need to add dynamic condition contributions
-     * MassMatrix, AddMassMatrix, DampingMatrix, AddInertiaForces methods are: OPTIONAL and OBSOLETE
-     */
-
     /**
      * this is called during the assembling process in order
      * to calculate the condition mass matrix

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -212,7 +212,7 @@ public:
     @return SizeType, working space dimension of this geometry.
     */
 
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please ask the geometry directly") SizeType WorkingSpaceDimension() const
+    SizeType WorkingSpaceDimension() const
     {
         return pGetGeometry()->WorkingSpaceDimension();
     }
@@ -887,7 +887,7 @@ public:
      * @param rMassMatrix the condition mass matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void MassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+    virtual void MassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rMassMatrix.size1() != 0)
       rMassMatrix.resize(0, 0, false);
@@ -899,7 +899,7 @@ public:
      * @param coeff the given factor
      * @param rCurrentProcessInfo the current process info instance
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix, double coeff, ProcessInfo& rCurrentProcessInfo)
+    virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix, double coeff, ProcessInfo& rCurrentProcessInfo)
     {
     }
 
@@ -909,7 +909,7 @@ public:
      * @param rDampMatrix the condition damping matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void DampMatrix(MatrixType& rDampMatrix, ProcessInfo& rCurrentProcessInfo)
+    virtual void DampMatrix(MatrixType& rDampMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampMatrix.size1() != 0)
       rDampMatrix.resize(0, 0, false);
@@ -919,7 +919,7 @@ public:
      * adds the inertia forces to the RHS --> performs residua = static_residua - coeff*M*acc
      * @param rCurrentProcessInfo the current process info instance
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff, ProcessInfo& rCurrentProcessInfo)
+    virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff, ProcessInfo& rCurrentProcessInfo)
     {
     }
 
@@ -930,7 +930,7 @@ public:
      * @param rRightHandSideVector the condition right hand side matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampingMatrix.size1() != 0)
       rDampingMatrix.resize(0, 0, false);

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -212,7 +212,7 @@ public:
     @return SizeType, working space dimension of this geometry.
     */
 
-    SizeType WorkingSpaceDimension() const
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please ask the geometry directly") SizeType WorkingSpaceDimension() const
     {
         return pGetGeometry()->WorkingSpaceDimension();
     }

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -887,7 +887,7 @@ public:
      * @param rMassMatrix the condition mass matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void MassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void MassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rMassMatrix.size1() != 0)
       rMassMatrix.resize(0, 0, false);
@@ -899,7 +899,7 @@ public:
      * @param coeff the given factor
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix, double coeff, ProcessInfo& rCurrentProcessInfo)
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix, double coeff, ProcessInfo& rCurrentProcessInfo)
     {
     }
 
@@ -909,7 +909,7 @@ public:
      * @param rDampMatrix the condition damping matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void DampMatrix(MatrixType& rDampMatrix, ProcessInfo& rCurrentProcessInfo)
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void DampMatrix(MatrixType& rDampMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampMatrix.size1() != 0)
       rDampMatrix.resize(0, 0, false);
@@ -919,7 +919,7 @@ public:
      * adds the inertia forces to the RHS --> performs residua = static_residua - coeff*M*acc
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff, ProcessInfo& rCurrentProcessInfo)
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff, ProcessInfo& rCurrentProcessInfo)
     {
     }
 
@@ -930,7 +930,7 @@ public:
      * @param rRightHandSideVector the condition right hand side matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampingMatrix.size1() != 0)
       rDampingMatrix.resize(0, 0, false);

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -938,7 +938,7 @@ public:
      * @param rMassMatrix the elemental mass matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void MassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+   KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void MassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rMassMatrix.size1() != 0)
 	  rMassMatrix.resize(0, 0, false);
@@ -950,7 +950,7 @@ public:
      * @param coeff the given factor
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix,
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix,
                                double coeff, ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -961,7 +961,7 @@ public:
      * @param rDampMatrix the elemental damping matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void DampMatrix(MatrixType& rDampMatrix, ProcessInfo& rCurrentProcessInfo)
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void DampMatrix(MatrixType& rDampMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampMatrix.size1() != 0)
 	  rDampMatrix.resize(0, 0, false);
@@ -971,7 +971,7 @@ public:
      * adds the inertia forces to the RHS --> performs residua = static_residua - coeff*M*acc
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff,
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff,
                                   ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -982,7 +982,7 @@ public:
      * @param rRightHandSideVector the elemental right hand side matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
             VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampingMatrix.size1() != 0)

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -921,17 +921,6 @@ public:
         KRATOS_CATCH("")
     }
 
-    //METHODS TO BE CLEANED: DEPRECATED start
-
-    //NOTE: They will be deleted in December, 2015
-
-
-    /**
-     * ELEMENTS inherited from this class must implement this methods
-     * if they need to add dynamic element contributions
-     * MassMatrix, AddMassMatrix, DampMatrix, AddInertiaForces methods are: OPTIONAL and OBSOLETE
-     */
-
     /**
      * this is called during the assembling process in order
      * to calculate the elemental mass matrix

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -207,7 +207,7 @@ public:
 	@return SizeType, working space dimension of this geometry.
     */
 
-    SizeType WorkingSpaceDimension() const
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please ask the geometry directly") SizeType WorkingSpaceDimension() const
     {
          return pGetGeometry()->WorkingSpaceDimension();
     }

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -207,7 +207,7 @@ public:
 	@return SizeType, working space dimension of this geometry.
     */
 
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please ask the geometry directly") SizeType WorkingSpaceDimension() const
+    SizeType WorkingSpaceDimension() const
     {
          return pGetGeometry()->WorkingSpaceDimension();
     }
@@ -938,7 +938,7 @@ public:
      * @param rMassMatrix the elemental mass matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-   KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void MassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
+    virtual void MassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rMassMatrix.size1() != 0)
 	  rMassMatrix.resize(0, 0, false);
@@ -950,7 +950,7 @@ public:
      * @param coeff the given factor
      * @param rCurrentProcessInfo the current process info instance
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix,
+    virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix,
                                double coeff, ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -961,7 +961,7 @@ public:
      * @param rDampMatrix the elemental damping matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void DampMatrix(MatrixType& rDampMatrix, ProcessInfo& rCurrentProcessInfo)
+    virtual void DampMatrix(MatrixType& rDampMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampMatrix.size1() != 0)
 	  rDampMatrix.resize(0, 0, false);
@@ -971,7 +971,7 @@ public:
      * adds the inertia forces to the RHS --> performs residua = static_residua - coeff*M*acc
      * @param rCurrentProcessInfo the current process info instance
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff,
+    virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff,
                                   ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -982,7 +982,7 @@ public:
      * @param rRightHandSideVector the elemental right hand side matrix
      * @param rCurrentProcessInfo the current process info instance
      */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
+    virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
             VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampingMatrix.size1() != 0)


### PR DESCRIPTION
While looking through the code in element and condition I saw that [there are several functions that are deprecated and were supposed to be removed in December 2015](https://github.com/KratosMultiphysics/Kratos/blob/master/kratos/includes/condition.h#L872-L937) (I had just started using Kratos back then :D )

I don't know how relevant this still is but looking at the functions I think it still is

@jcotela the function `CalculateLocalVelocityContribution` is among those functions, it seems to be used a lot in fluids. What do you think? To me it sounds quite specific.

Also I deprecated `WorkingSpaceDimension` since it only calls the Geometry. The same functionality can be achieved by asking the Element/Condition first for the Geometry and then The Geometry for the WorkingSpaceDimension

After all this is a proposal for improving/cleaning `Condition` and `Element`
Decision is up to you @KratosMultiphysics/technical-committee 