### PR TITLE
Fluid/assign neighbour elements from python

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -11,8 +11,19 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
     def __init__(self, main_model_part, Parameters ):
         self.main_model_part = main_model_part
 
+        default_parameters = KratosMultiphysics.Parameters(r'''{
+            "volume_model_part_name" : "",
+            "skin_parts" : [],
+            "assign_neighbour_elements_to_conditions" : false
+        }''')
+        Parameters.ValidateAndAssignDefaults(default_parameters)
+        if Parameters["volume_model_part_name"].GetString() == "":
+            raise Exception("Please define the \"volume_model_part_name\" (string) argument.")
+
         self.volume_model_part_name = Parameters["volume_model_part_name"].GetString()
         self.skin_name_list = Parameters["skin_parts"]
+
+        self.assign_neighbour_elements = Parameters["assign_neighbour_elements_to_conditions"].GetBool()
 
 
         #self.volume_model_part_name = Parameters["volume_model_part_name"].GetString()
@@ -49,6 +60,12 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         fluid_computational_model_part.AddConditions(list(list_of_ids))
 
         #verify the orientation of the skin
+        tmoc = KratosMultiphysics.TetrahedralMeshOrientationCheck
         throw_errors = False
-        KratosMultiphysics.TetrahedralMeshOrientationCheck(fluid_computational_model_part,throw_errors).Execute()
+        flags = tmoc.NOT_COMPUTE_NODAL_NORMALS | tmoc.NOT_COMPUTE_CONDITION_NORMALS
+        if self.assign_neighbour_elements:
+            flags |= tmoc.ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
+        else:
+            flags |= tmoc.NOT_ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS
+        KratosMultiphysics.TetrahedralMeshOrientationCheck(fluid_computational_model_part,throw_errors, flags).Execute()
 

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -176,11 +176,18 @@ void  AddProcessesToPython(pybind11::module& m)
             .def(py::init<const Geometry< Node<3> >&, ModelPart&, Parameters&>()) //TODO: VERIFY IF THE NEXT IS NEEDED: [with_custodian_and_ward<1, 2>()])
     ;
 
-    py::class_<TetrahedralMeshOrientationCheck, TetrahedralMeshOrientationCheck::Pointer, Process>(m,"TetrahedralMeshOrientationCheck")
+    auto orientation_check_interface = py::class_<TetrahedralMeshOrientationCheck, TetrahedralMeshOrientationCheck::Pointer, Process>(m,"TetrahedralMeshOrientationCheck")
             .def(py::init<ModelPart&, bool>())
+            .def(py::init<ModelPart&, bool, Kratos::Flags>())
     .def("SwapAll",&TetrahedralMeshOrientationCheck::SwapAll)
     .def("SwapNegativeElements",&TetrahedralMeshOrientationCheck::SwapNegativeElements)
     ;
+    orientation_check_interface.attr("ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS") = &TetrahedralMeshOrientationCheck::ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS;
+    orientation_check_interface.attr("NOT_ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS") = &TetrahedralMeshOrientationCheck::ASSIGN_NEIGHBOUR_ELEMENTS_TO_CONDITIONS;
+    orientation_check_interface.attr("COMPUTE_NODAL_NORMALS") = &TetrahedralMeshOrientationCheck::COMPUTE_NODAL_NORMALS;
+    orientation_check_interface.attr("NOT_COMPUTE_NODAL_NORMALS") = &TetrahedralMeshOrientationCheck::NOT_COMPUTE_NODAL_NORMALS;
+    orientation_check_interface.attr("COMPUTE_CONDITION_NORMALS") = &TetrahedralMeshOrientationCheck::COMPUTE_CONDITION_NORMALS;
+    orientation_check_interface.attr("NOT_COMPUTE_CONDITION_NORMALS") = &TetrahedralMeshOrientationCheck::NOT_COMPUTE_CONDITION_NORMALS;
 
     py::class_<ComputeBDFCoefficientsProcess, ComputeBDFCoefficientsProcess::Pointer, Process>(m,"ComputeBDFCoefficientsProcess")
             .def(py::init<ModelPart&, const unsigned int>())
@@ -276,7 +283,7 @@ void  AddProcessesToPython(pybind11::module& m)
             .def(py::init<ModelPart&, component_type&, Variable<array_1d<double,3> >& , Variable<double>& >())
     ;
 
-    // Discontinuous distance computation methods        
+    // Discontinuous distance computation methods
     py::class_<CalculateDiscontinuousDistanceToSkinProcess<2>, CalculateDiscontinuousDistanceToSkinProcess<2>::Pointer, Process>(m,"CalculateDiscontinuousDistanceToSkinProcess2D")
         .def(py::init<ModelPart&, ModelPart&>())
         .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinArray<2>)


### PR DESCRIPTION
This exposes to python the capability to assign neighbor elements to conditions, which is already provided by the TetrahedralMeshOrientationCheck utility. It also adds a json parameter that can be used to request this feature.

If this option is used, weak pointers to "parent" elements can be accessed from the conditions by reading `GetValue(NEIGHBOUR_ELEMENTS)`

FYI @sunethwarna @swenczowski 