### PR TITLE
Fixing possible segfault in distance_modification_process.

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -178,13 +178,14 @@ void DistanceModificationProcess::ModifyDistance() {
         for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
         {
             auto nodes_begin = r_nodes.begin() + partition_vec[i_chunk];
-            auto nodes_end = r_nodes.begin() + partition_vec[i_chunk + 1];
+            const int chunk_end = partition_vec[i_chunk + 1] < r_nodes.size() ? partition_vec[i_chunk + 1] : r_nodes.size();
+            auto nodes_end = r_nodes.begin() + chunk_end;
 
             // Auxiliar chunk arrays
             std::vector<unsigned int> aux_modified_distances_ids;
             std::vector<double> aux_modified_distance_values;
 
-            for (auto it_node = nodes_begin; it_node != nodes_end; ++it_node) {
+            for (auto it_node = nodes_begin; it_node < nodes_end; ++it_node) {
                 const double h = it_node->FastGetSolutionStepValue(NODAL_H);
                 const double tol_d = mDistanceThreshold*h;
                 double &d = it_node->FastGetSolutionStepValue(DISTANCE);
@@ -258,13 +259,14 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance(){
         for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
         {
             auto elems_begin = r_elems.begin() + partition_vec[i_chunk];
-            auto elems_end = r_elems.begin() + partition_vec[i_chunk + 1];
+            const int chunk_end = partition_vec[i_chunk + 1] < r_elems.size() ? partition_vec[i_chunk + 1] : r_elems.size();
+            auto elems_end = r_elems.begin() + chunk_end;
 
             // Auxiliar chunk arrays
             std::vector<unsigned int> aux_modified_distances_ids;
             std::vector<Vector> aux_modified_elemental_distances;
 
-            for (auto it_elem = elems_begin; it_elem != elems_end; ++it_elem){
+            for (auto it_elem = elems_begin; it_elem < elems_end; ++it_elem){
                 // Compute the distance tolerance
                 const double tol_d = mDistanceThreshold * (it_elem->GetGeometry()).Length();
 

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -178,7 +178,8 @@ void DistanceModificationProcess::ModifyDistance() {
         for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
         {
             auto nodes_begin = r_nodes.begin() + partition_vec[i_chunk];
-            const int chunk_end = partition_vec[i_chunk + 1] < r_nodes.size() ? partition_vec[i_chunk + 1] : r_nodes.size();
+            const int node_size = r_nodes.size();
+            const int chunk_end = partition_vec[i_chunk + 1] < node_size ? partition_vec[i_chunk + 1] : node_size;
             auto nodes_end = r_nodes.begin() + chunk_end;
 
             // Auxiliar chunk arrays
@@ -259,7 +260,8 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance(){
         for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
         {
             auto elems_begin = r_elems.begin() + partition_vec[i_chunk];
-            const int chunk_end = partition_vec[i_chunk + 1] < r_elems.size() ? partition_vec[i_chunk + 1] : r_elems.size();
+            const int elem_size = r_elems.size();
+            const int chunk_end = partition_vec[i_chunk + 1] < elem_size ? partition_vec[i_chunk + 1] : elem_size;
             auto elems_end = r_elems.begin() + chunk_end;
 
             // Auxiliar chunk arrays

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -178,9 +178,7 @@ void DistanceModificationProcess::ModifyDistance() {
         for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
         {
             auto nodes_begin = r_nodes.begin() + partition_vec[i_chunk];
-            const int node_size = r_nodes.size();
-            const int chunk_end = partition_vec[i_chunk + 1] < node_size ? partition_vec[i_chunk + 1] : node_size;
-            auto nodes_end = r_nodes.begin() + chunk_end;
+            auto nodes_end = r_nodes.begin() + partition_vec[i_chunk + 1];
 
             // Auxiliar chunk arrays
             std::vector<unsigned int> aux_modified_distances_ids;
@@ -260,9 +258,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance(){
         for (int i_chunk = 0; i_chunk < num_chunks; ++i_chunk)
         {
             auto elems_begin = r_elems.begin() + partition_vec[i_chunk];
-            const int elem_size = r_elems.size();
-            const int chunk_end = partition_vec[i_chunk + 1] < elem_size ? partition_vec[i_chunk + 1] : elem_size;
-            auto elems_end = r_elems.begin() + chunk_end;
+            auto elems_end = r_elems.begin() + partition_vec[i_chunk + 1];
 
             // Auxiliar chunk arrays
             std::vector<unsigned int> aux_modified_distances_ids;

--- a/kratos/utilities/openmp_utils.h
+++ b/kratos/utilities/openmp_utils.h
@@ -68,7 +68,7 @@ public:
         return 1;
 #endif
     }
-    
+
 
     /// Wrapper for omp_get_thread_num().
     /**
@@ -82,7 +82,7 @@ public:
         return 0;
 #endif
     }
-    
+
     /// Wrapper for omp_in_parallel().
     /**
      @return Maximum number of OpenMP threads that will be used in
@@ -128,18 +128,12 @@ public:
         const int NumThreads,
         PartitionVector& Partitions)
     {
-#ifdef _OPENMP
         Partitions.resize(NumThreads + 1);
         int PartitionSize = NumTerms / NumThreads;
         Partitions[0] = 0;
         Partitions[NumThreads] = NumTerms;
         for(int i = 1; i < NumThreads; i++)
             Partitions[i] = Partitions[i-1] + PartitionSize ;
-#else
-        Partitions.resize(2);
-        Partitions[0] = 0;
-        Partitions[1] = NumTerms;
-#endif
     }
 
     /// Generate a partition for an std::vector-like array, providing iterators to the begin and end positions for each thread.
@@ -182,16 +176,16 @@ public:
     static inline void SetNumThreads(int NumThreads = 1)
     {
 #ifdef _OPENMP
-      
+
       int procs    = omp_get_num_procs();
       if( procs < NumThreads ){
 	std::cout<<" WARNING: Maximimun number of threads is EXCEEDED "<<std::endl;
-	/* Set thread number */  
+	/* Set thread number */
 	omp_set_num_threads(procs);
 	std::cout<<" Number of Threads Set To : "<<procs<<std::endl;
       }
       else{
-	/* Set thread number */  
+	/* Set thread number */
 	omp_set_num_threads(NumThreads);
       }
 
@@ -206,19 +200,19 @@ public:
 #ifdef _OPENMP
 
       int nthreads,tid, procs, maxt, inpar, dynamic, nested;
-  
+
       /* Start parallel region */
-  
+
 #pragma omp parallel private(nthreads, tid)
       {
 	/* Obtain thread number */
 	tid = omp_get_thread_num();
-    
+
 	/* Only master thread does this */
 	if (tid == 0)
 	  {
 	    printf("  Thread %d getting environment info...\n", tid);
-	
+
 	    /* Get environment information */
 	    procs    = omp_get_num_procs();
 	    nthreads = omp_get_num_threads();
@@ -228,7 +222,7 @@ public:
 	    dynamic  = omp_get_dynamic();
 	    //omp_set_nested(true);
 	    nested   = omp_get_nested();
-	
+
 	    /* Print environment information */
 	    printf( "  | ------------ OMP IN USE --------- |\n");
 	    printf( "  | Machine number of processors  = %d |\n", procs);
@@ -238,15 +232,15 @@ public:
 	    printf( "  | Dynamic threads enabled?      = %d |\n", dynamic);
 	    printf( "  | Nested parallelism supported? = %d |\n", nested);
 	    printf( "  | --------------------------------- |\n");
-	
-	    
+
+
 	    if( procs < nthreads )
 	      std::cout<<" ( WARNING: Maximimun number of threads is EXCEEDED )"<<std::endl;
-	    	    
+
 	  }
-    
+
       }
-      
+
 #endif
     }
 


### PR DESCRIPTION
Adding a guard on some openmp loops when the number of nodes/elements is not exactly divisible by the number of chunks.

I believe this might be related to #3512 (since it is segfault in debug, but I suspect may give an infinite loop in some very bad cases if bounds are not checked correctly).