### PR TITLE
added ModelPart as parameter to CalculateValue of core response fct

### DIFF
--- a/applications/FluidDynamicsApplication/custom_python/add_custom_response_functions_to_python.cpp
+++ b/applications/FluidDynamicsApplication/custom_python/add_custom_response_functions_to_python.cpp
@@ -25,8 +25,8 @@ class PyDragResponseFunction : public DragResponseFunction<TDim>
         void FinalizeSolutionStep() override {
             PYBIND11_OVERLOAD(void, DragResponseFunction<TDim>, FinalizeSolutionStep, );
         }
-        double CalculateValue() override {
-            PYBIND11_OVERLOAD_PURE(double, DragResponseFunction<TDim>, CalculateValue, );
+        double CalculateValue(ModelPart& rModelPart) override {
+            PYBIND11_OVERLOAD_PURE(double, DragResponseFunction<TDim>, CalculateValue, rModelPart);
         }
 };
 

--- a/applications/FluidDynamicsApplication/custom_response_functions/drag_response_function.h
+++ b/applications/FluidDynamicsApplication/custom_response_functions/drag_response_function.h
@@ -7,7 +7,7 @@
 //  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
-//  Main authors:    
+//  Main authors:
 //
 
 #if !defined(KRATOS_DRAG_RESPONSE_FUNCTION_H_INCLUDED)
@@ -165,11 +165,11 @@ public:
         KRATOS_CATCH("");
     }
 
-    double CalculateValue() override
+    double CalculateValue(ModelPart& rModelPart) override
     {
         KRATOS_TRY;
         KRATOS_ERROR
-            << "DragResponseFunction::CalculateValue() is not implemented!!!\n";
+            << "DragResponseFunction::CalculateValue(ModelPart& rModelPart) is not implemented!!!\n";
         KRATOS_CATCH("");
     }
 

--- a/kratos/python/add_response_functions_to_python.cpp
+++ b/kratos/python/add_response_functions_to_python.cpp
@@ -18,6 +18,7 @@
 #include "includes/define_python.h"
 #include "add_response_functions_to_python.h"
 #include "response_functions/adjoint_response_function.h"
+#include "includes/model_part.h"
 
 namespace Kratos
 {
@@ -38,8 +39,8 @@ class PyAdjointResponseFunction : public AdjointResponseFunction
         void FinalizeSolutionStep() override {
             PYBIND11_OVERLOAD(void, AdjointResponseFunction, FinalizeSolutionStep, );
         }
-        double CalculateValue() override {
-            PYBIND11_OVERLOAD_PURE(double, AdjointResponseFunction, CalculateValue, );
+        double CalculateValue(ModelPart& rModelPart) override {
+            PYBIND11_OVERLOAD_PURE(double, AdjointResponseFunction, CalculateValue, rModelPart);
         }
 };
 

--- a/kratos/response_functions/adjoint_response_function.h
+++ b/kratos/response_functions/adjoint_response_function.h
@@ -246,7 +246,7 @@ public:
     }
 
     /// Calculate the scalar valued response function.
-    virtual double CalculateValue() = 0;
+    virtual double CalculateValue(ModelPart& rModelPart) = 0;
 
     ///@}
 

--- a/kratos/tests/strategies/schemes/test_residual_based_adjoint_bossak_scheme.cpp
+++ b/kratos/tests/strategies/schemes/test_residual_based_adjoint_bossak_scheme.cpp
@@ -492,7 +492,7 @@ class ResponseFunction : public AdjointResponseFunction
             rSensitivityGradient(0) = 0.;
         }
 
-        double CalculateValue() override
+        double CalculateValue(ModelPart& rModelPart) override
         {
             const double& x1 =
                 mrModelPart.GetNode(1).FastGetSolutionStepValue(DISPLACEMENT_X);


### PR DESCRIPTION
Within this PR we add  ```ModelPart``` as parameter to the function ```CalculateValue``` of the core class ```AdjointResponseFunction```.

The reason for this modification is that we like to derive the class ```AdjointStructuralResponseFunction``` of the Structural Mechanics Application from the core response class in a next step. This will lead to a decrease of code duplication since in order to that also the adjoint schemes and the sensitivity builder of the core can used from the adjoint sensitivity analysis of the Structural Mechanics Application. The only obstacle which forbids currently this inheritance is the fact that we need to give a model part to the ```CalculateValue``` function.

@msandre, @armingeiser and me had a long discussion on this issue. The outcome was the agreement that adding the model part to ```CalculateValue``` is not best practice. But nevertheless we agreed also to do this modification for now in order to open the core class in order to enable the described inheritance. 

Once the inheritance is done and the adjoint schemes and the sensitivity builder of the core are usable also from Structural Mechanics Application we will come back to this issue.