### PR TITLE
[StructuralMechanicsApplication] CPP tests name cleanup

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_shell_to_solid_shell_process.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_shell_to_solid_shell_process.cpp
@@ -95,7 +95,7 @@ namespace Kratos
         * Test 1 layer
         */
 
-        KRATOS_TEST_CASE_IN_SUITE(TestShellToSolidShellProcess1, KratosStructuralMechanicsFastSuite)
+        KRATOS_TEST_CASE_IN_SUITE(ShellToSolidShellProcess1, KratosStructuralMechanicsFastSuite)
         {
             Model current_model;
             ModelPart& this_model_part =  current_model.CreateModelPart("Main");
@@ -127,7 +127,7 @@ namespace Kratos
         * Test 2 layer
         */
 
-        KRATOS_TEST_CASE_IN_SUITE(TestShellToSolidShellProcess2, KratosStructuralMechanicsFastSuite)
+        KRATOS_TEST_CASE_IN_SUITE(ShellToSolidShellProcess2, KratosStructuralMechanicsFastSuite)
         {
             Model current_model;
             ModelPart& this_model_part =  current_model.CreateModelPart("Main");
@@ -159,7 +159,7 @@ namespace Kratos
         * Test 2 layer with external conditions
         */
 
-        KRATOS_TEST_CASE_IN_SUITE(TestShellToSolidShellProcess3, KratosStructuralMechanicsFastSuite)
+        KRATOS_TEST_CASE_IN_SUITE(ShellToSolidShellProcess3, KratosStructuralMechanicsFastSuite)
         {
             Model current_model;
             ModelPart& this_model_part = current_model.CreateModelPart("Main");

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_shell_thickness_compute_process.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_shell_thickness_compute_process.cpp
@@ -57,7 +57,7 @@ namespace Kratos
         * Checks the correct work of the thickness compute for solid shells
         */
 
-        KRATOS_TEST_CASE_IN_SUITE(TestSolidShellThicknessCompute, KratosStructuralMechanicsFastSuite)
+        KRATOS_TEST_CASE_IN_SUITE(SolidShellThicknessCompute, KratosStructuralMechanicsFastSuite)
         {
             Model current_model;
             ModelPart& this_model_part = current_model.CreateModelPart("Main");

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_spr_error_process.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_spr_error_process.cpp
@@ -197,7 +197,7 @@ namespace Kratos
         * Test triangle 
         */
 
-        KRATOS_TEST_CASE_IN_SUITE(TestSPRErrorProcess1, KratosStructuralMechanicsFastSuite)
+        KRATOS_TEST_CASE_IN_SUITE(SPRErrorProcess1, KratosStructuralMechanicsFastSuite)
         {
             Model current_model;
             ModelPart& this_model_part = current_model.CreateModelPart("Main",2);
@@ -246,7 +246,7 @@ namespace Kratos
         * Test tetrahedra
         */
 
-        KRATOS_TEST_CASE_IN_SUITE(TestSPRErrorProcess2, KratosStructuralMechanicsFastSuite)
+        KRATOS_TEST_CASE_IN_SUITE(SPRErrorProcess2, KratosStructuralMechanicsFastSuite)
         {
             Model current_model;
             ModelPart& this_model_part = current_model.CreateModelPart("Main",2);


### PR DESCRIPTION
The cpp test interface already appends "Test" at the beginning of the name