### PR TITLE
[MPI][FluidDynamicsApplication] Importing Metis BEFORE Trilinos to avoid SegFault on cluster

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
@@ -8,6 +8,7 @@ import KratosMultiphysics.mpi as KratosMPI                          # MPI-python
 KratosMultiphysics.CheckRegisteredApplications("FluidDynamicsApplication","MetisApplication","TrilinosApplication")
 
 # Import applications
+import KratosMultiphysics.MetisApplication as KratosMetis
 import KratosMultiphysics.TrilinosApplication as KratosTrilinos     # MPI solvers
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid   # Fluid dynamics application
 


### PR DESCRIPTION
The following modification is proposed to avoid crashes with "segmentation fault" when the solver is run on the Acuario cluster (not yet tested for other clusters):

- Unfortunately, I cannot explain why it is necessary to have the imports in this sequence. The solution is more "of experimental nature".
- Every other Trilinos solver has it this way (... still a bad argument ...)
- Errors occur on the cluster (not observed on local machine!) if the line is left out

In case somebody is interested, I am attaching the otherwise received error message in a *.txt file.
(@philbucher, I think we already discussed it once and both agreed that it could be left out after positive tests on the laptop)

[SegFaultInMetis.txt](https://github.com/KratosMultiphysics/Kratos/files/2766607/SegFaultInMetis.txt)