### PR TITLE
[MPI] Include path of "mpi_communicator.h" adapted

### DIFF
--- a/applications/SwimmingDEMApplication/custom_utilities/search/mpi_discrete_particle_configure.h
+++ b/applications/SwimmingDEMApplication/custom_utilities/search/mpi_discrete_particle_configure.h
@@ -1,4 +1,4 @@
-//   Project Name:        Kratos       
+//   Project Name:        Kratos
 //   Last Modified by:    $Author: Nelson Lafontaine  $
 //   Date:                $Date: 2012-05-24 $
 //   Revision:            $Revision: 1.0 $
@@ -12,10 +12,10 @@
 
 // System includes
 #include <string>
-#include <iostream> 
+#include <iostream>
 #include <cmath>
 #include "utilities/spatial_containers_configure.h"
-#include "includes/mpi_communicator.h"
+#include "mpi/includes/mpi_communicator.h"
 #include "mpi.h"
 
 namespace Kratos
@@ -40,7 +40,7 @@ namespace Kratos
   ///@name Kratos Classes
   ///@{
 
-    
+
 template <std::size_t TDimension>
 class MpiDiscreteParticleConfigure{
 public:
@@ -50,7 +50,7 @@ public:
              MAX_LEVEL = 16,
              MIN_LEVEL = 2
       };
-      
+
         typedef  Point                        PointType;
         typedef  std::vector<double>::iterator                   DistanceIteratorType;
         typedef  std::vector<typename Element::Pointer>          ContainerType; // ModelPart::ElementsContainerType::ContainerType ContainerType;
@@ -64,14 +64,14 @@ public:
         typedef  std::vector<ContactPairType>                    ContainerContactType;
         typedef  ContainerContactType::iterator                  IteratorContactType;
         typedef  ContainerContactType::value_type                PointerContactType;
-      
+
         typedef  std::vector<PointerType>::iterator              PointerTypeIterator;
 
 
 
 
 
-      
+
       /// Pointer definition of SpatialContainersConfigure
       KRATOS_CLASS_POINTER_DEFINITION(MpiDiscreteParticleConfigure);
 
@@ -91,11 +91,11 @@ public:
           ///@name Operations
           ///@{
 
-	    
+
     //******************************************************************************************************************
 
     static inline void CalculateBoundingBox(const PointerType& rObject, PointType& rLowPoint, PointType& rHighPoint){
-        
+
         rHighPoint = rLowPoint  = rObject->GetGeometry().GetPoint(0);
 	double radius = rObject->GetGeometry()[0].GetSolutionStepValue(RADIUS);
 
@@ -108,14 +108,14 @@ public:
     static inline void CalculateBoundingBox(const PointerType& rObject, PointType& rLowPoint, PointType& rHighPoint, const double& Radius){
 
         rHighPoint = rLowPoint  = rObject->GetGeometry().GetPoint(0);
-        
+
         for(std::size_t i = 0; i < 3; i++){
             rLowPoint[i]  += -Radius;
             rHighPoint[i] += Radius;
             }
 
         }
-        
+
     static inline void CalculateCenter(const PointerType& rObject, PointType& rCenter){
 
         rCenter  = rObject->GetGeometry().GetPoint(0);
@@ -151,21 +151,21 @@ public:
 
 
     //******************************************************************************************************************
-    
+
     static inline bool  IntersectionBox(const PointerType& rObject,  const PointType& rLowPoint, const PointType& rHighPoint)
     {
- 
+
 //        double separation_from_particle_radius_ratio = 0.1;
 
         array_1d<double, 3> center_of_particle = rObject->GetGeometry().GetPoint(0);
- 
+
         const double& radius = rObject->GetGeometry()[0].GetSolutionStepValue(RADIUS);
 
         bool intersect = (rLowPoint[0] - radius <= center_of_particle[0] && rLowPoint[1] - radius <= center_of_particle[1] && rLowPoint[2] - radius <= center_of_particle[2] &&
         rHighPoint[0] + radius >= center_of_particle[0] && rHighPoint[1] + radius >= center_of_particle[1] && rHighPoint[2] + radius >= center_of_particle[2]);
 
         return  intersect;
- 
+
     }
 
     static inline bool  IntersectionBox(const PointerType& rObject,  const PointType& rLowPoint, const PointType& rHighPoint, const double& Radius)
@@ -175,7 +175,7 @@ public:
 
         double radius = Radius;//Cambien el radi del objecte de cerca per el gran, aixi no tindria que petar res
         bool intersect = (rLowPoint[0] - radius <= center_of_particle[0] && rLowPoint[1] - radius <= center_of_particle[1] && rLowPoint[2] - radius <= center_of_particle[2] &&
- 
+
         rHighPoint[0] + radius >= center_of_particle[0] && rHighPoint[1] + radius >= center_of_particle[1] && rHighPoint[2] + radius >= center_of_particle[2]);
         return  intersect;
     }
@@ -195,22 +195,22 @@ public:
     {
         int mpi_rank;
         int mpi_size;
-        
+
         MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
         MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-        
+
         std::vector<int> reduceArray(mpi_size+1);
-        
+
         MPI_Allgather(&total_elements,1,MPI_INT,&reduceArray[1],1,MPI_INT,MPI_COMM_WORLD);
-        
+
         reduceArray[0] = 1;
         for(int i = 1; i <= mpi_size; i++)
             reduceArray[i] += reduceArray[i-1];
-        
+
         first_element = reduceArray[mpi_rank];
     }
 
-    template<class TObjectType>                            
+    template<class TObjectType>
     static inline void AsyncSendAndReceive(Communicator::Pointer Communicator,
                                            std::vector<TObjectType>& SendObjects,
                                            std::vector<TObjectType>& RecvObjects,
@@ -221,52 +221,52 @@ public:
         Communicator->AsyncSendAndReceiveNodes(SendObjects,RecvObjects,msgSendSize,msgRecvSize);
         Timer::Stop("ASYNC2");
     }
-    
+
     template<class TObjectType>
     static inline void AsyncSendAndReceive(std::vector<TObjectType>& SendObjects,
                                            std::vector<TObjectType>& RecvObjects,
                                            int * msgSendSize,
-                                           int * msgRecvSize)                                       
+                                           int * msgRecvSize)
     {
         Timer::Start("ASYNC1");
-        
+
         int mpi_rank;
         int mpi_size;
-      
+
         MPI_Comm_rank(MPI_COMM_WORLD, &mpi_rank);
         MPI_Comm_size(MPI_COMM_WORLD, &mpi_size);
-  
+
         std::stringstream * serializer_buffer;
         std::vector<std::string> buffer(mpi_size);
 //         std::string buffer[mpi_size];
-        
+
         for(int i = 0; i < mpi_size; i++)
         {
             if(mpi_rank != i)
             {
                 Kratos::Serializer particleSerializer;
                 particleSerializer.save("nodes",SendObjects[i]);
-                
+
                 serializer_buffer = (std::stringstream *)particleSerializer.pGetBuffer();
                 buffer[i] = std::string(serializer_buffer->str());
                 msgSendSize[i] = buffer[i].size();
             }
         }
-  
+
         MPI_Alltoall(msgSendSize,1,MPI_INT,msgRecvSize,1,MPI_INT,MPI_COMM_WORLD);
-  
+
         int NumberOfCommunicationEvents = 0;
         int NumberOfCommunicationEventsIndex = 0;
-        
+
         char * message[mpi_size];
         char * mpi_send_buffer[mpi_size];
-        
+
         for(int j = 0; j < mpi_size; j++)
         {
             if(j != mpi_rank && msgRecvSize[j]) NumberOfCommunicationEvents++;
             if(j != mpi_rank && msgSendSize[j]) NumberOfCommunicationEvents++;
         }
-        
+
         MPI_Request reqs[NumberOfCommunicationEvents];
         MPI_Status stats[NumberOfCommunicationEvents];
 
@@ -293,7 +293,7 @@ public:
         MPI_Barrier(MPI_COMM_WORLD);
 
         for(int i = 0; i < mpi_size; i++)
-        { 
+        {
             if (i != mpi_rank && msgRecvSize[i])
             {
                 Kratos::Serializer particleSerializer;
@@ -305,19 +305,19 @@ public:
 
             MPI_Barrier(MPI_COMM_WORLD);
         }
-        
+
         // Free buffers
         for(int i = 0; i < mpi_size; i++)
         {
             if(mpi_rank != i && msgRecvSize[i])
                 free(message[i]);
-            
+
             if(i != mpi_rank && msgSendSize[i])
                 free(mpi_send_buffer[i]);
         }
         Timer::Stop("ASYNC1");
     }
-     
+
     //******************************************************************************************************************
 
     ///@}
@@ -346,7 +346,7 @@ public:
     ///@}
     ///@name Friends
     ///@{
-      
+
 
     ///@}
 
@@ -442,7 +442,7 @@ private:
 
         return rOStream;
         }
-        
+
     ///@}
 
 }   // namespace Kratos.

--- a/applications/metis_application/custom_processes/metis_contact_partitioning_process.h
+++ b/applications/metis_application/custom_processes/metis_contact_partitioning_process.h
@@ -35,7 +35,7 @@
 #include "includes/node.h"
 #include "includes/element.h"
 #include "includes/model_part.h"
-#include "includes/mpi_communicator.h"
+#include "mpi/includes/mpi_communicator.h"
 
 extern "C" {
     //extern void METIS_PartMeshDual(int*, int*, idxtype*, int*, int*, int*, int*, idxtype*, idxtype*);
@@ -728,5 +728,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }  // namespace Kratos.
 
 #endif // KRATOS_METIS_CONTACTmContactNodes[i]_PARTITIONING_PROCESS_INCLUDED defined
-
-

--- a/applications/metis_application/custom_processes/metis_partitioning_process.h
+++ b/applications/metis_application/custom_processes/metis_partitioning_process.h
@@ -35,7 +35,7 @@
 #include "includes/node.h"
 #include "includes/element.h"
 #include "includes/model_part.h"
-#include "includes/mpi_communicator.h"
+#include "mpi/includes/mpi_communicator.h"
 
 extern "C"
 {
@@ -723,5 +723,3 @@ inline std::ostream & operator <<(std::ostream& rOStream,
 } // namespace Kratos.
 
 #endif // KRATOS_METIS_PARTITIONING_PROCESS_INCLUDED defined
-
-

--- a/applications/metis_application/custom_processes/metis_partitioning_process_quadratic.h
+++ b/applications/metis_application/custom_processes/metis_partitioning_process_quadratic.h
@@ -35,7 +35,7 @@
 #include "includes/node.h"
 #include "includes/element.h"
 #include "includes/model_part.h"
-#include "includes/mpi_communicator.h"
+#include "mpi/includes/mpi_communicator.h"
 #include "custom_processes/metis_partitioning_process.h"
 
 extern "C" {
@@ -760,5 +760,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }  // namespace Kratos.
 
 #endif // KRATOS_METIS_PARTITIONING_PROCESS_QUADRATIC_INCLUDED defined
-
-

--- a/applications/mpi_search_application/custom_configures/mpi_discrete_particle_configure.h
+++ b/applications/mpi_search_application/custom_configures/mpi_discrete_particle_configure.h
@@ -21,7 +21,7 @@
 #include "mpi.h"
 
 // Project includes
-#include "includes/mpi_communicator.h"
+#include "mpi/includes/mpi_communicator.h"
 #include "utilities/spatial_containers_configure.h"
 #include "spatial_containers/spatial_search.h"
 

--- a/applications/mpi_search_application/custom_configures/mpi_point_configure.h
+++ b/applications/mpi_search_application/custom_configures/mpi_point_configure.h
@@ -20,7 +20,7 @@
 #include <cmath>
 
 #include "mpi.h"
-#include "includes/mpi_communicator.h"
+#include "mpi/includes/mpi_communicator.h"
 #include "spatial_containers/configures/point_configure.h"
 
 namespace Kratos {

--- a/applications/mpi_search_application/custom_utilities/bins_dynamic_objects_mpi.h
+++ b/applications/mpi_search_application/custom_utilities/bins_dynamic_objects_mpi.h
@@ -31,7 +31,7 @@
 
 // Project includes
 #include "includes/define.h"
-#include "includes/mpi_communicator.h"
+#include "mpi/includes/mpi_communicator.h"
 
 #include "spatial_containers/tree.h"
 #include "spatial_containers/cell.h"


### PR DESCRIPTION
During a fresh compilation of Kratos, I noticed some errors pointing out that the header file "mpi_communicator.h" was not found. I am sorry in case I made a mistake in my personal settings but correcting the include path by adding "mpi/" helped for me.

Thus, I am suggesting a correction (if it is a general problem) in 7 files concerned by the problem.

from : #include "includes/mpi_communicator.h"
to : #include "mpi/includes/mpi_communicator.h"
(I am sorry for the white space changes in one file - I do not know how to avoid this...)