### PR TITLE
[FluidDynamicsApplication] [TwoFluids] Small updates to serial and parallel version  

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -35,7 +35,6 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
                 "distance_file_name"  : "no_distance_file"
             },
             "maximum_iterations": 7,
-            "dynamic_tau": 1.0,
             "echo_level": 0,
             "time_order": 2,
             "compute_reactions": false,
@@ -57,7 +56,10 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
                 "maximum_delta_time"  : 1.0
             },
             "periodic": "periodic",
-            "move_mesh_flag": false
+            "move_mesh_flag": false,
+            "formulation": {
+                "dynamic_tau": 1.0
+            }
         }""")
 
         settings.ValidateAndAssignDefaults(default_settings)
@@ -165,7 +167,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
         (self.solver).Initialize() # Initialize the solver. Otherwise the constitutive law is not initializated.
         (self.solver).Check()
 
-        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DYNAMIC_TAU, self.settings["dynamic_tau"].GetDouble())
+        self.main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DYNAMIC_TAU, self.settings["formulation"]["dynamic_tau"].GetDouble())
 
         KratosMultiphysics.Logger.PrintInfo("NavierStokesTwoFluidsSolver", "Solver initialization finished.")
 

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -249,11 +249,13 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
             variational_distance_process = KratosMultiphysics.VariationalDistanceCalculationProcess2D(
                 self.main_model_part,
                 self.linear_solver,
-                maximum_iterations)
+                maximum_iterations,
+                KratosMultiphysics.ParallelDistanceCalculator2D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
         else:
             variational_distance_process = KratosMultiphysics.VariationalDistanceCalculationProcess3D(
                 self.main_model_part,
                 self.linear_solver,
-                maximum_iterations)
+                maximum_iterations,
+                KratosMultiphysics.ParallelDistanceCalculator3D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
 
         return variational_distance_process

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
@@ -227,12 +227,14 @@ class NavierStokesMPITwoFluidsSolver(navier_stokes_two_fluids_solver.NavierStoke
                 self.EpetraCommunicator,
                 self.computing_model_part,
                 self.trilinos_linear_solver,
-                maximum_iterations)
+                maximum_iterations,
+                KratosMultiphysics.ParallelDistanceCalculator2D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
         else:
             variational_distance_process = KratosTrilinos.TrilinosVariationalDistanceCalculationProcess3D(
                 self.EpetraCommunicator,
                 self.computing_model_part,
                 self.trilinos_linear_solver,
-                maximum_iterations)
+                maximum_iterations,
+                KratosMultiphysics.ParallelDistanceCalculator3D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
 
         return variational_distance_process


### PR DESCRIPTION
The following small update of both solver versions is suggested after the exact distance computation is now available. A huge "thank you" to @ddiezrod for #3571.

- Adding the new flag for the exact computation in serial and MPI version.

- The MPI version of the solver has "dynamic_tau" in a separate sub dictionary "formulation" as originally suggested by @jcotela. This is currently not the case for the serial version and causes problems when switching between both. I would like to use the chance and change the serial version, accordingly.