### PR TITLE
Add buffer size in default settings in ConvectionDiffusionBaseSolver

### DIFF
--- a/applications/convection_diffusion_application/python_scripts/convection_diffusion_base_solver.py
+++ b/applications/convection_diffusion_application/python_scripts/convection_diffusion_base_solver.py
@@ -107,7 +107,8 @@ class ConvectionDiffusionBaseSolver(PythonSolver):
             },
             "problem_domain_sub_model_part_list": [""],
             "processes_sub_model_part_list": [""],
-            "auxiliary_variables_list" : []
+            "auxiliary_variables_list" : [],
+            "buffer_size" : -1
         }
         """)
 


### PR DESCRIPTION
I added the buffer size in the default settings of the base solver in order to serialize the project parameters.