### PR TITLE
[Fluid] fix pringting in MPI

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -115,7 +115,8 @@ class NavierStokesEmbeddedMonolithicSolver(FluidSolver):
         self.main_model_part.AddNodalSolutionStepVariable(KratosCFD.EMBEDDED_WET_PRESSURE)          # Post-process variable (stores the fluid nodes pressure and is set to 0 in the structure ones)
         self.main_model_part.AddNodalSolutionStepVariable(KratosCFD.EMBEDDED_WET_VELOCITY)          # Post-process variable (stores the fluid nodes velocity and is set to 0 in the structure ones)
 
-        KratosMultiphysics.Logger.PrintInfo("NavierStokesEmbeddedMonolithicSolver", "Fluid solver variables added correctly.")
+        if self._IsPrintingRank():
+            KratosMultiphysics.Logger.PrintInfo("NavierStokesEmbeddedMonolithicSolver", "Fluid solver variables added correctly.")
 
 
     def ImportModelPart(self):

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
@@ -130,7 +130,8 @@ class NavierStokesSolverFractionalStep(FluidSolver):
         if self.settings["consider_periodic_conditions"].GetBool() == True:
             self.main_model_part.AddNodalSolutionStepVariable(KratosCFD.PATCH_INDEX)
 
-        KratosMultiphysics.Logger.PrintInfo("NavierStokesSolverFractionalStep", "Fluid solver variables added correctly.")
+        if self._IsPrintingRank():
+            KratosMultiphysics.Logger.PrintInfo("NavierStokesSolverFractionalStep", "Fluid solver variables added correctly.")
 
     def PrepareModelPart(self):
         if not self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED]:

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
@@ -230,7 +230,8 @@ class NavierStokesSolverMonolithic(FluidSolver):
         if self.settings["consider_periodic_conditions"].GetBool() == True:
             self.main_model_part.AddNodalSolutionStepVariable(KratosCFD.PATCH_INDEX)
 
-        KratosMultiphysics.Logger.PrintInfo("NavierStokesSolverMonolithic", "Fluid solver variables added correctly.")
+        if self._IsPrintingRank():
+            KratosMultiphysics.Logger.PrintInfo("NavierStokesSolverMonolithic", "Fluid solver variables added correctly.")
 
 
     def PrepareModelPart(self):


### PR DESCRIPTION
AddVariables is called from the Trilinos-solvers, therefore it need to only print on one rank