### PR TITLE
Adding flag argument in TrilinosVariationalDistanceCalculationProcess3D

### DIFF
--- a/applications/trilinos_application/tests/test_trilinos_redistance.py
+++ b/applications/trilinos_application/tests/test_trilinos_redistance.py
@@ -83,7 +83,8 @@ class TestTrilinosRedistance(KratosUnittest.TestCase):
 
         max_iterations = 2
         TrilinosApplication.TrilinosVariationalDistanceCalculationProcess3D(
-            epetra_comm, self.model_part, trilinos_linear_solver, max_iterations).Execute()
+            epetra_comm, self.model_part, trilinos_linear_solver, max_iterations,
+            KratosMultiphysics.VariationalDistanceCalculationProcess3D.NOT_CALCULATE_EXACT_DISTANCES_TO_PLANE).Execute()
 
         # Check the obtained values
         max_distance = -1.0


### PR DESCRIPTION
This addresses a sub-issue described in #3694 by @philbucher.
However, it does not solve the problems concerning the "no dofs" error message.

I am sorry for missing the flag argument in the test in an earlier commit.