### PR TITLE
Prevent rewriting of results files in adjoint test cases

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
@@ -123,7 +123,7 @@
             "tolerance"            : 1e-5,
             "time_frequency"   : -2.0
         }
-    }],
+    }]},
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",
@@ -136,5 +136,5 @@
                 "model_part_name"  : "Structure",
                 "time_frequency"   : -2.0
             }
-        }]}
+        }]
 }

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
@@ -110,20 +110,23 @@
                 "list_of_variables": ["DISPLACEMENT", "ROTATION"]
             }
         }
-    },
-     {
-        "python_module"   : "from_json_check_result_process",
-        "kratos_module" : "KratosMultiphysics",
-        "help"                  : "",
-        "process_name"          : "FromJsonCheckResultProcess",
-        "Parameters"            : {
-            "check_variables"  : ["ADJOINT_DISPLACEMENT", "ADJOINT_ROTATION", "SHAPE_SENSITIVITY"],
-            "input_file_name"  : "beam_test_local_stress_results.json",
-            "model_part_name"  : "Structure",
-            "tolerance"            : 1e-5,
-            "time_frequency"   : -2.0
+    }],
+    "json_check_process" : [
+        {
+            "python_module"   : "from_json_check_result_process",
+            "kratos_module" : "KratosMultiphysics",
+            "help"                  : "",
+            "process_name"          : "FromJsonCheckResultProcess",
+            "Parameters"            : {
+                "check_variables"  : ["ADJOINT_DISPLACEMENT", "ADJOINT_ROTATION", "SHAPE_SENSITIVITY"],
+                "input_file_name"  : "beam_test_local_stress_results.json",
+                "model_part_name"  : "Structure",
+                "tolerance"            : 1e-5,
+                "time_frequency"   : -2.0
+            }
         }
-    }]},
+        ]
+    },
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_nodal_disp_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_nodal_disp_adjoint_parameters.json
@@ -108,20 +108,23 @@
                 "list_of_variables": ["DISPLACEMENT", "ROTATION"]
             }
         }
-     },
-     {
-        "python_module"   : "from_json_check_result_process",
-        "kratos_module" : "KratosMultiphysics",
-        "help"                  : "",
-        "process_name"          : "FromJsonCheckResultProcess",
-        "Parameters"            : {
-            "check_variables"  : ["ADJOINT_DISPLACEMENT", "ADJOINT_ROTATION", "SHAPE_SENSITIVITY"],
-            "input_file_name"  : "beam_test_nodal_disp_results.json",
-            "model_part_name"  : "Structure",
-            "tolerance"        : 1e-5,
-            "time_frequency"   : -2.0
+     }],
+    "json_check_process" : [
+        {
+            "python_module"   : "from_json_check_result_process",
+            "kratos_module" : "KratosMultiphysics",
+            "help"                  : "",
+            "process_name"          : "FromJsonCheckResultProcess",
+            "Parameters"            : {
+                "check_variables"  : ["ADJOINT_DISPLACEMENT", "ADJOINT_ROTATION", "SHAPE_SENSITIVITY"],
+                "input_file_name"  : "beam_test_nodal_disp_results.json",
+                "model_part_name"  : "Structure",
+                "tolerance"        : 1e-5,
+                "time_frequency"   : -2.0
+            }
         }
-    }]},
+        ]
+    },
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_nodal_disp_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_nodal_disp_adjoint_parameters.json
@@ -121,7 +121,7 @@
             "tolerance"        : 1e-5,
             "time_frequency"   : -2.0
         }
-    }],
+    }]},
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",
@@ -134,5 +134,5 @@
                 "model_part_name"  : "Structure",
                 "time_frequency"   : -2.0
             }
-        }]}
+        }]
 }

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_strain_energy_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_strain_energy_adjoint_parameters.json
@@ -119,7 +119,7 @@
             "tolerance"            : 1e-5,
             "time_frequency"   : -2.0
         }
-    }],
+    }]},
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",
@@ -132,5 +132,5 @@
                 "model_part_name"  : "Structure",
                 "time_frequency"   : -2.0
             }
-        }]}
+        }]
 }

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_strain_energy_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_strain_energy_adjoint_parameters.json
@@ -106,20 +106,23 @@
                 "list_of_variables": ["DISPLACEMENT", "ROTATION"]
             }
         }
-     },
-     {
-        "python_module"   : "from_json_check_result_process",
-        "kratos_module" : "KratosMultiphysics",
-        "help"                  : "",
-        "process_name"          : "FromJsonCheckResultProcess",
-        "Parameters"            : {
-            "check_variables"  : ["ADJOINT_DISPLACEMENT", "ADJOINT_ROTATION", "SHAPE_SENSITIVITY"],
-            "input_file_name"  : "beam_test_strain_energy_results.json",
-            "model_part_name"  : "Structure",
-            "tolerance"            : 1e-5,
-            "time_frequency"   : -2.0
+     }],
+    "json_check_process" : [
+        {
+            "python_module"   : "from_json_check_result_process",
+            "kratos_module" : "KratosMultiphysics",
+            "help"                  : "",
+            "process_name"          : "FromJsonCheckResultProcess",
+            "Parameters"            : {
+                "check_variables"  : ["ADJOINT_DISPLACEMENT", "ADJOINT_ROTATION", "SHAPE_SENSITIVITY"],
+                "input_file_name"  : "beam_test_strain_energy_results.json",
+                "model_part_name"  : "Structure",
+                "tolerance"            : 1e-5,
+                "time_frequency"   : -2.0
+            }
         }
-    }]},
+        ]
+    },
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_local_stress_adjoint_parameters.json
@@ -95,20 +95,23 @@
                 "list_of_variables": ["DISPLACEMENT", "ROTATION"]
             }
         }
-     },
-     {
-        "python_module"   : "from_json_check_result_process",
-        "kratos_module" : "KratosMultiphysics",
-        "help"                  : "",
-        "process_name"          : "FromJsonCheckResultProcess",
-        "Parameters"            : {
-            "check_variables"  : ["ADJOINT_DISPLACEMENT", "SHAPE_SENSITIVITY"],
-            "input_file_name"  : "linear_shell_test_local_stress_results.json",
-            "model_part_name"  : "Structure",
-            "tolerance"            : 1e-5,
-            "time_frequency"   : -2.0
+     }],
+    "json_check_process" : [
+        {
+            "python_module"   : "from_json_check_result_process",
+            "kratos_module" : "KratosMultiphysics",
+            "help"                  : "",
+            "process_name"          : "FromJsonCheckResultProcess",
+            "Parameters"            : {
+                "check_variables"  : ["ADJOINT_DISPLACEMENT", "SHAPE_SENSITIVITY"],
+                "input_file_name"  : "linear_shell_test_local_stress_results.json",
+                "model_part_name"  : "Structure",
+                "tolerance"            : 1e-5,
+                "time_frequency"   : -2.0
+            }
         }
-    }]},
+        ]
+    },
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_local_stress_adjoint_parameters.json
@@ -108,7 +108,7 @@
             "tolerance"            : 1e-5,
             "time_frequency"   : -2.0
         }
-    }],
+    }]},
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",
@@ -121,5 +121,5 @@
                 "model_part_name"  : "Structure",
                 "time_frequency"   : -2.0
             }
-        }]}
+        }]
 }

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_nodal_disp_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_nodal_disp_adjoint_parameters.json
@@ -106,7 +106,7 @@
             "tolerance"            : 1e-5,
             "time_frequency"   : -2.0
         }
-    }],
+    }]},
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",
@@ -119,5 +119,5 @@
                 "model_part_name"  : "Structure",
                 "time_frequency"   : -2.0
             }
-        }]}
+        }]
 }

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_nodal_disp_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_nodal_disp_adjoint_parameters.json
@@ -93,20 +93,23 @@
                 "list_of_variables": ["DISPLACEMENT", "ROTATION"]
             }
         }
-     },
-     {
-        "python_module"   : "from_json_check_result_process",
-        "kratos_module" : "KratosMultiphysics",
-        "help"                  : "",
-        "process_name"          : "FromJsonCheckResultProcess",
-        "Parameters"            : {
-            "check_variables"  : ["ADJOINT_DISPLACEMENT", "SHAPE_SENSITIVITY"],
-            "input_file_name"  : "linear_shell_test_nodal_disp_results.json",
-            "model_part_name"  : "Structure",
-            "tolerance"            : 1e-5,
-            "time_frequency"   : -2.0
+     }],
+    "json_check_process" : [
+        {
+            "python_module"   : "from_json_check_result_process",
+            "kratos_module" : "KratosMultiphysics",
+            "help"                  : "",
+            "process_name"          : "FromJsonCheckResultProcess",
+            "Parameters"            : {
+                "check_variables"  : ["ADJOINT_DISPLACEMENT", "SHAPE_SENSITIVITY"],
+                "input_file_name"  : "linear_shell_test_nodal_disp_results.json",
+                "model_part_name"  : "Structure",
+                "tolerance"            : 1e-5,
+                "time_frequency"   : -2.0
+            }
         }
-    }]},
+        ]
+    },
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_strain_energy_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_strain_energy_adjoint_parameters.json
@@ -104,7 +104,7 @@
             "tolerance"            : 1e-5,
             "time_frequency"   : -2.0
         }
-    }],
+    }]},
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",
@@ -117,5 +117,5 @@
                 "model_part_name"  : "Structure",
                 "time_frequency"   : -2.0
             }
-        }]}
+        }]
 }

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_strain_energy_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_shell_structure_3d3n/linear_shell_test_strain_energy_adjoint_parameters.json
@@ -91,20 +91,23 @@
                 "list_of_variables": ["DISPLACEMENT", "ROTATION"]
             }
         }
-     },
-     {
-        "python_module"   : "from_json_check_result_process",
-        "kratos_module" : "KratosMultiphysics",
-        "help"                  : "",
-        "process_name"          : "FromJsonCheckResultProcess",
-        "Parameters"            : {
-            "check_variables"  : ["ADJOINT_DISPLACEMENT", "SHAPE_SENSITIVITY"],
-            "input_file_name"  : "linear_shell_test_strain_energy_results.json",
-            "model_part_name"  : "Structure",
-            "tolerance"            : 1e-5,
-            "time_frequency"   : -2.0
+     }],
+    "json_check_process" : [
+        {
+            "python_module"   : "from_json_check_result_process",
+            "kratos_module" : "KratosMultiphysics",
+            "help"                  : "",
+            "process_name"          : "FromJsonCheckResultProcess",
+            "Parameters"            : {
+                "check_variables"  : ["ADJOINT_DISPLACEMENT", "SHAPE_SENSITIVITY"],
+                "input_file_name"  : "linear_shell_test_strain_energy_results.json",
+                "model_part_name"  : "Structure",
+                "tolerance"            : 1e-5,
+                "time_frequency"   : -2.0
+            }
         }
-    }]},
+        ]
+    },
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_truss_stucture_3d2n/linear_truss_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_truss_stucture_3d2n/linear_truss_test_local_stress_adjoint_parameters.json
@@ -123,7 +123,7 @@
             "time_frequency"   : -2.0
         }
     }
-    ],
+    ]},
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",
@@ -137,7 +137,7 @@
                 "model_part_name"  : "Structure",
                 "time_frequency"   : -2.0
             }
-        }]},
+        }],
     "_output_configuration"     : {
         "result_file_configuration" : {
             "gidpost_flags"       : {

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_truss_stucture_3d2n/linear_truss_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_truss_stucture_3d2n/linear_truss_test_local_stress_adjoint_parameters.json
@@ -108,22 +108,24 @@
                 "list_of_variables": ["DISPLACEMENT"]
             }
         }
-     },
-     {
-        "python_module"   : "from_json_check_result_process",
-        "kratos_module" : "KratosMultiphysics",
-        "help"                  : "",
-        "process_name"          : "FromJsonCheckResultProcess",
-        "Parameters"            : {
-            "check_variables"  : ["ADJOINT_DISPLACEMENT", "SHAPE_SENSITIVITY"],
-            "gauss_points_check_variables" : [],
-            "input_file_name"  : "linear_truss_test_local_stress_results.json",
-            "model_part_name"  : "Structure",
-            "tolerance"            : 1e-4,
-            "time_frequency"   : -2.0
+    }],
+    "json_check_process":[
+        {
+            "python_module"   : "from_json_check_result_process",
+            "kratos_module" : "KratosMultiphysics",
+            "help"                  : "",
+            "process_name"          : "FromJsonCheckResultProcess",
+            "Parameters"            : {
+                "check_variables"  : ["ADJOINT_DISPLACEMENT", "SHAPE_SENSITIVITY"],
+                "gauss_points_check_variables" : [],
+                "input_file_name"  : "linear_truss_test_local_stress_results.json",
+                "model_part_name"  : "Structure",
+                "tolerance"            : 1e-4,
+                "time_frequency"   : -2.0
+            }
         }
-    }
-    ]},
+        ]
+    },
     "_json_output_process" : [
         {
             "python_module" : "json_output_process",

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_truss_stucture_3d2n/nonlinear_truss_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_truss_stucture_3d2n/nonlinear_truss_test_local_stress_adjoint_parameters.json
@@ -108,22 +108,24 @@
                 "list_of_variables": ["DISPLACEMENT"]
             }
         }
-     },
-     {
-        "python_module"   : "from_json_check_result_process",
-        "kratos_module" : "KratosMultiphysics",
-        "help"                  : "",
-        "process_name"          : "FromJsonCheckResultProcess",
-        "Parameters"            : {
-            "check_variables"  : ["ADJOINT_DISPLACEMENT", "SHAPE_SENSITIVITY"],
-            "gauss_points_check_variables" : ["CROSS_AREA_SENSITIVITY"],
-            "input_file_name"  : "nonlinear_truss_test_local_stress_results.json",
-            "model_part_name"  : "Structure",
-            "tolerance"            : 1e-4,
-            "time_frequency"   : -2.0
+    }],
+    "json_check_process":[
+        {
+            "python_module"   : "from_json_check_result_process",
+            "kratos_module" : "KratosMultiphysics",
+            "help"                  : "",
+            "process_name"          : "FromJsonCheckResultProcess",
+            "Parameters"            : {
+                "check_variables"  : ["ADJOINT_DISPLACEMENT", "SHAPE_SENSITIVITY"],
+                "gauss_points_check_variables" : ["CROSS_AREA_SENSITIVITY"],
+                "input_file_name"  : "nonlinear_truss_test_local_stress_results.json",
+                "model_part_name"  : "Structure",
+                "tolerance"            : 1e-4,
+                "time_frequency"   : -2.0
+            }
         }
-    }
-    ]},
+        ]
+    },
     "_output_configuration"     : {
         "result_file_configuration" : {
             "gidpost_flags"       : {


### PR DESCRIPTION
With the changes of this PR the rewriting of the results files of the adjoint structural test cases should be prevented again. 