### PR TITLE
Fixed clang warnings in HDF5

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp
@@ -50,17 +50,17 @@ void ConnectivitiesData::WriteData(File& rFile, const std::string& rPath, WriteI
     int ws_dim, dim, num_nodes;
     if (KratosComponents<ElementType>::Has(mName))
     {
-        const auto& r_elem = KratosComponents<ElementType>::Get(mName);
-        ws_dim = r_elem.WorkingSpaceDimension();
-        dim = r_elem.GetGeometry().Dimension();
-        num_nodes = r_elem.GetGeometry().size();
+        const auto& r_geom = KratosComponents<ElementType>::Get(mName).GetGeometry();
+        ws_dim = r_geom.WorkingSpaceDimension();
+        dim = r_geom.Dimension();
+        num_nodes = r_geom.size();
     }
     else
     {
-        const auto& r_cond = KratosComponents<ConditionType>::Get(mName);
-        ws_dim = r_cond.WorkingSpaceDimension();
-        dim = r_cond.GetGeometry().Dimension();
-        num_nodes = r_cond.GetGeometry().size();
+        const auto& r_geom = KratosComponents<ConditionType>::Get(mName).GetGeometry();
+        ws_dim = r_geom.WorkingSpaceDimension();
+        dim = r_geom.Dimension();
+        num_nodes = r_geom.size();
     }
     rFile.WriteAttribute(rPath, "Name", mName);
     rFile.WriteAttribute(rPath, "WorkingSpaceDimension", ws_dim);

--- a/applications/HDF5Application/custom_io/hdf5_points_data.h
+++ b/applications/HDF5Application/custom_io/hdf5_points_data.h
@@ -31,7 +31,7 @@ namespace HDF5
 {
 
 class File;
-class WriteInfo;
+struct WriteInfo;
 
 namespace Internals
 {


### PR DESCRIPTION
Fixes warnings reported by @philbucher:

applications/HDF5Application/custom_io/hdf5_points_data.h:34:1: warning: class 'WriteInfo' was previously declared as a struct [-Wmismatched-tags]
applications/HDF5Application/custom_io/hdf5_connectivities_data.cpp:54:25: warning: 'WorkingSpaceDimension' is deprecated: This is legacy version, please ask directly the Geometry [-Wdeprecated-declarations]