### PR TITLE
[Hotfix][Core] FullDebug line geometries correction

### DIFF
--- a/kratos/geometries/line_2d.h
+++ b/kratos/geometries/line_2d.h
@@ -769,13 +769,13 @@ private:
         const IntegrationPointsContainerType& all_integration_points = AllIntegrationPoints();
         const IntegrationPointsArrayType& IntegrationPoints = all_integration_points[ThisMethod];
         ShapeFunctionsGradientsType DN_De(IntegrationPoints.size());
-        std::fill(DN_De.begin(), DN_De.end(), Matrix(2,1));
 
         for(unsigned int it_gp = 0; it_gp < IntegrationPoints.size(); it_gp++)
         {
-            //	double e = IntegrationPoints[it_gp].X();
-            DN_De[it_gp](0,0) = -0.5;
-            DN_De[it_gp](1,0) =  0.5;
+            Matrix aux_mat = ZeroMatrix(2,1);
+            aux_mat(0,0) = -0.5;
+            aux_mat(1,0) =  0.5;
+            DN_De[it_gp] = aux_mat;
         }
         return DN_De;
 

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -1121,13 +1121,13 @@ private:
         const IntegrationPointsContainerType& all_integration_points = AllIntegrationPoints();
         const IntegrationPointsArrayType& IntegrationPoints = all_integration_points[ThisMethod];
         ShapeFunctionsGradientsType DN_De( IntegrationPoints.size() );
-        std::fill( DN_De.begin(), DN_De.end(), Matrix( 2, 1 ) );
 
         for ( unsigned int it_gp = 0; it_gp < IntegrationPoints.size(); it_gp++ )
         {
-            // double e = IntegrationPoints[it_gp].X();
-            DN_De[it_gp]( 0, 0 ) = -0.5;
-            DN_De[it_gp]( 1, 0 ) =  0.5;
+            Matrix aux_mat = ZeroMatrix(2, 1);
+            aux_mat(0, 0) = -0.5;
+            aux_mat(1, 0) =  0.5;
+            DN_De[it_gp] = aux_mat;
         }
 
         return DN_De;

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -829,13 +829,13 @@ private:
         const IntegrationPointsContainerType& all_integration_points = AllIntegrationPoints();
         const IntegrationPointsArrayType& IntegrationPoints = all_integration_points[ThisMethod];
         ShapeFunctionsGradientsType DN_De( IntegrationPoints.size() );
-        std::fill( DN_De.begin(), DN_De.end(), Matrix( 2, 1 ) );
 
         for ( unsigned int it_gp = 0; it_gp < IntegrationPoints.size(); it_gp++ )
         {
-            // double e = IntegrationPoints[it_gp].X();
-            DN_De[it_gp]( 0, 0 ) = -0.5;
-            DN_De[it_gp]( 1, 0 ) =  0.5;
+            Matrix aux_mat = ZeroMatrix(2,1);
+            aux_mat(0,0) = -0.5;
+            aux_mat(1,0) =  0.5;
+            DN_De[it_gp] = aux_mat;
         }
 
         return DN_De;

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -954,10 +954,12 @@ private:
 
         for ( unsigned int it_gp = 0; it_gp < IntegrationPoints.size(); it_gp++ )
         {
-            double e = IntegrationPoints[it_gp].X();
-            DN_De[it_gp]( 0, 0 ) = e - 0.5;
-            DN_De[it_gp]( 2, 0 ) = -2.0 * e;
-            DN_De[it_gp]( 1, 0 ) = e + 0.5;
+            Matrix aux_mat = ZeroMatrix(3,1);
+            const double e = IntegrationPoints[it_gp].X();
+            aux_mat(0,0) = e - 0.5;
+            aux_mat(2,0) = -2.0 * e;
+            aux_mat(1,0) = e + 0.5;
+            DN_De[it_gp] = aux_mat;
         }
 
         return DN_De;

--- a/kratos/geometries/line_gauss_lobatto_3d_2.h
+++ b/kratos/geometries/line_gauss_lobatto_3d_2.h
@@ -803,13 +803,13 @@ private:
         const IntegrationPointsContainerType& all_integration_points = AllIntegrationPoints();
         const IntegrationPointsArrayType& IntegrationPoints = all_integration_points[ThisMethod];
         ShapeFunctionsGradientsType DN_De( IntegrationPoints.size() );
-        std::fill( DN_De.begin(), DN_De.end(), Matrix( 2, 1 ) );
 
         for ( unsigned int it_gp = 0; it_gp < IntegrationPoints.size(); it_gp++ )
         {
-            // double e = IntegrationPoints[it_gp].X();
-            DN_De[it_gp]( 0, 0 ) = -0.5;
-            DN_De[it_gp]( 1, 0 ) =  0.5;
+            Matrix aux_mat = ZeroMatrix(2,1);
+            aux_mat(0,0) = -0.5;
+            aux_mat(1,0) =  0.5;
+            DN_De[it_gp] = aux_mat;
         }
 
         return DN_De;


### PR DESCRIPTION
Last day we detected that these geometries were causing problems when importing Kratos in FullDebug mode. The problem was that the previous implementation used to fill the shape functions gradient with a given size Matrix before setting the values. The proposed implementation, which goes in the line of the other geometries, do not present this problem since it creates an auxiliary matrix to set de values and then saves it in the shape functions gradients container.