### PR TITLE
[ExternalSolversApplication] This allows to compile the app using the  ninja compiler

### DIFF
--- a/applications/ExternalSolversApplication/custom_python/add_linear_solvers_to_python.cpp
+++ b/applications/ExternalSolversApplication/custom_python/add_linear_solvers_to_python.cpp
@@ -44,13 +44,13 @@ namespace Kratos {
 namespace Python {
 
 template <class TDataType>
-using TSpaceType = UblasSpace<TDataType, compressed_matrix<TDataType>, vector<TDataType>>;
+using TSpaceType = UblasSpace<TDataType, boost::numeric::ublas::compressed_matrix<TDataType>, boost::numeric::ublas::vector<TDataType>>;
 template <class TDataType>
-using TLocalSpaceType = UblasSpace<TDataType, matrix<TDataType>, vector<TDataType>>;
+using TLocalSpaceType = UblasSpace<TDataType, DenseMatrix<TDataType>, DenseVector<TDataType>>;
 template <class TDataType>
 using TLinearSolverType = LinearSolver<TSpaceType<TDataType>, TLocalSpaceType<TDataType>>;
 template <class TDataType>
-using TDirectSolverType = DirectSolver<TSpaceType<TDataType>, TLocalSpaceType<TDataType>>;
+using TDirectSolverType = DirectSolver<TUblasSparseSpace<TDataType>, TUblasDenseSpace<TDataType>>;
 
 void  AddLinearSolversToPython(pybind11::module& m)
 {


### PR DESCRIPTION
Equivalent to kratos/python/add_linear_solvers_to_python.cpp

The Fortran compatible version of Ninja is needed:

https://github.com/Kitware/ninja