### PR TITLE
[Core][GiDpost] add option to force flush after an output step has been written

### DIFF
--- a/kratos/python_scripts/gid_output_process.py
+++ b/kratos/python_scripts/gid_output_process.py
@@ -23,6 +23,7 @@ class GiDOutputProcess(Process):
             "file_label": "time",
             "output_control_type": "step",
             "output_frequency": 1.0,
+            "flush_after_output": false,
             "body_output": true,
             "node_output": false,
             "skin_output": false,
@@ -178,6 +179,7 @@ class GiDOutputProcess(Process):
             raise Exception(msg)
 
         self.output_frequency = result_file_configuration["output_frequency"].GetDouble()
+        self.flush_after_output = result_file_configuration["flush_after_output"].GetBool()
 
         # get .post.lst files
         additional_list_file_data = result_file_configuration["additional_list_files"]
@@ -282,6 +284,12 @@ class GiDOutputProcess(Process):
         self.__write_nonhistorical_nodal_results(time)
         self.__write_nodal_flags(time)
         self.__write_elemental_conditional_flags(time)
+
+        if self.flush_after_output and self.multifile_flag != MultiFileFlag.MultipleFiles:
+            if self.body_io is not None:
+                self.body_io.Flush()
+            if self.cut_io is not None:
+                self.cut_io.Flush()
 
         if self.multifile_flag == MultiFileFlag.MultipleFiles:
             self.__finalize_results()


### PR DESCRIPTION
Problem:  
When importing intermediate results for large models in GiD while the simulation is still running, I often got an Error in Gid saying that the file is incomplete. Because of this it was not possible to check results at all, because the import was aborted.

I added an option to force flushing of the GiDpost IO after an output step has been written. Like this it is possible to visualize the results, however an error does still appear in GiD about an unexpected end of file. I guess this is because the binary result file is still open in the gidpost process.

closes #3505 - more detailed information about the problem can be found there.

