### PR TITLE
[ConstitutiveLaw] adding deprecation-warnings in python

### DIFF
--- a/kratos/python/add_constitutive_law_to_python.cpp
+++ b/kratos/python/add_constitutive_law_to_python.cpp
@@ -82,7 +82,35 @@ Matrix& GetConstitutiveMatrix2(ConstitutiveLaw::Parameters& rThisParameters, Mat
 const Matrix& GetDeformationGradientF1(ConstitutiveLaw::Parameters& rThisParameters){ return rThisParameters.GetDeformationGradientF();}
 Matrix& GetDeformationGradientF2(ConstitutiveLaw::Parameters& rThisParameters, Matrix& F){ return rThisParameters.GetDeformationGradientF(F);}
 
+void DeprecatedInitializeSolutionStep( ConstitutiveLaw& rThisConstitutiveLaw,
+                                       const Properties& rMaterialProperties,
+                                       const ConstitutiveLaw::GeometryType& rElementGeometry,
+                                       const Vector& rShapeFunctionsValues,
+                                       const ProcessInfo& rCurrentProcessInfo )
+{
+    // function wrapper to issue a deprecation-warning when called from python
+    KRATOS_WARNING_FIRST_N("ConstitutiveLaw-Python Interface", 10) << "\"InitializeSolutionStep\" "
+        << "is deprecated, please don't use it" << std::endl;
+    rThisConstitutiveLaw.InitializeSolutionStep(rMaterialProperties,
+                                                rElementGeometry,
+                                                rShapeFunctionsValues,
+                                                rCurrentProcessInfo);
+}
 
+void DeprecatedFinalizeSolutionStep( ConstitutiveLaw& rThisConstitutiveLaw,
+                                     const Properties& rMaterialProperties,
+                                     const ConstitutiveLaw::GeometryType& rElementGeometry,
+                                     const Vector& rShapeFunctionsValues,
+                                     const ProcessInfo& rCurrentProcessInfo )
+{
+    // function wrapper to issue a deprecation-warning when called from python
+    KRATOS_WARNING_FIRST_N("ConstitutiveLaw-Python Interface", 10) << "\"FinalizeSolutionStep\" "
+        << "is deprecated, please don't use it.\nUse \"FinalizeMaterialResponse\" instead" << std::endl;
+    rThisConstitutiveLaw.FinalizeSolutionStep(rMaterialProperties,
+                                              rElementGeometry,
+                                              rShapeFunctionsValues,
+                                              rCurrentProcessInfo);
+}
 
 void  AddConstitutiveLawToPython(pybind11::module& m)
 {
@@ -206,8 +234,8 @@ void  AddConstitutiveLawToPython(pybind11::module& m)
     .def("FinalizeMaterialResponsePK2",&ConstitutiveLaw::FinalizeMaterialResponsePK2)
     .def("FinalizeMaterialResponseKirchhoff",&ConstitutiveLaw::FinalizeMaterialResponseKirchhoff)
     .def("FinalizeMaterialResponseCauchy",&ConstitutiveLaw::FinalizeMaterialResponseCauchy)
-    .def("FinalizeSolutionStep",&ConstitutiveLaw::FinalizeSolutionStep)
-    .def("InitializeSolutionStep",&ConstitutiveLaw::InitializeSolutionStep)
+    .def("FinalizeSolutionStep",DeprecatedFinalizeSolutionStep)
+    .def("InitializeSolutionStep",DeprecatedInitializeSolutionStep)
     .def("InitializeMaterial",&ConstitutiveLaw::InitializeMaterial)
     .def("ResetMaterial",&ConstitutiveLaw::ResetMaterial)
     .def("TransformStrains",&ConstitutiveLaw::TransformStrains, py::return_value_policy::reference_internal)


### PR DESCRIPTION
now if the deprecation methods (recently deprecated by @RiccardoRossi ) of the ConstitutiveLaw are called from python, they will also issue a deprecation-warning