### PR TITLE
[ConvDiff] CHT solver thermal model_part_name check.

### DIFF
--- a/applications/convection_diffusion_application/python_scripts/conjugate_heat_transfer_solver.py
+++ b/applications/convection_diffusion_application/python_scripts/conjugate_heat_transfer_solver.py
@@ -113,7 +113,7 @@ class ConjugateHeatTransferSolver(PythonSolver):
 
     def ImportModelPart(self):
         # Check that both thermal solvers have a different model part name. If
-        # both model part names coincide the solver will fail to acces them. This 
+        # both model part names coincide the solver will fail to acces them. This
         # is the case if the default one in the convection diffusion is taken.
         fluid_thermal_model_part_name = self.settings["fluid_domain_solver_settings"]["thermal_solver_settings"]["model_part_name"].GetString()
         solid_thermal_model_part_name = self.settings["solid_domain_solver_settings"]["thermal_solver_settings"]["model_part_name"].GetString()

--- a/applications/convection_diffusion_application/python_scripts/conjugate_heat_transfer_solver.py
+++ b/applications/convection_diffusion_application/python_scripts/conjugate_heat_transfer_solver.py
@@ -41,6 +41,7 @@ class ConjugateHeatTransferSolver(PythonSolver):
                     }
                 },
                 "thermal_solver_settings":{
+                    "model_part_name": "FluidThermalModelPart",
                     "solver_type": "Transient",
                     "analysis_type": "linear",
                     "model_import_settings": {
@@ -55,6 +56,7 @@ class ConjugateHeatTransferSolver(PythonSolver):
                 "solid_solver_settings": {
                 },
                 "thermal_solver_settings": {
+                    "model_part_name": "SolidThermalModelPart",
                     "solver_type": "Transient",
                     "analysis_type": "linear",
                     "model_import_settings": {
@@ -110,6 +112,18 @@ class ConjugateHeatTransferSolver(PythonSolver):
         self.solid_thermal_solver.main_model_part.AddNodalSolutionStepVariable(KratosConvDiff.AUX_TEMPERATURE)
 
     def ImportModelPart(self):
+        # Check that both thermal solvers have a different model part name. If
+        # both model part names coincide the solver will fail to acces them. This 
+        # is the case if the default one in the convection diffusion is taken.
+        fluid_thermal_model_part_name = self.settings["fluid_domain_solver_settings"]["thermal_solver_settings"]["model_part_name"].GetString()
+        solid_thermal_model_part_name = self.settings["solid_domain_solver_settings"]["thermal_solver_settings"]["model_part_name"].GetString()
+        if fluid_thermal_model_part_name == solid_thermal_model_part_name:
+            err_msg = "\nFluid thermal solver settings model_part_name and solid thermal solver settings model_part_name can not coincide.\n"
+            err_msg += "- fluid model_part_name: " + fluid_thermal_model_part_name + "\n"
+            err_msg += "- solid model_part_name: " + solid_thermal_model_part_name + "\n"
+            err_msg += "Provide different model_part_names in the JSON settings file."
+            raise Exception(err_msg)
+
         # Import the fluid domain in the fluid dynamics solver
         self.fluid_solver.ImportModelPart()
         


### PR DESCRIPTION
If we let the convection diffusion solver to set the default model_part_name both fluid and solid thermal model parts have the same name. Thus it breaks when accessing them. This is a simple check to avoid such situation.

@jginternational is already aware of that and we will always write the model_part_name for the CHT .json settings as we used to do in the past for other apps.