### PR TITLE
[ParticleMechanics] Particle generator fix

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
@@ -229,9 +229,9 @@ public:
                         {
                             shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_4);
                         }
-                        else if(m_NumPar == 16)
+                        else if(m_NumPar == 12)
                         {
-                            shape_functions_values = this->MP16ShapeFunctions();
+                            shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_5);
                         }
                     }
                     else if(m_GeometryElement == "Quadrilateral")
@@ -494,20 +494,21 @@ public:
 		return 0.00;
     }
 
+    // TODO: Check whether this is used in any part of the code, or remove it.
     virtual Matrix MP16ShapeFunctions()
     {
-        double Na1 = 0.33333333333333;
-        double Nb1 = 0.45929258829272;
-        double Nb2 = 0.08141482341455;
-        double Nc1 = 0.17056930775176;
-        double Nc2 = 0.65886138449648;
+        const double Na1 = 0.33333333333333;
+        const double Nb1 = 0.45929258829272;
+        const double Nb2 = 0.08141482341455;
+        const double Nc1 = 0.17056930775176;
+        const double Nc2 = 0.65886138449648;
 
-        double Nd1 = 0.05054722831703;
-        double Nd2 = 0.89890554336594;
+        const double Nd1 = 0.05054722831703;
+        const double Nd2 = 0.89890554336594;
 
-        double Ne1 = 0.26311282963464;
-        double Ne2 = 0.72849239295540;
-        double Ne3 = 0.00839477740996;
+        const double Ne1 = 0.26311282963464;
+        const double Ne2 = 0.72849239295540;
+        const double Ne3 = 0.00839477740996;
 
         BoundedMatrix<double,16,3> MP_ShapeFunctions;// = ZeroMatrix(16,3);
         MP_ShapeFunctions(0,0) = Na1;
@@ -583,34 +584,35 @@ public:
 
     }
 
+    // TODO: Check whether this is used in any part of the code, or remove it.
     virtual Matrix MP33ShapeFunctions()
     {
-        double Na2 = 0.02356522045239;
-        double Na1 = 0.488217389773805;
+        const double Na2 = 0.02356522045239;
+        const double Na1 = 0.488217389773805;
 
-        double Nb2 = 0.120551215411079;
-        double Nb1 = 0.43972439229446;
+        const double Nb2 = 0.120551215411079;
+        const double Nb1 = 0.43972439229446;
 
-        double Nc2 = 0.457579229975768;
-        double Nc1 = 0.271210385012116;
+        const double Nc2 = 0.457579229975768;
+        const double Nc1 = 0.271210385012116;
 
-        double Nd2 = 0.744847708916828;
-        double Nd1 = 0.127576145541586;
+        const double Nd2 = 0.744847708916828;
+        const double Nd1 = 0.127576145541586;
 
-        double Ne2 = 0.957365299093579;
-        double Ne1 = 0.021317350453210;
+        const double Ne2 = 0.957365299093579;
+        const double Ne1 = 0.021317350453210;
 
-        double Nf1 = 0.115343494534698;
-        double Nf2 = 0.275713269685514;
-        double Nf3 = 0.608943235779788;
+        const double Nf1 = 0.115343494534698;
+        const double Nf2 = 0.275713269685514;
+        const double Nf3 = 0.608943235779788;
 
-        double Ng1 = 0.022838332222257;
-        double Ng2 = 0.281325580989940;
-        double Ng3 = 0.695836086787803;
+        const double Ng1 = 0.022838332222257;
+        const double Ng2 = 0.281325580989940;
+        const double Ng3 = 0.695836086787803;
 
-        double Nh1 = 0.025734050548330;
-        double Nh2 = 0.116251915907597;
-        double Nh3 = 0.858014033544073;
+        const double Nh1 = 0.025734050548330;
+        const double Nh2 = 0.116251915907597;
+        const double Nh3 = 0.858014033544073;
         BoundedMatrix<double,33,3> MP_ShapeFunctions;// = ZeroMatrix(16,3);
 
         MP_ShapeFunctions(0,0) = Na1;

--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
@@ -217,40 +217,62 @@ public:
                     Matrix shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
                     if (m_GeometryElement == "Triangle")
                     {
-                        if(m_NumPar == 1)
+                        switch (m_NumPar)
                         {
-                            shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_1);
-                        }
-                        else if(m_NumPar == 3)
-                        {
-                            shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
-                        }
-                        else if(m_NumPar == 6)
-                        {
-                            shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_4);
-                        }
-                        else if(m_NumPar == 12)
-                        {
-                            shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_5);
+                            case 1:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_1);
+                                break;
+                            case 3:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
+                                break;
+                            case 6:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_4);
+                                break;
+                            case 12:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_5);
+                                break;
+                            case 16:
+                                if (TDim==2){
+                                    shape_functions_values = this->MP16ShapeFunctions();
+                                    break;
+                                }
+                            case 33:
+                                if (TDim==2) {
+                                    shape_functions_values = this->MP33ShapeFunctions();
+                                    break;
+                                }
+                            default:
+                                std::string warning_msg = "The input number of particle: " + std::to_string(m_NumPar);
+                                warning_msg += " is not available for Triangular" + std::to_string(TDim) + "D.\n";
+                                warning_msg += "Available options are: 1, 3, 6, 12, 16 (only 2D), and 33 (only 2D).\n";
+                                warning_msg += "The default number of particle: 3 is currently assumed.";
+                                KRATOS_INFO("MPM_Strategy") << "WARNING: " << warning_msg << std::endl;
+                                break;
                         }
                     }
                     else if(m_GeometryElement == "Quadrilateral")
                     {
-                        if(m_NumPar == 1)
+                        switch (m_NumPar)
                         {
-                            shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_1);
-                        }
-                        else if(m_NumPar == 4)
-                        {
-                            shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
-                        }
-                        else if(m_NumPar == 9)
-                        {
-                            shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_3);
-                        }
-                        else if(m_NumPar == 16)
-                        {
-                            shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_4);
+                            case 1:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_1);
+                                break;
+                            case 4:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
+                                break;
+                            case 9:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_3);
+                                break;
+                            case 16:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_4);
+                                break;
+                            default:
+                                std::string warning_msg = "The input number of particle: " + std::to_string(m_NumPar);
+                                warning_msg += " is not available for Quadrilateral" + std::to_string(TDim) + "D.\n";
+                                warning_msg += "Available options are: 1, 4, 9, 16.\n";
+                                warning_msg += "The default number of particle: 4 is currently assumed.";
+                                KRATOS_INFO("MPM_Strategy") << "WARNING: " << warning_msg << std::endl;
+                                break;
                         }
                     }
 
@@ -494,7 +516,6 @@ public:
 		return 0.00;
     }
 
-    // TODO: Check whether this is used in any part of the code, or remove it.
     virtual Matrix MP16ShapeFunctions()
     {
         const double Na1 = 0.33333333333333;
@@ -584,7 +605,6 @@ public:
 
     }
 
-    // TODO: Check whether this is used in any part of the code, or remove it.
     virtual Matrix MP33ShapeFunctions()
     {
         const double Na2 = 0.02356522045239;

--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
@@ -531,7 +531,7 @@ public:
         const double Ne2 = 0.72849239295540;
         const double Ne3 = 0.00839477740996;
 
-        BoundedMatrix<double,16,3> MP_ShapeFunctions;// = ZeroMatrix(16,3);
+        BoundedMatrix<double,16,3> MP_ShapeFunctions;
         MP_ShapeFunctions(0,0) = Na1;
         MP_ShapeFunctions(0,1) = Na1;
         MP_ShapeFunctions(0,2) = Na1;
@@ -633,7 +633,7 @@ public:
         const double Nh1 = 0.025734050548330;
         const double Nh2 = 0.116251915907597;
         const double Nh3 = 0.858014033544073;
-        BoundedMatrix<double,33,3> MP_ShapeFunctions;// = ZeroMatrix(16,3);
+        BoundedMatrix<double,33,3> MP_ShapeFunctions;
 
         MP_ShapeFunctions(0,0) = Na1;
         MP_ShapeFunctions(0,1) = Na1;

--- a/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle.py
+++ b/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle.py
@@ -99,7 +99,7 @@ class TestGenerateMPMParticle(KratosUnittest.TestCase):
 
     def test_GenerateMPMParticleTriangle2D16P(self):
         current_model = KratosMultiphysics.Model()
-        self._generate_particle_element_and_check(current_model, dimension=2, geometry_element="Triangle", num_particle=16, expected_num_particle=16)
+        self._generate_particle_element_and_check(current_model, dimension=2, geometry_element="Triangle", num_particle=12, expected_num_particle=12)
 
     def test_GenerateMPMParticleTriangle3D1P(self):
         current_model = KratosMultiphysics.Model()
@@ -115,7 +115,7 @@ class TestGenerateMPMParticle(KratosUnittest.TestCase):
 
     def test_GenerateMPMParticleTriangle3D16P(self):
         current_model = KratosMultiphysics.Model()
-        self._generate_particle_element_and_check(current_model, dimension=3, geometry_element="Triangle", num_particle=16, expected_num_particle=16)
+        self._generate_particle_element_and_check(current_model, dimension=3, geometry_element="Triangle", num_particle=12, expected_num_particle=24)
 
     def test_GenerateMPMParticleQuadrilateral2D1P(self):
         current_model = KratosMultiphysics.Model()

--- a/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle.py
+++ b/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle.py
@@ -97,9 +97,21 @@ class TestGenerateMPMParticle(KratosUnittest.TestCase):
         current_model = KratosMultiphysics.Model()
         self._generate_particle_element_and_check(current_model, dimension=2, geometry_element="Triangle", num_particle=6, expected_num_particle=6)
 
-    def test_GenerateMPMParticleTriangle2D16P(self):
+    def test_GenerateMPMParticleTriangle2D12P(self):
         current_model = KratosMultiphysics.Model()
         self._generate_particle_element_and_check(current_model, dimension=2, geometry_element="Triangle", num_particle=12, expected_num_particle=12)
+
+    def test_GenerateMPMParticleTriangle2D16P(self):
+        current_model = KratosMultiphysics.Model()
+        self._generate_particle_element_and_check(current_model, dimension=2, geometry_element="Triangle", num_particle=16, expected_num_particle=16)
+
+    def test_GenerateMPMParticleTriangle2D33P(self):
+        current_model = KratosMultiphysics.Model()
+        self._generate_particle_element_and_check(current_model, dimension=2, geometry_element="Triangle", num_particle=33, expected_num_particle=33)
+
+    def test_GenerateMPMParticleTriangle2DDefault(self):
+        current_model = KratosMultiphysics.Model()
+        self._generate_particle_element_and_check(current_model, dimension=2, geometry_element="Triangle", num_particle=50, expected_num_particle=3)
 
     def test_GenerateMPMParticleTriangle3D1P(self):
         current_model = KratosMultiphysics.Model()
@@ -113,9 +125,13 @@ class TestGenerateMPMParticle(KratosUnittest.TestCase):
         current_model = KratosMultiphysics.Model()
         self._generate_particle_element_and_check(current_model, dimension=3, geometry_element="Triangle", num_particle=6, expected_num_particle=14)
 
-    def test_GenerateMPMParticleTriangle3D16P(self):
+    def test_GenerateMPMParticleTriangle3D24P(self):
         current_model = KratosMultiphysics.Model()
         self._generate_particle_element_and_check(current_model, dimension=3, geometry_element="Triangle", num_particle=12, expected_num_particle=24)
+
+    def test_GenerateMPMParticleTriangle3DDefault(self):
+        current_model = KratosMultiphysics.Model()
+        self._generate_particle_element_and_check(current_model, dimension=3, geometry_element="Triangle", num_particle=50, expected_num_particle=4)
 
     def test_GenerateMPMParticleQuadrilateral2D1P(self):
         current_model = KratosMultiphysics.Model()
@@ -133,6 +149,10 @@ class TestGenerateMPMParticle(KratosUnittest.TestCase):
         current_model = KratosMultiphysics.Model()
         self._generate_particle_element_and_check(current_model, dimension=2, geometry_element="Quadrilateral", num_particle=16, expected_num_particle=16)
 
+    def test_GenerateMPMParticleQuadrilateral2DDefault(self):
+        current_model = KratosMultiphysics.Model()
+        self._generate_particle_element_and_check(current_model, dimension=2, geometry_element="Quadrilateral", num_particle=50, expected_num_particle=4)
+
     def test_GenerateMPMParticleQuadrilateral3D1P(self):
         current_model = KratosMultiphysics.Model()
         self._generate_particle_element_and_check(current_model, dimension=3, geometry_element="Quadrilateral", num_particle=1, expected_num_particle=1)
@@ -148,6 +168,10 @@ class TestGenerateMPMParticle(KratosUnittest.TestCase):
     def test_GenerateMPMParticleQuadrilateral3D64P(self):
         current_model = KratosMultiphysics.Model()
         self._generate_particle_element_and_check(current_model, dimension=3, geometry_element="Quadrilateral", num_particle=16, expected_num_particle=64)
+
+    def test_GenerateMPMParticleQuadrilateral3DDefault(self):
+        current_model = KratosMultiphysics.Model()
+        self._generate_particle_element_and_check(current_model, dimension=3, geometry_element="Quadrilateral", num_particle=50, expected_num_particle=8)
 
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
I decided to change to the default shape function value as the function MP16ShapeFunctions() returns me the size of (16,3) which leads to bad index when I do a loop from a tetrahedral mesh with 4 nodes. The test is modified accordingly and GiDInterface will be modified too.