### PR TITLE
[StructuralMechanics] removing validation suite from allsuite

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -422,7 +422,6 @@ def AssembleTestSuites():
     # Create a test suit that contains all the tests:
     allSuite = suites['all']
     allSuite.addTests(nightSuite) # already contains the smallSuite
-    allSuite.addTests(validationSuite)
 
     return suites
 

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -421,7 +421,8 @@ def AssembleTestSuites():
 
     # Create a test suit that contains all the tests:
     allSuite = suites['all']
-    allSuite.addTests(nightSuite) # already contains the smallSuite
+    allSuite.addTests(nightSuite) # Already contains the smallSuite
+    validationSuite.addTests(allSuite) # Validation contains all
 
     return suites
 


### PR DESCRIPTION
after #3472 the validation tests take very long, therefore I am removing the validationsuite from the allsuite

I am not particularly happy about this change but this is also done in other apps
I am just concerned that now the test won't be run any more bcs they take too long

@KratosMultiphysics/technical-committee do you have a guideline for how long validation-tests should run?
