### PR TITLE
[Fluid] Nodal density and viscosity in old elements

### DIFF
--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_drag_utils.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_drag_utils.cpp
@@ -51,6 +51,7 @@ namespace Kratos {
             rModelPart.AddNodalSolutionStepVariable(MESH_VELOCITY);
             rModelPart.AddNodalSolutionStepVariable(SOUND_VELOCITY);
             rModelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
+            rModelPart.AddNodalSolutionStepVariable(REACTION_WATER_PRESSURE);
 
             // Process info creation
             double delta_time = 0.1;

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_ausas_navier_stokes_wall_condition.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_ausas_navier_stokes_wall_condition.cpp
@@ -42,6 +42,7 @@ namespace Kratos {
 			modelPart.SetBufferSize(3);
 
 			// Variables addition
+			modelPart.AddNodalSolutionStepVariable(DISTANCE);
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
 			modelPart.AddNodalSolutionStepVariable(DENSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
@@ -50,6 +51,7 @@ namespace Kratos {
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
 			modelPart.AddNodalSolutionStepVariable(VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(MESH_VELOCITY);
+			modelPart.AddNodalSolutionStepVariable(EXTERNAL_PRESSURE);
 
 			// Process info creation
 			double delta_time = 0.1;
@@ -151,6 +153,7 @@ namespace Kratos {
 			// Variables addition
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
 			modelPart.AddNodalSolutionStepVariable(DENSITY);
+			modelPart.AddNodalSolutionStepVariable(REACTION);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_TAU);
 			modelPart.AddNodalSolutionStepVariable(SOUND_VELOCITY);
@@ -159,6 +162,7 @@ namespace Kratos {
 			modelPart.AddNodalSolutionStepVariable(DISTANCE);
 			modelPart.AddNodalSolutionStepVariable(EMBEDDED_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(MESH_VELOCITY);
+			modelPart.AddNodalSolutionStepVariable(EXTERNAL_PRESSURE);
 
 			// Process info creation
 			double delta_time = 0.1;
@@ -247,13 +251,13 @@ namespace Kratos {
 			KRATOS_CHECK_NEAR(condRHS(1),  0.0, tolerance);
 			KRATOS_CHECK_NEAR(condRHS(2),  0.0, tolerance);
 			KRATOS_CHECK_NEAR(condRHS(3),  0.0034375, tolerance);
-			KRATOS_CHECK_NEAR(condRHS(4), -0.00583333, tolerance);
-			KRATOS_CHECK_NEAR(condRHS(5),  0.0141667, tolerance);
-			KRATOS_CHECK_NEAR(condRHS(6), -0.0025, tolerance);
+			KRATOS_CHECK_NEAR(condRHS(4),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(condRHS(5),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(condRHS(6),  0.0, tolerance);
 			KRATOS_CHECK_NEAR(condRHS(7),  0.0115625, tolerance);
-			KRATOS_CHECK_NEAR(condRHS(8), -0.0065625, tolerance);
-			KRATOS_CHECK_NEAR(condRHS(9),  0.0159375, tolerance);
-			KRATOS_CHECK_NEAR(condRHS(10), -0.0028125, tolerance);
+			KRATOS_CHECK_NEAR(condRHS(8),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(condRHS(9),  0.0, tolerance);
+			KRATOS_CHECK_NEAR(condRHS(10), 0.0, tolerance);
 			KRATOS_CHECK_NEAR(condRHS(11), 0.0111458, tolerance);
 		}
 	} // namespace Testing

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element.cpp
@@ -30,6 +30,8 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     model_part.SetBufferSize(3);
 
     // Variables addition
+    model_part.AddNodalSolutionStepVariable(DENSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
+    model_part.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
     model_part.AddNodalSolutionStepVariable(BODY_FORCE);
     model_part.AddNodalSolutionStepVariable(DYNAMIC_TAU);
     model_part.AddNodalSolutionStepVariable(SOUND_VELOCITY);
@@ -92,6 +94,8 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     Element::Pointer p_element = model_part.pGetElement(1);
 
     for(unsigned int i=0; i<3; i++){
+        p_element->GetGeometry()[i].FastGetSolutionStepValue(DENSITY) = p_properties->GetValue(DENSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
+        p_element->GetGeometry()[i].FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = p_properties->GetValue(DYNAMIC_VISCOSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
         p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE)    = 0.0;
         p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 1) = 0.0;
         p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 2) = 0.0;

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element.cpp
@@ -32,6 +32,7 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     // Variables addition
     model_part.AddNodalSolutionStepVariable(DENSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
     model_part.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
+    model_part.AddNodalSolutionStepVariable(REACTION);
     model_part.AddNodalSolutionStepVariable(BODY_FORCE);
     model_part.AddNodalSolutionStepVariable(DYNAMIC_TAU);
     model_part.AddNodalSolutionStepVariable(SOUND_VELOCITY);
@@ -40,6 +41,9 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     model_part.AddNodalSolutionStepVariable(MESH_VELOCITY);
     model_part.AddNodalSolutionStepVariable(DISTANCE);
     model_part.AddNodalSolutionStepVariable(ACCELERATION);
+    model_part.AddNodalSolutionStepVariable(EXTERNAL_PRESSURE);
+    model_part.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
+    model_part.AddNodalSolutionStepVariable(REACTION_WATER_PRESSURE);
 
     // For VMS comparison
     model_part.AddNodalSolutionStepVariable(NODAL_AREA);

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_navier_stokes_element.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_navier_stokes_element.cpp
@@ -40,6 +40,8 @@ namespace Kratos {
 			modelPart.SetBufferSize(3);
 
 			// Variables addition
+			modelPart.AddNodalSolutionStepVariable(DISTANCE);
+			modelPart.AddNodalSolutionStepVariable(REACTION);
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
 			modelPart.AddNodalSolutionStepVariable(DENSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
@@ -48,6 +50,8 @@ namespace Kratos {
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
 			modelPart.AddNodalSolutionStepVariable(VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(MESH_VELOCITY);
+			modelPart.AddNodalSolutionStepVariable(EMBEDDED_VELOCITY);
+			modelPart.AddNodalSolutionStepVariable(EXTERNAL_PRESSURE);
 
 			// Process info creation
 			double delta_time = 0.1;
@@ -121,13 +125,13 @@ namespace Kratos {
 			// hence, it is assumed that if the RHS is correct, the LHS is correct as well)
 			KRATOS_CHECK_NEAR(RHS(0), 0.0475309, 1e-7);
 			KRATOS_CHECK_NEAR(RHS(1), 0.0975309, 1e-7);
-			KRATOS_CHECK_NEAR(RHS(2), -0.0545696, 1e-7);
+			KRATOS_CHECK_NEAR(RHS(2), -0.0546391, 1e-7);
 			KRATOS_CHECK_NEAR(RHS(3), 0.0469136, 1e-7);
 			KRATOS_CHECK_NEAR(RHS(4), 0.0969136, 1e-7);
 			KRATOS_CHECK_NEAR(RHS(5), 0.0176796, 1e-7);
 			KRATOS_CHECK_NEAR(RHS(6), 16436.9, 1e-1 );
 			KRATOS_CHECK_NEAR(RHS(7), 33828.9, 1e-1);
-			KRATOS_CHECK_NEAR(RHS(8), 0.0202233, 1e-7);
+			KRATOS_CHECK_NEAR(RHS(8), 0.0202928, 1e-7);
 		}
 
 	    // /** Checks the EmbeddedNavierStokes3D4N element.

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_qs_vms_element.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_qs_vms_element.cpp
@@ -39,6 +39,8 @@ KRATOS_TEST_CASE_IN_SUITE(QSVMS2D4N, FluidDynamicsApplicationFastSuite)
     model_part.AddNodalSolutionStepVariable(NODAL_AREA);
     model_part.AddNodalSolutionStepVariable(ADVPROJ);
     model_part.AddNodalSolutionStepVariable(DIVPROJ);
+    model_part.AddNodalSolutionStepVariable(REACTION);
+    model_part.AddNodalSolutionStepVariable(REACTION_WATER_PRESSURE);
 
     // Process info creation
     double delta_time = 0.1;


### PR DESCRIPTION
@jcotela in last PR we removed the nodal density and viscosity from the embedded elements tests. I didn't realize that the old elements still use it (because of this we got a nan in all the RHS values). The worse point is that the nan's aren't catch by the KRATOS_CHECK_NEAR... This is a potential source of underlying troubles and it's probably worth to start a general discussion on that.

I did also realize that several tests were failing in FullDebug mode because of the variables allocation. I took the chance to also fix that.