### PR TITLE
[Core] Removing default C++11 in configure.sh

### DIFF
--- a/cmake_build/example_configure.sh.do_not_touch
+++ b/cmake_build/example_configure.sh.do_not_touch
@@ -24,7 +24,7 @@ rm -rf CMakeFiles\
 cmake ..                                                                            \
 -DCMAKE_C_COMPILER=/usr/bin/gcc                                                     \
 -DCMAKE_CXX_COMPILER=/usr/bin/g++                                                   \
--DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -msse3 -std=c++11 "                           \
+-DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -msse3"                                       \
 -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -msse3 "                                          \
 -DBOOST_ROOT="${HOME}/boost"                                                        \
 -DPYTHON_EXECUTABLE="/usr/bin/python3"                                              \


### PR DESCRIPTION
Currently all compilers use at least C++14. maybe @roigcarlo prefer to keep it for user with old distros 