### PR TITLE
Comment/remove extern "C"

### DIFF
--- a/applications/HDF5Application/hdf5_application_define.h
+++ b/applications/HDF5Application/hdf5_application_define.h
@@ -17,9 +17,9 @@
 #include <vector>
 
 // External includes
-extern "C" {
+//extern "C" {
 #include "hdf5.h"
-}
+//}
 #include "includes/ublas_interface.h"
 
 // Project includes


### PR DESCRIPTION
The Intel compiler 2018/IntelMPI compiler 2018 throws linking error when compiling the parallel version of HDF5Application, due to external "C" in header.  This error does not occur with OpenMPI 3.1.2 and gcc 7.

Removing this part works in my case in serial and parallel version with both types of compilers, i.e. all tests are running. 

Please check.