### PR TITLE
[DEM] SKIP_TIMER when reading the ModelParts

### DIFF
--- a/applications/DEMApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/DEMApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -314,6 +314,7 @@ void AddCustomUtilitiesToPython(pybind11::module& m) {
     py::class_<ReorderConsecutiveFromGivenIdsModelPartIO, ReorderConsecutiveFromGivenIdsModelPartIO::Pointer, ReorderConsecutiveModelPartIO>(m, "ReorderConsecutiveFromGivenIdsModelPartIO")
         .def(py::init<std::string const& >())
         .def(py::init<std::string const&, const int, const int, const int>())
+        .def(py::init<std::string const&, const int, const int, const int, const Flags>())
         ;
 
     py::class_<AuxiliaryUtilities, AuxiliaryUtilities::Pointer>(m, "AuxiliaryUtilities")

--- a/applications/DEMApplication/custom_utilities/reorder_consecutive_from_given_ids_model_part_io.h
+++ b/applications/DEMApplication/custom_utilities/reorder_consecutive_from_given_ids_model_part_io.h
@@ -16,14 +16,14 @@ class ReorderConsecutiveFromGivenIdsModelPartIO : public ReorderConsecutiveModel
 {
 public:
     KRATOS_CLASS_POINTER_DEFINITION(ReorderConsecutiveFromGivenIdsModelPartIO);
-    ReorderConsecutiveFromGivenIdsModelPartIO(std::string const& Filename, const int node_id=0, const int element_id=0, const int condition_id=0): 
-                ReorderConsecutiveModelPartIO(Filename)
+    ReorderConsecutiveFromGivenIdsModelPartIO(std::string const& Filename, const int node_id=0, const int element_id=0, const int condition_id=0, const Flags Options = IO::READ|IO::NOT_IGNORE_VARIABLES_ERROR):
+                ReorderConsecutiveModelPartIO(Filename, Options)
     {
         mNumberOfNodes = node_id;
         mNumberOfElements = element_id;
         mNumberOfConditions = condition_id;
     }
-       
+
     virtual ~ReorderConsecutiveFromGivenIdsModelPartIO(){}
 
 protected:
@@ -34,5 +34,5 @@ private:
 
 }  // namespace Kratos.
 
-#endif // KRATOS_REORDER_CONSECUTIVE_FROM_GIVEN_IDS_MODEL_PART_IO_H_INCLUDED  defined 
+#endif // KRATOS_REORDER_CONSECUTIVE_FROM_GIVEN_IDS_MODEL_PART_IO_H_INCLUDED  defined
 

--- a/applications/DEMApplication/python_scripts/main_script.py
+++ b/applications/DEMApplication/python_scripts/main_script.py
@@ -47,7 +47,7 @@ class Solution(object):
 
     @classmethod
     def model_part_reader(self, modelpart, nodeid=0, elemid=0, condid=0):
-        return ReorderConsecutiveFromGivenIdsModelPartIO(modelpart, nodeid, elemid, condid)
+        return ReorderConsecutiveFromGivenIdsModelPartIO(modelpart, nodeid, elemid, condid, IO.SKIP_TIMER)
 
     @classmethod
     def GetMainPath(self):


### PR DESCRIPTION
With this hardcoded option, the file with 'time' extension is no longer printed.