### PR TITLE
[Core] Correcting a stupid mistake in connectivity preserve modeler. 

### DIFF
--- a/kratos/sources/connectivity_preserve_modeler.cpp
+++ b/kratos/sources/connectivity_preserve_modeler.cpp
@@ -128,16 +128,16 @@ void ConnectivityPreserveModeler::DuplicateElements(
     ModelPart &rDestinationModelPart,
     Element const &rReferenceElement)
 {
+    std::cout << "duplicating element with new create" << std::endl;
     // Generate the elements
     ModelPart::ElementsContainerType temp_elements;
     temp_elements.reserve(rOriginModelPart.NumberOfElements());
     for (auto i_elem = rOriginModelPart.ElementsBegin(); i_elem != rOriginModelPart.ElementsEnd(); ++i_elem)
     {
         Properties::Pointer properties = i_elem->pGetProperties();
-        Element::Pointer p_element = rReferenceElement.Create(i_elem->Id(), i_elem->GetGeometry(), properties);
 
         // Reuse the geometry of the old element (to save memory)
-        p_element->pGetGeometry() = i_elem->pGetGeometry();
+        Element::Pointer p_element = rReferenceElement.Create(i_elem->Id(), i_elem->pGetGeometry(), properties);
 
         temp_elements.push_back(p_element);
     }
@@ -157,10 +157,9 @@ void ConnectivityPreserveModeler::DuplicateConditions(
     for (auto i_cond = rOriginModelPart.ConditionsBegin(); i_cond != rOriginModelPart.ConditionsEnd(); ++i_cond)
     {
         Properties::Pointer properties = i_cond->pGetProperties();
-        Condition::Pointer p_condition = rReferenceBoundaryCondition.Create(i_cond->Id(), i_cond->GetGeometry(), properties);
 
         // Reuse the geometry of the old element (to save memory)
-        p_condition->pGetGeometry() = i_cond->pGetGeometry();
+        Condition::Pointer p_condition = rReferenceBoundaryCondition.Create(i_cond->Id(), i_cond->pGetGeometry(), properties);
 
         temp_conditions.push_back(p_condition);
     }

--- a/kratos/sources/connectivity_preserve_modeler.cpp
+++ b/kratos/sources/connectivity_preserve_modeler.cpp
@@ -128,7 +128,6 @@ void ConnectivityPreserveModeler::DuplicateElements(
     ModelPart &rDestinationModelPart,
     Element const &rReferenceElement)
 {
-    std::cout << "duplicating element with new create" << std::endl;
     // Generate the elements
     ModelPart::ElementsContainerType temp_elements;
     temp_elements.reserve(rOriginModelPart.NumberOfElements());


### PR DESCRIPTION
geometries were copied instead of passing the pointer.

with this correction modelparts filled by connectivity preserve modeler  should occupy way less memory.

@ddiezrod @jrubiogonzalez @pooyan-dadvand ...i owe you one (or more) beers

