### PR TITLE
Implementing AND operation for flags

### DIFF
--- a/kratos/containers/flags.h
+++ b/kratos/containers/flags.h
@@ -345,12 +345,10 @@ public:
         return results;
     }
 
-    KRATOS_DEPRECATED friend Flags operator&(const Flags& Left, const Flags& Right )
+    friend Flags operator&(const Flags& Left, const Flags& Right )
     {
-        // This looks like copy paste error but the idea is to
-        // define the & operator like the or one.
         Flags results(Left);
-        results |= Right;
+        results &= Right;
         return results;
     }
 
@@ -361,12 +359,10 @@ public:
         return *this;
     }
 
-    KRATOS_DEPRECATED const Flags& operator&=(const Flags& Other )
+    const Flags& operator&=(const Flags& Other )
     {
-        // This looks like copy paste error but the idea is to
-        // define the & operator like the or one.
-        mIsDefined |= Other.mIsDefined;
-        mFlags |= Other.mFlags;
+        mIsDefined &= Other.mIsDefined;
+        mFlags &= Other.mFlags;
         return *this;
     }
 

--- a/kratos/python/add_containers_to_python.cpp
+++ b/kratos/python/add_containers_to_python.cpp
@@ -63,9 +63,7 @@ Flags FlagsOr(const Flags& Left, const Flags& Right )
 
 Flags FlagsAnd(const Flags& Left, const Flags& Right )
 {
-    KRATOS_WARNING("Kratos::Flags Python interface") << "Using deprecated flag & operation, which internally perfms a union (bitwise or)." << std::endl
-                 << "Please use | instead, since this behaviour will be soon deprecated." << std::endl;
-    return (Left|Right);
+    return (Left&Right);
 }
 
 void FlagsSet1(Flags& ThisFlag, const Flags& OtherFlag )

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -37,6 +37,7 @@ import test_variable_redistribution
 import test_object_printing
 import test_array_1d_interface
 import test_linear_master_slave_constraints
+import test_flags
 
 
 def AssembleTestSuites():
@@ -92,6 +93,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_object_printing.TestObjectPrinting]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_array_1d_interface.TestArray1DInterface]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_linear_master_slave_constraints.TestLinearMultipointConstraints]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_flags.TestFlags]))
 
     # Create a test suite with the selected tests plus all small tests
     nightSuite = suites['nightly']

--- a/kratos/tests/test_flags.py
+++ b/kratos/tests/test_flags.py
@@ -1,0 +1,97 @@
+from __future__ import print_function, absolute_import, division
+
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+from KratosMultiphysics import *
+
+class TestFlags(KratosUnittest.TestCase):
+    def setUp(self):
+        self.model = Model()
+        self.model_part = self.model.CreateModelPart("TestModelPart")
+        self.model_part.CreateNewNode(1, 0.0, 0.0, 0.0)
+
+    def tearDown(self):
+        pass
+
+    def testFlagSetReset(self):
+        node = self.model_part.GetNode(1)
+
+        node.Set(STRUCTURE)
+        node.Set(INTERFACE, True)
+        node.Set(VISITED, False)
+
+        self.assertTrue(node.IsDefined(STRUCTURE))
+        self.assertTrue(node.IsDefined(INTERFACE))
+        self.assertTrue(node.IsDefined(VISITED))
+        self.assertFalse(node.IsDefined(RIGID))
+
+        self.assertFalse(node.IsNotDefined(STRUCTURE))
+        self.assertTrue(node.IsNotDefined(RIGID))
+
+        self.assertTrue(node.Is(STRUCTURE))
+        self.assertTrue(node.Is(INTERFACE))
+        self.assertFalse(node.Is(VISITED))
+        self.assertFalse(node.Is(RIGID))
+
+        self.assertFalse(node.IsNot(STRUCTURE))
+        self.assertTrue(node.IsNot(RIGID)) # unset flags default to False
+
+
+        node.Reset(STRUCTURE)
+
+        self.assertFalse(node.IsDefined(STRUCTURE))
+
+        node.Clear() # reset all flags
+
+        self.assertFalse(node.IsDefined(INTERFACE))
+        self.assertFalse(node.IsDefined(VISITED))
+        self.assertFalse(node.IsDefined(RIGID))
+
+    def testFlagOr(self):
+        node = self.model_part.GetNode(1)
+
+        # set using OR
+        node.Set(BOUNDARY | FLUID)
+
+        self.assertTrue(node.Is(BOUNDARY))
+        self.assertTrue(node.Is(FLUID))
+
+        # check using OR
+        self.assertTrue(node.Is(BOUNDARY))
+        self.assertFalse(node.Is(TO_SPLIT))
+        self.assertTrue(node.Is(BOUNDARY | TO_SPLIT))
+
+    def testFlagAnd(self):
+        node1 = self.model_part.GetNode(1)
+        node2 = self.model_part.CreateNewNode(2, 1.0, 1.0, 1.0)
+
+        # the AND of two flags is always nothing
+        node1.Set(TO_SPLIT & TO_ERASE)
+
+        self.assertTrue(node1.IsNotDefined(TO_SPLIT))
+        self.assertTrue(node1.IsNotDefined(TO_ERASE))
+
+        # Using AND to check for intersection
+        node1.Set(ACTIVE | MODIFIED)
+        node2.Set(ACTIVE | MPI_BOUNDARY)
+
+        self.assertTrue( (node1 & node2).Is(ACTIVE) )
+        self.assertFalse( (node1 & node2).Is(MPI_BOUNDARY) )
+
+    def testFlagFlip(self):
+        node = self.model_part.GetNode(1)
+
+        node.Set(RIGID, False)
+        node.Flip(RIGID)
+
+        self.assertTrue(node.IsDefined(RIGID))
+        self.assertTrue(node.Is(RIGID))
+
+        # unset flags can be flipped too
+        self.assertFalse(node.IsDefined(MPI_BOUNDARY))
+        node.Flip(MPI_BOUNDARY)
+
+        self.assertTrue(node.IsDefined(MPI_BOUNDARY))
+        self.assertTrue(node.Is(MPI_BOUNDARY))
+
+if __name__ == "__main__":
+    KratosUnittest.main()

--- a/kratos/tests/test_flags.py
+++ b/kratos/tests/test_flags.py
@@ -64,7 +64,7 @@ class TestFlags(KratosUnittest.TestCase):
         node1 = self.model_part.GetNode(1)
         node2 = self.model_part.CreateNewNode(2, 1.0, 1.0, 1.0)
 
-        # the AND of two flags is always nothing
+        # the AND of two named flags is always nothing
         node1.Set(TO_SPLIT & TO_ERASE)
 
         self.assertTrue(node1.IsNotDefined(TO_SPLIT))


### PR DESCRIPTION
This PR implements the correct behavior for the flags `And` operation and a set of tests for Kratos flags. The old behavior was marked as deprecated in #2269 (merged in Jun 6). My motivation for pushing for this now is that, once the MPI core (#3340) goes ahead, it should be straightforward to add MPI flag synchronization (#1277) and use it in various utilities (such as coordinate transformation utils #214).

This is a behavior change, so it should only go ahead with agreement of the @KratosMultiphysics/technical-committee 