### PR TITLE
Fluid/faster nightly tests

### DIFF
--- a/applications/FluidDynamicsApplication/tests/buoyancy_test.py
+++ b/applications/FluidDynamicsApplication/tests/buoyancy_test.py
@@ -140,8 +140,10 @@ class BuoyancyTest(UnitTest.TestCase):
         alpha = -0.3
         move_mesh = 0
         self.fluid_solver.time_scheme = ResidualBasedPredictorCorrectorVelocityBossakSchemeTurbulent(alpha,move_mesh,self.domain_size)
-        precond = DiagonalPreconditioner()
-        self.fluid_solver.linear_solver = BICGSTABSolver(1e-6, 5000, precond)
+        import linear_solver_factory
+        self.fluid_solver.linear_solver = linear_solver_factory.ConstructSolver(Parameters(r'''{
+                "solver_type" : "AMGCL"
+            }'''))
         builder_and_solver = ResidualBasedBlockBuilderAndSolver(self.fluid_solver.linear_solver)
         self.fluid_solver.max_iter = 50
         self.fluid_solver.compute_reactions = False
@@ -169,7 +171,7 @@ class BuoyancyTest(UnitTest.TestCase):
 
         if self.convection_diffusion_solver == 'eulerian':
             # Duplicate model part
-            
+
             thermal_model_part = self.model.CreateModelPart("Thermal")
             conv_diff_element = "EulerianConvDiff2D"
             conv_diff_condition = "Condition2D2N"

--- a/applications/FluidDynamicsApplication/tests/darcy_channel_test.py
+++ b/applications/FluidDynamicsApplication/tests/darcy_channel_test.py
@@ -111,7 +111,7 @@ class DarcyChannelTest(UnitTest.TestCase):
                 self.density = float(density)
                 self.temperature = float(temperature)
                 self.kinematic_viscosity = float(kinematic_viscosity)
- 
+
         fluids = [
             Fluid("Water",7,1000,1.38E-06),
             Fluid("Pure Aluminium",710,2386,5.25E-07),
@@ -228,8 +228,11 @@ class DarcyChannelTest(UnitTest.TestCase):
         self.fluid_solver.conv_criteria.SetEchoLevel(0)
 
         self.fluid_solver.time_scheme = ResidualBasedPredictorCorrectorBDFSchemeTurbulentNoReaction(self.domain_size)
-        precond = DiagonalPreconditioner()
-        self.fluid_solver.linear_solver = BICGSTABSolver(1e-6, 5000, precond)
+
+        import linear_solver_factory
+        self.fluid_solver.linear_solver = linear_solver_factory.ConstructSolver(Parameters(r'''{
+                "solver_type" : "AMGCL"
+            }'''))
         builder_and_solver = ResidualBasedBlockBuilderAndSolver(self.fluid_solver.linear_solver)
         self.fluid_solver.max_iter = 50
         self.fluid_solver.compute_reactions = False
@@ -326,7 +329,7 @@ class DarcyChannelTest(UnitTest.TestCase):
         label = self.fluid_model_part.ProcessInfo[TIME]
         self.gid_io.WriteNodalResults(VELOCITY,self.fluid_model_part.Nodes,label,0)
         self.gid_io.WriteNodalResults(PRESSURE,self.fluid_model_part.Nodes,label,0)
-    
+
     def FinalizeOutput(self):
         self.gid_io.FinalizeResults()
 

--- a/applications/FluidDynamicsApplication/tests/fluid_element_test.py
+++ b/applications/FluidDynamicsApplication/tests/fluid_element_test.py
@@ -2,7 +2,7 @@ from KratosMultiphysics import *
 from KratosMultiphysics.FluidDynamicsApplication import *
 
 import KratosMultiphysics.KratosUnittest as UnitTest
-        
+
 import vms_monolithic_solver
 
 class WorkFolderScope:
@@ -53,7 +53,7 @@ class FluidElementTest(UnitTest.TestCase):
 
             self.checkResults()
 
-    
+
     def testCavityQSASGS(self):
         self.reference_file = "reference10_qsasgs"
         self.element = "QSVMS2D3N"
@@ -65,7 +65,7 @@ class FluidElementTest(UnitTest.TestCase):
         self.element = "QSVMS2D3N"
         self.oss_switch = 1
         self.testCavity()
-    
+
     def testCavityDASGS(self):
         self.reference_file = "reference10_dasgs"
         self.element = "DVMS2D3N"
@@ -113,8 +113,10 @@ class FluidElementTest(UnitTest.TestCase):
         alpha = -0.3
         move_mesh = 0
         self.fluid_solver.time_scheme = ResidualBasedPredictorCorrectorVelocityBossakSchemeTurbulent(alpha,move_mesh,self.domain_size)
-        precond = DiagonalPreconditioner()
-        self.fluid_solver.linear_solver = BICGSTABSolver(1e-6, 5000, precond)
+        import linear_solver_factory
+        self.fluid_solver.linear_solver = linear_solver_factory.ConstructSolver(Parameters(r'''{
+                "solver_type" : "AMGCL"
+            }'''))
         builder_and_solver = ResidualBasedBlockBuilderAndSolver(self.fluid_solver.linear_solver)
         self.fluid_solver.max_iter = 50
         self.fluid_solver.compute_reactions = False

--- a/applications/FluidDynamicsApplication/tests/time_integrated_fluid_element_test.py
+++ b/applications/FluidDynamicsApplication/tests/time_integrated_fluid_element_test.py
@@ -95,8 +95,10 @@ class TimeIntegratedFluidElementTest(UnitTest.TestCase):
         self.fluid_solver.conv_criteria.SetEchoLevel(0)
 
         self.fluid_solver.time_scheme = ResidualBasedIncrementalUpdateStaticScheme()
-        precond = DiagonalPreconditioner()
-        self.fluid_solver.linear_solver = BICGSTABSolver(1e-6, 5000, precond)
+        import linear_solver_factory
+        self.fluid_solver.linear_solver = linear_solver_factory.ConstructSolver(Parameters(r'''{
+                "solver_type" : "AMGCL"
+            }'''))
         builder_and_solver = ResidualBasedBlockBuilderAndSolver(self.fluid_solver.linear_solver)
         self.fluid_solver.max_iter = 50
         self.fluid_solver.compute_reactions = False

--- a/applications/FluidDynamicsApplication/tests/volume_source_test.py
+++ b/applications/FluidDynamicsApplication/tests/volume_source_test.py
@@ -37,7 +37,7 @@ class VolumeSourceTest(UnitTest.TestCase):
         self.print_reference_values = False
 
     def tearDown(self):
-       
+
         import os
         with WorkFolderScope("BuoyancyTest"):
             try:
@@ -132,8 +132,10 @@ class VolumeSourceTest(UnitTest.TestCase):
         alpha = -0.3
         move_mesh = 0
         self.fluid_solver.time_scheme = ResidualBasedPredictorCorrectorVelocityBossakSchemeTurbulent(alpha,move_mesh,self.domain_size)
-        precond = DiagonalPreconditioner()
-        self.fluid_solver.linear_solver = BICGSTABSolver(1e-6, 5000, precond)
+        import linear_solver_factory
+        self.fluid_solver.linear_solver = linear_solver_factory.ConstructSolver(Parameters(r'''{
+                "solver_type" : "AMGCL"
+            }'''))
         builder_and_solver = ResidualBasedBlockBuilderAndSolver(self.fluid_solver.linear_solver)
         self.fluid_solver.max_iter = 50
         self.fluid_solver.compute_reactions = False


### PR DESCRIPTION
Apparently, what makes the fluid tests take too long is the use of the bicgstab solver. I can only guess that it is related to the extra bounds checks enabled in debug mode, since the tests work just fine in release. I have changed fluid tests to use AMGCL instead, which is much faster in debug mode.

If tests keep taking too long after this, we may have to remove some of them.

Related to #3512