### PR TITLE
removing type qualifier

### DIFF
--- a/kratos/utilities/embedded_skin_utility.cpp
+++ b/kratos/utilities/embedded_skin_utility.cpp
@@ -224,7 +224,7 @@ namespace Kratos
     }
 
     template<std::size_t TDim>
-    const bool inline EmbeddedSkinUtility<TDim>::ElementIsSplit(
+    bool inline EmbeddedSkinUtility<TDim>::ElementIsSplit(
         const Geometry<Node<3>> &rGeometry,
         const Vector &rNodalDistances)
     {

--- a/kratos/utilities/embedded_skin_utility.h
+++ b/kratos/utilities/embedded_skin_utility.h
@@ -190,7 +190,7 @@ private:
      * @return true if the element is split
      * @return false if the element is not split
      */
-    const bool inline ElementIsSplit(
+    bool inline ElementIsSplit(
         const Geometry<Node<3>> &rGeometry,
         const Vector &rNodalDistances);
 


### PR DESCRIPTION
this gives a compiler-warning with the intel-compiler

=> the const does not do anything, so it can be removed