### PR TITLE
[ParticleMechanics] Cleanup strategy and solver

### DIFF
--- a/applications/ParticleMechanicsApplication/README.md
+++ b/applications/ParticleMechanicsApplication/README.md
@@ -70,7 +70,7 @@ The following features are currently available and subject to development within
     * Particle erase features - to delete particle outside the interest domain
     * Arbitrary slip boundary condition
 
-Some unit tests of the above features can be found in the [tests](https://github.com/KratosMultiphysics/Kratos/tree/master/applications/ParticleMechanicsApplication/tests) folder.
+Some unit tests of the above features can be found in the [tests](https://github.com/KratosMultiphysics/Kratos/tree/master/applications/ParticleMechanicsApplication/tests) folder, while some use-cases and validation examples are also available in the [Examples](https://github.com/KratosMultiphysics/Examples/tree/master/particle_mechanics) repository.
 
 ## Available Interfaces
 

--- a/applications/ParticleMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/ParticleMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -75,7 +75,7 @@ namespace Python{
 
         // Strategy Type
         py::class_< MPMStrategyType2D,typename MPMStrategyType2D::Pointer, BaseSolvingStrategyType >(m,"MPM2D")
-            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, bool, std::string, bool, bool>() )
+            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, bool, std::string, bool, bool, bool>() )
             .def( "SearchElement", &MPMStrategyType2D::SearchElement)
             .def( "MP16ShapeFunctions", &MPMStrategyType2D::MP16ShapeFunctions)
             .def( "MP33ShapeFunctions", &MPMStrategyType2D::MP33ShapeFunctions)
@@ -83,7 +83,7 @@ namespace Python{
             ;
 
         py::class_< MPMStrategyType3D,typename MPMStrategyType3D::Pointer, BaseSolvingStrategyType >(m,"MPM3D")
-            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, bool, std::string, bool, bool>() )
+            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, bool, std::string, bool, bool, bool>() )
             .def( "SearchElement", &MPMStrategyType3D::SearchElement)
             .def( "MP16ShapeFunctions", &MPMStrategyType3D::MP16ShapeFunctions)
             .def( "MP33ShapeFunctions", &MPMStrategyType3D::MP33ShapeFunctions)

--- a/applications/ParticleMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/ParticleMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -75,7 +75,7 @@ namespace Python{
 
         // Strategy Type
         py::class_< MPMStrategyType2D,typename MPMStrategyType2D::Pointer, BaseSolvingStrategyType >(m,"MPM2D")
-            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, bool, std::string, bool, bool, bool>() )
+            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, std::string, bool, bool, bool, bool>() )
             .def( "SearchElement", &MPMStrategyType2D::SearchElement)
             .def( "MP16ShapeFunctions", &MPMStrategyType2D::MP16ShapeFunctions)
             .def( "MP33ShapeFunctions", &MPMStrategyType2D::MP33ShapeFunctions)
@@ -83,7 +83,7 @@ namespace Python{
             ;
 
         py::class_< MPMStrategyType3D,typename MPMStrategyType3D::Pointer, BaseSolvingStrategyType >(m,"MPM3D")
-            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, bool, std::string, bool, bool, bool>() )
+            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, std::string, bool, bool, bool, bool>() )
             .def( "SearchElement", &MPMStrategyType3D::SearchElement)
             .def( "MP16ShapeFunctions", &MPMStrategyType3D::MP16ShapeFunctions)
             .def( "MP33ShapeFunctions", &MPMStrategyType3D::MP33ShapeFunctions)

--- a/applications/ParticleMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/ParticleMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -75,7 +75,7 @@ namespace Python{
 
         // Strategy Type
         py::class_< MPMStrategyType2D,typename MPMStrategyType2D::Pointer, BaseSolvingStrategyType >(m,"MPM2D")
-            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, std::string, bool, bool, bool, bool>() )
+            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, std::string, int, bool, bool, bool, bool>() )
             .def( "SearchElement", &MPMStrategyType2D::SearchElement)
             .def( "MP16ShapeFunctions", &MPMStrategyType2D::MP16ShapeFunctions)
             .def( "MP33ShapeFunctions", &MPMStrategyType2D::MP33ShapeFunctions)
@@ -83,7 +83,7 @@ namespace Python{
             ;
 
         py::class_< MPMStrategyType3D,typename MPMStrategyType3D::Pointer, BaseSolvingStrategyType >(m,"MPM3D")
-            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, std::string, bool, bool, bool, bool>() )
+            .def(py::init< ModelPart&, ModelPart&, ModelPart&, LinearSolverType::Pointer,const Element&, std::string, int, bool, bool, bool, bool>() )
             .def( "SearchElement", &MPMStrategyType3D::SearchElement)
             .def( "MP16ShapeFunctions", &MPMStrategyType3D::MP16ShapeFunctions)
             .def( "MP33ShapeFunctions", &MPMStrategyType3D::MP33ShapeFunctions)

--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
@@ -157,7 +157,7 @@ public:
     /*@{ */
 
     MPMStrategy(ModelPart& grid_model_part, ModelPart& initial_model_part, ModelPart& mpm_model_part, typename TLinearSolver::Pointer plinear_solver,
-        Element const& NewElement, bool MoveMeshFlag = false, std::string SolutionType = "StaticType", bool BlockBuilder = false, bool isMixedFormulation = false)
+        Element const& NewElement, bool MoveMeshFlag = false, std::string SolutionType = "static", bool ComputeReaction = false, bool BlockBuilder = false, bool isMixedFormulation = false)
         : SolvingStrategyType(grid_model_part, MoveMeshFlag), mr_grid_model_part(grid_model_part), mr_initial_model_part(initial_model_part),
         mr_mpm_model_part(mpm_model_part)
     {
@@ -388,11 +388,10 @@ public:
             typename TConvergenceCriteriaType::Pointer pConvergenceCriteria = typename TConvergenceCriteriaType::Pointer(new ResidualCriteria< TSparseSpace, TDenseSpace >(ratio_tolerance,always_converged_norm));
 
             int max_iteration = 20;
-            bool calculate_reaction = false;
             bool reform_DOF_at_each_iteration = false;
             bool move_mesh_flag = false;
 
-            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,calculate_reaction,reform_DOF_at_each_iteration,move_mesh_flag) );
+            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,move_mesh_flag) );
         }
 
         // Define a quasi-static strategy to be used in the calculation
@@ -417,11 +416,10 @@ public:
             typename TConvergenceCriteriaType::Pointer pConvergenceCriteria = typename TConvergenceCriteriaType::Pointer(new ResidualCriteria< TSparseSpace, TDenseSpace >(ratio_tolerance,always_converged_norm));
 
             int max_iteration = 100;
-            bool calculate_reaction = false;
             bool reform_DOF_at_each_iteration = false;
             bool move_mesh_flag = false;
 
-            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,calculate_reaction,reform_DOF_at_each_iteration,move_mesh_flag) );
+            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,move_mesh_flag) );
         }
 
         // Define a dynamic strategy to be used in the calculation
@@ -446,11 +444,10 @@ public:
 
             typename TConvergenceCriteriaType::Pointer pConvergenceCriteria = typename TConvergenceCriteriaType::Pointer(new ResidualCriteria< TSparseSpace, TDenseSpace >(ratio_tolerance,always_converged_norm));
             int max_iteration = 20;
-            bool calculate_reaction = false;
             bool reform_DOF_at_each_iteration = false;
             bool move_mesh_flag = false;
 
-            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,calculate_reaction,reform_DOF_at_each_iteration,move_mesh_flag) );
+            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,move_mesh_flag) );
         }
 
     }

--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
@@ -157,7 +157,7 @@ public:
     /*@{ */
 
     MPMStrategy(ModelPart& grid_model_part, ModelPart& initial_model_part, ModelPart& mpm_model_part, typename TLinearSolver::Pointer plinear_solver,
-        Element const& NewElement, std::string SolutionType = "static", bool ComputeReaction = false, bool BlockBuilder = false,
+        Element const& NewElement, std::string SolutionType = "static", int MaxIteration = 10, bool ComputeReaction = false, bool BlockBuilder = false,
         bool isMixedFormulation = false, bool MoveMeshFlag = false)
         : SolvingStrategyType(grid_model_part, MoveMeshFlag), mr_grid_model_part(grid_model_part), mr_initial_model_part(initial_model_part),
         mr_mpm_model_part(mpm_model_part)
@@ -388,10 +388,9 @@ public:
             const double always_converged_norm = 1e-09;
             typename TConvergenceCriteriaType::Pointer pConvergenceCriteria = typename TConvergenceCriteriaType::Pointer(new ResidualCriteria< TSparseSpace, TDenseSpace >(ratio_tolerance,always_converged_norm));
 
-            int max_iteration = 20;
             bool reform_DOF_at_each_iteration = false;
 
-            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,MoveMeshFlag) );
+            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,MaxIteration,ComputeReaction,reform_DOF_at_each_iteration,MoveMeshFlag) );
         }
 
         // Define a quasi-static strategy to be used in the calculation
@@ -415,10 +414,9 @@ public:
             const double always_converged_norm = 1e-09;
             typename TConvergenceCriteriaType::Pointer pConvergenceCriteria = typename TConvergenceCriteriaType::Pointer(new ResidualCriteria< TSparseSpace, TDenseSpace >(ratio_tolerance,always_converged_norm));
 
-            int max_iteration = 100;
             bool reform_DOF_at_each_iteration = false;
 
-            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,MoveMeshFlag) );
+            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,MaxIteration,ComputeReaction,reform_DOF_at_each_iteration,MoveMeshFlag) );
         }
 
         // Define a dynamic strategy to be used in the calculation
@@ -442,10 +440,9 @@ public:
             const double always_converged_norm = 1e-09;
 
             typename TConvergenceCriteriaType::Pointer pConvergenceCriteria = typename TConvergenceCriteriaType::Pointer(new ResidualCriteria< TSparseSpace, TDenseSpace >(ratio_tolerance,always_converged_norm));
-            int max_iteration = 20;
             bool reform_DOF_at_each_iteration = false;
 
-            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,MoveMeshFlag) );
+            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,MaxIteration,ComputeReaction,reform_DOF_at_each_iteration,MoveMeshFlag) );
         }
 
     }

--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
@@ -157,217 +157,30 @@ public:
     /*@{ */
 
     MPMStrategy(ModelPart& grid_model_part, ModelPart& initial_model_part, ModelPart& mpm_model_part, typename TLinearSolver::Pointer plinear_solver,
-        Element const& NewElement, std::string SolutionType = "static", int MaxIteration = 10, bool ComputeReaction = false, bool BlockBuilder = false,
-        bool isMixedFormulation = false, bool MoveMeshFlag = false)
+        Element const& rNewElement, std::string SolutionType = "static", int MaxIteration = 10, bool ComputeReaction = false, bool BlockBuilder = false,
+        bool IsMixedFormulation = false, bool MoveMeshFlag = false)
         : SolvingStrategyType(grid_model_part, MoveMeshFlag), mr_grid_model_part(grid_model_part), mr_initial_model_part(initial_model_part),
         mr_mpm_model_part(mpm_model_part)
     {
 
         // Assigning the nodes to the new model part
-        mpm_model_part.Nodes() = grid_model_part.Nodes();
+        mr_mpm_model_part.Nodes() = mr_grid_model_part.Nodes();
 
-        mpm_model_part.SetProcessInfo(grid_model_part.pGetProcessInfo());
-        mpm_model_part.SetBufferSize(grid_model_part.GetBufferSize());
-        mpm_model_part.SetProperties(initial_model_part.pProperties());
-        mpm_model_part.SetConditions(grid_model_part.pConditions());
-
-        array_1d<double,3> xg = ZeroVector(3);
-        array_1d<double,3> MP_Displacement = ZeroVector(3);
-        array_1d<double,3> MP_Velocity = ZeroVector(3);
-        array_1d<double,3> MP_Acceleration = ZeroVector(3);
-        array_1d<double,3> Aux_MP_Velocity = ZeroVector(3);
-        array_1d<double,3> Aux_MP_Acceleration = ZeroVector(3);
-        array_1d<double,3> MP_Volume_Acceleration = ZeroVector(3);
-
-        Vector MP_Cauchy_Stress_Vector = ZeroVector(6);
-        Vector MP_Almansi_Strain_Vector = ZeroVector(6);
-        double MP_Pressure = 0.0;
-        double Aux_MP_Pressure = 0.0;
-
-        double MP_Mass;
-        double MP_Volume;
+        mr_mpm_model_part.SetProcessInfo(mr_grid_model_part.pGetProcessInfo());
+        mr_mpm_model_part.SetBufferSize(mr_grid_model_part.GetBufferSize());
+        mr_mpm_model_part.SetProperties(mr_initial_model_part.pProperties());
 
         // Prepare Dimension and Block Size
         unsigned int TBlock = TDim;
-        if (isMixedFormulation) TBlock ++;
+        if (IsMixedFormulation) TBlock ++;
 
         KRATOS_INFO("MPM_Strategy") << "Dimension Size = " << TDim << " and Block Size = " << TBlock << std::endl;
 
-        const unsigned int number_elements = grid_model_part.NumberOfElements() + initial_model_part.NumberOfElements();
-        const unsigned int number_nodes = grid_model_part.NumberOfNodes();
-        unsigned int last_element_id;
-        if (number_nodes>number_elements)
-            last_element_id = number_nodes + 1;
-        else
-            last_element_id = number_elements + 1;
+        // Create Material Point Element
+        this->CreateMaterialPointElement(rNewElement, IsMixedFormulation);
 
-        // Loop over the submodelpart of initial_model_part
-        for (ModelPart::SubModelPartIterator submodelpart_it = initial_model_part.SubModelPartsBegin();
-                submodelpart_it != initial_model_part.SubModelPartsEnd(); submodelpart_it++)
-        {
-            ModelPart& submodelpart = *submodelpart_it;
-            std::string submodelpart_name = submodelpart.Name();
-
-            mpm_model_part.CreateSubModelPart(submodelpart_name);
-
-            // Loop over the element of submodelpart's submodelpart and generate mpm element to be appended to the mpm_model_part
-            for (ModelPart::ElementIterator i = submodelpart.ElementsBegin();
-                    i != submodelpart.ElementsEnd(); i++)
-            {
-                if(i->IsDefined(ACTIVE))
-                {
-                    Properties::Pointer properties = i->pGetProperties();
-                    const int material_id = i->GetProperties().Id();
-                    const double density  = i->GetProperties()[DENSITY];
-
-                    unsigned int particles_per_element;
-                    if (i->GetProperties().Has( PARTICLES_PER_ELEMENT )){
-                        particles_per_element = i->GetProperties()[PARTICLES_PER_ELEMENT];
-                    }
-                    else{
-                        std::string warning_msg = "PARTICLES_PER_ELEMENT is not specified in Properties, ";
-                        warning_msg += "1 Particle per element is assumed.";
-                        KRATOS_WARNING("MPM_Strategy") << "WARNING: " << warning_msg << std::endl;
-                        particles_per_element = 1;
-                    }
-
-                    const Geometry< Node < 3 > >& rGeom = i->GetGeometry(); // current element's connectivity
-                    const GeometryData::KratosGeometryType rGeoType = rGeom.GetGeometryType();
-                    Matrix shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
-                    if (rGeoType == GeometryData::Kratos_Tetrahedra3D4  || rGeoType == GeometryData::Kratos_Triangle2D3)
-                    {
-                        switch (particles_per_element)
-                        {
-                            case 1:
-                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_1);
-                                break;
-                            case 3:
-                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
-                                break;
-                            case 6:
-                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_4);
-                                break;
-                            case 12:
-                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_5);
-                                break;
-                            case 16:
-                                if (TDim==2){
-                                    shape_functions_values = this->MP16ShapeFunctions();
-                                    break;
-                                }
-                            case 33:
-                                if (TDim==2) {
-                                    shape_functions_values = this->MP33ShapeFunctions();
-                                    break;
-                                }
-                            default:
-                                std::string warning_msg = "The input number of PARTICLES_PER_ELEMENT: " + std::to_string(particles_per_element);
-                                warning_msg += " is not available for Triangular" + std::to_string(TDim) + "D.\n";
-                                warning_msg += "Available options are: 1, 3, 6, 12, 16 (only 2D), and 33 (only 2D).\n";
-                                warning_msg += "The default number of particle: 3 is currently assumed.";
-                                KRATOS_INFO("MPM_Strategy") << "WARNING: " << warning_msg << std::endl;
-                                break;
-                        }
-                    }
-                    else if(rGeoType == GeometryData::Kratos_Hexahedra3D8  || rGeoType == GeometryData::Kratos_Quadrilateral2D4)
-                    {
-                        switch (particles_per_element)
-                        {
-                            case 1:
-                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_1);
-                                break;
-                            case 4:
-                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
-                                break;
-                            case 9:
-                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_3);
-                                break;
-                            case 16:
-                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_4);
-                                break;
-                            default:
-                                std::string warning_msg = "The input number of PARTICLES_PER_ELEMENT: " + std::to_string(particles_per_element);
-                                warning_msg += " is not available for Quadrilateral" + std::to_string(TDim) + "D.\n";
-                                warning_msg += "Available options are: 1, 4, 9, 16.\n";
-                                warning_msg += "The default number of particle: 4 is currently assumed.";
-                                KRATOS_INFO("MPM_Strategy") << "WARNING: " << warning_msg << std::endl;
-                                break;
-                        }
-                    }
-                    else{
-                        std::string error_msg = "The Geometry type of the Element given is invalid or currently not available. ";
-                        error_msg += "Please remesh the problem domain to Triangle2D3N or Quadrilateral2D4N for 2D or ";
-                        error_msg += "Tetrahedral3D4N or Hexahedral3D8N for 3D.";
-                        KRATOS_ERROR << error_msg << std::endl;
-                    }
-
-                    // Number of MP per elements
-                    const unsigned int integration_point_per_elements = shape_functions_values.size1();
-
-                    // Evaluation of element area/volume
-                    const double area = rGeom.Area();
-                    if(TDim == 2 && i->GetProperties().Has( THICKNESS )){
-						const double thickness = i->GetProperties()[THICKNESS];
-						MP_Mass = area * thickness * density / integration_point_per_elements;
-					}
-					else {
-                        MP_Mass = area * density / integration_point_per_elements;
-                    }
-                    MP_Volume = area / integration_point_per_elements;
-
-                    // Loop over the material points that fall in each grid element
-                    unsigned int new_element_id = 0;
-                    for ( unsigned int PointNumber = 0; PointNumber < integration_point_per_elements; PointNumber++ )
-                    {
-                        new_element_id = last_element_id + PointNumber;
-                        Element::Pointer p_element = NewElement.Create(new_element_id, grid_model_part.ElementsBegin()->GetGeometry(), properties);
-                        const double MP_Density  = density;
-                        const int MP_Material_Id = material_id;
-
-                        xg.clear();
-
-                        // Loop over the nodes of the grid element
-                        for (unsigned int dim = 0; dim < rGeom.WorkingSpaceDimension(); dim++)
-                        {
-                            for ( unsigned int j = 0; j < rGeom.size(); j ++)
-                            {
-                                xg[dim] = xg[dim] + shape_functions_values(PointNumber, j) * rGeom[j].Coordinates()[dim];
-                            }
-                        }
-
-                        // Setting particle element's initial condition
-                        p_element->SetValue(MP_MATERIAL_ID, MP_Material_Id);
-                        p_element->SetValue(MP_DENSITY, MP_Density);
-                        p_element->SetValue(MP_MASS, MP_Mass);
-                        p_element->SetValue(MP_VOLUME, MP_Volume);
-                        p_element->SetValue(MP_COORD, xg);
-                        p_element->SetValue(MP_DISPLACEMENT, MP_Displacement);
-                        p_element->SetValue(MP_VELOCITY, MP_Velocity);
-                        p_element->SetValue(MP_ACCELERATION, MP_Acceleration);
-                        p_element->SetValue(AUX_MP_VELOCITY, Aux_MP_Velocity);
-                        p_element->SetValue(AUX_MP_ACCELERATION, Aux_MP_Acceleration);
-                        p_element->SetValue(MP_VOLUME_ACCELERATION, MP_Volume_Acceleration);
-                        p_element->SetValue(MP_CAUCHY_STRESS_VECTOR, MP_Cauchy_Stress_Vector);
-                        p_element->SetValue(MP_ALMANSI_STRAIN_VECTOR, MP_Almansi_Strain_Vector);
-
-                        if(isMixedFormulation)
-                        {
-                            p_element->SetValue(MP_PRESSURE, MP_Pressure);
-                            p_element->SetValue(AUX_MP_PRESSURE, Aux_MP_Pressure);
-                        }
-
-                        // Add the MP Element to the model part
-                        mpm_model_part.GetSubModelPart(submodelpart_name).AddElement(p_element);
-                    }
-
-                    last_element_id += integration_point_per_elements;
-
-                }
-
-
-            }
-
-        }
+        // Create Material Point Condition
+        this->CreateMaterialPointCondition();
 
         // Define a standard static strategy to be used in the calculation
         if(SolutionType == "static" || SolutionType == "Static")
@@ -571,6 +384,218 @@ public:
 
         return 0;
         KRATOS_CATCH("")
+    }
+
+    /**
+     * @brief Function to Initiate material point element.
+     * @details It is designed to be called ONCE by the class constructor.
+     */
+    virtual void CreateMaterialPointElement(Element const& rNewElement, bool IsMixedFormulation = false)
+    {
+        // Initialize zero the variables needed
+        array_1d<double,3> xg = ZeroVector(3);
+        array_1d<double,3> MP_Displacement = ZeroVector(3);
+        array_1d<double,3> MP_Velocity = ZeroVector(3);
+        array_1d<double,3> MP_Acceleration = ZeroVector(3);
+        array_1d<double,3> Aux_MP_Velocity = ZeroVector(3);
+        array_1d<double,3> Aux_MP_Acceleration = ZeroVector(3);
+        array_1d<double,3> MP_Volume_Acceleration = ZeroVector(3);
+
+        Vector MP_Cauchy_Stress_Vector = ZeroVector(6);
+        Vector MP_Almansi_Strain_Vector = ZeroVector(6);
+        double MP_Pressure = 0.0;
+        double Aux_MP_Pressure = 0.0;
+
+        double MP_Mass;
+        double MP_Volume;
+
+        // Determine element index
+        const unsigned int number_elements = mr_grid_model_part.NumberOfElements() + mr_initial_model_part.NumberOfElements();
+        const unsigned int number_nodes = mr_grid_model_part.NumberOfNodes();
+        unsigned int last_element_id;
+        if (number_nodes>number_elements)
+            last_element_id = number_nodes + 1;
+        else
+            last_element_id = number_elements + 1;
+
+        // Loop over the submodelpart of mr_initial_model_part
+        for (ModelPart::SubModelPartIterator submodelpart_it = mr_initial_model_part.SubModelPartsBegin();
+                submodelpart_it != mr_initial_model_part.SubModelPartsEnd(); submodelpart_it++)
+        {
+            ModelPart& submodelpart = *submodelpart_it;
+            std::string submodelpart_name = submodelpart.Name();
+
+            mr_mpm_model_part.CreateSubModelPart(submodelpart_name);
+
+            // Loop over the element of submodelpart's submodelpart and generate mpm element to be appended to the mr_mpm_model_part
+            for (ModelPart::ElementIterator i = submodelpart.ElementsBegin();
+                    i != submodelpart.ElementsEnd(); i++)
+            {
+                if(i->IsDefined(ACTIVE))
+                {
+                    Properties::Pointer properties = i->pGetProperties();
+                    const int material_id = i->GetProperties().Id();
+                    const double density  = i->GetProperties()[DENSITY];
+
+                    // Check number of particles per element to be created
+                    unsigned int particles_per_element;
+                    if (i->GetProperties().Has( PARTICLES_PER_ELEMENT )){
+                        particles_per_element = i->GetProperties()[PARTICLES_PER_ELEMENT];
+                    }
+                    else{
+                        std::string warning_msg = "PARTICLES_PER_ELEMENT is not specified in Properties, ";
+                        warning_msg += "1 Particle per element is assumed.";
+                        KRATOS_WARNING("MPM_Strategy") << "WARNING: " << warning_msg << std::endl;
+                        particles_per_element = 1;
+                    }
+
+                    const Geometry< Node < 3 > >& rGeom = i->GetGeometry(); // current element's connectivity
+                    const GeometryData::KratosGeometryType rGeoType = rGeom.GetGeometryType();
+                    Matrix shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
+                    if (rGeoType == GeometryData::Kratos_Tetrahedra3D4  || rGeoType == GeometryData::Kratos_Triangle2D3)
+                    {
+                        switch (particles_per_element)
+                        {
+                            case 1:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_1);
+                                break;
+                            case 3:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
+                                break;
+                            case 6:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_4);
+                                break;
+                            case 12:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_5);
+                                break;
+                            case 16:
+                                if (TDim==2){
+                                    shape_functions_values = this->MP16ShapeFunctions();
+                                    break;
+                                }
+                            case 33:
+                                if (TDim==2) {
+                                    shape_functions_values = this->MP33ShapeFunctions();
+                                    break;
+                                }
+                            default:
+                                std::string warning_msg = "The input number of PARTICLES_PER_ELEMENT: " + std::to_string(particles_per_element);
+                                warning_msg += " is not available for Triangular" + std::to_string(TDim) + "D.\n";
+                                warning_msg += "Available options are: 1, 3, 6, 12, 16 (only 2D), and 33 (only 2D).\n";
+                                warning_msg += "The default number of particle: 3 is currently assumed.";
+                                KRATOS_INFO("MPM_Strategy") << "WARNING: " << warning_msg << std::endl;
+                                break;
+                        }
+                    }
+                    else if(rGeoType == GeometryData::Kratos_Hexahedra3D8  || rGeoType == GeometryData::Kratos_Quadrilateral2D4)
+                    {
+                        switch (particles_per_element)
+                        {
+                            case 1:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_1);
+                                break;
+                            case 4:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_2);
+                                break;
+                            case 9:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_3);
+                                break;
+                            case 16:
+                                shape_functions_values = rGeom.ShapeFunctionsValues( GeometryData::GI_GAUSS_4);
+                                break;
+                            default:
+                                std::string warning_msg = "The input number of PARTICLES_PER_ELEMENT: " + std::to_string(particles_per_element);
+                                warning_msg += " is not available for Quadrilateral" + std::to_string(TDim) + "D.\n";
+                                warning_msg += "Available options are: 1, 4, 9, 16.\n";
+                                warning_msg += "The default number of particle: 4 is currently assumed.";
+                                KRATOS_INFO("MPM_Strategy") << "WARNING: " << warning_msg << std::endl;
+                                break;
+                        }
+                    }
+                    else{
+                        std::string error_msg = "The Geometry type of the Element given is invalid or currently not available. ";
+                        error_msg += "Please remesh the problem domain to Triangle2D3N or Quadrilateral2D4N for 2D or ";
+                        error_msg += "Tetrahedral3D4N or Hexahedral3D8N for 3D.";
+                        KRATOS_ERROR << error_msg << std::endl;
+                    }
+
+                    // Number of MP per elements
+                    const unsigned int integration_point_per_elements = shape_functions_values.size1();
+
+                    // Evaluation of element area/volume
+                    const double area = rGeom.Area();
+                    if(TDim == 2 && i->GetProperties().Has( THICKNESS )){
+						const double thickness = i->GetProperties()[THICKNESS];
+						MP_Mass = area * thickness * density / integration_point_per_elements;
+					}
+					else {
+                        MP_Mass = area * density / integration_point_per_elements;
+                    }
+                    MP_Volume = area / integration_point_per_elements;
+
+                    // Loop over the material points that fall in each grid element
+                    unsigned int new_element_id = 0;
+                    for ( unsigned int PointNumber = 0; PointNumber < integration_point_per_elements; PointNumber++ )
+                    {
+                        new_element_id = last_element_id + PointNumber;
+                        Element::Pointer p_element = rNewElement.Create(new_element_id, mr_grid_model_part.ElementsBegin()->GetGeometry(), properties);
+                        const double MP_Density  = density;
+                        const int MP_Material_Id = material_id;
+
+                        xg.clear();
+
+                        // Loop over the nodes of the grid element
+                        for (unsigned int dim = 0; dim < rGeom.WorkingSpaceDimension(); dim++)
+                        {
+                            for ( unsigned int j = 0; j < rGeom.size(); j ++)
+                            {
+                                xg[dim] = xg[dim] + shape_functions_values(PointNumber, j) * rGeom[j].Coordinates()[dim];
+                            }
+                        }
+
+                        // Setting particle element's initial condition
+                        p_element->SetValue(MP_MATERIAL_ID, MP_Material_Id);
+                        p_element->SetValue(MP_DENSITY, MP_Density);
+                        p_element->SetValue(MP_MASS, MP_Mass);
+                        p_element->SetValue(MP_VOLUME, MP_Volume);
+                        p_element->SetValue(MP_COORD, xg);
+                        p_element->SetValue(MP_DISPLACEMENT, MP_Displacement);
+                        p_element->SetValue(MP_VELOCITY, MP_Velocity);
+                        p_element->SetValue(MP_ACCELERATION, MP_Acceleration);
+                        p_element->SetValue(AUX_MP_VELOCITY, Aux_MP_Velocity);
+                        p_element->SetValue(AUX_MP_ACCELERATION, Aux_MP_Acceleration);
+                        p_element->SetValue(MP_VOLUME_ACCELERATION, MP_Volume_Acceleration);
+                        p_element->SetValue(MP_CAUCHY_STRESS_VECTOR, MP_Cauchy_Stress_Vector);
+                        p_element->SetValue(MP_ALMANSI_STRAIN_VECTOR, MP_Almansi_Strain_Vector);
+
+                        if(IsMixedFormulation)
+                        {
+                            p_element->SetValue(MP_PRESSURE, MP_Pressure);
+                            p_element->SetValue(AUX_MP_PRESSURE, Aux_MP_Pressure);
+                        }
+
+                        // Add the MP Element to the model part
+                        mr_mpm_model_part.GetSubModelPart(submodelpart_name).AddElement(p_element);
+                    }
+
+                    last_element_id += integration_point_per_elements;
+
+                }
+
+
+            }
+
+        }
+    }
+
+    /**
+     * @brief Function to Initiate material point condition.
+     * @details It is designed to be called ONCE by the class constructor.
+     */
+    virtual void CreateMaterialPointCondition()
+    {
+        mr_mpm_model_part.SetConditions(mr_grid_model_part.pConditions());
+        // TODO: Going to be implemented further to generate particle condition
     }
 
     /**

--- a/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
+++ b/applications/ParticleMechanicsApplication/custom_strategies/strategies/MPM_strategy.h
@@ -157,7 +157,8 @@ public:
     /*@{ */
 
     MPMStrategy(ModelPart& grid_model_part, ModelPart& initial_model_part, ModelPart& mpm_model_part, typename TLinearSolver::Pointer plinear_solver,
-        Element const& NewElement, bool MoveMeshFlag = false, std::string SolutionType = "static", bool ComputeReaction = false, bool BlockBuilder = false, bool isMixedFormulation = false)
+        Element const& NewElement, std::string SolutionType = "static", bool ComputeReaction = false, bool BlockBuilder = false,
+        bool isMixedFormulation = false, bool MoveMeshFlag = false)
         : SolvingStrategyType(grid_model_part, MoveMeshFlag), mr_grid_model_part(grid_model_part), mr_initial_model_part(initial_model_part),
         mr_mpm_model_part(mpm_model_part)
     {
@@ -389,9 +390,8 @@ public:
 
             int max_iteration = 20;
             bool reform_DOF_at_each_iteration = false;
-            bool move_mesh_flag = false;
 
-            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,move_mesh_flag) );
+            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,MoveMeshFlag) );
         }
 
         // Define a quasi-static strategy to be used in the calculation
@@ -417,9 +417,8 @@ public:
 
             int max_iteration = 100;
             bool reform_DOF_at_each_iteration = false;
-            bool move_mesh_flag = false;
 
-            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,move_mesh_flag) );
+            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,MoveMeshFlag) );
         }
 
         // Define a dynamic strategy to be used in the calculation
@@ -445,9 +444,8 @@ public:
             typename TConvergenceCriteriaType::Pointer pConvergenceCriteria = typename TConvergenceCriteriaType::Pointer(new ResidualCriteria< TSparseSpace, TDenseSpace >(ratio_tolerance,always_converged_norm));
             int max_iteration = 20;
             bool reform_DOF_at_each_iteration = false;
-            bool move_mesh_flag = false;
 
-            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,move_mesh_flag) );
+            mp_solving_strategy = typename SolvingStrategyType::Pointer( new MPMResidualBasedNewtonRaphsonStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(mr_mpm_model_part,pscheme,plinear_solver,pConvergenceCriteria,pBuilderAndSolver,max_iteration,ComputeReaction,reform_DOF_at_each_iteration,MoveMeshFlag) );
         }
 
     }

--- a/applications/ParticleMechanicsApplication/python_scripts/particle_mpm_solver.py
+++ b/applications/ParticleMechanicsApplication/python_scripts/particle_mpm_solver.py
@@ -48,23 +48,15 @@ class ParticleMPMSolver(PythonSolver):
             "material_import_settings"           : {
                 "materials_filename" : ""
             },
-            "time_step_prediction_level"         : "Automatic",
-            "rayleigh_damping"                   : false,
             "pressure_dofs"                      : false,
-            "reform_dof_set_at_each_step"        : false,
-            "line_search"                        : false,
-            "implex"                             : false,
             "compute_reactions"                  : false,
-            "compute_contact_forces"             : false,
             "convergence_criterion"              : "Residual_criteria",
             "displacement_relative_tolerance"    : 1.0E-4,
             "displacement_absolute_tolerance"    : 1.0E-9,
             "residual_relative_tolerance"        : 1.0E-4,
             "residual_absolute_tolerance"        : 1.0E-9,
             "max_iteration"                      : 20,
-            "number_of_material"                 : 1,
             "axis_symmetric_flag"                : false,
-            "impenetrability_condition"          : true,
             "move_mesh_flag"                     : false,
             "problem_domain_sub_model_part_list" : [],
             "processes_sub_model_part_list"      : [],
@@ -100,6 +92,11 @@ class ParticleMPMSolver(PythonSolver):
             warning = '\n::[ParticleMPMSolver]:: W-A-R-N-I-N-G: You have specified "particle_per_element", '
             warning += 'which is deprecated and will be removed soon. \nPlease remove it from the "solver settings"!\n'
             self.print_warning_on_rank_zero("Particle per element", warning)
+        if custom_settings.Has("line_search"):
+            custom_settings.RemoveValue("line_search")
+            warning = '\n::[ParticleMPMSolver]:: W-A-R-N-I-N-G: You have specified "line_search", '
+            warning += 'which is deprecated and will be removed soon. \nPlease remove it from the "solver settings"!\n'
+            self.print_warning_on_rank_zero("Geometry element", warning)
 
         # Overwrite the default settings with user-provided parameters
         self.settings.ValidateAndAssignDefaults(default_settings)
@@ -172,7 +169,6 @@ class ParticleMPMSolver(PythonSolver):
         # Set definition of the solver parameters
         self.compute_reactions      = self.settings["compute_reactions"].GetBool()
         self.pressure_dofs          = self.settings["pressure_dofs"].GetBool()
-        self.implex                 = self.settings["implex"].GetBool()
         self.axis_symmetric_flag    = self.settings["axis_symmetric_flag"].GetBool()
         self.move_mesh_flag         = self.settings["move_mesh_flag"].GetBool()
 

--- a/applications/ParticleMechanicsApplication/python_scripts/particle_mpm_solver.py
+++ b/applications/ParticleMechanicsApplication/python_scripts/particle_mpm_solver.py
@@ -54,7 +54,7 @@ class ParticleMPMSolver(PythonSolver):
             "reform_dof_set_at_each_step"        : false,
             "line_search"                        : false,
             "implex"                             : false,
-            "compute_reactions"                  : true,
+            "compute_reactions"                  : false,
             "compute_contact_forces"             : false,
             "convergence_criterion"              : "Residual_criteria",
             "displacement_relative_tolerance"    : 1.0E-4,
@@ -218,12 +218,12 @@ class ParticleMPMSolver(PythonSolver):
         # Initialize solver
         if(self.domain_size==2):
             self.solver = KratosParticle.MPM2D(self.grid_model_part, self.initial_material_model_part, self.material_model_part,
-                                self.linear_solver, self.new_element, self.move_mesh_flag, self.solver_type, self.block_builder,
-                                self.pressure_dofs)
+                                self.linear_solver, self.new_element, self.move_mesh_flag, self.solver_type, self.compute_reactions,
+                                self.block_builder, self.pressure_dofs)
         else:
             self.solver = KratosParticle.MPM3D(self.grid_model_part, self.initial_material_model_part, self.material_model_part,
-                                self.linear_solver, self.new_element, self.move_mesh_flag, self.solver_type, self.block_builder,
-                                self.pressure_dofs)
+                                self.linear_solver, self.new_element, self.move_mesh_flag, self.solver_type, self.compute_reactions,
+                                self.block_builder, self.pressure_dofs)
 
         # Set echo level
         self._set_echo_level()

--- a/applications/ParticleMechanicsApplication/python_scripts/particle_mpm_solver.py
+++ b/applications/ParticleMechanicsApplication/python_scripts/particle_mpm_solver.py
@@ -61,7 +61,7 @@ class ParticleMPMSolver(PythonSolver):
             "displacement_absolute_tolerance"    : 1.0E-9,
             "residual_relative_tolerance"        : 1.0E-4,
             "residual_absolute_tolerance"        : 1.0E-9,
-            "max_iteration"                      : 10,
+            "max_iteration"                      : 20,
             "number_of_material"                 : 1,
             "axis_symmetric_flag"                : false,
             "impenetrability_condition"          : true,
@@ -164,7 +164,7 @@ class ParticleMPMSolver(PythonSolver):
         self.abs_disp_tol               = self.settings["displacement_absolute_tolerance"].GetDouble()
         self.rel_res_tol                = self.settings["residual_relative_tolerance"].GetDouble()
         self.abs_res_tol                = self.settings["residual_absolute_tolerance"].GetDouble()
-        self.max_iters                  = self.settings["max_iteration"].GetInt()
+        self.max_iteration              = self.settings["max_iteration"].GetInt()
 
         # Set definition of the global solver type
         self.solver_type                    = self.settings["solver_type"].GetString()
@@ -216,11 +216,11 @@ class ParticleMPMSolver(PythonSolver):
         # Initialize solver
         if(self.domain_size==2):
             self.solver = KratosParticle.MPM2D(self.grid_model_part, self.initial_material_model_part, self.material_model_part,
-                                self.linear_solver, self.new_element, self.solver_type, self.compute_reactions,
+                                self.linear_solver, self.new_element, self.solver_type, self.max_iteration, self.compute_reactions,
                                 self.block_builder, self.pressure_dofs, self.move_mesh_flag)
         else:
             self.solver = KratosParticle.MPM3D(self.grid_model_part, self.initial_material_model_part, self.material_model_part,
-                                self.linear_solver, self.new_element, self.solver_type, self.compute_reactions,
+                                self.linear_solver, self.new_element, self.solver_type, self.max_iteration, self.compute_reactions,
                                 self.block_builder, self.pressure_dofs, self.move_mesh_flag)
 
         # Set echo level

--- a/applications/ParticleMechanicsApplication/python_scripts/particle_mpm_solver.py
+++ b/applications/ParticleMechanicsApplication/python_scripts/particle_mpm_solver.py
@@ -171,9 +171,7 @@ class ParticleMPMSolver(PythonSolver):
 
         # Set definition of the solver parameters
         self.compute_reactions      = self.settings["compute_reactions"].GetBool()
-        self.compute_contact_forces = self.settings["compute_contact_forces"].GetBool()
         self.pressure_dofs          = self.settings["pressure_dofs"].GetBool()
-        self.line_search            = self.settings["line_search"].GetBool()
         self.implex                 = self.settings["implex"].GetBool()
         self.axis_symmetric_flag    = self.settings["axis_symmetric_flag"].GetBool()
         self.move_mesh_flag         = self.settings["move_mesh_flag"].GetBool()
@@ -218,12 +216,12 @@ class ParticleMPMSolver(PythonSolver):
         # Initialize solver
         if(self.domain_size==2):
             self.solver = KratosParticle.MPM2D(self.grid_model_part, self.initial_material_model_part, self.material_model_part,
-                                self.linear_solver, self.new_element, self.move_mesh_flag, self.solver_type, self.compute_reactions,
-                                self.block_builder, self.pressure_dofs)
+                                self.linear_solver, self.new_element, self.solver_type, self.compute_reactions,
+                                self.block_builder, self.pressure_dofs, self.move_mesh_flag)
         else:
             self.solver = KratosParticle.MPM3D(self.grid_model_part, self.initial_material_model_part, self.material_model_part,
-                                self.linear_solver, self.new_element, self.move_mesh_flag, self.solver_type, self.compute_reactions,
-                                self.block_builder, self.pressure_dofs)
+                                self.linear_solver, self.new_element, self.solver_type, self.compute_reactions,
+                                self.block_builder, self.pressure_dofs, self.move_mesh_flag)
 
         # Set echo level
         self._set_echo_level()

--- a/applications/ParticleMechanicsApplication/tests/axisym_tests/circular_plate_axisym_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/axisym_tests/circular_plate_axisym_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/axisym_tests/circular_plate_axisym_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/axisym_tests/circular_plate_axisym_test_parameters.json
@@ -28,7 +28,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1","LineLoad2D_Load_on_lines_Auto1"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_line_load_2D_quad_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_line_load_2D_quad_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_line_load_2D_quad_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_line_load_2D_quad_test_parameters.json
@@ -28,7 +28,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1","LineLoad2D_Load_on_lines_Auto1"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_point_load_2D_tri_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_point_load_2D_tri_test_parameters.json
@@ -29,7 +29,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1","PointLoad2D_Load_on_points_Auto1"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_point_load_2D_tri_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_point_load_2D_tri_test_parameters.json
@@ -23,7 +23,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_surface_load_3D_hexa_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_surface_load_3D_hexa_test_parameters.json
@@ -28,7 +28,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1","SurfaceLoad3D_Load_on_surfaces_Auto1"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_surface_load_3D_hexa_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/cantilever_beam/static_surface_load_3D_hexa_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/hyperelastic_cantilever_beam/self_weight_load_2D_quad_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/hyperelastic_cantilever_beam/self_weight_load_2D_quad_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/beam_tests/hyperelastic_cantilever_beam/self_weight_load_2D_quad_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/beam_tests/hyperelastic_cantilever_beam/self_weight_load_2D_quad_test_parameters.json
@@ -28,7 +28,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/cl_tests/solid_cl/linear_elastic_3D_hexa_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cl_tests/solid_cl/linear_elastic_3D_hexa_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/cl_tests/solid_cl/linear_elastic_3D_hexa_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cl_tests/solid_cl/linear_elastic_3D_hexa_test_parameters.json
@@ -28,7 +28,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1","DISPLACEMENT_Displacement_Auto2"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_compressible_cook_membrane_2D_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_compressible_cook_membrane_2D_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_compressible_cook_membrane_2D_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_compressible_cook_membrane_2D_test_parameters.json
@@ -28,7 +28,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1","LineLoad2D_Load_on_lines_Auto1"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_incompressible_cook_membrane_2D_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_incompressible_cook_membrane_2D_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_incompressible_cook_membrane_2D_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/UP_incompressible_cook_membrane_2D_test_parameters.json
@@ -28,7 +28,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1","LineLoad2D_Load_on_lines_Auto1"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/compressible_cook_membrane_2D_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/compressible_cook_membrane_2D_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/compressible_cook_membrane_2D_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/cooks_membrane_tests/compressible_cook_membrane_2D_test_parameters.json
@@ -28,7 +28,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1","LineLoad2D_Load_on_lines_Auto1"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/gravity_tests/dynamic_gravity_application_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/gravity_tests/dynamic_gravity_application_test_parameters.json
@@ -30,7 +30,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/gravity_tests/dynamic_gravity_application_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/gravity_tests/dynamic_gravity_application_test_parameters.json
@@ -24,7 +24,6 @@
         "time_stepping"                      : {
             "time_step" : 0.05
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/slip_tests/slip_boundary_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/slip_tests/slip_boundary_test_parameters.json
@@ -30,7 +30,7 @@
         "displacement_absolute_tolerance"    : 1e-9,
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
+        "max_iteration"                      : 20,
         "problem_domain_sub_model_part_list" : ["Parts_Parts_Auto1","Parts_Parts_Auto2"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_Displacement_Auto1","Slip2D_Slip_Auto1"],
         "grid_model_import_settings"         : {

--- a/applications/ParticleMechanicsApplication/tests/slip_tests/slip_boundary_test_parameters.json
+++ b/applications/ParticleMechanicsApplication/tests/slip_tests/slip_boundary_test_parameters.json
@@ -24,7 +24,6 @@
         "time_stepping"                      : {
             "time_step" : 0.05
         },
-        "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,

--- a/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle.py
+++ b/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle.py
@@ -51,9 +51,9 @@ class TestGenerateMPMParticle(KratosUnittest.TestCase):
 
         # Initialize solver
         if(dimension==2):
-            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False, False)
+            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", False, False, False, False)
         else:
-            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False, False)
+            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", False, False, False, False)
 
         # Check total number of element
         particle_counter = len(material_model_part.Elements)

--- a/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle.py
+++ b/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle.py
@@ -51,9 +51,9 @@ class TestGenerateMPMParticle(KratosUnittest.TestCase):
 
         # Initialize solver
         if(dimension==2):
-            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", False, False, False, False)
+            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", 20, False, False, False, False)
         else:
-            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", False, False, False, False)
+            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", 20, False, False, False, False)
 
         # Check total number of element
         particle_counter = len(material_model_part.Elements)

--- a/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle.py
+++ b/applications/ParticleMechanicsApplication/tests/test_generate_mpm_particle.py
@@ -51,9 +51,9 @@ class TestGenerateMPMParticle(KratosUnittest.TestCase):
 
         # Initialize solver
         if(dimension==2):
-            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False)
+            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False, False)
         else:
-            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False)
+            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False, False)
 
         # Check total number of element
         particle_counter = len(material_model_part.Elements)

--- a/applications/ParticleMechanicsApplication/tests/test_particle_erase_process.py
+++ b/applications/ParticleMechanicsApplication/tests/test_particle_erase_process.py
@@ -43,7 +43,7 @@ class TestParticleEraseProcess(KratosUnittest.TestCase):
         new_element = KratosParticle.CreateUpdatedLagragian3D8N()
 
         # Initialize solver
-        self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", False, False, False, False)
+        self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", 20, False, False, False, False)
 
     def _create_nodes(self, initial_mp):
         initial_mp.CreateNewNode(1, -0.5, -0.5, 0.0)

--- a/applications/ParticleMechanicsApplication/tests/test_particle_erase_process.py
+++ b/applications/ParticleMechanicsApplication/tests/test_particle_erase_process.py
@@ -43,7 +43,7 @@ class TestParticleEraseProcess(KratosUnittest.TestCase):
         new_element = KratosParticle.CreateUpdatedLagragian3D8N()
 
         # Initialize solver
-        self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False)
+        self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False, False)
 
     def _create_nodes(self, initial_mp):
         initial_mp.CreateNewNode(1, -0.5, -0.5, 0.0)

--- a/applications/ParticleMechanicsApplication/tests/test_particle_erase_process.py
+++ b/applications/ParticleMechanicsApplication/tests/test_particle_erase_process.py
@@ -43,7 +43,7 @@ class TestParticleEraseProcess(KratosUnittest.TestCase):
         new_element = KratosParticle.CreateUpdatedLagragian3D8N()
 
         # Initialize solver
-        self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False, False)
+        self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", False, False, False, False)
 
     def _create_nodes(self, initial_mp):
         initial_mp.CreateNewNode(1, -0.5, -0.5, 0.0)

--- a/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle.py
+++ b/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle.py
@@ -62,9 +62,9 @@ class TestSearchMPMParticle(KratosUnittest.TestCase):
 
         # Initialize solver
         if(dimension==2):
-            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False, False)
+            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", False, False, False, False)
         else:
-            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False, False)
+            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", False, False, False, False)
 
 
     def _create_nodes_structured(self, model_part, dimension, geometry_element):

--- a/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle.py
+++ b/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle.py
@@ -62,9 +62,9 @@ class TestSearchMPMParticle(KratosUnittest.TestCase):
 
         # Initialize solver
         if(dimension==2):
-            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", False, False, False, False)
+            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", 20, False, False, False, False)
         else:
-            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", False, False, False, False)
+            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, "static", 20, False, False, False, False)
 
 
     def _create_nodes_structured(self, model_part, dimension, geometry_element):

--- a/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle.py
+++ b/applications/ParticleMechanicsApplication/tests/test_search_mpm_particle.py
@@ -62,9 +62,9 @@ class TestSearchMPMParticle(KratosUnittest.TestCase):
 
         # Initialize solver
         if(dimension==2):
-            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False)
+            self.solver = KratosParticle.MPM2D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False, False)
         else:
-            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False)
+            self.solver = KratosParticle.MPM3D(grid_model_part, initial_material_model_part, material_model_part, linear_solver, new_element, False, "static", False, False, False)
 
 
     def _create_nodes_structured(self, model_part, dimension, geometry_element):


### PR DESCRIPTION
This PR continues the modification and cleanup done in #3639 and introduces some minor updates as follow:
- compute_reaction and max_iteration for each time step are now linked with solver
- tidy up the MPM_Strategy particularly in generate particle element and prepare for generating particle condition needed (ping: @ga69kid)
- remove some useless default parameters in the solver.
- very minor update of readme.