### PR TITLE
Bring updates from upstream amgcl

### DIFF
--- a/external_libraries/amgcl/detail/qr.hpp
+++ b/external_libraries/amgcl/detail/qr.hpp
@@ -387,7 +387,8 @@ class QR {
 
             if (math::is_zero(xnorm2)) return tau;
 
-            scalar_type beta = -std::copysign(sqrt(sqr(math::norm(alpha)) + xnorm2), amgcl::detail::real(alpha));
+            scalar_type beta = -std::abs(sqrt(sqr(math::norm(alpha)) + xnorm2));
+            if (amgcl::detail::real(alpha) < 0) beta = -beta;
 
             tau = math::identity<value_type>() - math::inverse(beta) * alpha;
             alpha = math::inverse(alpha - beta * math::identity<value_type>());

--- a/external_libraries/amgcl/mpi/coarsening/runtime.hpp
+++ b/external_libraries/amgcl/mpi/coarsening/runtime.hpp
@@ -53,7 +53,7 @@ enum type {
     smoothed_aggregation
 };
 
-std::ostream& operator<<(std::ostream &os, type s)
+inline std::ostream& operator<<(std::ostream &os, type s)
 {
     switch (s) {
         case aggregation:
@@ -65,7 +65,7 @@ std::ostream& operator<<(std::ostream &os, type s)
     }
 }
 
-std::istream& operator>>(std::istream &in, type &s)
+inline std::istream& operator>>(std::istream &in, type &s)
 {
     std::string val;
     in >> val;

--- a/external_libraries/amgcl/mpi/direct_solver/runtime.hpp
+++ b/external_libraries/amgcl/mpi/direct_solver/runtime.hpp
@@ -62,7 +62,7 @@ enum type {
 #endif
 };
 
-std::ostream& operator<<(std::ostream &os, type s)
+inline std::ostream& operator<<(std::ostream &os, type s)
 {
     switch (s) {
         case skyline_lu:
@@ -82,7 +82,7 @@ std::ostream& operator<<(std::ostream &os, type s)
     }
 }
 
-std::istream& operator>>(std::istream &in, type &s)
+inline std::istream& operator>>(std::istream &in, type &s)
 {
     std::string val;
     in >> val;

--- a/external_libraries/amgcl/mpi/partition/runtime.hpp
+++ b/external_libraries/amgcl/mpi/partition/runtime.hpp
@@ -63,7 +63,7 @@ enum type {
 #endif
 };
 
-std::ostream& operator<<(std::ostream &os, type s)
+inline std::ostream& operator<<(std::ostream &os, type s)
 {
     switch (s) {
         case merge:
@@ -81,7 +81,7 @@ std::ostream& operator<<(std::ostream &os, type s)
     }
 }
 
-std::istream& operator>>(std::istream &in, type &s)
+inline std::istream& operator>>(std::istream &in, type &s)
 {
     std::string val;
     in >> val;


### PR DESCRIPTION
This resolves duplicate declaration linker error when amgcl code is included in several object units. See https://github.com/ddemidov/amgcl/issues/99#issuecomment-450445115. 