### PR TITLE
[ParticleMechanics] Set all tests' linear solver to default

### DIFF
--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_line_load_2D_quad_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_line_load_2D_quad_test_parameters.json
@@ -37,11 +37,7 @@
             "input_filename" : "beam_tests/cantilever_beam/static_line_load_2D_quad_test_Grid"
         },
         "particle_per_element"               : 4,
-        "pressure_dofs"                      : false,
-        "linear_solver_settings"             : {
-            "solver_type" : "SuperLUSolver",
-            "scaling"     : false
-        }
+        "pressure_dofs"                      : false
     },
     "processes"        : {
         "constraints_process_list" : [{

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_point_load_2D_tri_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_point_load_2D_tri_test_parameters.json
@@ -38,11 +38,7 @@
             "input_filename" : "beam_tests/cantilever_beam/static_point_load_2D_tri_test_Grid"
         },
         "particle_per_element"               : 3,
-        "pressure_dofs"                      : false,
-        "linear_solver_settings"             : {
-            "solver_type" : "SuperLUSolver",
-            "scaling"     : false
-        }
+        "pressure_dofs"                      : false
     },
     "processes"        : {
         "constraints_process_list" : [{

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_surface_load_3D_hexa_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_surface_load_3D_hexa_test_parameters.json
@@ -37,11 +37,7 @@
             "input_filename" : "beam_tests/cantilever_beam/static_surface_load_3D_hexa_test_Grid"
         },
         "particle_per_element"               : 4,
-        "pressure_dofs"                      : false,
-        "linear_solver_settings"             : {
-            "solver_type" : "SuperLUSolver",
-            "scaling"     : false
-        }
+        "pressure_dofs"                      : false
     },
     "processes"        : {
         "constraints_process_list" : [{

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/hyperelastic_cantilever_beam/self_weight_load_2D_quad_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/hyperelastic_cantilever_beam/self_weight_load_2D_quad_test_parameters.json
@@ -37,11 +37,7 @@
             "input_filename" : "beam_tests/hyperelastic_cantilever_beam/self_weight_load_2D_quad_test_Grid"
         },
         "particle_per_element"               : 4,
-        "pressure_dofs"                      : false,
-        "linear_solver_settings"             : {
-            "solver_type" : "SuperLUSolver",
-            "scaling"     : false
-        }
+        "pressure_dofs"                      : false
     },
     "processes"        : {
         "constraints_process_list" : [{

--- a/applications/ParticleMechanicsApplication/tests/cl_tests/solid_cl/linear_elastic_3D_hexa_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cl_tests/solid_cl/linear_elastic_3D_hexa_test_parameters.json
@@ -37,11 +37,7 @@
             "input_filename" : "cl_tests/solid_cl/linear_elastic_3D_hexa_test_Grid"
         },
         "particle_per_element"               : 4,
-        "pressure_dofs"                      : false,
-        "linear_solver_settings"             : {
-            "solver_type" : "SuperLUSolver",
-            "scaling"     : false
-        }
+        "pressure_dofs"                      : false
     },
     "processes"        : {
         "constraints_process_list" : [{

--- a/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_compressible_cook_membrane_2D_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_compressible_cook_membrane_2D_test_parameters.json
@@ -37,11 +37,7 @@
             "input_filename" : "cooks_membrane_tests/cook_membrane_2D_test_Grid"
         },
         "particle_per_element"               : 3,
-        "pressure_dofs"                      : true,
-        "linear_solver_settings"             : {
-            "solver_type" : "SuperLUSolver",
-            "scaling"     : false
-        }
+        "pressure_dofs"                      : true
     },
     "processes"        : {
         "constraints_process_list" : [{

--- a/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_incompressible_cook_membrane_2D_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_incompressible_cook_membrane_2D_test_parameters.json
@@ -37,11 +37,7 @@
             "input_filename" : "cooks_membrane_tests/cook_membrane_2D_test_Grid"
         },
         "particle_per_element"               : 3,
-        "pressure_dofs"                      : true,
-        "linear_solver_settings"             : {
-            "solver_type" : "SuperLUSolver",
-            "scaling"     : false
-        }
+        "pressure_dofs"                      : true
     },
     "processes"        : {
         "constraints_process_list" : [{

--- a/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/compressible_cook_membrane_2D_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/compressible_cook_membrane_2D_test_parameters.json
@@ -37,11 +37,7 @@
             "input_filename" : "cooks_membrane_tests/cook_membrane_2D_test_Grid"
         },
         "particle_per_element"               : 3,
-        "pressure_dofs"                      : false,
-        "linear_solver_settings"             : {
-            "solver_type" : "SuperLUSolver",
-            "scaling"     : false
-        }
+        "pressure_dofs"                      : false
     },
     "processes"        : {
         "constraints_process_list" : [{

--- a/applications/ParticleMechanicsApplication/tests/gravity_tests/dynamic_gravity_application_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/gravity_tests/dynamic_gravity_application_test_parameters.json
@@ -39,11 +39,7 @@
             "input_filename" : "gravity_tests/dynamic_gravity_application_test_Grid"
         },
         "particle_per_element"               : 1,
-        "pressure_dofs"                      : false,
-        "linear_solver_settings"             : {
-            "solver_type" : "SuperLUSolver",
-            "scaling"     : false
-        }
+        "pressure_dofs"                      : false
     },
     "processes"        : {
         "constraints_process_list" : [{


### PR DESCRIPTION
@loumalouomega @philbucher 
this increase the speed of the test as I am switching it to default (AMGCL) from SuperLU.
All tests works fine.