### PR TITLE
[Core] Some minor warnings on VTK IO

### DIFF
--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -49,18 +49,18 @@ VtkOutput::VtkOutput(ModelPart& rModelPart, Parameters Parameters)
 void VtkOutput::PrintOutput()
 {
     //For whole model part
-    WriteModelPartInVTK(mrModelPart, false);
+    WriteModelPartToFile(mrModelPart, false);
 
     //For sub model parts
     const bool print_sub_model_parts = mOutputSettings["output_sub_model_parts"].GetBool();
     if(print_sub_model_parts) {
         for (const auto& r_sub_model_part : mrModelPart.SubModelParts()) {
-            WriteModelPartInVTK(r_sub_model_part, true);
+            WriteModelPartToFile(r_sub_model_part, true);
         }
     }
 }
 
-void VtkOutput::WriteModelPartInVTK(const ModelPart& rModelPart, const bool IsSubModelPart)
+void VtkOutput::WriteModelPartToFile(const ModelPart& rModelPart, const bool IsSubModelPart)
 {
     Initialize(rModelPart);
 
@@ -75,11 +75,11 @@ void VtkOutput::WriteModelPartInVTK(const ModelPart& rModelPart, const bool IsSu
         output_file.open(output_file_name, std::ios::out | std::ios::binary | std::ios::trunc);
     }
 
-    WriteHeaderInVTK(rModelPart, output_file);
-    WriteMeshInVTK(rModelPart, output_file);
-    WriteNodalResultsInVTK(rModelPart, output_file);
-    WriteElementResultsInVTK(rModelPart, output_file);
-    WriteConditionResultsInVTK(rModelPart, output_file);
+    WriteHeaderToFile(rModelPart, output_file);
+    WriteMeshToFile(rModelPart, output_file);
+    WriteNodalResultsToFile(rModelPart, output_file);
+    WriteElementResultsToFile(rModelPart, output_file);
+    WriteConditionResultsToFile(rModelPart, output_file);
 
     output_file.close();
 }
@@ -136,7 +136,7 @@ void VtkOutput::CreateMapFromKratosIdToVTKId(const ModelPart& rModelPart)
     }
 }
 
-void VtkOutput::WriteHeaderInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const
+void VtkOutput::WriteHeaderToFile(const ModelPart& rModelPart, std::ofstream& rFileStream) const
 {
     rFileStream << "# vtk DataFile Version 4.0"
                 << "\n"
@@ -152,13 +152,13 @@ void VtkOutput::WriteHeaderInVTK(const ModelPart& rModelPart, std::ofstream& rFi
                 << "\n";
 }
 
-void VtkOutput::WriteMeshInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const
+void VtkOutput::WriteMeshToFile(const ModelPart& rModelPart, std::ofstream& rFileStream) const
 {
-    WriteNodesInVTK(rModelPart, rFileStream);
-    WriteConditionsAndElementsInVTK(rModelPart, rFileStream);
+    WriteNodesToFile(rModelPart, rFileStream);
+    WriteConditionsAndElementsToFile(rModelPart, rFileStream);
 }
 
-void VtkOutput::WriteNodesInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const
+void VtkOutput::WriteNodesToFile(const ModelPart& rModelPart, std::ofstream& rFileStream) const
 {
     // NOTE: also in MPI all nodes (local and ghost) have to be written, because
     // they might be needed by the elements/conditions due to the connectivity
@@ -173,7 +173,7 @@ void VtkOutput::WriteNodesInVTK(const ModelPart& rModelPart, std::ofstream& rFil
     }
 }
 
-void VtkOutput::WriteConditionsAndElementsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const
+void VtkOutput::WriteConditionsAndElementsToFile(const ModelPart& rModelPart, std::ofstream& rFileStream) const
 {
     const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
 
@@ -276,7 +276,7 @@ void VtkOutput::WriteCellType(const TContainerType& rContainer, std::ofstream& r
     }
 }
 
-void VtkOutput::WriteNodalResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream)
+void VtkOutput::WriteNodalResultsToFile(const ModelPart& rModelPart, std::ofstream& rFileStream)
 {
     // NOTE: also in MPI all nodes (local and ghost) have to be written, because
     // they might be needed by the elements/conditions due to the connectivity
@@ -307,7 +307,7 @@ void VtkOutput::WriteNodalResultsInVTK(const ModelPart& rModelPart, std::ofstrea
     }
 }
 
-void VtkOutput::WriteElementResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream)
+void VtkOutput::WriteElementResultsToFile(const ModelPart& rModelPart, std::ofstream& rFileStream)
 {
     const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
     Parameters element_results = mOutputSettings["element_data_value_variables"];
@@ -326,7 +326,7 @@ void VtkOutput::WriteElementResultsInVTK(const ModelPart& rModelPart, std::ofstr
     }
 }
 
-void VtkOutput::WriteConditionResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream)
+void VtkOutput::WriteConditionResultsToFile(const ModelPart& rModelPart, std::ofstream& rFileStream)
 {
     const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
     Parameters condition_results = mOutputSettings["condition_data_value_variables"];

--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -49,18 +49,18 @@ VtkOutput::VtkOutput(ModelPart& rModelPart, Parameters Parameters)
 void VtkOutput::PrintOutput()
 {
     //For whole model part
-    WriteModelPart(mrModelPart, false);
+    WriteModelPartInVTK(mrModelPart, false);
 
     //For sub model parts
     const bool print_sub_model_parts = mOutputSettings["output_sub_model_parts"].GetBool();
     if(print_sub_model_parts) {
         for (const auto& r_sub_model_part : mrModelPart.SubModelParts()) {
-            WriteModelPart(r_sub_model_part, true);
+            WriteModelPartInVTK(r_sub_model_part, true);
         }
     }
 }
 
-void VtkOutput::WriteModelPart(const ModelPart& rModelPart, const bool IsSubModelPart)
+void VtkOutput::WriteModelPartInVTK(const ModelPart& rModelPart, const bool IsSubModelPart)
 {
     Initialize(rModelPart);
 
@@ -75,11 +75,11 @@ void VtkOutput::WriteModelPart(const ModelPart& rModelPart, const bool IsSubMode
         output_file.open(output_file_name, std::ios::out | std::ios::binary | std::ios::trunc);
     }
 
-    WriteHeader(rModelPart, output_file);
-    WriteMesh(rModelPart, output_file);
-    WriteNodalResults(rModelPart, output_file);
-    WriteElementResults(rModelPart, output_file);
-    WriteConditionResults(rModelPart, output_file);
+    WriteHeaderInVTK(rModelPart, output_file);
+    WriteMeshInVTK(rModelPart, output_file);
+    WriteNodalResultsInVTK(rModelPart, output_file);
+    WriteElementResultsInVTK(rModelPart, output_file);
+    WriteConditionResultsInVTK(rModelPart, output_file);
 
     output_file.close();
 }
@@ -136,7 +136,7 @@ void VtkOutput::CreateMapFromKratosIdToVTKId(const ModelPart& rModelPart)
     }
 }
 
-void VtkOutput::WriteHeader(const ModelPart& rModelPart, std::ofstream& rFileStream) const
+void VtkOutput::WriteHeaderInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const
 {
     rFileStream << "# vtk DataFile Version 4.0"
                 << "\n"
@@ -152,13 +152,13 @@ void VtkOutput::WriteHeader(const ModelPart& rModelPart, std::ofstream& rFileStr
                 << "\n";
 }
 
-void VtkOutput::WriteMesh(const ModelPart& rModelPart, std::ofstream& rFileStream) const
+void VtkOutput::WriteMeshInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const
 {
-    WriteNodes(rModelPart, rFileStream);
-    WriteConditionsAndElements(rModelPart, rFileStream);
+    WriteNodesInVTK(rModelPart, rFileStream);
+    WriteConditionsAndElementsInVTK(rModelPart, rFileStream);
 }
 
-void VtkOutput::WriteNodes(const ModelPart& rModelPart, std::ofstream& rFileStream) const
+void VtkOutput::WriteNodesInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const
 {
     // NOTE: also in MPI all nodes (local and ghost) have to be written, because
     // they might be needed by the elements/conditions due to the connectivity
@@ -173,7 +173,7 @@ void VtkOutput::WriteNodes(const ModelPart& rModelPart, std::ofstream& rFileStre
     }
 }
 
-void VtkOutput::WriteConditionsAndElements(const ModelPart& rModelPart, std::ofstream& rFileStream) const
+void VtkOutput::WriteConditionsAndElementsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const
 {
     const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
 
@@ -276,7 +276,7 @@ void VtkOutput::WriteCellType(const TContainerType& rContainer, std::ofstream& r
     }
 }
 
-void VtkOutput::WriteNodalResults(const ModelPart& rModelPart, std::ofstream& rFileStream)
+void VtkOutput::WriteNodalResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream)
 {
     // NOTE: also in MPI all nodes (local and ghost) have to be written, because
     // they might be needed by the elements/conditions due to the connectivity
@@ -307,7 +307,7 @@ void VtkOutput::WriteNodalResults(const ModelPart& rModelPart, std::ofstream& rF
     }
 }
 
-void VtkOutput::WriteElementResults(const ModelPart& rModelPart, std::ofstream& rFileStream)
+void VtkOutput::WriteElementResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream)
 {
     const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
     Parameters element_results = mOutputSettings["element_data_value_variables"];
@@ -326,7 +326,7 @@ void VtkOutput::WriteElementResults(const ModelPart& rModelPart, std::ofstream& 
     }
 }
 
-void VtkOutput::WriteConditionResults(const ModelPart& rModelPart, std::ofstream& rFileStream)
+void VtkOutput::WriteConditionResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream)
 {
     const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
     Parameters condition_results = mOutputSettings["condition_data_value_variables"];

--- a/kratos/input_output/vtk_output.h
+++ b/kratos/input_output/vtk_output.h
@@ -94,7 +94,7 @@ protected:
      * @param IsSubModelPart whether the modelpart is to be treated as a submodelpart
      * this is only relevant for the file-name
      */
-    void WriteModelPart(const ModelPart& rModelPart, const bool IsSubModelPart);
+    void WriteModelPartInVTK(const ModelPart& rModelPart, const bool IsSubModelPart);
 
     /**
      * @brief Get the output file name based on the provided settings and the MPI rank
@@ -119,21 +119,21 @@ protected:
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteHeader(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
+    void WriteHeaderInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
 
     /**
      * @brief Write the mesh from rModelPart. Nodes, Elements or/and Conditions.
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteMesh(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
+    void WriteMeshInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
 
     /**
      * @brief Write the nodes in the rModelPart.
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteNodes(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
+    void WriteNodesInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
 
     /**
      * @brief Write the elements and conditions in rModelPart.
@@ -141,7 +141,7 @@ protected:
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteConditionsAndElements(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
+    void WriteConditionsAndElementsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
 
     /**
      * @brief Calculate the total number of cells which are in the provided rModelPart. = num_elements + num_conditions
@@ -175,21 +175,21 @@ protected:
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteNodalResults(const ModelPart& rModelPart, std::ofstream& rFileStream);
+    void WriteNodalResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream);
 
     /**
      * @brief Write the results/flags on the elements of rModelPart.
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteElementResults(const ModelPart& rModelPart, std::ofstream& rFileStream);
+    void WriteElementResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream);
 
     /**
      * @brief Write the results/flags on the conditions of rModelPart.
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteConditionResults(const ModelPart& rModelPart, std::ofstream& rFileStream);
+    void WriteConditionResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream);
 
     /**
      * @brief Write the results of rNodes. Synchronization is necessary because both local

--- a/kratos/input_output/vtk_output.h
+++ b/kratos/input_output/vtk_output.h
@@ -94,7 +94,7 @@ protected:
      * @param IsSubModelPart whether the modelpart is to be treated as a submodelpart
      * this is only relevant for the file-name
      */
-    void WriteModelPartInVTK(const ModelPart& rModelPart, const bool IsSubModelPart);
+    void WriteModelPartToFile(const ModelPart& rModelPart, const bool IsSubModelPart);
 
     /**
      * @brief Get the output file name based on the provided settings and the MPI rank
@@ -119,21 +119,21 @@ protected:
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteHeaderInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
+    void WriteHeaderToFile(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
 
     /**
      * @brief Write the mesh from rModelPart. Nodes, Elements or/and Conditions.
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteMeshInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
+    void WriteMeshToFile(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
 
     /**
      * @brief Write the nodes in the rModelPart.
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteNodesInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
+    void WriteNodesToFile(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
 
     /**
      * @brief Write the elements and conditions in rModelPart.
@@ -141,7 +141,7 @@ protected:
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteConditionsAndElementsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
+    void WriteConditionsAndElementsToFile(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
 
     /**
      * @brief Calculate the total number of cells which are in the provided rModelPart. = num_elements + num_conditions
@@ -175,21 +175,21 @@ protected:
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteNodalResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream);
+    void WriteNodalResultsToFile(const ModelPart& rModelPart, std::ofstream& rFileStream);
 
     /**
      * @brief Write the results/flags on the elements of rModelPart.
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteElementResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream);
+    void WriteElementResultsToFile(const ModelPart& rModelPart, std::ofstream& rFileStream);
 
     /**
      * @brief Write the results/flags on the conditions of rModelPart.
      * @param rModelPart modelpart which is beging output
      * @param rFileStream the file stream to which data is to be written.
      */
-    void WriteConditionResultsInVTK(const ModelPart& rModelPart, std::ofstream& rFileStream);
+    void WriteConditionResultsToFile(const ModelPart& rModelPart, std::ofstream& rFileStream);
 
     /**
      * @brief Write the results of rNodes. Synchronization is necessary because both local


### PR DESCRIPTION
~~~
In file included from /home/vicente/src/Kratos/kratos/input_output/vtk_output.cpp:20:
/home/vicente/src/Kratos/kratos/input_output/vtk_output.h:97:10: warning: 'Kratos::VtkOutput::WriteModelPart' hides overloaded virtual function [-Woverloaded-virtual]
    void WriteModelPart(const ModelPart& rModelPart, const bool IsSubModelPart);
         ^
/home/vicente/src/Kratos/kratos/includes/io.h:217:18: note: hidden overloaded virtual function 'Kratos::IO::WriteModelPart' declared here: different number of parameters (1 vs 2)
    virtual void WriteModelPart(ModelPart & rThisModelPart)
                 ^
In file included from /home/vicente/src/Kratos/kratos/input_output/vtk_output.cpp:20:
/home/vicente/src/Kratos/kratos/input_output/vtk_output.h:136:10: warning: 'Kratos::VtkOutput::WriteNodes' hides overloaded virtual function [-Woverloaded-virtual]
    void WriteNodes(const ModelPart& rModelPart, std::ofstream& rFileStream) const;
         ^
/home/vicente/src/Kratos/kratos/includes/io.h:135:18: note: hidden overloaded virtual function 'Kratos::IO::WriteNodes' declared here: different number of parameters (1 vs 2)
    virtual void WriteNodes(NodesContainerType const& rThisNodes)
~~~
 This solves the previous warnings. @philbucher I changed the name of some other functions for the sake of consistency, I expect you would have comment that, I hope I predicted correctly ;)