### PR TITLE
[FluidDynamics] Two Fluid - redefinition of Darcy Coefficients

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
@@ -350,8 +350,8 @@ KRATOS_WATCH(Ngauss);  */
 
         // Porous media losses
         const Properties& r_properties = this->GetProperties();
-        const double A = r_properties[LIN_DARCY_COEF];
-        const double B = r_properties[NONLIN_DARCY_COEF];
+        const double c1 = r_properties[LIN_DARCY_COEF];
+        const double c2 = r_properties[NONLIN_DARCY_COEF];
 
 
         //****************************************************
@@ -385,7 +385,7 @@ KRATOS_WATCH(Ngauss);  */
             this->GetAdvectiveVel(AdvVel, N);
             const double VelNorm = MathUtils<double>::Norm3(AdvVel);
 
-            const double DarcyTerm = this->CalculateDarcyTerm(Density, Viscosity, A, B, N);
+            const double DarcyTerm = this->CalculateDarcyTerm(Density, Viscosity, c1, c2, N);
             // Calculate stabilization parameters
             double TauOne, TauTwo;
 
@@ -501,7 +501,7 @@ KRATOS_WATCH(Ngauss);  */
             this->GetAdvectiveVel(AdvVel, N);
             const double VelNorm = MathUtils<double>::Norm3(AdvVel);
 
-            const double DarcyTerm = this->CalculateDarcyTerm(Density, Viscosity, A, B, N);
+            const double DarcyTerm = this->CalculateDarcyTerm(Density, Viscosity, c1, c2, N);
 
             double TauOne,TauTwo;
             this->CalculateStabilizationTau(TauOne, TauTwo, VelNorm, ElemSize, Density, Viscosity, DarcyTerm, rCurrentProcessInfo);

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
@@ -385,7 +385,7 @@ KRATOS_WATCH(Ngauss);  */
             this->GetAdvectiveVel(AdvVel, N);
             const double VelNorm = MathUtils<double>::Norm3(AdvVel);
 
-            const double DarcyTerm = this->CalculateDarcyTerm(A,B,N);
+            const double DarcyTerm = this->CalculateDarcyTerm(Density, Viscosity, A, B, N);
             // Calculate stabilization parameters
             double TauOne, TauTwo;
 
@@ -501,7 +501,7 @@ KRATOS_WATCH(Ngauss);  */
             this->GetAdvectiveVel(AdvVel, N);
             const double VelNorm = MathUtils<double>::Norm3(AdvVel);
 
-            const double DarcyTerm = this->CalculateDarcyTerm(A,B,N);
+            const double DarcyTerm = this->CalculateDarcyTerm(Density, Viscosity, A, B, N);
 
             double TauOne,TauTwo;
             this->CalculateStabilizationTau(TauOne, TauTwo, VelNorm, ElemSize, Density, Viscosity, DarcyTerm, rCurrentProcessInfo);
@@ -1107,6 +1107,8 @@ protected:
     }
 
     virtual double CalculateDarcyTerm(
+        const double Density,
+        const double DynamicViscosity,
         const double LinearCoefficient,
         const double NonlinearCoefficient,
         const array_1d<double, TNumNodes>& rShapefunctions) {
@@ -1115,7 +1117,7 @@ protected:
         this->GetAdvectiveVel(velocity, rShapefunctions);
         const double velocity_norm = MathUtils<double>::Norm3(velocity);
 
-        return LinearCoefficient + NonlinearCoefficient*velocity_norm;
+        return DynamicViscosity * LinearCoefficient + Density * NonlinearCoefficient*velocity_norm;
     }
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms_linearized_darcy.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms_linearized_darcy.h
@@ -145,6 +145,8 @@ protected:
     ///@{
 
     double CalculateDarcyTerm(
+        const double Density,
+        const double DynamicViscosity,
         const double LinearCoefficient,
         const double NonlinearCoefficient,
         const array_1d<double, TNumNodes>& rShapefunctions) override {
@@ -153,7 +155,7 @@ protected:
         this->GetAdvectiveVel(old_velocity, rShapefunctions,1);
         const double old_velocity_norm = MathUtils<double>::Norm3(old_velocity);
 
-        return LinearCoefficient + NonlinearCoefficient*old_velocity_norm;
+        return DynamicViscosity * LinearCoefficient + Density * NonlinearCoefficient*old_velocity_norm;
     }
     ///@}
 

--- a/applications/FluidDynamicsApplication/tests/darcy_channel_test.py
+++ b/applications/FluidDynamicsApplication/tests/darcy_channel_test.py
@@ -175,8 +175,8 @@ class DarcyChannelTest(UnitTest.TestCase):
         self.rho = fluid.density
         self.nu = fluid.kinematic_viscosity
 
-        self.linear_darcy_coefficient = self.rho * self.nu / filt.k1
-        self.nonlinear_darcy_coefficient = self.rho / filt.k2
+        self.linear_darcy_coefficient = 1.0 / filt.k1
+        self.nonlinear_darcy_coefficient = 1.0 / filt.k2
 
         print("A: {0} B: {1}".format(self.linear_darcy_coefficient,self.nonlinear_darcy_coefficient))
 
@@ -192,7 +192,7 @@ class DarcyChannelTest(UnitTest.TestCase):
 
 
         # dP/dX = (mu/k1) * u0 + (rho/k2) * u0**2
-        expected_pressure_drop = (self.xmax - self.xmin) * (self.linear_darcy_coefficient*self.u0 + self.nonlinear_darcy_coefficient*self.u0**2)
+        expected_pressure_drop = (self.xmax - self.xmin) * (self.nu*self.rho*self.linear_darcy_coefficient*self.u0 + self.rho*self.nonlinear_darcy_coefficient*self.u0**2)
         measured_pressure_drop = p_in - p_out
         rel_error = 100. * (measured_pressure_drop-expected_pressure_drop)/expected_pressure_drop
         outfile.write("{0}; {1}; {2}; {3}; {4}; {5}; {6}\n".format(fluid.name,filt.name,self.dt,self.dynamic_tau,expected_pressure_drop,measured_pressure_drop,rel_error))
@@ -304,7 +304,7 @@ class DarcyChannelTest(UnitTest.TestCase):
             p_out = node_out.GetSolutionStepValue(PRESSURE)
 
             # dP/dX = (mu/k1) * u0 + (rho/k2) * u0**2
-            expected_pressure_drop = (self.xmax-self.xmin) * (self.linear_darcy_coefficient*self.u0 + self.nonlinear_darcy_coefficient*self.u0**2)
+            expected_pressure_drop = (self.xmax-self.xmin) * (self.nu*self.rho*self.linear_darcy_coefficient*self.u0 + self.rho*self.nonlinear_darcy_coefficient*self.u0**2)
             measured_pressure_drop = p_in - p_out
             self.assertAlmostEqual(expected_pressure_drop,measured_pressure_drop,6)
         else:

--- a/applications/FluidDynamicsApplication/tests/darcy_channel_test.py
+++ b/applications/FluidDynamicsApplication/tests/darcy_channel_test.py
@@ -83,9 +83,9 @@ class DarcyChannelTest(UnitTest.TestCase):
 
     def testDarcyDensity(self):
         self.u0 = 2.0
-        self.linear_darcy_coefficient = 1.0
-        self.nonlinear_darcy_coefficient = 1.0
         self.rho = 1000.0
+        self.linear_darcy_coefficient = 1.0/self.rho
+        self.nonlinear_darcy_coefficient = 1.0/self.rho
         self.testDarcyChannel()
 
     def testReferenceValues(self):


### PR DESCRIPTION
@jcotela @jrubiogonzalez 
As we talked, the Darcy Coefficients are now defined as:

LINEAR_DARCY_COEF = c1 = 1/k1
NONLINEAR_DARCY_COEF = c2 = 1/k2

Therefore, now the Density and the Dynamic Viscosity are introduced explicitly in the formulation.
Test has been updated to take into account this modification.