### PR TITLE
[StructuralMechanics] adding missing const

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_conditions/axisym_line_load_condition_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/axisym_line_load_condition_2d.cpp
@@ -82,7 +82,7 @@ double AxisymLineLoadCondition2D::GetIntegrationWeight(
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
     const SizeType PointNumber,
     const double detJ
-    )
+    ) const
 {
     // We calculate the axisymmetric coefficient
     Vector N;
@@ -100,7 +100,6 @@ double AxisymLineLoadCondition2D::GetIntegrationWeight(
 
 void AxisymLineLoadCondition2D::save( Serializer& rSerializer ) const
 {
-    rSerializer.save( "Name", "AxisymLineLoadCondition2D" );
     KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, LineLoadCondition2D );
 }
 

--- a/applications/StructuralMechanicsApplication/custom_conditions/axisym_line_load_condition_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/axisym_line_load_condition_2d.h
@@ -165,7 +165,7 @@ private:
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const SizeType PointNumber,
         const double detJ
-        ) override;
+        ) const override;
 
     ///@}
     ///@name Private  Access

--- a/applications/StructuralMechanicsApplication/custom_conditions/axisym_point_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/axisym_point_load_condition.cpp
@@ -78,7 +78,7 @@ namespace Kratos
     //********************************* PROTECTED ****************************************
     //************************************************************************************
 
-    double AxisymPointLoadCondition::GetPointLoadIntegrationWeight()
+    double AxisymPointLoadCondition::GetPointLoadIntegrationWeight() const
     {
         // We calculate the axisymmetric coefficient
         const double Radius = StructuralMechanicsMathUtilities::CalculateRadiusPoint(GetGeometry());
@@ -94,7 +94,6 @@ namespace Kratos
 
     void AxisymPointLoadCondition::save( Serializer& rSerializer ) const
     {
-        rSerializer.save( "Name", "AxisymPointLoadCondition" );
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, PointLoadCondition );
     }
 

--- a/applications/StructuralMechanicsApplication/custom_conditions/axisym_point_load_condition.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/axisym_point_load_condition.h
@@ -158,7 +158,7 @@ private:
      /**
      * It calcules the integration load for the point load
      */
-    double GetPointLoadIntegrationWeight() override;
+    double GetPointLoadIntegrationWeight() const override;
 
     ///@}
     ///@name Private  Access

--- a/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.cpp
@@ -291,8 +291,8 @@ void BaseLoadCondition::CalculateDampingMatrix(
 void BaseLoadCondition::CalculateAll(
     MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,
     const ProcessInfo& rCurrentProcessInfo,
-    bool CalculateStiffnessMatrixFlag,
-    bool CalculateResidualVectorFlag
+    const bool CalculateStiffnessMatrixFlag,
+    const bool CalculateResidualVectorFlag
     )
 {
     KRATOS_ERROR << "You are calling the CalculateAll from the base class for loads" << std::endl;

--- a/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.cpp
@@ -310,7 +310,6 @@ int BaseLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo )
     KRATOS_CHECK_VARIABLE_KEY(DISPLACEMENT)
 
     // Check that the condition's nodes contain all required SolutionStepData and Degrees of freedom
-    const SizeType number_of_nodes = this->GetGeometry().size();
     for (const auto& r_node : this->GetGeometry().Points()) {
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,r_node)
 

--- a/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.cpp
@@ -86,46 +86,6 @@ Condition::Pointer BaseLoadCondition::Clone (
 /***********************************************************************************/
 /***********************************************************************************/
 
-void BaseLoadCondition::Initialize()
-{
-    // TODO: Add somethig if necessary
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void BaseLoadCondition::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo )
-{
-    // TODO: Add somethig if necessary
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void BaseLoadCondition::InitializeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
-{
-    // TODO: Add somethig if necessary
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void BaseLoadCondition::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
-{
-    // TODO: Add somethig if necessary
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-void BaseLoadCondition::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
-{
-    // TODO: Add somethig if necessary
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
 void BaseLoadCondition::EquationIdVector(
     EquationIdVectorType& rResult,
     ProcessInfo& rCurrentProcessInfo

--- a/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.cpp
@@ -290,7 +290,7 @@ void BaseLoadCondition::CalculateDampingMatrix(
 
 void BaseLoadCondition::CalculateAll(
     MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,
-    ProcessInfo& rCurrentProcessInfo,
+    const ProcessInfo& rCurrentProcessInfo,
     bool CalculateStiffnessMatrixFlag,
     bool CalculateResidualVectorFlag
     )
@@ -311,13 +311,12 @@ int BaseLoadCondition::Check( const ProcessInfo& rCurrentProcessInfo )
 
     // Check that the condition's nodes contain all required SolutionStepData and Degrees of freedom
     const SizeType number_of_nodes = this->GetGeometry().size();
-    for ( SizeType i = 0; i < number_of_nodes; ++i ) {
-        NodeType &rnode = this->GetGeometry()[i];
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rnode)
+    for (const auto& r_node : this->GetGeometry().Points()) {
+        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,r_node)
 
-        KRATOS_CHECK_DOF_IN_NODE(DISPLACEMENT_X, rnode)
-        KRATOS_CHECK_DOF_IN_NODE(DISPLACEMENT_Y, rnode)
-        KRATOS_CHECK_DOF_IN_NODE(DISPLACEMENT_Z, rnode)
+        KRATOS_CHECK_DOF_IN_NODE(DISPLACEMENT_X, r_node)
+        KRATOS_CHECK_DOF_IN_NODE(DISPLACEMENT_Y, r_node)
+        KRATOS_CHECK_DOF_IN_NODE(DISPLACEMENT_Z, r_node)
     }
 
     return 0;
@@ -330,7 +329,7 @@ double BaseLoadCondition::GetIntegrationWeight(
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
     const SizeType PointNumber,
     const double detJ
-    )
+    ) const
 {
     return IntegrationPoints[PointNumber].Weight() * detJ;
 }

--- a/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.h
@@ -274,9 +274,12 @@ public:
     /**
      * Check if Rotational Dof existant
      */
-    virtual bool HasRotDof(){return (GetGeometry()[0].HasDofFor(ROTATION_X) && GetGeometry().size() == 2);};
+    virtual bool HasRotDof() const
+    {
+        return (GetGeometry()[0].HasDofFor(ROTATION_X) && GetGeometry().size() == 2);
+    }
 
-    unsigned int GetBlockSize()
+    unsigned int GetBlockSize() const
     {
         unsigned int dim = GetGeometry().WorkingSpaceDimension();
         if( HasRotDof() ) { // if it has rotations
@@ -356,7 +359,7 @@ protected:
     virtual void CalculateAll(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
+        const ProcessInfo& rCurrentProcessInfo,
         const bool CalculateStiffnessMatrixFlag,
         const bool CalculateResidualVectorFlag
         );
@@ -371,7 +374,7 @@ protected:
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const SizeType PointNumber,
         const double detJ
-        );
+        ) const;
 
     ///@}
     ///@name Protected  Access

--- a/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/base_load_condition.h
@@ -154,36 +154,6 @@ public:
         ) const override;
 
     /**
-     * Called to initialize the element.
-     * Must be called before any calculation is done
-     */
-    void Initialize() override;
-
-    /**
-     * Called at the beginning of each solution step
-     * @param rCurrentProcessInfo: the current process info instance
-     */
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
-     * This is called for non-linear analysis at the beginning of the iteration process
-     * @param rCurrentProcessInfo the current process info instance
-     */
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
-     * This is called for non-linear analysis at the beginning of the iteration process
-     * @param rCurrentProcessInfo the current process info instance
-     */
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
-     * Called at the end of eahc solution step
-     * @param rCurrentProcessInfo the current process info instance
-     */
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
-
-    /**
      * Sets on rResult the ID's of the element degrees of freedom
      * @param rResult The vector containing the equation id
      * @param rCurrentProcessInfo The current process info instance

--- a/applications/StructuralMechanicsApplication/custom_conditions/line_load_condition_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/line_load_condition_2d.cpp
@@ -78,9 +78,9 @@ namespace Kratos
     void LineLoadCondition2D::CalculateAll(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
-        bool CalculateStiffnessMatrixFlag,
-        bool CalculateResidualVectorFlag
+        const ProcessInfo& rCurrentProcessInfo,
+        const bool CalculateStiffnessMatrixFlag,
+        const bool CalculateResidualVectorFlag
         )
     {
         KRATOS_TRY;
@@ -239,7 +239,7 @@ namespace Kratos
         const Vector& N,
         const double Pressure,
         const double IntegrationWeight
-        )
+        ) const
     {
         KRATOS_TRY
 
@@ -282,7 +282,7 @@ namespace Kratos
         const array_1d<double, 3>& Normal,
         double Pressure,
         double IntegrationWeight
-        )
+        ) const
     {
         const unsigned int number_of_nodes = GetGeometry().size();
         const unsigned int block_size = this->GetBlockSize();

--- a/applications/StructuralMechanicsApplication/custom_conditions/line_load_condition_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/line_load_condition_2d.h
@@ -151,9 +151,9 @@ protected:
     void CalculateAll(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
-        bool CalculateStiffnessMatrixFlag,
-        bool CalculateResidualVectorFlag
+        const ProcessInfo& rCurrentProcessInfo,
+        const bool CalculateStiffnessMatrixFlag,
+        const bool CalculateResidualVectorFlag
         ) override;
 
     void CalculateAndSubKp(
@@ -162,7 +162,7 @@ protected:
         const Vector& N,
         const double Pressure,
         const double IntegrationWeight
-        );
+        ) const;
 
     void CalculateAndAddPressureForce(
         VectorType& rRightHandSideVector,
@@ -170,7 +170,7 @@ protected:
         const array_1d<double, 3>& Normal,
         const double Pressure,
         const double IntegrationWeight
-        );
+        ) const;
 
     ///@}
     ///@name Protected  Access

--- a/applications/StructuralMechanicsApplication/custom_conditions/point_contact_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/point_contact_condition.cpp
@@ -67,10 +67,11 @@ namespace Kratos
     //************************************************************************************
 
     void PointContactCondition::CalculateAll(
-        MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
-        bool CalculateStiffnessMatrixFlag,
-        bool CalculateResidualVectorFlag
+        MatrixType& rLeftHandSideMatrix,
+        VectorType& rRightHandSideVector,
+        const ProcessInfo& rCurrentProcessInfo,
+        const bool CalculateStiffnessMatrixFlag,
+        const bool CalculateResidualVectorFlag
         )
     {
         KRATOS_TRY
@@ -192,7 +193,7 @@ namespace Kratos
     //************************************************************************************
     //************************************************************************************
 
-    double PointContactCondition::GetPointLoadIntegrationWeight()
+    double PointContactCondition::GetPointLoadIntegrationWeight() const
     {
         return 1.0;
     }

--- a/applications/StructuralMechanicsApplication/custom_conditions/point_contact_condition.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/point_contact_condition.h
@@ -159,15 +159,15 @@ protected:
     void CalculateAll(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
-        bool CalculateStiffnessMatrixFlag,
-        bool CalculateResidualVectorFlag
+        const ProcessInfo& rCurrentProcessInfo,
+        const bool CalculateStiffnessMatrixFlag,
+        const bool CalculateResidualVectorFlag
         ) override;
 
     /**
      * It calcules the integration load for the point load
      */
-    virtual double GetPointLoadIntegrationWeight();
+    virtual double GetPointLoadIntegrationWeight() const;
 
     ///@}
     ///@name Protected  Access
@@ -196,7 +196,6 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
-
 
 
     ///@}

--- a/applications/StructuralMechanicsApplication/custom_conditions/point_load_condition.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/point_load_condition.cpp
@@ -68,9 +68,9 @@ namespace Kratos
 
     void PointLoadCondition::CalculateAll(
         MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
-        bool CalculateStiffnessMatrixFlag,
-        bool CalculateResidualVectorFlag
+        const ProcessInfo& rCurrentProcessInfo,
+        const bool CalculateStiffnessMatrixFlag,
+        const bool CalculateResidualVectorFlag
         )
     {
         KRATOS_TRY
@@ -130,7 +130,7 @@ namespace Kratos
     //************************************************************************************
     //************************************************************************************
 
-    double PointLoadCondition::GetPointLoadIntegrationWeight()
+    double PointLoadCondition::GetPointLoadIntegrationWeight() const
     {
         return 1.0;
     }

--- a/applications/StructuralMechanicsApplication/custom_conditions/point_load_condition.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/point_load_condition.h
@@ -101,7 +101,7 @@ public:
     /**
      * Check if Rotational Dof existant
      */
-    bool HasRotDof() override {return false;};
+    bool HasRotDof() const override {return false;};
 
     ///@}
     ///@name Access
@@ -164,15 +164,15 @@ protected:
     void CalculateAll(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
-        bool CalculateStiffnessMatrixFlag,
-        bool CalculateResidualVectorFlag
+        const ProcessInfo& rCurrentProcessInfo,
+        const bool CalculateStiffnessMatrixFlag,
+        const bool CalculateResidualVectorFlag
         ) override;
 
     /**
      * It calcules the integration load for the point load
      */
-    virtual double GetPointLoadIntegrationWeight();
+    virtual double GetPointLoadIntegrationWeight() const;
 
     ///@}
     ///@name Protected  Access

--- a/applications/StructuralMechanicsApplication/custom_conditions/point_moment_condition_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/point_moment_condition_3d.cpp
@@ -152,9 +152,9 @@ namespace Kratos
     void PointMomentCondition3D::CalculateAll(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
-        bool CalculateStiffnessMatrixFlag,
-        bool CalculateResidualVectorFlag
+        const ProcessInfo& rCurrentProcessInfo,
+        const bool CalculateStiffnessMatrixFlag,
+        const bool CalculateResidualVectorFlag
         )
     {
         KRATOS_TRY
@@ -208,7 +208,7 @@ namespace Kratos
     //************************************************************************************
     //************************************************************************************
 
-    double PointMomentCondition3D::GetPointMomentIntegrationWeight()
+    double PointMomentCondition3D::GetPointMomentIntegrationWeight() const
     {
         return 1.0;
     }
@@ -220,7 +220,7 @@ namespace Kratos
     {
         KRATOS_CHECK_VARIABLE_KEY(ROTATION);
 
-        const auto& r_node =this->GetGeometry()[0];
+        const auto& r_node = this->GetGeometry()[0];
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ROTATION, r_node);
 
         KRATOS_CHECK_DOF_IN_NODE(ROTATION_X, r_node);

--- a/applications/StructuralMechanicsApplication/custom_conditions/point_moment_condition_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/point_moment_condition_3d.h
@@ -200,7 +200,7 @@ protected:
     void CalculateAll(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
+        const ProcessInfo& rCurrentProcessInfo,
         const bool CalculateStiffnessMatrixFlag,
         const bool CalculateResidualVectorFlag
         ) override;
@@ -208,7 +208,7 @@ protected:
     /**
      * It calcules the integration weight for the point moment
      */
-    virtual double GetPointMomentIntegrationWeight();
+    virtual double GetPointMomentIntegrationWeight() const;
 
     ///@}
     ///@name Protected  Access

--- a/applications/StructuralMechanicsApplication/custom_conditions/surface_load_condition_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_conditions/surface_load_condition_3d.cpp
@@ -94,7 +94,7 @@ void SurfaceLoadCondition3D::CalculateAndSubKp(
     const Vector& rN,
     const double Pressure,
     const double Weight
-    )
+    ) const
 {
     KRATOS_TRY
 
@@ -132,7 +132,7 @@ void SurfaceLoadCondition3D::CalculateAndSubKp(
 void SurfaceLoadCondition3D::MakeCrossMatrix(
     BoundedMatrix<double, 3, 3>& rM,
     const array_1d<double, 3>& rU
-    )
+    ) const
 {
     rM(0, 0) = 0.0;
     rM(0, 1) = -rU[2];
@@ -155,7 +155,7 @@ void SurfaceLoadCondition3D::CalculateAndAddPressureForce(
     const double Pressure,
     const double Weight,
     const ProcessInfo& rCurrentProcessInfo
-    )
+    ) const
 {
     KRATOS_TRY;
 
@@ -178,7 +178,7 @@ void SurfaceLoadCondition3D::CalculateAndAddPressureForce(
 void SurfaceLoadCondition3D::CalculateAll(
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
-    ProcessInfo& rCurrentProcessInfo,
+    const ProcessInfo& rCurrentProcessInfo,
     const bool CalculateStiffnessMatrixFlag,
     const bool CalculateResidualVectorFlag
     )

--- a/applications/StructuralMechanicsApplication/custom_conditions/surface_load_condition_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_conditions/surface_load_condition_3d.h
@@ -152,7 +152,7 @@ protected:
     void CalculateAll(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
+        const ProcessInfo& rCurrentProcessInfo,
         const bool CalculateStiffnessMatrixFlag,
         const bool CalculateResidualVectorFlag
         ) override;
@@ -175,7 +175,7 @@ protected:
         const Vector& rN,
         const double Pressure,
         const double Weight
-        );
+        ) const;
 
     /**
      * @brief This method computes the cross product matrix
@@ -185,7 +185,7 @@ protected:
     void MakeCrossMatrix(
         BoundedMatrix<double, 3, 3>& rM,
         const array_1d<double, 3>& rU
-        );
+        ) const;
 
     /**
      * @brief This method adds the pressure contribution to the RHS
@@ -203,7 +203,7 @@ protected:
         const double Pressure,
         const double Weight,
         const ProcessInfo& rCurrentProcessInfo
-        );
+        ) const;
 
     ///@}
     ///@name Protected  Access

--- a/applications/StructuralMechanicsApplication/custom_elements/axisym_small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/axisym_small_displacement.cpp
@@ -84,7 +84,7 @@ void AxisymSmallDisplacement::CalculateB(
     const Matrix& DN_DX,
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
     const IndexType PointNumber
-    )
+    ) const
 {
     KRATOS_TRY;
 
@@ -114,7 +114,7 @@ void AxisymSmallDisplacement::CalculateB(
 //************************************************************************************
 //************************************************************************************
 
-Matrix AxisymSmallDisplacement::ComputeEquivalentF(const Vector& rStrainVector)
+Matrix AxisymSmallDisplacement::ComputeEquivalentF(const Vector& rStrainVector) const
 {
     Matrix F(3, 3);
 
@@ -138,7 +138,7 @@ double AxisymSmallDisplacement::GetIntegrationWeight(
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
     const IndexType PointNumber,
     const double detJ
-    )
+    ) const
 {
     // We calculate the axisymmetric coefficient
     Vector N;
@@ -156,7 +156,6 @@ double AxisymSmallDisplacement::GetIntegrationWeight(
 
 void AxisymSmallDisplacement::save( Serializer& rSerializer ) const
 {
-    rSerializer.save( "Name", "AxisymSmallDisplacement" );
     KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, SmallDisplacement );
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/axisym_small_displacement.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/axisym_small_displacement.h
@@ -192,14 +192,14 @@ private:
         const Matrix& DN_DX,
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const IndexType PointNumber
-        ) override;
+        ) const override;
 
     /**
      * Calculation of the equivalent deformation gradient
      * @param StrainVector: The strain tensor (Voigt notation)
      * @return The deformation gradient F
      */
-    Matrix ComputeEquivalentF(const Vector& rStrainVector) override;
+    Matrix ComputeEquivalentF(const Vector& rStrainVector) const override;
 
     /**
      * This functions computes the integration weight to consider
@@ -211,7 +211,7 @@ private:
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const IndexType PointNumber,
         const double detJ
-        ) override;
+        ) const override;
 
     ///@}
     ///@name Private  Access

--- a/applications/StructuralMechanicsApplication/custom_elements/axisym_total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/axisym_total_lagrangian.cpp
@@ -82,7 +82,7 @@ double AxisymTotalLagrangian::GetIntegrationWeight(
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
     const IndexType PointNumber,
     const double detJ
-    )
+    ) const
 {
     // We calculate the axisymmetric coefficient
     Vector N;
@@ -99,7 +99,6 @@ double AxisymTotalLagrangian::GetIntegrationWeight(
 
 void AxisymTotalLagrangian::save( Serializer& rSerializer ) const
 {
-    rSerializer.save( "Name", "AxisymTotalLagrangian" );
     KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, TotalLagrangian );
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/axisym_total_lagrangian.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/axisym_total_lagrangian.h
@@ -192,7 +192,7 @@ private:
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const IndexType PointNumber,
         const double detJ
-        ) override;
+        ) const override;
 
     ///@}
     ///@name Private  Access

--- a/applications/StructuralMechanicsApplication/custom_elements/axisym_updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/axisym_updated_lagrangian.cpp
@@ -82,7 +82,7 @@ double AxisymUpdatedLagrangian::GetIntegrationWeight(
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
     const IndexType PointNumber,
     const double detJ
-    )
+    ) const
 {
     // We calculate the axisymmetric coefficient
     Vector N;
@@ -99,7 +99,6 @@ double AxisymUpdatedLagrangian::GetIntegrationWeight(
 
 void AxisymUpdatedLagrangian::save( Serializer& rSerializer ) const
 {
-    rSerializer.save( "Name", "AxisymUpdatedLagrangian" );
     KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, UpdatedLagrangian );
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/axisym_updated_lagrangian.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/axisym_updated_lagrangian.h
@@ -192,7 +192,7 @@ private:
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const IndexType PointNumber,
         const double detJ
-        ) override;
+        ) const override;
 
     ///@}
     ///@name Private  Access

--- a/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.cpp
@@ -399,23 +399,20 @@ void BaseShellElement::PrintData(std::ostream& rOStream) const {
   pGetGeometry()->PrintData(rOStream);
 }
 
-SizeType BaseShellElement::GetNumberOfDofs()
+SizeType BaseShellElement::GetNumberOfDofs() const
 {
     return ( 6 * GetGeometry().PointsNumber() ); // 6 dofs per node
 }
 
-SizeType BaseShellElement::GetNumberOfGPs()
+SizeType BaseShellElement::GetNumberOfGPs() const
 {
-    const auto& integrationPoints =
-    GetGeometry().IntegrationPoints(mIntegrationMethod);
-
-    return integrationPoints.size();
+    return GetGeometry().IntegrationPoints(mIntegrationMethod).size();
 }
 
 void BaseShellElement::CalculateAll(
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
-    ProcessInfo& rCurrentProcessInfo,
+    const ProcessInfo& rCurrentProcessInfo,
     const bool CalculateStiffnessMatrixFlag,
     const bool CalculateResidualVectorFlag
     )
@@ -423,7 +420,7 @@ void BaseShellElement::CalculateAll(
     KRATOS_ERROR << "You have called to the CalculateAll from the base class for shell elements" << std::endl;
 }
 
-ShellCrossSection::SectionBehaviorType BaseShellElement::GetSectionBehavior()
+ShellCrossSection::SectionBehaviorType BaseShellElement::GetSectionBehavior() const
 {
     KRATOS_ERROR << "You have called to the GetSectionBehavior from the base class for shell elements" << std::endl;
 }
@@ -433,7 +430,7 @@ void BaseShellElement::SetupOrientationAngles()
     KRATOS_ERROR << "You have called to the SetupOrientationAngles from the base class for shell elements" << std::endl;
 }
 
-void BaseShellElement::CheckVariables()
+void BaseShellElement::CheckVariables() const
 {
     KRATOS_CHECK_VARIABLE_KEY(DISPLACEMENT);
     KRATOS_CHECK_VARIABLE_KEY(ROTATION);
@@ -449,13 +446,11 @@ void BaseShellElement::CheckVariables()
     KRATOS_CHECK_VARIABLE_KEY(SHELL_CROSS_SECTION);
 }
 
-void BaseShellElement::CheckDofs()
+void BaseShellElement::CheckDofs() const
 {
-    auto& r_geom = GetGeometry();
     // verify that the dofs exist
-    for (IndexType i = 0; i < r_geom.size(); ++i)
+    for (const auto& r_node : GetGeometry().Points())
     {
-        auto& r_node = r_geom[i];
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ROTATION, r_node);
 
@@ -472,7 +467,7 @@ void BaseShellElement::CheckDofs()
     }
 }
 
-void BaseShellElement::CheckProperties(const ProcessInfo& rCurrentProcessInfo)
+void BaseShellElement::CheckProperties(const ProcessInfo& rCurrentProcessInfo) const
 {
     // check properties
     if(pGetProperties() == nullptr)
@@ -540,7 +535,7 @@ void BaseShellElement::CheckProperties(const ProcessInfo& rCurrentProcessInfo)
     }
 }
 
-void BaseShellElement::CheckSpecificProperties()
+void BaseShellElement::CheckSpecificProperties() const
 {
     const auto& r_props = GetProperties();
 

--- a/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_shell_element.h
@@ -277,11 +277,9 @@ protected:
     {
     }
 
-    SizeType GetNumberOfDofs();
+    SizeType GetNumberOfDofs() const;
 
-    SizeType GetNumberOfGPs();
-
-    void SetBaseMembers();
+    SizeType GetNumberOfGPs() const;
 
     /**
      * @brief This functions calculates both the RHS and the LHS
@@ -294,7 +292,7 @@ protected:
     virtual void CalculateAll(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
+        const ProcessInfo& rCurrentProcessInfo,
         const bool CalculateStiffnessMatrixFlag,
         const bool CalculateResidualVectorFlag
     );
@@ -309,10 +307,10 @@ protected:
 
     virtual void SetupOrientationAngles();
 
-    void CheckVariables();
-    void CheckDofs();
-    void CheckProperties(const ProcessInfo& rCurrentProcessInfo);
-    void CheckSpecificProperties();
+    void CheckVariables() const;
+    void CheckDofs() const;
+    void CheckProperties(const ProcessInfo& rCurrentProcessInfo) const;
+    void CheckSpecificProperties() const;
 
     /**
     * computes the local axis of the element (for visualization)
@@ -323,7 +321,7 @@ protected:
     template <typename T>
     void ComputeLocalAxis(const Variable<array_1d<double, 3> >& rVariable,
         std::vector<array_1d<double, 3> >& rOutput,
-        const T& rpCoordinateTransformation)
+        const T& rpCoordinateTransformation) const
     {
         const SizeType num_gps = GetNumberOfGPs();
         if (rOutput.size() != num_gps) rOutput.resize(num_gps);
@@ -356,7 +354,7 @@ protected:
     template <typename T>
     void ComputeLocalMaterialAxis(const Variable<array_1d<double, 3> >& rVariable,
         std::vector<array_1d<double, 3> >& rOutput,
-        const T& rpCoordinateTransformation)
+        const T& rpCoordinateTransformation) const
     {
         const double mat_angle = Has(MATERIAL_ORIENTATION_ANGLE) ? GetValue(MATERIAL_ORIENTATION_ANGLE) : 0.0;
 
@@ -392,7 +390,7 @@ protected:
     * Returns the behavior of this shell (thin/thick)
     * @return the shell behavior
     */
-    virtual ShellCrossSection::SectionBehaviorType GetSectionBehavior();
+    virtual ShellCrossSection::SectionBehaviorType GetSectionBehavior() const;
 
     ///@}
     ///@name Protected  Access

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -223,7 +223,7 @@ ConstitutiveLaw::StressMeasure BaseSolidElement::GetStressMeasure() const
 /***********************************************************************************/
 /***********************************************************************************/
 
-bool BaseSolidElement::UseElementProvidedStrain()
+bool BaseSolidElement::UseElementProvidedStrain() const
 {
     return false;
 }
@@ -1431,7 +1431,7 @@ int  BaseSolidElement::Check( const ProcessInfo& rCurrentProcessInfo )
 
     // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom
     for ( IndexType i = 0; i < number_of_nodes; i++ ) {
-        NodeType &rnode = this->GetGeometry()[i];
+        const NodeType &rnode = this->GetGeometry()[i];
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISPLACEMENT,rnode)
 //         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY,rnode)
 //         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ACCELERATION,rnode)
@@ -1483,7 +1483,7 @@ double BaseSolidElement::GetIntegrationWeight(
     const GeometryType::IntegrationPointsArrayType& rThisIntegrationPoints,
     const IndexType PointNumber,
     const double detJ
-    )
+    ) const
 {
     return rThisIntegrationPoints[PointNumber].Weight() * detJ;
 }
@@ -1491,7 +1491,7 @@ double BaseSolidElement::GetIntegrationWeight(
 //***********************************************************************
 //***********************************************************************
 
-void BaseSolidElement::CalculateShapeGradientOfMassMatrix(MatrixType& rMassMatrix, ShapeParameter Deriv)
+void BaseSolidElement::CalculateShapeGradientOfMassMatrix(MatrixType& rMassMatrix, ShapeParameter Deriv) const
 {
     KRATOS_TRY;
 
@@ -1606,7 +1606,7 @@ void BaseSolidElement::SetConstitutiveVariables(
 /***********************************************************************************/
 /***********************************************************************************/
 
-Matrix& BaseSolidElement::CalculateDeltaDisplacement(Matrix& DeltaDisplacement)
+Matrix& BaseSolidElement::CalculateDeltaDisplacement(Matrix& DeltaDisplacement) const
 {
     KRATOS_TRY
 
@@ -1637,9 +1637,9 @@ double BaseSolidElement::CalculateDerivativesOnReferenceConfiguration(
     Matrix& rDN_DX,
     const IndexType PointNumber,
     IntegrationMethod ThisIntegrationMethod
-    )
+    ) const
 {
-    GeometryType& r_geom = GetGeometry();
+    const GeometryType& r_geom = GetGeometry();
     GeometryUtils::JacobianOnInitialConfiguration(
         r_geom,
         r_geom.IntegrationPoints(ThisIntegrationMethod)[PointNumber], rJ0);
@@ -1660,7 +1660,7 @@ double BaseSolidElement::CalculateDerivativesOnCurrentConfiguration(
     Matrix& rDN_DX,
     const IndexType PointNumber,
     IntegrationMethod ThisIntegrationMethod
-    )
+    ) const
 {
     double detJ;
     rJ = GetGeometry().Jacobian( rJ, PointNumber, ThisIntegrationMethod );
@@ -1705,7 +1705,7 @@ void BaseSolidElement::CalculateAndAddKm(
     const Matrix& B,
     const Matrix& D,
     const double IntegrationWeight
-    )
+    ) const
 {
     KRATOS_TRY
 
@@ -1722,7 +1722,7 @@ void BaseSolidElement::CalculateAndAddKg(
     const Matrix& DN_DX,
     const Vector& StressVector,
     const double IntegrationWeight
-    )
+    ) const
 {
     KRATOS_TRY
 
@@ -1744,7 +1744,7 @@ void BaseSolidElement::CalculateAndAddResidualVector(
     const Vector& rBodyForce,
     const Vector& rStressVector,
     const double IntegrationWeight
-    )
+    ) const
 {
     KRATOS_TRY
 
@@ -1766,7 +1766,7 @@ void BaseSolidElement::CalculateAndAddExtForceContribution(
     const Vector& rBodyForce,
     VectorType& rRightHandSideVector,
     const double Weight
-    )
+    ) const
 {
     KRATOS_TRY;
 
@@ -1786,7 +1786,7 @@ void BaseSolidElement::CalculateAndAddExtForceContribution(
 /***********************************************************************************/
 /***********************************************************************************/
 
-void BaseSolidElement::CalculateLumpedMassVector(VectorType& rMassVector)
+void BaseSolidElement::CalculateLumpedMassVector(VectorType& rMassVector) const
 {
     KRATOS_TRY;
 

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -704,7 +704,7 @@ protected:
     /**
      * @brief This method returns if the element provides the strain
      */
-    virtual bool UseElementProvidedStrain();
+    virtual bool UseElementProvidedStrain() const;
 
     /**
      * @brief This functions calculates both the RHS and the LHS
@@ -773,7 +773,7 @@ protected:
      * @param DeltaDisplacement The matrix containing the increment of displacements
      * @return DeltaDisplacement: The matrix containing the increment of displacements
      */
-    Matrix& CalculateDeltaDisplacement(Matrix& DeltaDisplacement);
+    Matrix& CalculateDeltaDisplacement(Matrix& DeltaDisplacement) const;
 
     /**
      * @brief This functions calculate the derivatives in the reference frame
@@ -790,7 +790,7 @@ protected:
         Matrix& rDN_DX,
         const IndexType PointNumber,
         IntegrationMethod ThisIntegrationMethod
-        );
+        ) const;
 
     /**
      * @brief This functions calculate the derivatives in the current frame
@@ -807,7 +807,7 @@ protected:
         Matrix& rDN_DX,
         const IndexType PointNumber,
         IntegrationMethod ThisIntegrationMethod
-        );
+        ) const;
 
     /**
      * @brief This function computes the body force
@@ -832,7 +832,7 @@ protected:
         const Matrix& B,
         const Matrix& D,
         const double IntegrationWeight
-        );
+        ) const;
 
     /**
      * @brief Calculation of the Geometric Stiffness Matrix. Kg = dB * S
@@ -846,7 +846,7 @@ protected:
         const Matrix& DN_DX,
         const Vector& rStressVector,
         const double IntegrationWeight
-        );
+        ) const;
 
     /**
      * @brief Calculation of the RHS
@@ -864,7 +864,7 @@ protected:
         const Vector& rBodyForce,
         const Vector& rStressVector,
         const double IntegrationWeight
-        );
+        ) const;
 
     /**
      * @brief This function add the external force contribution
@@ -880,7 +880,7 @@ protected:
         const Vector& rBodyForce,
         VectorType& rRightHandSideVector,
         const double IntegrationWeight
-        );
+        ) const;
 
     /**
      * @brief This functions computes the integration weight to consider
@@ -892,14 +892,14 @@ protected:
         const GeometryType::IntegrationPointsArrayType& rThisIntegrationPoints,
         const IndexType PointNumber,
         const double detJ
-        );
+        ) const;
 
     /**
     * @brief This function computes the shape gradient of mass matrix
     * @param rMassMatrix The mass matrix
     * @param Deriv The shape parameter
     */
-    void CalculateShapeGradientOfMassMatrix(MatrixType& rMassMatrix, ShapeParameter Deriv);
+    void CalculateShapeGradientOfMassMatrix(MatrixType& rMassMatrix, ShapeParameter Deriv) const;
 
     ///@}
     ///@name Protected  Access
@@ -933,7 +933,7 @@ private:
      * @brief This method computes directly the lumped mass vector
      * @param rMassMatrix The lumped mass vector
      */
-    void CalculateLumpedMassVector(VectorType& rMassVector);
+    void CalculateLumpedMassVector(VectorType& rMassVector) const;
 
     /**
      * @brief This method computes directly the lumped mass matrix

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -273,7 +273,7 @@ void CrBeamElement2D2N::CalculateLeftHandSide(
 /////////////////////////////////////////////////
 
 BoundedVector<double, CrBeamElement2D2N::msElementSize>
-CrBeamElement2D2N::CalculateBodyForces() {
+CrBeamElement2D2N::CalculateBodyForces() const {
   KRATOS_TRY
   // getting shapefunctionvalues for linear SF
   const Matrix &Ncontainer =
@@ -316,7 +316,7 @@ void CrBeamElement2D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
     const BoundedVector<double, 3> ForceInput,
     BoundedVector<double, CrBeamElement2D2N::msElementSize>
         &rRightHandSideVector,
-    const double GeometryLength) {
+    const double GeometryLength) const {
   KRATOS_TRY;
   // calculate orthogonal load vector
   const double numerical_limit = std::numeric_limits<double>::epsilon();
@@ -382,7 +382,7 @@ void CrBeamElement2D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
   KRATOS_CATCH("")
 }
 
-double CrBeamElement2D2N::CalculateShearModulus() {
+double CrBeamElement2D2N::CalculateShearModulus() const {
   KRATOS_TRY;
   const double nu = this->GetProperties()[POISSON_RATIO];
   const double E = this->GetProperties()[YOUNG_MODULUS];
@@ -391,7 +391,7 @@ double CrBeamElement2D2N::CalculateShearModulus() {
   KRATOS_CATCH("")
 }
 
-double CrBeamElement2D2N::CalculatePsi(const double I, const double A_eff) {
+double CrBeamElement2D2N::CalculatePsi(const double I, const double A_eff) const {
 
   KRATOS_TRY;
   const double E = this->GetProperties()[YOUNG_MODULUS];
@@ -410,7 +410,7 @@ double CrBeamElement2D2N::CalculatePsi(const double I, const double A_eff) {
   KRATOS_CATCH("")
 }
 
-double CrBeamElement2D2N::CalculateInitialElementAngle() {
+double CrBeamElement2D2N::CalculateInitialElementAngle() const{
   KRATOS_TRY;
   const double numerical_limit = std::numeric_limits<double>::epsilon();
 
@@ -471,7 +471,7 @@ double CrBeamElement2D2N::CalculateDeformedElementAngle() {
   KRATOS_CATCH("")
 }
 
-double CrBeamElement2D2N::CalculateLength() {
+double CrBeamElement2D2N::CalculateLength() const {
   KRATOS_TRY;
   const double numerical_limit = std::numeric_limits<double>::epsilon();
   const double du =
@@ -492,7 +492,7 @@ double CrBeamElement2D2N::CalculateLength() {
   KRATOS_CATCH("")
 }
 
-double CrBeamElement2D2N::CalculateReferenceLength() {
+double CrBeamElement2D2N::CalculateReferenceLength() const {
   KRATOS_TRY;
   const double numerical_limit = std::numeric_limits<double>::epsilon();
   const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
@@ -507,7 +507,7 @@ double CrBeamElement2D2N::CalculateReferenceLength() {
 
 BoundedMatrix<double, CrBeamElement2D2N::msElementSize,
                CrBeamElement2D2N::msLocalSize>
-CrBeamElement2D2N::CalculateTransformationS() {
+CrBeamElement2D2N::CalculateTransformationS() const {
   KRATOS_TRY;
   const double L = this->CalculateLength();
   BoundedMatrix<double, msElementSize, msLocalSize> S =
@@ -526,7 +526,7 @@ CrBeamElement2D2N::CalculateTransformationS() {
 
 BoundedMatrix<double, CrBeamElement2D2N::msLocalSize,
                CrBeamElement2D2N::msLocalSize>
-CrBeamElement2D2N::CreateElementStiffnessMatrix_Kd_mat() {
+CrBeamElement2D2N::CreateElementStiffnessMatrix_Kd_mat() const {
   KRATOS_TRY
   // element properties
   const double E = this->GetProperties()[YOUNG_MODULUS];
@@ -555,7 +555,7 @@ CrBeamElement2D2N::CreateElementStiffnessMatrix_Kd_mat() {
 
 BoundedMatrix<double, CrBeamElement2D2N::msLocalSize,
                CrBeamElement2D2N::msLocalSize>
-CrBeamElement2D2N::CreateElementStiffnessMatrix_Kd_geo() {
+CrBeamElement2D2N::CreateElementStiffnessMatrix_Kd_geo() const {
   KRATOS_TRY
   // element properties
   const double L = this->CalculateLength();
@@ -573,7 +573,7 @@ CrBeamElement2D2N::CreateElementStiffnessMatrix_Kd_geo() {
 
 BoundedMatrix<double, CrBeamElement2D2N::msElementSize,
                CrBeamElement2D2N::msElementSize>
-CrBeamElement2D2N::CreateElementStiffnessMatrix_Kr() {
+CrBeamElement2D2N::CreateElementStiffnessMatrix_Kr() const {
   KRATOS_TRY
   // element properties
   const double L = this->CalculateLength();
@@ -603,7 +603,7 @@ CrBeamElement2D2N::CreateElementStiffnessMatrix_Kr() {
 
 BoundedMatrix<double, CrBeamElement2D2N::msElementSize,
                CrBeamElement2D2N::msElementSize>
-CrBeamElement2D2N::CreateElementStiffnessMatrix_Total() {
+CrBeamElement2D2N::CreateElementStiffnessMatrix_Total() const {
   KRATOS_TRY
   // co-rotating K
   BoundedMatrix<double, msElementSize, msElementSize> K_r =
@@ -805,7 +805,7 @@ CrBeamElement2D2N::ReturnElementForces_Local() {
   KRATOS_CATCH("")
 }
 
-double CrBeamElement2D2N::Modulus2Pi(double A) {
+double CrBeamElement2D2N::Modulus2Pi(double A) const {
   KRATOS_TRY;
   const int B = A / (2.00 * Globals::Pi);
   const double C = A - (B * 2.00 * Globals::Pi);

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.hpp
@@ -150,7 +150,7 @@ namespace Kratos
         /**
          * @brief This function calculates shear modulus from user input values
          */
-        double CalculateShearModulus();
+        double CalculateShearModulus() const;
 
 
         /**
@@ -158,12 +158,12 @@ namespace Kratos
          * @param I The second moment of area
          * @param A_eff The shear-effective area
          */
-        double CalculatePsi(const double I, const double A_eff);
+        double CalculatePsi(const double I, const double A_eff) const;
 
         /**
          * @brief This function calculates the initial angle
          */
-        double CalculateInitialElementAngle();
+        double CalculateInitialElementAngle() const;
 
         /**
          * @brief This function calculates the current angle
@@ -173,7 +173,7 @@ namespace Kratos
         /**
          * @brief This function calculates self-weight forces
          */
-        BoundedVector<double,msElementSize> CalculateBodyForces();
+        BoundedVector<double,msElementSize> CalculateBodyForces() const;
 
         /**
          * @brief This function calculates nodal moments due to self-weight
@@ -184,45 +184,45 @@ namespace Kratos
         void CalculateAndAddWorkEquivalentNodalForcesLineLoad(
             const BoundedVector<double,3> ForceInput,
             BoundedVector<double,msElementSize>& rRightHandSideVector,
-            const double GeometryLength);
+            const double GeometryLength)const ;
 
         IntegrationMethod GetIntegrationMethod() const override;
 
         /**
          * @brief This function calculates a transformation matrix from deformation modes to real deformations
          */
-        BoundedMatrix<double,msElementSize,msLocalSize> CalculateTransformationS();
+        BoundedMatrix<double,msElementSize,msLocalSize> CalculateTransformationS() const;
 
         /**
          * @brief This function calculates the current length
          */
-        virtual double CalculateLength();
+        virtual double CalculateLength() const;
 
         /**
          * @brief This function calculates the reference length
          */
-        double CalculateReferenceLength();
+        double CalculateReferenceLength() const;
 
 
         /**
          * @brief This function calculates the elastic part of the total stiffness matrix
          */
-        BoundedMatrix<double,msLocalSize,msLocalSize> CreateElementStiffnessMatrix_Kd_mat();
+        BoundedMatrix<double,msLocalSize,msLocalSize> CreateElementStiffnessMatrix_Kd_mat() const;
 
         /**
          * @brief This function calculates the geometric part of the total stiffness matrix
          */
-        BoundedMatrix<double,msLocalSize,msLocalSize> CreateElementStiffnessMatrix_Kd_geo();
+        BoundedMatrix<double,msLocalSize,msLocalSize> CreateElementStiffnessMatrix_Kd_geo() const;
 
         /**
          * @brief This function calculates the co-rotating part of the total stiffness matrix
          */
-        BoundedMatrix<double,msElementSize,msElementSize> CreateElementStiffnessMatrix_Kr();
+        BoundedMatrix<double,msElementSize,msElementSize> CreateElementStiffnessMatrix_Kr() const;
 
         /**
          * @brief This function assembles the total stiffness matrix
          */
-        BoundedMatrix<double,msElementSize,msElementSize> CreateElementStiffnessMatrix_Total();
+        BoundedMatrix<double,msElementSize,msElementSize> CreateElementStiffnessMatrix_Total() const;
 
 
         /**
@@ -241,7 +241,7 @@ namespace Kratos
          * @brief This function calculates the modulus to 2 PI to keep the rotation angle between 0 and 2PI
          * @param A The current angle
          */
-        double Modulus2Pi(double A);
+        double Modulus2Pi(double A) const;
 
         /**
          * @brief This function calculates the transformation matrix to globalize/localize vectors and/or matrices

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -165,7 +165,7 @@ void CrBeamElement3D2N::GetValuesVector(Vector &rValues, int Step) {
 }
 
 BoundedVector<double, CrBeamElement3D2N::msElementSize>
-CrBeamElement3D2N::CalculateBodyForces() {
+CrBeamElement3D2N::CalculateBodyForces() const {
   KRATOS_TRY
   // getting shapefunctionvalues for linear SF
   const Matrix &Ncontainer =
@@ -209,7 +209,7 @@ void CrBeamElement3D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
     const BoundedVector<double, CrBeamElement3D2N::msDimension> ForceInput,
     BoundedVector<double, CrBeamElement3D2N::msElementSize>
         &rRightHandSideVector,
-    const double GeometryLength) {
+    const double GeometryLength) const {
   KRATOS_TRY;
   // calculate orthogonal load vector
   const double numerical_limit = std::numeric_limits<double>::epsilon();
@@ -334,7 +334,7 @@ void CrBeamElement3D2N::CalculateLocalNodalForces(
 
 BoundedMatrix<double, CrBeamElement3D2N::msElementSize,
                CrBeamElement3D2N::msElementSize>
-CrBeamElement3D2N::CreateElementStiffnessMatrix_Material() {
+CrBeamElement3D2N::CreateElementStiffnessMatrix_Material() const {
 
   KRATOS_TRY;
   const double E = this->GetProperties()[YOUNG_MODULUS];
@@ -418,7 +418,7 @@ CrBeamElement3D2N::CreateElementStiffnessMatrix_Material() {
 
 BoundedMatrix<double, CrBeamElement3D2N::msElementSize,
                CrBeamElement3D2N::msElementSize>
-CrBeamElement3D2N::CreateElementStiffnessMatrix_Geometry() {
+CrBeamElement3D2N::CreateElementStiffnessMatrix_Geometry() const {
 
   KRATOS_TRY;
 
@@ -541,7 +541,7 @@ CrBeamElement3D2N::CreateElementStiffnessMatrix_Geometry() {
 
 BoundedMatrix<double, CrBeamElement3D2N::msLocalSize,
                CrBeamElement3D2N::msLocalSize>
-CrBeamElement3D2N::CalculateDeformationStiffness() {
+CrBeamElement3D2N::CalculateDeformationStiffness() const {
 
   KRATOS_TRY
   BoundedMatrix<double, msLocalSize, msLocalSize> Kd =
@@ -603,7 +603,7 @@ CrBeamElement3D2N::CalculateDeformationStiffness() {
 
 BoundedMatrix<double, CrBeamElement3D2N::msElementSize,
                CrBeamElement3D2N::msElementSize>
-CrBeamElement3D2N::CalculateInitialLocalCS() {
+CrBeamElement3D2N::CalculateInitialLocalCS() const {
 
   KRATOS_TRY
   const double numerical_limit = std::numeric_limits<double>::epsilon();
@@ -906,7 +906,7 @@ CrBeamElement3D2N::UpdateRotationMatrixLocal(Vector &Bisectrix,
 }
 
 Vector CrBeamElement3D2N::CalculateSymmetricDeformationMode(
-    const Vector &VectorDifference) {
+    const Vector &VectorDifference) const {
   Vector phi_s = ZeroVector(msDimension);
   if (this->mIterationCount != 0) {
     phi_s = prod(Matrix(trans(this->mLocalRotationMatrix)), VectorDifference);
@@ -916,7 +916,7 @@ Vector CrBeamElement3D2N::CalculateSymmetricDeformationMode(
 }
 
 Vector CrBeamElement3D2N::CalculateAntiSymmetricDeformationMode(
-    const Vector &Bisectrix) {
+    const Vector &Bisectrix) const {
   Vector phi_a = ZeroVector(msDimension);
   if (this->mIterationCount != 0) {
     Vector rotated_nx0 = ZeroVector(msDimension);
@@ -932,7 +932,7 @@ Vector CrBeamElement3D2N::CalculateAntiSymmetricDeformationMode(
 
 BoundedMatrix<double, CrBeamElement3D2N::msElementSize,
                CrBeamElement3D2N::msLocalSize>
-CrBeamElement3D2N::CalculateTransformationS() {
+CrBeamElement3D2N::CalculateTransformationS() const {
 
   KRATOS_TRY
   const double L = this->CalculateCurrentLength();
@@ -1071,7 +1071,7 @@ void CrBeamElement3D2N::CalculateLeftHandSide(
 
 BoundedVector<double, CrBeamElement3D2N::msLocalSize>
 CrBeamElement3D2N::CalculateElementForces(const Vector &Bisectrix,
-                                          const Vector &VectorDifference) {
+                                          const Vector &VectorDifference) const{
 
   KRATOS_TRY;
   BoundedVector<double, msLocalSize> deformation_modes_total_v =
@@ -1101,7 +1101,7 @@ CrBeamElement3D2N::CalculateElementForces(const Vector &Bisectrix,
   KRATOS_CATCH("")
 }
 
-double CrBeamElement3D2N::CalculatePsi(const double I, const double A_eff) {
+double CrBeamElement3D2N::CalculatePsi(const double I, const double A_eff) const {
 
   KRATOS_TRY;
   const double E = this->GetProperties()[YOUNG_MODULUS];
@@ -1120,7 +1120,7 @@ double CrBeamElement3D2N::CalculatePsi(const double I, const double A_eff) {
   KRATOS_CATCH("")
 }
 
-double CrBeamElement3D2N::CalculateReferenceLength() {
+double CrBeamElement3D2N::CalculateReferenceLength() const {
 
   KRATOS_TRY;
   const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
@@ -1131,7 +1131,7 @@ double CrBeamElement3D2N::CalculateReferenceLength() {
   KRATOS_CATCH("")
 }
 
-double CrBeamElement3D2N::CalculateCurrentLength() {
+double CrBeamElement3D2N::CalculateCurrentLength() const {
 
   KRATOS_TRY;
   const double du =
@@ -1153,7 +1153,7 @@ double CrBeamElement3D2N::CalculateCurrentLength() {
 }
 
 BoundedVector<double, CrBeamElement3D2N::msLocalSize>
-CrBeamElement3D2N::GetCurrentNodalPosition() {
+CrBeamElement3D2N::GetCurrentNodalPosition() const {
   BoundedVector<double, msLocalSize> current_nodal_position =
       ZeroVector(msLocalSize);
   for (unsigned int i = 0; i < msNumberOfNodes; ++i) {
@@ -1268,7 +1268,7 @@ void CrBeamElement3D2N::GetValueOnIntegrationPoints(
 void CrBeamElement3D2N::AssembleSmallInBigMatrix(
     Matrix SmallMatrix,
     BoundedMatrix<double, CrBeamElement3D2N::msElementSize,
-                   CrBeamElement3D2N::msElementSize> &BigMatrix) {
+                   CrBeamElement3D2N::msElementSize> &BigMatrix) const {
   KRATOS_TRY
   const double numerical_limit = std::numeric_limits<double>::epsilon();
   BigMatrix.clear();
@@ -1287,7 +1287,7 @@ void CrBeamElement3D2N::AssembleSmallInBigMatrix(
 
 void CrBeamElement3D2N::BuildSingleMassMatrix(MatrixType &rMassMatrix,
                                               double Phi, double CT, double CR,
-                                              double L, double dir) {
+                                              double L, double dir) const {
   KRATOS_TRY;
   const SizeType MatSize = msNumberOfNodes * 2;
 
@@ -1362,7 +1362,7 @@ void CrBeamElement3D2N::BuildSingleMassMatrix(MatrixType &rMassMatrix,
 }
 
 void CrBeamElement3D2N::CalculateConsistentMassMatrix(
-    MatrixType &rMassMatrix, ProcessInfo &rCurrentProcessInfo) {
+    MatrixType &rMassMatrix, const ProcessInfo &rCurrentProcessInfo) const {
   KRATOS_TRY;
   const int smallMatSize = msNumberOfNodes * 2;
 
@@ -1467,7 +1467,7 @@ void CrBeamElement3D2N::CalculateConsistentMassMatrix(
 }
 
 void CrBeamElement3D2N::CalculateLumpedMassMatrix(
-    MatrixType &rMassMatrix, ProcessInfo &rCurrentProcessInfo) {
+    MatrixType &rMassMatrix, const ProcessInfo &rCurrentProcessInfo) const {
   KRATOS_TRY;
   if (rMassMatrix.size1() != msElementSize) {
     rMassMatrix.resize(msElementSize, msElementSize, false);
@@ -1581,7 +1581,7 @@ void CrBeamElement3D2N::AddExplicitContribution(
     KRATOS_CATCH("")
 }
 
-double CrBeamElement3D2N::CalculateShearModulus() {
+double CrBeamElement3D2N::CalculateShearModulus() const {
   KRATOS_TRY;
   const double nu = this->GetProperties()[POISSON_RATIO];
   const double E = this->GetProperties()[YOUNG_MODULUS];

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.hpp
@@ -105,32 +105,32 @@ namespace Kratos
         /**
          * @brief This function calculates the elastic part of the total stiffness matrix
          */
-        BoundedMatrix<double,msElementSize,msElementSize> CreateElementStiffnessMatrix_Material();
+        BoundedMatrix<double,msElementSize,msElementSize> CreateElementStiffnessMatrix_Material() const;
 
         /**
          * @brief This function calculates the geometric part of the total stiffness matrix
          */
-        BoundedMatrix<double,msElementSize,msElementSize>  CreateElementStiffnessMatrix_Geometry();
+        BoundedMatrix<double,msElementSize,msElementSize>  CreateElementStiffnessMatrix_Geometry() const;
 
         /**
          * @brief This function calculates the element stiffness w.r.t. deformation modes
          */
-        virtual BoundedMatrix<double,msLocalSize,msLocalSize> CalculateDeformationStiffness();
+        virtual BoundedMatrix<double,msLocalSize,msLocalSize> CalculateDeformationStiffness() const;
 
         /**
          * @brief This function calculates a transformation matrix from deformation modes to real deformations
          */
-        BoundedMatrix<double,msElementSize,msLocalSize> CalculateTransformationS();
+        BoundedMatrix<double,msElementSize,msLocalSize> CalculateTransformationS() const;
 
         /**
          * @brief This function calculates the current nodal position
          */
-        BoundedVector<double,msLocalSize> GetCurrentNodalPosition();
+        BoundedVector<double,msLocalSize> GetCurrentNodalPosition() const;
 
         /**
          * @brief This function calculates the internal element forces
          */
-        BoundedVector<double,msLocalSize> CalculateElementForces(const Vector& Bisectrix,const Vector& VectorDifference);
+        BoundedVector<double,msLocalSize> CalculateElementForces(const Vector& Bisectrix,const Vector& VectorDifference) const;
 
 
         /**
@@ -145,7 +145,7 @@ namespace Kratos
         /**
          * @brief This function calculates the initial transformation matrix to globalize/localize vectors and/or matrices
          */
-        BoundedMatrix<double,msElementSize,msElementSize> CalculateInitialLocalCS();
+        BoundedMatrix<double,msElementSize,msElementSize> CalculateInitialLocalCS() const;
 
 
         /**
@@ -178,7 +178,7 @@ namespace Kratos
          */
         void CalculateLumpedMassMatrix(
             MatrixType& rMassMatrix,
-            ProcessInfo& rCurrentProcessInfo);
+            const ProcessInfo& rCurrentProcessInfo) const;
 
 
         /**
@@ -188,7 +188,7 @@ namespace Kratos
          */
         void CalculateConsistentMassMatrix(
             MatrixType& rMassMatrix,
-            ProcessInfo& rCurrentProcessInfo);
+            const ProcessInfo& rCurrentProcessInfo) const;
 
 
         /**
@@ -202,7 +202,7 @@ namespace Kratos
          */
         void BuildSingleMassMatrix(
             MatrixType& rMassMatrix,
-            const double Phi, const double CT, const double CR, const double L, const double dir);
+            const double Phi, const double CT, const double CR, const double L, const double dir) const;
 
         void CalculateDampingMatrix(
             MatrixType& rDampingMatrix,
@@ -231,7 +231,7 @@ namespace Kratos
          * @param BigMatrix The total global rotation matrix
          */
         void AssembleSmallInBigMatrix(Matrix SmallMatrix, BoundedMatrix<double,
-            msElementSize,msElementSize>& BigMatrix);
+            msElementSize,msElementSize>& BigMatrix) const;
 
         int Check(const ProcessInfo& rCurrentProcessInfo) override;
 
@@ -241,22 +241,22 @@ namespace Kratos
          * @param I The second moment of area
          * @param A_eff The shear-effective area
          */
-        double CalculatePsi(const double I, const double A_eff);
+        double CalculatePsi(const double I, const double A_eff) const;
 
         /**
          * @brief This function calculates shear modulus from user input values
          */
-        double CalculateShearModulus();
+        double CalculateShearModulus() const;
 
         /**
          * @brief This function calculates the reference length
          */
-        double CalculateReferenceLength();
+        double CalculateReferenceLength() const;
 
         /**
          * @brief This function calculates the current length
          */
-        double CalculateCurrentLength();
+        double CalculateCurrentLength() const;
 
         /**
          * @brief This function updates incremental deformation w.r.t. to current and previous deformations
@@ -267,7 +267,7 @@ namespace Kratos
         /**
          * @brief This function calculates self-weight forces
          */
-        BoundedVector<double,msElementSize> CalculateBodyForces();
+        BoundedVector<double,msElementSize> CalculateBodyForces() const;
 
         void CalculateOnIntegrationPoints(
             const Variable<array_1d<double, 3 > >& rVariable,
@@ -291,20 +291,20 @@ namespace Kratos
         void CalculateAndAddWorkEquivalentNodalForcesLineLoad(
             const BoundedVector<double,msDimension> ForceInput,
             BoundedVector<double,msElementSize>& rRightHandSideVector,
-            const double GeometryLength);
+            const double GeometryLength) const;
 
 
         /**
          * @brief This function calculates the symmetric deformation modes
          * @param VectorDifference The vector differences of the quaternions
          */
-        Vector CalculateSymmetricDeformationMode(const Vector& VectorDifference);
+        Vector CalculateSymmetricDeformationMode(const Vector& VectorDifference) const;
 
         /**
          * @brief This function calculates the antisymmetric deformation modes
          * @param Bisectrix The bisectrix between the local axis1 from the last iter. step and the updated axis 1
          */
-        Vector CalculateAntiSymmetricDeformationMode(const Vector& Bisectrix);
+        Vector CalculateAntiSymmetricDeformationMode(const Vector& Bisectrix) const;
 
         /**
          * @brief This function calculates the local nodal forces

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_2D2N.cpp
@@ -209,7 +209,7 @@ void CrBeamElementLinear2D2N::GetValueOnIntegrationPoints(
   KRATOS_CATCH("")
 }
 
-double CrBeamElementLinear2D2N::CalculateLength() {
+double CrBeamElementLinear2D2N::CalculateLength() const {
   KRATOS_TRY;
   return this->CalculateReferenceLength();
   KRATOS_CATCH("")

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_2D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_2D2N.hpp
@@ -100,7 +100,7 @@ namespace Kratos
         /**
          * @brief This function calculates the reference length
          */
-        double CalculateLength() override;
+        double CalculateLength() const override;
 
 
         void GetValueOnIntegrationPoints(

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_3D2N.cpp
@@ -147,7 +147,7 @@ void CrBeamElementLinear3D2N::CalculateMassMatrix(MatrixType &rMassMatrix,
 
 BoundedMatrix<double, CrBeamElement3D2N::msLocalSize,
                CrBeamElement3D2N::msLocalSize>
-CrBeamElementLinear3D2N::CalculateDeformationStiffness() {
+CrBeamElementLinear3D2N::CalculateDeformationStiffness() const {
 
   KRATOS_TRY
   BoundedMatrix<double, msLocalSize, msLocalSize> Kd =

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_3D2N.hpp
@@ -94,7 +94,7 @@ namespace Kratos
             /**
              * @brief This function calculates the element stiffness w.r.t. deformation modes
              */
-            BoundedMatrix<double,msLocalSize,msLocalSize> CalculateDeformationStiffness() override;
+            BoundedMatrix<double,msLocalSize,msLocalSize> CalculateDeformationStiffness() const override;
 
             void CalculateOnIntegrationPoints(
                 const Variable<array_1d<double, 3 > >& rVariable,

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
@@ -1750,7 +1750,7 @@ void ShellThickElement3D3N::AddBodyForces(CalculationData& data, VectorType& rRi
 
 void ShellThickElement3D3N::CalculateAll(MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
-    ProcessInfo& rCurrentProcessInfo,
+    const ProcessInfo& rCurrentProcessInfo,
     const bool CalculateStiffnessMatrixFlag,
     const bool CalculateResidualVectorFlag)
 {
@@ -2140,7 +2140,7 @@ bool ShellThickElement3D3N::TryCalculateOnIntegrationPoints_GeneralizedStrainsOr
     return true;
 }
 
-ShellCrossSection::SectionBehaviorType ShellThickElement3D3N::GetSectionBehavior()
+ShellCrossSection::SectionBehaviorType ShellThickElement3D3N::GetSectionBehavior() const
 {
     return ShellCrossSection::Thick;
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
@@ -163,14 +163,14 @@ void ShellThickElement3D3N::Initialize()
 void ShellThickElement3D3N::InitializeNonLinearIteration
 (ProcessInfo& rCurrentProcessInfo)
 {
-    mpCoordinateTransformation->InitializeNonLinearIteration(rCurrentProcessInfo);
+    mpCoordinateTransformation->InitializeNonLinearIteration();
 
     BaseInitializeNonLinearIteration(rCurrentProcessInfo);
 }
 
 void ShellThickElement3D3N::FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
 {
-    mpCoordinateTransformation->FinalizeNonLinearIteration(rCurrentProcessInfo);
+    mpCoordinateTransformation->FinalizeNonLinearIteration();
 
     BaseFinalizeNonLinearIteration(rCurrentProcessInfo);
 }
@@ -179,14 +179,14 @@ void ShellThickElement3D3N::InitializeSolutionStep(ProcessInfo& rCurrentProcessI
 {
     BaseInitializeSolutionStep(rCurrentProcessInfo);
 
-    mpCoordinateTransformation->InitializeSolutionStep(rCurrentProcessInfo);
+    mpCoordinateTransformation->InitializeSolutionStep();
 }
 
 void ShellThickElement3D3N::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
 {
     BaseFinalizeSolutionStep(rCurrentProcessInfo);
 
-    mpCoordinateTransformation->FinalizeSolutionStep(rCurrentProcessInfo);
+    mpCoordinateTransformation->FinalizeSolutionStep();
 }
 
 void ShellThickElement3D3N::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.hpp
@@ -335,7 +335,7 @@ namespace Kratos
 
         void CalculateAll(MatrixType& rLeftHandSideMatrix,
             VectorType& rRightHandSideVector,
-            ProcessInfo& rCurrentProcessInfo,
+            const ProcessInfo& rCurrentProcessInfo,
             const bool CalculateStiffnessMatrixFlag,
             const bool CalculateResidualVectorFlag) override;
 
@@ -347,7 +347,7 @@ namespace Kratos
         * Returns the behavior of this shell (thin/thick)
         * @return the shell behavior
         */
-        ShellCrossSection::SectionBehaviorType GetSectionBehavior() override;
+        ShellCrossSection::SectionBehaviorType GetSectionBehavior() const override;
 
         ///@}
 

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
@@ -1374,7 +1374,7 @@ void ShellThickElement3D4N::CalculateBMatrix(double xi, double eta,
 
 void ShellThickElement3D4N::CalculateAll(MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
-    ProcessInfo& rCurrentProcessInfo,
+    const ProcessInfo& rCurrentProcessInfo,
     const bool CalculateStiffnessMatrixFlag,
     const bool CalculateResidualVectorFlag)
 {
@@ -1892,7 +1892,7 @@ bool ShellThickElement3D4N::TryCalculateOnIntegrationPoints_GeneralizedStrainsOr
     return true;
 }
 
-ShellCrossSection::SectionBehaviorType ShellThickElement3D4N::GetSectionBehavior()
+ShellCrossSection::SectionBehaviorType ShellThickElement3D4N::GetSectionBehavior() const
 {
     return ShellCrossSection::Thick;
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
@@ -161,19 +161,19 @@ void ShellThickElement3D4N::EASOperatorStorage::Initialize(const GeometryType& g
     }
 }
 
-void ShellThickElement3D4N::EASOperatorStorage::InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+void ShellThickElement3D4N::EASOperatorStorage::InitializeSolutionStep()
 {
     displ = displ_converged;
     alpha = alpha_converged;
 }
 
-void ShellThickElement3D4N::EASOperatorStorage::FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo)
+void ShellThickElement3D4N::EASOperatorStorage::FinalizeSolutionStep()
 {
     displ_converged = displ;
     alpha_converged = alpha;
 }
 
-void ShellThickElement3D4N::EASOperatorStorage::FinalizeNonLinearIteration(const Vector& displacementVector, ProcessInfo& CurrentProcessInfo)
+void ShellThickElement3D4N::EASOperatorStorage::FinalizeNonLinearIteration(const Vector& displacementVector)
 {
     Vector incrementalDispl(24);
     noalias(incrementalDispl) = displacementVector - displ;
@@ -415,21 +415,21 @@ void ShellThickElement3D4N::Initialize()
 
 void ShellThickElement3D4N::InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
 {
-    mpCoordinateTransformation->InitializeNonLinearIteration(rCurrentProcessInfo);
+    mpCoordinateTransformation->InitializeNonLinearIteration();
 
     BaseInitializeNonLinearIteration(rCurrentProcessInfo);
 }
 
 void ShellThickElement3D4N::FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
 {
-    mpCoordinateTransformation->FinalizeNonLinearIteration(rCurrentProcessInfo);
+    mpCoordinateTransformation->FinalizeNonLinearIteration();
 
     ShellQ4_LocalCoordinateSystem LCS( mpCoordinateTransformation->CreateLocalCoordinateSystem() );
     Vector globalDisplacementVector(24);
     GetValuesVector(globalDisplacementVector);
     Vector localDisplacementVector( mpCoordinateTransformation->CalculateLocalDisplacements( LCS, globalDisplacementVector ) );
 
-    mEASStorage.FinalizeNonLinearIteration(localDisplacementVector, rCurrentProcessInfo);
+    mEASStorage.FinalizeNonLinearIteration(localDisplacementVector);
 
     BaseFinalizeNonLinearIteration(rCurrentProcessInfo);
 }
@@ -438,18 +438,18 @@ void ShellThickElement3D4N::InitializeSolutionStep(ProcessInfo& rCurrentProcessI
 {
     BaseInitializeSolutionStep(rCurrentProcessInfo);
 
-    mpCoordinateTransformation->InitializeSolutionStep(rCurrentProcessInfo);
+    mpCoordinateTransformation->InitializeSolutionStep();
 
-    mEASStorage.InitializeSolutionStep(rCurrentProcessInfo);
+    mEASStorage.InitializeSolutionStep();
 }
 
 void ShellThickElement3D4N::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
 {
     BaseFinalizeSolutionStep(rCurrentProcessInfo);
 
-    mpCoordinateTransformation->FinalizeSolutionStep(rCurrentProcessInfo);
+    mpCoordinateTransformation->FinalizeSolutionStep();
 
-    mEASStorage.FinalizeSolutionStep(rCurrentProcessInfo);
+    mEASStorage.FinalizeSolutionStep();
 }
 
 void ShellThickElement3D4N::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
@@ -178,11 +178,11 @@ public:
 
         inline void Initialize(const GeometryType& geom);
 
-        inline void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo);
+        inline void InitializeSolutionStep();
 
-        inline void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo);
+        inline void FinalizeSolutionStep();
 
-        inline void FinalizeNonLinearIteration(const Vector& displacementVector, ProcessInfo& CurrentProcessInfo);
+        inline void FinalizeNonLinearIteration(const Vector& displacementVector);
 
     private:
 

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.hpp
@@ -409,7 +409,7 @@ private:
 
     void CalculateAll(MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
+        const ProcessInfo& rCurrentProcessInfo,
         const bool CalculateStiffnessMatrixFlag,
         const bool CalculateResidualVectorFlag) override;
 
@@ -423,7 +423,7 @@ private:
     * Returns the behavior of this shell (thin/thick)
     * @return the shell behavior
     */
-    ShellCrossSection::SectionBehaviorType GetSectionBehavior() override;
+    ShellCrossSection::SectionBehaviorType GetSectionBehavior() const override;
 
     ///@}
 

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
@@ -1381,7 +1381,7 @@ void ShellThinElement3D3N::AddBodyForces(CalculationData& data, VectorType& rRig
 
 void ShellThinElement3D3N::CalculateAll(MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
-    ProcessInfo& rCurrentProcessInfo,
+    const ProcessInfo& rCurrentProcessInfo,
     const bool CalculateStiffnessMatrixFlag,
     const bool CalculateResidualVectorFlag)
 {
@@ -1648,7 +1648,7 @@ bool ShellThinElement3D3N::TryCalculateOnIntegrationPoints_GeneralizedStrainsOrS
     return true;
 }
 
-ShellCrossSection::SectionBehaviorType ShellThinElement3D3N::GetSectionBehavior()
+ShellCrossSection::SectionBehaviorType ShellThinElement3D3N::GetSectionBehavior() const
 {
     return ShellCrossSection::Thin;
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
@@ -128,14 +128,14 @@ void ShellThinElement3D3N::Initialize()
 
 void ShellThinElement3D3N::InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
 {
-    mpCoordinateTransformation->InitializeNonLinearIteration(rCurrentProcessInfo);
+    mpCoordinateTransformation->InitializeNonLinearIteration();
 
     BaseInitializeNonLinearIteration(rCurrentProcessInfo);
 }
 
 void ShellThinElement3D3N::FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
 {
-    mpCoordinateTransformation->FinalizeNonLinearIteration(rCurrentProcessInfo);
+    mpCoordinateTransformation->FinalizeNonLinearIteration();
 
     BaseFinalizeNonLinearIteration(rCurrentProcessInfo);
 }
@@ -144,14 +144,14 @@ void ShellThinElement3D3N::InitializeSolutionStep(ProcessInfo& rCurrentProcessIn
 {
     BaseInitializeSolutionStep(rCurrentProcessInfo);
 
-    mpCoordinateTransformation->InitializeSolutionStep(rCurrentProcessInfo);
+    mpCoordinateTransformation->InitializeSolutionStep();
 }
 
 void ShellThinElement3D3N::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
 {
     BaseFinalizeSolutionStep(rCurrentProcessInfo);
 
-    mpCoordinateTransformation->FinalizeSolutionStep(rCurrentProcessInfo);
+    mpCoordinateTransformation->FinalizeSolutionStep();
 }
 
 void ShellThinElement3D3N::CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.hpp
@@ -317,7 +317,7 @@ private:
 
     void CalculateAll(MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
+        const ProcessInfo& rCurrentProcessInfo,
         const bool CalculateStiffnessMatrixFlag,
         const bool CalculateResidualVectorFlag) override;
 
@@ -329,7 +329,7 @@ private:
     * Returns the behavior of this shell (thin/thick)
     * @return the shell behavior
     */
-    ShellCrossSection::SectionBehaviorType GetSectionBehavior() override;
+    ShellCrossSection::SectionBehaviorType GetSectionBehavior() const override;
 
     ///@}
 

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
@@ -171,7 +171,7 @@ void ShellThinElement3D4N::Initialize()
 void ShellThinElement3D4N::InitializeNonLinearIteration
 (ProcessInfo& rCurrentProcessInfo)
 {
-    mpCoordinateTransformation->InitializeNonLinearIteration(rCurrentProcessInfo);
+    mpCoordinateTransformation->InitializeNonLinearIteration();
 
     BaseInitializeNonLinearIteration(rCurrentProcessInfo);
 }
@@ -179,7 +179,7 @@ void ShellThinElement3D4N::InitializeNonLinearIteration
 void ShellThinElement3D4N::FinalizeNonLinearIteration
 (ProcessInfo& rCurrentProcessInfo)
 {
-    mpCoordinateTransformation->FinalizeNonLinearIteration(rCurrentProcessInfo);
+    mpCoordinateTransformation->FinalizeNonLinearIteration();
 
     BaseFinalizeNonLinearIteration(rCurrentProcessInfo);
 }
@@ -189,7 +189,7 @@ void ShellThinElement3D4N::InitializeSolutionStep
 {
     BaseInitializeSolutionStep(rCurrentProcessInfo);
 
-    mpCoordinateTransformation->InitializeSolutionStep(rCurrentProcessInfo);
+    mpCoordinateTransformation->InitializeSolutionStep();
 }
 
 void ShellThinElement3D4N::FinalizeSolutionStep
@@ -197,7 +197,7 @@ void ShellThinElement3D4N::FinalizeSolutionStep
 {
     BaseFinalizeSolutionStep(rCurrentProcessInfo);
 
-    mpCoordinateTransformation->FinalizeSolutionStep(rCurrentProcessInfo);
+    mpCoordinateTransformation->FinalizeSolutionStep();
 }
 
 void ShellThinElement3D4N::CalculateMassMatrix(MatrixType& rMassMatrix,

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
@@ -1982,7 +1982,7 @@ void ShellThinElement3D4N::CalculateGaussPointContribution
 
 void ShellThinElement3D4N::CalculateAll(MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
-    ProcessInfo& rCurrentProcessInfo,
+    const ProcessInfo& rCurrentProcessInfo,
     const bool CalculateStiffnessMatrixFlag,
     const bool CalculateResidualVectorFlag)
 {
@@ -2407,7 +2407,7 @@ ShellThinElement3D4N::CalculationData::CalculationData
 {
 }
 
-ShellCrossSection::SectionBehaviorType ShellThinElement3D4N::GetSectionBehavior()
+ShellCrossSection::SectionBehaviorType ShellThinElement3D4N::GetSectionBehavior() const
 {
     return ShellCrossSection::Thin;
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.hpp
@@ -393,7 +393,7 @@ private:
 
     void CalculateAll(MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo,
+        const ProcessInfo& rCurrentProcessInfo,
         const bool CalculateStiffnessMatrixFlag,
         const bool CalculateResidualVectorFlag) override;
 
@@ -405,7 +405,7 @@ private:
     * Returns the behavior of this shell (thin/thick)
     * @return the shell behavior
     */
-    ShellCrossSection::SectionBehaviorType GetSectionBehavior() override;
+    ShellCrossSection::SectionBehaviorType GetSectionBehavior() const override;
 
     ///@}
 

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -65,7 +65,7 @@ SmallDisplacement::~SmallDisplacement()
 /***********************************************************************************/
 /***********************************************************************************/
 
-bool SmallDisplacement::UseElementProvidedStrain()
+bool SmallDisplacement::UseElementProvidedStrain() const
 {
     return true;
 }
@@ -235,7 +235,7 @@ void SmallDisplacement::CalculateB(
     const Matrix& rDN_DX,
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
     const IndexType PointNumber
-    )
+    ) const
 {
     KRATOS_TRY;
 
@@ -271,7 +271,7 @@ void SmallDisplacement::CalculateB(
 /***********************************************************************************/
 /***********************************************************************************/
 
-Matrix SmallDisplacement::ComputeEquivalentF(const Vector& rStrainTensor)
+Matrix SmallDisplacement::ComputeEquivalentF(const Vector& rStrainTensor) const
 {
     const SizeType dim = GetGeometry().WorkingSpaceDimension();
     Matrix F(dim,dim);

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.h
@@ -179,7 +179,7 @@ protected:
      /**
      * @brief This method returns if the element provides the strain
      */
-    bool UseElementProvidedStrain() override;
+    bool UseElementProvidedStrain() const override;
 
     /**
      * @brief This functions calculates both the RHS and the LHS
@@ -253,14 +253,14 @@ protected:
         const Matrix& rDN_DX,
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const IndexType PointNumber
-        );
+        ) const;
 
     /**
      * Calculation of the equivalent deformation gradient
      * @param StrainVector The strain tensor (Voigt notation)
      * @return The deformation gradient F
      */
-    virtual Matrix ComputeEquivalentF(const Vector& StrainVector);
+    virtual Matrix ComputeEquivalentF(const Vector& StrainVector) const;
 
     ///@}
     ///@name Protected Operations

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -72,7 +72,7 @@ SmallDisplacementBbar::~SmallDisplacementBbar()
 //************************************************************************************
 //************************************************************************************
 
-bool SmallDisplacementBbar::UseElementProvidedStrain()
+bool SmallDisplacementBbar::UseElementProvidedStrain() const
 {
     return true;
 }
@@ -888,7 +888,7 @@ void SmallDisplacementBbar::CalculateAndAddResidualVector(
         const Vector& rBodyForce,
         const Vector& rStressVector,
         const double IntegrationWeight
-    )
+    ) const
 {
     KRATOS_TRY
 

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.h
@@ -198,7 +198,7 @@ protected:
     /**
     * @brief This method returns if the element provides the strain
     */
-    bool UseElementProvidedStrain() override;
+    bool UseElementProvidedStrain() const override;
 
     /**
     * This functions updates the kinematics variables
@@ -221,7 +221,7 @@ protected:
             const Vector& rBodyForce,
             const Vector& rStressVector,
             const double IntegrationWeight
-            ) override ;
+            ) const override;
 
     /**
      * This functions updates the data structure passed to the CL

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -310,7 +310,7 @@ double UpdatedLagrangian::CalculateDerivativesOnReferenceConfiguration(
     Matrix& DN_DX,
     const IndexType PointNumber,
     IntegrationMethod ThisIntegrationMethod
-    )
+    ) const
 {
     J0.clear();
 

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.h
@@ -342,7 +342,7 @@ protected:
         Matrix& DN_DX,
         const IndexType PointNumber,
         IntegrationMethod ThisIntegrationMethod
-        ) override;
+        ) const override;
 
     ///@}
     ///@name Protected Operations

--- a/applications/StructuralMechanicsApplication/custom_utilities/shellq4_coordinate_transformation.hpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shellq4_coordinate_transformation.hpp
@@ -68,19 +68,19 @@ namespace Kratos
 		{
 		}
 
-		virtual void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+		virtual void InitializeSolutionStep()
 		{
 		}
-		
-		virtual void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo)
+
+		virtual void FinalizeSolutionStep()
 		{
 		}
-		
-		virtual void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+
+		virtual void InitializeNonLinearIteration()
 		{
 		}
-		
-		virtual void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+
+		virtual void FinalizeNonLinearIteration()
 		{
 		}
 
@@ -98,7 +98,7 @@ namespace Kratos
 			return CreateReferenceCoordinateSystem();
 		}
 
-		virtual Vector CalculateLocalDisplacements(const ShellQ4_LocalCoordinateSystem & LCS, 
+		virtual Vector CalculateLocalDisplacements(const ShellQ4_LocalCoordinateSystem & LCS,
 												   const VectorType & globalDisplacements)
 		{
 			MatrixType R(24, 24);

--- a/applications/StructuralMechanicsApplication/custom_utilities/shellq4_corotational_coordinate_transformation.hpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shellq4_corotational_coordinate_transformation.hpp
@@ -106,7 +106,7 @@ namespace Kratos
 			KRATOS_CATCH("")
 		}
 
-		void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override
+		void InitializeSolutionStep() override
 		{
 			for(int i = 0; i < 4; i++)
 			{
@@ -115,7 +115,7 @@ namespace Kratos
 			}
 		}
 
-		void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo) override
+		void FinalizeSolutionStep() override
 		{
 			for(int i = 0; i < 4; i++)
 			{
@@ -124,11 +124,7 @@ namespace Kratos
 			}
 		}
 
-		void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override
-		{
-		}
-
-		void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override
+		void FinalizeNonLinearIteration() override
 		{
 			const GeometryType & geom = GetGeometry();
 			Vector3Type incrementalRotation;

--- a/applications/StructuralMechanicsApplication/custom_utilities/shellt3_coordinate_transformation.hpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shellt3_coordinate_transformation.hpp
@@ -67,19 +67,19 @@ public:
     {
     }
 
-    virtual void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo)
+    virtual void InitializeSolutionStep()
     {
     }
 
-    virtual void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo)
+    virtual void FinalizeSolutionStep()
     {
     }
 
-    virtual void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+    virtual void InitializeNonLinearIteration()
     {
     }
 
-    virtual void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo)
+    virtual void FinalizeNonLinearIteration()
     {
     }
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/shellt3_corotational_coordinate_transformation.hpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/shellt3_corotational_coordinate_transformation.hpp
@@ -110,7 +110,7 @@ public:
         KRATOS_CATCH("")
     }
 
-    void InitializeSolutionStep(ProcessInfo& CurrentProcessInfo) override
+    void InitializeSolutionStep() override
     {
         for(int i = 0; i < 3; i++)
         {
@@ -119,7 +119,7 @@ public:
         }
     }
 
-    void FinalizeSolutionStep(ProcessInfo& CurrentProcessInfo) override
+    void FinalizeSolutionStep() override
     {
         for(int i = 0; i < 3; i++)
         {
@@ -128,11 +128,7 @@ public:
         }
     }
 
-    void InitializeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override
-    {
-    }
-
-    void FinalizeNonLinearIteration(ProcessInfo& CurrentProcessInfo) override
+    void FinalizeNonLinearIteration() override
     {
         const GeometryType & geom = GetGeometry();
         Vector3Type incrementalRotation;

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_math_utilities.hpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_math_utilities.hpp
@@ -315,7 +315,7 @@ public:
 
     static inline double CalculateRadius(
         const Vector N,
-        GeometryType& Geom,
+        const GeometryType& Geom,
         const Configuration ThisConfiguration = Current
         )
     {
@@ -348,7 +348,7 @@ public:
      */
 
     static inline double CalculateRadiusPoint(
-        GeometryType& Geom,
+        const GeometryType& Geom,
         const Configuration ThisConfiguration = Current
         )
     {


### PR DESCRIPTION
@KratosMultiphysics/structural-mechanics please make all methods that don't modify the members `const` in the future!
This helps a lot when searching for bugs => you will get compiler-errors!

Necessary / Preparation for #2993 