### PR TITLE
[StructuralMechanics] setting default linear-solver to superlu in tests

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/structural_mechanics_test_factory.py
+++ b/applications/StructuralMechanicsApplication/tests/structural_mechanics_test_factory.py
@@ -2,11 +2,10 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 
 # Importing the Kratos Library
 import KratosMultiphysics
-import KratosMultiphysics.StructuralMechanicsApplication
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
 
 # Import KratosUnittest
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-import structural_mechanics_analysis
 
 # Other imports
 import os
@@ -36,6 +35,20 @@ class StructuralMechanicsTestFactory(KratosUnittest.TestCase):
             with open(self.file_name + "_parameters.json",'r') as parameter_file:
                 ProjectParameters = KratosMultiphysics.Parameters(parameter_file.read())
 
+            # The mechanical solver selects automatically the fastest linear-solver available
+            # this might not be appropriate for a test, therefore in case nothing is specified,
+            # the previous default linear-solver is set
+            if not ProjectParameters["solver_settings"].Has("linear_solver_settings"):
+                default_lin_solver_settings = KratosMultiphysics.Parameters("""{
+                "solver_type": "SuperLUSolver",
+                    "max_iteration": 500,
+                    "tolerance": 1e-9,
+                    "scaling": false,
+                    "symmetric_scaling": true,
+                    "verbosity": 1
+                }""")
+                ProjectParameters["solver_settings"].AddValue("linear_solver_settings", default_lin_solver_settings)
+
             self.modify_parameters(ProjectParameters)
 
             # To avoid many prints
@@ -44,7 +57,7 @@ class StructuralMechanicsTestFactory(KratosUnittest.TestCase):
 
             # Creating the test
             model = KratosMultiphysics.Model()
-            self.test = structural_mechanics_analysis.StructuralMechanicsAnalysis(model, ProjectParameters)
+            self.test = StructuralMechanicsAnalysis(model, ProjectParameters)
             self.test.Initialize()
 
     def modify_parameters(self, project_parameters):


### PR DESCRIPTION
thus restoring the previous behavior

Other solvers can have problems, which might not be detected by the one making the test

@AndreasWinterstein can you please try if with this change the failing tests are working now?