### PR TITLE
[FluidDynamicsApplication][MPI] Correction of mistake in serial and parallel version

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -125,7 +125,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
         self.neighbour_search = KratosMultiphysics.FindNodalNeighboursProcess(self.computing_model_part, 10, 10)
         (self.neighbour_search).Execute()
 
-        self.accelerationLimitationUtility = KratosMultiphysics.FluidDynamicsApplication.AccelerationLimitationUtilities( self.computing_model_part, 1.0 )
+        self.accelerationLimitationUtility = KratosMultiphysics.FluidDynamicsApplication.AccelerationLimitationUtilities( self.computing_model_part, 5.0 )
 
         # If needed, create the estimate time step utility
         if (self.settings["time_stepping"]["automatic_time_step"].GetBool()):

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -64,7 +64,6 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
         return settings
 
     def __init__(self, model, custom_settings):
-        # the constructor of the "grand-parent" (jumping constructor of parent) is called to avoid conflicts in attribute settings
         super(NavierStokesTwoFluidsSolver,self).__init__(model,custom_settings)
 
         self.element_name = "TwoFluidNavierStokes"

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -65,7 +65,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
 
     def __init__(self, model, custom_settings):
         # the constructor of the "grand-parent" (jumping constructor of parent) is called to avoid conflicts in attribute settings
-        super(navier_stokes_two_fluids_solver.NavierStokesTwoFluidsSolver,self).__init__(model,custom_settings)
+        super(NavierStokesTwoFluidsSolver,self).__init__(model,custom_settings)
 
         self.element_name = "TwoFluidNavierStokes"
         self.condition_name = "NavierStokesWallCondition"
@@ -125,7 +125,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
         self.neighbour_search = KratosMultiphysics.FindNodalNeighboursProcess(self.computing_model_part, 10, 10)
         (self.neighbour_search).Execute()
 
-        self.accelerationLimitationUtility = KratosMultiphysics.FluidDynamicsApplication.AccelerationLimitationUtilities( self.computing_model_part, 5.0 )
+        self.accelerationLimitationUtility = KratosMultiphysics.FluidDynamicsApplication.AccelerationLimitationUtilities( self.computing_model_part, 1.0 )
 
         # If needed, create the estimate time step utility
         if (self.settings["time_stepping"]["automatic_time_step"].GetBool()):

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
@@ -73,7 +73,7 @@ class NavierStokesMPITwoFluidsSolver(navier_stokes_two_fluids_solver.NavierStoke
         return settings
 
     def __init__(self, model, custom_settings):
-        super(NavierStokesMPITwoFluidsSolver, self).__init__(model,custom_settings)
+        super(navier_stokes_two_fluids_solver.NavierStokesTwoFluidsSolver, self).__init__(model,custom_settings)
 
         self.element_name = "TwoFluidNavierStokes"
         self.condition_name = "NavierStokesWallCondition"

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
@@ -73,6 +73,7 @@ class NavierStokesMPITwoFluidsSolver(navier_stokes_two_fluids_solver.NavierStoke
         return settings
 
     def __init__(self, model, custom_settings):
+        # the constructor of the "grand-parent" (jumping constructor of parent) is called to avoid conflicts in attribute settings
         super(navier_stokes_two_fluids_solver.NavierStokesTwoFluidsSolver, self).__init__(model,custom_settings)
 
         self.element_name = "TwoFluidNavierStokes"


### PR DESCRIPTION
I am very sorry for this stupid mistake which I made because I confused the serial and the parallel version. The following corrections were necessary:

- Restoring the original constructor of the serial version

- Adding the constructor that jumps the parent constructor to the MPI version. Also, the comment pointing out this necessity was added in the correct position and removed from the wrong place.

To avoid further mistakes resulting from insufficient test, both the serial and MPI version were tested in FullDebug, again. 

My apologies for the inconveniences resulting from the mistake.