### PR TITLE
Adding properties get Tables object

### DIFF
--- a/kratos/includes/properties.h
+++ b/kratos/includes/properties.h
@@ -291,6 +291,15 @@ public:
         return mData;
     }
 
+    TablesContainerType& Tables()
+    {
+        return mTables;
+    }
+
+    TablesContainerType const& Tables() const
+    {
+        return mTables;
+    }
 
 
     ///@}


### PR DESCRIPTION
Data container of properties can be obtained, but not Tables container, this method is of the same importance and is missing here.