### PR TITLE
[MPI-Python] function renamings

### DIFF
--- a/applications/DEM_application/python_scripts/DEM_material_test_script.py
+++ b/applications/DEM_application/python_scripts/DEM_material_test_script.py
@@ -156,11 +156,11 @@ class MaterialTest(object):
 
         (self.xtop_area,self.xbot_area,self.xlat_area,self.xtopcorner_area,self.xbotcorner_area,y_top_total,weight_top, y_bot_total, weight_bot) = self.CylinderSkinDetermination()
 
-        #xtop_area_gath        = mpi.allgather(mpi.world, xtop_area)
-        #xbot_area_gath        = mpi.allgather(mpi.world, xbot_area)
-        #xlat_area_gath        = mpi.allgather(mpi.world, xlat_area)
-        #xtopcorner_area_gath  = mpi.allgather(mpi.world, xtopcorner_area)
-        #xbotcorner_area_gath  = mpi.allgather(mpi.world, xbotcorner_area)
+        #xtop_area_gath        = mpi.allgather_double(mpi.world, xtop_area)
+        #xbot_area_gath        = mpi.allgather_double(mpi.world, xbot_area)
+        #xlat_area_gath        = mpi.allgather_double(mpi.world, xlat_area)
+        #xtopcorner_area_gath  = mpi.allgather_double(mpi.world, xtopcorner_area)
+        #xbotcorner_area_gath  = mpi.allgather_double(mpi.world, xbotcorner_area)
 
         #xtop_area = reduce(lambda x, y: x + y, xtop_area_gath)
         #xbot_area = reduce(lambda x, y: x + y, xbot_area_gath)
@@ -168,10 +168,10 @@ class MaterialTest(object):
         #xtopcorner_area = reduce(lambda x, y: x + y, xtopcorner_area_gath)
         #xbotcorner_area = reduce(lambda x, y: x + y, xbotcorner_area_gath)
 
-        #weight_top_gath = mpi.allgather(mpi.world, weight_top)
-        #weight_bot_gath = mpi.allgather(mpi.world, weight_bot)
-        #y_top_total_gath = mpi.allgather(mpi.world, y_top_total)
-        #y_bot_total_gath = mpi.allgather(mpi.world, y_bot_total)
+        #weight_top_gath = mpi.allgather_double(mpi.world, weight_top)
+        #weight_bot_gath = mpi.allgather_double(mpi.world, weight_bot)
+        #y_top_total_gath = mpi.allgather_double(mpi.world, y_top_total)
+        #y_bot_total_gath = mpi.allgather_double(mpi.world, y_bot_total)
 
         #weight_top = reduce(lambda x, y: x + y, weight_top_gath)
         #weight_bot = reduce(lambda x, y: x + y, weight_bot_gath)

--- a/applications/DEM_application/python_scripts/DEM_material_test_script_mpi.py
+++ b/applications/DEM_application/python_scripts/DEM_material_test_script_mpi.py
@@ -61,11 +61,11 @@ class MaterialTest(DEM_material_test_script.MaterialTest):
 
         (xtop_area,xbot_area,xlat_area,xtopcorner_area,xbotcorner_area,y_top_total,weight_top, y_bot_total, weight_bot) = self.CylinderSkinDetermination()
 
-        xtop_area_gath        = mpi.allgather(mpi.world, xtop_area)
-        xbot_area_gath        = mpi.allgather(mpi.world, xbot_area)
-        xlat_area_gath        = mpi.allgather(mpi.world, xlat_area)
-        xtopcorner_area_gath  = mpi.allgather(mpi.world, xtopcorner_area)
-        xbotcorner_area_gath  = mpi.allgather(mpi.world, xbotcorner_area)
+        xtop_area_gath        = mpi.allgather_double(mpi.world, xtop_area)
+        xbot_area_gath        = mpi.allgather_double(mpi.world, xbot_area)
+        xlat_area_gath        = mpi.allgather_double(mpi.world, xlat_area)
+        xtopcorner_area_gath  = mpi.allgather_double(mpi.world, xtopcorner_area)
+        xbotcorner_area_gath  = mpi.allgather_double(mpi.world, xbotcorner_area)
 
         xtop_area = reduce(lambda x, y: x + y, xtop_area_gath)
         xbot_area = reduce(lambda x, y: x + y, xbot_area_gath)
@@ -73,10 +73,10 @@ class MaterialTest(DEM_material_test_script.MaterialTest):
         xtopcorner_area = reduce(lambda x, y: x + y, xtopcorner_area_gath)
         xbotcorner_area = reduce(lambda x, y: x + y, xbotcorner_area_gath)
 
-        weight_top_gath = mpi.allgather(mpi.world, weight_top)
-        weight_bot_gath = mpi.allgather(mpi.world, weight_bot)
-        y_top_total_gath = mpi.allgather(mpi.world, y_top_total)
-        y_bot_total_gath = mpi.allgather(mpi.world, y_bot_total)
+        weight_top_gath = mpi.allgather_double(mpi.world, weight_top)
+        weight_bot_gath = mpi.allgather_double(mpi.world, weight_bot)
+        y_top_total_gath = mpi.allgather_double(mpi.world, y_top_total)
+        y_bot_total_gath = mpi.allgather_double(mpi.world, y_bot_total)
 
         weight_top = reduce(lambda x, y: x + y, weight_top_gath)
         weight_bot = reduce(lambda x, y: x + y, weight_bot_gath)
@@ -116,10 +116,10 @@ class MaterialTest(DEM_material_test_script.MaterialTest):
             self.bot_mesh_nodes = smp.Nodes
             prepare_check[3] = -1
 
-    prepare_check_gath[0] = mpi.gather(mpi.world,prepare_check[0],0)
-    prepare_check_gath[1] = mpi.gather(mpi.world,prepare_check[1],0)
-    prepare_check_gath[2] = mpi.gather(mpi.world,prepare_check[2],0)
-    prepare_check_gath[3] = mpi.gather(mpi.world,prepare_check[3],0)
+    prepare_check_gath[0] = mpi.gather_int(mpi.world,prepare_check[0],0)
+    prepare_check_gath[1] = mpi.gather_int(mpi.world,prepare_check[1],0)
+    prepare_check_gath[2] = mpi.gather_int(mpi.world,prepare_check[2],0)
+    prepare_check_gath[3] = mpi.gather_int(mpi.world,prepare_check[3],0)
 
     if(mpi.rank == 0 ):
       prepare_check[0] = reduce(lambda x,y: max(x,y), prepare_check_gath[0])
@@ -152,7 +152,7 @@ class MaterialTest(DEM_material_test_script.MaterialTest):
         total_force_bts += force_node_y
 
       if(mpi.rank == 0 ):
-        total_force_bts_gather = mpi.gather(mpi.world, total_force_bts, 0)
+        total_force_bts_gather = mpi.gather_double(mpi.world, total_force_bts, 0)
         total_force_bts = reduce(lambda x, y: x + y, total_force_bts_gather)
 
         self.total_stress_bts = 2.0*total_force_bts/(3.14159*self.parameters.SpecimenLength*self.parameters.SpecimenDiameter*1e6)
@@ -175,7 +175,7 @@ class MaterialTest(DEM_material_test_script.MaterialTest):
 
         total_force_top += force_node_y
 
-      total_force_top_gath = mpi.allgather(mpi.world, total_force_top)
+      total_force_top_gath = mpi.allgather_double(mpi.world, total_force_top)
       total_force_top = reduce(lambda x, y: x + y, total_force_top_gath)
 
       self.total_stress_top = total_force_top/(self.parameters.MeasuringSurface*1000000)
@@ -186,7 +186,7 @@ class MaterialTest(DEM_material_test_script.MaterialTest):
 
         total_force_bot += force_node_y
 
-      total_force_bot_gath = mpi.allgather(mpi.world, total_force_bot)
+      total_force_bot_gath = mpi.allgather_double(mpi.world, total_force_bot)
       total_force_bot = reduce(lambda x, y: x + y, total_force_bot_gath)
 
       self.total_stress_bot = total_force_bot/(self.parameters.MeasuringSurface*1000000)
@@ -238,8 +238,8 @@ class MaterialTest(DEM_material_test_script.MaterialTest):
 
       weight += r*r
 
-    mean_radial_strain_gath = mpi.allgather(mpi.world,mean_radial_strain)
-    weight_gath = mpi.allgather(mpi.world,weight)
+    mean_radial_strain_gath = mpi.allgather_double(mpi.world,mean_radial_strain)
+    weight_gath = mpi.allgather_double(mpi.world,weight)
 
     mean_radial_strain = reduce(lambda x, y: x + y, mean_radial_strain_gath)
     weight = reduce(lambda x, y: x + y, weight_gath)

--- a/applications/DEM_application/python_scripts/DEM_procedures_mpi.py
+++ b/applications/DEM_application/python_scripts/DEM_procedures_mpi.py
@@ -71,7 +71,7 @@ class Procedures(DEM_procedures.Procedures):
     def FindMaxNodeIdInModelPart(self, model_part):
 
         node_max = super(Procedures,self).FindMaxNodeIdInModelPart(model_part)
-        node_max_gath = mpi.allgather(mpi.world,node_max)
+        node_max_gath = mpi.allgather_int(mpi.world,node_max)
         total_max = reduce(lambda x,y: max(x,y), node_max_gath)
         return total_max
 

--- a/applications/trilinos_application/tests/test_kratos_mpi_interface.py
+++ b/applications/trilinos_application/tests/test_kratos_mpi_interface.py
@@ -11,7 +11,7 @@ class TestKratosMPIInterface(KratosUnittest.TestCase):
 
         my_value = my_rank # this is an int
 
-        gathered_values = mpi.gather(mpi.world, my_value, rank_to_gather_on)
+        gathered_values = mpi.gather_int(mpi.world, my_value, rank_to_gather_on)
 
         self.assertEqual(type(gathered_values), list)
 
@@ -29,7 +29,7 @@ class TestKratosMPIInterface(KratosUnittest.TestCase):
 
         my_value = my_rank+0.5 # this is a double
 
-        gathered_values = mpi.gather(mpi.world, my_value, rank_to_gather_on)
+        gathered_values = mpi.gather_double(mpi.world, my_value, rank_to_gather_on)
 
         self.assertEqual(type(gathered_values), list)
 
@@ -50,7 +50,7 @@ class TestKratosMPIInterface(KratosUnittest.TestCase):
         for i in range(my_rank+1):
             local_list.append(i+1.3)
 
-        gathered_lists = mpi.gatherv(mpi.world, local_list, rank_to_gather_on) # this is a list of lists, one from each rank
+        gathered_lists = mpi.gatherv_double(mpi.world, local_list, rank_to_gather_on) # this is a list of lists, one from each rank
 
         self.assertEqual(type(gathered_lists), list)
         for sublist in gathered_lists:
@@ -70,7 +70,7 @@ class TestKratosMPIInterface(KratosUnittest.TestCase):
     def test_allgather_int(self):
         my_value = mpi.rank # this is an int
 
-        gathered_values = mpi.allgather(mpi.world, my_value)
+        gathered_values = mpi.allgather_int(mpi.world, my_value)
 
         self.assertEqual(type(gathered_values), list)
 
@@ -82,7 +82,7 @@ class TestKratosMPIInterface(KratosUnittest.TestCase):
     def test_allgather_double(self):
         my_value = mpi.rank+0.5 # this is a double
 
-        gathered_values = mpi.allgather(mpi.world, my_value)
+        gathered_values = mpi.allgather_double(mpi.world, my_value)
 
         self.assertEqual(type(gathered_values), list)
 
@@ -164,7 +164,7 @@ class TestKratosMPIInterface(KratosUnittest.TestCase):
         val_to_broadcast = (mpi.rank+1)*5
         rank_to_broadcast_from = 0
 
-        broadcasted_value = mpi.broadcast(mpi.world, val_to_broadcast, rank_to_broadcast_from)
+        broadcasted_value = mpi.broadcast_int(mpi.world, val_to_broadcast, rank_to_broadcast_from)
 
         exp_val = (rank_to_broadcast_from+1)*5
 
@@ -174,29 +174,47 @@ class TestKratosMPIInterface(KratosUnittest.TestCase):
         val_to_broadcast = (mpi.rank+1)*5.333
         rank_to_broadcast_from = 0
 
-        broadcasted_value = mpi.broadcast(mpi.world, val_to_broadcast, rank_to_broadcast_from)
+        broadcasted_value = mpi.broadcast_double(mpi.world, val_to_broadcast, rank_to_broadcast_from)
 
         exp_val = (rank_to_broadcast_from+1)*5.333
 
         self.assertAlmostEqual(exp_val, broadcasted_value)
 
-    def test_reduce_int_max(self):
+    def test_max_int(self):
         self._execute_reduction_test_int_max(is_allreduce=False)
 
-    def test_allreduce_int_max(self):
+    def test_max_all_int(self):
         self._execute_reduction_test_int_max(is_allreduce=True)
 
-    def test_reduce_int_min(self):
+    def test_min_int(self):
         self._execute_reduction_test_int_min(is_allreduce=False)
 
-    def test_allreduce_int_min(self):
+    def test_min_all_int(self):
         self._execute_reduction_test_int_min(is_allreduce=True)
 
-    def test_reduce_int_sum(self):
+    def test_sum_int(self):
         self._execute_reduction_test_int_sum(is_allreduce=False)
 
-    def test_allreduce_int_sum(self):
+    def test_sum_all_int(self):
         self._execute_reduction_test_int_sum(is_allreduce=True)
+
+    def test_max_double(self):
+        self._execute_reduction_test_double_max(is_allreduce=False)
+
+    def test_max_all_double(self):
+        self._execute_reduction_test_double_max(is_allreduce=True)
+
+    def test_min_double(self):
+        self._execute_reduction_test_double_min(is_allreduce=False)
+
+    def test_min_all_double(self):
+        self._execute_reduction_test_double_min(is_allreduce=True)
+
+    def test_sum_double(self):
+        self._execute_reduction_test_double_sum(is_allreduce=False)
+
+    def test_sum_all_double(self):
+        self._execute_reduction_test_double_sum(is_allreduce=True)
 
     def _execute_reduction_test_int_max(self, is_allreduce):
         my_rank = mpi.rank
@@ -205,9 +223,9 @@ class TestKratosMPIInterface(KratosUnittest.TestCase):
         my_value = my_rank + 2 # this is an int
 
         if is_allreduce:
-            max_val = mpi.allreduce(mpi.world, my_value, mpi.MPI_op.MAX)
+            max_val = mpi.max_all_int(mpi.world, my_value)
         else:
-            max_val = mpi.reduce(mpi.world, my_value, rank_to_reduce_on, mpi.MPI_op.MAX)
+            max_val = mpi.max_int(mpi.world, my_value, rank_to_reduce_on)
 
         if is_allreduce or my_rank == rank_to_reduce_on:
             self.assertEqual(mpi.size+1, max_val)
@@ -219,9 +237,9 @@ class TestKratosMPIInterface(KratosUnittest.TestCase):
         my_value = my_rank - 2 # this is an int
 
         if is_allreduce:
-            min_val = mpi.allreduce(mpi.world, my_value, mpi.MPI_op.MIN)
+            min_val = mpi.min_all_int(mpi.world, my_value)
         else:
-            min_val = mpi.reduce(mpi.world, my_value, rank_to_reduce_on, mpi.MPI_op.MIN)
+            min_val = mpi.min_int(mpi.world, my_value, rank_to_reduce_on)
 
         if is_allreduce or my_rank == rank_to_reduce_on:
             self.assertEqual(-2, min_val)
@@ -233,14 +251,60 @@ class TestKratosMPIInterface(KratosUnittest.TestCase):
         my_value = my_rank+1 # this is an int
 
         if is_allreduce:
-            sum_val = mpi.allreduce(mpi.world, my_value, mpi.MPI_op.SUM)
+            sum_val = mpi.sum_all_int(mpi.world, my_value)
         else:
-            sum_val = mpi.reduce(mpi.world, my_value, rank_to_reduce_on, mpi.MPI_op.SUM)
+            sum_val = mpi.sum_int(mpi.world, my_value, rank_to_reduce_on)
 
         if is_allreduce or my_rank == rank_to_reduce_on:
             comm_size = mpi.size
             exp_val = int((comm_size)*(comm_size+1)/2)
             self.assertEqual(exp_val, sum_val)
+
+    def _execute_reduction_test_double_max(self, is_allreduce):
+        my_rank = mpi.rank
+        rank_to_reduce_on = 0
+
+        my_value = my_rank + 2.34 # this is a double
+
+        if is_allreduce:
+            max_val = mpi.max_all_double(mpi.world, my_value)
+        else:
+            max_val = mpi.max_double(mpi.world, my_value, rank_to_reduce_on)
+
+        if is_allreduce or my_rank == rank_to_reduce_on:
+            self.assertAlmostEqual(mpi.size+1.34, max_val)
+
+    def _execute_reduction_test_double_min(self, is_allreduce):
+        my_rank = mpi.rank
+        rank_to_reduce_on = 0
+
+        my_value = my_rank - 2.45 # this is a double
+
+        if is_allreduce:
+            min_val = mpi.min_all_double(mpi.world, my_value)
+        else:
+            min_val = mpi.min_double(mpi.world, my_value, rank_to_reduce_on)
+
+        if is_allreduce or my_rank == rank_to_reduce_on:
+            self.assertAlmostEqual(-2.45, min_val)
+
+    def _execute_reduction_test_double_sum(self, is_allreduce):
+        my_rank = mpi.rank
+        rank_to_reduce_on = 0
+
+        offset = 1.932
+
+        my_value = my_rank+offset # this is a double
+
+        if is_allreduce:
+            sum_val = mpi.sum_all_double(mpi.world, my_value)
+        else:
+            sum_val = mpi.sum_double(mpi.world, my_value, rank_to_reduce_on)
+
+        if is_allreduce or my_rank == rank_to_reduce_on:
+            comm_size = mpi.size
+            exp_val = comm_size*(offset + (comm_size-1)/2)
+            self.assertAlmostEqual(exp_val, sum_val)
 
 def DoubleScatterVList(range_list):
     return [(2.125**x)/(2**(x-6)) for x in range_list]

--- a/external_libraries/mpi_python/python_interface.cpp
+++ b/external_libraries/mpi_python/python_interface.cpp
@@ -44,29 +44,39 @@ PYBIND11_MODULE(mpipython, m)
     const auto py_mpi = py::class_<PythonMPI>(m,"PythonMPI")
     .def_property_readonly("rank",FRank)
     .def_property_readonly("size",FSize)
-    .def("broadcast",&PythonMPI::broadcast<double>)
-    .def("broadcast",&PythonMPI::broadcast<int>)
-    .def("reduce",&PythonMPI::reduce<double>)
-    .def("reduce",&PythonMPI::reduce<int>)
-    .def("allreduce",&PythonMPI::allreduce<double>)
-    .def("allreduce",&PythonMPI::allreduce<int>)
+    .def_property_readonly("world",&PythonMPI::GetWorld,py::return_value_policy::reference_internal )
+
+    .def("broadcast_double",&PythonMPI::broadcast<double>)
+    .def("broadcast_int",&PythonMPI::broadcast<int>)
+
+    .def("max_double",&PythonMPI::max<double>)
+    .def("max_int",&PythonMPI::max<int>)
+    .def("min_double",&PythonMPI::min<double>)
+    .def("min_int",&PythonMPI::min<int>)
+    .def("sum_double",&PythonMPI::sum<double>)
+    .def("sum_int",&PythonMPI::sum<int>)
+
+    .def("max_all_double",&PythonMPI::max_all<double>)
+    .def("max_all_int",&PythonMPI::max_all<int>)
+    .def("min_all_double",&PythonMPI::min_all<double>)
+    .def("min_all_int",&PythonMPI::min_all<int>)
+    .def("sum_all_double",&PythonMPI::sum_all<double>)
+    .def("sum_all_int",&PythonMPI::sum_all<int>)
+
     .def("scatter_double", &PythonMPI::scatter<double>)
     .def("scatter_int", &PythonMPI::scatter<int>)
+
     .def("scatterv_double", &PythonMPI::scatterv<double>)
     .def("scatterv_int", &PythonMPI::scatterv<int>)
-    .def("gather", &PythonMPI::gather<double>)
-    .def("gather", &PythonMPI::gather<int>)
-    .def("gatherv", &PythonMPI::gatherv<double>)
-    .def("gatherv", &PythonMPI::gatherv<int>)
-    .def("allgather",&PythonMPI::allgather<double>)
-    .def("allgather",&PythonMPI::allgather<int>)
-    .def_property_readonly("world",&PythonMPI::GetWorld,py::return_value_policy::reference_internal )
-    ;
 
-    py::enum_<PythonMPI::MPI_Operation>(py_mpi, "MPI_op")
-    .value("MAX", PythonMPI::MPI_Operation::MAX)
-    .value("MIN", PythonMPI::MPI_Operation::MIN)
-    .value("SUM", PythonMPI::MPI_Operation::SUM)
+    .def("gather_double", &PythonMPI::gather<double>)
+    .def("gather_int", &PythonMPI::gather<int>)
+
+    .def("gatherv_double", &PythonMPI::gatherv<double>)
+    .def("gatherv_int", &PythonMPI::gatherv<int>)
+
+    .def("allgather_double",&PythonMPI::allgather<double>)
+    .def("allgather_int",&PythonMPI::allgather<int>)
     ;
 
     m.def("GetMPIInterface",&GetMPIInterface,py::return_value_policy::reference);


### PR DESCRIPTION
This PR changes the function_names in the MPI_python interface => now the data-type has to be specified
This follows what has to be done for MPI natively

This is done because sometimes it is necessary (e.g. for scatter) and also to prevent potential deadlocks (e.g. if on one list an int is passed and on another rank a double => different functions are called => deadlock) => this would be very nasty to debug

Also more datatypes can be easily specified, e.g. bool

Sorry for the noise, I think I am done now, this should now also be usable for the MPI-Core

@maceligueta I updated what I wound in the DEM-App, can you please have a look