### PR TITLE
[StructuralMechanicsApplication] Changing moving mesh test to elimination b&s

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/mesh_moving_test/simple_mesh_moving_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/mesh_moving_test/simple_mesh_moving_test_parameters.json
@@ -10,6 +10,7 @@
         "solver_type"                        : "Dynamic",
         "time_integration_method"            : "implicit",
         "analysis_type"                      : "linear",
+        "block_builder"                      : false,
         "model_part_name" : "Structure",
         "echo_level"                         : 0,
         "domain_size"     : 2,


### PR DESCRIPTION
This way we will have a way to check that the ResiudalbasedEliminationBuilderAndSolver is still working on the solver of the StructuralMechanicsApplication.

Related with #3235