### PR TITLE
deprecating WorkingSpaceDimension in Condition / Element

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -212,7 +212,7 @@ public:
     @return SizeType, working space dimension of this geometry.
     */
 
-    SizeType WorkingSpaceDimension() const
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please ask directly the Geometry") SizeType WorkingSpaceDimension() const
     {
         return pGetGeometry()->WorkingSpaceDimension();
     }

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -207,7 +207,7 @@ public:
 	@return SizeType, working space dimension of this geometry.
     */
 
-    SizeType WorkingSpaceDimension() const
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please ask directly the Geometry") SizeType WorkingSpaceDimension() const
     {
          return pGetGeometry()->WorkingSpaceDimension();
     }


### PR DESCRIPTION
as suggested by @jcotela this should be discussed in a separate PR

I think this method is not really necessary since the Geometry can directly be asked