### PR TITLE
[Core] test import variable-keys

### DIFF
--- a/kratos/python/add_containers_to_python.cpp
+++ b/kratos/python/add_containers_to_python.cpp
@@ -154,6 +154,7 @@ void  AddContainersToPython(pybind11::module& m)
 
     py::class_<VariableData>(m, "VariableData" )
     .def("Name", &VariableData::Name, py::return_value_policy::copy)
+    .def("Key", &VariableData::Key)
     .def("__str__", PrintObject<VariableData>)
     ;
 

--- a/kratos/tests/test_importing.py
+++ b/kratos/tests/test_importing.py
@@ -28,19 +28,18 @@ class TestImporting(KratosUnittest.TestCase):
 
         #self.assertTrue(model_part.Nodes[1].GetSolutionStepValue(VELOCITY_X) == 1.0)
         self.assertTrue(model_part.Nodes[1].GetSolutionStepValue(VELOCITY_Y) == 2.0)
-        #print(model_part.Nodes[1].GetSolutionStepValue(VELOCITY))
 
     def _aux_func(self,model_part):
         try:
-            import KratosMultiphysics.ConvectionDiffusionApplication #upon importing the key of velocity is changed, so that the database does not work any longer
+            import KratosMultiphysics.FluidDynamicsApplication #upon importing the key of velocity is changed, so that the database does not work any longer
         except:
-            self.skipTest("KratosMultiphysics.ConvectionDiffusionApplication is not available")
-        #model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY) #the problem is that here the key of VELOCITY is changed...
+            self.skipTest("KratosMultiphysics.FluidDynamicsApplication is not available")
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY) #the problem is that here the key of VELOCITY is changed...
         model_part.Nodes[1].SetSolutionStepValue(VELOCITY_Y,0,2.0)
 
     def test_has_application(self):
         current_model = Model()
-        
+
         self.assertTrue(Kernel().IsImported("KratosMultiphysics"))
 
         try:
@@ -49,6 +48,27 @@ class TestImporting(KratosUnittest.TestCase):
             self.skipTest("KratosMultiphysics.ExternalSolversApplication is not available")
 
         self.assertTrue(Kernel().IsImported("ExternalSolversApplication"))
+
+    def test_variable_keys_reordering(self):
+        key_vel_before_import = VELOCITY.Key()
+
+        try:
+            import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
+        except:
+            self.skipTest("KratosMultiphysics.FluidDynamicsApplication is not available")
+
+        self.assertEqual(key_vel_before_import, VELOCITY.Key())
+
+        key_ssp_before_import = KratosCFD.SUBSCALE_PRESSURE.Key()
+
+        try:
+            import KratosMultiphysics.StructuralMechanicsApplication
+        except:
+            self.skipTest("KratosMultiphysics.StructuralMechanicsApplication is not available")
+
+        self.assertEqual(key_vel_before_import, VELOCITY.Key())
+        self.assertEqual(key_ssp_before_import, KratosCFD.SUBSCALE_PRESSURE.Key())
+
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/tests/test_importing.py
+++ b/kratos/tests/test_importing.py
@@ -14,27 +14,26 @@ class TestImporting(KratosUnittest.TestCase):
     def test_importing(self):
         current_model = Model()
 
-        #import KratosMultiphysics.FluidDynamicsApplication
         model_part= current_model.CreateModelPart("Main")
         model_part.AddNodalSolutionStepVariable(VELOCITY)
 
         model_part.CreateNewNode(1,0.0,0.0,0.0)
         model_part.SetBufferSize(3)
         model_part.CloneTimeStep(1.0)
-        #model_part.Nodes[1].SetSolutionStepValue(VELOCITY_X,0,1.0) #here i set VELOCITY_X to 1.0
+        model_part.Nodes[1].SetSolutionStepValue(VELOCITY_X,0,1.0) #here i set VELOCITY_X to 1.0
 
         #import aux_external_import
         self._aux_func(model_part) #here i set VELOCITY_Y to 2.0
 
-        #self.assertTrue(model_part.Nodes[1].GetSolutionStepValue(VELOCITY_X) == 1.0)
+        self.assertTrue(model_part.Nodes[1].GetSolutionStepValue(VELOCITY_X) == 1.0)
         self.assertTrue(model_part.Nodes[1].GetSolutionStepValue(VELOCITY_Y) == 2.0)
 
     def _aux_func(self,model_part):
         try:
-            import KratosMultiphysics.FluidDynamicsApplication #upon importing the key of velocity is changed, so that the database does not work any longer
+            import KratosMultiphysics.FluidDynamicsApplication
         except:
             self.skipTest("KratosMultiphysics.FluidDynamicsApplication is not available")
-        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY) #the problem is that here the key of VELOCITY is changed...
+        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
         model_part.Nodes[1].SetSolutionStepValue(VELOCITY_Y,0,2.0)
 
     def test_has_application(self):
@@ -50,7 +49,7 @@ class TestImporting(KratosUnittest.TestCase):
         self.assertTrue(Kernel().IsImported("ExternalSolversApplication"))
 
     def test_variable_keys_reordering(self):
-        key_vel_before_import = VELOCITY.Key()
+        key_vel_before_import = VELOCITY.Key() # test a var from the Kerne
 
         try:
             import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
@@ -59,7 +58,7 @@ class TestImporting(KratosUnittest.TestCase):
 
         self.assertEqual(key_vel_before_import, VELOCITY.Key())
 
-        key_ssp_before_import = KratosCFD.SUBSCALE_PRESSURE.Key()
+        key_ssp_before_import = KratosCFD.SUBSCALE_PRESSURE.Key() # test an Application-Variable
 
         try:
             import KratosMultiphysics.StructuralMechanicsApplication

--- a/kratos/tests/test_importing.py
+++ b/kratos/tests/test_importing.py
@@ -1,62 +1,61 @@
 ﻿from __future__ import print_function, absolute_import, division
 
+import KratosMultiphysics as KM
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-from KratosMultiphysics import *
-import math
-import os
-
-def GetFilePath(fileName):
-    return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
-
 
 class TestImporting(KratosUnittest.TestCase):
 
     def test_importing(self):
-        current_model = Model()
+        """With this test we chack that the keys are not reordered after
+        importing applications. Also we check that the nodal values can
+        still be accessed with the variables. This would break if the
+        keys are being reordered
+        """
+        current_model = KM.Model()
 
         model_part= current_model.CreateModelPart("Main")
-        model_part.AddNodalSolutionStepVariable(VELOCITY)
+        model_part.AddNodalSolutionStepVariable(KM.VELOCITY)
+        key_VELOCITY_before_import = KM.VELOCITY.Key() # test a var from the Kernel
 
         model_part.CreateNewNode(1,0.0,0.0,0.0)
         model_part.SetBufferSize(3)
         model_part.CloneTimeStep(1.0)
-        model_part.Nodes[1].SetSolutionStepValue(VELOCITY_X,0,1.0) #here i set VELOCITY_X to 1.0
+        model_part.Nodes[1].SetSolutionStepValue(KM.VELOCITY_X,0,1.0) #here i set VELOCITY_X to 1.0
 
-        #import aux_external_import
+        # import aux_external_import
         self._aux_func(model_part) #here i set VELOCITY_Y to 2.0
+        self.assertEqual(key_VELOCITY_before_import, KM.VELOCITY.Key())
 
-        self.assertTrue(model_part.Nodes[1].GetSolutionStepValue(VELOCITY_X) == 1.0)
-        self.assertTrue(model_part.Nodes[1].GetSolutionStepValue(VELOCITY_Y) == 2.0)
+        self.assertTrue(model_part.Nodes[1].GetSolutionStepValue(KM.VELOCITY_X) == 1.0)
+        self.assertTrue(model_part.Nodes[1].GetSolutionStepValue(KM.VELOCITY_Y) == 2.0)
 
     def _aux_func(self,model_part):
         try:
             import KratosMultiphysics.FluidDynamicsApplication
         except:
             self.skipTest("KratosMultiphysics.FluidDynamicsApplication is not available")
-        model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
-        model_part.Nodes[1].SetSolutionStepValue(VELOCITY_Y,0,2.0)
+        model_part.AddNodalSolutionStepVariable(KM.VELOCITY)
+        model_part.Nodes[1].SetSolutionStepValue(KM.VELOCITY_Y,0,2.0)
 
     def test_has_application(self):
-        current_model = Model()
+        current_model = KM.Model()
 
-        self.assertTrue(Kernel().IsImported("KratosMultiphysics"))
+        self.assertTrue(KM.Kernel().IsImported("KratosMultiphysics"))
 
         try:
             import KratosMultiphysics.ExternalSolversApplication
         except:
             self.skipTest("KratosMultiphysics.ExternalSolversApplication is not available")
 
-        self.assertTrue(Kernel().IsImported("ExternalSolversApplication"))
+        self.assertTrue(KM.Kernel().IsImported("ExternalSolversApplication"))
 
     def test_variable_keys_reordering(self):
-        key_vel_before_import = VELOCITY.Key() # test a var from the Kerne
+        key_vel_before_import = KM.VELOCITY.Key() # test a var from the Kernel
 
         try:
             import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
         except:
             self.skipTest("KratosMultiphysics.FluidDynamicsApplication is not available")
-
-        self.assertEqual(key_vel_before_import, VELOCITY.Key())
 
         key_ssp_before_import = KratosCFD.SUBSCALE_PRESSURE.Key() # test an Application-Variable
 
@@ -65,8 +64,9 @@ class TestImporting(KratosUnittest.TestCase):
         except:
             self.skipTest("KratosMultiphysics.StructuralMechanicsApplication is not available")
 
-        self.assertEqual(key_vel_before_import, VELOCITY.Key())
+        self.assertEqual(key_vel_before_import, KM.VELOCITY.Key())
         self.assertEqual(key_ssp_before_import, KratosCFD.SUBSCALE_PRESSURE.Key())
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
closes #3328 

=> @jcotela told me to make a test for this, in order to answer #3328 

I had to expose the Key of the variables in order to do the test

I also updated/extended the previous tests, since now the var-keys are no longer reordered

Should we deprecate `CheckRegisteredApplications`?