### PR TITLE
[MPI][Testing] Re-renaming main model part for RedistanceProcess to "main" (in Pyhton file)

### DIFF
--- a/applications/trilinos_application/tests/test_trilinos_redistance.py
+++ b/applications/trilinos_application/tests/test_trilinos_redistance.py
@@ -52,7 +52,7 @@ class TestTrilinosRedistance(KratosUnittest.TestCase):
     def testTrilinosRedistance(self):
         # Set the model part
         current_model = KratosMultiphysics.Model()
-        self.model_part = current_model.CreateModelPart("RedistanceCalculationPart")
+        self.model_part = current_model.CreateModelPart("Main")
         self.model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
         self.model_part.AddNodalSolutionStepVariable(KratosMultiphysics.FLAG_VARIABLE)
         self.model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)


### PR DESCRIPTION
Addresses parts of issue #3694 as described by @philbucher.

The problem was a conflict in the naming of the model parts.