### PR TITLE
Adding execution of apps-cpp-tests in run-tests.py

### DIFF
--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -185,11 +185,15 @@ class Commander(object):
                         file=sys.stderr)
                     sys.stderr.flush()
 
-    def RunCppTests(self):
+    def RunCppTests(self, applications):
         ''' Calls the cpp tests directly
         '''
 
         self.exitCode = 0
+
+        # importing the apps such that they get registered for the cpp-tests
+        for application in applications:
+            __import__("KratosMultiphysics." + application)
 
         try:
             Tester.SetVerbosity(Tester.Verbosity.PROGRESS)
@@ -325,7 +329,7 @@ def main():
     # Run the cpp tests (does the same as run_cpp_tests.py)
     print('Running cpp tests', file=sys.stderr)
     with SupressConsoleOutput():
-        commander.RunCppTests()
+        commander.RunCppTests(applications)
 
     exit_code = max(exit_code, commander.exitCode)
 


### PR DESCRIPTION
I noticed that the cpp-tests of the apps are not run when running `run_tests.py`

Since the number of cpp-tests in the apps increases I suggest to add them

I am not sure if my solution is the best one but it seems to work and also is not much change