### PR TITLE
Temporaly disabling LTO in custom builds to reduce CI congestion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,11 @@ if(CMAKE_BUILD_TYPE MATCHES FullDebug)
     set(PYBIND11_LTO_LINKER_FLAGS "" CACHE INTERNAL "")
 endif(CMAKE_BUILD_TYPE MATCHES FullDebug)
 
+if(CMAKE_BUILD_TYPE MATCHES Custom)
+    set(PYBIND11_LTO_CXX_FLAGS "" CACHE INTERNAL "")
+    set(PYBIND11_LTO_LINKER_FLAGS "" CACHE INTERNAL "")
+endif(CMAKE_BUILD_TYPE MATCHES Custom)
+
 ######################################################################################
 ######################################################################################
 ######################################################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,14 @@ if(${MSVC})
   message("Detected compiler as MSVC")
   SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /W1 /bigobj /EHsc -DBOOST_ALL_NO_LIB -D_SCL_SECURE_NO_WARNINGS")
   SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W1 /bigobj /EHsc -DBOOST_ALL_NO_LIB -D_SCL_SECURE_NO_WARNINGS")
+
+  # Enable partial symbol linkage only in debug mode. This will make the code only able to run in the machine
+  # it was compiled, but should speedup the linkage.
+  if( ${CMAKE_BUILD_TYPE} MATCHES "Debug" )
+    SET (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Debug:FASTLINK")
+    SET (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Debug:FASTLINK")
+  endif( ${CMAKE_BUILD_TYPE} MATCHES "Debug" )
+
   string( REPLACE "/W3" "" CMAKE_C_FLAGS ${CMAKE_C_FLAGS} )
   string( REPLACE "/W3" "" CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} )
 endif(${MSVC})

--- a/scripts/build/travis/configure_travis_trusty.sh
+++ b/scripts/build/travis/configure_travis_trusty.sh
@@ -143,7 +143,7 @@ CMAKE_BUILD=(
   # Build type
   # NOTE: This is better commented for travis since we don't want to use
   # a default configuration. (-O0 is prefered here)
-  # -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
+  -DCMAKE_BUILD_TYPE="${BUILD_TYPE}"
 
   # Install info
   -DCMAKE_INSTALL_RPATH="${KRATOS_ROOT}/libs"


### PR DESCRIPTION
This is not strictly correct but will hopefully save us some minutes until we have the new CI.
After that I propose to set up a custom flag for enabling or disabling LTO on demand.

Edit: @Hubertus248 found a bug in the travis script and reenabling the custom mode again should speed up the travis build

Edit2: I am trying an new flag in vs15 and vs17 which halves the link time