### PR TITLE
Core/pointer vector defaults

### DIFF
--- a/kratos/containers/pointer_vector.h
+++ b/kratos/containers/pointer_vector.h
@@ -66,7 +66,7 @@ namespace Kratos
     deleting.
  */
 template<class TDataType,
-         class TPointerType = Kratos::shared_ptr<TDataType>,
+         class TPointerType = typename TDataType::Pointer,
          class TContainerType = std::vector<TPointerType> >
 class PointerVector
 {

--- a/kratos/containers/pointer_vector_set.h
+++ b/kratos/containers/pointer_vector_set.h
@@ -69,7 +69,7 @@ template<class TDataType,
          class TGetKeyType = SetIdentityFunction<TDataType>,
          class TCompareType = std::less<typename TGetKeyType::result_type>,
          class TEqualType = std::equal_to<typename TGetKeyType::result_type>,
-         class TPointerType = Kratos::shared_ptr<TDataType>,
+         class TPointerType = typename TDataType::Pointer,
          class TContainerType = std::vector<TPointerType> >
 class PointerVectorSet
 {

--- a/kratos/containers/weak_pointer_vector.h
+++ b/kratos/containers/weak_pointer_vector.h
@@ -64,7 +64,7 @@ namespace Kratos
     deleting.
  */
 template<class TDataType,
-         class TPointerType = Kratos::weak_ptr<TDataType>,
+         class TPointerType = typename TDataType::WeakPointer,
          class TContainerType = std::vector<TPointerType> >
 class WeakPointerVector
 {

--- a/kratos/processes/calculate_signed_distance_to_3d_condition_skin_process.h
+++ b/kratos/processes/calculate_signed_distance_to_3d_condition_skin_process.h
@@ -76,10 +76,24 @@ class DistanceSpatialContainersConditionConfigure
 
     typedef Point                                               PointType;  /// always the point 3D
     typedef std::vector<double>::iterator                       DistanceIteratorType;
-    typedef PointerVectorSet<GeometricalObject::Pointer, IndexedObject>  ContainerType;
+    typedef PointerVectorSet<
+                GeometricalObject::Pointer, 
+                IndexedObject,
+                std::less<typename IndexedObject::result_type>,
+                std::equal_to<typename IndexedObject::result_type>,
+                Kratos::shared_ptr<typename GeometricalObject::Pointer>,
+                std::vector< Kratos::shared_ptr<typename GeometricalObject::Pointer> >
+                    >  ContainerType;
     typedef ContainerType::value_type                           PointerType;
     typedef ContainerType::iterator                             IteratorType;
-    typedef PointerVectorSet<GeometricalObject::Pointer, IndexedObject>  ResultContainerType;
+    typedef PointerVectorSet<
+                GeometricalObject::Pointer, 
+                IndexedObject,
+                std::less<typename IndexedObject::result_type>,
+                std::equal_to<typename IndexedObject::result_type>,
+                Kratos::shared_ptr<typename GeometricalObject::Pointer>,
+                std::vector< Kratos::shared_ptr<typename GeometricalObject::Pointer> >
+                    >  ResultContainerType;
     typedef ResultContainerType::value_type                     ResultPointerType;
     typedef ResultContainerType::iterator                       ResultIteratorType;
 


### PR DESCRIPTION
As of now PointerVector containers define PointerType=std::shared_ptr<TDataType>.

This is unconvenient in the cases in which someone wants to change the Pointer definition to something different than shared_ptr. I am hence proposing to default to 

       PointerType = typename TDataType::Pointer

the whole kratos compiles with this change, with the only exception of the file i committed.
The correction i pushed for this file corresponds to marking explicitly the defaults that are currently being used, however ... it looks strange to me that someone wants to hold 
  
        Kratos::shared_ptr< NodeType::Pointer >

[edit:] it should have been 

        Kratos::shared_ptr< GeometricalObject::Pointer >
