### PR TITLE
[ModelPartIO][DivideInputToPartitions] fixing file-opening check

### DIFF
--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -652,7 +652,7 @@ namespace Kratos
             std::stringstream buffer;
             buffer << mBaseFilename << "_" << i << ".mdpa";
             std::ofstream* p_ofstream = new std::ofstream(buffer.str().c_str());
-            KRATOS_ERROR_IF_NOT(!(*p_ofstream)) << "Error opening mdpa file : " << buffer.str() << std::endl;
+            KRATOS_ERROR_IF_NOT(*p_ofstream) << "Error opening mdpa file : " << buffer.str() << std::endl;
 
             output_files.push_back(p_ofstream);
         }


### PR DESCRIPTION
this was broken in #3126 => https://github.com/KratosMultiphysics/Kratos/pull/3126/files#diff-3f9a8239da83eb6bb4c283f3ad8d138dR655
The partitioning was not working, in case someone else has problems