### PR TITLE
Fluid/fluid element cleanup

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
@@ -91,8 +91,7 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::CalculateLocalSystem(
     const unsigned int number_of_positive_gauss_points = data.PositiveSideWeights.size();
     for (unsigned int g = 0; g < number_of_positive_gauss_points; ++g){
         const size_t gauss_pt_index = g;
-        data.UpdateGeometryValues(gauss_pt_index, data.PositiveSideWeights[g], row(data.PositiveSideN, g), data.PositiveSideDNDX[g]);
-        this->CalculateMaterialResponse(data);
+        this->UpdateIntegrationPointData(data, gauss_pt_index, data.PositiveSideWeights[g], row(data.PositiveSideN, g), data.PositiveSideDNDX[g]);
         this->AddTimeIntegratedSystem(data, rLeftHandSideMatrix, rRightHandSideVector);
     }
 
@@ -100,28 +99,26 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::CalculateLocalSystem(
     const unsigned int number_of_negative_gauss_points = data.NegativeSideWeights.size();
     for (unsigned int g = 0; g < number_of_negative_gauss_points; ++g){
         const size_t gauss_pt_index = g + number_of_negative_gauss_points;
-        data.UpdateGeometryValues(gauss_pt_index, data.NegativeSideWeights[g], row(data.NegativeSideN, g), data.NegativeSideDNDX[g]);
-        this->CalculateMaterialResponse(data);
+        this->UpdateIntegrationPointData(data, gauss_pt_index, data.NegativeSideWeights[g], row(data.NegativeSideN, g), data.NegativeSideDNDX[g]);
         this->AddTimeIntegratedSystem(data, rLeftHandSideMatrix, rRightHandSideVector);
     }
 
     // If the element is cut, add the interface contributions
     if ( data.IsCut() ) {
 
-        // Add the boundary term together with the interface equilibrium imposition. Note that the interface 
-        // equilibrium imposition and boundary term addition yields minus the base element boundary term. 
-        // Therefore, two auxiliar arrays are used (aux_LHS and aux_RHS) to store the base element boundary 
+        // Add the boundary term together with the interface equilibrium imposition. Note that the interface
+        // equilibrium imposition and boundary term addition yields minus the base element boundary term.
+        // Therefore, two auxiliar arrays are used (aux_LHS and aux_RHS) to store the base element boundary
         // term contribution. Finally, the opposite of these arrays is added to the local system.
         const size_t volume_gauss_points = number_of_positive_gauss_points + number_of_negative_gauss_points;
-        VectorType aux_RHS = ZeroVector(LocalSize); 
+        VectorType aux_RHS = ZeroVector(LocalSize);
         MatrixType aux_LHS = ZeroMatrix(LocalSize, LocalSize);
 
         // Add the base element boundary contribution on the positive interface
         const unsigned int number_of_positive_interface_gauss_points = data.PositiveInterfaceWeights.size();
         for (unsigned int g = 0; g < number_of_positive_interface_gauss_points; ++g){
             const size_t gauss_pt_index = g + volume_gauss_points;
-            data.UpdateGeometryValues(gauss_pt_index, data.PositiveInterfaceWeights[g], row(data.PositiveInterfaceN, g), data.PositiveInterfaceDNDX[g]);
-            this->CalculateMaterialResponse(data);
+            this->UpdateIntegrationPointData(data, gauss_pt_index, data.PositiveInterfaceWeights[g], row(data.PositiveInterfaceN, g), data.PositiveInterfaceDNDX[g]);
             this-> AddBoundaryTraction(data, data.PositiveInterfaceUnitNormals[g], aux_LHS, aux_RHS);
         }
 
@@ -129,8 +126,7 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::CalculateLocalSystem(
         const unsigned int number_of_negative_interface_gauss_points = data.NegativeInterfaceWeights.size();
         for (unsigned int g = 0; g < number_of_negative_interface_gauss_points; ++g){
             const size_t gauss_pt_index = g + volume_gauss_points + number_of_positive_interface_gauss_points;
-            data.UpdateGeometryValues(gauss_pt_index, data.NegativeInterfaceWeights[g], row(data.NegativeInterfaceN, g), data.NegativeInterfaceDNDX[g]);
-            this->CalculateMaterialResponse(data);
+            this->UpdateIntegrationPointData(data, gauss_pt_index, data.NegativeInterfaceWeights[g], row(data.NegativeInterfaceN, g), data.NegativeInterfaceDNDX[g]);
             this-> AddBoundaryTraction(data, data.NegativeInterfaceUnitNormals[g], aux_LHS, aux_RHS);
         }
 
@@ -179,17 +175,14 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::Calculate(
             const unsigned int n_int_pos_gauss = data.PositiveInterfaceWeights.size();
             for (unsigned int g = 0; g < n_int_pos_gauss; ++g) {
 
-                // Update the Gauss pt. data
-                data.UpdateGeometryValues(g + number_of_positive_gauss_points,data.PositiveInterfaceWeights[g],row(data.PositiveInterfaceN, g),data.PositiveInterfaceDNDX[g]);
+                // Update the Gauss pt. data and the constitutive law
+                this->UpdateIntegrationPointData(data, g + number_of_positive_gauss_points,data.PositiveInterfaceWeights[g],row(data.PositiveInterfaceN, g),data.PositiveInterfaceDNDX[g]);
 
                 // Get the interface Gauss pt. unit noromal
                 const auto &aux_unit_normal = data.PositiveInterfaceUnitNormals[g];
 
                 // Compute Gauss pt. pressure
                 const double p_gauss = inner_prod(data.N, data.Pressure);
-
-                // Call the constitutive law to compute the shear contribution
-                this->CalculateMaterialResponse(data);
 
                 // Get the normal projection matrix in Voigt notation
                 BoundedMatrix<double, Dim, StrainSize> voigt_normal_proj_matrix = ZeroMatrix(Dim, StrainSize);
@@ -207,17 +200,14 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::Calculate(
             const unsigned int n_int_neg_gauss = data.NegativeInterfaceWeights.size();
             for (unsigned int g = 0; g < n_int_neg_gauss; ++g) {
 
-                // Update the Gauss pt. data
-                data.UpdateGeometryValues(g + number_of_positive_gauss_points,data.NegativeInterfaceWeights[g],row(data.NegativeInterfaceN, g),data.NegativeInterfaceDNDX[g]);
+                // Update the Gauss pt. data and the constitutive law
+                this->UpdateIntegrationPointData(data, g + number_of_positive_gauss_points,data.NegativeInterfaceWeights[g],row(data.NegativeInterfaceN, g),data.NegativeInterfaceDNDX[g]);
 
                 // Get the interface Gauss pt. unit noromal
                 const auto &aux_unit_normal = data.NegativeInterfaceUnitNormals[g];
 
                 // Compute Gauss pt. pressure
                 const double p_gauss = inner_prod(data.N, data.Pressure);
-
-                // Call the constitutive law to compute the shear contribution
-                this->CalculateMaterialResponse(data);
 
                 // Get the normal projection matrix in Voigt notation
                 BoundedMatrix<double, Dim, StrainSize> voigt_normal_proj_matrix = ZeroMatrix(Dim, StrainSize);
@@ -336,20 +326,20 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::DefineCutGeometryData(Embe
 
     ModifiedShapeFunctions::Pointer p_calculator =
         EmbeddedDiscontinuousInternals::GetShapeFunctionCalculator<EmbeddedDiscontinuousElementData::Dim, EmbeddedDiscontinuousElementData::NumNodes>(
-            *this, 
+            *this,
             elemental_distances);
 
     // Positive side volume
     p_calculator->ComputePositiveSideShapeFunctionsAndGradientsValues(
-        rData.PositiveSideN, 
-        rData.PositiveSideDNDX, 
+        rData.PositiveSideN,
+        rData.PositiveSideDNDX,
         rData.PositiveSideWeights,
         GeometryData::GI_GAUSS_2);
 
     // Negative side volume
     p_calculator->ComputeNegativeSideShapeFunctionsAndGradientsValues(
-        rData.NegativeSideN, 
-        rData.NegativeSideDNDX, 
+        rData.NegativeSideN,
+        rData.NegativeSideDNDX,
         rData.NegativeSideWeights,
         GeometryData::GI_GAUSS_2);
 
@@ -439,7 +429,7 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::AddNormalPenaltyContributi
                     const unsigned int row = i * BlockSize + m;
                     for (unsigned int n = 0; n < Dim; ++n){
                         const unsigned int col = j * BlockSize + n;
-                        const double aux = pen_coef*weight*aux_N(i)*aux_unit_normal(m)*aux_unit_normal(n)*aux_N(j); 
+                        const double aux = pen_coef*weight*aux_N(i)*aux_unit_normal(m)*aux_unit_normal(n)*aux_N(j);
                         rLHS(row, col) += aux;
                         rRHS(row) -= aux*values(col);
                     }
@@ -628,7 +618,7 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::AddTangentialPenaltyContri
     BoundedMatrix<double, LocalSize, LocalSize> aux_LHS_1 = ZeroMatrix(LocalSize, LocalSize); // Adds the contribution coming from the tangential component of the Cauchy stress vector
     BoundedMatrix<double, LocalSize, LocalSize> aux_LHS_2 = ZeroMatrix(LocalSize, LocalSize); // Adds the contribution generated by the viscous shear force generated by the velocity
 
-    // Compute positive side LHS contribution 
+    // Compute positive side LHS contribution
     const unsigned int number_of_positive_interface_integration_points = rData.PositiveInterfaceWeights.size();
     for (unsigned int g = 0; g < number_of_positive_interface_integration_points; ++g){
         // Get the Gauss pt. data
@@ -671,7 +661,7 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::AddTangentialPenaltyContri
         noalias(aux_LHS_2) += pen_coefs.second*weight*prod(aux_matrix_N_trans_tang, N_mat);
     }
 
-    // Compute negative side LHS contribution 
+    // Compute negative side LHS contribution
     const unsigned int number_of_negative_interface_integration_points = rData.NegativeInterfaceWeights.size();
     for (unsigned int g = 0; g < number_of_negative_interface_integration_points; ++g){
         // Get the Gauss pt. data

--- a/applications/FluidDynamicsApplication/custom_elements/fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/fluid_element.cpp
@@ -127,10 +127,9 @@ void FluidElement<TElementData>::CalculateLocalSystem(MatrixType& rLeftHandSideM
         // Iterate over integration points to evaluate local contribution
         for (unsigned int g = 0; g < number_of_gauss_points; g++) {
 
-            data.UpdateGeometryValues(g, gauss_weights[g], row(shape_functions, g),
-                shape_derivatives[g]);
-
-            this->CalculateMaterialResponse(data);
+            this->UpdateIntegrationPointData(
+                data, g, gauss_weights[g],
+                row(shape_functions, g),shape_derivatives[g]);
 
             this->AddTimeIntegratedSystem(
                 data, rLeftHandSideMatrix, rRightHandSideVector);
@@ -162,10 +161,9 @@ void FluidElement<TElementData>::CalculateLeftHandSide(MatrixType& rLeftHandSide
 
         // Iterate over integration points to evaluate local contribution
         for (unsigned int g = 0; g < number_of_gauss_points; g++) {
-            data.UpdateGeometryValues(g, gauss_weights[g], row(shape_functions, g),
-                shape_derivatives[g]);
-
-            this->CalculateMaterialResponse(data);
+            this->UpdateIntegrationPointData(
+                data, g, gauss_weights[g],
+                row(shape_functions, g),shape_derivatives[g]);
 
             this->AddTimeIntegratedLHS(data, rLeftHandSideMatrix);
         }
@@ -195,10 +193,9 @@ void FluidElement<TElementData>::CalculateRightHandSide(VectorType& rRightHandSi
 
         // Iterate over integration points to evaluate local contribution
         for (unsigned int g = 0; g < number_of_gauss_points; g++) {
-            data.UpdateGeometryValues(g, gauss_weights[g], row(shape_functions, g),
-                shape_derivatives[g]);
-
-            this->CalculateMaterialResponse(data);
+            this->UpdateIntegrationPointData(
+                data, g, gauss_weights[g],
+                row(shape_functions, g),shape_derivatives[g]);
 
             this->AddTimeIntegratedRHS(data, rRightHandSideVector);
         }
@@ -234,10 +231,9 @@ void FluidElement<TElementData>::CalculateLocalVelocityContribution(
         // Iterate over integration points to evaluate local contribution
         for (unsigned int g = 0; g < number_of_gauss_points; g++) {
             const auto& r_dndx = shape_derivatives[g];
-            data.UpdateGeometryValues(
-                g, gauss_weights[g], row(shape_functions, g), r_dndx);
-
-            this->CalculateMaterialResponse(data);
+            this->UpdateIntegrationPointData(
+                data, g, gauss_weights[g],
+                row(shape_functions, g),r_dndx);
 
             this->AddVelocitySystem(data, rDampMatrix, rRightHandSideVector);
         }
@@ -268,10 +264,9 @@ void FluidElement<TElementData>::CalculateMassMatrix(MatrixType& rMassMatrix,
 
         // Iterate over integration points to evaluate local contribution
         for (unsigned int g = 0; g < number_of_gauss_points; g++) {
-            data.UpdateGeometryValues(g, gauss_weights[g], row(shape_functions, g),
-                shape_derivatives[g]);
-
-            this->CalculateMaterialResponse(data);
+            this->UpdateIntegrationPointData(
+                data, g, gauss_weights[g],
+                row(shape_functions, g),shape_derivatives[g]);
 
             this->AddMassLHS(data, rMassMatrix);
         }
@@ -563,6 +558,19 @@ double FluidElement<TElementData>::GetAtCoordinate(
     const typename TElementData::ShapeFunctionsType& rN) const
 {
     return Value;
+}
+
+template <class TElementData>
+void FluidElement<TElementData>::UpdateIntegrationPointData(
+    TElementData& rData,
+    unsigned int IntegrationPointIndex,
+    double Weight,
+    const typename TElementData::MatrixRowType& rN,
+    const typename TElementData::ShapeDerivativesType& rDN_DX) const
+{
+    rData.UpdateGeometryValues(IntegrationPointIndex, Weight, rN, rDN_DX);
+
+    this->CalculateMaterialResponse(rData);
 }
 
 template <class TElementData>

--- a/applications/FluidDynamicsApplication/custom_elements/fluid_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/fluid_element.h
@@ -389,6 +389,19 @@ protected:
         const double Value,
         const typename TElementData::ShapeFunctionsType& rN) const;
 
+    /// Set up the element's data and constitutive law for the current integration point.
+    /** @param[in/out] rData Container for the current element's data.
+     *  @param[in] Weight Integration point weight.
+     *  @param[in] rN Values of nodal shape functions at the integration point.
+     *  @param[in] rDN_DX Values of nodal shape function gradients at the integration point.
+     */
+    virtual void UpdateIntegrationPointData(
+        TElementData& rData,
+        unsigned int IntegrationPointIndex,
+        double Weight,
+        const typename TElementData::MatrixRowType& rN,
+        const typename TElementData::ShapeDerivativesType& rDN_DX) const;
+
     virtual void CalculateMaterialResponse(TElementData& rData) const;
 
     /// Determine integration point weights and shape funcition derivatives from the element's geometry.

--- a/applications/FluidDynamicsApplication/custom_elements/qs_vms.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/qs_vms.cpp
@@ -142,8 +142,7 @@ void QSVMS<TElementData>::GetValueOnIntegrationPoints(
 
         for (unsigned int g = 0; g < NumGauss; g++)
         {
-            data.UpdateGeometryValues(g, GaussWeights[g], row(ShapeFunctions, g), ShapeDerivatives[g]);
-            this->CalculateMaterialResponse(data);
+            this->UpdateIntegrationPointData(data, g, GaussWeights[g], row(ShapeFunctions, g), ShapeDerivatives[g]);
 
             this->SubscaleVelocity(data, rValues[g]);
         }
@@ -175,8 +174,7 @@ void QSVMS<TElementData>::GetValueOnIntegrationPoints(
 
         for (unsigned int g = 0; g < NumGauss; g++)
         {
-            data.UpdateGeometryValues(g, GaussWeights[g], row(ShapeFunctions, g), ShapeDerivatives[g]);
-            this->CalculateMaterialResponse(data);
+            this->UpdateIntegrationPointData(data, g, GaussWeights[g], row(ShapeFunctions, g), ShapeDerivatives[g]);
 
             this->SubscalePressure(data,rValues[g]);
         }
@@ -680,8 +678,7 @@ void QSVMS<TElementData>::CalculateProjections(const ProcessInfo &rCurrentProces
 
     for (unsigned int g = 0; g < NumGauss; g++)
     {
-        data.UpdateGeometryValues(g, GaussWeights[g], row(ShapeFunctions, g), ShapeDerivatives[g]);
-        this->CalculateMaterialResponse(data);
+        this->UpdateIntegrationPointData(data, g, GaussWeights[g], row(ShapeFunctions, g), ShapeDerivatives[g]);
 
         array_1d<double, 3> MomentumRes = ZeroVector(3);
         double MassRes = 0.0;


### PR DESCRIPTION
As discussed in #2795. I implemented a new function `UpdateIntegrationPointData` combining `TData::UpdateGeometryValues` and `FluidElement::CalculateMaterialResponse`. This makes them easier to use (no need to always call both of them in the correct order anymore) and should make it possible to correctly calculate the non-linear Darcy porosity term.

@ddiezrod I didn't check your branch, but in the current master, the two_fluid_navier_stokes element reimplements `CalculateMaterialResponse`. If you can move the code there directly to your derived version of the new `UpdateIntegrationPointData`, I would completely remove `CalculateMaterialResponse` from `FluidElement`(or at least make it private).

FYI @swenczowski (in case you were using it).