### PR TITLE
[StructuralMechanics] adapting Eigen-Postprocess for multi-step

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_processes/postprocess_eigenvalues_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/postprocess_eigenvalues_process.cpp
@@ -31,18 +31,19 @@ namespace Kratos
     {
         Parameters default_parameters(R"(
             {
-                "result_file_name" : "",
-                "result_file_format_use_ascii" : false,
-                "animation_steps"   :  1,
-                "label_type" : "angular_frequency",
-                "list_of_result_variables" : []
+                "result_file_name"              : "Structure",
+                "file_label"                    : "step",
+                "result_file_format_use_ascii"  : false,
+                "animation_steps"               : 20,
+                "label_type"                    : "frequency",
+                "list_of_result_variables"      : ["DISPLACEMENT"]
             }  )"
         );
 
         mOutputParameters.RecursivelyValidateAndAssignDefaults(default_parameters);
     }
 
-    void PostprocessEigenvaluesProcess::Execute()
+    void PostprocessEigenvaluesProcess::ExecuteFinalizeSolutionStep()
     {
         std::string result_file_name = mOutputParameters["result_file_name"].GetString();
 
@@ -50,7 +51,17 @@ namespace Kratos
             result_file_name = mrModelPart.Name();
         }
 
-        result_file_name += "_EigenResults";
+        result_file_name += "_EigenResults_";
+
+        const std::string file_label = mOutputParameters["file_label"].GetString();
+
+        if (file_label == "step") {
+            result_file_name += std::to_string(mrModelPart.GetProcessInfo()[STEP]);
+        } else if (file_label == "time") {
+            result_file_name += std::to_string(mrModelPart.GetProcessInfo()[TIME]);
+        } else {
+            KRATOS_ERROR << "\"file_label\" can only be \"step\" or \"time\"" << std::endl;
+        }
 
         auto post_mode = GiD_PostBinary;
         if (mOutputParameters["result_file_format_use_ascii"].GetBool()) { // this format is only needed for testing

--- a/applications/StructuralMechanicsApplication/custom_processes/postprocess_eigenvalues_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/postprocess_eigenvalues_process.h
@@ -86,7 +86,7 @@ class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) PostprocessEigenvaluesProcess
     ///@name Operations
     ///@{
 
-    void Execute() override;
+    void ExecuteFinalizeSolutionStep() override;
 
     ///@}
     ///@name Access

--- a/applications/StructuralMechanicsApplication/python_scripts/postprocess_eigenvalues_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/postprocess_eigenvalues_process.py
@@ -13,11 +13,14 @@ def Factory(settings, Model):
     if(type(settings) != KratosMultiphysics.Parameters):
         raise Exception("Expected input shall be a Parameters object, encapsulating a json string")
 
-    if settings.Has("computing_model_part_name"):
-        computing_model_part = Model[settings["computing_model_part_name"].GetString()]
+    process_settings = settings["Parameters"]
+
+    if process_settings.Has("computing_model_part_name"):
+        computing_model_part = Model[process_settings["computing_model_part_name"].GetString()]
     else: # using default name
         computing_model_part = Model["Structure.computing_domain"]
 
-    settings.RemoveValue("help")
+    process_settings.RemoveValue("computing_model_part_name")
+    process_settings.RemoveValue("help")
 
-    return KSM.PostprocessEigenvaluesProcess(computing_model_part, settings)
+    return KSM.PostprocessEigenvaluesProcess(computing_model_part, process_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/postprocess_eigenvalues_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/postprocess_eigenvalues_process.py
@@ -7,57 +7,17 @@ import KratosMultiphysics
 KratosMultiphysics.CheckRegisteredApplications("StructuralMechanicsApplication")
 
 # Import applications
-import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
-
+import KratosMultiphysics.StructuralMechanicsApplication as KSM
 
 def Factory(settings, Model):
     if(type(settings) != KratosMultiphysics.Parameters):
         raise Exception("Expected input shall be a Parameters object, encapsulating a json string")
-    return PostProcessEigenvaluesProcess(Model, settings["Parameters"])
 
-class PostProcessEigenvaluesProcess(KratosMultiphysics.Process):
-    def __init__(self, Model, settings):
+    if settings.Has("computing_model_part_name"):
+        computing_model_part = Model[settings["computing_model_part_name"].GetString()]
+    else: # using default name
+        computing_model_part = Model["Structure.computing_domain"]
 
-        default_settings = KratosMultiphysics.Parameters(
-            """
-            {
-                "help"                         :"This process can be used in order to generate a postprocess files for eigenvalues problems. It uses the C++ class PostprocessEigenvaluesProcess",
-                "result_file_name"             : "Structure",
-                "result_file_format_use_ascii" : false,
-                "computing_model_part_name"    : "Structure.computing_domain",
-                "animation_steps"              :  20,
-                "list_of_result_variables"     : ["DISPLACEMENT"],
-                "label_type"                   : "frequency"
-            }
-            """
-        )
+    settings.RemoveValue("help")
 
-        settings.ValidateAndAssignDefaults(default_settings)
-        settings.RemoveValue("help")
-
-        KratosMultiphysics.Process.__init__(self)
-        self.model_part = Model[settings["computing_model_part_name"].GetString()]
-        settings.RemoveValue("computing_model_part_name")
-        self.settings = settings
-
-    def ExecuteInitialize(self):
-        pass
-
-    def ExecuteBeforeSolutionLoop(self):
-        pass
-
-    def ExecuteInitializeSolutionStep(self):
-        pass
-
-    def ExecuteFinalizeSolutionStep(self):
-        pass
-
-    def ExecuteBeforeOutputStep(self):
-        pass
-
-    def ExecuteAfterOutputStep(self):
-        pass
-
-    def ExecuteFinalize(self):
-        StructuralMechanicsApplication.PostprocessEigenvaluesProcess(
-            self.model_part, self.settings).Execute()
+    return KSM.PostprocessEigenvaluesProcess(computing_model_part, settings)

--- a/applications/StructuralMechanicsApplication/tests/test_postprocess_eigenvalues_process.py
+++ b/applications/StructuralMechanicsApplication/tests/test_postprocess_eigenvalues_process.py
@@ -4,7 +4,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils
-from postprocess_eigenvalues_process import PostProcessEigenvaluesProcess
+import postprocess_eigenvalues_process
 from compare_two_files_check_process import CompareTwoFilesCheckProcess
 
 import os
@@ -45,8 +45,8 @@ def GetEigenVectorMatrix(num_eigenvalues, node_id):
 
 class TestPostprocessEigenvaluesProcess(KratosUnittest.TestCase):
     def tearDown(self):
-        kratos_utils.DeleteFileIfExisting("Structure_EigenResults_0.post.msh")
-        kratos_utils.DeleteFileIfExisting("Structure_EigenResults_0.post.res") # usually this is deleted by the check process but not if it fails
+        kratos_utils.DeleteFileIfExisting("Structure_EigenResults_15_0.post.msh")
+        kratos_utils.DeleteFileIfExisting("Structure_EigenResults_15_0.post.res") # usually this is deleted by the check process but not if it fails
 
 
     def test_PostprocessEigenvaluesProcess(self):
@@ -58,6 +58,8 @@ class TestPostprocessEigenvaluesProcess(KratosUnittest.TestCase):
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION)
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ROTATION)
         model_part.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION_MOMENT)
+
+        model_part.ProcessInfo[KratosMultiphysics.STEP] = 15
 
         CreateNodes(comp_model_part)
 
@@ -83,7 +85,7 @@ class TestPostprocessEigenvaluesProcess(KratosUnittest.TestCase):
         # here the minimum settings are specified to test the default values!
         settings_eigen_process = KratosMultiphysics.Parameters("""{"result_file_format_use_ascii" : true}""")
 
-        post_eigen_process = PostProcessEigenvaluesProcess(test_model, settings_eigen_process)
+        post_eigen_process = postprocess_eigenvalues_process.Factory(settings_eigen_process, test_model)
 
         post_eigen_process.ExecuteInitialize()
         post_eigen_process.ExecuteBeforeSolutionLoop()
@@ -104,7 +106,7 @@ class TestPostprocessEigenvaluesProcess(KratosUnittest.TestCase):
         """)
 
         settings_check_process["reference_file_name"].SetString(GetFilePath("test_postprocess_eigenvalues_process.ref"))
-        settings_check_process["output_file_name"].SetString("Structure_EigenResults_0.post.res")
+        settings_check_process["output_file_name"].SetString("Structure_EigenResults_15_0.post.res")
 
         check_process = CompareTwoFilesCheckProcess(settings_check_process)
 

--- a/applications/StructuralMechanicsApplication/tests/test_postprocess_eigenvalues_process.py
+++ b/applications/StructuralMechanicsApplication/tests/test_postprocess_eigenvalues_process.py
@@ -83,7 +83,11 @@ class TestPostprocessEigenvaluesProcess(KratosUnittest.TestCase):
 
         # Use the process
         # here the minimum settings are specified to test the default values!
-        settings_eigen_process = KratosMultiphysics.Parameters("""{"result_file_format_use_ascii" : true}""")
+        settings_eigen_process = KratosMultiphysics.Parameters("""{
+            "Parameters" : {
+                "result_file_format_use_ascii" : true
+            }
+        }""")
 
         post_eigen_process = postprocess_eigenvalues_process.Factory(settings_eigen_process, test_model)
 


### PR DESCRIPTION
the essential change is that the eigen-postprocessing will now be called in `FinalizeSolutionStep` instead of `Finalize` 
This means that it is now possible to have several steps in an eigenvalue analysis
Also I simplified the python-interface

=> @dbaumgaertner can you please test if this now works as intended?

In a regular analysis nothing should change

FYI @e-dub