### PR TITLE
[sdem] Renumbering utility for post-process

### DIFF
--- a/applications/swimming_DEM_application/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/swimming_DEM_application/custom_python/add_custom_utilities_to_python.cpp
@@ -82,6 +82,7 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include "custom_utilities/swimming_dem_in_pfem_utils.h"
 #include "custom_utilities/AuxiliaryFunctions.h"
 #include "custom_utilities/mesh_rotation_utility.h"
+#include "custom_utilities/renumbering_nodes_utility.h"
 
 namespace Kratos{
 
@@ -490,6 +491,15 @@ void  AddCustomUtilitiesToPython(pybind11::module& m){
         .def("RotateDEMMesh", &MeshRotationUtility::RotateDEMMesh)
         .def("SetStationaryField", &MeshRotationUtility::SetStationaryField)
         .def("RotateFluidVelocities", &MeshRotationUtility::RotateFluidVelocities)
+        ;
+    class_<RenumberingNodesUtility> (m, "RenumberingNodesUtility")
+        .def(init<ModelPart&>())
+        .def(init<ModelPart&,ModelPart&>())
+        .def(init<ModelPart&,ModelPart&,ModelPart&>())
+        .def(init<ModelPart&,ModelPart&,ModelPart&,ModelPart&>())
+        .def(init<ModelPart&,ModelPart&,ModelPart&,ModelPart&,ModelPart&>())
+        .def("Renumber", &RenumberingNodesUtility::Renumber)
+        .def("UndoRenumber", &RenumberingNodesUtility::UndoRenumber)
         ;
     }
 

--- a/applications/swimming_DEM_application/custom_utilities/renumbering_nodes_utility.h
+++ b/applications/swimming_DEM_application/custom_utilities/renumbering_nodes_utility.h
@@ -1,0 +1,98 @@
+//Author: Miguel Angel Celigueta. maceli@cimne.upc.edu
+
+#if !defined(KRATOS_RENUMBERING_NODES_UTILITY)
+#define KRATOS_RENUMBERING_NODES_UTILITY
+
+// /* External includes */
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
+// Project includes
+#include "includes/model_part.h"
+
+#include "pybind11/stl.h"
+
+
+namespace Kratos
+{
+class RenumberingNodesUtility
+{
+
+public:
+
+KRATOS_CLASS_POINTER_DEFINITION(RenumberingNodesUtility);
+
+RenumberingNodesUtility(ModelPart& mp1) {
+    mListOfModelParts.push_back(&mp1);
+    std::map<int,int> aux_map;
+    mListOfMapsOfIdsNewToOld.push_back(aux_map);
+}
+
+RenumberingNodesUtility(ModelPart& mp1, ModelPart& mp2): RenumberingNodesUtility(mp1){
+    mListOfModelParts.push_back(&mp2);
+    std::map<int,int> aux_map;
+    mListOfMapsOfIdsNewToOld.push_back(aux_map);
+}
+
+RenumberingNodesUtility(ModelPart& mp1, ModelPart& mp2, ModelPart& mp3): RenumberingNodesUtility(mp1, mp2) {
+    mListOfModelParts.push_back(&mp3);
+    std::map<int,int> aux_map;
+    mListOfMapsOfIdsNewToOld.push_back(aux_map);
+}
+
+RenumberingNodesUtility(ModelPart& mp1, ModelPart& mp2, ModelPart& mp3, ModelPart& mp4): RenumberingNodesUtility(mp1, mp2, mp3) {
+    mListOfModelParts.push_back(&mp4);
+    std::map<int,int> aux_map;
+    mListOfMapsOfIdsNewToOld.push_back(aux_map);
+}
+
+RenumberingNodesUtility(ModelPart& mp1, ModelPart& mp2, ModelPart& mp3, ModelPart& mp4, ModelPart& mp5): RenumberingNodesUtility(mp1, mp2, mp3, mp4) {
+    mListOfModelParts.push_back(&mp5);
+    std::map<int,int> aux_map;
+    mListOfMapsOfIdsNewToOld.push_back(aux_map);
+}
+
+
+virtual ~RenumberingNodesUtility(){}
+
+void Renumber() {
+    int id = 1;
+    for (int i=0; i<(int)mListOfModelParts.size(); i++){
+        ModelPart& mp = *mListOfModelParts[i];
+        std::map<int,int>& new_to_old = mListOfMapsOfIdsNewToOld[i];
+
+        for (int j = 0; j < (int)mp.Nodes().size(); j++){
+            auto it = mp.NodesBegin() + j;
+            new_to_old[id] = it->Id();
+            it->SetId(id);
+            id++;
+        }
+    }
+}
+
+void UndoRenumber() {
+    for (int i=0; i<(int)mListOfModelParts.size(); i++){
+        ModelPart& mp = *mListOfModelParts[i];
+        std::map<int,int>& new_to_old = mListOfMapsOfIdsNewToOld[i];
+
+        for (int j = 0; j < (int)mp.Nodes().size(); j++){
+            auto it = mp.NodesBegin() + j;
+            it->SetId(new_to_old[it->Id()]);
+        }
+    }
+}
+
+
+
+private:
+
+std::vector<ModelPart*> mListOfModelParts;
+std::vector<std::map<int,int> > mListOfMapsOfIdsNewToOld;
+
+}; // Class RenumberingNodesUtility
+
+} // namespace Kratos.
+
+#endif // KRATOS_RENUMBERING_NODES_UTILITY  defined
+

--- a/applications/swimming_DEM_application/custom_utilities/swimming_dem_in_pfem_utils.h
+++ b/applications/swimming_DEM_application/custom_utilities/swimming_dem_in_pfem_utils.h
@@ -63,10 +63,10 @@ void TransferWalls(ModelPart& r_source_model_part, ModelPart& r_destination_mode
   r_destination_model_part.Conditions().Sort();
   int id = 1;
   if (r_destination_model_part.Conditions().size()) {
-    id = (r_destination_model_part.ConditionsEnd()-1)->Id() + 1;  
+    id = (r_destination_model_part.ConditionsEnd()-1)->Id() + 1;
   }
 
-  ModelPart::ElementsContainerType& source_elements = r_source_model_part.Elements();    
+  ModelPart::ElementsContainerType& source_elements = r_source_model_part.Elements();
 
   for (unsigned int i = 0; i < source_elements.size(); i++) {
     ModelPart::ElementsContainerType::iterator it = r_source_model_part.ElementsBegin() + i;

--- a/applications/swimming_DEM_application/python_scripts/swimming_DEM_procedures.py
+++ b/applications/swimming_DEM_application/python_scripts/swimming_DEM_procedures.py
@@ -467,6 +467,9 @@ class PostUtils:
         Logger.Flush()
 
         if self.pp.GiDMultiFileFlag == "Multiples":
+            renumbering_utility = RenumberingNodesUtility(self.fluid_model_part, self.rigid_faces_model_part, self.balls_model_part)
+            renumbering_utility.Renumber()
+
             self.mixed_model_part.Elements.clear()
             self.mixed_model_part.Nodes.clear()
             # here order is important!
@@ -486,6 +489,9 @@ class PostUtils:
                                                self.pp.rigid_faces_nodal_results,
                                                self.pp.mixed_nodal_results,
                                                self.pp.gauss_points_results)
+
+        if self.pp.GiDMultiFileFlag == "Multiples":
+            renumbering_utility.UndoRenumber()
 
     def ComputeMeanVelocitiesinTrap(self, file_name, time_dem):
 


### PR DESCRIPTION
This puts consecutive ids to the nodes to a group of modelparts. It has Undo function so the modelparts remain unchanged after using the utility.
This was necessary because Id's were overlapped in some cases. Can't be avoided from input or computation when using PFEM and DEM.
I tried, but I could not pass an array of modelparts from Python (ModelPart::Pointer can no longer be used).