### PR TITLE
[Core] Clean up includes model

### DIFF
--- a/kratos/containers/model.cpp
+++ b/kratos/containers/model.cpp
@@ -13,17 +13,10 @@
 
 // System includes
 
-
 // External includes
 
-
 // Project includes
-#include "includes/define.h"
 #include "containers/model.h"
-#include <iostream>
-#include <string>
-#include <sstream>
-
 
 namespace Kratos
 {
@@ -280,5 +273,3 @@ namespace Kratos
 
 
 }  // namespace Kratos.
-
-


### PR DESCRIPTION
This cleans the includes of the model.cpp, that are already included in the header. This does not affect other files, because is the cpp