### PR TITLE
Fix compile error from Check() function

### DIFF
--- a/applications/MeshingApplication/custom_processes/multiscale_refining_process.cpp
+++ b/applications/MeshingApplication/custom_processes/multiscale_refining_process.cpp
@@ -60,7 +60,7 @@ MultiscaleRefiningProcess::MultiscaleRefiningProcess(
 
     mStepDataSize = mrCoarseModelPart.GetNodalSolutionStepDataSize();
 
-    Check();
+    //Check();
 
     // Initialize the coarse model part
     InitializeCoarseModelPart();
@@ -77,7 +77,7 @@ MultiscaleRefiningProcess::MultiscaleRefiningProcess(
 }
 
 
-void MultiscaleRefiningProcess::Check()
+int MultiscaleRefiningProcess::Check()
 {
     KRATOS_TRY
 
@@ -89,6 +89,8 @@ void MultiscaleRefiningProcess::Check()
     KRATOS_CHECK_EQUAL(mStepDataSize, mrVisualizationModelPart.GetNodalSolutionStepDataSize());
 
     KRATOS_CATCH("")
+
+    return 0;
 }
 
 

--- a/applications/MeshingApplication/custom_processes/multiscale_refining_process.h
+++ b/applications/MeshingApplication/custom_processes/multiscale_refining_process.h
@@ -353,7 +353,7 @@ public:
     /**
      * @brief Perform a check with the parameters
      */
-    void Check();
+    int Check() override;
 
     /**
      * @brief


### PR DESCRIPTION
When I was trying to compile the latest master branch, there was a compile error due to the Check() function in the MeshingApplication. 

@miguelmaso I think this function should be overridden from the process.h. It is then automatically called once at  ExecuteInitialize and you do not have to call it explicitly in the constructor yourself.

I do not know how it was possible to merge this, since it should not go through the travis build?

@philbucher and @roigcarlo Please correct me if I am wrong.