### PR TITLE
[StructuralMechanics] moving slow tests

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -49,6 +49,7 @@ from test_spring_damper_element import SpringDamperElementTests as TSpringDamper
 # Harmonic analysis tests
 from test_harmonic_analysis import HarmonicAnalysisTests as THarmonicAnalysisTests
 # Dynamic basic tests
+from test_dynamic_schemes import FastDynamicSchemesTests as TFastDynamicSchemesTests
 from test_dynamic_schemes import DynamicSchemesTests as TDynamicSchemesTests
 # Eigenvalues Postprocessing Process test
 from test_postprocess_eigenvalues_process import TestPostprocessEigenvaluesProcess as TTestPostprocessEigenvaluesProcess
@@ -237,7 +238,7 @@ def AssembleTestSuites():
     # Nodal Damping
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TNodalDampingTests])) # TODO should be in smallSuite but is too slow
     # Dynamic basic tests
-    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TDynamicSchemesTests]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TFastDynamicSchemesTests]))
     # Eigenvalues Postprocessing Process test
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestPostprocessEigenvaluesProcess]))
     # local-axis visualization tests
@@ -341,6 +342,9 @@ def AssembleTestSuites():
     nightSuite.addTest(TTestAdjointStrainEnergyResponseFunction('test_execution'))
     nightSuite.addTest(TTestAdjointDisplacementResponseFunction('test_execution'))
     nightSuite.addTest(TTestAdjointStressResponseFunction('test_execution'))
+
+    # Dynamic basic tests
+    nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TDynamicSchemesTests]))
 
     nightSuite.addTests(smallSuite)
 

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -48,6 +48,7 @@ from test_nodal_damping import NodalDampingTests as TNodalDampingTests
 from test_spring_damper_element import SpringDamperElementTests as TSpringDamperElementTests
 # Harmonic analysis tests
 from test_harmonic_analysis import HarmonicAnalysisTests as THarmonicAnalysisTests
+from test_harmonic_analysis import HarmonicAnalysisTestsWithHDF5 as THarmonicAnalysisTestsWithHDF5
 # Dynamic basic tests
 from test_dynamic_schemes import FastDynamicSchemesTests as TFastDynamicSchemesTests
 from test_dynamic_schemes import DynamicSchemesTests as TDynamicSchemesTests
@@ -326,6 +327,7 @@ def AssembleTestSuites():
             nightSuite.addTest(TEigen3D3NThinCircleTests('test_execution'))
             # Harmonic analysis test
             smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([THarmonicAnalysisTests]))
+            nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([THarmonicAnalysisTestsWithHDF5]))
             # Element damping test
             nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TSpringDamperElementTests])) # TODO should be in smallSuite but is too slow
         else:

--- a/applications/StructuralMechanicsApplication/tests/test_dynamic_schemes.py
+++ b/applications/StructuralMechanicsApplication/tests/test_dynamic_schemes.py
@@ -6,11 +6,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 from math import sqrt, cos, sin
 
-class DynamicSchemesTests(KratosUnittest.TestCase):
-    def setUp(self):
-        pass
-    
-
+class BaseDynamicSchemesTests(KratosUnittest.TestCase):
     def _base_spring_test_pseudo_static_scheme(self, current_model, scheme_name = "pseudo_static", buffer_size = 2, dt = 5.0e-3, beta = 0):
         mp = current_model.CreateModelPart("sdof")
         add_variables(mp, scheme_name)
@@ -232,6 +228,8 @@ class DynamicSchemesTests(KratosUnittest.TestCase):
             self.assertAlmostEqual(node.GetSolutionStepValue(KratosMultiphysics.VELOCITY_Y,0), current_analytical_velocity_y, delta=1e-3)
             self.assertAlmostEqual(node.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y,0), current_analytical_displacement_y, delta=1e-3)
 
+
+class FastDynamicSchemesTests(BaseDynamicSchemesTests):
     def test_spring_bossak_scheme(self):
         current_model = KratosMultiphysics.Model()
         self._base_spring_test_dynamic_schemes(current_model,"bossak", 2)
@@ -264,10 +262,6 @@ class DynamicSchemesTests(KratosUnittest.TestCase):
         current_model = KratosMultiphysics.Model()
         self._base_fall_test_dynamic_schemes(current_model,"bdf2", 3)
 
-    def test_fall_explicit_scheme(self):
-        current_model = KratosMultiphysics.Model()
-        self._base_fall_test_dynamic_schemes(current_model,"explicit", 2, 1.0e-5)
-
     def test_spring_test_pseudo_static_scheme(self):
         current_model = KratosMultiphysics.Model()
         self._base_spring_test_pseudo_static_scheme(current_model,"pseudo_static", 2, 1.0e-2)
@@ -275,6 +269,11 @@ class DynamicSchemesTests(KratosUnittest.TestCase):
     def test_spring_test_pseudo_static_with_damping_scheme(self):
         current_model = KratosMultiphysics.Model()
         self._base_spring_test_pseudo_static_scheme(current_model,"pseudo_static", 2, 1.0e-2, 1.0)
+
+class DynamicSchemesTests(BaseDynamicSchemesTests):
+    def test_fall_explicit_scheme(self):
+        current_model = KratosMultiphysics.Model()
+        self._base_fall_test_dynamic_schemes(current_model,"explicit", 2, 1.0e-5)
 
 def set_and_fill_buffer(mp,buffer_size,delta_time):
     # Set buffer size

--- a/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
+++ b/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
@@ -157,8 +157,8 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
             exfreq = exfreq + df
 
     def test_damped_mdof_harmonic(self):
-        current_model = KratosMultiphysics.Model()        
-        
+        current_model = KratosMultiphysics.Model()
+
         #analytic solution taken from Humar - Dynamics of Structures p. 677
 
         #material properties
@@ -213,12 +213,13 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
 
             exfreq = exfreq + df
 
+class HarmonicAnalysisTestsWithHDF5(KratosUnittest.TestCase):
     def test_harmonic_mdpa_input(self):
         try:
             import KratosMultiphysics.HDF5Application as HDF5Application
         except ImportError as e:
             self.skipTest("HDF5Application not found: Skipping harmonic analysis mdpa test")
-        
+
         import structural_mechanics_analysis
         with ControlledExecutionScope(os.path.dirname(os.path.realpath(__file__))):
             #run simulation and write to hdf5 file

--- a/applications/StructuralMechanicsApplication/tests/test_mass_calculation.py
+++ b/applications/StructuralMechanicsApplication/tests/test_mass_calculation.py
@@ -7,9 +7,8 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 from math import sqrt, sin, cos, pi, exp, atan
 
 class TestMassCalculation(KratosUnittest.TestCase):
-    def setUp(self):
-        pass
-    
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
+
     def _add_dofs(self,mp):
         # Adding dofs AND their corresponding reactions
         KratosMultiphysics.VariableUtils().AddDof(KratosMultiphysics.DISPLACEMENT_X, KratosMultiphysics.REACTION_X,mp)


### PR DESCRIPTION
I noticed that Travis started failing more often bcs of StructuralMechanics recently, the python-tests were taking too long.

This PR moves the slowest tests to the nightly suite

@loumalouomega @KlausBSautter the dynamic-scheme-tests for the explicit stuff is quite slow, therefore I moved it
@qaumann the harmonic-analysis test with HDF5 takes very long (many) timesteps, therefore it was also moved

@KratosMultiphysics/technical-committee this should reduce the time needed for the python-tests of StructuralMechanics by ~50%

I tried several times making this PR, I am not sure if there are others around ...