### PR TITLE
Classes with virtual functions should have virtual destructors.

### DIFF
--- a/kratos/includes/linear_solver_factory.h
+++ b/kratos/includes/linear_solver_factory.h
@@ -75,6 +75,8 @@ public:
     ///@name Life Cycle
     ///@{
 
+    virtual ~LinearSolverFactory(){}
+
     ///@}
     ///@name Operators
     ///@{

--- a/kratos/includes/preconditioner_factory.h
+++ b/kratos/includes/preconditioner_factory.h
@@ -78,6 +78,8 @@ public:
     ///@name Life Cycle
     ///@{
 
+    virtual ~PreconditionerFactory() {}
+
     ///@}
     ///@name Operators
     ///@{

--- a/kratos/tests/strategies/schemes/test_residual_based_adjoint_bossak_scheme.cpp
+++ b/kratos/tests/strategies/schemes/test_residual_based_adjoint_bossak_scheme.cpp
@@ -43,6 +43,7 @@ typedef SolvingStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType> Solvi
 struct PrimalResults
 {
     KRATOS_CLASS_POINTER_DEFINITION(PrimalResults);
+    virtual ~PrimalResults() {};
     virtual void StoreCurrentSolutionStep(const ModelPart& rModelPart) = 0;
     virtual void LoadCurrentSolutionStep(ModelPart& rModelPart) const = 0;
 };
@@ -131,15 +132,15 @@ namespace NonLinearSpringMassDamper
  * @brief A system of two mass-spring-dampers for testing a second-order ode.
  * @details Taken from L.F. Fernandez, D.A. Tortorelli, Semi-analytical
  * sensitivity analysis for nonlinear transient problems.
- * 
+ *
  *  |                _____                 _____
  *  |---[ Damper ]--|mass1|---[ Damper ]--|mass2|
  *  |-----/\/\/\----|_____|-----/\/\/\----|_____|
  *  |
- * 
+ *
  * Spring force: fe = x + stiffness * x^3
  * Damper force: fc = damping * x'
- * 
+ *
  * Momentum equations:
  * mass1 * acc1 + 2 * damping * vel1 - damping * vel2 + 2 * disp1 - disp2 + stiffness * disp1^3 - stiffness * (disp2 - disp1)^3 = 0,
  * mass2 * acc2 - damping * vel1 + damping * vel2 - disp1 + disp2 + stiffness * (disp2 - disp1)^3 = 0.
@@ -636,7 +637,7 @@ KRATOS_TEST_CASE_IN_SUITE(ResidualBasedAdjointBossak_TwoMassSpringDamperSystem, 
     // Solve the primal problem.
     Model current_model;
     ModelPart& model_part = current_model.CreateModelPart("test");
-    
+
     Nlsmd::InitializePrimalModelPart(model_part);
     auto p_results_data = Kratos::make_shared<Nlsmd::PrimalResults>();
     Base::PrimalStrategy solver(model_part, p_results_data);

--- a/kratos/utilities/adjoint_extensions.h
+++ b/kratos/utilities/adjoint_extensions.h
@@ -2,12 +2,12 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    
+//  Main authors:
 //
 //
 
@@ -37,6 +37,10 @@ class AdjointExtensions
 {
 public:
     KRATOS_CLASS_POINTER_DEFINITION(AdjointExtensions);
+
+    virtual ~AdjointExtensions()
+    {
+    }
 
     virtual void GetFirstDerivativesVector(std::size_t NodeId,
                                            std::vector<IndirectScalar<double>>& rVector,
@@ -89,4 +93,4 @@ private:
 
 }  // namespace Kratos.
 
-#endif // KRATOS_ADJOINT_EXTENSIONS_INCLUDED  defined 
+#endif // KRATOS_ADJOINT_EXTENSIONS_INCLUDED  defined

--- a/kratos/utilities/assign_unique_model_part_collection_tag_utility.h
+++ b/kratos/utilities/assign_unique_model_part_collection_tag_utility.h
@@ -62,7 +62,7 @@ namespace Kratos
  * @class AssignUniqueModelPartCollectionTagUtility
  * @ingroup KratosCore
  * @brief Get the collection of submodelparts each node, condition and element belongs to
- * @details This class compute a map of collections of submodelparts. A tag is assigned 
+ * @details This class compute a map of collections of submodelparts. A tag is assigned
  * to each node, condition and element in order to get the collections it belongs to
  * ModelPart tag is 0. Each submodelpart has 1, 2... tag. A combintation of submodelparts
  * has another tag
@@ -78,7 +78,7 @@ class KRATOS_API(KRATOS_CORE) AssignUniqueModelPartCollectionTagUtility
     /// Vector of strings
     typedef std::vector<std::string> StringVectorType;
 
-    /// The map containing the id for each component and the corresponding tag 
+    /// The map containing the id for each component and the corresponding tag
     typedef std::unordered_map<IndexType,IndexType> IndexIndexMapType;
 
     /// The map containing the tags and the names of the related submodelparts
@@ -103,7 +103,7 @@ class KRATOS_API(KRATOS_CORE) AssignUniqueModelPartCollectionTagUtility
     AssignUniqueModelPartCollectionTagUtility(ModelPart& rModelPart);
 
     /// Destructor.
-    ~AssignUniqueModelPartCollectionTagUtility();
+    virtual ~AssignUniqueModelPartCollectionTagUtility();
 
 
     ///@}
@@ -245,7 +245,7 @@ class KRATOS_API(KRATOS_CORE) AssignUniqueModelPartCollectionTagUtility
     ///@}
     ///@name Private Operations
     ///@{
-    
+
     static ModelPart& AuxGetSubModelPart(ModelPart& rThisModelPart, std::istringstream& rFullName);
 
     ///@}

--- a/kratos/utilities/read_materials_utility.cpp
+++ b/kratos/utilities/read_materials_utility.cpp
@@ -71,6 +71,13 @@ ReadMaterialsUtility::ReadMaterialsUtility(
 /***********************************************************************************/
 /***********************************************************************************/
 
+ReadMaterialsUtility::~ReadMaterialsUtility()
+{
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 void ReadMaterialsUtility::ReadMaterials(Parameters MaterialData)
 {
     GetPropertyBlock(MaterialData);

--- a/kratos/utilities/read_materials_utility.h
+++ b/kratos/utilities/read_materials_utility.h
@@ -101,6 +101,9 @@ class KRATOS_API(KRATOS_CORE) ReadMaterialsUtility
      */
     ReadMaterialsUtility(const std::string& rParametersName, Model& rModel);
 
+    /** @brief Destructor */
+    virtual ~ReadMaterialsUtility();
+
     ///@}
     ///@name Operators
     ///@{

--- a/kratos/utilities/sub_model_parts_list_utility.h
+++ b/kratos/utilities/sub_model_parts_list_utility.h
@@ -106,7 +106,7 @@ class KRATOS_API(KRATOS_CORE) SubModelPartsListUtility
     KRATOS_DEPRECATED_MESSAGE("Please, use AssignUniqueModelPartCollectionTagUtility") SubModelPartsListUtility(ModelPart& rModelPart);
 
     /// Destructor.
-    ~SubModelPartsListUtility();
+    virtual ~SubModelPartsListUtility();
 
 
     ///@}


### PR DESCRIPTION
I am explicitly defining a virtual destructor for several classes that have virtual methods. In theory, as soon as a class has a virtual method it should get a virtual destructor too. gcc seems to do just fine without, but clang was complaining.