### PR TITLE
[DEMApplication] Removing symbolic linked folder that don't allow to use git difftool

### DIFF
--- a/applications/DEMApplication/custom_problemtype/DEMpack/C-DEMPack/kratos.gid/kratos
+++ b/applications/DEMApplication/custom_problemtype/DEMpack/C-DEMPack/kratos.gid/kratos
@@ -1,1 +1,0 @@
-/home/maceli/kratos

--- a/applications/DEMApplication/custom_problemtype/DEMpack/F-DEMPack/kratos.gid/kratos
+++ b/applications/DEMApplication/custom_problemtype/DEMpack/F-DEMPack/kratos.gid/kratos
@@ -1,1 +1,0 @@
-/home/maceli/kratos

--- a/applications/DEMApplication/custom_problemtype/DEMpack/G-DEMPack/kratos.gid/.directory
+++ b/applications/DEMApplication/custom_problemtype/DEMpack/G-DEMPack/kratos.gid/.directory
@@ -1,5 +1,0 @@
-[Dolphin]
-SortOrder=1
-Sorting=2
-Timestamp=2014,5,23,12,39,25
-ViewMode=1

--- a/applications/DEMApplication/custom_problemtype/DEMpack/S-DEMPack/kratos.gid/.directory
+++ b/applications/DEMApplication/custom_problemtype/DEMpack/S-DEMPack/kratos.gid/.directory
@@ -1,5 +1,0 @@
-[Dolphin]
-SortOrder=1
-Sorting=2
-Timestamp=2014,5,23,12,39,25
-ViewMode=1


### PR DESCRIPTION
I have the following error due to the symbolic link file:

~~~sh
fatal: no se pudo abrir '/tmp/git-difftool.lOvcbt/left/applications/DEM_application/custom_problemtype/DEMpack/C-DEMPack/kratos.gid/kratos' para escritura: No existe el archivo o el directorio
~~~