### PR TITLE
[DAM] Importing PoromechanicsApplication in CL python utility

### DIFF
--- a/applications/DamApplication/python_scripts/dam_constitutive_law_utility.py
+++ b/applications/DamApplication/python_scripts/dam_constitutive_law_utility.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import, division #makes KratosMu
 #importing the Kratos Library
 from KratosMultiphysics import *
 from KratosMultiphysics.SolidMechanicsApplication import *
+from KratosMultiphysics.PoromechanicsApplication import *
 from KratosMultiphysics.DamApplication import *
 
 def SetConstitutiveLaw(model_part):


### PR DESCRIPTION
It is necessary to import PoromechanicsApplication here to use joint constitutive laws in DamApplication. 