### PR TITLE
[Core][MeshMoving] Corrections towards embedded FSI

### DIFF
--- a/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.cpp
+++ b/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.cpp
@@ -34,11 +34,12 @@ namespace Kratos
         const double SearchRadius) : 
         mSearchRadius(SearchRadius),
         mrVirtualModelPart(rModelPart),
-        mrStructureModelPart(rStructureModelPart){
-
-        KRATOS_WARNING_IF("ExplicitMeshMovingUtilities",mrStructureModelPart.GetBufferSize() == 1) << 
-            "Structure model part buffer size is 1. Setting buffer size to 2." << std::endl;
-        mrStructureModelPart.SetBufferSize(2);
+        mrStructureModelPart(rStructureModelPart)
+    {
+        if (mrStructureModelPart.GetBufferSize() < 2) {
+            (mrStructureModelPart.GetRootModelPart()).SetBufferSize(2);
+            KRATOS_WARNING("ExplicitMeshMovingUtilities") << "Structure model part buffer size is 1. Setting buffer size to 2." << std::endl;
+        }
     }
 
     void ExplicitMeshMovingUtilities::FillVirtualModelPart(ModelPart& rOriginModelPart){

--- a/kratos/utilities/embedded_skin_utility.cpp
+++ b/kratos/utilities/embedded_skin_utility.cpp
@@ -82,9 +82,9 @@ namespace Kratos
         VariableUtils().SetFlag<ModelPart::ConditionsContainerType>(TO_ERASE, true, mrSkinModelPart.Conditions());
 
         // Remove all the skin model part geometrical entities
-        // mrSkinModelPart.RemoveNodes(TO_ERASE);
-        // mrSkinModelPart.RemoveElements(TO_ERASE);
-        // mrSkinModelPart.RemoveConditions(TO_ERASE);
+        mrSkinModelPart.RemoveNodes(TO_ERASE);
+        mrSkinModelPart.RemoveElements(TO_ERASE);
+        mrSkinModelPart.RemoveConditions(TO_ERASE);
     }
 
     template<std::size_t TDim>


### PR DESCRIPTION
This PR slightly changes two files towards the implementation of the embedded FSI solver:

- One is to clear the generated intersections skin. Otherwise the geometrical entities will accumulate as the skin is recomputed at each time step.
- The other is to check the current structure buffer size in the FM-ALE utility. 