### PR TITLE
[StructuralMechanics] Unify rayleigh damping

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -16,12 +16,11 @@
 
 // Project includes
 #include "includes/checks.h"
-#include "includes/define.h"
 #include "custom_elements/base_solid_element.h"
 #include "utilities/math_utils.h"
 #include "utilities/geometry_utilities.h"
-#include "includes/constitutive_law.h"
 #include "structural_mechanics_application_variables.h"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 
 namespace Kratos
 {
@@ -583,52 +582,13 @@ void BaseSolidElement::CalculateDampingMatrix(
     ProcessInfo& rCurrentProcessInfo
     )
 {
-    KRATOS_TRY;
+    const unsigned int mat_size = GetGeometry().PointsNumber() * GetGeometry().WorkingSpaceDimension();
 
-    unsigned int number_of_nodes = GetGeometry().size();
-    unsigned int dimension = GetGeometry().WorkingSpaceDimension();
-
-    // Resizing as needed the LHS
-    unsigned int mat_size = number_of_nodes * dimension;
-
-    if ( rDampingMatrix.size1() != mat_size || rDampingMatrix.size2() != mat_size )
-        rDampingMatrix.resize( mat_size, mat_size, false );
-
-    noalias( rDampingMatrix ) = ZeroMatrix( mat_size, mat_size );
-
-    // 1.-Calculate StiffnessMatrix:
-
-    MatrixType StiffnessMatrix( mat_size, mat_size );
-    VectorType ResidualVector( mat_size );
-
-    this->CalculateAll(StiffnessMatrix, ResidualVector, rCurrentProcessInfo, true, false);
-
-    // 2.-Calculate MassMatrix:
-
-    MatrixType MassMatrix( mat_size, mat_size );
-
-    this->CalculateMassMatrix ( MassMatrix, rCurrentProcessInfo );
-
-    // 3.-Get Damping Coeffitients (RAYLEIGH_ALPHA, RAYLEIGH_BETA)
-    double alpha = 0.0;
-    if( GetProperties().Has(RAYLEIGH_ALPHA) )
-        alpha = GetProperties()[RAYLEIGH_ALPHA];
-    else if( rCurrentProcessInfo.Has(RAYLEIGH_ALPHA) )
-        alpha = rCurrentProcessInfo[RAYLEIGH_ALPHA];
-
-    double beta  = 0.0;
-    if( GetProperties().Has(RAYLEIGH_BETA) )
-        beta = GetProperties()[RAYLEIGH_BETA];
-    else if( rCurrentProcessInfo.Has(RAYLEIGH_BETA) )
-        beta = rCurrentProcessInfo[RAYLEIGH_BETA];
-
-    // 4.-Compose the Damping Matrix:
-
-    // Rayleigh Damping Matrix: alpha*M + beta*K
-    noalias( rDampingMatrix ) += alpha * MassMatrix;
-    noalias( rDampingMatrix ) += beta  * StiffnessMatrix;
-
-    KRATOS_CATCH( "" )
+    StructuralMechanicsElementUtilities::CalculateRayleighDampingMatrix(
+        *this,
+        rDampingMatrix,
+        rCurrentProcessInfo,
+        mat_size);
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -18,6 +18,7 @@
 #include "custom_elements/cr_beam_element_2D2N.hpp"
 #include "includes/define.h"
 #include "structural_mechanics_application_variables.h"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 
 namespace Kratos {
 
@@ -189,41 +190,13 @@ void CrBeamElement2D2N::CalculateMassMatrix(MatrixType &rMassMatrix,
 }
 
 void CrBeamElement2D2N::CalculateDampingMatrix(
-    MatrixType &rDampingMatrix, ProcessInfo &rCurrentProcessInfo) {
-
-  KRATOS_TRY
-  if (rDampingMatrix.size1() != msElementSize) {
-    rDampingMatrix.resize(msElementSize, msElementSize, false);
-  }
-
-  rDampingMatrix = ZeroMatrix(msElementSize, msElementSize);
-
-  Matrix stiffness_matrix = ZeroMatrix(msElementSize, msElementSize);
-
-  this->CalculateLeftHandSide(stiffness_matrix, rCurrentProcessInfo);
-
-  Matrix mass_matrix = ZeroMatrix(msElementSize, msElementSize);
-
-  this->CalculateMassMatrix(mass_matrix, rCurrentProcessInfo);
-
-  double alpha = 0.0;
-  if (this->GetProperties().Has(RAYLEIGH_ALPHA)) {
-    alpha = this->GetProperties()[RAYLEIGH_ALPHA];
-  } else if (rCurrentProcessInfo.Has(RAYLEIGH_ALPHA)) {
-    alpha = rCurrentProcessInfo[RAYLEIGH_ALPHA];
-  }
-
-  double beta = 0.0;
-  if (this->GetProperties().Has(RAYLEIGH_BETA)) {
-    beta = this->GetProperties()[RAYLEIGH_BETA];
-  } else if (rCurrentProcessInfo.Has(RAYLEIGH_BETA)) {
-    beta = rCurrentProcessInfo[RAYLEIGH_BETA];
-  }
-
-  noalias(rDampingMatrix) += alpha * mass_matrix;
-  noalias(rDampingMatrix) += beta * stiffness_matrix;
-
-  KRATOS_CATCH("")
+    MatrixType &rDampingMatrix, ProcessInfo &rCurrentProcessInfo)
+{
+    StructuralMechanicsElementUtilities::CalculateRayleighDampingMatrix(
+        *this,
+        rDampingMatrix,
+        rCurrentProcessInfo,
+        msElementSize);
 }
 
 void CrBeamElement2D2N::CalculateLocalSystem(MatrixType &rLeftHandSideMatrix,

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -18,6 +18,7 @@
 #include "custom_elements/cr_beam_element_3D2N.hpp"
 #include "includes/define.h"
 #include "structural_mechanics_application_variables.h"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 
 namespace Kratos {
 
@@ -282,41 +283,13 @@ void CrBeamElement3D2N::CalculateAndAddWorkEquivalentNodalForcesLineLoad(
 }
 
 void CrBeamElement3D2N::CalculateDampingMatrix(
-    MatrixType &rDampingMatrix, ProcessInfo &rCurrentProcessInfo) {
-
-  KRATOS_TRY
-  if (rDampingMatrix.size1() != msElementSize) {
-    rDampingMatrix.resize(msElementSize, msElementSize, false);
-  }
-
-  rDampingMatrix = ZeroMatrix(msElementSize, msElementSize);
-
-  Matrix stiffness_matrix = ZeroMatrix(msElementSize, msElementSize);
-
-  this->CalculateLeftHandSide(stiffness_matrix, rCurrentProcessInfo);
-
-  Matrix mass_matrix = ZeroMatrix(msElementSize, msElementSize);
-
-  this->CalculateLumpedMassMatrix(mass_matrix, rCurrentProcessInfo);
-
-  double alpha = 0.0;
-  if (this->GetProperties().Has(RAYLEIGH_ALPHA)) {
-    alpha = this->GetProperties()[RAYLEIGH_ALPHA];
-  } else if (rCurrentProcessInfo.Has(RAYLEIGH_ALPHA)) {
-    alpha = rCurrentProcessInfo[RAYLEIGH_ALPHA];
-  }
-
-  double beta = 0.0;
-  if (this->GetProperties().Has(RAYLEIGH_BETA)) {
-    beta = this->GetProperties()[RAYLEIGH_BETA];
-  } else if (rCurrentProcessInfo.Has(RAYLEIGH_BETA)) {
-    beta = rCurrentProcessInfo[RAYLEIGH_BETA];
-  }
-
-  noalias(rDampingMatrix) += alpha * mass_matrix;
-  noalias(rDampingMatrix) += beta * stiffness_matrix;
-
-  KRATOS_CATCH("")
+    MatrixType &rDampingMatrix, ProcessInfo &rCurrentProcessInfo)
+{
+    StructuralMechanicsElementUtilities::CalculateRayleighDampingMatrix(
+        *this,
+        rDampingMatrix,
+        rCurrentProcessInfo,
+        msElementSize);
 }
 
 void CrBeamElement3D2N::CalculateLocalNodalForces(

--- a/applications/StructuralMechanicsApplication/custom_elements/nodal_concentrated_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/nodal_concentrated_element.cpp
@@ -17,6 +17,7 @@
 #include "includes/define.h"
 #include "includes/checks.h"
 #include "custom_elements/nodal_concentrated_element.hpp"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 
 #include "structural_mechanics_application_variables.h"
 
@@ -415,40 +416,11 @@ void NodalConcentratedElement::CalculateDampingMatrix(
 
     //Check, if Rayleigh damping is available; use nodal damping, if not
     if( mUseRayleighDamping ) {
-        //1.-Calculate StiffnessMatrix:
-
-        MatrixType stiffness_matrix     = ZeroMatrix( system_size, system_size );
-        VectorType right_hand_side_vector = ZeroVector( system_size );
-
-        this->CalculateLocalSystem( stiffness_matrix, right_hand_side_vector, rCurrentProcessInfo );
-
-        //2.-Calculate MassMatrix:
-
-        MatrixType mass_matrix  = ZeroMatrix( system_size, system_size );
-
-        this->CalculateMassMatrix ( mass_matrix, rCurrentProcessInfo );
-
-        //3.-Get Damping Coeffitients (RAYLEIGH_ALPHA, RAYLEIGH_BETA)
-        double alpha = 0.0;
-        if( GetProperties().Has(RAYLEIGH_ALPHA) )
-            alpha = GetProperties()[RAYLEIGH_ALPHA];
-        else if( rCurrentProcessInfo.Has(RAYLEIGH_ALPHA) )
-            alpha = rCurrentProcessInfo[RAYLEIGH_ALPHA];
-
-        double beta  = 0.0;
-        if( GetProperties().Has(RAYLEIGH_BETA) )
-            beta = GetProperties()[RAYLEIGH_BETA];
-        else if( rCurrentProcessInfo.Has(RAYLEIGH_BETA) )
-            beta = rCurrentProcessInfo[RAYLEIGH_BETA];
-
-        //4.-Compose the Damping Matrix:
-
-        //Rayleigh Damping Matrix: alpha*M + beta*K
-        mass_matrix      *= alpha;
-        stiffness_matrix *= beta;
-
-        rDampingMatrix  = mass_matrix;
-        rDampingMatrix += stiffness_matrix;
+        StructuralMechanicsElementUtilities::CalculateRayleighDampingMatrix(
+            *this,
+            rDampingMatrix,
+            rCurrentProcessInfo,
+            system_size);
     } else {
         const array_1d<double, 3 >& nodal_damping_ratio = this->GetValue(NODAL_DAMPING_RATIO);
         for ( unsigned int j = 0; j < dimension; ++j )

--- a/applications/StructuralMechanicsApplication/custom_elements/prestress_membrane_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/prestress_membrane_element.cpp
@@ -20,6 +20,7 @@
 #include "includes/checks.h"
 #include "custom_elements/prestress_membrane_element.hpp"
 #include "structural_mechanics_application_variables.h"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 
 namespace Kratos
 {
@@ -157,7 +158,26 @@ void PrestressMembraneElement::Initialize()
     KRATOS_CATCH( "" )
 }
 
+//***********************************************************************************
+//***********************************************************************************
 
+void PrestressMembraneElement::CalculateLeftHandSide(
+    MatrixType& rLeftHandSideMatrix,
+    ProcessInfo& rCurrentProcessInfo)
+
+{
+    //calculation flags
+    const bool calculate_stiffness_matrix_flag = true;
+    const bool calculate_residual_vector_flag = false;
+    VectorType temp = VectorType();
+
+    CalculateAll(
+        rLeftHandSideMatrix,
+        temp,
+        rCurrentProcessInfo,
+        calculate_stiffness_matrix_flag,
+        calculate_residual_vector_flag);
+}
 
 //***********************************************************************************
 //***********************************************************************************
@@ -170,9 +190,14 @@ void PrestressMembraneElement::CalculateRightHandSide(
     //calculation flags
     const bool calculate_stiffness_matrix_flag = false;
     const bool calculate_residual_vector_flag = true;
-    MatrixType temp = Matrix();
+    MatrixType temp = MatrixType();
 
-    CalculateAll(temp, rRightHandSideVector, rCurrentProcessInfo, calculate_stiffness_matrix_flag, calculate_residual_vector_flag);
+    CalculateAll(
+        temp,
+        rRightHandSideVector,
+        rCurrentProcessInfo,
+        calculate_stiffness_matrix_flag,
+        calculate_residual_vector_flag);
 }
 
 
@@ -184,49 +209,13 @@ void PrestressMembraneElement::CalculateDampingMatrix(
     ProcessInfo& rCurrentProcessInfo
     )
 {
-    KRATOS_TRY;
+    const std::size_t matrix_size = GetGeometry().PointsNumber() * 3;
 
-    const SizeType number_of_nodes = this->GetGeometry().size();
-    const SizeType num_dofs = number_of_nodes * 3;
-
-    if ( rDampingMatrix.size1() != num_dofs )
-        rDampingMatrix.resize( num_dofs, num_dofs, false );
-
-    noalias( rDampingMatrix ) = ZeroMatrix( num_dofs, num_dofs );
-
-    // 1.-Calculate StiffnessMatrix:
-
-    MatrixType stiffness_matrix  = Matrix();
-    VectorType residual_vector  = Vector();
-
-    CalculateAll(stiffness_matrix, residual_vector, rCurrentProcessInfo, true, false);
-
-    // 2.-Calculate MassMatrix:
-
-    MatrixType mass_matrix  = Matrix();
-
-    CalculateMassMatrix(mass_matrix, rCurrentProcessInfo);
-
-    // 3.-Get Damping Coeffitients (RAYLEIGH_ALPHA, RAYLEIGH_BETA)
-    double alpha = 0.0;
-    if( GetProperties().Has(RAYLEIGH_ALPHA) )
-        alpha = GetProperties()[RAYLEIGH_ALPHA];
-    else if( rCurrentProcessInfo.Has(RAYLEIGH_ALPHA) )
-        alpha = rCurrentProcessInfo[RAYLEIGH_ALPHA];
-
-    double beta  = 0.0;
-    if( GetProperties().Has(RAYLEIGH_BETA) )
-        beta = GetProperties()[RAYLEIGH_BETA];
-    else if( rCurrentProcessInfo.Has(RAYLEIGH_BETA) )
-        beta = rCurrentProcessInfo[RAYLEIGH_BETA];
-
-    // 4.-Compose the Damping Matrix:
-
-    // Rayleigh Damping Matrix: alpha*M + beta*K
-    noalias( rDampingMatrix ) += alpha * mass_matrix;
-    noalias( rDampingMatrix ) += beta  * stiffness_matrix;
-
-    KRATOS_CATCH( "" )
+    StructuralMechanicsElementUtilities::CalculateRayleighDampingMatrix(
+        *this,
+        rDampingMatrix,
+        rCurrentProcessInfo,
+        matrix_size);
 }
 
 //***********************************************************************************

--- a/applications/StructuralMechanicsApplication/custom_elements/prestress_membrane_element.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/prestress_membrane_element.hpp
@@ -87,6 +87,10 @@ namespace Kratos
 
     void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
 
+    void CalculateLeftHandSide(
+    MatrixType& rLeftHandSideMatrix,
+    ProcessInfo& rCurrentProcessInfo) override;
+
     void CalculateRightHandSide(
       VectorType& rRightHandSideVector,
       ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -19,6 +19,7 @@
 #include "custom_elements/truss_element_3D2N.hpp"
 #include "includes/define.h"
 #include "structural_mechanics_application_variables.h"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 #include "includes/checks.h"
 
 namespace Kratos {
@@ -112,35 +113,13 @@ TrussElement3D2N::CreateElementStiffnessMatrix(
 }
 
 void TrussElement3D2N::CalculateDampingMatrix(
-    MatrixType &rDampingMatrix, ProcessInfo &rCurrentProcessInfo) {
-
-  KRATOS_TRY
-  MatrixType stiffness_matrix = ZeroMatrix(msLocalSize, msLocalSize);
-
-  this->CalculateLeftHandSide(stiffness_matrix, rCurrentProcessInfo);
-
-  MatrixType mass_matrix = ZeroMatrix(msLocalSize, msLocalSize);
-
-  this->CalculateMassMatrix(mass_matrix, rCurrentProcessInfo);
-
-  double alpha = 0.0;
-  if (this->GetProperties().Has(RAYLEIGH_ALPHA)) {
-    alpha = this->GetProperties()[RAYLEIGH_ALPHA];
-  } else if (rCurrentProcessInfo.Has(RAYLEIGH_ALPHA)) {
-    alpha = rCurrentProcessInfo[RAYLEIGH_ALPHA];
-  }
-
-  double beta = 0.0;
-  if (this->GetProperties().Has(RAYLEIGH_BETA)) {
-    beta = this->GetProperties()[RAYLEIGH_BETA];
-  } else if (rCurrentProcessInfo.Has(RAYLEIGH_BETA)) {
-    beta = rCurrentProcessInfo[RAYLEIGH_BETA];
-  }
-
-  rDampingMatrix = alpha * mass_matrix;
-  noalias(rDampingMatrix) += beta * stiffness_matrix;
-
-  KRATOS_CATCH("")
+    MatrixType &rDampingMatrix, ProcessInfo &rCurrentProcessInfo)
+{
+    StructuralMechanicsElementUtilities::CalculateRayleighDampingMatrix(
+        *this,
+        rDampingMatrix,
+        rCurrentProcessInfo,
+        msLocalSize);
 }
 
 void TrussElement3D2N::CalculateMassMatrix(

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -16,7 +16,7 @@
 
 // Project includes
 #include "structural_mechanics_element_utilities.h"
-#include "includes/variables.h"
+#include "structural_mechanics_application_variables.h"
 
 namespace Kratos {
 namespace StructuralMechanicsElementUtilities {
@@ -39,6 +39,81 @@ bool ComputeLumpedMassMatrix(
     // the default for all elements in StructuralMechanics is
     // to use the consistent-mass-matrix, hence returning false here
     return false;
+}
+
+bool HasRayleighDamping(
+    const Properties& rProperites,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    return (GetRayleighAlpha(rProperites, rCurrentProcessInfo) > 0.0 ||
+            GetRayleighBeta(rProperites, rCurrentProcessInfo) > 0.0);
+}
+
+double GetRayleighAlpha(
+    const Properties& rProperites,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    // giving the locally defined setting (through Properties) priority
+    // over the globally defined one (through ProcessInfo)
+    if (rProperites.Has(RAYLEIGH_ALPHA)) {
+        return rProperites[RAYLEIGH_ALPHA];
+    }
+    else if (rCurrentProcessInfo.Has(RAYLEIGH_ALPHA)) {
+        return rCurrentProcessInfo[RAYLEIGH_ALPHA];
+    }
+
+    return 0.0;
+}
+
+double GetRayleighBeta(
+    const Properties& rProperites,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    // giving the locally defined setting (through Properties) priority
+    // over the globally defined one (through ProcessInfo)
+    if (rProperites.Has(RAYLEIGH_BETA)) {
+        return rProperites[RAYLEIGH_BETA];
+    }
+    else if (rCurrentProcessInfo.Has(RAYLEIGH_BETA)) {
+        return rCurrentProcessInfo[RAYLEIGH_BETA];
+    }
+
+    return 0.0;
+}
+
+void CalculateRayleighDampingMatrix(
+    Element& rElement,
+    Element::MatrixType& rDampingMatrix,
+    /*const*/ProcessInfo& rCurrentProcessInfo,
+    const std::size_t MatrixSize)
+{
+    KRATOS_TRY;
+
+    // 1.-Resizing if needed
+    if (rDampingMatrix.size1() != MatrixSize || rDampingMatrix.size2() != MatrixSize) {
+        rDampingMatrix.resize( MatrixSize, MatrixSize, false );
+    }
+    noalias(rDampingMatrix) = ZeroMatrix(MatrixSize, MatrixSize);
+
+    if (!HasRayleighDamping(rElement.GetProperties(), rCurrentProcessInfo)) {
+        // Do nothing if no rayleigh-damping is specified
+        return;
+    }
+
+    // 2.-Calculate StiffnessMatrix:
+    Element::MatrixType stiffness_matrix;
+    rElement.CalculateLeftHandSide(stiffness_matrix, rCurrentProcessInfo);
+
+    // 3.-Calculate MassMatrix:
+    Element::MatrixType mass_matrix;
+    rElement.CalculateMassMatrix(mass_matrix, rCurrentProcessInfo);
+
+    // 4.-Compose the Damping Matrix:
+    // Rayleigh Damping Matrix: alpha*M + beta*K
+    noalias(rDampingMatrix) += GetRayleighAlpha(rElement.GetProperties(), rCurrentProcessInfo) * mass_matrix;
+    noalias(rDampingMatrix) += GetRayleighBeta(rElement.GetProperties(), rCurrentProcessInfo)  * stiffness_matrix;
+
+    KRATOS_CATCH( "CalculateRayleighDampingMatrix" )
 }
 
 } // namespace StructuralMechanicsElementUtilities.

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
@@ -23,22 +23,53 @@
 namespace Kratos {
 namespace StructuralMechanicsElementUtilities {
 
+/**
+ * @brief Method to specify if the lumped or the consistent mass-matrix should be computed
+ * @param rProperites The Properties where it is specified
+ * @param rCurrentProcessInfo The ProcessInfo where it is specified
+ * @return whether to compute the lumped mass-matrix
+ */
 bool ComputeLumpedMassMatrix(
     const Properties& rProperites,
     const ProcessInfo& rCurrentProcessInfo);
 
+/**
+ * @brief Method to specify if rayligh-damping is specified
+ * @param rProperites The Properties where it is specified
+ * @param rCurrentProcessInfo The ProcessInfo where it is specified
+ * @return whether rayleigh-damping was specified
+ */
 bool HasRayleighDamping(
     const Properties& rProperites,
     const ProcessInfo& rCurrentProcessInfo);
 
+/**
+ * @brief Method to get the rayleigh-alpha parameter
+ * @param rProperites The Properties where it is specified
+ * @param rCurrentProcessInfo The ProcessInfo where it is specified
+ * @return rayleigh-alpha
+ */
 double GetRayleighAlpha(
     const Properties& rProperites,
     const ProcessInfo& rCurrentProcessInfo);
 
+/**
+ * @brief Method to get the rayleigh-beta parameter
+ * @param rProperites The Properties where it is specified
+ * @param rCurrentProcessInfo The ProcessInfo where it is specified
+ * @return rayleigh-beta
+ */
 double GetRayleighBeta(
     const Properties& rProperites,
     const ProcessInfo& rCurrentProcessInfo);
 
+/**
+ * @brief Method to claculate the rayleigh damping-matrix
+ * @param rElement The Element for which the damping-matrix should be computed
+ * @param rDampingMatrix The current ProcessInfo
+ * @param rCurrentProcessInfo The ProcessInfo where it is specified
+ * @param MatrixSize The size of the damping-matrix
+ */
 void CalculateRayleighDampingMatrix(
     Element& rElement,
     Element::MatrixType& rDampingMatrix,

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
@@ -27,6 +27,24 @@ bool ComputeLumpedMassMatrix(
     const Properties& rProperites,
     const ProcessInfo& rCurrentProcessInfo);
 
+bool HasRayleighDamping(
+    const Properties& rProperites,
+    const ProcessInfo& rCurrentProcessInfo);
+
+double GetRayleighAlpha(
+    const Properties& rProperites,
+    const ProcessInfo& rCurrentProcessInfo);
+
+double GetRayleighBeta(
+    const Properties& rProperites,
+    const ProcessInfo& rCurrentProcessInfo);
+
+void CalculateRayleighDampingMatrix(
+    Element& rElement,
+    Element::MatrixType& rDampingMatrix,
+    /*const*/ ProcessInfo& rCurrentProcessInfo,
+    const std::size_t MatrixSize);
+
 } // namespace StructuralMechanicsElementUtilities.
 }  // namespace Kratos.
 

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
@@ -16,6 +16,7 @@
 // Project includes
 #include "testing/testing.h"
 #include "custom_utilities/structural_mechanics_element_utilities.h"
+#include "structural_mechanics_application_variables.h"
 
 namespace Kratos {
 namespace Testing {
@@ -45,6 +46,49 @@ KRATOS_TEST_CASE_IN_SUITE(MassMatrixSelection, KratosStructuralMechanicsFastSuit
     aux_props[COMPUTE_LUMPED_MASS_MATRIX] = true;
     aux_process_info[COMPUTE_LUMPED_MASS_MATRIX] = false;
     KRATOS_CHECK_IS_FALSE(StructuralMechanicsElementUtilities::ComputeLumpedMassMatrix(aux_props, aux_process_info));
+}
+
+// testing the selection for rayleigh-damping (has to be consistent if nothing else
+// is specified through Properties or ProcessInfo)
+KRATOS_TEST_CASE_IN_SUITE(RayleighDampingSelection, KratosStructuralMechanicsFastSuite)
+{
+    Properties aux_props_1;
+    ProcessInfo aux_process_info_1;
+
+    KRATOS_CHECK_IS_FALSE(StructuralMechanicsElementUtilities::HasRayleighDamping(aux_props_1, aux_process_info_1));
+
+    const double alpha_0 = StructuralMechanicsElementUtilities::GetRayleighAlpha(aux_props_1, aux_process_info_1);
+    KRATOS_CHECK_DOUBLE_EQUAL(0.00, alpha_0);
+
+    const double beta_0 = StructuralMechanicsElementUtilities::GetRayleighBeta(aux_props_1, aux_process_info_1);
+    KRATOS_CHECK_DOUBLE_EQUAL(0.0, beta_0);
+
+    const double val_alpha = 0.01;
+    aux_props_1[RAYLEIGH_ALPHA] = val_alpha;
+    KRATOS_CHECK(StructuralMechanicsElementUtilities::HasRayleighDamping(aux_props_1, aux_process_info_1));
+    aux_process_info_1[RAYLEIGH_ALPHA] = 0.05;
+    KRATOS_CHECK(StructuralMechanicsElementUtilities::HasRayleighDamping(aux_props_1, aux_process_info_1));
+
+    Properties aux_props_2;
+    ProcessInfo aux_process_info_2;
+
+    const double val_beta = 0.025;
+    aux_props_2[RAYLEIGH_BETA] = val_beta;
+    KRATOS_CHECK(StructuralMechanicsElementUtilities::HasRayleighDamping(aux_props_2, aux_process_info_2));
+    aux_process_info_2[RAYLEIGH_BETA] = 0.06;
+    KRATOS_CHECK(StructuralMechanicsElementUtilities::HasRayleighDamping(aux_props_2, aux_process_info_2));
+
+    Properties aux_props_3;
+    ProcessInfo aux_process_info_3;
+    aux_process_info_3[RAYLEIGH_BETA] = 0.07;
+    KRATOS_CHECK(StructuralMechanicsElementUtilities::HasRayleighDamping(aux_props_3, aux_process_info_3));
+
+    // testing if the value defined in the Properties has priority over the value defined in the ProcessInfo
+    const double alpha_1 = StructuralMechanicsElementUtilities::GetRayleighAlpha(aux_props_1, aux_process_info_1);
+    KRATOS_CHECK_DOUBLE_EQUAL(val_alpha, alpha_1);
+
+    const double beta_1 = StructuralMechanicsElementUtilities::GetRayleighBeta(aux_props_2, aux_process_info_2);
+    KRATOS_CHECK_DOUBLE_EQUAL(val_beta, beta_1);
 }
 
 } // namespace Testing

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_membrane.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_membrane.py
@@ -349,7 +349,7 @@ class TestPatchTestMembrane(KratosUnittest.TestCase):
 
         #self.__post_process(mp)
 
-    def _test_membrane_3d4n_dynamic(self):
+    def test_membrane_3d4n_dynamic(self):
 
         displacement_results = [-0.004416597413161373, -0.017672715828946108, -0.0383282878649957,
         -0.060720299929014065, -0.07850778062395564, -0.08727738281567025,


### PR DESCRIPTION
Next round of cleaning up the elements in StructuralMechanics:
the implementation of  rayleigh-damping was copy-pasted all over the place. This PR unifies the implementation by porting it to an external utility (even improving it if no rayleigh-damping is specified!)