### PR TITLE
[PfemFluid] Setting rigid to inlet boundary in process

### DIFF
--- a/applications/PfemFluidDynamicsApplication/custom_processes/set_inlet_process.hpp
+++ b/applications/PfemFluidDynamicsApplication/custom_processes/set_inlet_process.hpp
@@ -107,6 +107,7 @@ public:
       {
 	// count++;
 	i_node->Set(INLET);
+	i_node->Set(RIGID);
 	// std::cout<<"x y ("<<")  "<<i_node->X()<<" "<<i_node->Y();
         // i_node->Set(RIGID);
 	// std::cout<<count<<".  "<<i_node->X()<<std::endl;


### PR DESCRIPTION
Inlet boundary are not defined as rigid in the interface anymore. It is done in C++ process