### PR TITLE
Adding const to empty check in data_value_container

### DIFF
--- a/kratos/containers/data_value_container.h
+++ b/kratos/containers/data_value_container.h
@@ -310,7 +310,7 @@ public:
         return (std::find_if(mData.begin(), mData.end(), IndexCheck(rThisVariable.GetSourceVariable().Key())) != mData.end());
     }
 
-    bool IsEmpty()
+    bool IsEmpty() const
     {
         return mData.empty();
     }


### PR DESCRIPTION
When operating with const properties object, this method can not be called if it is not const.