### PR TITLE
[core] Sync with upstream amgcl

### DIFF
--- a/external_libraries/amgcl/adapter/block_matrix.hpp
+++ b/external_libraries/amgcl/adapter/block_matrix.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/adapter/complex.hpp
+++ b/external_libraries/amgcl/adapter/complex.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/adapter/crs_builder.hpp
+++ b/external_libraries/amgcl/adapter/crs_builder.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/adapter/crs_tuple.hpp
+++ b/external_libraries/amgcl/adapter/crs_tuple.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/adapter/eigen.hpp
+++ b/external_libraries/amgcl/adapter/eigen.hpp
@@ -1,0 +1,147 @@
+#ifndef AMGCL_ADAPTER_EIGEN_HPP
+#define AMGCL_ADAPTER_EIGEN_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+\file    amgcl/adapter/eigen.hpp
+\author  Denis Demidov <dennis.demidov@gmail.com>
+\brief   Adapters for Eigen types to be used with builtin backend.
+\ingroup adapters
+*/
+
+#include <type_traits>
+#include <Eigen/SparseCore>
+#include <amgcl/util.hpp>
+#include <amgcl/backend/builtin.hpp>
+
+namespace amgcl {
+namespace backend {
+
+//---------------------------------------------------------------------------
+// Backend interface specialization for Eigen types
+//---------------------------------------------------------------------------
+template <class T, class Enable = void>
+struct is_eigen_sparse_matrix : std::false_type {};
+
+template <class T, class Enable = void>
+struct is_eigen_type : std::false_type {};
+
+template <typename Scalar, int Flags, typename Storage>
+struct is_eigen_sparse_matrix<
+    Eigen::MappedSparseMatrix<Scalar, Flags, Storage>
+    > : std::true_type
+{};
+
+template <typename Scalar, int Flags, typename Storage>
+struct is_eigen_sparse_matrix<
+    Eigen::SparseMatrix<Scalar, Flags, Storage>
+    > : std::true_type
+{};
+
+template <class T>
+struct is_eigen_type<
+    T,
+    typename std::enable_if<
+        std::is_arithmetic<typename T::Scalar>::value &&
+        std::is_base_of<Eigen::EigenBase<T>, T>::value
+        >::type
+    > : std::true_type
+{};
+
+template <class T>
+struct value_type<
+    T,
+    typename std::enable_if<is_eigen_type<T>::value>::type
+    >
+{
+    typedef typename T::Scalar type;
+};
+
+template <class T>
+struct rows_impl<
+    T,
+    typename std::enable_if<is_eigen_sparse_matrix<T>::value>::type
+    >
+{
+    static size_t get(const T &matrix) {
+        return matrix.rows();
+    }
+};
+
+template <class T>
+struct cols_impl<
+    T,
+    typename std::enable_if<is_eigen_sparse_matrix<T>::value>::type
+    >
+{
+    static size_t get(const T &matrix) {
+        return matrix.cols();
+    }
+};
+
+template <class T>
+struct nonzeros_impl<
+    T,
+    typename std::enable_if<is_eigen_sparse_matrix<T>::value>::type
+    >
+{
+    static size_t get(const T &matrix) {
+        return matrix.nonZeros();
+    }
+};
+
+template <class T>
+struct row_iterator <
+    T,
+    typename std::enable_if<is_eigen_sparse_matrix<T>::value>::type
+    >
+{
+    typedef typename T::InnerIterator type;
+};
+
+template <class T>
+struct row_begin_impl <
+    T,
+    typename std::enable_if<is_eigen_sparse_matrix<T>::value>::type
+    >
+{
+    typedef typename row_iterator<T>::type iterator;
+    static iterator get(const T &matrix, size_t row) {
+        return iterator(matrix, row);
+    }
+};
+
+} // namespace backend
+} // namespace amgcl
+
+#define AMGCL_USE_EIGEN_VECTORS_WITH_BUILTIN_BACKEND()                         \
+    namespace amgcl { namespace backend {                                      \
+        template <class T >                                                    \
+        struct is_builtin_vector< Eigen::Matrix<T, Eigen::Dynamic, 1> >        \
+          : std::true_type {};                                                 \
+    } }
+
+#endif

--- a/external_libraries/amgcl/adapter/reorder.hpp
+++ b/external_libraries/amgcl/adapter/reorder.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/adapter/ublas.hpp
+++ b/external_libraries/amgcl/adapter/ublas.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 Copyright (c) 2014, Riccardo Rossi, CIMNE (International Center for Numerical Methods in Engineering)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/external_libraries/amgcl/adapter/zero_copy.hpp
+++ b/external_libraries/amgcl/adapter/zero_copy.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/amg.hpp
+++ b/external_libraries/amgcl/amg.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/backend/blaze.hpp
+++ b/external_libraries/amgcl/backend/blaze.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/backend/block_crs.hpp
+++ b/external_libraries/amgcl/backend/block_crs.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/backend/builtin.hpp
+++ b/external_libraries/amgcl/backend/builtin.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/backend/cuda.hpp
+++ b/external_libraries/amgcl/backend/cuda.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/backend/detail/default_direct_solver.hpp
+++ b/external_libraries/amgcl/backend/detail/default_direct_solver.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/backend/detail/matrix_ops.hpp
+++ b/external_libraries/amgcl/backend/detail/matrix_ops.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/backend/eigen.hpp
+++ b/external_libraries/amgcl/backend/eigen.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -31,11 +31,8 @@ THE SOFTWARE.
  * \brief  Sparse matrix in CRS format.
  */
 
-#include <type_traits>
 #include <memory>
-#include <Eigen/SparseCore>
-#include <amgcl/util.hpp>
-#include <amgcl/backend/builtin.hpp>
+#include <amgcl/adapter/eigen.hpp>
 #include <amgcl/solver/skyline_lu.hpp>
 
 namespace amgcl {
@@ -129,100 +126,6 @@ struct eigen {
             }
         };
 
-};
-
-//---------------------------------------------------------------------------
-// Backend interface specialization for Eigen types
-//---------------------------------------------------------------------------
-template <class T, class Enable = void>
-struct is_eigen_sparse_matrix : std::false_type {};
-
-template <class T, class Enable = void>
-struct is_eigen_type : std::false_type {};
-
-template <typename Scalar, int Flags, typename Storage>
-struct is_eigen_sparse_matrix<
-    Eigen::MappedSparseMatrix<Scalar, Flags, Storage>
-    > : std::true_type
-{};
-
-template <typename Scalar, int Flags, typename Storage>
-struct is_eigen_sparse_matrix<
-    Eigen::SparseMatrix<Scalar, Flags, Storage>
-    > : std::true_type
-{};
-
-template <class T>
-struct is_eigen_type<
-    T,
-    typename std::enable_if<
-        std::is_arithmetic<typename T::Scalar>::value &&
-        std::is_base_of<Eigen::EigenBase<T>, T>::value
-        >::type
-    > : std::true_type
-{};
-
-template <class T>
-struct value_type<
-    T,
-    typename std::enable_if<is_eigen_type<T>::value>::type
-    >
-{
-    typedef typename T::Scalar type;
-};
-
-template <class T>
-struct rows_impl<
-    T,
-    typename std::enable_if<is_eigen_sparse_matrix<T>::value>::type
-    >
-{
-    static size_t get(const T &matrix) {
-        return matrix.rows();
-    }
-};
-
-template <class T>
-struct cols_impl<
-    T,
-    typename std::enable_if<is_eigen_sparse_matrix<T>::value>::type
-    >
-{
-    static size_t get(const T &matrix) {
-        return matrix.cols();
-    }
-};
-
-template <class T>
-struct nonzeros_impl<
-    T,
-    typename std::enable_if<is_eigen_sparse_matrix<T>::value>::type
-    >
-{
-    static size_t get(const T &matrix) {
-        return matrix.nonZeros();
-    }
-};
-
-template <class T>
-struct row_iterator <
-    T,
-    typename std::enable_if<is_eigen_sparse_matrix<T>::value>::type
-    >
-{
-    typedef typename T::InnerIterator type;
-};
-
-template <class T>
-struct row_begin_impl <
-    T,
-    typename std::enable_if<is_eigen_sparse_matrix<T>::value>::type
-    >
-{
-    typedef typename row_iterator<T>::type iterator;
-    static iterator get(const T &matrix, size_t row) {
-        return iterator(matrix, row);
-    }
 };
 
 template < class Alpha, class M, class V1, class Beta, class V2 >

--- a/external_libraries/amgcl/backend/hpx.hpp
+++ b/external_libraries/amgcl/backend/hpx.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/backend/interface.hpp
+++ b/external_libraries/amgcl/backend/interface.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/backend/vexcl.hpp
+++ b/external_libraries/amgcl/backend/vexcl.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -37,7 +37,8 @@ THE SOFTWARE.
 #include <boost/range/iterator_range.hpp>
 
 #include <amgcl/solver/skyline_lu.hpp>
-#include <vexcl/vexcl.hpp>
+#include <vexcl/vector.hpp>
+#include <vexcl/gather.hpp>
 #include <vexcl/sparse/matrix.hpp>
 #include <vexcl/sparse/distributed.hpp>
 

--- a/external_libraries/amgcl/backend/vexcl_static_matrix.hpp
+++ b/external_libraries/amgcl/backend/vexcl_static_matrix.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/backend/viennacl.hpp
+++ b/external_libraries/amgcl/backend/viennacl.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/coarsening/aggregation.hpp
+++ b/external_libraries/amgcl/coarsening/aggregation.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/coarsening/detail/galerkin.hpp
+++ b/external_libraries/amgcl/coarsening/detail/galerkin.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/coarsening/detail/scaled_galerkin.hpp
+++ b/external_libraries/amgcl/coarsening/detail/scaled_galerkin.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/coarsening/plain_aggregates.hpp
+++ b/external_libraries/amgcl/coarsening/plain_aggregates.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/coarsening/pointwise_aggregates.hpp
+++ b/external_libraries/amgcl/coarsening/pointwise_aggregates.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/coarsening/ruge_stuben.hpp
+++ b/external_libraries/amgcl/coarsening/ruge_stuben.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/coarsening/runtime.hpp
+++ b/external_libraries/amgcl/coarsening/runtime.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/coarsening/smoothed_aggr_emin.hpp
+++ b/external_libraries/amgcl/coarsening/smoothed_aggr_emin.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/coarsening/smoothed_aggregation.hpp
+++ b/external_libraries/amgcl/coarsening/smoothed_aggregation.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/coarsening/tentative_prolongation.hpp
+++ b/external_libraries/amgcl/coarsening/tentative_prolongation.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/detail/inverse.hpp
+++ b/external_libraries/amgcl/detail/inverse.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/detail/qr.hpp
+++ b/external_libraries/amgcl/detail/qr.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/detail/sort_row.hpp
+++ b/external_libraries/amgcl/detail/sort_row.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/detail/spgemm.hpp
+++ b/external_libraries/amgcl/detail/spgemm.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/io/binary.hpp
+++ b/external_libraries/amgcl/io/binary.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/io/mm.hpp
+++ b/external_libraries/amgcl/io/mm.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -340,13 +340,13 @@ namespace detail {
 template <typename Val>
 typename std::enable_if<is_complex<Val>::value, std::ostream&>::type
 write_value(std::ostream &s, Val v) {
-    return s << std::real(v) << " " << std::imag(v);
+    return s << std::scientific << std::setprecision(20) << std::real(v) << " " << std::imag(v);
 }
 
 template <typename Val>
 typename std::enable_if<!is_complex<Val>::value, std::ostream&>::type
 write_value(std::ostream &s, Val v) {
-    return s << v;
+    return s << std::scientific << std::setprecision(20) << v;
 }
 
 } // namespace detail

--- a/external_libraries/amgcl/make_solver.hpp
+++ b/external_libraries/amgcl/make_solver.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -42,7 +42,7 @@ template <
     class Precond,
     class IterativeSolver
     >
-class make_solver {
+class make_solver : public amgcl::detail::non_copyable {
     static_assert(
             backend::backends_compatible<
                 typename IterativeSolver::backend_type,
@@ -320,7 +320,7 @@ template <
     class Precond,
     class IterativeSolver
     >
-class make_scaling_solver {
+class make_scaling_solver : public amgcl::detail::non_copyable {
     public:
         typedef typename Precond::backend_type             backend_type;
         typedef typename backend_type::value_type          value_type;

--- a/external_libraries/amgcl/mpi/amg.hpp
+++ b/external_libraries/amgcl/mpi/amg.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/block_preconditioner.hpp
+++ b/external_libraries/amgcl/mpi/block_preconditioner.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/coarsening/aggregation.hpp
+++ b/external_libraries/amgcl/mpi/coarsening/aggregation.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/coarsening/pmis.hpp
+++ b/external_libraries/amgcl/mpi/coarsening/pmis.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/coarsening/runtime.hpp
+++ b/external_libraries/amgcl/mpi/coarsening/runtime.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/coarsening/smoothed_aggregation.hpp
+++ b/external_libraries/amgcl/mpi/coarsening/smoothed_aggregation.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/cpr.hpp
+++ b/external_libraries/amgcl/mpi/cpr.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/direct_solver/eigen_splu.hpp
+++ b/external_libraries/amgcl/mpi/direct_solver/eigen_splu.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/direct_solver/pastix.hpp
+++ b/external_libraries/amgcl/mpi/direct_solver/pastix.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/direct_solver/runtime.hpp
+++ b/external_libraries/amgcl/mpi/direct_solver/runtime.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/direct_solver/skyline_lu.hpp
+++ b/external_libraries/amgcl/mpi/direct_solver/skyline_lu.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/direct_solver/solver_base.hpp
+++ b/external_libraries/amgcl/mpi/direct_solver/solver_base.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/distributed_matrix.hpp
+++ b/external_libraries/amgcl/mpi/distributed_matrix.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/inner_product.hpp
+++ b/external_libraries/amgcl/mpi/inner_product.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/make_solver.hpp
+++ b/external_libraries/amgcl/mpi/make_solver.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -48,7 +48,7 @@ template <
     class Precond,
     template <class, class> class IterativeSolver
     >
-class make_solver {
+class make_solver : public amgcl::detail::non_copyable {
     public:
         typedef typename Precond::backend_type backend_type;
         typedef typename Precond::matrix matrix;

--- a/external_libraries/amgcl/mpi/partition/merge.hpp
+++ b/external_libraries/amgcl/mpi/partition/merge.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/partition/parmetis.hpp
+++ b/external_libraries/amgcl/mpi/partition/parmetis.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/partition/ptscotch.hpp
+++ b/external_libraries/amgcl/mpi/partition/ptscotch.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/partition/runtime.hpp
+++ b/external_libraries/amgcl/mpi/partition/runtime.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/partition/util.hpp
+++ b/external_libraries/amgcl/mpi/partition/util.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/relaxation/as_preconditioner.hpp
+++ b/external_libraries/amgcl/mpi/relaxation/as_preconditioner.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/relaxation/runtime.hpp
+++ b/external_libraries/amgcl/mpi/relaxation/runtime.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/relaxation/spai0.hpp
+++ b/external_libraries/amgcl/mpi/relaxation/spai0.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/schur_pressure_correction.hpp
+++ b/external_libraries/amgcl/mpi/schur_pressure_correction.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/mpi/subdomain_deflation.hpp
+++ b/external_libraries/amgcl/mpi/subdomain_deflation.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 Copyright (c) 2014-2015, Riccardo Rossi, CIMNE (International Center for Numerical Methods in Engineering)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/external_libraries/amgcl/mpi/util.hpp
+++ b/external_libraries/amgcl/mpi/util.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 Copyright (c) 2014, Riccardo Rossi, CIMNE (International Center for Numerical Methods in Engineering)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/external_libraries/amgcl/perf_counter/clock.hpp
+++ b/external_libraries/amgcl/perf_counter/clock.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/perf_counter/cray_energy.hpp
+++ b/external_libraries/amgcl/perf_counter/cray_energy.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 Copyright (c) 2016 Mohammad Siahatgar <siahatgar@luis.uni-hannover.de>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/external_libraries/amgcl/perf_counter/mpi_aggregator.hpp
+++ b/external_libraries/amgcl/perf_counter/mpi_aggregator.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 Copyright (c) 2016 Mohammad Siahatgar <siahatgar@luis.uni-hannover.de>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/external_libraries/amgcl/preconditioner/cpr.hpp
+++ b/external_libraries/amgcl/preconditioner/cpr.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/preconditioner/cpr_drs.hpp
+++ b/external_libraries/amgcl/preconditioner/cpr_drs.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/preconditioner/dummy.hpp
+++ b/external_libraries/amgcl/preconditioner/dummy.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/preconditioner/runtime.hpp
+++ b/external_libraries/amgcl/preconditioner/runtime.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/preconditioner/schur_pressure_correction.hpp
+++ b/external_libraries/amgcl/preconditioner/schur_pressure_correction.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 Copyright (c) 2016, Riccardo Rossi, CIMNE (International Center for Numerical Methods in Engineering)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/external_libraries/amgcl/profiler.hpp
+++ b/external_libraries/amgcl/profiler.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/as_preconditioner.hpp
+++ b/external_libraries/amgcl/relaxation/as_preconditioner.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/chebyshev.hpp
+++ b/external_libraries/amgcl/relaxation/chebyshev.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/cusparse_ilu0.hpp
+++ b/external_libraries/amgcl/relaxation/cusparse_ilu0.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/damped_jacobi.hpp
+++ b/external_libraries/amgcl/relaxation/damped_jacobi.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/detail/ilu_solve.hpp
+++ b/external_libraries/amgcl/relaxation/detail/ilu_solve.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/gauss_seidel.hpp
+++ b/external_libraries/amgcl/relaxation/gauss_seidel.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/ilu0.hpp
+++ b/external_libraries/amgcl/relaxation/ilu0.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/iluk.hpp
+++ b/external_libraries/amgcl/relaxation/iluk.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/ilut.hpp
+++ b/external_libraries/amgcl/relaxation/ilut.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/runtime.hpp
+++ b/external_libraries/amgcl/relaxation/runtime.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/spai0.hpp
+++ b/external_libraries/amgcl/relaxation/spai0.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/relaxation/spai1.hpp
+++ b/external_libraries/amgcl/relaxation/spai1.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/reorder/cuthill_mckee.hpp
+++ b/external_libraries/amgcl/reorder/cuthill_mckee.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/bicgstab.hpp
+++ b/external_libraries/amgcl/solver/bicgstab.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/bicgstabl.hpp
+++ b/external_libraries/amgcl/solver/bicgstabl.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/cg.hpp
+++ b/external_libraries/amgcl/solver/cg.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/detail/default_inner_product.hpp
+++ b/external_libraries/amgcl/solver/detail/default_inner_product.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/detail/givens_rotations.hpp
+++ b/external_libraries/amgcl/solver/detail/givens_rotations.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/eigen.hpp
+++ b/external_libraries/amgcl/solver/eigen.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/fgmres.hpp
+++ b/external_libraries/amgcl/solver/fgmres.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/gmres.hpp
+++ b/external_libraries/amgcl/solver/gmres.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/idrs.hpp
+++ b/external_libraries/amgcl/solver/idrs.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/lgmres.hpp
+++ b/external_libraries/amgcl/solver/lgmres.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/precond_side.hpp
+++ b/external_libraries/amgcl/solver/precond_side.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/runtime.hpp
+++ b/external_libraries/amgcl/solver/runtime.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/solver/skyline_lu.hpp
+++ b/external_libraries/amgcl/solver/skyline_lu.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/util.hpp
+++ b/external_libraries/amgcl/util.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -318,6 +318,19 @@ inline std::string human_readable_memory(size_t bytes) {
     s << std::fixed << std::setprecision(2) << m << " " << suffix[i];
     return s.str();
 }
+
+namespace detail {
+
+class non_copyable {
+    protected:
+        non_copyable() = default;
+        ~non_copyable() = default;
+
+        non_copyable(non_copyable const &) = delete;
+        void operator=(non_copyable const &x) = delete;
+};
+
+} // namespace detail
 
 } // namespace amgcl
 

--- a/external_libraries/amgcl/value_type/eigen.hpp
+++ b/external_libraries/amgcl/value_type/eigen.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/value_type/interface.hpp
+++ b/external_libraries/amgcl/value_type/interface.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/external_libraries/amgcl/value_type/static_matrix.hpp
+++ b/external_libraries/amgcl/value_type/static_matrix.hpp
@@ -4,7 +4,7 @@
 /*
 The MIT License
 
-Copyright (c) 2012-2018 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Main reason is this commit: ddemidov/amgcl@3468ad8.
The Epetra adapter is modified so that it outputs rows sorted by columns.
It should fix #3868 in particular and block solves in general (not sure how or if MPI block solves worked before).