### PR TITLE
[IGA] Expose single-index-access for surface weights via python

### DIFF
--- a/applications/IgaApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/IgaApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -301,7 +301,10 @@ void RegisterSurfaceGeometryBase(
             "IndexU"_a,
             "IndexV"_a,
             "Value"_a)
-        .def("Weight", &Type::Weight,
+        .def("Weight", (double (Type::*)(const int) const) &Type::Weight,
+            "Index"_a)
+        .def("Weight", (double (Type::*)(const int, const int) const)
+            &Type::Weight,
             "IndexU"_a,
             "IndexV"_a)
         .def("SetWeight", (void (Type::*)(const int, const double))


### PR DESCRIPTION
Fixes #3566

- compiles under Windows ✔️ 
- compiles under Ubuntu ✔️ 
- tested under Windows ✔️