### PR TITLE
[IGA] Add NodeSurface3D

### DIFF
--- a/applications/IgaApplication/custom_utilities/node_curve_geometry_3d.h
+++ b/applications/IgaApplication/custom_utilities/node_curve_geometry_3d.h
@@ -20,6 +20,7 @@
 #include "includes/node.h"
 #include "includes/variables.h"
 #include "anurbs.h"
+#include "iga_application_variables.h"
 
 namespace Kratos {
 

--- a/applications/IgaApplication/custom_utilities/node_surface_geometry_3d.h
+++ b/applications/IgaApplication/custom_utilities/node_surface_geometry_3d.h
@@ -229,6 +229,8 @@ public:
     }
 };
 
+using NodeSurface3D = ANurbs::Surface<NodeSurfaceGeometry3D>;
+
 }
 
 #endif // !defined(KRATOS_NODE_SURFACE_GEOMETRY_3D_H_INCLUDED)

--- a/applications/IgaApplication/custom_utilities/node_surface_geometry_3d.h
+++ b/applications/IgaApplication/custom_utilities/node_surface_geometry_3d.h
@@ -20,6 +20,7 @@
 #include "includes/node.h"
 #include "includes/variables.h"
 #include "anurbs.h"
+#include "iga_application_variables.h"
 
 namespace Kratos {
 


### PR DESCRIPTION
Add NodeSurface3D: Allows to create a Surface from a FE-Node-based Geometry
```c++
// NURBS-Surface-Geometry based on FE-Nodes
auto nodeSurfaceGeometry3d = Kratos::make_shared<NodeSurfaceGeometry3D>(
    2,      // DegreeU
    2,      // DegreeV
    4,      // NumberOfPolesU
    4       // NumberOfPolesV
);

// Surface
auto surface3d = Kratos::make_shared<NodeSurface3D>(
    nodeSurfaceGeometry3d
);
```

Cleanup: Some header files