### PR TITLE
[StructuralMechanics] removing Solve

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
@@ -78,13 +78,6 @@ class StructuralMechanicsAdjointStaticSolver(structural_mechanics_solver.Mechani
 
         self.print_on_rank_zero("::[AdjointMechanicalSolver]:: ", "Finished initialization.")
 
-    def Solve(self):
-        if self.response_function_settings["response_type"].GetString() == "adjoint_linear_strain_energy":
-            self._SolveSolutionStepSpecialLinearStrainEnergy()
-        else:
-            super(StructuralMechanicsAdjointStaticSolver, self).Solve()
-
-
     def InitializeSolutionStep(self):
         super(StructuralMechanicsAdjointStaticSolver, self).InitializeSolutionStep()
         self.response_function.InitializeSolutionStep()

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -229,13 +229,10 @@ class MechanicalSolver(PythonSolver):
                 pass
         self.print_on_rank_zero("::[MechanicalSolver]:: ", "Finished initialization.")
 
-    def Solve(self):
+    def InitializeSolutionStep(self):
         if self.settings["clear_storage"].GetBool():
             self.Clear()
-        mechanical_solution_strategy = self.get_mechanical_solution_strategy()
-        mechanical_solution_strategy.Solve()
-
-    def InitializeSolutionStep(self):
+            self.Initialize() #required after clearing
         self.get_mechanical_solution_strategy().InitializeSolutionStep()
 
     def Predict(self):

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -63,9 +63,12 @@ class StaticMechanicalSolver(structural_mechanics_solver.MechanicalSolver):
         super(StaticMechanicalSolver, self).Initialize() # The mechanical solver is created here.
         self.print_on_rank_zero("::[StaticMechanicalSolver]:: ", "Finished initialization.")
 
-    def Solve(self):
-        super(StaticMechanicalSolver, self).Solve()
+    def SolveSolutionStep(self):
+        super(StaticMechanicalSolver, self).SolveSolutionStep()
         if self.settings["analysis_type"].GetString() == "arc_length":
+            raise Exception('"arc_length is not available at the moment"')
+            # it is not clear if this should be called after SolveSolutionStep or FinalizeSolutionStep
+            # this has to be updated once the ArcLength-Method is working again
             lambda_value = self.main_model_part.ProcessInfo[StructuralMechanicsApplication.LAMBDA]
             if self.settings["echo_level"].GetInt() > 0:
                 self.print_on_rank_zero("LAMBDA: ", lambda_value)


### PR DESCRIPTION
this method is very deprecated and only gives problems (see #3375)

in a standard-workflow this is not used for a while already

Btw this brings also back the possibility to use `clear_storage` in a standard-case