### PR TITLE
[Core] Removing deprecated OMP operations in FastTransferBetweenModelPartsProcess

### DIFF
--- a/kratos/processes/fast_transfer_between_model_parts_process.cpp
+++ b/kratos/processes/fast_transfer_between_model_parts_process.cpp
@@ -111,13 +111,6 @@ void FastTransferBetweenModelPartsProcess::TransferWithoutFlags()
 
 void FastTransferBetweenModelPartsProcess::TransferWithFlags()
 {
-    // Creating a buffer for parallel vector fill
-    const int num_threads = OpenMPUtils::GetNumThreads();
-    std::vector<NodesArrayType> nodes_buffer_vector(num_threads);
-    std::vector<ElementsArrayType> elements_buffer_vector(num_threads);
-    std::vector<ConditionsArrayType> conditions_buffer_vector(num_threads);
-    std::vector<MasterSlaveConstraintArrayType> constraints_buffer_vector(num_threads);
-
     // Auxiliar sizes
     const int num_nodes = static_cast<int>(mrOriginModelPart.Nodes().size());
     const int num_elements = static_cast<int>(mrOriginModelPart.Elements().size());
@@ -126,75 +119,79 @@ void FastTransferBetweenModelPartsProcess::TransferWithFlags()
 
     #pragma omp parallel
     {
-        const int thread_id = OpenMPUtils::ThisThread();
+        // Creating a buffer for parallel vector fill
+        NodesArrayType nodes_buffer_vector;
+        ElementsArrayType elements_buffer_vector;
+        ConditionsArrayType conditions_buffer_vector;
+        MasterSlaveConstraintArrayType constraints_buffer_vector;
 
         if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
+            const auto it_node_begin = mrOriginModelPart.NodesBegin();
             #pragma omp for
             for(int i = 0; i < num_nodes; ++i) {
-                auto it_node = mrOriginModelPart.NodesBegin() + i;
+                auto it_node = it_node_begin + i;
                 if (it_node->Is(mFlag)) {
-                    (nodes_buffer_vector[thread_id]).insert((nodes_buffer_vector[thread_id]).begin(), *(it_node.base()));
+                    nodes_buffer_vector.insert(nodes_buffer_vector.begin(), *(it_node.base()));
                 }
             }
         }
 
         if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS)) {
+            const auto it_elem_begin = mrOriginModelPart.ElementsBegin();
             #pragma omp for
             for(int i = 0; i < num_elements; ++i) {
-                auto it_elem = mrOriginModelPart.ElementsBegin() + i;
+                auto it_elem = it_elem_begin + i;
                 if (it_elem->Is(mFlag)) {
-                    (elements_buffer_vector[thread_id]).insert((elements_buffer_vector[thread_id]).begin(), *(it_elem.base()));
+                    elements_buffer_vector.insert(elements_buffer_vector.begin(), *(it_elem.base()));
                 }
             }
         }
 
         if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
+            const auto it_cond_begin = mrOriginModelPart.ConditionsBegin();
             #pragma omp for
             for(int i = 0; i < num_conditions; ++i) {
-                auto it_cond = mrOriginModelPart.ConditionsBegin() + i;
+                auto it_cond = it_cond_begin + i;
                 if (it_cond->Is(mFlag)) {
-                    (conditions_buffer_vector[thread_id]).insert((conditions_buffer_vector[thread_id]).begin(), *(it_cond.base()));
+                    conditions_buffer_vector.insert(conditions_buffer_vector.begin(), *(it_cond.base()));
                 }
             }
         }
 
         if (num_constraints != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONSTRAINTS || mEntity == EntityTransfered::NODESANDCONSTRAINTS)) {
+            const auto it_const_begin = mrOriginModelPart.MasterSlaveConstraintsBegin();
             #pragma omp for
             for(int i = 0; i < num_constraints; ++i) {
-                auto it_const = mrOriginModelPart.MasterSlaveConstraintsBegin() + i;
+                auto it_const = it_const_begin + i;
                 if (it_const->Is(mFlag)) {
-                    (constraints_buffer_vector[thread_id]).insert((constraints_buffer_vector[thread_id]).begin(), *(it_const.base()));
+                    constraints_buffer_vector.insert(constraints_buffer_vector.begin(), *(it_const.base()));
                 }
             }
         }
 
         // We transfer
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS))
-                for( auto& node_buffer_vector : nodes_buffer_vector)
-                    mrDestinationModelPart.AddNodes(node_buffer_vector.begin(),node_buffer_vector.end());
+                mrDestinationModelPart.AddNodes(nodes_buffer_vector.begin(),nodes_buffer_vector.end());
         }
 
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS))
-                for( auto& element_buffer_vector : elements_buffer_vector)
-                    mrDestinationModelPart.AddElements(element_buffer_vector.begin(),element_buffer_vector.end());
+                mrDestinationModelPart.AddElements(elements_buffer_vector.begin(),elements_buffer_vector.end());
         }
 
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS))
-                for( auto& condition_buffer_vector : conditions_buffer_vector)
-                    mrDestinationModelPart.AddConditions(condition_buffer_vector.begin(),condition_buffer_vector.end());
+                mrDestinationModelPart.AddConditions(conditions_buffer_vector.begin(),conditions_buffer_vector.end());
         }
 
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_constraints != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONSTRAINTS || mEntity == EntityTransfered::NODESANDCONSTRAINTS))
-                for( auto& constraint_buffer_vector : constraints_buffer_vector)
-                    mrDestinationModelPart.AddMasterSlaveConstraints(constraint_buffer_vector.begin(),constraint_buffer_vector.end());
+                mrDestinationModelPart.AddMasterSlaveConstraints(constraints_buffer_vector.begin(),constraints_buffer_vector.end());
         }
     }
 }
@@ -205,20 +202,24 @@ void FastTransferBetweenModelPartsProcess::TransferWithFlags()
 void FastTransferBetweenModelPartsProcess::ReorderAllIds(ModelPart& rThisModelPart)
 {
     NodesArrayType& nodes_array = rThisModelPart.Nodes();
-    for(SizeType i = 0; i < nodes_array.size(); ++i)
-        (nodes_array.begin() + i)->SetId(i + 1);
+    const auto it_node_begin = nodes_array.begin();
+    for(IndexType i = 0; i < nodes_array.size(); ++i)
+        (it_node_begin + i)->SetId(i + 1);
 
     ElementsArrayType& element_array = rThisModelPart.Elements();
-    for(SizeType i = 0; i < element_array.size(); ++i)
-        (element_array.begin() + i)->SetId(i + 1);
+    const auto it_elem_begin = element_array.begin();
+    for(IndexType i = 0; i < element_array.size(); ++i)
+        (it_elem_begin + i)->SetId(i + 1);
 
     ConditionsArrayType& condition_array = rThisModelPart.Conditions();
-    for(SizeType i = 0; i < condition_array.size(); ++i)
-        (condition_array.begin() + i)->SetId(i + 1);
+    const auto it_cond_begin = condition_array.begin();
+    for(IndexType i = 0; i < condition_array.size(); ++i)
+        (it_cond_begin + i)->SetId(i + 1);
 
     MasterSlaveConstraintArrayType& constraint_array = rThisModelPart.MasterSlaveConstraints();
-    for(SizeType i = 0; i < constraint_array.size(); ++i)
-        (constraint_array.begin() + i)->SetId(i + 1);
+    const auto it_const_begin = constraint_array.begin();
+    for(IndexType i = 0; i < constraint_array.size(); ++i)
+        (it_const_begin + i)->SetId(i + 1);
 }
 
 /***********************************************************************************/
@@ -226,13 +227,6 @@ void FastTransferBetweenModelPartsProcess::ReorderAllIds(ModelPart& rThisModelPa
 
 void FastTransferBetweenModelPartsProcess::ReplicateWithoutFlags()
 {
-    // Creating a buffer for parallel vector fill
-    const int num_threads = OpenMPUtils::GetNumThreads();
-    std::vector<NodesArrayType> nodes_buffer_vector(num_threads);
-    std::vector<ElementsArrayType> elements_buffer_vector(num_threads);
-    std::vector<ConditionsArrayType> conditions_buffer_vector(num_threads);
-    std::vector<MasterSlaveConstraintArrayType> constraints_buffer_vector(num_threads);
-
     // Reordering ids (necessary for consistency)
     ModelPart& root_model_part = mrOriginModelPart.GetRootModelPart();
     ReorderAllIds(root_model_part);
@@ -249,72 +243,76 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithoutFlags()
 
     #pragma omp parallel
     {
-        const int thread_id = OpenMPUtils::ThisThread();
+        // Creating a buffer for parallel vector fill
+        NodesArrayType nodes_buffer_vector;
+        ElementsArrayType elements_buffer_vector;
+        ConditionsArrayType conditions_buffer_vector;
+        MasterSlaveConstraintArrayType constraints_buffer_vector;
 
         if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
+            const auto it_node_begin = mrOriginModelPart.NodesBegin();
             #pragma omp for
             for(int i = 0; i < num_nodes; ++i) {
-                auto it_node = mrOriginModelPart.NodesBegin() + i;
+                auto it_node = it_node_begin + i;
                 NodeType::Pointer p_new_node = it_node->Clone();
                 p_new_node->SetId(total_num_nodes + i + 1);
-                (nodes_buffer_vector[thread_id]).insert((nodes_buffer_vector[thread_id]).begin(), p_new_node);
+                nodes_buffer_vector.insert(nodes_buffer_vector.begin(), p_new_node);
             }
         }
 
         if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS)) {
+            const auto it_elem_begin = mrOriginModelPart.ElementsBegin();
             #pragma omp for
             for(int i = 0; i < num_elements; ++i) {
-                auto it_elem = mrOriginModelPart.ElementsBegin() + i;
+                auto it_elem = it_elem_begin + i;
                 Element::Pointer p_new_elem = it_elem->Clone(total_num_elements + i + 1, it_elem->GetGeometry());
-                (elements_buffer_vector[thread_id]).insert((elements_buffer_vector[thread_id]).begin(), p_new_elem);
+                elements_buffer_vector.insert(elements_buffer_vector.begin(), p_new_elem);
             }
         }
 
         if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
+            const auto it_cond_begin = mrOriginModelPart.ConditionsBegin();
             #pragma omp for
             for(int i = 0; i < num_conditions; ++i) {
-                auto it_cond = mrOriginModelPart.ConditionsBegin() + i;
+                auto it_cond = it_cond_begin + i;
                 Condition::Pointer p_new_cond = it_cond->Clone(total_num_conditions + i + 1, it_cond->GetGeometry());
-                (conditions_buffer_vector[thread_id]).insert((conditions_buffer_vector[thread_id]).begin(), p_new_cond);
+                conditions_buffer_vector.insert(conditions_buffer_vector.begin(), p_new_cond);
             }
         }
 
         if (num_constraints != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONSTRAINTS || mEntity == EntityTransfered::NODESANDCONSTRAINTS)) {
+            const auto it_const_begin = mrOriginModelPart.MasterSlaveConstraintsBegin();
             #pragma omp for
             for(int i = 0; i < num_constraints; ++i) {
-                auto it_const = mrOriginModelPart.MasterSlaveConstraintsBegin() + i;
+                auto it_const = it_const_begin + i;
                 MasterSlaveConstraint::Pointer p_new_const = it_const->Clone(total_num_constraints + i + 1);
-                (constraints_buffer_vector[thread_id]).insert((constraints_buffer_vector[thread_id]).begin(), p_new_const);
+                constraints_buffer_vector.insert(constraints_buffer_vector.begin(), p_new_const);
             }
         }
 
         // We add to the model part
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS))
-                for( auto& node_buffer_vector : nodes_buffer_vector)
-                    mrDestinationModelPart.AddNodes(node_buffer_vector.begin(),node_buffer_vector.end());
+                mrDestinationModelPart.AddNodes(nodes_buffer_vector.begin(),nodes_buffer_vector.end());
         }
 
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS))
-                for( auto& element_buffer_vector : elements_buffer_vector)
-                    mrDestinationModelPart.AddElements(element_buffer_vector.begin(),element_buffer_vector.end());
+                mrDestinationModelPart.AddElements(elements_buffer_vector.begin(),elements_buffer_vector.end());
         }
 
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS))
-                for( auto& condition_buffer_vector : conditions_buffer_vector)
-                    mrDestinationModelPart.AddConditions(condition_buffer_vector.begin(),condition_buffer_vector.end());
+                mrDestinationModelPart.AddConditions(conditions_buffer_vector.begin(),conditions_buffer_vector.end());
         }
 
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_constraints != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONSTRAINTS || mEntity == EntityTransfered::NODESANDCONSTRAINTS))
-                for( auto& constraint_buffer_vector : constraints_buffer_vector)
-                    mrDestinationModelPart.AddMasterSlaveConstraints(constraint_buffer_vector.begin(),constraint_buffer_vector.end());
+                mrDestinationModelPart.AddMasterSlaveConstraints(constraints_buffer_vector.begin(),constraints_buffer_vector.end());
         }
     }
 }
@@ -324,13 +322,6 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithoutFlags()
 
 void FastTransferBetweenModelPartsProcess::ReplicateWithFlags()
 {
-    // Creating a buffer for parallel vector fill
-    const int num_threads = OpenMPUtils::GetNumThreads();
-    std::vector<NodesArrayType> nodes_buffer_vector(num_threads);
-    std::vector<ElementsArrayType> elements_buffer_vector(num_threads);
-    std::vector<ConditionsArrayType> conditions_buffer_vector(num_threads);
-    std::vector<MasterSlaveConstraintArrayType> constraints_buffer_vector(num_threads);
-
     // Reordering ids (necessary for consistency)
     ModelPart& root_model_part = mrOriginModelPart.GetRootModelPart();
     ReorderAllIds(root_model_part);
@@ -347,80 +338,84 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithFlags()
 
     #pragma omp parallel
     {
-        const int thread_id = OpenMPUtils::ThisThread();
+        // Creating a buffer for parallel vector fill
+        NodesArrayType nodes_buffer_vector;
+        ElementsArrayType elements_buffer_vector;
+        ConditionsArrayType conditions_buffer_vector;
+        MasterSlaveConstraintArrayType constraints_buffer_vector;
 
         if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
+            const auto it_node_begin = mrOriginModelPart.NodesBegin();
             #pragma omp for
             for(int i = 0; i < num_nodes; ++i) {
-                auto it_node = mrOriginModelPart.NodesBegin() + i;
+                auto it_node = it_node_begin + i;
                 if (it_node->Is(mFlag)) {
                     NodeType::Pointer p_new_node = it_node->Clone();
                     p_new_node->SetId(total_num_nodes + i + 1);
-                    (nodes_buffer_vector[thread_id]).insert((nodes_buffer_vector[thread_id]).begin(), p_new_node);
+                    (nodes_buffer_vector).insert(nodes_buffer_vector.begin(), p_new_node);
                 }
             }
         }
 
         if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS)) {
+            const auto it_elem_begin = mrOriginModelPart.ElementsBegin();
             #pragma omp for
             for(int i = 0; i < num_elements; ++i) {
-                auto it_elem = mrOriginModelPart.ElementsBegin() + i;
+                auto it_elem = it_elem_begin + i;
                 if (it_elem->Is(mFlag)) {
                     Element::Pointer p_new_elem = it_elem->Clone(total_num_elements + i + 1, it_elem->GetGeometry());
-                    (elements_buffer_vector[thread_id]).insert((elements_buffer_vector[thread_id]).begin(), p_new_elem);
+                    (elements_buffer_vector).insert(elements_buffer_vector.begin(), p_new_elem);
                 }
             }
         }
 
         if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
+            const auto it_cond_begin = mrOriginModelPart.ConditionsBegin();
             #pragma omp for
             for(int i = 0; i < num_conditions; ++i) {
-                auto it_cond = mrOriginModelPart.ConditionsBegin() + i;
+                auto it_cond = it_cond_begin + i;
                 if (it_cond->Is(mFlag)) {
                     Condition::Pointer p_new_cond = it_cond->Clone(total_num_conditions + i + 1, it_cond->GetGeometry());
-                    (conditions_buffer_vector[thread_id]).insert((conditions_buffer_vector[thread_id]).begin(), p_new_cond);
+                    (conditions_buffer_vector).insert(conditions_buffer_vector.begin(), p_new_cond);
                 }
             }
         }
 
         if (num_constraints != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONSTRAINTS || mEntity == EntityTransfered::NODESANDCONSTRAINTS)) {
+            const auto it_const_begin = mrOriginModelPart.MasterSlaveConstraintsBegin();
             #pragma omp for
             for(int i = 0; i < num_constraints; ++i) {
-                auto it_const = mrOriginModelPart.MasterSlaveConstraintsBegin() + i;
+                auto it_const = it_const_begin + i;
                 if (it_const->Is(mFlag)) {
                     MasterSlaveConstraint::Pointer p_new_const = it_const->Clone(total_num_constraints + i + 1);
-                    (constraints_buffer_vector[thread_id]).insert((constraints_buffer_vector[thread_id]).begin(), p_new_const);
+                    (constraints_buffer_vector).insert(constraints_buffer_vector.begin(), p_new_const);
                 }
             }
         }
 
         // We add to the model part
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS))
-                for( auto& node_buffer_vector : nodes_buffer_vector)
-                    mrDestinationModelPart.AddNodes(node_buffer_vector.begin(),node_buffer_vector.end());
+                mrDestinationModelPart.AddNodes(nodes_buffer_vector.begin(),nodes_buffer_vector.end());
         }
 
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS))
-                for( auto& element_buffer_vector : elements_buffer_vector)
-                    mrDestinationModelPart.AddElements(element_buffer_vector.begin(),element_buffer_vector.end());
+                mrDestinationModelPart.AddElements(elements_buffer_vector.begin(),elements_buffer_vector.end());
         }
 
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS))
-                for( auto& condition_buffer_vector : conditions_buffer_vector)
-                    mrDestinationModelPart.AddConditions(condition_buffer_vector.begin(),condition_buffer_vector.end());
+                mrDestinationModelPart.AddConditions(conditions_buffer_vector.begin(),conditions_buffer_vector.end());
         }
 
-        #pragma omp single
+        #pragma omp critical
         {
             if (num_constraints != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONSTRAINTS || mEntity == EntityTransfered::NODESANDCONSTRAINTS))
-                for( auto& constraint_buffer_vector : constraints_buffer_vector)
-                    mrDestinationModelPart.AddMasterSlaveConstraints(constraint_buffer_vector.begin(),constraint_buffer_vector.end());
+                mrDestinationModelPart.AddMasterSlaveConstraints(constraints_buffer_vector.begin(),constraints_buffer_vector.end());
         }
     }
 }

--- a/kratos/processes/fast_transfer_between_model_parts_process.cpp
+++ b/kratos/processes/fast_transfer_between_model_parts_process.cpp
@@ -174,22 +174,13 @@ void FastTransferBetweenModelPartsProcess::TransferWithFlags()
         {
             if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS))
                 mrDestinationModelPart.AddNodes(nodes_buffer_vector.begin(),nodes_buffer_vector.end());
-        }
 
-        #pragma omp critical
-        {
             if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS))
                 mrDestinationModelPart.AddElements(elements_buffer_vector.begin(),elements_buffer_vector.end());
-        }
 
-        #pragma omp critical
-        {
             if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS))
                 mrDestinationModelPart.AddConditions(conditions_buffer_vector.begin(),conditions_buffer_vector.end());
-        }
 
-        #pragma omp critical
-        {
             if (num_constraints != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONSTRAINTS || mEntity == EntityTransfered::NODESANDCONSTRAINTS))
                 mrDestinationModelPart.AddMasterSlaveConstraints(constraints_buffer_vector.begin(),constraints_buffer_vector.end());
         }
@@ -295,22 +286,13 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithoutFlags()
         {
             if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS))
                 mrDestinationModelPart.AddNodes(nodes_buffer_vector.begin(),nodes_buffer_vector.end());
-        }
 
-        #pragma omp critical
-        {
             if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS))
                 mrDestinationModelPart.AddElements(elements_buffer_vector.begin(),elements_buffer_vector.end());
-        }
 
-        #pragma omp critical
-        {
             if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS))
                 mrDestinationModelPart.AddConditions(conditions_buffer_vector.begin(),conditions_buffer_vector.end());
-        }
 
-        #pragma omp critical
-        {
             if (num_constraints != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONSTRAINTS || mEntity == EntityTransfered::NODESANDCONSTRAINTS))
                 mrDestinationModelPart.AddMasterSlaveConstraints(constraints_buffer_vector.begin(),constraints_buffer_vector.end());
         }
@@ -398,22 +380,13 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithFlags()
         {
             if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS))
                 mrDestinationModelPart.AddNodes(nodes_buffer_vector.begin(),nodes_buffer_vector.end());
-        }
 
-        #pragma omp critical
-        {
             if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS))
                 mrDestinationModelPart.AddElements(elements_buffer_vector.begin(),elements_buffer_vector.end());
-        }
 
-        #pragma omp critical
-        {
             if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS))
                 mrDestinationModelPart.AddConditions(conditions_buffer_vector.begin(),conditions_buffer_vector.end());
-        }
 
-        #pragma omp critical
-        {
             if (num_constraints != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONSTRAINTS || mEntity == EntityTransfered::NODESANDCONSTRAINTS))
                 mrDestinationModelPart.AddMasterSlaveConstraints(constraints_buffer_vector.begin(),constraints_buffer_vector.end());
         }

--- a/kratos/processes/fast_transfer_between_model_parts_process.cpp
+++ b/kratos/processes/fast_transfer_between_model_parts_process.cpp
@@ -127,7 +127,7 @@ void FastTransferBetweenModelPartsProcess::TransferWithFlags()
 
         if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
             const auto it_node_begin = mrOriginModelPart.NodesBegin();
-            #pragma omp for
+            #pragma omp for schedule(guided, 512) nowait
             for(int i = 0; i < num_nodes; ++i) {
                 auto it_node = it_node_begin + i;
                 if (it_node->Is(mFlag)) {
@@ -138,7 +138,7 @@ void FastTransferBetweenModelPartsProcess::TransferWithFlags()
 
         if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS)) {
             const auto it_elem_begin = mrOriginModelPart.ElementsBegin();
-            #pragma omp for
+            #pragma omp for schedule(guided, 512) nowait
             for(int i = 0; i < num_elements; ++i) {
                 auto it_elem = it_elem_begin + i;
                 if (it_elem->Is(mFlag)) {
@@ -149,7 +149,7 @@ void FastTransferBetweenModelPartsProcess::TransferWithFlags()
 
         if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
             const auto it_cond_begin = mrOriginModelPart.ConditionsBegin();
-            #pragma omp for
+            #pragma omp for schedule(guided, 512) nowait
             for(int i = 0; i < num_conditions; ++i) {
                 auto it_cond = it_cond_begin + i;
                 if (it_cond->Is(mFlag)) {
@@ -251,7 +251,7 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithoutFlags()
 
         if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
             const auto it_node_begin = mrOriginModelPart.NodesBegin();
-            #pragma omp for
+            #pragma omp for schedule(guided, 512) nowait
             for(int i = 0; i < num_nodes; ++i) {
                 auto it_node = it_node_begin + i;
                 NodeType::Pointer p_new_node = it_node->Clone();
@@ -262,7 +262,7 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithoutFlags()
 
         if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS)) {
             const auto it_elem_begin = mrOriginModelPart.ElementsBegin();
-            #pragma omp for
+            #pragma omp for schedule(guided, 512) nowait
             for(int i = 0; i < num_elements; ++i) {
                 auto it_elem = it_elem_begin + i;
                 Element::Pointer p_new_elem = it_elem->Clone(total_num_elements + i + 1, it_elem->GetGeometry());
@@ -272,7 +272,7 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithoutFlags()
 
         if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
             const auto it_cond_begin = mrOriginModelPart.ConditionsBegin();
-            #pragma omp for
+            #pragma omp for schedule(guided, 512) nowait
             for(int i = 0; i < num_conditions; ++i) {
                 auto it_cond = it_cond_begin + i;
                 Condition::Pointer p_new_cond = it_cond->Clone(total_num_conditions + i + 1, it_cond->GetGeometry());
@@ -346,7 +346,7 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithFlags()
 
         if (num_nodes != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::NODES || mEntity == EntityTransfered::NODESANDELEMENTS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
             const auto it_node_begin = mrOriginModelPart.NodesBegin();
-            #pragma omp for
+            #pragma omp for schedule(guided, 512) nowait
             for(int i = 0; i < num_nodes; ++i) {
                 auto it_node = it_node_begin + i;
                 if (it_node->Is(mFlag)) {
@@ -359,7 +359,7 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithFlags()
 
         if (num_elements != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::ELEMENTS || mEntity == EntityTransfered::NODESANDELEMENTS)) {
             const auto it_elem_begin = mrOriginModelPart.ElementsBegin();
-            #pragma omp for
+            #pragma omp for schedule(guided, 512) nowait
             for(int i = 0; i < num_elements; ++i) {
                 auto it_elem = it_elem_begin + i;
                 if (it_elem->Is(mFlag)) {
@@ -371,7 +371,7 @@ void FastTransferBetweenModelPartsProcess::ReplicateWithFlags()
 
         if (num_conditions != 0 && (mEntity == EntityTransfered::ALL || mEntity == EntityTransfered::CONDITIONS || mEntity == EntityTransfered::NODESANDCONDITIONS)) {
             const auto it_cond_begin = mrOriginModelPart.ConditionsBegin();
-            #pragma omp for
+            #pragma omp for schedule(guided, 512) nowait
             for(int i = 0; i < num_conditions; ++i) {
                 auto it_cond = it_cond_begin + i;
                 if (it_cond->Is(mFlag)) {

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -284,12 +284,12 @@ void  AddProcessesToPython(pybind11::module& m)
     .def(py::init<ModelPart&, component_type&, Variable<array_1d<double,3> >& , Variable<double>& >())
     .def(py::init<ModelPart&, Variable<double>&, Variable<array_1d<double,3> >& , Variable<double>& >())
     ;
-    
+
     m.attr("ComputeNodalGradientProcess2D") = m.attr("ComputeNodalGradientProcess");
     m.attr("ComputeNodalGradientProcess3D") = m.attr("ComputeNodalGradientProcess");
     m.attr("ComputeNodalGradientProcessComp2D") = m.attr("ComputeNodalGradientProcess");
     m.attr("ComputeNodalGradientProcessComp3D") = m.attr("ComputeNodalGradientProcess");
-    
+
     /* Non-Historical */
     py::class_<ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsNonHistoricalVariable>, ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsNonHistoricalVariable>::Pointer, Process>(m,"ComputeNonHistoricalNodalGradientProcess")
     .def(py::init<ModelPart&, component_type&, Variable<array_1d<double,3> >& , Variable<double>& >())
@@ -447,15 +447,15 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     // Transfer between model parts
-    py::class_<FastTransferBetweenModelPartsProcess, FastTransferBetweenModelPartsProcess::Pointer, Process> FastTransferBetweenModelPartsProcess_Scope(m, "FastTransferBetweenModelPartsProcess");
-
-    FastTransferBetweenModelPartsProcess_Scope.def(py::init<ModelPart&, ModelPart&>());
-    FastTransferBetweenModelPartsProcess_Scope.def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered>());
-    FastTransferBetweenModelPartsProcess_Scope.def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered, const Flags >());
-    FastTransferBetweenModelPartsProcess_Scope.def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered, const Flags, const bool >());
+    py::class_<FastTransferBetweenModelPartsProcess, FastTransferBetweenModelPartsProcess::Pointer, Process>(m, "FastTransferBetweenModelPartsProcess")
+    .def(py::init<ModelPart&, ModelPart&>())
+    .def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered>())
+    .def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered, const Flags >())
+    .def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered, const Flags, const bool >())
+    ;
 
     // Adding FastTransferBetweenModelPartsProcess related enums
-    py::enum_<FastTransferBetweenModelPartsProcess::EntityTransfered>(FastTransferBetweenModelPartsProcess_Scope, "EntityTransfered")
+    py::enum_<FastTransferBetweenModelPartsProcess::EntityTransfered>(m,"EntityTransfered")
     .value("NODES", FastTransferBetweenModelPartsProcess::EntityTransfered::NODES)
     .value("ELEMENTS", FastTransferBetweenModelPartsProcess::EntityTransfered::ELEMENTS)
     .value("NODESANDELEMENTS", FastTransferBetweenModelPartsProcess::EntityTransfered::NODESANDELEMENTS)
@@ -464,6 +464,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .value("CONSTRAINTS", FastTransferBetweenModelPartsProcess::EntityTransfered::CONSTRAINTS)
     .value("NODESANDCONSTRAINTS", FastTransferBetweenModelPartsProcess::EntityTransfered::NODESANDCONSTRAINTS)
     .value("ALL", FastTransferBetweenModelPartsProcess::EntityTransfered::ALL)
+    .export_values()
     ;
 
     py::class_<SkinDetectionProcess<2>, SkinDetectionProcess<2>::Pointer, Process>(m, "SkinDetectionProcess2D")

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -284,12 +284,12 @@ void  AddProcessesToPython(pybind11::module& m)
     .def(py::init<ModelPart&, component_type&, Variable<array_1d<double,3> >& , Variable<double>& >())
     .def(py::init<ModelPart&, Variable<double>&, Variable<array_1d<double,3> >& , Variable<double>& >())
     ;
-
+    
     m.attr("ComputeNodalGradientProcess2D") = m.attr("ComputeNodalGradientProcess");
     m.attr("ComputeNodalGradientProcess3D") = m.attr("ComputeNodalGradientProcess");
     m.attr("ComputeNodalGradientProcessComp2D") = m.attr("ComputeNodalGradientProcess");
     m.attr("ComputeNodalGradientProcessComp3D") = m.attr("ComputeNodalGradientProcess");
-
+    
     /* Non-Historical */
     py::class_<ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsNonHistoricalVariable>, ComputeNodalGradientProcess<ComputeNodalGradientProcessSettings::SaveAsNonHistoricalVariable>::Pointer, Process>(m,"ComputeNonHistoricalNodalGradientProcess")
     .def(py::init<ModelPart&, component_type&, Variable<array_1d<double,3> >& , Variable<double>& >())
@@ -447,15 +447,15 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     // Transfer between model parts
-    py::class_<FastTransferBetweenModelPartsProcess, FastTransferBetweenModelPartsProcess::Pointer, Process>(m, "FastTransferBetweenModelPartsProcess")
-    .def(py::init<ModelPart&, ModelPart&>())
-    .def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered>())
-    .def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered, const Flags >())
-    .def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered, const Flags, const bool >())
-    ;
+    py::class_<FastTransferBetweenModelPartsProcess, FastTransferBetweenModelPartsProcess::Pointer, Process> FastTransferBetweenModelPartsProcess_Scope(m, "FastTransferBetweenModelPartsProcess");
+
+    FastTransferBetweenModelPartsProcess_Scope.def(py::init<ModelPart&, ModelPart&>());
+    FastTransferBetweenModelPartsProcess_Scope.def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered>());
+    FastTransferBetweenModelPartsProcess_Scope.def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered, const Flags >());
+    FastTransferBetweenModelPartsProcess_Scope.def(py::init<ModelPart&, ModelPart&, const FastTransferBetweenModelPartsProcess::EntityTransfered, const Flags, const bool >());
 
     // Adding FastTransferBetweenModelPartsProcess related enums
-    py::enum_<FastTransferBetweenModelPartsProcess::EntityTransfered>(m,"EntityTransfered")
+    py::enum_<FastTransferBetweenModelPartsProcess::EntityTransfered>(FastTransferBetweenModelPartsProcess_Scope, "EntityTransfered")
     .value("NODES", FastTransferBetweenModelPartsProcess::EntityTransfered::NODES)
     .value("ELEMENTS", FastTransferBetweenModelPartsProcess::EntityTransfered::ELEMENTS)
     .value("NODESANDELEMENTS", FastTransferBetweenModelPartsProcess::EntityTransfered::NODESANDELEMENTS)
@@ -464,7 +464,6 @@ void  AddProcessesToPython(pybind11::module& m)
     .value("CONSTRAINTS", FastTransferBetweenModelPartsProcess::EntityTransfered::CONSTRAINTS)
     .value("NODESANDCONSTRAINTS", FastTransferBetweenModelPartsProcess::EntityTransfered::NODESANDCONSTRAINTS)
     .value("ALL", FastTransferBetweenModelPartsProcess::EntityTransfered::ALL)
-    .export_values()
     ;
 
     py::class_<SkinDetectionProcess<2>, SkinDetectionProcess<2>::Pointer, Process>(m, "SkinDetectionProcess2D")


### PR DESCRIPTION
While looking for a OMP error I clean up the old OMP operations in FastTransferBetweenModelPartsProcess