### PR TITLE
[MeshMoving] increasing buffer-size only if needed

### DIFF
--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
@@ -37,7 +37,7 @@ class MeshSolverBase(PythonSolver):
         default_settings = KratosMultiphysics.Parameters("""
         {
             "solver_type"           : "mesh_solver_structural_similarity",
-            "buffer_size"           : 3,
+            "buffer_size"           : 1,
             "echo_level"            : 0,
             "domain_size"           : -1,
             "model_part_name"       : "",
@@ -141,13 +141,15 @@ class MeshSolverBase(PythonSolver):
         self.get_mesh_motion_solving_strategy().Check()
 
     def GetMinimumBufferSize(self):
-        time_order = self.settings["time_order"].GetInt()
-        if time_order == 1:
-            buffer_size = 2
-        elif time_order == 2:
-            buffer_size = 3
-        else:
-            raise Exception('"time_order" can only be 1 or 2!')
+        buffer_size = 0
+        if (self.settings["calculate_mesh_velocities"].GetBool() == True):
+            time_order = self.settings["time_order"].GetInt()
+            if time_order == 1:
+                buffer_size = 2
+            elif time_order == 2:
+                buffer_size = 3
+            else:
+                raise Exception('"time_order" can only be 1 or 2!')
         return max(buffer_size, self.settings["buffer_size"].GetInt())
 
     def MoveMesh(self):

--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
@@ -150,7 +150,7 @@ class MeshSolverBase(PythonSolver):
                 buffer_size = 3
             else:
                 raise Exception('"time_order" can only be 1 or 2!')
-        return max(buffer_size, self.settings["buffer_size"].GetInt())
+        return max(buffer_size, self.settings["buffer_size"].GetInt(), self.mesh_model_part.GetBufferSize())
 
     def MoveMesh(self):
         self.get_mesh_motion_solving_strategy().MoveMesh()

--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_laplacian.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_laplacian.py
@@ -19,6 +19,12 @@ def CreateSolver(mesh_model_part, custom_settings):
 
 class MeshSolverLaplacian(mesh_solver_base.MeshSolverBase):
     def __init__(self, mesh_model_part, custom_settings):
+        if custom_settings.Has("buffer_size"):
+            buffer_size = custom_settings["buffer_size"]
+            if buffer_size < 2:
+                raise Exception("A buffer_size of at least 2 is required!")
+        else: # overwritting baseclass-default
+            custom_settings.AddEmptyValue("buffer_size").SetInt(2)
         super(MeshSolverLaplacian, self).__init__(mesh_model_part, custom_settings)
         print("::[MeshSolverLaplacian]:: Construction finished")
 

--- a/applications/MeshMovingApplication/python_scripts/trilinos_mesh_solver_laplacian.py
+++ b/applications/MeshMovingApplication/python_scripts/trilinos_mesh_solver_laplacian.py
@@ -20,6 +20,12 @@ def CreateSolver(mesh_model_part, custom_settings):
 
 class TrilinosMeshSolverComponentwise(trilinos_mesh_solver_base.TrilinosMeshSolverBase):
     def __init__(self, mesh_model_part, custom_settings):
+        if custom_settings.Has("buffer_size"):
+            buffer_size = custom_settings["buffer_size"]
+            if buffer_size < 2:
+                raise Exception("A buffer_size of at least 2 is required!")
+        else: # overwritting baseclass-default
+            custom_settings.AddEmptyValue("buffer_size").SetInt(2)
         super(TrilinosMeshSolverComponentwise, self).__init__(mesh_model_part, custom_settings)
         self.print_on_rank_zero("::[TrilinosMeshSolverComponentwise]:: Construction finished")
 


### PR DESCRIPTION
In this PR I decrease the min-buffer size for the mesh-motion-solver

If it is used only for solving the mesh and not for computing the mesh-velocity (for which I am currently writing another utility) then a buffer-size of 1 should be sufficient
Only the [laplacian-solver needs 2](https://github.com/KratosMultiphysics/Kratos/blob/master/applications/MeshMovingApplication/custom_elements/laplacian_meshmoving_element.cpp#L65-L66)
@AndreasWinterstein can you confirm this please? We should speak abt this next week

@rubenzorrilla @dbaumgaertner I don't know how you handle the buffer-sizes
This solver used quite a large one so far (3), it could be if you don't do this yourselves so far that you now have to do it (which I think is the correct way anyway)
Please check your scripts

Tests are still working