### PR TITLE
[StructuralMechanics] importing apps for linear solvers

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -422,9 +422,9 @@ class MechanicalSolver(PythonSolver):
             # using a default linear solver (selecting the fastest one available)
             import KratosMultiphysics.kratos_utilities as kratos_utils
             if kratos_utils.IsApplicationAvailable("EigenSolversApplication"):
-                import KratosMultiphysics.EigenSolversApplication
+                from KratosMultiphysics import EigenSolversApplication
             elif kratos_utils.IsApplicationAvailable("ExternalSolversApplication"):
-                import KratosMultiphysics.ExternalSolversApplication
+                from KratosMultiphysics import ExternalSolversApplication
 
             linear_solvers_by_speed = [
                 "PardisoLUSolver", # EigenSolversApplication (if compiled with Intel-support)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -423,7 +423,7 @@ class MechanicalSolver(PythonSolver):
             import KratosMultiphysics.kratos_utilities as kratos_utils
             if kratos_utils.IsApplicationAvailable("EigenSolversApplication"):
                 import KratosMultiphysics.EigenSolversApplication
-            else if kratos_utils.IsApplicationAvailable("ExternalSolversApplication"):
+            elif kratos_utils.IsApplicationAvailable("ExternalSolversApplication"):
                 import KratosMultiphysics.ExternalSolversApplication
 
             linear_solvers_by_speed = [

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -420,6 +420,12 @@ class MechanicalSolver(PythonSolver):
                 return KratosMultiphysics.LinearSolverFactory().Create(linear_solver_configuration)
         else:
             # using a default linear solver (selecting the fastest one available)
+            import KratosMultiphysics.kratos_utilities as kratos_utils
+            if kratos_utils.IsApplicationAvailable("EigenSolversApplication"):
+                import KratosMultiphysics.EigenSolversApplication
+            else if kratos_utils.IsApplicationAvailable("ExternalSolversApplication"):
+                import KratosMultiphysics.ExternalSolversApplication
+
             linear_solvers_by_speed = [
                 "PardisoLUSolver", # EigenSolversApplication (if compiled with Intel-support)
                 "SparseLUSolver",  # EigenSolversApplication
@@ -427,6 +433,7 @@ class MechanicalSolver(PythonSolver):
                 "SuperLUSolver",   # ExternalSolversApplication
                 "SkylineLUFactorizationSolver" # in Core, always available, but slow
             ]
+
             for solver_name in linear_solvers_by_speed:
                 if KratosMultiphysics.LinearSolverFactory().Has(solver_name):
                     linear_solver_configuration.AddEmptyValue("solver_type").SetString(solver_name)


### PR DESCRIPTION
follow up of #3732 

now the good solvers are also imported if they are available (only in case the user did not specify anything => selecting the fastest available as default)

the proper availability-check (without importing!) was added in #3738 