### PR TITLE
[Metis] make output of debug-modelpart depending on verbosity

### DIFF
--- a/applications/metis_application/custom_processes/metis_divide_heterogeneous_input_in_memory_process.h
+++ b/applications/metis_application/custom_processes/metis_divide_heterogeneous_input_in_memory_process.h
@@ -324,11 +324,10 @@ public:
             streams[mpi_rank]->write(mpi_recv_buffer[mpi_rank], msgRecvSize[mpi_rank]);
         }
 
-#ifdef KRATOS_DEBUG
-        // Print the partitions in debug mode
-        std::ofstream debug_ofstream("debug_modelpart_"+std::to_string(mpi_rank)+".mdpa");
-        debug_ofstream << stringbufs[mpi_rank].str() << std::endl;
-#endif
+        if (mVerbosity > 1) {
+            std::ofstream debug_ofstream("MetisDivideHeterogeneousInputInMemoryProcess_debug_modelpart_"+std::to_string(mpi_rank)+".mdpa");
+            debug_ofstream << stringbufs[mpi_rank].str() << std::endl;
+        }
 
         // TODO: Try to come up with a better way to change the buffer.
         mrSerialIO.SwapStreamSource(streams[mpi_rank]);


### PR DESCRIPTION
It is quite verbose to print it unconditional

I hope this change is ok, seems more natural to me