### PR TITLE
Adding support for single process to trilinos_import_model_part_utility

### DIFF
--- a/applications/trilinos_application/python_scripts/trilinos_import_model_part_utility.py
+++ b/applications/trilinos_application/python_scripts/trilinos_import_model_part_utility.py
@@ -26,6 +26,9 @@ class TrilinosImportModelPartUtility():
         model_part_import_settings = self.settings["model_import_settings"]
         input_type = model_part_import_settings["input_type"].GetString()
 
+        # in single process runs, do not call metis (no partitioning is necessary)
+        is_single_process_run = (KratosMPI.mpi.size == 1)
+
         if input_type == "mdpa":
             input_filename = model_part_import_settings["input_filename"].GetString()
 
@@ -52,7 +55,7 @@ class TrilinosImportModelPartUtility():
             if model_part_import_settings.Has("partition_in_memory"):
                 partition_in_memory = model_part_import_settings["partition_in_memory"].GetBool()
 
-            if perform_partitioning == True and KratosMPI.mpi.size > 1:
+            if not is_single_process_run and perform_partitioning == True:
                 import KratosMultiphysics.MetisApplication as KratosMetis
 
                 # Partition of the original .mdpa file
@@ -91,14 +94,14 @@ class TrilinosImportModelPartUtility():
             KratosMPI.mpi.world.barrier()
 
             ## Reset as input file name the obtained Metis partition one
-            if KratosMPI.mpi.size > 1:
-                mpi_input_filename = input_filename + "_" + str(KratosMPI.mpi.rank)
-            else:
+            if is_single_process_run:
                 mpi_input_filename = input_filename
+            else:
+                mpi_input_filename = input_filename + "_" + str(KratosMPI.mpi.rank)
             model_part_import_settings["input_filename"].SetString(mpi_input_filename)
 
             ## Read the new generated *.mdpa files
-            if not partition_in_memory:
+            if not partition_in_memory or is_single_process_run:
                 KratosMultiphysics.ModelPartIO(mpi_input_filename, import_flags).ReadModelPart(self.main_model_part)
 
         elif input_type == "rest":

--- a/applications/trilinos_application/tests/test_mpi_communicator.py
+++ b/applications/trilinos_application/tests/test_mpi_communicator.py
@@ -5,6 +5,7 @@ import KratosMultiphysics
 import KratosMultiphysics.mpi as KratosMPI
 import KratosMultiphysics.MetisApplication as KratosMetis
 import KratosMultiphysics.TrilinosApplication as KratosTrilinos
+import kratos_utilities
 
 
 def GetFilePath(fileName):
@@ -13,19 +14,26 @@ def GetFilePath(fileName):
 
 class TestMPICommunicator(KratosUnittest.TestCase):
 
+    def tearDown(self):
+        if KratosMPI.mpi.rank == 0:
+            kratos_utilities.DeleteFileIfExisting("test_mpi_communicator.time")
+        kratos_utilities.DeleteFileIfExisting("test_mpi_communicator_"+str(KratosMPI.mpi.rank)+".mdpa")
+        kratos_utilities.DeleteFileIfExisting("test_mpi_communicator_"+str(KratosMPI.mpi.rank)+".time")
+        KratosMPI.mpi.world.barrier()
+
     def _read_model_part_mpi(self,main_model_part):
-        
+
         if(KratosMPI.mpi.size == 1):
             self.skipTest("Test can be run only using more than one mpi process")
-        
+
         ## Add variables to the model part
         main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DENSITY)
         main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VISCOSITY)
         main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
-        main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)  
-     
+        main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)
+
         ## Serial partition of the original .mdpa file
-        input_filename = "test_mpi_communicator"   
+        input_filename = "test_mpi_communicator"
         if KratosMPI.mpi.rank == 0 :
 
             # Original .mdpa file reading
@@ -36,45 +44,45 @@ class TestMPICommunicator(KratosUnittest.TestCase):
             domain_size = main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE]
             verbosity = 0
             sync_conditions = True # Make sure that the condition goes to the same partition as the element is a face of
-            
+
             partitioner = KratosMetis.MetisDivideHeterogeneousInputProcess(model_part_io, number_of_partitions , domain_size, verbosity, sync_conditions)
-            partitioner.Execute() 
+            partitioner.Execute()
 
             print("Metis divide finished.")
 
         KratosMPI.mpi.world.barrier()
-    
+
         ## Read the partitioned .mdpa files
         mpi_input_filename = input_filename + "_" + str(KratosMPI.mpi.rank)
         model_part_io = KratosMultiphysics.ModelPartIO(mpi_input_filename)
         model_part_io.ReadModelPart(main_model_part)
-    
+
         ## Construct and execute the MPICommunicator
         KratosMetis.SetMPICommunicatorProcess(main_model_part).Execute()
-        
+
         ## Construct and execute the Parallel fill communicator
         ParallelFillCommunicator = KratosTrilinos.ParallelFillCommunicator(main_model_part.GetRootModelPart())
         ParallelFillCommunicator.Execute()
-      
+
         ## Check submodelpart of each main_model_part of each processor
         self.assertTrue(main_model_part.HasSubModelPart("Skin"))
         skin_sub_model_part = main_model_part.GetSubModelPart("Skin")
-        
-        
+
+
     def test_assemble_variable_in_model_part(self):
         current_model = KratosMultiphysics.Model()
         main_model_part = current_model.CreateModelPart("MainModelPart")
         main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, 2)
-                
+
         self._read_model_part_mpi(main_model_part)
-        
+
         ## Initialize DENSITY variable
         for node in main_model_part.Nodes:
             node.SetSolutionStepValue(KratosMultiphysics.DENSITY, 0, 0.0)
             node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_X, 0, 0.0)
             node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y, 0, 0.0)
             node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Z, 0, 0.0)
-            
+
         ## Fill the DENSITY value in each processor
         for elem in main_model_part.Elements:
             for node in elem.GetNodes():
@@ -84,7 +92,7 @@ class TestMPICommunicator(KratosUnittest.TestCase):
                 node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_X,0,d)
                 node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y,0,d)
                 node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Z,0,d)
-        
+
         ## Communicate between processors
         main_model_part.GetCommunicator().AssembleCurrentData(KratosMultiphysics.DENSITY)
         main_model_part.GetCommunicator().AssembleCurrentData(KratosMultiphysics.DISPLACEMENT)
@@ -99,26 +107,26 @@ class TestMPICommunicator(KratosUnittest.TestCase):
                            7 : 1,
                            8 : 3,
                            9 : 2}
-        
+
         ## Check the obtained values
         for node in main_model_part.Nodes:
             self.assertEqual(node.GetSolutionStepValue(KratosMultiphysics.DENSITY), expected_values[node.Id])
             self.assertEqual(node.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_X), expected_values[node.Id])
             self.assertEqual(node.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y), expected_values[node.Id])
             self.assertEqual(node.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Z), expected_values[node.Id])
-            
-                
+
+
     def test_assemble_variable_in_sub_model_part(self):
         current_model = KratosMultiphysics.Model()
         main_model_part = current_model.CreateModelPart("MainModelPart")
         main_model_part.ProcessInfo.SetValue(KratosMultiphysics.DOMAIN_SIZE, 2)
-         
+
         self._read_model_part_mpi(main_model_part)
-       
-        submodelpart = main_model_part.GetSubModelPart("Skin")      
-        
+
+        submodelpart = main_model_part.GetSubModelPart("Skin")
+
         KratosMPI.mpi.world.barrier()
-        
+
         # Check partitioning
         #~ for i in range(KratosMPI.mpi.size):
             #~ if(KratosMPI.mpi.rank == i):
@@ -140,13 +148,13 @@ class TestMPICommunicator(KratosUnittest.TestCase):
                     #~ print(node.Id)
                 #~ print(" ")
             #~ KratosMPI.mpi.world.barrier()
-        
+
         for node in submodelpart.Nodes:
             node.SetSolutionStepValue(KratosMultiphysics.DENSITY, 0, 0.0)
             node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_X, 0, 0.0)
             node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y, 0, 0.0)
             node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Z, 0, 0.0)
-            
+
         for condition in submodelpart.Conditions:
             for node in condition.GetNodes():
                 d = node.GetSolutionStepValue(KratosMultiphysics.DENSITY)
@@ -155,10 +163,10 @@ class TestMPICommunicator(KratosUnittest.TestCase):
                 node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_X, 0, d)
                 node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y, 0, d)
                 node.SetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Z, 0, d)
-        
+
         submodelpart.GetCommunicator().AssembleCurrentData(KratosMultiphysics.DENSITY)
         submodelpart.GetCommunicator().AssembleCurrentData(KratosMultiphysics.DISPLACEMENT)
-                
+
         for node in submodelpart.Nodes:
             self.assertEqual(node.GetSolutionStepValue(KratosMultiphysics.DENSITY), 2.0)
             self.assertEqual(node.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_X), 2.0)


### PR DESCRIPTION
The only reason why we cannot currently run mpi simulations on a single process is because metis does not support it. A simple modification to `trilinos_import_model_part_utility` can be used to bypass this limitation.

I know this does not have a wide applicability, but I often find single-process runs useful to debug certain mpi issues, and I would like to be able to run them out of the box.