### PR TITLE
[StructMech] fix header for default console width of 80 chars

### DIFF
--- a/applications/StructuralMechanicsApplication/structural_mechanics_application.cpp
+++ b/applications/StructuralMechanicsApplication/structural_mechanics_application.cpp
@@ -179,10 +179,10 @@ void KratosStructuralMechanicsApplication::Register() {
     // calling base class register to register Kratos components
     KratosApplication::Register();
 
-    KRATOS_INFO("") << "     KRATOS   ___|  |                   |                   |                     " << std::endl
-                    << "            \\___ \\  __|  __| |   |  __| __| |   |  __| _` | |                   " << std::endl
-                    << "                  | |   |    |   | (    |   |   | |   (   | |                     " << std::endl
-                    << "            _____/ \\__|_|   \\__,_|\\___|\\__|\\__,_|_|  \\__,_|_| MECHANICS     " << std::endl;
+    KRATOS_INFO("") << "    KRATOS   ___|  |                   |                   |                    " << std::endl
+                    << "           \\___ \\  __|  __| |   |  __| __| |   |  __| _` | |                  " << std::endl
+                    << "                 | |   |    |   | (    |   |   | |   (   | |                    " << std::endl
+                    << "           _____/ \\__|_|   \\__,_|\\___|\\__|\\__,_|_|  \\__,_|_| MECHANICS    " << std::endl;
 
     // General pourpose
     KRATOS_REGISTER_VARIABLE(INTEGRATION_ORDER); // The integration order considered on the element


### PR DESCRIPTION
it had a line length of 82 chars previously, which made it look strange in most terminals

```
    KRATOS   ___|  |                   |                   |                    
           \___ \  __|  __| |   |  __| __| |   |  __| _` | |                  
                 | |   |    |   | (    |   |   | |   (   | |                    
           _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS    
```