### PR TITLE
Removing call to non-existing << operator for TrilinosSpace.

### DIFF
--- a/applications/trilinos_application/custom_python/add_trilinos_space_to_python.cpp
+++ b/applications/trilinos_application/custom_python/add_trilinos_space_to_python.cpp
@@ -302,7 +302,6 @@ void  AddBasicOperations(pybind11::module& m)
     .def("CreateEmptyVectorPointer", CreateEmptyVectorPointer)
     .def("ReadMatrixMarketMatrix", ReadMatrixMarketMatrix)
     .def("SetValue", SetValue)
-    .def("__str__", PrintObject<TrilinosSparseSpaceType>)
     ;
 
 


### PR DESCRIPTION
PrintObject calls `operator<<` (which is not defined), while the old `__str__` wrapper called `PrintInfo`. Removing the method in any case, since TrilinosSpace holds no data to print.