### PR TITLE
[MeshMoving] removing MESH_RHS

### DIFF
--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
@@ -93,7 +93,6 @@ class MeshSolverBase(PythonSolver):
     def AddVariables(self):
         self.mesh_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.MESH_DISPLACEMENT)
         self.mesh_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.MESH_REACTION)
-        self.mesh_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.MESH_RHS)
         if (self.settings["calculate_mesh_velocities"].GetBool() == True):
             self.mesh_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.MESH_VELOCITY)
         self.print_on_rank_zero("::[MeshSolverBase]:: Variables ADDED.")


### PR DESCRIPTION
This variable is not used anywhere in Kratos atm

@dbaumgaertner I think you once used this, but whatever it was used for is no longer available
Therefore I remove it for now to decrease the memory footprint
We can speak next week abt it

@rubenzorrilla fyi