### PR TITLE
[Structural Mechanics] Improvements to Plasticity and Damage CLs

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.h
@@ -161,18 +161,6 @@ public:
                             const Vector& rShapeFunctionsValues) override;
 
     /**
-     * @brief To be called at the end of each solution step  (e.g. from Element::FinalizeSolutionStep)
-     * @param rMaterialProperties the Properties instance of the current element
-     * @param rElementGeometry the geometry of the current element
-     * @param rShapeFunctionsValues the shape functions values in the current integration point
-     * @param rCurrentProcessInfo the current ProcessInfo instance
-     */
-    void FinalizeSolutionStep(const Properties& rMaterialProperties,
-                            const GeometryType& rElementGeometry,
-                            const Vector& rShapeFunctionsValues,
-                            const ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
      * @brief Computes the material response in terms of 1st Piola-Kirchhoff stresses and constitutive tensor
      * @param rValues The specific parameters of the current constitutive law
      * @see Parameters
@@ -263,14 +251,6 @@ public:
      * @param rValue a reference to the returned value
      * @return rValue output: the value of the specified variable
      */
-
-    /**
-     * @brief calculates the value of a specified variable
-     * @param rValues the needed parameters for the CL calculation
-     * @param rThisVariable the variable to be returned
-     * @param rValue a reference to the returned value
-     * @return rValue output: the value of the specified variable
-     */
     double& CalculateValue(Parameters& rValues,
                            const Variable<double>& rThisVariable,
                            double& rValue) override;
@@ -310,7 +290,6 @@ protected:
     ///@name Protected member Variables
     ///@{
     bool mInelasticFlag; /// Flags when in inelastic regime
-    double mStrainVariable;
     double mStrainVariableOld;
     ///@}
 
@@ -320,8 +299,24 @@ protected:
 
     ///@name Protected Operations
     ///@{
+
+    /**
+     * @brief This method computes the stress and constitutive tensor
+     * @param rValues The norm of the deviation stress
+     * @param rStrainVariable
+     */
+    virtual void CalculateStressResponse(
+            ConstitutiveLaw::Parameters& rValues,
+            double& rStrainVariable);
+
     double EvaluateHardeningLaw(double StrainVariable, const Properties &rMaterialProperties);
-    virtual void CalculateConstitutiveMatrix(Matrix &rConstitTensor, const Properties &rMaterialProperties);
+
+    /**
+     * @brief This method computes the constitutive tensor
+     * @param rMaterialProperties The properties of the material
+     * @param rTensor The elastic tensor/matrix to be computed
+     */
+    virtual void CalculateConstitutiveMatrix(const Properties &rMaterialProperties, Matrix &rTensor);
     ///@}
 
 private:

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.h
@@ -290,7 +290,7 @@ protected:
     ///@name Protected member Variables
     ///@{
     bool mInelasticFlag; /// Flags when in inelastic regime
-    double mStrainVariableOld;
+    double mStrainVariable;
     ///@}
 
     ///@name Protected Operators
@@ -314,9 +314,9 @@ protected:
     /**
      * @brief This method computes the constitutive tensor
      * @param rMaterialProperties The properties of the material
-     * @param rTensor The elastic tensor/matrix to be computed
+     * @param rElasticMatrix The elastic tensor/matrix to be computed
      */
-    virtual void CalculateConstitutiveMatrix(const Properties &rMaterialProperties, Matrix &rTensor);
+    virtual void CalculateElasticMatrix(const Properties &rMaterialProperties, Matrix &rElasticMatrix);
     ///@}
 
 private:

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_3D_law.h
@@ -201,6 +201,34 @@ public:
     void CalculateMaterialResponseCauchy(Parameters& rValues) override;
 
     /**
+     * @brief Initialize the material response in terms of 1st Piola-Kirchhoff stresses
+     * @param rValues The specific parameters of the current constitutive law
+     * @see Parameters
+     */
+    void InitializeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues) override;
+
+    /**
+     * @brief Initialize the material response in terms of 2nd Piola-Kirchhoff stresses
+     * @param rValues The specific parameters of the current constitutive law
+     * @see Parameters
+     */
+    void InitializeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) override;
+
+    /**
+     * @brief Initialize the material response in terms of Kirchhoff stresses
+     * @param rValues The specific parameters of the current constitutive law
+     * @see Parameters
+     */
+    void InitializeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues) override;
+
+    /**
+     * @brief Initialize the material response in terms of Cauchy stresses
+     * @param rValues The specific parameters of the current constitutive law
+     * @see Parameters
+     */
+    void InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) override;
+
+    /**
      * @brief Finalize the material response in terms of 1st Piola-Kirchhoff stresses
      * @param rValues The specific parameters of the current constitutive law
      * @see Parameters
@@ -230,7 +258,7 @@ public:
 
     /**
      * @brief calculates the value of a specified variable
-     * @param rParameterValues the needed parameters for the CL calculation
+     * @param rValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
      * @return rValue output: the value of the specified variable
@@ -238,12 +266,12 @@ public:
 
     /**
      * @brief calculates the value of a specified variable
-     * @param rParameterValues the needed parameters for the CL calculation
+     * @param rValues the needed parameters for the CL calculation
      * @param rThisVariable the variable to be returned
      * @param rValue a reference to the returned value
      * @return rValue output: the value of the specified variable
      */
-    double& CalculateValue(Parameters& rParameterValues,
+    double& CalculateValue(Parameters& rValues,
                            const Variable<double>& rThisVariable,
                            double& rValue) override;
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_plane_strain_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_plane_strain_2d.cpp
@@ -23,11 +23,12 @@ LinearIsotropicDamagePlaneStrain2D::LinearIsotropicDamagePlaneStrain2D()
 
 //********************************COPY CONSTRUCTOR************************************
 //************************************************************************************
+
 LinearIsotropicDamagePlaneStrain2D::LinearIsotropicDamagePlaneStrain2D(
-    const LinearIsotropicDamagePlaneStrain2D &rOther)
-    : LinearIsotropicDamage3D(rOther)
-{
-}
+    const LinearIsotropicDamagePlaneStrain2D &rOther) = default;
+//    : LinearIsotropicDamage3D(rOther)
+//{
+//}
 
 //********************************CLONE***********************************************
 //************************************************************************************
@@ -45,10 +46,7 @@ LinearIsotropicDamagePlaneStrain2D::~LinearIsotropicDamagePlaneStrain2D() = defa
 //************************************************************************************
 //************************************************************************************
 
-void LinearIsotropicDamagePlaneStrain2D::CalculateConstitutiveMatrix(
-    Matrix &rConstitTensor,
-    const Properties &rMaterialProperties
-    )
+void LinearIsotropicDamagePlaneStrain2D::CalculateConstitutiveMatrix(const Properties &rMaterialProperties, Matrix &rConstitTensor)
 {
     const double E = rMaterialProperties[YOUNG_MODULUS];
     const double nu = rMaterialProperties[POISSON_RATIO];
@@ -79,8 +77,8 @@ void LinearIsotropicDamagePlaneStrain2D::GetLawFeatures(Features& rFeatures)
     rFeatures.mOptions.Set(INFINITESIMAL_STRAINS);
     rFeatures.mOptions.Set(ISOTROPIC);
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
-    rFeatures.mStrainSize = WorkingSpaceDimension();
-    rFeatures.mSpaceDimension = GetStrainSize();
+    rFeatures.mStrainSize = this->WorkingSpaceDimension();
+    rFeatures.mSpaceDimension = this->GetStrainSize();
 }
 
 //************************************************************************************

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_plane_strain_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_plane_strain_2d.cpp
@@ -26,9 +26,6 @@ LinearIsotropicDamagePlaneStrain2D::LinearIsotropicDamagePlaneStrain2D()
 
 LinearIsotropicDamagePlaneStrain2D::LinearIsotropicDamagePlaneStrain2D(
     const LinearIsotropicDamagePlaneStrain2D &rOther) = default;
-//    : LinearIsotropicDamage3D(rOther)
-//{
-//}
 
 //********************************CLONE***********************************************
 //************************************************************************************
@@ -46,26 +43,29 @@ LinearIsotropicDamagePlaneStrain2D::~LinearIsotropicDamagePlaneStrain2D() = defa
 //************************************************************************************
 //************************************************************************************
 
-void LinearIsotropicDamagePlaneStrain2D::CalculateConstitutiveMatrix(const Properties &rMaterialProperties, Matrix &rConstitTensor)
+void LinearIsotropicDamagePlaneStrain2D::CalculateElasticMatrix(
+    const Properties &rMaterialProperties, Matrix &rElasticMatrix)
 {
     const double E = rMaterialProperties[YOUNG_MODULUS];
     const double nu = rMaterialProperties[POISSON_RATIO];
     const double Ebar = E / (1. - nu * nu);
     const double nubar = nu / (1. - nu);
 
-    rConstitTensor.clear();
+    if (rElasticMatrix.size1() != 3 || rElasticMatrix.size2() != 3)
+        rElasticMatrix.resize(3, 3, false);
+    rElasticMatrix.clear();
 
-    rConstitTensor(0, 0) = 1;
-    rConstitTensor(0, 1) = nubar;
-    rConstitTensor(0, 2) = 0;
-    rConstitTensor(1, 0) = nubar;
-    rConstitTensor(1, 1) = 1;
-    rConstitTensor(1, 2) = 0;
-    rConstitTensor(2, 0) = 0;
-    rConstitTensor(2, 1) = 0;
-    rConstitTensor(2, 2) = 0.5 * (1 - nubar);
+    rElasticMatrix(0, 0) = 1;
+    rElasticMatrix(0, 1) = nubar;
+    rElasticMatrix(0, 2) = 0;
+    rElasticMatrix(1, 0) = nubar;
+    rElasticMatrix(1, 1) = 1;
+    rElasticMatrix(1, 2) = 0;
+    rElasticMatrix(2, 0) = 0;
+    rElasticMatrix(2, 1) = 0;
+    rElasticMatrix(2, 2) = 0.5 * (1 - nubar);
 
-    rConstitTensor *= Ebar / (1. - nubar * nubar);
+    rElasticMatrix *= Ebar / (1. - nubar * nubar);
 }
 
 //************************************************************************************

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_plane_strain_2d.h
@@ -128,10 +128,7 @@ protected:
 
     ///@name Protected Operators
     ///@{
-    void CalculateConstitutiveMatrix(
-            Matrix &constitutiveMatrix,
-            const Properties &rMaterialProperties
-            ) override;
+    void CalculateConstitutiveMatrix(const Properties &rMaterialProperties, Matrix &constitutiveMatrix) override;
     ///@}
 
     ///@name Protected Operations

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_isotropic_damage_plane_strain_2d.h
@@ -128,7 +128,7 @@ protected:
 
     ///@name Protected Operators
     ///@{
-    void CalculateConstitutiveMatrix(const Properties &rMaterialProperties, Matrix &constitutiveMatrix) override;
+    void CalculateElasticMatrix(const Properties &rMaterialProperties, Matrix &rElasticMatrix) override;
     ///@}
 
     ///@name Protected Operations

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.cpp
@@ -139,16 +139,16 @@ void LinearJ2Plasticity3D::InitializeMaterial(
 //************************************************************************************
 //************************************************************************************
 
-void LinearJ2Plasticity3D::InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
+void LinearJ2Plasticity3D::InitializeMaterialResponseCauchy(
+    Kratos::ConstitutiveLaw::Parameters &rValues)
 {
-    // TODO: Add something if necessary
 }
 
 //************************************************************************************
 //************************************************************************************
 
-
-void LinearJ2Plasticity3D::InitializeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
+void LinearJ2Plasticity3D::InitializeMaterialResponsePK2(
+    Kratos::ConstitutiveLaw::Parameters &rValues)
 {
     // In small deformation is the same as compute Cauchy
     InitializeMaterialResponseCauchy(rValues);
@@ -157,7 +157,8 @@ void LinearJ2Plasticity3D::InitializeMaterialResponsePK1(ConstitutiveLaw::Parame
 //************************************************************************************
 //************************************************************************************
 
-void LinearJ2Plasticity3D::InitializeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
+void LinearJ2Plasticity3D::InitializeMaterialResponsePK1(
+    Kratos::ConstitutiveLaw::Parameters &rValues)
 {
     // In small deformation is the same as compute Cauchy
     InitializeMaterialResponseCauchy(rValues);
@@ -166,7 +167,8 @@ void LinearJ2Plasticity3D::InitializeMaterialResponsePK2(ConstitutiveLaw::Parame
 //************************************************************************************
 //************************************************************************************
 
-void LinearJ2Plasticity3D::InitializeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
+void LinearJ2Plasticity3D::InitializeMaterialResponseKirchhoff(
+    Kratos::ConstitutiveLaw::Parameters &rValues)
 {
     // In small deformation is the same as compute Cauchy
     InitializeMaterialResponseCauchy(rValues);
@@ -174,7 +176,22 @@ void LinearJ2Plasticity3D::InitializeMaterialResponseKirchhoff(ConstitutiveLaw::
 
 //************************************************************************************
 //************************************************************************************
-void LinearJ2Plasticity3D::FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
+
+void LinearJ2Plasticity3D::FinalizeMaterialResponseCauchy(
+    Kratos::ConstitutiveLaw::Parameters &rValues)
+{
+    Vector plastic_strain(6);
+    double accumulated_plastic_strain;
+    this->CalculateStressResponse(rValues, plastic_strain, accumulated_plastic_strain);
+    mPlasticStrainOld = plastic_strain;
+    mAccumulatedPlasticStrainOld = accumulated_plastic_strain;
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void LinearJ2Plasticity3D::FinalizeMaterialResponsePK2(
+    Kratos::ConstitutiveLaw::Parameters &rValues)
 {
     // In small deformation is the same as compute Cauchy
     FinalizeMaterialResponseCauchy(rValues);
@@ -183,7 +200,8 @@ void LinearJ2Plasticity3D::FinalizeMaterialResponsePK1(ConstitutiveLaw::Paramete
 //************************************************************************************
 //************************************************************************************
 
-void LinearJ2Plasticity3D::FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
+void LinearJ2Plasticity3D::FinalizeMaterialResponsePK1(
+    Kratos::ConstitutiveLaw::Parameters &rValues)
 {
     // In small deformation is the same as compute Cauchy
     FinalizeMaterialResponseCauchy(rValues);
@@ -192,28 +210,11 @@ void LinearJ2Plasticity3D::FinalizeMaterialResponsePK2(ConstitutiveLaw::Paramete
 //************************************************************************************
 //************************************************************************************
 
-void LinearJ2Plasticity3D::FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
+void LinearJ2Plasticity3D::FinalizeMaterialResponseKirchhoff(
+    Kratos::ConstitutiveLaw::Parameters &rValues)
 {
     // In small deformation is the same as compute Cauchy
     FinalizeMaterialResponseCauchy(rValues);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void LinearJ2Plasticity3D::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
-{
-    // TODO: Add something if necessary
-}
-
-void LinearJ2Plasticity3D::FinalizeSolutionStep(
-    const Properties& rMaterialProperties,
-    const GeometryType& rElementGeometry,
-    const Vector& rShapeFunctionsValues,
-    const ProcessInfo& rCurrentProcessInfo)
-{
-    mPlasticStrainOld = mPlasticStrain;
-    mAccumulatedPlasticStrainOld = mAccumulatedPlasticStrain;
 }
 
 //************************************************************************************
@@ -229,6 +230,7 @@ void LinearJ2Plasticity3D::CalculateMaterialResponsePK1(ConstitutiveLaw::Paramet
 
 void LinearJ2Plasticity3D::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
 {
+    // In small deformation is the same as compute Cauchy
     CalculateMaterialResponseCauchy(rValues);
 }
 
@@ -237,6 +239,7 @@ void LinearJ2Plasticity3D::CalculateMaterialResponsePK2(ConstitutiveLaw::Paramet
 
 void LinearJ2Plasticity3D::CalculateMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
 {
+    // In small deformation is the same as compute Cauchy
     CalculateMaterialResponseCauchy(rValues);
 }
 
@@ -245,20 +248,36 @@ void LinearJ2Plasticity3D::CalculateMaterialResponseKirchhoff(ConstitutiveLaw::P
 
 void LinearJ2Plasticity3D::CalculateMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
 {
+    Vector plastic_strain(6);
+    double accumulated_plastic_strain;
+    this->CalculateStressResponse(rValues, plastic_strain, accumulated_plastic_strain);
+}
+
+//************************************************************************************
+//************************************************************************************
+
+void LinearJ2Plasticity3D::CalculateStressResponse(
+    ConstitutiveLaw::Parameters& rValues,
+    Vector& rPlasticStrain,
+    double& rAccumulatedPlasticStrain)
+{
+    //mPlasticStrain = mPlasticStrainOld;
+    //mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld;
+
     const Properties& r_material_properties = rValues.GetMaterialProperties();
-    Flags & r_constitutive_law_options=rValues.GetOptions();
+    Flags & r_constitutive_law_options = rValues.GetOptions();
     Vector& r_strain_vector = rValues.GetStrainVector();
     if (rValues.GetProcessInfo().Has(INITIAL_STRAIN)) {
         noalias(r_strain_vector) += rValues.GetProcessInfo()[INITIAL_STRAIN];
     }
 
-    if( r_constitutive_law_options.IsNot( ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN )) {
-        this->CalculateValue(rValues, STRAIN, r_strain_vector);
+    if( r_constitutive_law_options.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN)) {
+        //this->CalculateValue(rValues, STRAIN, r_strain_vector);
     }
 
     // If we compute the tangent moduli or the stress
-    if( r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ||
-        r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR )) {
+    if( r_constitutive_law_options.Is(ConstitutiveLaw::COMPUTE_STRESS) ||
+        r_constitutive_law_options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
         Vector& r_stress_vector = rValues.GetStressVector();
         Matrix& tangent_tensor = rValues.GetConstitutiveMatrix();
         const double hardening_modulus = r_material_properties[ISOTROPIC_HARDENING_MODULUS];
@@ -271,8 +290,10 @@ void LinearJ2Plasticity3D::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
         const double sqrt_two_thirds = std::sqrt(2. / 3.); // = 0.8164965809277260
         double trial_yield_function;
 
-        mPlasticStrain = mPlasticStrainOld;
-        mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld;
+        rPlasticStrain = mPlasticStrainOld;
+        //mPlasticStrain = mPlasticStrainOld;
+        rAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld;
+        //mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld;
 
         Matrix elastic_tensor;
         elastic_tensor.resize(6, 6, false);
@@ -292,7 +313,7 @@ void LinearJ2Plasticity3D::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
                                         2. * stress_trial_dev(3) * stress_trial_dev(3) +
                                         2. * stress_trial_dev(4) * stress_trial_dev(4) +
                                         2. * stress_trial_dev(5) * stress_trial_dev(5));
-        trial_yield_function = this->YieldFunction(norm_dev_stress, r_material_properties);
+        trial_yield_function = this->YieldFunction(norm_dev_stress, r_material_properties, mAccumulatedPlasticStrainOld);
 
         if (trial_yield_function <= 0.) {
             // ELASTIC
@@ -311,11 +332,11 @@ void LinearJ2Plasticity3D::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
             double dgamma = 0;
             Vector yield_function_normal_vector = stress_trial_dev / norm_dev_stress;
             if (delta_k != 0.0 && hardening_exponent != 0.0) {
-                // Exponential softening
-                dgamma = GetDeltaGamma(norm_dev_stress, r_material_properties);
+                // Exponential hardening
+                dgamma = GetDeltaGamma(norm_dev_stress, r_material_properties, mAccumulatedPlasticStrainOld);
             }
             else {
-                // Linear softening
+                // Linear hardening
                 dgamma = trial_yield_function /
                         (2. * mu * (1. + (hardening_modulus / (3. * mu))));
             }
@@ -339,20 +360,30 @@ void LinearJ2Plasticity3D::CalculateMaterialResponseCauchy(ConstitutiveLaw::Para
                     stress_trial_dev(5) - 2. * mu * dgamma * yield_function_normal_vector(5);
             }
 
-            mPlasticStrain(0) = mPlasticStrainOld(0) + dgamma * yield_function_normal_vector(0);
-            mPlasticStrain(1) = mPlasticStrainOld(1) + dgamma * yield_function_normal_vector(1);
-            mPlasticStrain(2) = mPlasticStrainOld(2) + dgamma * yield_function_normal_vector(2);
-            mPlasticStrain(3) = mPlasticStrainOld(3) + dgamma * yield_function_normal_vector(3) * 2;
-            mPlasticStrain(4) = mPlasticStrainOld(4) + dgamma * yield_function_normal_vector(4) * 2;
-            mPlasticStrain(5) = mPlasticStrainOld(5) + dgamma * yield_function_normal_vector(5) * 2;
-            mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld + sqrt_two_thirds * dgamma;
+            //rPlasticStrain(0) = mPlasticStrainOld(0) + dgamma * yield_function_normal_vector(0);
+            //rPlasticStrain(1) = mPlasticStrainOld(1) + dgamma * yield_function_normal_vector(1);
+            //rPlasticStrain(2) = mPlasticStrainOld(2) + dgamma * yield_function_normal_vector(2);
+            //rPlasticStrain(3) = mPlasticStrainOld(3) + dgamma * yield_function_normal_vector(3) * 2;
+            //rPlasticStrain(4) = mPlasticStrainOld(4) + dgamma * yield_function_normal_vector(4) * 2;
+            //rPlasticStrain(5) = mPlasticStrainOld(5) + dgamma * yield_function_normal_vector(5) * 2;
+            //rAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld + sqrt_two_thirds * dgamma;
+            rPlasticStrain(0) += dgamma * yield_function_normal_vector(0);
+            rPlasticStrain(1) += dgamma * yield_function_normal_vector(1);
+            rPlasticStrain(2) += dgamma * yield_function_normal_vector(2);
+            rPlasticStrain(3) += dgamma * yield_function_normal_vector(3) * 2;
+            rPlasticStrain(4) += dgamma * yield_function_normal_vector(4) * 2;
+            rPlasticStrain(5) += dgamma * yield_function_normal_vector(5) * 2;
+            rAccumulatedPlasticStrain += sqrt_two_thirds * dgamma;
 
             // We update the tangent tensor
             if( r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
                 CalculateTangentTensor(dgamma, norm_dev_stress, yield_function_normal_vector,
-                                    r_material_properties, tangent_tensor);
+                                    r_material_properties, tangent_tensor, rAccumulatedPlasticStrain);
+                                    //r_material_properties, tangent_tensor, mAccumulatedPlasticStrain);
             }
         }
+        //rPlasticStrain = mPlasticStrain;
+        //rAccumulatedPlasticStrain = mAccumulatedPlasticStrain;
     }
 }
 
@@ -374,9 +405,12 @@ double& LinearJ2Plasticity3D::CalculateValue(
         Matrix elastic_tensor(6, 6);
         CalculateElasticMatrix(elastic_tensor, r_material_properties);
 
-        rValue = 0.5 * inner_prod(r_strain_vector - mPlasticStrain,
-                                  prod(elastic_tensor, r_strain_vector - mPlasticStrain))
-                 + GetPlasticPotential(r_material_properties, mAccumulatedPlasticStrain);
+        //rValue = 0.5 * inner_prod(r_strain_vector - mPlasticStrain,
+        //                          prod(elastic_tensor, r_strain_vector - mPlasticStrain))
+        //         + GetPlasticPotential(r_material_properties, mAccumulatedPlasticStrain);
+        rValue = 0.5 * inner_prod(r_strain_vector - mPlasticStrainOld,
+                                  prod(elastic_tensor, r_strain_vector - mPlasticStrainOld))
+                 + GetPlasticPotential(r_material_properties, mAccumulatedPlasticStrainOld);
     }
 
     return(rValue);
@@ -410,10 +444,8 @@ Vector& LinearJ2Plasticity3D::CalculateValue(
 //************************************************************************************
 //************************************************************************************
 
-//************************************************************************************
-//************************************************************************************
-
-double LinearJ2Plasticity3D::GetSaturationHardening(const Properties& rMaterialProperties)
+double LinearJ2Plasticity3D::GetSaturationHardening(const Properties& rMaterialProperties,
+    const double accumulated_plastic_strain)
 {
     const double yield_stress = rMaterialProperties[YIELD_STRESS];
     const double theta = rMaterialProperties[REFERENCE_HARDENING_MODULUS];
@@ -421,8 +453,8 @@ double LinearJ2Plasticity3D::GetSaturationHardening(const Properties& rMaterialP
     const double delta_k = rMaterialProperties[INFINITY_HARDENING_MODULUS];
     const double hardening_exponent = rMaterialProperties[HARDENING_EXPONENT];
 
-    const double k_new = yield_stress + (theta * hardening_modulus * mAccumulatedPlasticStrain) +
-                delta_k * (1. - std::exp(-hardening_exponent * mAccumulatedPlasticStrain));
+    const double k_new = yield_stress + (theta * hardening_modulus * accumulated_plastic_strain) +
+                delta_k * (1. - std::exp(-hardening_exponent * accumulated_plastic_strain));
     return k_new;
 }
 
@@ -449,7 +481,8 @@ double LinearJ2Plasticity3D::GetPlasticPotential(const Properties& rMaterialProp
 
 double LinearJ2Plasticity3D::GetDeltaGamma(
     const double NormStressTrial,
-    const Properties& rMaterialProperties
+    const Properties &rMaterialProperties,
+    const double AccumulatedPlasticStrainOld
     )
 {
     const double E = rMaterialProperties[YOUNG_MODULUS];
@@ -461,21 +494,22 @@ double LinearJ2Plasticity3D::GetDeltaGamma(
     const double hardening_exponent = rMaterialProperties[HARDENING_EXPONENT];
     const double tolerance = 1e-6 * yield_stress;
     const double mu = E / (2. * (1. + poisson_ratio));
-    const double sqrt_two_thirds = std::sqrt(2.0 / 3.0); // =0.8164965809277260
+    const double sqrt_two_thirds = std::sqrt(2. / 3.); // = 0.8164965809277260
     double dgamma = 0.0;
     double norm_yieldfunction = 1.0;
+    double accumulated_plastic_strain = AccumulatedPlasticStrainOld;
 
     while (norm_yieldfunction > tolerance)
     {
-        const double k_new = GetSaturationHardening(rMaterialProperties);
-        const double kp_new = theta * hardening_modulus + delta_k * (hardening_exponent * std::exp(-hardening_exponent * mAccumulatedPlasticStrain));
+        const double k_new = GetSaturationHardening(rMaterialProperties, AccumulatedPlasticStrainOld);
+        const double kp_new = theta * hardening_modulus + delta_k * (hardening_exponent * std::exp(-hardening_exponent * accumulated_plastic_strain));
         const double yieldfunction = - sqrt_two_thirds * k_new + NormStressTrial - 2. * mu * dgamma;
         const double derivative_yieldfunction = -2. * mu * (1. + kp_new / (3. * mu));
         dgamma -= yieldfunction / derivative_yieldfunction;
-        mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld + sqrt_two_thirds * dgamma;
+        accumulated_plastic_strain = AccumulatedPlasticStrainOld + sqrt_two_thirds * dgamma;
         norm_yieldfunction = std::abs(yieldfunction);
     }
-    // TODO (marcelo): handle the case when no convergence is achieved.
+    // TODO(@marandra): handle the case when no convergence is achieved.
     return dgamma;
 }
 
@@ -484,17 +518,18 @@ double LinearJ2Plasticity3D::GetDeltaGamma(
 
 double LinearJ2Plasticity3D::YieldFunction(
     const double NormDeviationStress,
-    const Properties& rMaterialProperties
+    const Properties& rMaterialProperties,
+    const double AccumulatedPlasticStrainOld
     )
 {
-    const double sqrt_two_thirds = std::sqrt(2.0 / 3.0);
+    const double sqrt_two_thirds = std::sqrt(2. / 3.);
     const double yield_stress = rMaterialProperties[YIELD_STRESS];
     const double hardening_modulus = rMaterialProperties[ISOTROPIC_HARDENING_MODULUS];
     const double theta = rMaterialProperties[REFERENCE_HARDENING_MODULUS];
     const double delta_k = rMaterialProperties[INFINITY_HARDENING_MODULUS];
     const double hardening_exponent = rMaterialProperties[HARDENING_EXPONENT];
-    const double k_old = yield_stress + (theta * hardening_modulus * mAccumulatedPlasticStrainOld) +
-        (delta_k) * (1. - std::exp(-hardening_exponent * mAccumulatedPlasticStrainOld));
+    const double k_old = yield_stress + (theta * hardening_modulus * AccumulatedPlasticStrainOld) +
+        (delta_k) * (1. - std::exp(-hardening_exponent * AccumulatedPlasticStrainOld));
 
     return NormDeviationStress - k_old * sqrt_two_thirds;
 }
@@ -537,9 +572,10 @@ void LinearJ2Plasticity3D::CalculateElasticMatrix(
 void LinearJ2Plasticity3D::CalculateTangentTensor(
     const double DeltaGamma,
     const double NormStressTrial,
-    const Vector& YieldFunctionNormalVector,
+    const Vector& rYieldFunctionNormalVector,
     const Properties& rMaterialProperties,
-    Matrix& rElasticityTensor
+    Matrix& rElasticityTensor,
+    const double AccumulatedPlasticStrain
     )
 {
     const double hardening_modulus = rMaterialProperties[ISOTROPIC_HARDENING_MODULUS];
@@ -551,61 +587,61 @@ void LinearJ2Plasticity3D::CalculateTangentTensor(
     const double mu = E / (2. + 2. * poisson_ratio);
     const double volumetric_modulus = E / (3. * (1. - 2. * poisson_ratio));
 
-    const double kp_new = (theta * hardening_modulus) +  delta_k * (hardening_exponent * std::exp(-hardening_exponent * mAccumulatedPlasticStrain));
+    const double kp_new = (theta * hardening_modulus) +  delta_k * (hardening_exponent * std::exp(-hardening_exponent * AccumulatedPlasticStrain));
 
     const double theta_new = 1 - (2. * mu * DeltaGamma) / NormStressTrial;
     const double theta_new_b = 1. / (1. + kp_new / (3. * mu)) - (1. - theta_new);
 
     rElasticityTensor(0, 0) = volumetric_modulus + (2. *mu * theta_new * 2. / 3.) -
-              (2. *mu * theta_new_b * (YieldFunctionNormalVector(0) * YieldFunctionNormalVector(0)));
+              (2. *mu * theta_new_b * (rYieldFunctionNormalVector(0) * rYieldFunctionNormalVector(0)));
     rElasticityTensor(0, 1) = volumetric_modulus + (2. *mu * theta_new * (-1. / 3.)) -
-              (2. *mu * theta_new_b * (YieldFunctionNormalVector(0) * YieldFunctionNormalVector(1)));
+              (2. *mu * theta_new_b * (rYieldFunctionNormalVector(0) * rYieldFunctionNormalVector(1)));
     rElasticityTensor(0, 2) = volumetric_modulus + (2. *mu * theta_new * (-1. / 3.)) -
-              (2. *mu * theta_new_b * (YieldFunctionNormalVector(0) * YieldFunctionNormalVector(2)));
-    rElasticityTensor(0, 3) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(0) * YieldFunctionNormalVector(3)));
-    rElasticityTensor(0, 4) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(0) * YieldFunctionNormalVector(4)));
-    rElasticityTensor(0, 5) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(0) * YieldFunctionNormalVector(5)));
+              (2. *mu * theta_new_b * (rYieldFunctionNormalVector(0) * rYieldFunctionNormalVector(2)));
+    rElasticityTensor(0, 3) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(0) * rYieldFunctionNormalVector(3)));
+    rElasticityTensor(0, 4) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(0) * rYieldFunctionNormalVector(4)));
+    rElasticityTensor(0, 5) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(0) * rYieldFunctionNormalVector(5)));
 
     rElasticityTensor(1, 0) = volumetric_modulus + (2. *mu * theta_new * (-1. / 3.)) -
-              (2. *mu * theta_new_b * (YieldFunctionNormalVector(1) * YieldFunctionNormalVector(0)));
+              (2. *mu * theta_new_b * (rYieldFunctionNormalVector(1) * rYieldFunctionNormalVector(0)));
     rElasticityTensor(1, 1) = volumetric_modulus + (2. *mu * theta_new * 2. / 3.) -
-              (2. *mu * theta_new_b * (YieldFunctionNormalVector(1) * YieldFunctionNormalVector(1)));
+              (2. *mu * theta_new_b * (rYieldFunctionNormalVector(1) * rYieldFunctionNormalVector(1)));
     rElasticityTensor(1, 2) = volumetric_modulus + (2. *mu * theta_new * (-1. / 3.)) -
-              (2. *mu * theta_new_b * (YieldFunctionNormalVector(1) * YieldFunctionNormalVector(2)));
-    rElasticityTensor(1, 3) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(1) * YieldFunctionNormalVector(3)));
-    rElasticityTensor(1, 4) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(1) * YieldFunctionNormalVector(4)));
-    rElasticityTensor(1, 5) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(1) * YieldFunctionNormalVector(5)));
+              (2. *mu * theta_new_b * (rYieldFunctionNormalVector(1) * rYieldFunctionNormalVector(2)));
+    rElasticityTensor(1, 3) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(1) * rYieldFunctionNormalVector(3)));
+    rElasticityTensor(1, 4) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(1) * rYieldFunctionNormalVector(4)));
+    rElasticityTensor(1, 5) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(1) * rYieldFunctionNormalVector(5)));
 
     rElasticityTensor(2, 0) = volumetric_modulus + (2. *mu * theta_new * (-1. / 3.)) -
-              (2. *mu * theta_new_b * (YieldFunctionNormalVector(2) * YieldFunctionNormalVector(0)));
+              (2. *mu * theta_new_b * (rYieldFunctionNormalVector(2) * rYieldFunctionNormalVector(0)));
     rElasticityTensor(2, 1) = volumetric_modulus + (2. *mu * theta_new * (-1. / 3.)) -
-              (2. *mu * theta_new_b * (YieldFunctionNormalVector(2) * YieldFunctionNormalVector(1)));
+              (2. *mu * theta_new_b * (rYieldFunctionNormalVector(2) * rYieldFunctionNormalVector(1)));
     rElasticityTensor(2, 2) = volumetric_modulus + (2. *mu * theta_new * 2. / 3.) -
-              (2. *mu * theta_new_b * (YieldFunctionNormalVector(2) * YieldFunctionNormalVector(2)));
-    rElasticityTensor(2, 3) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(2) * YieldFunctionNormalVector(3)));
-    rElasticityTensor(2, 4) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(2) * YieldFunctionNormalVector(4)));
-    rElasticityTensor(2, 5) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(2) * YieldFunctionNormalVector(5)));
+              (2. *mu * theta_new_b * (rYieldFunctionNormalVector(2) * rYieldFunctionNormalVector(2)));
+    rElasticityTensor(2, 3) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(2) * rYieldFunctionNormalVector(3)));
+    rElasticityTensor(2, 4) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(2) * rYieldFunctionNormalVector(4)));
+    rElasticityTensor(2, 5) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(2) * rYieldFunctionNormalVector(5)));
 
-    rElasticityTensor(3, 0) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(3) * YieldFunctionNormalVector(0)));
-    rElasticityTensor(3, 1) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(3) * YieldFunctionNormalVector(1)));
-    rElasticityTensor(3, 2) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(3) * YieldFunctionNormalVector(2)));
-    rElasticityTensor(3, 3) = mu * theta_new - (2. * mu * theta_new_b * (YieldFunctionNormalVector(3) * YieldFunctionNormalVector(3)));
-    rElasticityTensor(3, 4) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(3) * YieldFunctionNormalVector(4)));
-    rElasticityTensor(3, 5) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(3) * YieldFunctionNormalVector(5)));
+    rElasticityTensor(3, 0) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(3) * rYieldFunctionNormalVector(0)));
+    rElasticityTensor(3, 1) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(3) * rYieldFunctionNormalVector(1)));
+    rElasticityTensor(3, 2) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(3) * rYieldFunctionNormalVector(2)));
+    rElasticityTensor(3, 3) = mu * theta_new - (2. * mu * theta_new_b * (rYieldFunctionNormalVector(3) * rYieldFunctionNormalVector(3)));
+    rElasticityTensor(3, 4) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(3) * rYieldFunctionNormalVector(4)));
+    rElasticityTensor(3, 5) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(3) * rYieldFunctionNormalVector(5)));
 
-    rElasticityTensor(4, 0) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(4) * YieldFunctionNormalVector(0)));
-    rElasticityTensor(4, 1) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(4) * YieldFunctionNormalVector(1)));
-    rElasticityTensor(4, 2) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(4) * YieldFunctionNormalVector(2)));
-    rElasticityTensor(4, 3) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(4) * YieldFunctionNormalVector(3)));
-    rElasticityTensor(4, 4) = mu * theta_new - (2. * mu * theta_new_b * (YieldFunctionNormalVector(4) * YieldFunctionNormalVector(4)));
-    rElasticityTensor(4, 5) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(4) * YieldFunctionNormalVector(5)));
+    rElasticityTensor(4, 0) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(4) * rYieldFunctionNormalVector(0)));
+    rElasticityTensor(4, 1) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(4) * rYieldFunctionNormalVector(1)));
+    rElasticityTensor(4, 2) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(4) * rYieldFunctionNormalVector(2)));
+    rElasticityTensor(4, 3) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(4) * rYieldFunctionNormalVector(3)));
+    rElasticityTensor(4, 4) = mu * theta_new - (2. * mu * theta_new_b * (rYieldFunctionNormalVector(4) * rYieldFunctionNormalVector(4)));
+    rElasticityTensor(4, 5) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(4) * rYieldFunctionNormalVector(5)));
 
-    rElasticityTensor(5, 0) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(5) * YieldFunctionNormalVector(0)));
-    rElasticityTensor(5, 1) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(5) * YieldFunctionNormalVector(1)));
-    rElasticityTensor(5, 2) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(5) * YieldFunctionNormalVector(2)));
-    rElasticityTensor(5, 3) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(5) * YieldFunctionNormalVector(3)));
-    rElasticityTensor(5, 4) = -(2. *mu * theta_new_b * (YieldFunctionNormalVector(5) * YieldFunctionNormalVector(4)));
-    rElasticityTensor(5, 5) = mu * theta_new - (2. * mu * theta_new_b * (YieldFunctionNormalVector(5) * YieldFunctionNormalVector(5)));
+    rElasticityTensor(5, 0) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(5) * rYieldFunctionNormalVector(0)));
+    rElasticityTensor(5, 1) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(5) * rYieldFunctionNormalVector(1)));
+    rElasticityTensor(5, 2) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(5) * rYieldFunctionNormalVector(2)));
+    rElasticityTensor(5, 3) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(5) * rYieldFunctionNormalVector(3)));
+    rElasticityTensor(5, 4) = -(2. *mu * theta_new_b * (rYieldFunctionNormalVector(5) * rYieldFunctionNormalVector(4)));
+    rElasticityTensor(5, 5) = mu * theta_new - (2. * mu * theta_new_b * (rYieldFunctionNormalVector(5) * rYieldFunctionNormalVector(5)));
 }
 
 //************************************************************************************
@@ -617,8 +653,8 @@ void LinearJ2Plasticity3D::GetLawFeatures(Features& rFeatures)
     rFeatures.mOptions.Set(INFINITESIMAL_STRAINS);
     rFeatures.mOptions.Set(ISOTROPIC);
     rFeatures.mStrainMeasures.push_back(StrainMeasure_Infinitesimal);
-    rFeatures.mStrainSize = 6;
-    rFeatures.mSpaceDimension = 3;
+    rFeatures.mStrainSize = this->GetStrainSize();
+    rFeatures.mSpaceDimension = this->WorkingSpaceDimension();
 }
 
 //************************************************************************************

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
@@ -388,24 +388,24 @@ protected:
             const double accumulated_plastic_strain);
 
     /**
-     * @brief This method computes the plastic potential
+     * @brief This method computes the constitutive tensor
      * @param DeltaGamma The increment on the Gamma parameter
      * @param NormStressTrial The norm of the stress trial
-     * @param rYieldFunctionNormalVector The yield function normal vector
+     * @param rYFNormalVector The yield function normal vector
      * @param rMaterialProperties The properties of the material
-     * @param rElasticityTensor The elastic tensor/matrix to be computed
+     * @param rTMatrix The elastic tensor/matrix to be computed
      */
-    virtual void CalculateTangentTensor(const double DeltaGamma, const double NormStressTrial,
-                                        const Vector &rYieldFunctionNormalVector,
+    virtual void CalculateTangentMatrix(const double DeltaGamma, const double NormStressTrial,
+                                        const Vector &rYFNormalVector,
                                         const Properties &rMaterialProperties,
-                                        const double AccumulatedPlasticStrain, Matrix &rElasticityTensor);
+                                        const double AccumulatedPlasticStrain, Matrix &rTMatrix);
 
     /**
      * @brief This method computes the elastic tensor
-     * @param rElasticityTensor The elastic tensor/matrix to be computed
+     * @param rElasticMatrix The elastic tensor/matrix to be computed
      * @param rMaterialProperties The properties of the material
      */
-    virtual void CalculateElasticMatrix(const Properties &rMaterialProperties, Matrix &rElasticityTensor);
+    virtual void CalculateElasticMatrix(const Properties &rMaterialProperties, Matrix &rElasticMatrix);
 
     ///@}
     ///@name Protected  Access

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
@@ -19,7 +19,6 @@
 // External includes
 
 // Project includes
-#include "includes/checks.h"
 #include "includes/constitutive_law.h"
 
 namespace Kratos
@@ -391,7 +390,8 @@ protected:
      * @param rMaterialProperties The properties of the material
      * @return The plastic potential
      */
-    double GetPlasticPotential(const Properties& rMaterialProperties);
+    double GetPlasticPotential(const Properties& rMaterialProperties,
+            const double accumulated_plastic_strain);
 
     /**
      * @brief This method computes the plastic potential

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
@@ -115,7 +115,7 @@ public:
     void GetLawFeatures(Features& rFeatures) override;
 
     /**
-     * @brief Dimension of the law:
+     * @brief dimension of the constitutive law
      */
     SizeType WorkingSpaceDimension() override
     {
@@ -188,18 +188,6 @@ public:
     void InitializeMaterial(const Properties& rMaterialProperties,
                             const GeometryType& rElementGeometry,
                             const Vector& rShapeFunctionsValues) override;
-
-    /**
-     * @brief To be called at the end of each solution step  (e.g. from Element::FinalizeSolutionStep)
-     * @param rMaterialProperties the Properties instance of the current element
-     * @param rElementGeometry the geometry of the current element
-     * @param rShapeFunctionsValues the shape functions values in the current integration point
-     * @param rCurrentProcessInfo the current ProcessInfo instance
-     */
-    void FinalizeSolutionStep(const Properties& rMaterialProperties,
-                            const GeometryType& rElementGeometry,
-                            const Vector& rShapeFunctionsValues,
-                            const ProcessInfo& rCurrentProcessInfo) override;
 
     /**
      * @brief Computes the material response in terms of 1st Piola-Kirchhoff stresses and constitutive tensor
@@ -276,7 +264,7 @@ public:
      * @param rValues The specific parameters of the current constitutive law
      * @see Parameters
      */
-    void FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues) override;
+    void FinalizeMaterialResponseKirchhoff(Parameters& rValues) override;
 
     /**
      * @brief Finalize the material response in terms of Cauchy stresses
@@ -357,6 +345,16 @@ protected:
     ///@{
 
     /**
+     * @brief This method computes the stress and constitutive tensor
+     * @param rValues The norm of the deviation stress
+     * @param rPlasticStrain
+     * @param rAccumulatedPlasticStrain
+     */
+    void CalculateStressResponse(ConstitutiveLaw::Parameters& rValues,
+                                 Vector& rPlasticStrain,
+                                 double& rAccumulatedPlasticStrain );
+
+    /**
      * @brief This method computes the yield function
      * @param NormDeviationStress The norm of the deviation stress
      * @param rMaterialProperties The properties of the current material considered
@@ -364,7 +362,8 @@ protected:
      */
     double YieldFunction(
         const double NormDeviationStress,
-        const Properties& rMaterialProperties
+        const Properties& rMaterialProperties,
+        const double accumulated_plastic_strain
         );
 
     /**
@@ -373,17 +372,14 @@ protected:
      * @param rMaterialProperties The properties of the material
      * @return The increment of Gamma computed
      */
-    double GetDeltaGamma(
-        const double NormStressTrial,
-        const Properties& rMaterialProperties
-        );
+    double GetDeltaGamma(const double NormStressTrial, const Properties &rMaterialProperties, const double);
 
     /**
      * @brief This method gets the saturation hardening parameter
      * @param rMaterialProperties The properties of the material
      * @return The saturation hardening parameter
      */
-    double GetSaturationHardening(const Properties& rMaterialProperties);
+    double GetSaturationHardening(const Properties& rMaterialProperties, const double);
 
     /**
      * @brief This method computes the plastic potential
@@ -397,16 +393,17 @@ protected:
      * @brief This method computes the plastic potential
      * @param DeltaGamma The increment on the Gamma parameter
      * @param NormStressTrial The norm of the stress trial
-     * @param YieldFunctionNormalVector The yield function normal vector
+     * @param rYieldFunctionNormalVector The yield function normal vector
      * @param rMaterialProperties The properties of the material
      * @param rElasticityTensor The elastic tensor/matrix to be computed
      */
     virtual void CalculateTangentTensor(
         const double DeltaGamma,
         const double NormStressTrial,
-        const Vector& YieldFunctionNormalVector,
+        const Vector& rYieldFunctionNormalVector,
         const Properties& rMaterialProperties,
-        Matrix& rElasticityTensor
+        Matrix& rElasticityTensor,
+        const double AccumulatedPlasticStrain
         );
 
     /**

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_3d.h
@@ -68,9 +68,9 @@ public:
     ///@name Type Definitions
     ///@{
 
-    typedef ProcessInfo      ProcessInfoType;
-    typedef ConstitutiveLaw         BaseType;
-    typedef std::size_t             SizeType;
+    typedef ProcessInfo ProcessInfoType;
+    typedef ConstitutiveLaw BaseType;
+    typedef std::size_t SizeType;
 
     // Counted pointer of LinearJ2Plasticity3D
     KRATOS_CLASS_POINTER_DEFINITION(LinearJ2Plasticity3D);
@@ -331,10 +331,8 @@ protected:
     ///@{
 
     bool mInelasticFlag; /// This flags tells if we are in a elastic or ineslastic regime
-    Vector mPlasticStrain; /// The current plastic strain (one for each of the strain components)
-    Vector mPlasticStrainOld; /// The previous plastic strain (one for each of the strain components)
-    double mAccumulatedPlasticStrain; /// The current accumulated plastic strain
-    double mAccumulatedPlasticStrainOld; /// The previous accumulated plastic strain
+    Vector mPlasticStrain; /// The previous plastic strain (one for each of the strain components)
+    double mAccumulatedPlasticStrain; /// The previous accumulated plastic strain
 
     ///@}
     ///@name Protected Operators
@@ -350,7 +348,7 @@ protected:
      * @param rPlasticStrain
      * @param rAccumulatedPlasticStrain
      */
-    void CalculateStressResponse(ConstitutiveLaw::Parameters& rValues,
+    virtual void CalculateStressResponse(ConstitutiveLaw::Parameters& rValues,
                                  Vector& rPlasticStrain,
                                  double& rAccumulatedPlasticStrain );
 
@@ -363,7 +361,7 @@ protected:
     double YieldFunction(
         const double NormDeviationStress,
         const Properties& rMaterialProperties,
-        const double accumulated_plastic_strain
+        const double AccumulatedPlasticStrain
         );
 
     /**
@@ -397,24 +395,17 @@ protected:
      * @param rMaterialProperties The properties of the material
      * @param rElasticityTensor The elastic tensor/matrix to be computed
      */
-    virtual void CalculateTangentTensor(
-        const double DeltaGamma,
-        const double NormStressTrial,
-        const Vector& rYieldFunctionNormalVector,
-        const Properties& rMaterialProperties,
-        Matrix& rElasticityTensor,
-        const double AccumulatedPlasticStrain
-        );
+    virtual void CalculateTangentTensor(const double DeltaGamma, const double NormStressTrial,
+                                        const Vector &rYieldFunctionNormalVector,
+                                        const Properties &rMaterialProperties,
+                                        const double AccumulatedPlasticStrain, Matrix &rElasticityTensor);
 
     /**
      * @brief This method computes the elastic tensor
      * @param rElasticityTensor The elastic tensor/matrix to be computed
      * @param rMaterialProperties The properties of the material
      */
-    virtual void CalculateElasticMatrix(
-        Matrix &rElasticityTensor,
-        const Properties &rMaterialProperties
-        );
+    virtual void CalculateElasticMatrix(const Properties &rMaterialProperties, Matrix &rElasticityTensor);
 
     ///@}
     ///@name Protected  Access

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_plane_strain_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_plane_strain_2d.cpp
@@ -155,7 +155,7 @@ void LinearJ2PlasticityPlaneStrain2D::CalculateStressResponse(
 
             // We update the tangent tensor
             if( r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
-                CalculateTangentTensor(dgamma, norm_dev_stress, yield_function_normal_vector,
+                CalculateTangentMatrix(dgamma, norm_dev_stress, yield_function_normal_vector,
                                        r_material_properties, rAccumulatedPlasticStrain, tangent_tensor);
             }
         }
@@ -198,10 +198,11 @@ void LinearJ2PlasticityPlaneStrain2D::CalculateElasticMatrix(const Properties &r
 //************************************************************************************
 //************************************************************************************
 
-void LinearJ2PlasticityPlaneStrain2D::CalculateTangentTensor(const double DeltaGamma, const double NormStressTrial,
+void LinearJ2PlasticityPlaneStrain2D::CalculateTangentMatrix(const double DeltaGamma, const double NormStressTrial,
                                                              const Vector &YieldFunctionNormalVector,
                                                              const Properties &rMaterialProperties,
-                                                             const double AccumulatedPlasticStrain, Matrix &rElasticityTensor)
+                                                             const double AccumulatedPlasticStrain,
+                                                             Matrix &rElasticityTensor)
 {
     const double hardening_modulus = rMaterialProperties[ISOTROPIC_HARDENING_MODULUS];
     const double theta = rMaterialProperties[REFERENCE_HARDENING_MODULUS];

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_plane_strain_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_plane_strain_2d.cpp
@@ -12,6 +12,11 @@
 //  Collaborator:    Vicente Mataix Ferrandiz
 //
 
+// System includes
+
+// External includes
+
+// Project includes
 #include "linear_j2_plasticity_plane_strain_2d.h"
 #include "structural_mechanics_application_variables.h"
 
@@ -38,8 +43,7 @@ LinearJ2PlasticityPlaneStrain2D::LinearJ2PlasticityPlaneStrain2D(const LinearJ2P
 
 ConstitutiveLaw::Pointer LinearJ2PlasticityPlaneStrain2D::Clone() const
 {
-    LinearJ2PlasticityPlaneStrain2D::Pointer pclone(new LinearJ2PlasticityPlaneStrain2D(*this));
-    return pclone;
+    return Kratos::make_shared<LinearJ2PlasticityPlaneStrain2D>(LinearJ2PlasticityPlaneStrain2D(*this));
 }
 
 //********************************DESTRUCTOR******************************************
@@ -52,71 +56,50 @@ LinearJ2PlasticityPlaneStrain2D::~LinearJ2PlasticityPlaneStrain2D()
 //************************************************************************************
 //************************************************************************************
 
-void LinearJ2PlasticityPlaneStrain2D::CalculateMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
+void LinearJ2PlasticityPlaneStrain2D::CalculateStressResponse(
+        ConstitutiveLaw::Parameters& rValues,
+        Vector& rPlasticStrain,
+        double& rAccumulatedPlasticStrain)
 {
-    CalculateMaterialResponseCauchy(rValues);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void LinearJ2PlasticityPlaneStrain2D::CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
-{
-    CalculateMaterialResponseCauchy(rValues);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void LinearJ2PlasticityPlaneStrain2D::CalculateMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
-{
-    CalculateMaterialResponseCauchy(rValues);
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void LinearJ2PlasticityPlaneStrain2D::CalculateMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
-{
-    Flags &Options = rValues.GetOptions();
-
-    const Properties& rMaterialProperties = rValues.GetMaterialProperties();
-    Vector& strain_vector = rValues.GetStrainVector();
-    Vector& stress_vector = rValues.GetStressVector();
-
-    if (Options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
-        Matrix& ConstitutiveMatrix = rValues.GetConstitutiveMatrix();
-        CalculateElasticMatrix(ConstitutiveMatrix, rMaterialProperties);
+    rPlasticStrain.resize(4, false);
+    const Properties& r_material_properties = rValues.GetMaterialProperties();
+    Flags& r_constitutive_law_options = rValues.GetOptions();
+    Vector& r_strain_vector = rValues.GetStrainVector();
+    if (rValues.GetProcessInfo().Has(INITIAL_STRAIN)) {
+        noalias(r_strain_vector) += rValues.GetProcessInfo()[INITIAL_STRAIN];
     }
 
-    if (Options.Is(ConstitutiveLaw::COMPUTE_STRESS)) {
-        if (rValues.GetProcessInfo().Has(INITIAL_STRAIN)) {
-            noalias(strain_vector) += rValues.GetProcessInfo()[INITIAL_STRAIN];
-        }
-        Matrix elastic_tensor;
+    if( r_constitutive_law_options.IsNot(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN)) {
+        //this->CalculateValue(rValues, STRAIN, r_strain_vector);
+    }
+
+    if( r_constitutive_law_options.Is(ConstitutiveLaw::COMPUTE_STRESS) ||
+        r_constitutive_law_options.Is(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR)) {
+        Vector& r_stress_vector = rValues.GetStressVector();
         Matrix& tangent_tensor = rValues.GetConstitutiveMatrix();
-        const double hardening_modulus = rMaterialProperties[ISOTROPIC_HARDENING_MODULUS];
-        const double delta_k = rMaterialProperties[INFINITY_HARDENING_MODULUS];
-        const double hardening_exponent = rMaterialProperties[HARDENING_EXPONENT];
-        const double E = rMaterialProperties[YOUNG_MODULUS];
-        const double poisson_ratio = rMaterialProperties[POISSON_RATIO];
+        const double hardening_modulus = r_material_properties[ISOTROPIC_HARDENING_MODULUS];
+        const double delta_k = r_material_properties[INFINITY_HARDENING_MODULUS];
+        const double hardening_exponent = r_material_properties[HARDENING_EXPONENT];
+        const double E = r_material_properties[YOUNG_MODULUS];
+        const double poisson_ratio = r_material_properties[POISSON_RATIO];
         const double mu = E / (2. + 2. * poisson_ratio);
         const double volumetric_modulus = E / (3. * (1. - 2. * poisson_ratio));
-        const double sqrt_two_thirds = std::sqrt(2.0 / 3.0); // =0.8164965809277260
+        const double sqrt_two_thirds = std::sqrt(2. / 3.); // = 0.8164965809277260
         double trial_yield_function;
 
-        mPlasticStrain = mPlasticStrainOld;
-        mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld;
+        rPlasticStrain = mPlasticStrain;
+        rAccumulatedPlasticStrain = mAccumulatedPlasticStrain;
 
+        Matrix elastic_tensor;
         elastic_tensor.resize(4, 4, false);
-        CalculateElasticMatrix(elastic_tensor, rMaterialProperties);
-        Vector yield_tensionrial(4);
-        noalias(yield_tensionrial) = prod(elastic_tensor, strain_vector - mPlasticStrainOld);
+        CalculateElasticMatrix(r_material_properties, elastic_tensor);
+        Vector yield_tension(4);
+        noalias(yield_tension) = prod(elastic_tensor, r_strain_vector - mPlasticStrain);
 
         // stress_trial_dev = sigma - 1/3 tr(sigma) * I
-        Vector stress_trial_dev = yield_tensionrial;
+        Vector stress_trial_dev = yield_tension;
 
-        const double trace = 1.0 / 3.0 * (yield_tensionrial(0) + yield_tensionrial(1) + yield_tensionrial(2));
+        const double trace = 1. / 3. * (yield_tension(0) + yield_tension(1) + yield_tension(2));
         stress_trial_dev(0) -= trace;
         stress_trial_dev(1) -= trace;
         stress_trial_dev(2) -= trace;
@@ -124,50 +107,57 @@ void LinearJ2PlasticityPlaneStrain2D::CalculateMaterialResponseCauchy(Constituti
                                            stress_trial_dev(1) * stress_trial_dev(1) +
                                            stress_trial_dev(2) * stress_trial_dev(2) +
                                            2. * stress_trial_dev(3) * stress_trial_dev(3));
-        trial_yield_function = this->YieldFunction(norm_dev_stress, rMaterialProperties, mAccumulatedPlasticStrainOld);
+        trial_yield_function = this->YieldFunction(norm_dev_stress, r_material_properties, mAccumulatedPlasticStrain);
 
         if (trial_yield_function <= 0.) {
             // ELASTIC
             mInelasticFlag = false;
-            stress_vector = yield_tensionrial;
-            tangent_tensor = elastic_tensor;
+            if( r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
+                r_stress_vector = yield_tension;
+            }
+            if( r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
+                tangent_tensor = elastic_tensor;
+            }
         } else {
             // INELASTIC
             mInelasticFlag = true;
             double dgamma = 0;
             Vector yield_function_normal_vector = stress_trial_dev / norm_dev_stress;
             if (delta_k != 0.0 && hardening_exponent != 0.0) {
-                // Exponential softening
-                dgamma = GetDeltaGamma(norm_dev_stress, rMaterialProperties, mAccumulatedPlasticStrainOld);
+                // Exponential hardening
+                dgamma = GetDeltaGamma(norm_dev_stress, r_material_properties, mAccumulatedPlasticStrain);
             }
             else {
-                // Linear softening
+                // Linear hardening
                 dgamma = trial_yield_function /
                          (2. * mu * (1. + (hardening_modulus / (3. * mu))));
             }
 
-            stress_vector(0) =
-                volumetric_modulus * (strain_vector(0) + strain_vector(1) + strain_vector(2)) +
-                stress_trial_dev(0) - 2. * mu * dgamma * yield_function_normal_vector(0);
-            stress_vector(1) =
-                volumetric_modulus * (strain_vector(0) + strain_vector(1) + strain_vector(2)) +
-                stress_trial_dev(1) - 2. * mu * dgamma * yield_function_normal_vector(1);
-            stress_vector(2) =
-                volumetric_modulus * (strain_vector(0) + strain_vector(1) + strain_vector(2)) +
-                stress_trial_dev(2) - 2. * mu * dgamma * yield_function_normal_vector(2);
-            stress_vector(3) =
-                stress_trial_dev(3) - 2. * mu * dgamma * yield_function_normal_vector(3);
+            if( r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_STRESS ) ) {
+                r_stress_vector(0) =
+                    volumetric_modulus * (r_strain_vector(0) + r_strain_vector(1) + r_strain_vector(2)) +
+                    stress_trial_dev(0) - 2. * mu * dgamma * yield_function_normal_vector(0);
+                r_stress_vector(1) =
+                    volumetric_modulus * (r_strain_vector(0) + r_strain_vector(1) + r_strain_vector(2)) +
+                    stress_trial_dev(1) - 2. * mu * dgamma * yield_function_normal_vector(1);
+                r_stress_vector(2) =
+                    volumetric_modulus * (r_strain_vector(0) + r_strain_vector(1) + r_strain_vector(2)) +
+                    stress_trial_dev(2) - 2. * mu * dgamma * yield_function_normal_vector(2);
+                r_stress_vector(3) =
+                        stress_trial_dev(3) - 2. * mu * dgamma * yield_function_normal_vector(3);
+                }
 
-            mPlasticStrain(0) = mPlasticStrainOld(0) + dgamma * yield_function_normal_vector(0);
-            mPlasticStrain(1) = mPlasticStrainOld(1) + dgamma * yield_function_normal_vector(1);
-            mPlasticStrain(2) = mPlasticStrainOld(2) + dgamma * yield_function_normal_vector(2);
-            mPlasticStrain(3) = mPlasticStrainOld(3) + dgamma * yield_function_normal_vector(3) * 2;
-            mAccumulatedPlasticStrain = mAccumulatedPlasticStrainOld + sqrt_two_thirds * dgamma;
+            rPlasticStrain(0) += dgamma * yield_function_normal_vector(0);
+            rPlasticStrain(1) += dgamma * yield_function_normal_vector(1);
+            rPlasticStrain(2) += dgamma * yield_function_normal_vector(2);
+            rPlasticStrain(3) += dgamma * yield_function_normal_vector(3) * 2;
+            rAccumulatedPlasticStrain += sqrt_two_thirds * dgamma;
 
-            // Update derivative of the hardening-softening modulus
-
-            CalculateTangentTensor(dgamma, norm_dev_stress, yield_function_normal_vector,
-                                   rMaterialProperties, tangent_tensor, mAccumulatedPlasticStrain);
+            // We update the tangent tensor
+            if( r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR ) ) {
+                CalculateTangentTensor(dgamma, norm_dev_stress, yield_function_normal_vector,
+                                       r_material_properties, rAccumulatedPlasticStrain, tangent_tensor);
+            }
         }
     }
 }
@@ -175,40 +165,7 @@ void LinearJ2PlasticityPlaneStrain2D::CalculateMaterialResponseCauchy(Constituti
 //************************************************************************************
 //************************************************************************************
 
-void LinearJ2PlasticityPlaneStrain2D::FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues)
-{
-}
-
-//************************************************************************************
-//************************************************************************************
-
-
-void LinearJ2PlasticityPlaneStrain2D::FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues)
-{
-}
-
-//************************************************************************************
-//************************************************************************************
-
-
-void LinearJ2PlasticityPlaneStrain2D::FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues)
-{
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void LinearJ2PlasticityPlaneStrain2D::FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
-{
-}
-
-//************************************************************************************
-//************************************************************************************
-
-void LinearJ2PlasticityPlaneStrain2D::CalculateElasticMatrix(
-    Matrix &rElasticityTensor,
-    const Properties &rMaterialProperties
-    )
+void LinearJ2PlasticityPlaneStrain2D::CalculateElasticMatrix(const Properties &rMaterialProperties, Matrix &rElasticityTensor)
 {
     const double E = rMaterialProperties[YOUNG_MODULUS];
     const double poisson_ratio = rMaterialProperties[POISSON_RATIO];
@@ -241,14 +198,10 @@ void LinearJ2PlasticityPlaneStrain2D::CalculateElasticMatrix(
 //************************************************************************************
 //************************************************************************************
 
-void LinearJ2PlasticityPlaneStrain2D::CalculateTangentTensor(
-    const double DeltaGamma,
-    const double NormStressTrial,
-    const Vector& YieldFunctionNormalVector,
-    const Properties& rMaterialProperties,
-    Matrix& rElasticityTensor,
-    double AccumulatedPlasticStrain
-    )
+void LinearJ2PlasticityPlaneStrain2D::CalculateTangentTensor(const double DeltaGamma, const double NormStressTrial,
+                                                             const Vector &YieldFunctionNormalVector,
+                                                             const Properties &rMaterialProperties,
+                                                             const double AccumulatedPlasticStrain, Matrix &rElasticityTensor)
 {
     const double hardening_modulus = rMaterialProperties[ISOTROPIC_HARDENING_MODULUS];
     const double theta = rMaterialProperties[REFERENCE_HARDENING_MODULUS];

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_plane_strain_2d.h
@@ -69,13 +69,16 @@ public:
     ///@name Type Definitions
     ///@{
 
-    typedef ProcessInfo      ProcessInfoType;
-    typedef ConstitutiveLaw       CLBaseType;
-    typedef LinearJ2Plasticity3D    BaseType;
-    typedef std::size_t             SizeType;
+    typedef ProcessInfo ProcessInfoType;
+    typedef LinearJ2Plasticity3D BaseType;
+    typedef std::size_t SizeType;
 
-    // Counted pointer of LinearJ2Plasticity3D
+    // Counted pointer
     KRATOS_CLASS_POINTER_DEFINITION(LinearJ2PlasticityPlaneStrain2D);
+
+    ///@}
+    ///@name Lyfe Cycle
+    ///@{
 
     /**
      * @brief Default constructor.
@@ -128,62 +131,6 @@ public:
         return 4;
     };
 
-    /**
-     * @brief Computes the material response in terms of 1st Piola-Kirchhoff stresses and constitutive tensor
-     * @param rValues The specific parameters of the current constitutive law
-     * @see Parameters
-     */
-    void CalculateMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues) override;
-
-    /**
-     * @brief Computes the material response in terms of 2nd Piola-Kirchhoff stresses and constitutive tensor
-     * @param rValues The specific parameters of the current constitutive law
-     * @see Parameters
-     */
-    void CalculateMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) override;
-
-    /**
-     * @brief Computes the material response in terms of Kirchhoff stresses and constitutive tensor
-     * @param rValues The specific parameters of the current constitutive law
-     * @see Parameters
-     */
-    void CalculateMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues) override;
-
-    /**
-     * @brief Computes the material response in terms of Cauchy stresses and constitutive tensor
-     * @param rValues The specific parameters of the current constitutive law
-     * @see Parameters
-     */
-    void CalculateMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) override;
-
-    /**
-     * @brief Finalize the material response in terms of 1st Piola-Kirchhoff stresses
-     * @param rValues The specific parameters of the current constitutive law
-     * @see Parameters
-     */
-    void FinalizeMaterialResponsePK1(ConstitutiveLaw::Parameters& rValues) override;
-
-    /**
-     * @brief Finalize the material response in terms of 2nd Piola-Kirchhoff stresses
-     * @param rValues The specific parameters of the current constitutive law
-     * @see Parameters
-     */
-    void FinalizeMaterialResponsePK2(ConstitutiveLaw::Parameters& rValues) override;
-
-    /**
-     * @brief Finalize the material response in terms of Kirchhoff stresses
-     * @param rValues The specific parameters of the current constitutive law
-     * @see Parameters
-     */
-    void FinalizeMaterialResponseKirchhoff(ConstitutiveLaw::Parameters& rValues) override;
-
-    /**
-     * @brief Finalize the material response in terms of Cauchy stresses
-     * @param rValues The specific parameters of the current constitutive law
-     * @see Parameters
-     */
-    void FinalizeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) override;
-
     ///@}
     ///@name Inquiry
     ///@{
@@ -214,6 +161,18 @@ protected:
     ///@{
 
     /**
+     * @brief This method computes the stress and constitutive tensor
+     * @param rValues The norm of the deviation stress
+     * @param rPlasticStrain
+     * @param rAccumulatedPlasticStrain
+     */
+    void CalculateStressResponse(
+            ConstitutiveLaw::Parameters& rValues,
+            Vector& rPlasticStrain,
+            double& rAccumulatedPlasticStrain
+            ) override;
+
+    /**
      * @brief This method computes the plastic potential
      * @param DeltaGamma The increment on the Gamma parameter
      * @param NormStressTrial The norm of the stress trial
@@ -221,24 +180,17 @@ protected:
      * @param rMaterialProperties The properties of the material
      * @param rElasticityTensor The elastic tensor/matrix to be computed
      */
-    void CalculateTangentTensor(
-        const double DeltaGamma,
-        const double NormStressTrial,
-        const Vector& YieldFunctionNormalVector,
-        const Properties& rMaterialProperties,
-        Matrix& rElasticityTensor,
-        double
-        ) override;
+    void CalculateTangentTensor(const double DeltaGamma, const double NormStressTrial,
+                                const Vector &YieldFunctionNormalVector,
+                                const Properties &rMaterialProperties,
+                                const double AccumulatedPlasticStrain, Matrix &rElasticityTensor) override;
 
     /**
      * @brief This method computes the elastic tensor
      * @param rElasticityTensor The elastic tensor/matrix to be computed
      * @param rMaterialProperties The properties of the material
      */
-    void CalculateElasticMatrix(
-        Matrix &rElasticityTensor,
-        const Properties &rMaterialProperties
-        ) override;
+    void CalculateElasticMatrix(const Properties &rMaterialProperties, Matrix &rElasticityTensor) override;
 
     ///@}
     ///@name Protected  Access

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_plane_strain_2d.h
@@ -180,7 +180,7 @@ protected:
      * @param rMaterialProperties The properties of the material
      * @param rElasticityTensor The elastic tensor/matrix to be computed
      */
-    void CalculateTangentTensor(const double DeltaGamma, const double NormStressTrial,
+    void CalculateTangentMatrix(const double DeltaGamma, const double NormStressTrial,
                                 const Vector &YieldFunctionNormalVector,
                                 const Properties &rMaterialProperties,
                                 const double AccumulatedPlasticStrain, Matrix &rElasticityTensor) override;

--- a/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_plane_strain_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/linear_j2_plasticity_plane_strain_2d.h
@@ -226,7 +226,8 @@ protected:
         const double NormStressTrial,
         const Vector& YieldFunctionNormalVector,
         const Properties& rMaterialProperties,
-        Matrix& rElasticityTensor
+        Matrix& rElasticityTensor,
+        double
         ) override;
 
     /**

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -178,8 +178,10 @@ void SmallDisplacementBbar::CalculateKinematicVariables(
         const GeometryType::IntegrationMethod& rIntegrationMethod
 )
 {
+    const GeometryType::IntegrationPointsArrayType& r_integration_points =
+            GetGeometry().IntegrationPoints(rIntegrationMethod);
     // Shape functions
-    rThisKinematicVariables.N = row(GetGeometry().ShapeFunctionsValues(rIntegrationMethod), PointNumber);
+    rThisKinematicVariables.N = GetGeometry().ShapeFunctionsValues(rThisKinematicVariables.N, r_integration_points[PointNumber].Coordinates());
 
     rThisKinematicVariables.detJ0 = CalculateDerivativesOnReferenceConfiguration(
             rThisKinematicVariables.J0,
@@ -536,14 +538,14 @@ void SmallDisplacementBbar::CalculateOnIntegrationPoints(
         // Create constitutive law parameters:
         ConstitutiveLaw::Parameters Values(GetGeometry(),GetProperties(),rCurrentProcessInfo);
 
-        // Reading integration points
-        const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(this->GetIntegrationMethod());
-
         // Set constitutive law flags:
         Flags& ConstitutiveLawOptions=Values.GetOptions();
         ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
         ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, false);
         ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+
+        // Reading integration points
+        const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints(this->GetIntegrationMethod());
 
         // If strain has to be computed inside of the constitutive law with PK2
         Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -943,6 +943,9 @@ void SmallDisplacementBbar::FinalizeSolutionStep( ProcessInfo& rCurrentProcessIn
         // Compute element kinematics B, F, DN_DX ...
         CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
 
+        // Compute constitutive law variables
+        SetConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points);
+
         // Call the constitutive law to update material variables
         mConstitutiveLawVector[point_number]->FinalizeMaterialResponse(Values, GetStressMeasure());
 


### PR DESCRIPTION
- Removed unnecessary member variables used as internal variables in plasticity and damage CLs, optimizing memory.
- Added a missing initialization to the Bbar element (bug fix)
- Renamed function and variables for consistency
