### PR TITLE
[IGA] temp commenting execution of c-tests

### DIFF
--- a/applications/IgaApplication/tests/test_IgaApplication.py
+++ b/applications/IgaApplication/tests/test_IgaApplication.py
@@ -41,5 +41,5 @@ def AssembleTestSuites():
     return suites
 
 if __name__ == '__main__':
-    run_cpp_unit_tests.run()
+    #run_cpp_unit_tests.run()
     KratosUnittest.runTests(AssembleTestSuites())


### PR DESCRIPTION
there are no cpp-tests yet so this throws

this will be reenabled once there are c-tests (@tteschemacher is currently working on this)