### PR TITLE
[Core][MeshMov] Explicit mesh moving fixity correction

### DIFF
--- a/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.cpp
+++ b/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.cpp
@@ -59,8 +59,11 @@ namespace Kratos
         // Copy the origin model part nodes
         auto &r_nodes_array = rOriginModelPart.NodesArray();
         for(auto &it_node : r_nodes_array){
-            // Create a copy of the origin model part node
+            // Create a copy of the origin model part node and add DOFs
             auto p_node = mrVirtualModelPart.CreateNewNode(it_node->Id(),*it_node, 0);
+            p_node->pAddDof(MESH_DISPLACEMENT_X);
+            p_node->pAddDof(MESH_DISPLACEMENT_Y);
+            p_node->pAddDof(MESH_DISPLACEMENT_Z);
         }
 
         // Copy the origin model part elements
@@ -193,8 +196,8 @@ namespace Kratos
 
     void ExplicitMeshMovingUtilities::ComputeMeshDisplacement(
         const VectorResultNodesContainerType &rSearchResults,
-        const DistanceVectorContainerType &rSearchDistanceResults){
-
+        const DistanceVectorContainerType &rSearchDistanceResults)
+    {
         #pragma omp parallel for
         for(int i_fl = 0; i_fl < static_cast<int>(mrVirtualModelPart.NumberOfNodes()); ++i_fl){
             // Get auxiliar current fluid node info.

--- a/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.h
+++ b/applications/MeshMovingApplication/custom_utilities/explicit_mesh_moving_utilities.h
@@ -51,11 +51,11 @@ namespace Kratos
   /// Utility to initialize the historical data in moving boundary problems
   /** This utility is based on the Fixed Mesh - Arbitrary Lagrangian Eulerian
    * (FM-ALE) method but solving the mesh problem in an explicit manner. Thus,
-   * a virtual mesh is set. This virtual mesh is moved according to the embedded 
-   * object movement. The virtual mesh movement, is computed in an explicit 
-   * manner as a weighted average. Such weights are computed by means of a 
+   * a virtual mesh is set. This virtual mesh is moved according to the embedded
+   * object movement. The virtual mesh movement, is computed in an explicit
+   * manner as a weighted average. Such weights are computed by means of a
    * kernel function. Once the mesh movement (and velocity) have been computed,
-   * the origin mesh historical values (velocity and pressure) are computed as 
+   * the origin mesh historical values (velocity and pressure) are computed as
    * an interpolation in the virtualmodel part.
    */
   class ExplicitMeshMovingUtilities
@@ -81,7 +81,7 @@ namespace Kratos
 
     /// Constructor
     ExplicitMeshMovingUtilities(
-        ModelPart &rModelPart,
+        ModelPart &rVirtualModelPart,
         ModelPart &rStructureModelPart,
         const double SearchRadius);
 
@@ -106,13 +106,13 @@ namespace Kratos
 
     /**
     * This method fills the mrVirtualModelPart with the nodes and elmens of a given model part
-    * It is supposed to be performed once. 
+    * It is supposed to be performed once.
     * @param rOriginModelPart model part from where the nodes and elements are copied
     */
     void FillVirtualModelPart(ModelPart& rOriginModelPart);
 
     /**
-    * This method undoes the performed mesh movement to recover the original mesh in 
+    * This method undoes the performed mesh movement to recover the original mesh in
     */
     void UndoMeshMovement();
 
@@ -166,6 +166,7 @@ private:
 
     ModelPart &mrVirtualModelPart;
     ModelPart &mrStructureModelPart;
+    ModelPart *mpOriginModelPart = nullptr;
 
     ///@}
     ///@name Private Operators
@@ -178,8 +179,8 @@ private:
 
     /**
     * According to mSearchRadius, performs the bins search of the close structure nodes for each fluid node
-    * @return rSearchResults vector containing the the rStructureModelPart nodes inside 
-    * @return rSearchDistanceResults vector containing the the rStructureModelPart nodes 
+    * @return rSearchResults vector containing the the rStructureModelPart nodes inside
+    * @return rSearchDistanceResults vector containing the the rStructureModelPart nodes
     * inside SearchRadius distance values for each rModelPart nodes
     */
     void SearchStructureNodes(
@@ -187,11 +188,11 @@ private:
         DistanceVectorContainerType &rSearchDistanceResults);
 
     /**
-    * Computes the MESH_DISPLACEMENT value for each fluid node. This operation is explicitly computed 
-    * as a weighted average of the structure nodes DISPLACEMENT values within the mSearchRadius. The 
+    * Computes the MESH_DISPLACEMENT value for each fluid node. This operation is explicitly computed
+    * as a weighted average of the structure nodes DISPLACEMENT values within the mSearchRadius. The
     * weights are computed using a kernel function.
-    * @param rSearchResults vector containing the the rStructureModelPart nodes inside 
-    * @param rSearchDistanceResults vector containing the the rStructureModelPart nodes 
+    * @param rSearchResults vector containing the the rStructureModelPart nodes inside
+    * @param rSearchDistanceResults vector containing the the rStructureModelPart nodes
     * inside SearchRadius distance values for each rModelPart nodes
     */
     void ComputeMeshDisplacement(

--- a/applications/MeshMovingApplication/tests/cpp_tests/test_explicit_mesh_movement_utility.cpp
+++ b/applications/MeshMovingApplication/tests/cpp_tests/test_explicit_mesh_movement_utility.cpp
@@ -134,11 +134,12 @@ namespace Testing {
         const auto &r_mesh_vel = p_node_10->FastGetSolutionStepValue(MESH_VELOCITY);
 
         const double tol = 1e-6;
-        KRATOS_CHECK_NEAR(r_vel_n1(0), 0.0710645, tol);
-        KRATOS_CHECK_NEAR(r_vel_n1(1), 0.0294852, tol);
-        KRATOS_CHECK_NEAR(r_mesh_vel(0), -0.439785, tol);
-        KRATOS_CHECK_NEAR(r_mesh_vel(1), 0.384812, tol);
-
+        std::vector<double> expected_values = {0.070382, 0.0300401, -0.371536, 0.329322}; // Triangular kernel function
+        // std::vector<double> expected_values = {0.070382, 0.0294852, -0.439785, 0.384812}; // Epanechnikov (parabolic) kernel function
+        std::vector<double> obtained_values = {r_vel_n1(0), r_vel_n1(1), r_mesh_vel(0), r_mesh_vel(1)};
+        for (unsigned int i = 0; i < expected_values.size(); ++i) {
+            KRATOS_CHECK_NEAR(obtained_values[i], expected_values[i], tol);
+        }
     }
 }
 }  // namespace Kratos.


### PR DESCRIPTION
This PR can be summarized in:

- Addition of a new triangular kernel function to compute the mesh displacement
- `MESH_DISPLACEMENT`fixity check before each mesh displacement computation. Previously it was only checked when creating the virtual mesh nodes. To do that, a pointer to the origin mesh is saved.
- Test values update.