### PR TITLE
[Core] Distance processes embedded variables computation

### DIFF
--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -355,6 +355,99 @@ namespace Kratos
 		}
 	}
 
+	template<std::size_t TDim>
+	void CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateEmbeddedVariableFromSkin(
+		const Variable<double> &rVariable,
+		const Variable<double> &rEmbeddedVariable)
+	{
+		const auto &r_int_obj_vect= this->GetIntersections();
+		const int n_elems = mrVolumePart.NumberOfElements();
+
+		// Check requested variables
+		KRATOS_ERROR_IF(rEmbeddedVariable.Key() == 0) 
+				<< rEmbeddedVariable << " key is 0. Check that the variable is correctly registered." << std::endl;
+
+		KRATOS_ERROR_IF((mrSkinPart.NodesBegin())->SolutionStepsDataHas(rVariable) == false) 
+				<< "Skin model part solution step data missing variable: " << rVariable << std::endl;
+
+		// Initialize embedded variable value
+		#pragma omp parallel for
+		for (int i_elem = 0; i_elem < n_elems; ++i_elem) {
+			auto it_elem = mrVolumePart.ElementsBegin() + i_elem;
+			it_elem->SetValue(rEmbeddedVariable, 0.0);
+		}
+
+		// Compute the embedded variable value for each element
+		#pragma omp parallel for schedule(dynamic)
+		for (int i_elem = 0; i_elem < n_elems; ++i_elem) {
+			// Check if there are intersecting entities
+			if (r_int_obj_vect[i_elem].size() != 0) {
+				auto it_elem = mrVolumePart.ElementsBegin() + i_elem;
+				// Loop the current element intersecting skin entities
+				for (const auto &r_int_obj : r_int_obj_vect[i_elem]) {
+					// Compute the embedded variable intersecting nodes average value
+					double aux_val = 0.0;
+					for (unsigned int i_node = 0; i_node < r_int_obj.GetGeometry().PointsNumber(); ++i_node) {
+						aux_val += (r_int_obj.GetGeometry())[i_node].FastGetSolutionStepValue(rVariable);
+					}
+					aux_val /= r_int_obj.GetGeometry().PointsNumber();
+
+					// Accumulate the value
+					it_elem->GetValue(rEmbeddedVariable) += aux_val;
+				}
+				// Average all the intersecting skin entities
+				it_elem->GetValue(rEmbeddedVariable) /= r_int_obj_vect[i_elem].size();
+			}
+		}
+	}
+
+	template<std::size_t TDim>
+	void CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateEmbeddedVariableFromSkin(
+		const Variable<array_1d<double,3>> &rVariable,
+		const Variable<array_1d<double,3>> &rEmbeddedVariable)
+	{
+		const auto &r_int_obj_vect= this->GetIntersections();
+		const int n_elems = mrVolumePart.NumberOfElements();
+
+		// Check requested variables
+		KRATOS_ERROR_IF(rEmbeddedVariable.Key() == 0) 
+				<< rEmbeddedVariable << " key is 0. Check that the variable is correctly registered." << std::endl;
+
+		KRATOS_ERROR_IF((mrSkinPart.NodesBegin())->SolutionStepsDataHas(rVariable) == false) 
+				<< "Skin model part solution step data missing variable: " << rVariable << std::endl;
+
+		// Initialize embedded variable value
+		array_1d<double,3> zero_vect = ZeroVector(3);
+		#pragma omp parallel for firstprivate(zero_vect)
+		for (int i_elem = 0; i_elem < n_elems; ++i_elem) {
+			auto it_elem = mrVolumePart.ElementsBegin() + i_elem;
+			it_elem->SetValue(rEmbeddedVariable, zero_vect);
+		}
+
+		// Compute the embedded variable value for each element
+		#pragma omp parallel for schedule(dynamic)
+		for (int i_elem = 0; i_elem < n_elems; ++i_elem) {
+			// Check if there are intersecting entities
+			if (r_int_obj_vect[i_elem].size() != 0) {
+				auto it_elem = mrVolumePart.ElementsBegin() + i_elem;
+				// Loop the current element intersecting skin entities
+				for (const auto &r_int_obj : r_int_obj_vect[i_elem]) {
+					// Compute the embedded variable intersecting nodes average value
+					array_1d<double,3> aux_val = ZeroVector(3);
+					for (unsigned int i_node = 0; i_node < r_int_obj.GetGeometry().PointsNumber(); ++i_node) {
+						aux_val += (r_int_obj.GetGeometry())[i_node].FastGetSolutionStepValue(rVariable);
+					}
+					aux_val /= r_int_obj.GetGeometry().PointsNumber();
+
+					// Accumulate the value
+					it_elem->GetValue(rEmbeddedVariable) += aux_val;
+				}
+				// Average all the intersecting skin entities
+				it_elem->GetValue(rEmbeddedVariable) /= r_int_obj_vect[i_elem].size();
+			}
+		}
+	}
+
 	template<>
 	Plane3D CalculateDiscontinuousDistanceToSkinProcess<2>::SetIntersectionPlane(
 		const std::vector<array_1d<double,3>> &rIntPtsVector)

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
@@ -121,22 +121,20 @@ public:
     void Execute() override;
 
     /**
-     * @brief Computes the value of a double embedded variable
-     * For a given double variable in the skin mesh, this method calculates the value
-     * of such variable in the embedded mesh. This is done in each element of the volume 
-     * mesh elements by computing the average of the intersecting entities nodal values.
-     * @param rVariable double variable to be calculated
+     * @brief Calculate embedded variable from skin double specialization
+     * This method calls the specialization method for two double variables
+     * @param rVariable origin double variable in the skin mesh
+     * @param rEmbeddedVariable elemental double variable in the volume mesh to be computed
      */
     void CalculateEmbeddedVariableFromSkin(
         const Variable<double> &rVariable,
         const Variable<double> &rEmbeddedVariable);
 
     /**
-     * @brief Computes the value of an array embedded variable
-     * For a given array variable in the skin mesh, this method calculates the value
-     * of such variable in the embedded mesh. This is done in each element of the volume 
-     * mesh elements by computing the average of the intersecting entities nodal values.
-     * @param rVariable array variable to be calculated
+     * @brief Calculate embedded variable from skin array specialization
+     * This method calls the specialization method for two double variables
+     * @param rVariable origin array variable in the skin mesh
+     * @param rEmbeddedVariable elemental array variable in the volume mesh to be computed
      */
     void CalculateEmbeddedVariableFromSkin(
         const Variable<array_1d<double,3>> &rVariable,
@@ -283,6 +281,95 @@ private:
     void inline ComputeIntersectionNormalFromGeometry(
         const Element::GeometryType &rGeometry,
         array_1d<double,3> &rIntObjNormal);
+
+    /**
+     * @brief Computes the value of any embedded variable
+     * For a given array variable in the skin mesh, this method calculates the value
+     * of such variable in the embedded mesh. This is done in each element of the volume 
+     * mesh by computing the average value of all the edges intersections. This value 
+     * is averaged again according to the number of intersected edges.
+     * @tparam TVarType variable type
+     * @param rVariable origin variable in the skin mesh
+     * @param rEmbeddedVariable elemental variable in the volume mesh to be computed
+     */
+    template<class TVarType>
+	void CalculateEmbeddedVariableFromSkinSpecialization(
+		const Variable<TVarType> &rVariable,
+		const Variable<TVarType> &rEmbeddedVariable)
+	{
+		const auto &r_int_obj_vect= this->GetIntersections();
+		const int n_elems = mrVolumePart.NumberOfElements();
+
+		// Check requested variables
+		KRATOS_ERROR_IF(rEmbeddedVariable.Key() == 0) 
+			<< rEmbeddedVariable << " key is 0. Check that the variable is correctly registered." << std::endl;
+
+		KRATOS_ERROR_IF((mrSkinPart.NodesBegin())->SolutionStepsDataHas(rVariable) == false) 
+			<< "Skin model part solution step data missing variable: " << rVariable << std::endl;
+
+		// Initialize embedded variable value
+		#pragma omp parallel for
+		for (int i_elem = 0; i_elem < n_elems; ++i_elem) {
+			auto it_elem = mrVolumePart.ElementsBegin() + i_elem;
+			it_elem->SetValue(rEmbeddedVariable, rEmbeddedVariable.Zero());
+		}
+
+		// Compute the embedded variable value for each element
+		#pragma omp parallel for schedule(dynamic)
+		for (int i_elem = 0; i_elem < n_elems; ++i_elem) {
+			// Check if the current element has intersecting entities
+			if (r_int_obj_vect[i_elem].size() != 0) {
+				// Initialize the element values
+				unsigned int n_int_edges = 0;
+				auto it_elem = mrVolumePart.ElementsBegin() + i_elem;
+				auto &r_geom = it_elem->GetGeometry();
+				const auto edges = r_geom.Edges();
+
+				// Loop the element of interest edges
+				for (unsigned int i_edge = 0; i_edge < r_geom.EdgesNumber(); ++i_edge) {
+					// Initialize edge values
+					unsigned int n_int_obj = 0;
+					TVarType i_edge_val = rEmbeddedVariable.Zero();
+
+					// Check the edge intersection against all the candidates
+					for (auto &r_int_obj : r_int_obj_vect[i_elem]) {
+						Point intersection_point;
+						const int is_intersected = this->ComputeEdgeIntersection(
+							r_int_obj.GetGeometry(),
+							edges[i_edge][0],
+							edges[i_edge][1],
+							intersection_point);
+
+						// Compute the variable value in the intersection point
+                        if (is_intersected == 1) {
+							n_int_obj++;
+							array_1d<double,3> local_coords;
+                            r_int_obj.GetGeometry().PointLocalCoordinates(local_coords, intersection_point);
+                            Vector int_obj_N;
+                            r_int_obj.GetGeometry().ShapeFunctionsValues(int_obj_N, local_coords);
+                            for (unsigned int i_node = 0; i_node < r_int_obj.GetGeometry().PointsNumber(); ++i_node) {
+                                i_edge_val += r_int_obj.GetGeometry()[i_node].FastGetSolutionStepValue(rVariable) * int_obj_N[i_node];
+                            }
+                        }
+					}
+
+					// Check if the edge is intersected					
+					if (n_int_obj != 0) {
+						// Update the element intersected edges counter
+						n_int_edges++;
+						// Add the average edge value (there might exist cases in where
+						// more than one geometry intersects the edge of interest).
+						it_elem->GetValue(rEmbeddedVariable) += i_edge_val / n_int_obj;
+					}
+				}
+
+				// Average between all the intersected edges
+				if (n_int_edges != 0) {
+					it_elem->GetValue(rEmbeddedVariable) /= n_int_edges;
+				}
+			}
+		}
+	};
 
     ///@}
 

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
@@ -120,6 +120,28 @@ public:
      */
     void Execute() override;
 
+    /**
+     * @brief Computes the value of a double embedded variable
+     * For a given double variable in the skin mesh, this method calculates the value
+     * of such variable in the embedded mesh. This is done in each element of the volume 
+     * mesh elements by computing the average of the intersecting entities nodal values.
+     * @param rVariable double variable to be calculated
+     */
+    void CalculateEmbeddedVariableFromSkin(
+        const Variable<double> &rVariable,
+        const Variable<double> &rEmbeddedVariable);
+
+    /**
+     * @brief Computes the value of an array embedded variable
+     * For a given array variable in the skin mesh, this method calculates the value
+     * of such variable in the embedded mesh. This is done in each element of the volume 
+     * mesh elements by computing the average of the intersecting entities nodal values.
+     * @param rVariable array variable to be calculated
+     */
+    void CalculateEmbeddedVariableFromSkin(
+        const Variable<array_1d<double,3>> &rVariable,
+        const Variable<array_1d<double,3>> &rEmbeddedVariable);
+
     ///@}
     ///@name Access
     ///@{
@@ -143,6 +165,14 @@ protected:
     ///@name Protected Operations
     ///@{
 
+    /**
+     * @brief Set the Intersection Plane object
+     * This method returns the plane that defines the element intersection. The 2D
+     * case is considered to be a simplification of the 3D one, so a "fake" extra
+     * point is created by extruding the first point in the z-direction.
+     * @param rIntPtsVector array containing the intersecting points coordinates
+     * @return Plane3D the plane defined by the given intersecting points coordinates
+     */
     Plane3D SetIntersectionPlane(const std::vector<array_1d<double,3>> &rIntPtsVector);
 
     ///@}

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -68,6 +68,25 @@ namespace Python
 {
 typedef VariableComponent< VectorComponentAdaptor<array_1d<double, 3> > > component_type;
 
+// Discontinuous distance computation auxiliar functions
+template<std::size_t TDim>
+void CalculateEmbeddedVariableFromSkinDouble(
+    CalculateDiscontinuousDistanceToSkinProcess<TDim> &rDiscDistProcess,
+    const Variable<double> &rVariable,
+    const Variable<double> &rEmbeddedVariable)
+{
+    rDiscDistProcess.CalculateEmbeddedVariableFromSkin(rVariable, rEmbeddedVariable);
+}
+
+template<std::size_t TDim>
+void CalculateEmbeddedVariableFromSkinArray(
+    CalculateDiscontinuousDistanceToSkinProcess<TDim> &rDiscDistProcess,
+    const Variable<array_1d<double,3>> &rVariable,
+    const Variable<array_1d<double,3>> &rEmbeddedVariable)
+{
+    rDiscDistProcess.CalculateEmbeddedVariableFromSkin(rVariable, rEmbeddedVariable);
+}
+
 void  AddProcessesToPython(pybind11::module& m)
 {
     namespace py = pybind11;
@@ -257,14 +276,18 @@ void  AddProcessesToPython(pybind11::module& m)
             .def(py::init<ModelPart&, component_type&, Variable<array_1d<double,3> >& , Variable<double>& >())
     ;
 
-    // Discontinuous distance computation methods
+    // Discontinuous distance computation methods        
     py::class_<CalculateDiscontinuousDistanceToSkinProcess<2>, CalculateDiscontinuousDistanceToSkinProcess<2>::Pointer, Process>(m,"CalculateDiscontinuousDistanceToSkinProcess2D")
-            .def(py::init<ModelPart&, ModelPart&>())
-            ;
+        .def(py::init<ModelPart&, ModelPart&>())
+        .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinArray<2>)
+        .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinDouble<2>)
+        ;
 
     py::class_<CalculateDiscontinuousDistanceToSkinProcess<3>, CalculateDiscontinuousDistanceToSkinProcess<3>::Pointer, Process>(m,"CalculateDiscontinuousDistanceToSkinProcess3D")
-            .def(py::init<ModelPart&, ModelPart&>())
-            ;
+        .def(py::init<ModelPart&, ModelPart&>())
+        .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinArray<3>)
+        .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinDouble<3>)
+        ;
 
     // Continuous distance computation methods
     py::class_<CalculateDistanceToSkinProcess<2>, CalculateDistanceToSkinProcess<2>::Pointer, Process>(m,"CalculateDistanceToSkinProcess2D")

--- a/kratos/tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
@@ -4,11 +4,11 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:     BSD License
-//           Kratos default license: kratos/license.txt
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Pooyan Dadvand, Ruben Zorrilla
-//
+//  Main authors:    Pooyan Dadvand
+//					 Ruben Zorrilla
 //
 
 // Project includes
@@ -16,6 +16,7 @@
 #include "containers/model.h"
 #include "includes/checks.h"
 #include "geometries/hexahedra_3d_8.h"
+#include "geometries/quadrilateral_2d_4.h"
 #include "processes/structured_mesh_generator_process.h"
 #include "processes/calculate_discontinuous_distance_to_skin_process.h"
 
@@ -113,7 +114,6 @@ namespace Testing {
         ModelPart& volume_part = current_model.CreateModelPart("Volume");
         volume_part.AddNodalSolutionStepVariable(VELOCITY);
         volume_part.AddNodalSolutionStepVariable(DISTANCE);
-        volume_part.AddNodalSolutionStepVariable(EMBEDDED_VELOCITY);
         StructuredMeshGeneratorProcess(geometry, volume_part, mesher_parameters).Execute();
 
         // Generate the cube skin
@@ -562,6 +562,124 @@ namespace Testing {
         KRATOS_CHECK_NEAR(r_elem_dist[1], -0.00883326, 1e-6);
         KRATOS_CHECK_NEAR(r_elem_dist[2], 0.0352186, 1e-6);
         KRATOS_CHECK_NEAR(r_elem_dist[3], -0.103167, 1e-6);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceDoubleEmbeddedVariable, KratosCoreFastSuite)
+    {
+        Model current_model;
+
+        // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
+        Node<3>::Pointer p_point_1 = Kratos::make_shared<Node<3>>(1, -0.5, -0.5, 0.0);
+        Node<3>::Pointer p_point_2 = Kratos::make_shared<Node<3>>(2, -0.5,  0.5, 0.0);
+        Node<3>::Pointer p_point_3 = Kratos::make_shared<Node<3>>(3,  0.5,  0.5, 0.0);
+        Node<3>::Pointer p_point_4 = Kratos::make_shared<Node<3>>(4,  0.5, -0.5, 0.0);
+
+        Quadrilateral2D4<Node<3>> geometry(p_point_1, p_point_2, p_point_3, p_point_4);
+
+        Parameters mesher_parameters(R"(
+        {
+            "number_of_divisions": 7,
+            "element_name": "Element2D3N"
+        })");
+
+        ModelPart& volume_part = current_model.CreateModelPart("Volume");
+        volume_part.AddNodalSolutionStepVariable(DISTANCE);
+        volume_part.AddNodalSolutionStepVariable(TEMPERATURE);
+        StructuredMeshGeneratorProcess(geometry, volume_part, mesher_parameters).Execute();
+
+        // Generate the cube skin
+        const double cube_radious = 0.25;
+        ModelPart& skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(TEMPERATURE);
+        skin_part.CreateNewNode(1, -cube_radious, -cube_radious, 0.0);
+        skin_part.CreateNewNode(2, -cube_radious,  cube_radious, 0.0);
+        skin_part.CreateNewNode(3,  cube_radious,  cube_radious, 0.0);
+        skin_part.CreateNewNode(4,  cube_radious, -cube_radious, 0.0);
+        Properties::Pointer p_properties(new Properties(0));
+        skin_part.CreateNewElement("Element2D2N",  1, {{1,2}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N",  2, {{2,3}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N",  3, {{3,4}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N",  4, {{4,1}}, p_properties);
+
+        // Set the embedded cube double variable
+        for (auto &i_node : skin_part.Nodes()) {
+            i_node.FastGetSolutionStepValue(TEMPERATURE) = 1.0;
+        }
+
+        // Compute the discontinuous distance function
+        CalculateDiscontinuousDistanceToSkinProcess<2> disc_dist_proc(volume_part, skin_part);
+        disc_dist_proc.Execute();
+        disc_dist_proc.CalculateEmbeddedVariableFromSkin(TEMPERATURE, TEMPERATURE);
+
+        // Check values
+        KRATOS_CHECK_NEAR(volume_part.GetElement(16).GetValue(TEMPERATURE), 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(17).GetValue(TEMPERATURE), 1.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(68).GetValue(TEMPERATURE), 1.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(69).GetValue(TEMPERATURE), 0.0, 1e-6);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceArrayEmbeddedVariable, KratosCoreFastSuite)
+    {
+        Model current_model;
+
+        // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
+        Node<3>::Pointer p_point_1 = Kratos::make_shared<Node<3>>(1, -0.5, -0.5, 0.0);
+        Node<3>::Pointer p_point_2 = Kratos::make_shared<Node<3>>(2, -0.5,  0.5, 0.0);
+        Node<3>::Pointer p_point_3 = Kratos::make_shared<Node<3>>(3,  0.5,  0.5, 0.0);
+        Node<3>::Pointer p_point_4 = Kratos::make_shared<Node<3>>(4,  0.5, -0.5, 0.0);
+
+        Quadrilateral2D4<Node<3>> geometry(p_point_1, p_point_2, p_point_3, p_point_4);
+
+        Parameters mesher_parameters(R"(
+        {
+            "number_of_divisions": 7,
+            "element_name": "Element2D3N"
+        })");
+
+        ModelPart& volume_part = current_model.CreateModelPart("Volume");
+        volume_part.AddNodalSolutionStepVariable(DISTANCE);
+        StructuredMeshGeneratorProcess(geometry, volume_part, mesher_parameters).Execute();
+
+        // Generate the cube skin
+        const double cube_radious = 0.25;
+        ModelPart& skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(VELOCITY);
+        skin_part.CreateNewNode(1, -cube_radious, -cube_radious, 0.0);
+        skin_part.CreateNewNode(2, -cube_radious,  cube_radious, 0.0);
+        skin_part.CreateNewNode(3,  cube_radious,  cube_radious, 0.0);
+        skin_part.CreateNewNode(4,  cube_radious, -cube_radious, 0.0);
+        Properties::Pointer p_properties(new Properties(0));
+        skin_part.CreateNewElement("Element2D2N",  1, {{1,2}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N",  2, {{2,3}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N",  3, {{3,4}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N",  4, {{4,1}}, p_properties);
+
+        // Set the embedded cube array variable
+        array_1d<double,3> velocity = ZeroVector(3);
+        velocity[0] = 1.0;
+        velocity[1] = 1.0;
+        for (auto &i_node : skin_part.Nodes()) {
+            i_node.FastGetSolutionStepValue(VELOCITY) = velocity;
+        }
+
+        // Compute the discontinuous distance function
+        CalculateDiscontinuousDistanceToSkinProcess<2> disc_dist_proc(volume_part, skin_part);
+        disc_dist_proc.Execute();
+        disc_dist_proc.CalculateEmbeddedVariableFromSkin(VELOCITY, EMBEDDED_VELOCITY);
+
+        // Check values
+        KRATOS_CHECK_NEAR(volume_part.GetElement(16).GetValue(EMBEDDED_VELOCITY)[0], 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(16).GetValue(EMBEDDED_VELOCITY)[1], 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(16).GetValue(EMBEDDED_VELOCITY)[2], 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(17).GetValue(EMBEDDED_VELOCITY)[0], 1.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(17).GetValue(EMBEDDED_VELOCITY)[1], 1.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(17).GetValue(EMBEDDED_VELOCITY)[2], 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(68).GetValue(EMBEDDED_VELOCITY)[0], 1.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(68).GetValue(EMBEDDED_VELOCITY)[1], 1.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(68).GetValue(EMBEDDED_VELOCITY)[2], 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(69).GetValue(EMBEDDED_VELOCITY)[0], 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(69).GetValue(EMBEDDED_VELOCITY)[1], 0.0, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(69).GetValue(EMBEDDED_VELOCITY)[2], 0.0, 1e-6);
     }
 
 }  // namespace Testing.

--- a/kratos/tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
@@ -564,7 +564,7 @@ namespace Testing {
         KRATOS_CHECK_NEAR(r_elem_dist[3], -0.103167, 1e-6);
     }
 
-    KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceDoubleEmbeddedVariable, KratosCoreFastSuite)
+    KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceProcessDoubleEmbeddedVariable, KratosCoreFastSuite)
     {
         Model current_model;
 
@@ -618,7 +618,7 @@ namespace Testing {
         KRATOS_CHECK_NEAR(volume_part.GetElement(69).GetValue(TEMPERATURE), 0.0, 1e-6);
     }
 
-    KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceArrayEmbeddedVariable, KratosCoreFastSuite)
+    KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceProcessArrayEmbeddedVariable, KratosCoreFastSuite)
     {
         Model current_model;
 

--- a/kratos/tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
@@ -4,11 +4,11 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
-//					 Ruben Zorrilla
+//                   Ruben Zorrilla
 //
 
 // Project includes

--- a/kratos/tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
@@ -564,6 +564,90 @@ namespace Testing {
         KRATOS_CHECK_NEAR(r_elem_dist[3], -0.103167, 1e-6);
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceProcessDoubleEmbeddedVariableComplex, KratosCoreFastSuite)
+    {
+        Model current_model;
+
+        // Generate a triangle element
+        ModelPart& volume_part = current_model.CreateModelPart("Volume");
+        volume_part.AddNodalSolutionStepVariable(DISTANCE);
+        volume_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+        volume_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+        volume_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+        Properties::Pointer p_properties_0(new Properties(0));
+        volume_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties_0);
+
+        // Generate the skin
+        ModelPart& skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(TEMPERATURE);
+        skin_part.CreateNewNode(1,-0.1, 0.5,0.0);
+        skin_part.CreateNewNode(2, 0.1, 0.5,0.0);
+        skin_part.CreateNewNode(3,-0.1, 0.3,0.0);
+        skin_part.CreateNewNode(4, 0.1, 0.3,0.0);
+        skin_part.CreateNewNode(5, 0.1,-0.1,0.0);
+        Properties::Pointer p_properties_1(new Properties(1));
+        skin_part.CreateNewElement("Element2D2N", 1, {{1,2}}, p_properties_1);
+        skin_part.CreateNewElement("Element2D2N", 2, {{2,3}}, p_properties_1);
+        skin_part.CreateNewElement("Element2D2N", 3, {{3,4}}, p_properties_1);
+        skin_part.CreateNewElement("Element2D2N", 4, {{4,5}}, p_properties_1);
+
+        // Set the embedded cube double variable
+        for (auto &i_node : skin_part.Nodes()) {
+            i_node.FastGetSolutionStepValue(TEMPERATURE) = i_node.Y();
+        }
+
+        // Compute the discontinuous distance function
+        CalculateDiscontinuousDistanceToSkinProcess<2> disc_dist_proc(volume_part, skin_part);
+        disc_dist_proc.Execute();
+        disc_dist_proc.CalculateEmbeddedVariableFromSkin(TEMPERATURE, TEMPERATURE);
+
+        // Check values
+        KRATOS_CHECK_NEAR(volume_part.GetElement(1).GetValue(TEMPERATURE), 0.2, 1e-6);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceProcessArrayEmbeddedVariableComplex, KratosCoreFastSuite)
+    {
+        Model current_model;
+
+        // Generate a triangle element
+        ModelPart& volume_part = current_model.CreateModelPart("Volume");
+        volume_part.AddNodalSolutionStepVariable(DISTANCE);
+        volume_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+        volume_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+        volume_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+        Properties::Pointer p_properties_0(new Properties(0));
+        volume_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties_0);
+
+        // Generate the skin
+        ModelPart& skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(VELOCITY);
+        skin_part.CreateNewNode(1,-0.1, 0.5,0.0);
+        skin_part.CreateNewNode(2, 0.1, 0.5,0.0);
+        skin_part.CreateNewNode(3,-0.1, 0.3,0.0);
+        skin_part.CreateNewNode(4, 0.1, 0.3,0.0);
+        skin_part.CreateNewNode(5, 0.1,-0.1,0.0);
+        Properties::Pointer p_properties_1(new Properties(1));
+        skin_part.CreateNewElement("Element2D2N", 1, {{1,2}}, p_properties_1);
+        skin_part.CreateNewElement("Element2D2N", 2, {{2,3}}, p_properties_1);
+        skin_part.CreateNewElement("Element2D2N", 3, {{3,4}}, p_properties_1);
+        skin_part.CreateNewElement("Element2D2N", 4, {{4,5}}, p_properties_1);
+
+        // Set the embedded cube double variable
+        for (auto &i_node : skin_part.Nodes()) {
+            i_node.FastGetSolutionStepValue(VELOCITY_X) = i_node.X();
+            i_node.FastGetSolutionStepValue(VELOCITY_Y) = i_node.Y();
+        }
+
+        // Compute the discontinuous distance function
+        CalculateDiscontinuousDistanceToSkinProcess<2> disc_dist_proc(volume_part, skin_part);
+        disc_dist_proc.Execute();
+        disc_dist_proc.CalculateEmbeddedVariableFromSkin(VELOCITY, EMBEDDED_VELOCITY);
+
+        // Check values
+        KRATOS_CHECK_NEAR(volume_part.GetElement(1).GetValue(EMBEDDED_VELOCITY_X), 0.05, 1e-6);
+        KRATOS_CHECK_NEAR(volume_part.GetElement(1).GetValue(EMBEDDED_VELOCITY_Y), 0.2, 1e-6);
+    }
+
     KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceProcessDoubleEmbeddedVariable, KratosCoreFastSuite)
     {
         Model current_model;


### PR DESCRIPTION
This PR adds an extra feature to the new processes to compute discontinuous and continuous level set functions. Such feature is the computation of any skin mesh embedded variable in the volume mesh. In the past we used to do that by a simple average of the intersecting entities values. Now we have enhanced it to an average of the values in the intersection points. Besides, it has been implemented to be compatible with any variable type (so far only double and array_1d have been exported).