### PR TITLE
[Dam] Optimize construction

### DIFF
--- a/applications/DamApplication/custom_utilities/construction_utility.hpp
+++ b/applications/DamApplication/custom_utilities/construction_utility.hpp
@@ -47,7 +47,7 @@ class ConstructionUtility
 
         // Getting values
         mGravityDirection = rParameters["gravity_direction"].GetString();
-        mReferenceCoordinate = mCurrentHeight = rParameters["reservoir_bottom_coordinate_in_gravity_direction"].GetDouble();
+        mReferenceCoordinate = mHighestBlockHeight = rParameters["reservoir_bottom_coordinate_in_gravity_direction"].GetDouble();
         mHeight = rParameters["height_dam"].GetDouble();
         mPhases = rParameters["number_of_phases"].GetInt();
         mSourceType = rParameters["source_type"].GetString();
@@ -332,7 +332,7 @@ class ConstructionUtility
         // Getting the value of the table and computing the current height
         double current_height = mReferenceCoordinate + (mHeight / mPhases) * current_number_of_phase;
 
-        if (current_height > mCurrentHeight) mCurrentHeight = current_height;
+        if (current_height > mHighestBlockHeight) mHighestBlockHeight = current_height;
 
         if (nelements != 0)
         {
@@ -452,7 +452,7 @@ class ConstructionUtility
                     // Elements
                     if ((it_thermal)->IsNot(ACTIVE))
                     {
-                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)))
+                        if ((central_position(direction) <= mHighestBlockHeight + (mHeight / mPhases)))
                         {
                             for (unsigned int i_edge = 0; i_edge < (*it_thermal).GetGeometry().EdgesNumber(); ++i_edge)
                             {
@@ -493,7 +493,7 @@ class ConstructionUtility
                     // Elements
                     if ((it_thermal)->IsNot(ACTIVE))
                     {
-                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)))
+                        if ((central_position(direction) <= mHighestBlockHeight + (mHeight / mPhases)))
                         {
                             for (unsigned int i_face = 0; i_face < (*it_thermal).GetGeometry().FacesNumber(); ++i_face)
                             {
@@ -566,7 +566,7 @@ class ConstructionUtility
                     // Elements
                     if ((it_thermal)->IsNot(ACTIVE))
                     {
-                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)))
+                        if ((central_position(direction) <= mHighestBlockHeight + (mHeight / mPhases)))
                         {
                             for (unsigned int i_edge = 0; i_edge < (*it_thermal).GetGeometry().EdgesNumber(); ++i_edge)
                             {
@@ -608,7 +608,7 @@ class ConstructionUtility
                     // Elements
                     if ((it_thermal)->IsNot(ACTIVE))
                     {
-                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)))
+                        if ((central_position(direction) <= mHighestBlockHeight + (mHeight / mPhases)))
                         {
                             for (unsigned int i_face = 0; i_face < (*it_thermal).GetGeometry().FacesNumber(); ++i_face)
                             {
@@ -763,7 +763,7 @@ class ConstructionUtility
     bool mActivateSoilPart;
     bool mActivateExistingPart;
     double mReferenceCoordinate;
-    double mCurrentHeight;
+    double mHighestBlockHeight;
     double mHeight;
     int mPhases;
     double mH0;

--- a/applications/DamApplication/custom_utilities/construction_utility.hpp
+++ b/applications/DamApplication/custom_utilities/construction_utility.hpp
@@ -47,7 +47,7 @@ class ConstructionUtility
 
         // Getting values
         mGravityDirection = rParameters["gravity_direction"].GetString();
-        mReferenceCoordinate = rParameters["reservoir_bottom_coordinate_in_gravity_direction"].GetDouble();
+        mReferenceCoordinate = mCurrentHeight = rParameters["reservoir_bottom_coordinate_in_gravity_direction"].GetDouble();
         mHeight = rParameters["height_dam"].GetDouble();
         mPhases = rParameters["number_of_phases"].GetInt();
         mSourceType = rParameters["source_type"].GetString();
@@ -196,16 +196,17 @@ class ConstructionUtility
             {
                 ModelPart::ConditionsContainerType::iterator it_cond_mech = cond_begin_mech + k;
                 const unsigned int number_of_points = (*it_cond_mech).GetGeometry().PointsNumber();
-                unsigned int count = 0;
+                bool active_condition = true;
 
                 for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
                 {
-                    if ((*it_cond_mech).GetGeometry()[i_node].Is(ACTIVE) == true)
+                    if ((*it_cond_mech).GetGeometry()[i_node].IsNot(ACTIVE))
                     {
-                        count++;
+                        active_condition = false;
+                        break;
                     }
                 }
-                if (count == number_of_points) it_cond_mech->Set(ACTIVE, true);
+                if (active_condition) it_cond_mech->Set(ACTIVE, true);
                 else it_cond_mech->Set(ACTIVE, false);
             }
         }
@@ -221,16 +222,17 @@ class ConstructionUtility
             {
                 ModelPart::ConditionsContainerType::iterator it_cond_thermal = cond_begin_thermal + k;
                 const unsigned int number_of_points = (*it_cond_thermal).GetGeometry().PointsNumber();
-                unsigned int count = 0;
+                bool active_condition = true;
 
                 for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
                 {
-                    if ((*it_cond_thermal).GetGeometry()[i_node].Is(ACTIVE) == true)
+                    if ((*it_cond_thermal).GetGeometry()[i_node].IsNot(ACTIVE))
                     {
-                        count++;
+                        active_condition = false;
+                        break;
                     }
                 }
-                if (count == number_of_points) it_cond_thermal->Set(ACTIVE, true);
+                if (active_condition) it_cond_thermal->Set(ACTIVE, true);
                 else it_cond_thermal->Set(ACTIVE, false);
             }
         }
@@ -330,6 +332,8 @@ class ConstructionUtility
         // Getting the value of the table and computing the current height
         double current_height = mReferenceCoordinate + (mHeight / mPhases) * current_number_of_phase;
 
+        if (current_height > mCurrentHeight) mCurrentHeight = current_height;
+
         if (nelements != 0)
         {
             // ELEMENTS
@@ -368,16 +372,17 @@ class ConstructionUtility
             {
                 ModelPart::ConditionsContainerType::iterator it_cond_mech = cond_begin_mech + k;
                 const unsigned int number_of_points = (*it_cond_mech).GetGeometry().PointsNumber();
-                unsigned int count = 0;
+                bool active_condition = true;
 
                 for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
                 {
-                    if ((*it_cond_mech).GetGeometry()[i_node].Is(ACTIVE) == true)
+                    if ((*it_cond_mech).GetGeometry()[i_node].IsNot(ACTIVE))
                     {
-                        count++;
+                        active_condition = false;
+                        break;
                     }
                 }
-                if (count == number_of_points) it_cond_mech->Set(ACTIVE, true);
+                if (active_condition) it_cond_mech->Set(ACTIVE, true);
                 else it_cond_mech->Set(ACTIVE, false);
             }
         }
@@ -393,16 +398,17 @@ class ConstructionUtility
             {
                 ModelPart::ConditionsContainerType::iterator it_cond_thermal = cond_begin_thermal + k;
                 const unsigned int number_of_points = (*it_cond_thermal).GetGeometry().PointsNumber();
-                unsigned int count = 0;
+                bool active_condition = true;
 
                 for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
                 {
-                    if ((*it_cond_thermal).GetGeometry()[i_node].Is(ACTIVE) == true)
+                    if ((*it_cond_thermal).GetGeometry()[i_node].IsNot(ACTIVE))
                     {
-                        count++;
+                        active_condition = false;
+                        break;
                     }
                 }
-                if (count == number_of_points) it_cond_thermal->Set(ACTIVE, true);
+                if (active_condition) it_cond_thermal->Set(ACTIVE, true);
                 else it_cond_thermal->Set(ACTIVE, false);
             }
         }
@@ -423,6 +429,14 @@ class ConstructionUtility
             ConditionNodeIds.resize(Dim + 1);
 
         int last_condition_id = mMechanicalLastCondition + mThermalLastCondition;
+        int direction;
+
+        if (mGravityDirection == "X")
+            direction = 0;
+        else if (mGravityDirection == "Y")
+            direction = 1;
+        else
+            direction = 2;
 
         if (nelements != 0)
         {
@@ -433,31 +447,37 @@ class ConstructionUtility
                 for (int k = 0; k < nelements; ++k)
                 {
                     ModelPart::ElementsContainerType::iterator it_thermal = el_begin_thermal + k;
+                    array_1d<double, 3> central_position = it_thermal->GetGeometry().Center();
+
                     // Elements
-                    if ((it_thermal)->Is(ACTIVE) == false)
+                    if ((it_thermal)->IsNot(ACTIVE))
                     {
-                        for (unsigned int i_edge = 0; i_edge < (*it_thermal).GetGeometry().EdgesNumber(); ++i_edge)
+                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)) || solid)
                         {
-                            const unsigned int number_of_points = (*it_thermal).GetGeometry().Edges()[i_edge].PointsNumber();
-                            unsigned int count = 0;
-
-                            for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
+                            for (unsigned int i_edge = 0; i_edge < (*it_thermal).GetGeometry().EdgesNumber(); ++i_edge)
                             {
-                                if ((*it_thermal).GetGeometry().Edges()[i_edge][i_node].Is(ACTIVE) == true)
-                                {
-                                    count++;
-                                }
-                            }
-                            if (count == number_of_points)
-                            {
-                                for (unsigned int m = 0; m < number_of_points; ++m)
-                                {
-                                    ConditionNodeIds[m] = (*it_thermal).GetGeometry().Edges()[i_edge][m].Id();
-                                }
-                                this->DeactiveFaceHeatFluxStep(ConditionNodeIds);
+                                const unsigned int number_of_points = (*it_thermal).GetGeometry().Edges()[i_edge].PointsNumber();
+                                bool active_edge = true;
 
-                                mrThermalModelPart.RemoveConditionFromAllLevels(last_condition_id + 1, 0);
-                                last_condition_id++;
+                                for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
+                                {
+                                    if ((*it_thermal).GetGeometry().Edges()[i_edge][i_node].IsNot(ACTIVE))
+                                    {
+                                        active_edge = false;
+                                        break;
+                                    }
+                                }
+                                if (active_edge)
+                                {
+                                    for (unsigned int m = 0; m < number_of_points; ++m)
+                                    {
+                                        ConditionNodeIds[m] = (*it_thermal).GetGeometry().Edges()[i_edge][m].Id();
+                                    }
+                                    this->DeactiveFaceHeatFluxStep(ConditionNodeIds);
+
+                                    mrThermalModelPart.RemoveConditionFromAllLevels(last_condition_id + 1, 0);
+                                    last_condition_id++;
+                                }
                             }
                         }
                     }
@@ -468,31 +488,37 @@ class ConstructionUtility
                 for (int k = 0; k < nelements; ++k)
                 {
                     ModelPart::ElementsContainerType::iterator it_thermal = el_begin_thermal + k;
+                    array_1d<double, 3> central_position = it_thermal->GetGeometry().Center();
+
                     // Elements
-                    if ((it_thermal)->Is(ACTIVE) == false)
+                    if ((it_thermal)->IsNot(ACTIVE))
                     {
-                        for (unsigned int i_face = 0; i_face < (*it_thermal).GetGeometry().FacesNumber(); ++i_face)
+                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)) || solid)
                         {
-                            const unsigned int number_of_points = (*it_thermal).GetGeometry().Faces()[i_face].PointsNumber();
-                            unsigned int count = 0;
-
-                            for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
+                            for (unsigned int i_face = 0; i_face < (*it_thermal).GetGeometry().FacesNumber(); ++i_face)
                             {
-                                if ((*it_thermal).GetGeometry().Faces()[i_face][i_node].Is(ACTIVE) == true)
-                                {
-                                    count++;
-                                }
-                            }
-                            if (count == number_of_points)
-                            {
-                                for (unsigned int m = 0; m < number_of_points; ++m)
-                                {
-                                    ConditionNodeIds[m] = (*it_thermal).GetGeometry().Faces()[i_face][m].Id();
-                                }
-                                this->DeactiveFaceHeatFluxStep(ConditionNodeIds);
+                                const unsigned int number_of_points = (*it_thermal).GetGeometry().Faces()[i_face].PointsNumber();
+                                bool active_face = true;
 
-                                mrThermalModelPart.RemoveConditionFromAllLevels(last_condition_id + 1, 0);
-                                last_condition_id++;
+                                for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
+                                {
+                                    if ((*it_thermal).GetGeometry().Faces()[i_face][i_node].IsNot(ACTIVE))
+                                    {
+                                        active_face = false;
+                                        break;
+                                    }
+                                }
+                                if (active_face)
+                                {
+                                    for (unsigned int m = 0; m < number_of_points; ++m)
+                                    {
+                                        ConditionNodeIds[m] = (*it_thermal).GetGeometry().Faces()[i_face][m].Id();
+                                    }
+                                    this->DeactiveFaceHeatFluxStep(ConditionNodeIds);
+
+                                    mrThermalModelPart.RemoveConditionFromAllLevels(last_condition_id + 1, 0);
+                                    last_condition_id++;
+                                }
                             }
                         }
                     }
@@ -516,6 +542,14 @@ class ConstructionUtility
             ConditionNodeIds.resize(Dim + 1);
 
         int last_condition_id = mMechanicalLastCondition + mThermalLastCondition;
+        int direction;
+
+        if (mGravityDirection == "X")
+            direction = 0;
+        else if (mGravityDirection == "Y")
+            direction = 1;
+        else
+            direction = 2;
 
         if (nelements != 0)
         {
@@ -527,31 +561,37 @@ class ConstructionUtility
                 for (int k = 0; k < nelements; ++k)
                 {
                     ModelPart::ElementsContainerType::iterator it_thermal = el_begin_thermal + k;
+                    array_1d<double, 3> central_position = it_thermal->GetGeometry().Center();
+
                     // Elements
-                    if ((it_thermal)->Is(ACTIVE) == false)
+                    if ((it_thermal)->IsNot(ACTIVE))
                     {
-                        for (unsigned int i_edge = 0; i_edge < (*it_thermal).GetGeometry().EdgesNumber(); ++i_edge)
+                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)))
                         {
-                            const unsigned int number_of_points = (*it_thermal).GetGeometry().Edges()[i_edge].PointsNumber();
-                            unsigned int count = 0;
-
-                            for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
+                            for (unsigned int i_edge = 0; i_edge < (*it_thermal).GetGeometry().EdgesNumber(); ++i_edge)
                             {
-                                if ((*it_thermal).GetGeometry().Edges()[i_edge][i_node].Is(ACTIVE) == true)
-                                {
-                                    count++;
-                                }
-                            }
-                            if (count == number_of_points)
-                            {
-                                for (unsigned int m = 0; m < number_of_points; ++m)
-                                {
-                                    ConditionNodeIds[m] = (*it_thermal).GetGeometry().Edges()[i_edge][m].Id();
-                                }
-                                this->ActiveFaceHeatFluxStep(ConditionNodeIds);
+                                const unsigned int number_of_points = (*it_thermal).GetGeometry().Edges()[i_edge].PointsNumber();
+                                bool active_edge = true;
 
-                                mrThermalModelPart.CreateNewCondition("FluxCondition2D2N", last_condition_id + 1, ConditionNodeIds, 0);
-                                last_condition_id++;
+                                for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
+                                {
+                                    if ((*it_thermal).GetGeometry().Edges()[i_edge][i_node].IsNot(ACTIVE))
+                                    {
+                                        active_edge = false;
+                                        break;
+                                    }
+                                }
+                                if (active_edge)
+                                {
+                                    for (unsigned int m = 0; m < number_of_points; ++m)
+                                    {
+                                        ConditionNodeIds[m] = (*it_thermal).GetGeometry().Edges()[i_edge][m].Id();
+                                    }
+                                    this->ActiveFaceHeatFluxStep(ConditionNodeIds);
+
+                                    mrThermalModelPart.CreateNewCondition("FluxCondition2D2N", last_condition_id + 1, ConditionNodeIds, 0);
+                                    last_condition_id++;
+                                }
                             }
                         }
                     }
@@ -563,38 +603,44 @@ class ConstructionUtility
                 for (int k = 0; k < nelements; ++k)
                 {
                     ModelPart::ElementsContainerType::iterator it_thermal = el_begin_thermal + k;
+                    array_1d<double, 3> central_position = it_thermal->GetGeometry().Center();
+
                     // Elements
-                    if ((it_thermal)->Is(ACTIVE) == false)
+                    if ((it_thermal)->IsNot(ACTIVE))
                     {
-                        for (unsigned int i_face = 0; i_face < (*it_thermal).GetGeometry().FacesNumber(); ++i_face)
+                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)))
                         {
-                            const unsigned int number_of_points = (*it_thermal).GetGeometry().Faces()[i_face].PointsNumber();
-                            unsigned int count = 0;
-
-                            for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
+                            for (unsigned int i_face = 0; i_face < (*it_thermal).GetGeometry().FacesNumber(); ++i_face)
                             {
-                                if ((*it_thermal).GetGeometry().Faces()[i_face][i_node].Is(ACTIVE) == true)
-                                {
-                                    count++;
-                                }
-                            }
-                            if (count == number_of_points)
-                            {
-                                for (unsigned int m = 0; m < number_of_points; ++m)
-                                {
-                                    ConditionNodeIds[m] = (*it_thermal).GetGeometry().Faces()[i_face][m].Id();
-                                }
-                                this->ActiveFaceHeatFluxStep(ConditionNodeIds);
+                                const unsigned int number_of_points = (*it_thermal).GetGeometry().Faces()[i_face].PointsNumber();
+                                bool active_face = true;
 
-                                if (number_of_points == 3)
+                                for (unsigned int i_node = 0; i_node < number_of_points; ++i_node)
                                 {
-                                    mrThermalModelPart.CreateNewCondition("FluxCondition3D3N", last_condition_id + 1, ConditionNodeIds, 0);
-                                    last_condition_id++;
+                                    if ((*it_thermal).GetGeometry().Faces()[i_face][i_node].IsNot(ACTIVE))
+                                    {
+                                        active_face = false;
+                                        break;
+                                    }
                                 }
-                                else
+                                if (active_face)
                                 {
-                                    mrThermalModelPart.CreateNewCondition("FluxCondition3D4N", last_condition_id + 1, ConditionNodeIds, 0);
-                                    last_condition_id++;
+                                    for (unsigned int m = 0; m < number_of_points; ++m)
+                                    {
+                                        ConditionNodeIds[m] = (*it_thermal).GetGeometry().Faces()[i_face][m].Id();
+                                    }
+                                    this->ActiveFaceHeatFluxStep(ConditionNodeIds);
+
+                                    if (number_of_points == 3)
+                                    {
+                                        mrThermalModelPart.CreateNewCondition("FluxCondition3D3N", last_condition_id + 1, ConditionNodeIds, 0);
+                                        last_condition_id++;
+                                    }
+                                    else
+                                    {
+                                        mrThermalModelPart.CreateNewCondition("FluxCondition3D4N", last_condition_id + 1, ConditionNodeIds, 0);
+                                        last_condition_id++;
+                                    }
                                 }
                             }
                         }
@@ -717,6 +763,7 @@ class ConstructionUtility
     bool mActivateSoilPart;
     bool mActivateExistingPart;
     double mReferenceCoordinate;
+    double mCurrentHeight;
     double mHeight;
     int mPhases;
     double mH0;

--- a/applications/DamApplication/custom_utilities/construction_utility.hpp
+++ b/applications/DamApplication/custom_utilities/construction_utility.hpp
@@ -452,7 +452,7 @@ class ConstructionUtility
                     // Elements
                     if ((it_thermal)->IsNot(ACTIVE))
                     {
-                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)) || solid)
+                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)))
                         {
                             for (unsigned int i_edge = 0; i_edge < (*it_thermal).GetGeometry().EdgesNumber(); ++i_edge)
                             {
@@ -493,7 +493,7 @@ class ConstructionUtility
                     // Elements
                     if ((it_thermal)->IsNot(ACTIVE))
                     {
-                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)) || solid)
+                        if ((central_position(direction) <= mCurrentHeight + (mHeight / mPhases)))
                         {
                             for (unsigned int i_face = 0; i_face < (*it_thermal).GetGeometry().FacesNumber(); ++i_face)
                             {


### PR DESCRIPTION
Search boundary walls in the construction utility is very time consuming, for that reason we have optimized the process only searching conditions near the already constructed part.

The only drawback is that the flux in the soil where blocks are about to be constructed is neglected, an acceptable simplification considering that the computational time decreases almost 4 times in the first steps of Baserca calculation.