### PR TITLE
[Meshmoving] correct names in wrapper

### DIFF
--- a/applications/MeshMovingApplication/python_scripts/python_solvers_wrapper_mesh_motion.py
+++ b/applications/MeshMovingApplication/python_scripts/python_solvers_wrapper_mesh_motion.py
@@ -5,38 +5,43 @@ import KratosMultiphysics
 def CreateSolverByParameters(model, solver_settings, parallelism):
 
     solver_type = solver_settings["solver_type"].GetString()
+    if solver_type.startswith("mesh_solver_"):
+        solver_type = solver_type[12:] # remove preceeding "mesh_solver_"
+        depr_msg  = 'Using the old names to construct the MeshSolver\n'
+        depr_msg += 'Please remove the preceeding "mesh_solver_" from "solver_type"'
+        KratosMultiphysics.Logger.PrintWarning("DEPRECATION", depr_msg)
 
     # Solvers for OpenMP parallelism
     if (parallelism == "OpenMP"):
 
-        if (solver_type == "mesh_solver_laplacian"):
+        if (solver_type == "laplacian"):
             solver_module_name = "mesh_solver_laplacian"
 
-        elif (solver_type == "mesh_solver_structural_similarity"):
+        elif (solver_type == "structural_similarity"):
             solver_module_name = "mesh_solver_structural_similarity"
 
         else:
-            err_msg =  "The requested solver type \"" + solver_type + "\" is not in the python solvers wrapper\n"
-            err_msg += "Available options are: \"mesh_solver_laplacian\", \"mesh_solver_structural_similarity\""
+            err_msg =  'The requested solver type "' + solver_type + '" is not in the python solvers wrapper\n'
+            err_msg += 'Available options are: "laplacian", "structural_similarity"'
             raise Exception(err_msg)
 
     # Solvers for MPI parallelism
     elif (parallelism == "MPI"):
 
-        if (solver_type == "mesh_solver_laplacian"):
+        if (solver_type == "laplacian"):
             solver_module_name = "trilinos_mesh_solver_laplacian"
 
-        elif (solver_type == "mesh_solver_structural_similarity"):
+        elif (solver_type == "structural_similarity"):
             solver_module_name = "trilinos_mesh_solver_structural_similarity"
 
         else:
-            err_msg =  "The requested solver type \"" + solver_type + "\" is not in the python solvers wrapper\n"
-            err_msg += "Available options are: \"mesh_solver_laplacian\", \"mesh_solver_structural_similarity\""
+            err_msg =  'The requested solver type "' + solver_type + '" is not in the python solvers wrapper\n'
+            err_msg += 'Available options are: "laplacian", "structural_similarity"'
             raise Exception(err_msg)
 
     else:
-        err_msg =  "The requested parallel type \"" + parallelism + "\" is not available!\n"
-        err_msg += "Available options are: \"OpenMP\", \"MPI\""
+        err_msg =  'The requested parallel type "' + parallelism + '" is not available!\n'
+        err_msg += 'Available options are: "OpenMP", "MPI"'
         raise Exception(err_msg)
 
     solver_module = __import__(solver_module_name)

--- a/applications/MeshMovingApplication/python_scripts/python_solvers_wrapper_mesh_motion.py
+++ b/applications/MeshMovingApplication/python_scripts/python_solvers_wrapper_mesh_motion.py
@@ -6,9 +6,9 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
 
     solver_type = solver_settings["solver_type"].GetString()
     if solver_type.startswith("mesh_solver_"):
-        solver_type = solver_type[12:] # remove preceeding "mesh_solver_"
+        solver_type = solver_type[12:] # remove preceding "mesh_solver_"
         depr_msg  = 'Using the old names to construct the MeshSolver\n'
-        depr_msg += 'Please remove the preceeding "mesh_solver_" from "solver_type"'
+        depr_msg += 'Please remove the preceding "mesh_solver_" from "solver_type"'
         KratosMultiphysics.Logger.PrintWarning("DEPRECATION", depr_msg)
 
     # Solvers for OpenMP parallelism

--- a/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_2d/mpi_rectangle_2D3N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_2d/mpi_rectangle_2D3N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_laplacian",
+        "solver_type" : "laplacian",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_2D3N_test"

--- a/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_2d/mpi_rectangle_2D4N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_2d/mpi_rectangle_2D4N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_laplacian",
+        "solver_type" : "laplacian",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_2D4N_test"

--- a/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_2d/rectangle_2D3N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_2d/rectangle_2D3N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_laplacian",
+        "solver_type" : "laplacian",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_2D3N_test"

--- a/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_2d/rectangle_2D4N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_2d/rectangle_2D4N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_laplacian",
+        "solver_type" : "laplacian",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_2D4N_test"

--- a/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_3d/mpi_rectangle_3D4N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_3d/mpi_rectangle_3D4N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_laplacian",
+        "solver_type" : "laplacian",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_3D4N_test"

--- a/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_3d/mpi_rectangle_3D8N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_3d/mpi_rectangle_3D8N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_laplacian",
+        "solver_type" : "laplacian",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_3D8N_test"

--- a/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_3d/rectangle_3D4N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_3d/rectangle_3D4N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_laplacian",
+        "solver_type" : "laplacian",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_3D4N_test"

--- a/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_3d/rectangle_3D8N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_laplacian_mesh_motion_3d/rectangle_3D8N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_laplacian",
+        "solver_type" : "laplacian",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_3D8N_test"

--- a/applications/MeshMovingApplication/tests/test_structural_mesh_motion_2d/mpi_rectangle_2D3N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_structural_mesh_motion_2d/mpi_rectangle_2D3N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_structural_similarity",
+        "solver_type" : "structural_similarity",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_2D3N_test"

--- a/applications/MeshMovingApplication/tests/test_structural_mesh_motion_2d/mpi_rectangle_2D4N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_structural_mesh_motion_2d/mpi_rectangle_2D4N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_structural_similarity",
+        "solver_type" : "structural_similarity",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_2D4N_test"

--- a/applications/MeshMovingApplication/tests/test_structural_mesh_motion_2d/rectangle_2D3N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_structural_mesh_motion_2d/rectangle_2D3N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_structural_similarity",
+        "solver_type" : "structural_similarity",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_2D3N_test"

--- a/applications/MeshMovingApplication/tests/test_structural_mesh_motion_2d/rectangle_2D4N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_structural_mesh_motion_2d/rectangle_2D4N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_structural_similarity",
+        "solver_type" : "structural_similarity",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_2D4N_test"

--- a/applications/MeshMovingApplication/tests/test_structural_mesh_motion_3d/mpi_rectangle_3D4N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_structural_mesh_motion_3d/mpi_rectangle_3D4N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_structural_similarity",
+        "solver_type" : "structural_similarity",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_3D4N_test"

--- a/applications/MeshMovingApplication/tests/test_structural_mesh_motion_3d/mpi_rectangle_3D8N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_structural_mesh_motion_3d/mpi_rectangle_3D8N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_structural_similarity",
+        "solver_type" : "structural_similarity",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_3D8N_test"

--- a/applications/MeshMovingApplication/tests/test_structural_mesh_motion_3d/rectangle_3D4N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_structural_mesh_motion_3d/rectangle_3D4N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_structural_similarity",
+        "solver_type" : "structural_similarity",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_3D4N_test"

--- a/applications/MeshMovingApplication/tests/test_structural_mesh_motion_3d/rectangle_3D8N_test_parameters.json
+++ b/applications/MeshMovingApplication/tests/test_structural_mesh_motion_3d/rectangle_3D8N_test_parameters.json
@@ -36,7 +36,7 @@
         "Restart_Step"     : 0
     },
     "solver_settings" : {
-        "solver_type" : "mesh_solver_structural_similarity",
+        "solver_type" : "structural_similarity",
         "model_import_settings" : {
             "input_type"     : "mdpa",
             "input_filename" : "test_mdpa_files/rectangle_3D8N_test"


### PR DESCRIPTION
the names in the `python_solvers_wrapper_mesh_motion.py` are quite legacy, they are still the ones from back when we did a direct import with the names.
I.e. I removed the preceding `mesh_solver_`  from the solver-names

**This does not break existing code/examples!!!**
Backwards-compatibility is implemented