### PR TITLE
[MeshMoving] removing not-working fct "Check"

### DIFF
--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
@@ -137,9 +137,6 @@ class MeshSolverBase(PythonSolver):
     def Clear(self):
         self.get_mesh_motion_solving_strategy().Clear()
 
-    def Check(self):
-        self.get_mesh_motion_solving_strategy().Check()
-
     def GetMinimumBufferSize(self):
         buffer_size = 0
         if (self.settings["calculate_mesh_velocities"].GetBool() == True):


### PR DESCRIPTION
fixes #3425 
Can you please try this @dbaumgaertner ?

This is a bug in MeshMoving that was discovered with #3001 

The MeshMoving-Strategies do not implement `Check`, therefore the Baseclass (`SolvingStrategy`) is called, which has an inappropriate check for `DISPLACEMENT`, which is not used in MeshMoving (=> `MESH_DISPLACEMENT` is used there)

This PR therefore removes the call to `Check`

I am already working on improving this in another branch, then I will properly implement `Check` there.

fyi @rubenzorrilla @armingeiser 