### PR TITLE
[Core][Testing] change in detection of apps in test-runner

### DIFF
--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -60,7 +60,7 @@ def GetAvailableApplication():
     kratosPath = GetModulePath('KratosMultiphysics')
 
     apps = [
-        f.split('.')[0] for f in os.listdir(kratosPath) if re.match(r'.*Application\.py$', f)
+        f.split('.')[0] for f in os.listdir(kratosPath) if re.match(r'.*Application*', f)
     ]
 
     return apps


### PR DESCRIPTION
#3217 broke this, since now the folder-structure in the `KratosMultiphysics` - folder is different (see the [Wiki](https://github.com/KratosMultiphysics/Kratos/wiki/Applications-as-python-modules))

I hope this fix is ok, this should work in either case