### PR TITLE
[ContactStructuralMechanicsApplication] Duplicated message for not converged problems

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_implicit_dynamic_solver.py
@@ -177,6 +177,10 @@ class ContactImplicitMechanicalSolver(structural_mechanics_implicit_dynamic_solv
         #mechanical_solution_strategy.SolveSolutionStep()
         #mechanical_solution_strategy.FinalizeSolutionStep()
 
+    def SolveSolutionStep(self):
+        is_converged = self.get_mechanical_solution_strategy().SolveSolutionStep()
+        return is_converged
+
     def AddProcessesList(self, processes_list):
         self.processes_list = CSMA.ProcessFactoryUtility(processes_list)
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_static_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_static_solver.py
@@ -178,6 +178,10 @@ class ContactStaticMechanicalSolver(structural_mechanics_static_solver.StaticMec
         #mechanical_solution_strategy.SolveSolutionStep()
         #mechanical_solution_strategy.FinalizeSolutionStep()
 
+    def SolveSolutionStep(self):
+        is_converged = self.get_mechanical_solution_strategy().SolveSolutionStep()
+        return is_converged
+
     def AddProcessesList(self, processes_list):
         self.processes_list = CSMA.ProcessFactoryUtility(processes_list)
 

--- a/applications/ContactStructuralMechanicsApplication/tests/test_ContactStructuralMechanicsApplication.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/test_ContactStructuralMechanicsApplication.py
@@ -328,5 +328,10 @@ def AssembleTestSuites():
     return suites
 
 if __name__ == '__main__':
-    KratosUnittest.runTests(AssembleTestSuites())
+    KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning cpp unit tests ...")
     run_cpp_unit_tests.run()
+    KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished running cpp unit tests!")
+
+    KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning python tests ...")
+    KratosUnittest.runTests(AssembleTestSuites())
+    KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished python tests!")


### PR DESCRIPTION
I already have an output message for not converged problems, this overrides the message given by the base solver