### PR TITLE
[MeshingApplication] Removing [-Wmisleading-indentation] from MMGProcess

### DIFF
--- a/applications/MeshingApplication/custom_processes/mmg_process.cpp
+++ b/applications/MeshingApplication/custom_processes/mmg_process.cpp
@@ -1316,11 +1316,14 @@ ConditionType::Pointer MmgProcess<MMGLibray::MMG2D>::CreateCondition0(
 
     int edge_0, edge_1, is_ridge;
 
-    if (MMG2D_Get_edge(mmgMesh, &edge_0, &edge_1, &PropId, &is_ridge, &IsRequired) != 1 )
+    if (MMG2D_Get_edge(mmgMesh, &edge_0, &edge_1, &PropId, &is_ridge, &IsRequired) != 1 ) {
         exit(EXIT_FAILURE);
+    }
 
-	// Sometimes MMG creates conditions where there are not, then we skip
-	if (mpRefCondition[PropId] == nullptr) return p_condition;
+    // Sometimes MMG creates conditions where there are not, then we skip
+    if (mpRefCondition[PropId] == nullptr) {
+        return p_condition;
+    }
 
     // FIXME: This is not the correct solution to the problem, I asked in the MMG Forum
     if (edge_0 == 0) SkipCreation = true;
@@ -1354,11 +1357,14 @@ ConditionType::Pointer MmgProcess<MMGLibray::MMG3D>::CreateCondition0(
 
     int vertex_0, vertex_1, vertex_2;
 
-    if (MMG3D_Get_triangle(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &PropId, &IsRequired) != 1 )
+    if (MMG3D_Get_triangle(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &PropId, &IsRequired) != 1 ) {
         exit(EXIT_FAILURE);
+    }
 
-	// Sometimes MMG creates conditions where there are not, then we skip
-	if (mpRefCondition[PropId] == nullptr) return p_condition;
+    // Sometimes MMG creates conditions where there are not, then we skip
+    if (mpRefCondition[PropId] == nullptr) {
+        return p_condition;
+    }
 
     // FIXME: This is not the correct solution to the problem, I asked in the MMG Forum
     if (vertex_0 == 0) SkipCreation = true;
@@ -1394,11 +1400,14 @@ ConditionType::Pointer MmgProcess<MMGLibray::MMGS>::CreateCondition0(
 
     int edge_0, edge_1, is_ridge;
 
-    if (MMGS_Get_edge(mmgMesh, &edge_0, &edge_1, &PropId, &is_ridge, &IsRequired) != 1 )
+    if (MMGS_Get_edge(mmgMesh, &edge_0, &edge_1, &PropId, &is_ridge, &IsRequired) != 1 ) {
         exit(EXIT_FAILURE);
+    }
 
-	// Sometimes MMG creates conditions where there are not, then we skip
-	if (mpRefCondition[PropId] == nullptr) return p_condition;
+    // Sometimes MMG creates conditions where there are not, then we skip
+    if (mpRefCondition[PropId] == nullptr) {
+        return p_condition;
+    }
 
     // FIXME: This is not the correct solution to the problem, I asked in the MMG Forum
     if (edge_0 == 0) SkipCreation = true;
@@ -1445,11 +1454,14 @@ ConditionType::Pointer MmgProcess<MMGLibray::MMG3D>::CreateCondition1(
 
     int vertex_0, vertex_1, vertex_2, vertex_3;
 
-    if (MMG3D_Get_quadrilateral(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &vertex_3, &PropId, &IsRequired) != 1 )
+    if (MMG3D_Get_quadrilateral(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &vertex_3, &PropId, &IsRequired) != 1 ) {
         exit(EXIT_FAILURE);
+    }
 
-	// Sometimes MMG creates conditions where there are not, then we skip
-	if (mpRefCondition[PropId] == nullptr) return p_condition;
+    // Sometimes MMG creates conditions where there are not, then we skip
+    if (mpRefCondition[PropId] == nullptr) {
+        return p_condition;
+    }
 
     // FIXME: This is not the correct solution to the problem, I asked in the MMG Forum
     if (vertex_0 == 0) SkipCreation = true;
@@ -1500,11 +1512,14 @@ ElementType::Pointer MmgProcess<MMGLibray::MMG2D>::CreateElement0(
 
     int vertex_0, vertex_1, vertex_2;
 
-    if (MMG2D_Get_triangle(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &PropId, &IsRequired) != 1 )
+    if (MMG2D_Get_triangle(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &PropId, &IsRequired) != 1 ) {
         exit(EXIT_FAILURE);
+    }
 
-	// Sometimes MMG creates elements where there are not, then we skip
-	if (mpRefElement[PropId] == nullptr) return p_element;
+    // Sometimes MMG creates elements where there are not, then we skip
+    if (mpRefElement[PropId] == nullptr) {
+        return p_element;
+    }
 
     // FIXME: This is not the correct solution to the problem, I asked in the MMG Forum
     if (vertex_0 == 0) SkipCreation = true;
@@ -1542,8 +1557,10 @@ ElementType::Pointer MmgProcess<MMGLibray::MMG3D>::CreateElement0(
     if (MMG3D_Get_tetrahedron(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &vertex_3, &PropId, &IsRequired) != 1 )
         exit(EXIT_FAILURE);
 
-	// Sometimes MMG creates elements where there are not, then we skip
-	if (mpRefElement[PropId] == nullptr) return p_element;
+    // Sometimes MMG creates elements where there are not, then we skip
+    if (mpRefElement[PropId] == nullptr) {
+        return p_element;
+    }
 
     // FIXME: This is not the correct solution to the problem, I asked in the MMG Forum
     if (vertex_0 == 0) SkipCreation = true;
@@ -1583,8 +1600,10 @@ ElementType::Pointer MmgProcess<MMGLibray::MMGS>::CreateElement0(
     if (MMGS_Get_triangle(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &PropId, &IsRequired) != 1 )
         exit(EXIT_FAILURE);
 
-	// Sometimes MMG creates elements where there are not, then we skip
-	if (mpRefElement[PropId] == nullptr) return p_element;
+    // Sometimes MMG creates elements where there are not, then we skip
+    if (mpRefElement[PropId] == nullptr) {
+        return p_element;
+    }
 
     // FIXME: This is not the correct solution to the problem, I asked in the MMG Forum
     if (vertex_0 == 0) SkipCreation = true;
@@ -1633,11 +1652,14 @@ ElementType::Pointer MmgProcess<MMGLibray::MMG3D>::CreateElement1(
 
     int vertex_0, vertex_1, vertex_2, vertex_3, vertex_4, vertex_5;
 
-    if (MMG3D_Get_prism(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &vertex_3, &vertex_4, &vertex_5, &PropId, &IsRequired) != 1 )
+    if (MMG3D_Get_prism(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &vertex_3, &vertex_4, &vertex_5, &PropId, &IsRequired) != 1 ) {
         exit(EXIT_FAILURE);
+    }
 
-	// Sometimes MMG creates elements where there are not, then we skip
-	if (mpRefElement[PropId] == nullptr) return p_element;
+    // Sometimes MMG creates elements where there are not, then we skip
+    if (mpRefElement[PropId] == nullptr) {
+        return p_element;
+    }
 
     // FIXME: This is not the correct solution to the problem, I asked in the MMG Forum
     if (vertex_0 == 0) SkipCreation = true;


### PR DESCRIPTION
This removes the following warnings:

~~~sh
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp: In member function ‘Kratos::Condition::Pointer Kratos::MmgProcess<TMMGLibray>::CreateCondition0(Kratos::Flags::IndexType, int&, int&, bool) [with Kratos::MMGLibray TMMGLibray = (Kratos::MMGLibray)0; Kratos::Condition::Pointer = std::shared_ptr<Kratos::Condition>; Kratos::Flags::IndexType = long unsigned int]’:
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1319:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (MMG2D_Get_edge(mmgMesh, &edge_0, &edge_1, &PropId, &is_ridge, &IsRequired) != 1 )
     ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1323:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (mpRefCondition[PropId] == nullptr) return p_condition;
  ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp: In member function ‘Kratos::Condition::Pointer Kratos::MmgProcess<TMMGLibray>::CreateCondition0(Kratos::Flags::IndexType, int&, int&, bool) [with Kratos::MMGLibray TMMGLibray = (Kratos::MMGLibray)1; Kratos::Condition::Pointer = std::shared_ptr<Kratos::Condition>; Kratos::Flags::IndexType = long unsigned int]’:
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1357:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (MMG3D_Get_triangle(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &PropId, &IsRequired) != 1 )
     ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1361:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (mpRefCondition[PropId] == nullptr) return p_condition;
  ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp: In member function ‘Kratos::Condition::Pointer Kratos::MmgProcess<TMMGLibray>::CreateCondition0(Kratos::Flags::IndexType, int&, int&, bool) [with Kratos::MMGLibray TMMGLibray = (Kratos::MMGLibray)2; Kratos::Condition::Pointer = std::shared_ptr<Kratos::Condition>; Kratos::Flags::IndexType = long unsigned int]’:
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1397:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (MMGS_Get_edge(mmgMesh, &edge_0, &edge_1, &PropId, &is_ridge, &IsRequired) != 1 )
     ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1401:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (mpRefCondition[PropId] == nullptr) return p_condition;
  ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp: In member function ‘Kratos::Condition::Pointer Kratos::MmgProcess<TMMGLibray>::CreateCondition1(Kratos::Flags::IndexType, int&, int&, bool) [with Kratos::MMGLibray TMMGLibray = (Kratos::MMGLibray)1; Kratos::Condition::Pointer = std::shared_ptr<Kratos::Condition>; Kratos::Flags::IndexType = long unsigned int]’:
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1448:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (MMG3D_Get_quadrilateral(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &vertex_3, &PropId, &IsRequired) != 1 )
     ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1452:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (mpRefCondition[PropId] == nullptr) return p_condition;
  ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp: In member function ‘Kratos::Element::Pointer Kratos::MmgProcess<TMMGLibray>::CreateElement0(Kratos::Flags::IndexType, int&, int&, bool) [with Kratos::MMGLibray TMMGLibray = (Kratos::MMGLibray)0; Kratos::Element::Pointer = std::shared_ptr<Kratos::Element>; Kratos::Flags::IndexType = long unsigned int]’:
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1503:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (MMG2D_Get_triangle(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &PropId, &IsRequired) != 1 )
     ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1507:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (mpRefElement[PropId] == nullptr) return p_element;
  ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp: In member function ‘Kratos::Element::Pointer Kratos::MmgProcess<TMMGLibray>::CreateElement0(Kratos::Flags::IndexType, int&, int&, bool) [with Kratos::MMGLibray TMMGLibray = (Kratos::MMGLibray)1; Kratos::Element::Pointer = std::shared_ptr<Kratos::Element>; Kratos::Flags::IndexType = long unsigned int]’:
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1542:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (MMG3D_Get_tetrahedron(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &vertex_3, &PropId, &IsRequired) != 1 )
     ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1546:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (mpRefElement[PropId] == nullptr) return p_element;
  ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp: In member function ‘Kratos::Element::Pointer Kratos::MmgProcess<TMMGLibray>::CreateElement0(Kratos::Flags::IndexType, int&, int&, bool) [with Kratos::MMGLibray TMMGLibray = (Kratos::MMGLibray)2; Kratos::Element::Pointer = std::shared_ptr<Kratos::Element>; Kratos::Flags::IndexType = long unsigned int]’:
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1583:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (MMGS_Get_triangle(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &PropId, &IsRequired) != 1 )
     ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1587:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (mpRefElement[PropId] == nullptr) return p_element;
  ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp: In member function ‘Kratos::Element::Pointer Kratos::MmgProcess<TMMGLibray>::CreateElement1(Kratos::Flags::IndexType, int&, int&, bool) [with Kratos::MMGLibray TMMGLibray = (Kratos::MMGLibray)1; Kratos::Element::Pointer = std::shared_ptr<Kratos::Element>; Kratos::Flags::IndexType = long unsigned int]’:
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1636:5: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
     if (MMG3D_Get_prism(mmgMesh, &vertex_0, &vertex_1, &vertex_2, &vertex_3, &vertex_4, &vertex_5, &PropId, &IsRequired) != 1 )
     ^~
/home/vicente/src/Kratos/applications/MeshingApplication/custom_processes/mmg_process.cpp:1640:2: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘if’
  if (mpRefElement[PropId] == nullptr) return p_element;
~~~