### PR TITLE
[FluidDynamicsApplication] Correction for exact distance calculation (OpenMP and MPI)

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -252,12 +252,12 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
                 self.main_model_part,
                 self.linear_solver,
                 maximum_iterations,
-                KratosMultiphysics.ParallelDistanceCalculator2D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
+                KratosMultiphysics.VariationalDistanceCalculationProcess2D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
         else:
             variational_distance_process = KratosMultiphysics.VariationalDistanceCalculationProcess3D(
                 self.main_model_part,
                 self.linear_solver,
                 maximum_iterations,
-                KratosMultiphysics.ParallelDistanceCalculator3D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
+                KratosMultiphysics.VariationalDistanceCalculationProcess3D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
 
         return variational_distance_process

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
@@ -228,13 +228,13 @@ class NavierStokesMPITwoFluidsSolver(navier_stokes_two_fluids_solver.NavierStoke
                 self.computing_model_part,
                 self.trilinos_linear_solver,
                 maximum_iterations,
-                KratosMultiphysics.ParallelDistanceCalculator2D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
+                KratosMultiphysics.VariationalDistanceCalculationProcess2D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
         else:
             variational_distance_process = KratosTrilinos.TrilinosVariationalDistanceCalculationProcess3D(
                 self.EpetraCommunicator,
                 self.computing_model_part,
                 self.trilinos_linear_solver,
                 maximum_iterations,
-                KratosMultiphysics.ParallelDistanceCalculator3D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
+                KratosMultiphysics.VariationalDistanceCalculationProcess3D.CALCULATE_EXACT_DISTANCES_TO_PLANE)
 
         return variational_distance_process

--- a/applications/trilinos_application/custom_processes/trilinos_variational_distance_calculation_process.h
+++ b/applications/trilinos_application/custom_processes/trilinos_variational_distance_calculation_process.h
@@ -60,6 +60,8 @@ class TrilinosVariationalDistanceCalculationProcess
 {
 public:
 
+    KRATOS_DEFINE_LOCAL_FLAG(CALCULATE_EXACT_DISTANCES_TO_PLANE);
+
     ///@name Type Definitions
     ///@{
 
@@ -83,8 +85,9 @@ public:
         Epetra_MpiComm &rComm,
         ModelPart &base_model_part,
         LinearSolverPointerType plinear_solver,
-        unsigned int max_iterations = 10)
-        : VariationalDistanceCalculationProcess<TDim, TSparseSpace, TDenseSpace, TLinearSolver>(base_model_part, max_iterations),
+        unsigned int max_iterations = 10,
+        Flags Options = NOT_CALCULATE_EXACT_DISTANCES_TO_PLANE)
+        : VariationalDistanceCalculationProcess<TDim, TSparseSpace, TDenseSpace, TLinearSolver>(base_model_part, max_iterations, Options),
         mrComm(rComm)
     {
 
@@ -465,5 +468,3 @@ private:
 }  // namespace Kratos.
 
 #endif // KRATOS_TRILINOS_VARIATIONAL_DISTANCE_CALCULATION_PROCESS_INCLUDED  defined
-
-

--- a/applications/trilinos_application/custom_python/add_trilinos_processes_to_python.cpp
+++ b/applications/trilinos_application/custom_python/add_trilinos_processes_to_python.cpp
@@ -66,12 +66,12 @@ void AddProcesses(pybind11::module& m)
 
     typedef TrilinosVariationalDistanceCalculationProcess<2,TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType> TrilinosDistanceCalculationType2D;
     py::class_<TrilinosDistanceCalculationType2D, TrilinosDistanceCalculationType2D::Pointer, BaseDistanceCalculationType2D >(m,"TrilinosVariationalDistanceCalculationProcess2D")
-        .def(py::init<Epetra_MpiComm&, ModelPart&, TrilinosLinearSolverType::Pointer, unsigned int>())
+        .def(py::init<Epetra_MpiComm&, ModelPart&, TrilinosLinearSolverType::Pointer, unsigned int, Flags>())
         ;
 
     typedef TrilinosVariationalDistanceCalculationProcess<3,TrilinosSparseSpaceType, TrilinosLocalSpaceType, TrilinosLinearSolverType> TrilinosDistanceCalculationType3D;
     py::class_<TrilinosDistanceCalculationType3D, TrilinosDistanceCalculationType3D::Pointer, BaseDistanceCalculationType3D >(m,"TrilinosVariationalDistanceCalculationProcess3D")
-        .def(py::init<Epetra_MpiComm&, ModelPart&, TrilinosLinearSolverType::Pointer, unsigned int>())
+        .def(py::init<Epetra_MpiComm&, ModelPart&, TrilinosLinearSolverType::Pointer, unsigned int, Flags>())
         ;
 
     // Level set convection processes

--- a/kratos/processes/variational_distance_calculation_process.h
+++ b/kratos/processes/variational_distance_calculation_process.h
@@ -265,7 +265,7 @@ public:
                 else {
                     if(TDim==3){
                         GeometryUtils::CalculateTetrahedraDistances(geom, distances);
-                    } 
+                    }
                     else {
                         GeometryUtils::CalculateTriangleDistances(geom, distances);
                     }
@@ -405,8 +405,9 @@ protected:
     /// Minimal constructor for derived classes
     VariationalDistanceCalculationProcess(
         ModelPart &base_model_part,
-        unsigned int max_iterations)
-        : mr_base_model_part(base_model_part)
+        unsigned int max_iterations,
+        Flags Options = NOT_CALCULATE_EXACT_DISTANCES_TO_PLANE)
+        : mr_base_model_part(base_model_part), mOptions(Options)
     {
         mdistance_part_is_initialized = false;
         mmax_iterations = max_iterations;
@@ -658,5 +659,3 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }  // namespace Kratos.
 
 #endif // KRATOS_VARIATIONAL_DISTANCE_CALCULATION_PROCESS_INCLUDED  defined
-
-


### PR DESCRIPTION
The following corrections are suggested to make the exact distance calculation from #3571 available for the MPI version of the VariationalDistanceCalculationProcess.

- Adding correct flags to the python solver implementations
- Adding flag arguments to the correct constructors 

Test were re-conducted for the MPI implementation with the following results (solved with MultilevelSolver)

fig1: without flag for correct calculation
fig2: with flag for correct calculation

![uncorrectedmpi](https://user-images.githubusercontent.com/45034120/50577637-90ab3500-0e2c-11e9-87fa-5c786c11ec67.png)
![correctedmpi](https://user-images.githubusercontent.com/45034120/50577642-930d8f00-0e2c-11e9-8797-d3ccfd681c4f.png)