### PR TITLE
[StructuralMechanicsApplication] Real fix for Clang of SPR compilation with stl_io

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
@@ -18,7 +18,6 @@
 #include "processes/find_nodal_neighbours_process.h"
 #include "custom_processes/spr_error_process.h"
 #include "utilities/variable_utils.h"
-#include "utilities/stl_io.h"
 
 namespace Kratos
 {
@@ -155,7 +154,12 @@ void SPRErrorProcess<TDim>::CalculateErrorEstimation(
         const auto& process_info = mThisModelPart.GetProcessInfo();
         it_elem->GetValueOnIntegrationPoints(ERROR_INTEGRATION_POINT, error_integration_point, process_info);
 
-        KRATOS_INFO_IF("SPRErrorProcess", mEchoLevel > 2) << "Error GP:" << error_integration_point << std::endl;
+        // The error_integration_point is printed
+        if (mEchoLevel > 2) {
+            std::stringstream ss_error_integration_point;
+            ss_error_integration_point << error_integration_point;
+            KRATOS_INFO("SPRErrorProcess") << "Error GP:" << ss_error_integration_point.str() << std::endl;
+        }
 
         // We compute the error overall
         double error_energy_norm = 0.0;


### PR DESCRIPTION
The problem was the compiler, when I tried the include I change to debug, which I compile with gcc, but the problem was in the clang compilation