### PR TITLE
[StructuralMechanics] Fix incorrect use of CalculateMaterialResponse by default and in other cases

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -704,6 +704,22 @@ protected:
         );
 
     /**
+     * @brief This functions updates the data structure passed to the CL
+     * @param rThisKinematicVariables The kinematic variables to be calculated
+     * @param rThisConstitutiveVariables The constitutive variables
+     * @param rValues The CL parameters
+     * @param PointNumber The integration point considered
+     * @param IntegrationPoints The list of integration points
+     */
+    virtual void SetConstitutiveVariables(
+        KinematicVariables& rThisKinematicVariables,
+        ConstitutiveVariables& rThisConstitutiveVariables,
+        ConstitutiveLaw::Parameters& rValues,
+        const IndexType PointNumber,
+        const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+        );
+
+    /**
      * @brief This functions updates the constitutive variables
      * @param rThisKinematicVariables The kinematic variables to be calculated
      * @param rThisConstitutiveVariables The constitutive variables
@@ -718,7 +734,7 @@ protected:
         ConstitutiveLaw::Parameters& rValues,
         const IndexType PointNumber,
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-        const ConstitutiveLaw::StressMeasure ThisStressMeasure
+        const ConstitutiveLaw::StressMeasure ThisStressMeasure = ConstitutiveLaw::StressMeasure_PK2
         );
 
     /**
@@ -903,7 +919,7 @@ private:
     }
 
     /**
-     * @brief This method compues directly in the CL
+     * @brief This method computes directly in the CL
      * @details Avoids code repetition
      * @param rVariable The variable we want to get
      * @param rOutput The values obtained int the integration points
@@ -942,7 +958,7 @@ private:
             this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
 
             // Compute material reponse
-            this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, GetStressMeasure());
+            this->SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
 
             rOutput[point_number] = mConstitutiveLawVector[point_number]->CalculateValue( Values, rVariable, rOutput[point_number] );
         }

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -183,13 +183,12 @@ void SmallDisplacement::CalculateKinematicVariables(
 /***********************************************************************************/
 /***********************************************************************************/
 
-void SmallDisplacement::CalculateConstitutiveVariables(
+void SmallDisplacement::SetConstitutiveVariables(
     KinematicVariables& rThisKinematicVariables,
     ConstitutiveVariables& rThisConstitutiveVariables,
     ConstitutiveLaw::Parameters& rValues,
     const IndexType PointNumber,
-    const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-    const ConstitutiveLaw::StressMeasure ThisStressMeasure
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints
     )
 {
     // Displacements vector
@@ -207,6 +206,22 @@ void SmallDisplacement::CalculateConstitutiveVariables(
     // Here we set the space on which the results shall be written
     rValues.SetConstitutiveMatrix(rThisConstitutiveVariables.D); //assuming the determinant is computed somewhere else
     rValues.SetStressVector(rThisConstitutiveVariables.StressVector); //F computed somewhere else
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void SmallDisplacement::CalculateConstitutiveVariables(
+    KinematicVariables& rThisKinematicVariables,
+    ConstitutiveVariables& rThisConstitutiveVariables,
+    ConstitutiveLaw::Parameters& rValues,
+    const IndexType PointNumber,
+    const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
+    const ConstitutiveLaw::StressMeasure ThisStressMeasure
+    )
+{
+    // Set the constitutive variables
+    SetConstitutiveVariables(rThisKinematicVariables, rThisConstitutiveVariables, rValues, PointNumber, IntegrationPoints);
 
     // Actually do the computations in the ConstitutiveLaw
     mConstitutiveLawVector[PointNumber]->CalculateMaterialResponse(rValues, ThisStressMeasure); //here the calculations are actually done

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.h
@@ -207,8 +207,23 @@ protected:
         const IndexType PointNumber,
         const GeometryType::IntegrationMethod& rIntegrationMethod
         ) override;
+    /**
+     * @brief This functions updates the data structure passed to the CL
+     * @param rThisKinematicVariables The kinematic variables to be calculated
+     * @param rThisConstitutiveVariables The constitutive variables
+     * @param rValues The CL parameters
+     * @param PointNumber The integration point considered
+     * @param IntegrationPoints The list of integration points
+     */
+    void SetConstitutiveVariables(
+        KinematicVariables& rThisKinematicVariables,
+        ConstitutiveVariables& rThisConstitutiveVariables,
+        ConstitutiveLaw::Parameters& rValues,
+        const IndexType PointNumber,
+        const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+        ) override;
 
-     /**
+    /**
      * @brief This functions updates the constitutive variables
      * @param rThisKinematicVariables The kinematic variables to be calculated
      * @param rThisConstitutiveVariables The constitutive variables

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.h
@@ -224,22 +224,39 @@ protected:
             ) override ;
 
     /**
-    * This functions updates the constitutive variables
-    * @param rThisKinematicVariables The kinematic variables to be calculated
-    * @param rThisConstitutiveVariables The constitutive variables
-    * @param rValues The CL parameters
-    * @param PointNumber The integration point considered
-    * @param IntegrationPoints The list of integration points
-    * @param ThisStressMeasure The stress measure considered
-    */
+     * This functions updates the data structure passed to the CL
+     * @param rThisKinematicVariables The kinematic variables to be calculated
+     * @param rThisConstitutiveVariables The constitutive variables
+     * @param rValues The CL parameters
+     * @param PointNumber The integration point considered
+     * @param IntegrationPoints The list of integration points
+     * @param ThisStressMeasure The stress measure considered
+     */
+    void SetConstitutiveVariables(
+        KinematicVariables& rThisKinematicVariables,
+        ConstitutiveVariables& rThisConstitutiveVariables,
+        ConstitutiveLaw::Parameters& rValues,
+        const IndexType PointNumber,
+        const GeometryType::IntegrationPointsArrayType& IntegrationPoints
+        ) override;
+
+    /**
+     * This functions updates the constitutive variables
+     * @param rThisKinematicVariables The kinematic variables to be calculated
+     * @param rThisConstitutiveVariables The constitutive variables
+     * @param rValues The CL parameters
+     * @param PointNumber The integration point considered
+     * @param IntegrationPoints The list of integration points
+     * @param ThisStressMeasure The stress measure considered
+     */
     void CalculateConstitutiveVariables(
-            KinematicVariables& rThisKinematicVariables,
-            ConstitutiveVariables& rThisConstitutiveVariables,
-            ConstitutiveLaw::Parameters& rValues,
-            const IndexType PointNumber,
-            const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-            const ConstitutiveLaw::StressMeasure ThisStressMeasure
-            ) override;
+        KinematicVariables& rThisKinematicVariables,
+        ConstitutiveVariables& rThisConstitutiveVariables,
+        ConstitutiveLaw::Parameters& rValues,
+        const IndexType PointNumber,
+        const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
+        const ConstitutiveLaw::StressMeasure ThisStressMeasure
+        ) override;
 
     /**
     * This functions calculates both the RHS and the LHS


### PR DESCRIPTION
This PR removes the call to ComputeMaterialResponse by default in the base solid element. Also fixes configuration of options in the CalculateValue function of some variables.