### PR TITLE
[FluidDynamicsApplication][Fix] Corrections of Behr2004 part to adress #3595

### DIFF
--- a/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.cpp
+++ b/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.cpp
@@ -555,7 +555,7 @@ void NavierStokesWallCondition<TDim,TNumNodes>::ComputeGaussPointBehrSlipRHSCont
 	}
 
     // Computation of NodalProjectionMatrix = ( [I] - (na)(na) ) for all nodes and store it
-    std::vector< BoundedMatrix<double, 3, 3> > NodalProjectionMatrix(TNumNodes);
+    std::vector< BoundedMatrix<double, TNumNodes, TNumNodes> > NodalProjectionMatrix(TNumNodes);
     for(unsigned int node = 0; node < TNumNodes; node++){
         FluidElementUtilities<3>::SetTangentialProjectionMatrix( NodalNormals[node], NodalProjectionMatrix[node] );
     }
@@ -582,7 +582,7 @@ void NavierStokesWallCondition<TDim,TNumNodes>::ComputeGaussPointBehrSlipRHSCont
             CompleteNodalSigma[nnode][1] = ShearStressOfElement[1] - rGeom[nnode].FastGetSolutionStepValue(PRESSURE);
             CompleteNodalSigma[nnode][2] = ShearStressOfElement[2]; // no pressure in shear component
 #ifdef KRATOS_DEBUG
-            if ( abs( ShearStressOfElement[0] ) > 0.001 || abs( ShearStressOfElement[1] ) > 0.001 ){
+            if ( std::abs( ShearStressOfElement[0] ) > 0.001 || std::abs( ShearStressOfElement[1] ) > 0.001 ){
                 KRATOS_WARNING("Behr Contribution in SLIP condition") << "The normal components of the viscous stress are still present" << std::endl;
             }
 #endif
@@ -597,33 +597,31 @@ void NavierStokesWallCondition<TDim,TNumNodes>::ComputeGaussPointBehrSlipRHSCont
             CompleteNodalSigma[nnode][4] = ShearStressOfElement[4];  // no pressure in shear component
             CompleteNodalSigma[nnode][5] = ShearStressOfElement[5];  // no pressure in shear component
 #ifdef KRATOS_DEBUG
-            if ( abs( ShearStressOfElement[0] ) > 0.001 || abs( ShearStressOfElement[1] ) > 0.001 || abs( ShearStressOfElement[2] ) > 0.001 ){
+            if ( std::abs( ShearStressOfElement[0] ) > 0.001 || std::abs( ShearStressOfElement[1] ) > 0.001 || std::abs( ShearStressOfElement[2] ) > 0.001 ){
                 KRATOS_WARNING("Behr Contribution in SLIP condition") << "The normal components of the viscous stress are still present" << std::endl;
             }
 #endif
         }
     }
 
-    Vector CompleteSigmaInterpolated;
-    CompleteSigmaInterpolated = ZeroVector(3);
+    Vector CompleteSigmaInterpolated = ZeroVector(TNumNodes);
 
-    std::vector<array_1d<double,TNumNodes+1>> NodalEntriesRHS(TNumNodes);
+    std::vector<array_1d<double,TNumNodes>> NodalEntriesRHS(TNumNodes);
 
     // Loop all nodal contributions
     for (unsigned int nnode = 0; nnode < TNumNodes; nnode++){
 
-        NodalEntriesRHS[nnode] = zero_vector<double>(3);
+        NodalEntriesRHS[nnode] = zero_vector<double>(TNumNodes);
         const array_1d<double, TNumNodes> N = rDataStruct.N;
         const double wGauss = rDataStruct.wGauss;
 
-        CompleteSigmaInterpolated = ZeroVector(3);
+        CompleteSigmaInterpolated = ZeroVector(TNumNodes);
         for( unsigned int comp = 0; comp < TNumNodes; comp++){
 
             CompleteSigmaInterpolated += N[comp] * prod( conditionNormalForVoigt, CompleteNodalSigma[comp] );
         }
 
-        NodalEntriesRHS[nnode] = ( wGauss * N(nnode) * CompleteSigmaInterpolated );
-        NodalEntriesRHS[nnode] = prod( NodalProjectionMatrix[nnode], NodalEntriesRHS[nnode] );
+        NodalEntriesRHS[nnode] = prod( NodalProjectionMatrix[nnode], ( wGauss * N(nnode) * CompleteSigmaInterpolated ) );
     }
 
     for (unsigned int node = 0; node < TNumNodes; node++){

--- a/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.cpp
+++ b/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.cpp
@@ -611,7 +611,7 @@ void NavierStokesWallCondition<TDim,TNumNodes>::ComputeGaussPointBehrSlipRHSCont
     // Loop all nodal contributions
     for (unsigned int nnode = 0; nnode < TNumNodes; nnode++){
 
-        NodalEntriesRHS[nnode] = zero_vector<double>(TNumNodes);
+        NodalEntriesRHS[nnode] = ZeroVector(TNumNodes);
         const array_1d<double, TNumNodes> N = rDataStruct.N;
         const double wGauss = rDataStruct.wGauss;
 


### PR DESCRIPTION
The following fix for the problems detected in #3595 is suggested:

- Correction of the size of NodalProjectionMatrix to produce a 2x2 (for 2D) and a 3x3 (for3D). This did not yield wrong results, because the third diagonal entry multiplied with a zero in the 2D case. However, the sizes of the arrays were distorted as detected by @jcotela 
- To fit this change in NodalProjectionMatrix, the vector sizes were adapted.

According to tests on my local machine, the unit tests are finishing correctly. Also 2D and 3D application cases were re-run to assure the functionality.