### PR TITLE
Core/adding matrix row allias

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/fluid_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/fluid_element.h
@@ -92,11 +92,7 @@ public:
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
     /// Type for shape function values container
-    #ifdef KRATOS_USE_AMATRIX
-    typedef AMatrix::MatrixRow< Matrix > ShapeFunctionsType;
-    #else
-    typedef boost::numeric::ublas::matrix_row< Matrix > ShapeFunctionsType;
-    #endif
+    typedef MatrixRow< Matrix > ShapeFunctionsType;
 
     /// Type for a matrix containing the shape function gradients
     typedef Kratos::Matrix ShapeFunctionDerivativesType;
@@ -439,7 +435,7 @@ protected:
      * Such boundary integral must be implemented in all the fluid dynamics elements
      * deriving from this one in accordance to the formulation used. This method is
      * intended to be called from the derived elements to add the contribution of the
-     * tractions on the elemental cuts to enforce equilibrium. This means that what we 
+     * tractions on the elemental cuts to enforce equilibrium. This means that what we
      * call external traction is nothing but minus the base formulation boundary term.
      * @param rData Element data structure
      * @param rUnitNormal Outwards unit normal vector for the cut plane

--- a/applications/FluidDynamicsApplication/custom_utilities/fluid_element_data.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fluid_element_data.h
@@ -47,11 +47,7 @@ public:
 
     using ShapeDerivativesType = BoundedMatrix<double,TNumNodes,TDim>;
 
-    #ifdef KRATOS_USE_AMATRIX
-    typedef AMatrix::MatrixRow< Matrix > MatrixRowType;
-    #else
-    typedef boost::numeric::ublas::matrix_row< Matrix > MatrixRowType;
-    #endif
+    using MatrixRowType = MatrixRow< Matrix >;
 
     /// Physical space dimension for the problem.
     constexpr static unsigned int Dim = TDim;

--- a/kratos/includes/amatrix_interface.h
+++ b/kratos/includes/amatrix_interface.h
@@ -448,6 +448,8 @@ template <typename T> AMatrix::TransposeMatrix<T> trans(T& TheMatrix){ return AM
 
 template <typename TExpressionType> using vector_expression = AMatrix::MatrixExpression<TExpressionType,AMatrix::row_major_access>;
 
+template <typename TExpressionType> using MatrixRow = AMatrix::MatrixRow<TExpressionType>;
+
 
 template <typename TDataType>
 class KratosZeroMatrix

--- a/kratos/includes/ublas_interface.h
+++ b/kratos/includes/ublas_interface.h
@@ -99,12 +99,13 @@ namespace Kratos
     //typedef sparse_matrix<double> SparseMatrix;
     typedef mapped_matrix<double> SparseMatrix;
     typedef coordinate_matrix<double> CoordinateMatrix;
-    typedef matrix_row<Matrix> MatrixRow;
     typedef matrix_column<Matrix> MatrixColumn;
     typedef matrix_vector_range<Matrix> MatrixVectorRange;
     typedef matrix_vector_slice<Matrix> MatrixVectorSlice;
     typedef matrix_range<Matrix> MatrixRange;
     typedef matrix_slice<Matrix> MatrixSlice;
+
+	template <typename TExpressionType> using MatrixRow = matrix_row<TExpressionType>;
 
 #endif // ifndef KRATOS_USE_AMATRIX
 

--- a/kratos/solving_strategies/schemes/residual_based_adjoint_bossak_scheme.h
+++ b/kratos/solving_strategies/schemes/residual_based_adjoint_bossak_scheme.h
@@ -578,7 +578,7 @@ private:
             if (aux_adjoint_vector.size() != mSecondDerivsLHS[k].size1())
                 aux_adjoint_vector.resize(mSecondDerivsLHS[k].size1(), false);
             noalias(aux_adjoint_vector) =
-                -prod(mSecondDerivsLHS[k], mAdjointValuesVector[k]) -
+                prod(mSecondDerivsLHS[k], mAdjointValuesVector[k]) +
                 mSecondDerivsResponseGradient[k];
             auto& r_extensions = *r_element.GetValue(ADJOINT_EXTENSIONS);
             // Assemble the contributions to the corresponding nodal unknowns.
@@ -592,7 +592,7 @@ private:
                 r_node.SetLock();
                 for (unsigned d = 0; d < mAuxAdjointIndirectVector1[k].size(); ++d)
                 {
-                    mAuxAdjointIndirectVector1[k][d] += aux_adjoint_vector[local_index];
+                    mAuxAdjointIndirectVector1[k][d] -= aux_adjoint_vector[local_index];
                     ++local_index;
                 }
                 r_node.UnSetLock();


### PR DESCRIPTION
This PR adds a `MatrixRow` alias to amatrix interface. 

This alias was used in ublas interface to work with double Matrix. Now is changed to be an alias so it will take Matrix type as template argument and is not backward compatible. 

