### PR TITLE
Fixing a potential deadlock in SendRecv and adding the option to specify message tags.

### DIFF
--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -680,7 +680,7 @@ class DataCommunicator
      *  @param[in] SendTag Message tag for sent values.
      *  @param[out] rRecvValues Received values from rank RecvSource.
      *  @param[in] RecvSource Rank values are expected from.
-     *  @param[in] SendTag Message tag for received values.
+     *  @param[in] RecvTag Message tag for received values.
      */
     virtual void SendRecv(
         const std::vector<int>& rSendValues, const int SendDestination, const int SendTag,
@@ -694,7 +694,7 @@ class DataCommunicator
      *  @param[in] SendTag Message tag for sent values.
      *  @param[out] rRecvValues Received values from rank RecvSource.
      *  @param[in] RecvSource Rank values are expected from.
-     *  @param[in] SendTag Message tag for received values.
+     *  @param[in] RecvTag Message tag for received values.
      */
     virtual void SendRecv(
         const std::vector<double>& rSendValues, const int SendDestination, const int SendTag,
@@ -708,7 +708,7 @@ class DataCommunicator
      *  @param[in] SendTag Message tag for sent values.
      *  @param[out] rRecvValues Received string from rank RecvSource.
      *  @param[in] RecvSource Rank the string is expected from.
-     *  @param[in] SendTag Message tag for received values.
+     *  @param[in] RecvTag Message tag for received values.
      */
     virtual void SendRecv(
         const std::string& rSendValues, const int SendDestination, const int SendTag,

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -677,36 +677,42 @@ class DataCommunicator
     /** This is a wrapper for MPI_Sendrecv.
      *  @param[in] rSendValues Values to send to rank SendDestination.
      *  @param[in] SendDestination Rank the values will be sent to.
+     *  @param[in] SendTag Message tag for sent values.
      *  @param[out] rRecvValues Received values from rank RecvSource.
      *  @param[in] RecvSource Rank values are expected from.
+     *  @param[in] SendTag Message tag for received values.
      */
     virtual void SendRecv(
-        const std::vector<int>& rSendValues, const int SendDestination,
-        std::vector<int>& rRecvValues, const int RecvSource) const
+        const std::vector<int>& rSendValues, const int SendDestination, const int SendTag,
+        std::vector<int>& rRecvValues, const int RecvSource, const int RecvTag) const
     {}
 
     /// Exchange data with other ranks (double version).
     /** This is a wrapper for MPI_Sendrecv.
      *  @param[in] rSendValues Values to send to rank SendDestination.
      *  @param[in] SendDestination Rank the values will be sent to.
+     *  @param[in] SendTag Message tag for sent values.
      *  @param[out] rRecvValues Received values from rank RecvSource.
      *  @param[in] RecvSource Rank values are expected from.
+     *  @param[in] SendTag Message tag for received values.
      */
     virtual void SendRecv(
-        const std::vector<double>& rSendValues, const int SendDestination,
-        std::vector<double>& rRecvValues, const int RecvSource) const
+        const std::vector<double>& rSendValues, const int SendDestination, const int SendTag,
+        std::vector<double>& rRecvValues, const int RecvSource, const int RecvTag) const
     {}
 
     /// Exchange data with other ranks (string version).
     /** This is a wrapper for MPI_Sendrecv.
      *  @param[in] rSendValues String to send to rank SendDestination.
      *  @param[in] SendDestination Rank the string will be sent to.
+     *  @param[in] SendTag Message tag for sent values.
      *  @param[out] rRecvValues Received string from rank RecvSource.
      *  @param[in] RecvSource Rank the string is expected from.
+     *  @param[in] SendTag Message tag for received values.
      */
     virtual void SendRecv(
-        const std::string& rSendValues, const int SendDestination,
-        std::string& rRecvValues, const int RecvSource) const
+        const std::string& rSendValues, const int SendDestination, const int SendTag,
+        std::string& rRecvValues, const int RecvSource, const int RecvTag) const
     {}
 
     // Broadcast

--- a/kratos/mpi/includes/mpi_data_communicator.h
+++ b/kratos/mpi/includes/mpi_data_communicator.h
@@ -219,16 +219,16 @@ class MPIDataCommunicator: public DataCommunicator
         const int RecvSource) const override;
 
     void SendRecv(
-        const std::vector<int>& rSendValues, const int SendDestination,
-        std::vector<int>& rRecvValues, const int RecvSource) const override;
+        const std::vector<int>& rSendValues, const int SendDestination, const int SendTag,
+        std::vector<int>& rRecvValues, const int RecvSource, const int RecvTag) const override;
 
     void SendRecv(
-        const std::vector<double>& rSendValues, const int SendDestination,
-        std::vector<double>& rRecvValues, const int RecvSource) const override;
+        const std::vector<double>& rSendValues, const int SendDestination, const int SendTag,
+        std::vector<double>& rRecvValues, const int RecvSource, const int RecvTag) const override;
 
     void SendRecv(
-        const std::string& rSendValues, const int SendDestination,
-        std::string& rRecvValues, const int RecvSource) const override;
+        const std::string& rSendValues, const int SendDestination, const int SendTag,
+        std::string& rRecvValues, const int RecvSource, const int RecvTag) const override;
 
     // Broadcast
 
@@ -428,8 +428,8 @@ class MPIDataCommunicator: public DataCommunicator
         MPI_Op Operation) const;
 
     template<class TDataType> void SendRecvDetail(
-        const TDataType& rSendMessage, const int SendDestination,
-        TDataType& rRecvMessage, const int RecvSource) const;
+        const TDataType& rSendMessage, const int SendDestination, const int SendTag,
+        TDataType& rRecvMessage, const int RecvSource, const int RecvTag) const;
 
     template<class TDataType> void BroadcastDetail(
         TDataType& rBuffer, const int SourceRank) const;

--- a/kratos/mpi/includes/mpi_data_communicator.h
+++ b/kratos/mpi/includes/mpi_data_communicator.h
@@ -457,10 +457,6 @@ class MPIDataCommunicator: public DataCommunicator
 
     bool IsValidRank(const int Rank) const;
 
-    template<class TDataType> void ValidateSendRecvInput(
-        const TDataType& rSendMessage, const int SendDestination,
-        TDataType& rRecvMessage, const int RecvSource) const;
-
     template<class TDataType> void ValidateScattervInput(
         const TDataType& rSendValues,
         const std::vector<int>& rSendCounts, const std::vector<int>& rSendOffsets,

--- a/kratos/mpi/sources/mpi_data_communicator.cpp
+++ b/kratos/mpi/sources/mpi_data_communicator.cpp
@@ -874,10 +874,6 @@ template<class TDataType> void MPIDataCommunicator::SendRecvDetail(
     const TDataType& rSendMessage, const int SendDestination, const int SendTag,
     TDataType& rRecvMessage, const int RecvSource, const int RecvTag) const
 {
-    //#ifdef KRATOS_DEBUG
-    //ValidateSendRecvInput(rSendMessage, SendDestination, rRecvMessage, RecvSource);
-    //#endif
-
     int ierr = MPI_Sendrecv(
         MPIBuffer(rSendMessage), MPIMessageSize(rSendMessage),
         MPIDatatype(rSendMessage), SendDestination, SendTag,
@@ -1063,65 +1059,6 @@ bool MPIDataCommunicator::IsEqualOnAllRanks(const int LocalValue) const
 bool MPIDataCommunicator::IsValidRank(const int Rank) const
 {
     return (Rank >= 0) && (Rank < Size());
-}
-
-template<class TDataType> void MPIDataCommunicator::ValidateSendRecvInput(
-    const TDataType& rSendMessage, const int SendDestination,
-    TDataType& rRecvMessage, const int RecvSource) const
-{
-    // Check input ranks
-    KRATOS_ERROR_IF_NOT(ErrorIfFalseOnAnyRank(IsValidRank(SendDestination)))
-    << "In call to MPI_Sendrecv: " << SendDestination << " is not a valid rank." << std::endl;
-    KRATOS_ERROR_IF_NOT(ErrorIfFalseOnAnyRank(IsValidRank(RecvSource)))
-    << "In call to MPI_Sendrecv: " << RecvSource << " is not a valid rank." << std::endl;
-
-    // Check that send and recv ranks match
-    const int rank = Rank();
-    const int size = Size();
-    const int buffer_size = (rank == 0) ? size : 0;
-    int send_ranks[buffer_size];
-    int recv_ranks[buffer_size];
-    // These two can be merged, but I want the check to be simple (it is for debug only).
-    int ierr = MPI_Gather(&SendDestination, 1, MPI_INT, send_ranks, 1, MPI_INT, 0, mComm);
-    CheckMPIErrorCode(ierr, "MPI_Gather");
-    ierr = MPI_Gather(&RecvSource, 1, MPI_INT, recv_ranks, 1, MPI_INT, 0, mComm);
-    CheckMPIErrorCode(ierr, "MPI_Gather");
-
-    // No overflow in sent buffer.
-    std::stringstream message;
-    bool failed = false;
-    if (rank == 0)
-    {
-        for (int i = 0; i < size; i++)
-        {
-            if(i != recv_ranks[send_ranks[i]])
-            {
-                message
-                << "Input error in call to MPI_Sendrecv: "
-                << "Rank " << i << " is sending a message to rank " << send_ranks[i]
-                << " but rank " << send_ranks[i] << " expects a message from rank "
-                << recv_ranks[send_ranks[i]] << "." << std::endl;
-                failed = true;
-                break;
-            }
-        }
-    }
-    KRATOS_ERROR_IF(BroadcastErrorIfTrue(failed, 0)) << message.str();
-
-    // Check that message sizes match
-    const int send_tag = 0;
-    const int recv_tag = 0;
-    const int send_size = MPIMessageSize(rSendMessage);
-    int recv_size = 0;
-    const int expected_recv_size = MPIMessageSize(rRecvMessage);
-    ierr = MPI_Sendrecv(
-        &send_size, 1, MPI_INT, SendDestination, send_tag,
-        &recv_size, 1, MPI_INT, RecvSource, recv_tag,
-        mComm, MPI_STATUS_IGNORE);
-    CheckMPIErrorCode(ierr, "MPI_Sendrecv");
-    KRATOS_ERROR_IF(ErrorIfTrueOnAnyRank(recv_size != expected_recv_size))
-    << "Input error in call to MPI_Sendrecv for rank " << Rank() << ": "
-    << "Receiving " << recv_size << " values but " << expected_recv_size << " are expected." << std::endl;
 }
 
 template<class TDataType> void MPIDataCommunicator::ValidateScattervInput(

--- a/kratos/mpi/sources/mpi_data_communicator.cpp
+++ b/kratos/mpi/sources/mpi_data_communicator.cpp
@@ -417,10 +417,10 @@ std::vector<int> MPIDataCommunicator::SendRecv(
 {
     int send_size = rSendValues.size();
     int recv_size;
-    SendRecvDetail(send_size, SendDestination, recv_size, RecvSource);
+    SendRecvDetail(send_size, SendDestination, 0, recv_size, RecvSource, 0);
 
     std::vector<int> recv_values(recv_size);
-    SendRecvDetail(rSendValues, SendDestination, recv_values, RecvSource);
+    SendRecvDetail(rSendValues,SendDestination,0,recv_values,RecvSource,0);
     return recv_values;
 }
 
@@ -431,10 +431,10 @@ std::vector<double> MPIDataCommunicator::SendRecv(
 {
     int send_size = rSendValues.size();
     int recv_size;
-    SendRecvDetail(send_size, SendDestination, recv_size, RecvSource);
+    SendRecvDetail(send_size, SendDestination, 0, recv_size, RecvSource, 0);
 
     std::vector<double> recv_values(recv_size);
-    SendRecvDetail(rSendValues, SendDestination, recv_values, RecvSource);
+    SendRecvDetail(rSendValues,SendDestination,0,recv_values,RecvSource,0);
     return recv_values;
 }
 
@@ -445,33 +445,33 @@ std::string MPIDataCommunicator::SendRecv(
 {
     int send_size = rSendValues.size();
     int recv_size;
-    SendRecvDetail(send_size, SendDestination, recv_size, RecvSource);
+    SendRecvDetail(send_size, SendDestination, 0, recv_size, RecvSource, 0);
 
     std::string recv_values;
     recv_values.resize(recv_size);
-    SendRecvDetail(rSendValues, SendDestination, recv_values, RecvSource);
+    SendRecvDetail(rSendValues,SendDestination,0,recv_values,RecvSource,0);
     return recv_values;
 }
 
 void MPIDataCommunicator::SendRecv(
-    const std::vector<int>& rSendValues, const int SendDestination,
-    std::vector<int>& rRecvValues, const int RecvSource) const
+    const std::vector<int>& rSendValues, const int SendDestination, const int SendTag,
+    std::vector<int>& rRecvValues, const int RecvSource, const int RecvTag) const
 {
-    SendRecvDetail(rSendValues,SendDestination,rRecvValues,RecvSource);
+    SendRecvDetail(rSendValues,SendDestination,SendTag,rRecvValues,RecvSource,RecvTag);
 }
 
 void MPIDataCommunicator::SendRecv(
-    const std::vector<double>& rSendValues, const int SendDestination,
-    std::vector<double>& rRecvValues, const int RecvSource) const
+    const std::vector<double>& rSendValues, const int SendDestination, const int SendTag,
+    std::vector<double>& rRecvValues, const int RecvSource, const int RecvTag) const
 {
-    SendRecvDetail(rSendValues,SendDestination,rRecvValues,RecvSource);
+    SendRecvDetail(rSendValues,SendDestination,SendTag,rRecvValues,RecvSource,RecvTag);
 }
 
 void MPIDataCommunicator::SendRecv(
-        const std::string& rSendValues, const int SendDestination,
-        std::string& rRecvValues, const int RecvSource) const
+        const std::string& rSendValues, const int SendDestination, const int SendTag,
+        std::string& rRecvValues, const int RecvSource, const int RecvTag) const
 {
-    SendRecvDetail(rSendValues,SendDestination,rRecvValues,RecvSource);
+    SendRecvDetail(rSendValues,SendDestination,SendTag,rRecvValues,RecvSource,RecvTag);
 }
 
 // Broadcast
@@ -871,20 +871,18 @@ template<class TDataType> void MPIDataCommunicator::ScanDetail(
 }
 
 template<class TDataType> void MPIDataCommunicator::SendRecvDetail(
-    const TDataType& rSendMessage, const int SendDestination,
-    TDataType& rRecvMessage, const int RecvSource) const
+    const TDataType& rSendMessage, const int SendDestination, const int SendTag,
+    TDataType& rRecvMessage, const int RecvSource, const int RecvTag) const
 {
-    #ifdef KRATOS_DEBUG
-    ValidateSendRecvInput(rSendMessage, SendDestination, rRecvMessage, RecvSource);
-    #endif
-    const int send_tag = 0;
-    const int recv_tag = 0;
+    //#ifdef KRATOS_DEBUG
+    //ValidateSendRecvInput(rSendMessage, SendDestination, rRecvMessage, RecvSource);
+    //#endif
 
     int ierr = MPI_Sendrecv(
         MPIBuffer(rSendMessage), MPIMessageSize(rSendMessage),
-        MPIDatatype(rSendMessage), SendDestination, send_tag,
+        MPIDatatype(rSendMessage), SendDestination, SendTag,
         MPIBuffer(rRecvMessage), MPIMessageSize(rRecvMessage),
-        MPIDatatype(rRecvMessage), RecvSource, recv_tag,
+        MPIDatatype(rRecvMessage), RecvSource, RecvTag,
         mComm, MPI_STATUS_IGNORE);
     CheckMPIErrorCode(ierr, "MPI_Sendrecv");
 }

--- a/kratos/mpi/tests/sources/test_data_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_data_communicator.cpp
@@ -729,7 +729,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvInt, KratosMPICoreFastSuite)
     std::vector<int> recv_buffer = {-1, -1};
 
     // two-buffer version
-    serial_communicator.SendRecv(send_buffer, send_rank, recv_buffer, recv_rank);
+    serial_communicator.SendRecv(send_buffer, send_rank, 0, recv_buffer, recv_rank, 0);
     for (int i = 0; i < 2; i++)
     {
         KRATOS_CHECK_EQUAL(recv_buffer[i], -1);
@@ -766,7 +766,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvDouble, KratosMPICoreFastSuite
     std::vector<double> recv_buffer{-1.0, -1.0};
 
     // two-buffer version
-    serial_communicator.SendRecv(send_buffer, send_rank, recv_buffer, recv_rank);
+    serial_communicator.SendRecv(send_buffer, send_rank, 0, recv_buffer, recv_rank, 0);
     for (int i = 0; i < 2; i++)
     {
         KRATOS_CHECK_EQUAL(recv_buffer[i], -1.0);
@@ -804,7 +804,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvString, KratosMPICoreFastSuite
     std::string recv_buffer("************");
 
     // two-buffer version
-    serial_communicator.SendRecv(send_buffer, send_rank, recv_buffer, recv_rank);
+    serial_communicator.SendRecv(send_buffer, send_rank, 0, recv_buffer, recv_rank, 0);
     KRATOS_CHECK_C_STRING_EQUAL(recv_buffer.c_str(), "************");
 
     // return version

--- a/kratos/mpi/tests/sources/test_mpi_data_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_mpi_data_communicator.cpp
@@ -1014,7 +1014,7 @@ KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvInt, KratosMPICoreFastSuite
     if (world_size > 1)
     {
         // two-buffer version
-        mpi_world_communicator.SendRecv(send_buffer, send_rank, recv_buffer, recv_rank);
+        mpi_world_communicator.SendRecv(send_buffer, send_rank, 0, recv_buffer, recv_rank, 0);
 
         // return version
         std::vector<int> return_buffer = mpi_world_communicator.SendRecv(send_buffer, send_rank, recv_rank);
@@ -1028,22 +1028,6 @@ KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvInt, KratosMPICoreFastSuite
             KRATOS_CHECK_EQUAL(return_buffer[i], expected_recv);
         }
     }
-
-    #ifdef KRATOS_DEBUG
-    if (mpi_world_communicator.Size() > 1)
-    {
-        // One of the ranks has the wrong source/destination
-        int wrong_send_rank = send_rank;
-        if (mpi_world_communicator.Rank() == 0) {
-            wrong_send_rank = 2;
-        }
-        KRATOS_CHECK_EXCEPTION_IS_THROWN(mpi_world_communicator.SendRecv(send_buffer, wrong_send_rank, recv_buffer, recv_rank),"Error:");
-
-        // Input size != output size
-        std::vector<int> local_vector_wrong_size{1,2,3};
-        KRATOS_CHECK_EXCEPTION_IS_THROWN(mpi_world_communicator.SendRecv(local_vector_wrong_size, send_rank, recv_buffer, recv_rank),"Input error in call to MPI_Sendrecv");
-    }
-    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvDouble, KratosMPICoreFastSuite)
@@ -1060,7 +1044,7 @@ KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvDouble, KratosMPICoreFastSu
     if (world_size > 1)
     {
         // two-buffer version
-        mpi_world_communicator.SendRecv(send_buffer, send_rank, recv_buffer, recv_rank);
+        mpi_world_communicator.SendRecv(send_buffer, send_rank, 0, recv_buffer, recv_rank, 0);
 
         // return version
         std::vector<double> return_buffer = mpi_world_communicator.SendRecv(send_buffer, send_rank, recv_rank);
@@ -1074,22 +1058,6 @@ KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvDouble, KratosMPICoreFastSu
             KRATOS_CHECK_EQUAL(return_buffer[i], expected_recv);
         }
     }
-
-    #ifdef KRATOS_DEBUG
-    if (mpi_world_communicator.Size() > 1)
-    {
-        // One of the ranks has the wrong source/destination
-        int wrong_send_rank = send_rank;
-        if (mpi_world_communicator.Rank() == 0) {
-            wrong_send_rank = 2;
-        }
-        KRATOS_CHECK_EXCEPTION_IS_THROWN(mpi_world_communicator.SendRecv(send_buffer, wrong_send_rank, recv_buffer, recv_rank),"Error:");
-
-        // Input size != output size
-        std::vector<double> local_vector_wrong_size{1.0,2.0,3.0};
-        KRATOS_CHECK_EXCEPTION_IS_THROWN(mpi_world_communicator.SendRecv(local_vector_wrong_size, send_rank, recv_buffer, recv_rank),"Input error in call to MPI_Sendrecv");
-    }
-    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvString, KratosMPICoreFastSuite)
@@ -1107,7 +1075,7 @@ KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvString, KratosMPICoreFastSu
     if (world_size > 1)
     {
         // two-buffer version
-        mpi_world_communicator.SendRecv(send_buffer, send_rank, recv_buffer, recv_rank);
+        mpi_world_communicator.SendRecv(send_buffer, send_rank, 0, recv_buffer, recv_rank, 0);
 
         // return version
         std::string return_buffer = mpi_world_communicator.SendRecv(send_buffer, send_rank, recv_rank);
@@ -1116,23 +1084,6 @@ KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvString, KratosMPICoreFastSu
         KRATOS_CHECK_EQUAL(recv_buffer, send_buffer);
         KRATOS_CHECK_EQUAL(return_buffer, send_buffer);
     }
-
-    #ifdef KRATOS_DEBUG
-    if (mpi_world_communicator.Size() > 1)
-    {
-        // One of the ranks has the wrong source/destination
-        int wrong_send_rank = send_rank;
-        if (mpi_world_communicator.Rank() == 0) {
-            wrong_send_rank = 2;
-        }
-        KRATOS_CHECK_EXCEPTION_IS_THROWN(mpi_world_communicator.SendRecv(send_buffer, wrong_send_rank, recv_buffer, recv_rank),"Error:");
-
-        // Input size != output size
-        std::string local_string_wrong_size;
-        local_string_wrong_size.resize(send_buffer.size()+1);
-        KRATOS_CHECK_EXCEPTION_IS_THROWN(mpi_world_communicator.SendRecv(local_string_wrong_size, send_rank, recv_buffer, recv_rank),"Input error in call to MPI_Sendrecv");
-    }
-    #endif
 }
 
 // Broadcast //////////////////////////////////////////////////////////////////


### PR DESCRIPTION
I have just realized I made a design mistake in the debug checks for SendRecv. These checks were made using collective communication operations, but `MPI_Sendrecv` is not a collective operation itself. It is valid to to call `MPI_Sendrecv` only from some (not all) ranks, which will cause a deadlock if I try to use (for example) `MPI_Gather` to validate the input passed to the 'DataCommunictator::SendRecv` wrapper.

In this PR I remove these dangerous checks and add the possibility of specifying the message tags for the two-buffer version of `SendRecv`. I can also add the message tags to the return-buffer version, but I didn't do it for now because I do not know if it is worth the increased complexity in the function signature (if needed, one can always call the "advanced" two-buffer variant anyways). Suggestions on this last point will be especially welcome.