### PR TITLE
Apps/remove conditional imports

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_analysis.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_analysis.py
@@ -5,23 +5,6 @@ import KratosMultiphysics as KM
 import KratosMultiphysics.StructuralMechanicsApplication as SMA
 import KratosMultiphysics.ContactStructuralMechanicsApplication as CSMA
 
-# Importing the solvers (if available)
-try:
-    import KratosMultiphysics.ExternalSolversApplication
-    KratosMultiphysics.Logger.PrintInfo("ExternalSolversApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("ExternalSolversApplication", "not imported")
-try:
-    import KratosMultiphysics.EigenSolversApplication
-    KratosMultiphysics.Logger.PrintInfo("EigenSolversApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("EigenSolversApplication", "not imported")
-try:
-    import KratosMultiphysics.MeshingApplication as MA
-    KratosMultiphysics.Logger.PrintInfo("MeshingApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("MeshingApplication", "not imported")
-
 # Other imports
 import sys
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_analysis.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_analysis.py
@@ -5,18 +5,6 @@ import KratosMultiphysics as KM
 import KratosMultiphysics.StructuralMechanicsApplication as SM
 import KratosMultiphysics.ContactStructuralMechanicsApplication as CSM
 
-# Importing the solvers (if available)
-try:
-    import KratosMultiphysics.ExternalSolversApplication
-    KratosMultiphysics.Logger.PrintInfo("ExternalSolversApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("ExternalSolversApplication", "not imported")
-try:
-    import KratosMultiphysics.EigenSolversApplication
-    KratosMultiphysics.Logger.PrintInfo("EigenSolversApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("EigenSolversApplication", "not imported")
-
 # Other imports
 import sys
 

--- a/applications/FSIapplication/python_scripts/fsi_analysis.py
+++ b/applications/FSIapplication/python_scripts/fsi_analysis.py
@@ -4,10 +4,6 @@ import KratosMultiphysics as Kratos
 import KratosMultiphysics.MeshMovingApplication as MeshMovingApplication
 import KratosMultiphysics.FluidDynamicsApplication as FluidDynamicsApplication
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
-try:
-    import KratosMultiphysics.ExternalSolversApplication
-except ImportError:
-    pass
 
 from analysis_stage import AnalysisStage
 

--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_analysis.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_analysis.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import, division #makes KratosMultiphysics backw
 
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.FluidDynamicsApplication as KFluid
-try:
-    import KratosMultiphysics.ExternalSolversApplication
-except ImportError:
-    pass
 
 from analysis_stage import AnalysisStage
 from fluid_dynamics_analysis import FluidDynamicsAnalysis
@@ -41,11 +37,8 @@ class AdjointFluidAnalysis(AnalysisStage):
         self.number_of_steps = parameters["problem_data"]["nsteps"].GetInt()
 
         self.is_printing_rank = True
-        ## Import parallel modules if needed
         if (parameters["problem_data"]["parallel_type"].GetString() == "MPI"):
             from KratosMultiphysics.mpi import mpi
-            import KratosMultiphysics.MetisApplication as MetisApplication
-            import KratosMultiphysics.TrilinosApplication as TrilinosApplication
             self.is_printing_rank = (mpi.rank == 0)
 
         super(AdjointFluidAnalysis, self).__init__(model, parameters)

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis.py
@@ -2,10 +2,6 @@ from __future__ import absolute_import, division #makes KratosMultiphysics backw
 
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.FluidDynamicsApplication
-try:
-    import KratosMultiphysics.ExternalSolversApplication
-except ImportError:
-    pass
 
 from analysis_stage import AnalysisStage
 
@@ -35,12 +31,6 @@ class FluidDynamicsAnalysis(AnalysisStage):
             Kratos.Logger.PrintInfo("FluidDynamicsAnalysis", "Using the old way to pass the model_part_name, this will be removed!")
             solver_settings.AddEmptyValue("model_part_name")
             solver_settings["model_part_name"].SetString(parameters["problem_data"]["model_part_name"].GetString())
-
-        # Import parallel modules if needed
-        # has to be done before the base-class constuctor is called (in which the solver is constructed)
-        if (parameters["problem_data"]["parallel_type"].GetString() == "MPI"):
-            import KratosMultiphysics.MetisApplication as MetisApplication
-            import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 
         super(FluidDynamicsAnalysis,self).__init__(model,parameters)
 

--- a/applications/MeshMovingApplication/python_scripts/mesh_moving_analysis.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_moving_analysis.py
@@ -4,18 +4,6 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 import KratosMultiphysics
 import KratosMultiphysics.MeshMovingApplication as KratosMeshMoving
 
-# Importing the solvers (if available)
-try:
-    import KratosMultiphysics.ExternalSolversApplication
-    KratosMultiphysics.Logger.PrintInfo("ExternalSolversApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("ExternalSolversApplication", "not imported")
-try:
-    import KratosMultiphysics.EigenSolversApplication
-    KratosMultiphysics.Logger.PrintInfo("EigenSolversApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("EigenSolversApplication", "not imported")
-
 # Importing the base class
 from analysis_stage import AnalysisStage
 
@@ -48,12 +36,6 @@ class MeshMovingAnalysis(AnalysisStage):
             KratosMultiphysics.Logger.PrintInfo("MeshMovingAnalysis", '"solver_settings" does not have "echo_level", please add it!')
             solver_settings.AddEmptyValue("echo_level")
             solver_settings["echo_level"].SetInt(0)
-
-        # Import parallel modules if needed
-        # has to be done before the base-class constuctor is called (in which the solver is constructed)
-        if (project_parameters["problem_data"]["parallel_type"].GetString() == "MPI"):
-            import KratosMultiphysics.MetisApplication as MetisApplication
-            import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 
         super(MeshMovingAnalysis, self).__init__(model, project_parameters)
 

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_analysis.py
@@ -4,23 +4,6 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 import KratosMultiphysics as KM
 import KratosMultiphysics.StructuralMechanicsApplication as SMA
 
-# Importing the solvers (if available)
-try:
-    import KratosMultiphysics.ExternalSolversApplication
-    KratosMultiphysics.Logger.PrintInfo("ExternalSolversApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("ExternalSolversApplication", "not imported")
-try:
-    import KratosMultiphysics.EigenSolversApplication
-    KratosMultiphysics.Logger.PrintInfo("EigenSolversApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("EigenSolversApplication", "not imported")
-try:
-    import KratosMultiphysics.MeshingApplication as MA
-    KratosMultiphysics.Logger.PrintInfo("MeshingApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("MeshingApplication", "not imported")
-
 # Other imports
 import sys
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_analysis.py
@@ -4,23 +4,6 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
-# Importing the solvers (if available)
-try:
-    import KratosMultiphysics.ExternalSolversApplication
-    KratosMultiphysics.Logger.PrintInfo("ExternalSolversApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("ExternalSolversApplication", "not imported")
-try:
-    import KratosMultiphysics.EigenSolversApplication
-    KratosMultiphysics.Logger.PrintInfo("EigenSolversApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("EigenSolversApplication", "not imported")
-try:
-    import KratosMultiphysics.MeshingApplication
-    KratosMultiphysics.Logger.PrintInfo("MeshingApplication", "succesfully imported")
-except ImportError:
-    KratosMultiphysics.Logger.PrintInfo("MeshingApplication", "not imported")
-
 # Importing the base class
 from analysis_stage import AnalysisStage
 
@@ -64,12 +47,6 @@ class StructuralMechanicsAnalysis(AnalysisStage):
             KratosMultiphysics.Logger.PrintWarning("StructuralMechanicsAnalysis", "Using the old way to pass the model_part_name, this will be removed!")
             solver_settings.AddEmptyValue("model_part_name")
             solver_settings["model_part_name"].SetString(project_parameters["problem_data"]["model_part_name"].GetString())
-
-        # Import parallel modules if needed
-        # has to be done before the base-class constuctor is called (in which the solver is constructed)
-        if (project_parameters["problem_data"]["parallel_type"].GetString() == "MPI"):
-            import KratosMultiphysics.MetisApplication as MetisApplication
-            import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 
         super(StructuralMechanicsAnalysis, self).__init__(model, project_parameters)
 


### PR DESCRIPTION
these are no longer needed after #3586, #3590, #3600 

Now the scripts that actually need them can import them (in most cases the linear-solver-factory)

another step towards proper python-modules :+1: 

(Btw the conditional import can have some weird effects, so it is good that they are removed. Just had a case that I checked with @jcotela this week)