### PR TITLE
fix(core): added missing const qualifier

### DIFF
--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -1365,7 +1365,7 @@ public:
         return mpParentModelPart;
     }
 
-    bool HasSubModelPart(std::string const& ThisSubModelPartName)
+    bool HasSubModelPart(std::string const& ThisSubModelPartName) const
     {
         return (mSubModelParts.find(ThisSubModelPartName) != mSubModelParts.end());
     }


### PR DESCRIPTION
So that the following works:

```
const ModelPart& m = ...;
m.HasSubModelPart("...");
```

