### PR TITLE
[Core][Geometry] Making the "complete" ShapeFunctionsValues functionality available for Line classes (addressing #3742)

### DIFF
--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -70,6 +70,7 @@ public:
 
     /// Geometry as base class.
     typedef Geometry<TPointType> BaseType;
+    using Geometry<TPointType>::ShapeFunctionsValues;
 
     /// Pointer definition of Line2D2
     KRATOS_CLASS_POINTER_DEFINITION( Line2D2 );

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -70,6 +70,7 @@ public:
 
     /// Geometry as base class.
     typedef Geometry<TPointType> BaseType;
+    using Geometry<TPointType>::ShapeFunctionsValues;
 
     /// Pointer definition of Line3D2
     KRATOS_CLASS_POINTER_DEFINITION( Line3D2 );

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_2.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_2.cpp
@@ -315,6 +315,25 @@ namespace Testing {
         CrossCheckShapeFunctionsValues(*p_geom_nodes);
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(Line2D2ShapeFunctionsValuesMatrix, KratosCoreGeometriesFastSuite) {
+
+        Geometry<Point>::Pointer p_geom = GeneratePointsDiagonalLine2D2();
+        Line2D2<Point>::Pointer p_line = GeneratePointsDiagonalLine2D2();
+
+        const Matrix N_values_geom = p_geom->ShapeFunctionsValues(GeometryData::GI_GAUSS_2);
+        const Matrix N_values_line = p_line->ShapeFunctionsValues(GeometryData::GI_GAUSS_2);
+
+        KRATOS_CHECK_NEAR(N_values_geom(0, 0), 0.788675, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(0, 1), 0.211325, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(1, 0), 0.211325, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(1, 1), 0.788675, TOLERANCE);
+
+        KRATOS_CHECK_NEAR(N_values_line(0, 0), 0.788675, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_line(0, 1), 0.211325, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_line(1, 0), 0.211325, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_line(1, 1), 0.788675, TOLERANCE);
+    }
+
     KRATOS_TEST_CASE_IN_SUITE(Line2D2ShapeFunctionsLocalGradients, KratosCoreGeometriesFastSuite) {
         auto geom = GeneratePointsDiagonalLine2D2();
         auto& r_geom = *geom;

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_2.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_2.cpp
@@ -327,13 +327,22 @@ namespace Testing {
     }
 
     KRATOS_TEST_CASE_IN_SUITE(Line3D2ShapeFunctionsValuesMatrix, KratosCoreGeometriesFastSuite) {
-        Geometry<Point>::Pointer p_geom = GeneratePointsDiagonalLine3D2();
-        const Matrix N_values = p_geom->ShapeFunctionsValues(GeometryData::GI_GAUSS_2);
 
-        KRATOS_CHECK_NEAR(N_values(0, 0), 0.788675, TOLERANCE);
-        KRATOS_CHECK_NEAR(N_values(0, 1), 0.211325, TOLERANCE);
-        KRATOS_CHECK_NEAR(N_values(1, 0), 0.211325, TOLERANCE);
-        KRATOS_CHECK_NEAR(N_values(1, 1), 0.788675, TOLERANCE);
+        Geometry<Point>::Pointer p_geom = GeneratePointsDiagonalLine3D2();
+        Line3D2<Point>::Pointer p_line = GeneratePointsDiagonalLine3D2();
+
+        const Matrix N_values_geom = p_geom->ShapeFunctionsValues(GeometryData::GI_GAUSS_2);
+        const Matrix N_values_line = p_line->ShapeFunctionsValues(GeometryData::GI_GAUSS_2);
+
+        KRATOS_CHECK_NEAR(N_values_geom(0, 0), 0.788675, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(0, 1), 0.211325, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(1, 0), 0.211325, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_geom(1, 1), 0.788675, TOLERANCE);
+
+        KRATOS_CHECK_NEAR(N_values_line(0, 0), 0.788675, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_line(0, 1), 0.211325, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_line(1, 0), 0.211325, TOLERANCE);
+        KRATOS_CHECK_NEAR(N_values_line(1, 1), 0.788675, TOLERANCE);
     }
 
     KRATOS_TEST_CASE_IN_SUITE(Line3D2ShapeFunctionsLocalGradients, KratosCoreGeometriesFastSuite) {


### PR DESCRIPTION
Implementations are suggested to address the issue discussed in #3742. (closes #3742)

- following the advise of @roigcarlo (and the example in https://en.cppreference.com/w/cpp/language/using_declaration), functions of the base class are made available for the derived classes `Line2D2` and `Line3D2`

- tests are added to see if the functions are now available from the base class AND the derived classes