### PR TITLE
Removed unused vector_map.h includes

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
@@ -91,7 +91,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+    ;
 
     typedef Element::WeakPointer ElementWeakPointerType;
     

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
@@ -91,8 +91,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     typedef Element::WeakPointer ElementWeakPointerType;
     
     typedef Element::Pointer ElementPointerType;

--- a/applications/FluidDynamicsApplication/custom_conditions/fs_periodic_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/fs_periodic_condition.h
@@ -135,7 +135,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+    ;
 
 
     ///@}

--- a/applications/FluidDynamicsApplication/custom_conditions/fs_periodic_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/fs_periodic_condition.h
@@ -135,9 +135,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
-
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/FluidDynamicsApplication/custom_conditions/monolithic_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/monolithic_wall_condition.h
@@ -98,8 +98,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/FluidDynamicsApplication/custom_conditions/monolithic_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/monolithic_wall_condition.h
@@ -98,7 +98,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+    ;
 
     ///@}
     ///@name Life Cycle

--- a/applications/FluidDynamicsApplication/custom_conditions/stokes_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/stokes_wall_condition.h
@@ -94,7 +94,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+    ;
 
     ///@}
     ///@name Life Cycle

--- a/applications/FluidDynamicsApplication/custom_conditions/stokes_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/stokes_wall_condition.h
@@ -94,8 +94,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/FluidDynamicsApplication/custom_conditions/wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/wall_condition.h
@@ -126,7 +126,7 @@ namespace Kratos
 
         typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-        typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+        ;
 
         ///@}
         ///@name Life Cycle

--- a/applications/FluidDynamicsApplication/custom_conditions/wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/wall_condition.h
@@ -126,8 +126,6 @@ namespace Kratos
 
         typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-        ;
-
         ///@}
         ///@name Life Cycle
         ///@{

--- a/applications/FluidDynamicsApplication/custom_conditions/wall_condition_discontinuous.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/wall_condition_discontinuous.h
@@ -124,7 +124,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+    ;
 
     ///@}
     ///@name Life Cycle

--- a/applications/FluidDynamicsApplication/custom_conditions/wall_condition_discontinuous.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/wall_condition_discontinuous.h
@@ -124,8 +124,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/FluidDynamicsApplication/custom_elements/bingham_fluid.h
+++ b/applications/FluidDynamicsApplication/custom_elements/bingham_fluid.h
@@ -69,8 +69,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/FluidDynamicsApplication/custom_elements/dpg_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/dpg_vms.h
@@ -76,7 +76,6 @@ public:
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/FluidDynamicsApplication/custom_elements/fractional_step.h
+++ b/applications/FluidDynamicsApplication/custom_elements/fractional_step.h
@@ -95,8 +95,6 @@ namespace Kratos
 
         typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-        typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
-
         /// Type for shape function values container
         typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/FluidDynamicsApplication/custom_elements/fractional_step_discontinuous.h
+++ b/applications/FluidDynamicsApplication/custom_elements/fractional_step_discontinuous.h
@@ -96,8 +96,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/FluidDynamicsApplication/custom_elements/herschel_bulkley_fluid.h
+++ b/applications/FluidDynamicsApplication/custom_elements/herschel_bulkley_fluid.h
@@ -70,8 +70,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
@@ -105,7 +105,6 @@ public:
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/FluidDynamicsApplication/custom_elements/vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/vms.h
@@ -141,8 +141,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
-
     typedef array_1d<double, TNumNodes> ShapeFunctionsType;
     typedef BoundedMatrix<double, TNumNodes, TDim> ShapeFunctionDerivativesType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_element.h
@@ -115,8 +115,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_element.h
@@ -115,7 +115,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_fluid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_fluid_element.h
@@ -93,7 +93,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_fluid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_fluid_element.h
@@ -93,8 +93,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_solid_element.h
@@ -86,7 +86,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_explicit_solid_element.h
@@ -86,8 +86,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_element.h
@@ -112,7 +112,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_element.h
@@ -112,8 +112,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_element.h
@@ -93,7 +93,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_fluid_element.h
@@ -93,8 +93,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_element.h
@@ -112,7 +112,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_element.h
@@ -112,8 +112,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_fluid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_fluid_element.h
@@ -93,7 +93,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_fluid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_fluid_element.h
@@ -93,8 +93,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_solid_element.h
@@ -86,7 +86,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_solid_element.h
@@ -86,8 +86,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_solid_element.h
@@ -86,7 +86,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_solid_element.h
@@ -86,8 +86,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_element.h
@@ -131,7 +131,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_element.h
@@ -131,8 +131,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_explicit_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_explicit_solid_element.h
@@ -86,7 +86,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_explicit_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_explicit_solid_element.h
@@ -86,8 +86,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_implicit_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_implicit_solid_element.h
@@ -86,7 +86,7 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+      ;
 
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_implicit_solid_element.h
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/updated_lagrangian_V_implicit_solid_element.h
@@ -86,8 +86,6 @@ namespace Kratos
 
       typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-      ;
-
       /// Type for shape function values container
       typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/StabilizedCFDApplication/custom_conditions/dss_face.h
+++ b/applications/StabilizedCFDApplication/custom_conditions/dss_face.h
@@ -89,8 +89,6 @@ namespace Kratos
 
         typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-        ;
-
         /// Type for shape function values container
         typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/StabilizedCFDApplication/custom_conditions/dss_face.h
+++ b/applications/StabilizedCFDApplication/custom_conditions/dss_face.h
@@ -89,7 +89,7 @@ namespace Kratos
 
         typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-        typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+        ;
 
         /// Type for shape function values container
         typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_conditions/calculate_laplacian_simplex_condition.h
+++ b/applications/SwimmingDEMApplication/custom_conditions/calculate_laplacian_simplex_condition.h
@@ -91,8 +91,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     /// Pointer definition of ComputeLaplacianSimplexCondition
 
     ///@}

--- a/applications/SwimmingDEMApplication/custom_conditions/calculate_laplacian_simplex_condition.h
+++ b/applications/SwimmingDEMApplication/custom_conditions/calculate_laplacian_simplex_condition.h
@@ -91,7 +91,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+    ;
 
     /// Pointer definition of ComputeLaplacianSimplexCondition
 

--- a/applications/SwimmingDEMApplication/custom_conditions/monolithic_dem_coupled_wall_condition.h
+++ b/applications/SwimmingDEMApplication/custom_conditions/monolithic_dem_coupled_wall_condition.h
@@ -100,7 +100,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
     /// Pointer definition of MonolithicDEMCoupledWallCondition
 
     ///@}

--- a/applications/SwimmingDEMApplication/custom_conditions/monolithic_dem_coupled_wall_condition.h
+++ b/applications/SwimmingDEMApplication/custom_conditions/monolithic_dem_coupled_wall_condition.h
@@ -100,7 +100,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+    ;
     /// Pointer definition of MonolithicDEMCoupledWallCondition
 
     ///@}

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_component_gradient_simplex_element.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_component_gradient_simplex_element.h
@@ -97,8 +97,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_component_gradient_simplex_element.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_component_gradient_simplex_element.h
@@ -97,7 +97,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_gradient_Pouliot_2012.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_gradient_Pouliot_2012.h
@@ -96,7 +96,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_gradient_Pouliot_2012.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_gradient_Pouliot_2012.h
@@ -96,8 +96,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_gradient_Pouliot_2012_edge.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_gradient_Pouliot_2012_edge.h
@@ -92,7 +92,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_gradient_Pouliot_2012_edge.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_gradient_Pouliot_2012_edge.h
@@ -92,8 +92,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_laplacian_simplex_element.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_laplacian_simplex_element.h
@@ -97,8 +97,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_laplacian_simplex_element.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_laplacian_simplex_element.h
@@ -97,7 +97,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_mat_deriv_simplex_element.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_mat_deriv_simplex_element.h
@@ -92,7 +92,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_mat_deriv_simplex_element.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_mat_deriv_simplex_element.h
@@ -92,8 +92,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_velocity_laplacian.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_velocity_laplacian.h
@@ -96,7 +96,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_velocity_laplacian.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_velocity_laplacian.h
@@ -96,8 +96,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_velocity_laplacian_component.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_velocity_laplacian_component.h
@@ -97,8 +97,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/applications/SwimmingDEMApplication/custom_elements/calculate_velocity_laplacian_component.h
+++ b/applications/SwimmingDEMApplication/custom_elements/calculate_velocity_laplacian_component.h
@@ -97,7 +97,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_elements/monolithic_dem_coupled.h
+++ b/applications/SwimmingDEMApplication/custom_elements/monolithic_dem_coupled.h
@@ -174,7 +174,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 //G
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_elements/monolithic_dem_coupled.h
+++ b/applications/SwimmingDEMApplication/custom_elements/monolithic_dem_coupled.h
@@ -174,7 +174,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
 //G
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_elements/monolithic_dem_coupled_weak.h
+++ b/applications/SwimmingDEMApplication/custom_elements/monolithic_dem_coupled_weak.h
@@ -175,7 +175,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
 //G
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/SwimmingDEMApplication/custom_elements/monolithic_dem_coupled_weak.h
+++ b/applications/SwimmingDEMApplication/custom_elements/monolithic_dem_coupled_weak.h
@@ -175,7 +175,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 //G
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;

--- a/applications/ULFapplication/custom_elements/surface_tension.h
+++ b/applications/ULFapplication/custom_elements/surface_tension.h
@@ -128,8 +128,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
      typedef array_1d<double, TNumNodes> ShapeFunctionsType;
      typedef BoundedMatrix<double, TNumNodes, TDim> ShapeFunctionDerivativesType;
 

--- a/applications/ULFapplication/custom_elements/surface_tension.h
+++ b/applications/ULFapplication/custom_elements/surface_tension.h
@@ -128,7 +128,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 
      typedef array_1d<double, TNumNodes> ShapeFunctionsType;
      typedef BoundedMatrix<double, TNumNodes, TDim> ShapeFunctionDerivativesType;

--- a/applications/pfem_2_application/custom_conditions/autoslip_inlet.h
+++ b/applications/pfem_2_application/custom_conditions/autoslip_inlet.h
@@ -114,7 +114,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+    ;
 
     ///@}
     ///@name Life Cycle

--- a/applications/pfem_2_application/custom_conditions/autoslip_inlet.h
+++ b/applications/pfem_2_application/custom_conditions/autoslip_inlet.h
@@ -114,8 +114,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/pfem_2_application/custom_conditions/autoslip_inlet_3d.h
+++ b/applications/pfem_2_application/custom_conditions/autoslip_inlet_3d.h
@@ -116,8 +116,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    ;
-
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/pfem_2_application/custom_conditions/autoslip_inlet_3d.h
+++ b/applications/pfem_2_application/custom_conditions/autoslip_inlet_3d.h
@@ -116,7 +116,7 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
+    ;
 
     ///@}
     ///@name Life Cycle

--- a/applications/pfem_2_application/custom_elements/fractional_step_pfem_2_2d.h
+++ b/applications/pfem_2_application/custom_elements/fractional_step_pfem_2_2d.h
@@ -57,7 +57,6 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
 	
     /// Default constructor.
      FractionalStepPFEM22D(IndexType NewId, GeometryType::Pointer pGeometry);

--- a/applications/pfem_2_application/custom_elements/fractional_step_pfem_2_3d.h
+++ b/applications/pfem_2_application/custom_elements/fractional_step_pfem_2_3d.h
@@ -57,8 +57,7 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
-	
+
     /// Default constructor.
      FractionalStepPFEM23D(IndexType NewId, GeometryType::Pointer pGeometry);
      FractionalStepPFEM23D(IndexType NewId, GeometryType::Pointer pGeometry,  PropertiesType::Pointer pProperties);

--- a/applications/pfem_2_application/custom_elements/monolithic_2fluid_2d.h
+++ b/applications/pfem_2_application/custom_elements/monolithic_2fluid_2d.h
@@ -59,7 +59,6 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
 	typedef PointerVector< PFEM_Particle_Fluid, PFEM_Particle_Fluid*, std::vector<PFEM_Particle_Fluid*> > ParticlePointerVector;
 
     /// Default constructor.

--- a/applications/pfem_2_application/custom_elements/monolithic_2fluid_2d_partintegration.h
+++ b/applications/pfem_2_application/custom_elements/monolithic_2fluid_2d_partintegration.h
@@ -57,7 +57,6 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
 	
     /// Default constructor.
      MonolithicAutoSlipPFEM22D(IndexType NewId, GeometryType::Pointer pGeometry);

--- a/applications/pfem_2_application/custom_elements/monolithic_2fluid_3d.h
+++ b/applications/pfem_2_application/custom_elements/monolithic_2fluid_3d.h
@@ -57,7 +57,7 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    ;
+
 	
 	/// Default constructor.
     MonolithicPFEM23D(IndexType NewId = 0) :

--- a/applications/pfem_2_application/custom_elements/monolithic_2fluid_3d.h
+++ b/applications/pfem_2_application/custom_elements/monolithic_2fluid_3d.h
@@ -57,7 +57,7 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 	
 	/// Default constructor.
     MonolithicPFEM23D(IndexType NewId = 0) :

--- a/applications/pfem_2_application/custom_elements/monolithic_2fluid_3d_partintegration.h
+++ b/applications/pfem_2_application/custom_elements/monolithic_2fluid_3d_partintegration.h
@@ -57,7 +57,6 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
 	
 	/// Default constructor.
     MonolithicAutoSlipPFEM23D(IndexType NewId = 0) :

--- a/applications/pfem_2_application/custom_elements/monolithic_3fluid_2d.h
+++ b/applications/pfem_2_application/custom_elements/monolithic_3fluid_2d.h
@@ -57,7 +57,6 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    ;
 	
     /// Default constructor.
      Monolithic3FluidPFEM22D(IndexType NewId, GeometryType::Pointer pGeometry);

--- a/applications/pfem_2_application/custom_elements/monolithic_3fluid_2d.h
+++ b/applications/pfem_2_application/custom_elements/monolithic_3fluid_2d.h
@@ -57,7 +57,7 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 	
     /// Default constructor.
      Monolithic3FluidPFEM22D(IndexType NewId, GeometryType::Pointer pGeometry);

--- a/applications/pfem_2_application/custom_elements/monolithic_3fluid_3d.h
+++ b/applications/pfem_2_application/custom_elements/monolithic_3fluid_3d.h
@@ -57,7 +57,6 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    ;
 	
     /// Default constructor.
      Monolithic3FluidPFEM23D(IndexType NewId, GeometryType::Pointer pGeometry);

--- a/applications/pfem_2_application/custom_elements/monolithic_3fluid_3d.h
+++ b/applications/pfem_2_application/custom_elements/monolithic_3fluid_3d.h
@@ -57,7 +57,7 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 	
     /// Default constructor.
      Monolithic3FluidPFEM23D(IndexType NewId, GeometryType::Pointer pGeometry);

--- a/applications/pfem_2_application/custom_elements/nonewtonian_2fluid_2d.h
+++ b/applications/pfem_2_application/custom_elements/nonewtonian_2fluid_2d.h
@@ -73,7 +73,7 @@ public:
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 
     /// Default constructor.
     

--- a/applications/pfem_2_application/custom_elements/nonewtonian_2fluid_2d.h
+++ b/applications/pfem_2_application/custom_elements/nonewtonian_2fluid_2d.h
@@ -73,7 +73,6 @@ public:
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    ;
 
     /// Default constructor.
     

--- a/applications/pfem_2_application/custom_elements/nonewtonian_2fluid_3d.h
+++ b/applications/pfem_2_application/custom_elements/nonewtonian_2fluid_3d.h
@@ -73,7 +73,7 @@ public:
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 
     /// Default constructor.
     

--- a/applications/pfem_2_application/custom_elements/nonewtonian_2fluid_3d.h
+++ b/applications/pfem_2_application/custom_elements/nonewtonian_2fluid_3d.h
@@ -73,7 +73,6 @@ public:
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    ;
 
     /// Default constructor.
     

--- a/applications/pfem_2_application/custom_elements/vel_enriched_2fluid_2d.h
+++ b/applications/pfem_2_application/custom_elements/vel_enriched_2fluid_2d.h
@@ -59,7 +59,6 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    ;
 	typedef PointerVector< PFEM_Particle_Fluid, PFEM_Particle_Fluid*, std::vector<PFEM_Particle_Fluid*> > ParticlePointerVector;
 
     /// Default constructor.

--- a/applications/pfem_2_application/custom_elements/vel_enriched_2fluid_2d.h
+++ b/applications/pfem_2_application/custom_elements/vel_enriched_2fluid_2d.h
@@ -59,7 +59,7 @@ namespace Kratos
     typedef std::vector<std::size_t> EquationIdVectorType;
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
+    ;
 	typedef PointerVector< PFEM_Particle_Fluid, PFEM_Particle_Fluid*, std::vector<PFEM_Particle_Fluid*> > ParticlePointerVector;
 
     /// Default constructor.

--- a/kratos/elements/distance_calculation_element_simplex.h
+++ b/kratos/elements/distance_calculation_element_simplex.h
@@ -97,8 +97,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
-
     /// Type for shape function values container
     typedef Kratos::Vector ShapeFunctionsType;
 

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -108,8 +108,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
-
     ///Type definition for integration methods
     typedef GeometryData::IntegrationMethod IntegrationMethod;
 

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -108,8 +108,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsElementalDataContainerType;
-
     ///Type definition for integration methods
     typedef GeometryData::IntegrationMethod IntegrationMethod;
 

--- a/kratos/includes/node.h
+++ b/kratos/includes/node.h
@@ -29,7 +29,6 @@
 #include "includes/define.h"
 #include "geometries/point.h"
 #include "includes/dof.h"
-#include "containers/vector_map.h"
 #include "containers/pointer_vector_set.h"
 #include "containers/variables_list_data_value_container.h"
 #include "utilities/indexed_object.h"

--- a/kratos/includes/periodic_condition.h
+++ b/kratos/includes/periodic_condition.h
@@ -121,9 +121,6 @@ public:
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
 
-    typedef VectorMap<IndexType, DataValueContainer> SolutionStepsConditionalDataContainerType;
-
-
     ///@}
     ///@name Life Cycle
     ///@{


### PR DESCRIPTION
vector_map.h was included in node.h and typedefed in conditions and elements but apparently never used. This PR removes the include and typedefs.