### PR TITLE
Apps/more python modules

### DIFF
--- a/applications/FSIapplication/CMakeLists.txt
+++ b/applications/FSIapplication/CMakeLists.txt
@@ -62,4 +62,4 @@ endif(${INSTALL_PYTHON_FILES} MATCHES ON)
 # message("KratosIncompressibleFluidApplication subdir inc_dirs = ${inc_dirs}")
 
 # Add to the KratosMultiphisics Python module
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/FSIApplication.py" DESTINATION KratosMultiphysics )
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/FSIApplication.py" DESTINATION "KratosMultiphysics/FSIApplication" RENAME "__init__.py")

--- a/applications/FSIapplication/FSIApplication.py
+++ b/applications/FSIapplication/FSIApplication.py
@@ -5,7 +5,7 @@ application_name = "KratosFSIApplication"
 application_folder = "FSIapplication"
 
 # The following lines are common for all applications
-from . import application_importer
+from .. import application_importer
 import inspect
 caller = inspect.stack()[1]  # Information about the file that imported this, to check for unexpected imports
-application_importer.ImportApplication(application, application_name, application_folder, caller)
+application_importer.ImportApplication(application, application_name, application_folder, caller, __path__)

--- a/applications/MeshingApplication/CMakeLists.txt
+++ b/applications/MeshingApplication/CMakeLists.txt
@@ -8,7 +8,7 @@ include(pybind11Tools)
 include_directories( ${CMAKE_SOURCE_DIR}/kratos )
 include_directories( ${CMAKE_SOURCE_DIR}/external_libraries/triangle )
 include_directories( ${CMAKE_CURRENT_SOURCE_DIR}/custom_external_libraries/tetMeshOpt )
-include_directories( ${CMAKE_SOURCE_DIR}/applications/StructuralMechanicsApplication ) 
+include_directories( ${CMAKE_SOURCE_DIR}/applications/StructuralMechanicsApplication )
 
 if(${USE_TETGEN_NONFREE_TPL} MATCHES ON )
     add_definitions( -DTETGEN143 )
@@ -26,7 +26,7 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/custom_external_libraries/tetMeshOp
 
 ## generate variables with the sources
 if(${INCLUDE_MMG} MATCHES ON)
-set( KRATOS_MESHING_APPLICATION_CORE  
+set( KRATOS_MESHING_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/meshing_application.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/external_includes/mesh_suites.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/local_refine_geometry_mesh.cpp
@@ -43,7 +43,7 @@ set( KRATOS_MESHING_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/mmg_process.cpp
 )
 else(${INCLUDE_MMG} MATCHES ON)
-set( KRATOS_MESHING_APPLICATION_CORE  
+set( KRATOS_MESHING_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/meshing_application.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/external_includes/mesh_suites.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/local_refine_geometry_mesh.cpp
@@ -67,9 +67,9 @@ set (KRATOS_MESHING_APPLICATION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_utilities_to_python.cpp
 )
 
-if(${KRATOS_BUILD_TESTING} MATCHES ON) 
-    file(GLOB_RECURSE KRATOS_MESHING_APPLICATION_TESTING_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tests/cpp_tests/*.cpp) 
-endif(${KRATOS_BUILD_TESTING} MATCHES ON) 
+if(${KRATOS_BUILD_TESTING} MATCHES ON)
+    file(GLOB_RECURSE KRATOS_MESHING_APPLICATION_TESTING_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tests/cpp_tests/*.cpp)
+endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 
 add_library(KratosMeshingCore SHARED ${KRATOS_MESHING_APPLICATION_CORE} ${KRATOS_MESHING_APPLICATION_TESTING_SOURCES})
 target_link_libraries(KratosMeshingCore PUBLIC KratosCore triangle tetMeshOpt)
@@ -96,12 +96,12 @@ pybind11_add_module(KratosMeshingApplication MODULE THIN_LTO ${KRATOS_MESHING_AP
 target_link_libraries(KratosMeshingApplication PRIVATE KratosMeshingCore)
 set_target_properties(KratosMeshingApplication PROPERTIES PREFIX "")
 
-# changing the .dll suffix to .pyd 
+# changing the .dll suffix to .pyd
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set_target_properties(KratosMeshingApplication PROPERTIES SUFFIX .pyd)
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
-# changing the .dylib suffix to .so 
+# changing the .dylib suffix to .so
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_target_properties(KratosMeshingApplication PROPERTIES SUFFIX .so)
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
@@ -122,4 +122,4 @@ endif(${INSTALL_PYTHON_FILES} MATCHES ON)
 
 
 # Add to the KratosMultiphisics Python module
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/MeshingApplication.py" DESTINATION KratosMultiphysics )
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/MeshingApplication.py" DESTINATION "KratosMultiphysics/MeshingApplication" RENAME "__init__.py")

--- a/applications/MeshingApplication/MeshingApplication.py
+++ b/applications/MeshingApplication/MeshingApplication.py
@@ -5,7 +5,7 @@ application_name = "KratosMeshingApplication"
 application_folder = "MeshingApplication"
 
 # The following lines are common for all applications
-from . import application_importer
+from .. import application_importer
 import inspect
 caller = inspect.stack()[1]  # Information about the file that imported this, to check for unexpected imports
-application_importer.ImportApplication(application, application_name, application_folder, caller)
+application_importer.ImportApplication(application, application_name, application_folder, caller, __path__)

--- a/applications/convection_diffusion_application/CMakeLists.txt
+++ b/applications/convection_diffusion_application/CMakeLists.txt
@@ -73,4 +73,5 @@ install(TARGETS KratosConvectionDiffusionApplication DESTINATION libs )
 # message("KratosIncompressibleFluidApplication subdir inc_dirs = ${inc_dirs}")
 
 # Add to the KratosMultiphisics Python module
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/ConvectionDiffusionApplication.py" DESTINATION KratosMultiphysics )
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/ConvectionDiffusionApplication.py" DESTINATION "KratosMultiphysics/ConvectionDiffusionApplication" RENAME "__init__.py")
+

--- a/applications/convection_diffusion_application/ConvectionDiffusionApplication.py
+++ b/applications/convection_diffusion_application/ConvectionDiffusionApplication.py
@@ -5,7 +5,7 @@ application_name = "KratosConvectionDiffusionApplication"
 application_folder = "convection_diffusion_application"
 
 # The following lines are common for all applications
-from . import application_importer
+from .. import application_importer
 import inspect
 caller = inspect.stack()[1]  # Information about the file that imported this, to check for unexpected imports
-application_importer.ImportApplication(application, application_name, application_folder, caller)
+application_importer.ImportApplication(application, application_name, application_folder, caller, __path__)


### PR DESCRIPTION
updating FSI, ConvctionDiffusion and Meshing to act as python-modules

@maceligueta I think the DEM-apps are more or less the only ones missing now
I recommend to update this, since the current python-interface (only adding to path) will be removed at some point (not soon though), but it will be a breaking change and ideally users should have adapted their scripts long before that
=> see the Wiki-page: https://github.com/KratosMultiphysics/Kratos/wiki/Applications-as-python-modules