### PR TITLE
[Core][HotFix] DivideGeometry PrintData method

### DIFF
--- a/kratos/utilities/divide_geometry.cpp
+++ b/kratos/utilities/divide_geometry.cpp
@@ -54,12 +54,8 @@ namespace Kratos
 
         const array_1d<double, 3> point_coords = this->Coordinates();
         std::stringstream coordinates_buffer;
-        std::ostringstream stm;
-        for (unsigned int i = 0; i < 3; ++i) {
-            stm << point_coords(i);
-            coordinates_buffer << stm.str() << " ";
-        }
-        rOStream << "\tCoordinates: " << coordinates_buffer.str() << std::endl;
+        coordinates_buffer << "\tCoordinates: ( " << point_coords(0) << " , " << point_coords(1) << " , " << point_coords(2) << " )";
+        rOStream << coordinates_buffer.str() << std::endl;
     };
 
     /// DivideGeometry implementation


### PR DESCRIPTION
This fixes the misleading info return in PrintData method of the base DivideGeometry.