### PR TITLE
[ThermoMech] using new syntax for PointLocator

### DIFF
--- a/applications/ThermoMechanicalApplication/custom_utilities/particle_levelset_utilities.h
+++ b/applications/ThermoMechanicalApplication/custom_utilities/particle_levelset_utilities.h
@@ -155,7 +155,7 @@ public:
         KRATOS_TRY
 
         array_1d<double, 3 > veulerian;
-        array_1d<double, TDim + 1 > N;
+        Vector N;
         const int max_results = 10000;
         typename BinBasedFastPointLocator<TDim>::ResultContainerType results(max_results);
 
@@ -257,7 +257,7 @@ public:
 	}
         //loop over particles
 	double particle_dist= 0.0;
-        array_1d<double, TDim + 1 > N;
+        Vector N;
         const int max_results = 10000;
         typename BinBasedFastPointLocator<TDim>::ResultContainerType results(max_results);
 
@@ -352,7 +352,7 @@ public:
   {
     KRATOS_TRY;
     double particle_dist = 0.0;
-    array_1d<double, TDim + 1 > N;
+    Vector N;
     const int max_results = 10000;
     typename BinBasedFastPointLocator<TDim>::ResultContainerType results(max_results);
 
@@ -412,7 +412,7 @@ public:
         }
 
         //count particles that fall within an element
-        array_1d<double, TDim + 1 > N;
+        Vector N;
         const int max_results = 10000;
         typename BinBasedFastPointLocator<TDim>::ResultContainerType results(max_results);
         const int nparticles = rLagrangianModelPart.Nodes().size();


### PR DESCRIPTION
Using the new syntax for the BinBasedPointLocator
Otherwise the nightly build has a lot of warnings

@jcotela btw my compiler says that there is some misleading indentation in line 802 and following, you might want to take a look 

~~~
In file included from /home/philipp/software/Kratos_MasterBranch/applications/ThermoMechanicalApplication/custom_python/add_custom_utilities_to_python.cpp:27:0:
/home/philipp/software/Kratos_MasterBranch/applications/ThermoMechanicalApplication/custom_utilities/particle_levelset_utilities.h: In member function ‘void Kratos::ParticleLevelSetUtils<TDim>::ReseedOrDelete2D(Kratos::ModelPart&, Kratos::ModelPart&, double, double)’:
/home/philipp/software/Kratos_MasterBranch/applications/ThermoMechanicalApplication/custom_utilities/particle_levelset_utilities.h:804:5: warning: this ‘for’ clause does not guard... [-Wmisleading-indentation]
     for( int  kkk = ptr_elem_size; kkk>0; kkk-- )
     ^~~
/home/philipp/software/Kratos_MasterBranch/applications/ThermoMechanicalApplication/custom_utilities/particle_levelset_utilities.h:813:8: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the ‘for’
        if(swt )
~~~