### PR TITLE
[Core] Adding CreateNewProperties as part of transition to fix #3227

### DIFF
--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -867,7 +867,7 @@ public:
      * @param ThisIndex The Id of the mesh (0 by default)
      * @return The desired properties (reference)
      */
-    PropertiesType& GetProperties(IndexType PropertiesId, IndexType ThisIndex = 0)
+    PropertiesType& GetProperties(IndexType PropertiesId, IndexType MeshIndex = 0)
     {
         auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
         if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -841,7 +841,7 @@ public:
      * @param ThisIndex The Id of the mesh (0 by default)
      * @return The desired properties (pointer)
      */
-    PropertiesType::Pointer pGetProperties(IndexType PropertiesId, IndexType ThisIndex = 0)
+    PropertiesType::Pointer pGetProperties(IndexType PropertiesId, IndexType MeshIndex = 0)
     {
         auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
         if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -811,7 +811,7 @@ public:
      * @brief Creates a new property in the current mesh
      * @details If the property is already existing it will crash
      * @param PropertiesId The Id of the new property
-     * @param ThisIndex The Id of the mesh (0 by default)
+     * @param MeshIndex The Id of the mesh (0 by default)
      * @return The new created properties
      */
     PropertiesType::Pointer CreateNewProperties(IndexType PropertiesId, IndexType MeshIndex = 0)
@@ -836,7 +836,7 @@ public:
      * @brief Returns the Properties::Pointer  corresponding to it's identifier
      * @details If the property is not existing it will return a warning
      * @param PropertiesId The Id of the new property
-     * @param ThisIndex The Id of the mesh (0 by default)
+     * @param MeshIndex The Id of the mesh (0 by default)
      * @return The desired properties (pointer)
      */
     PropertiesType::Pointer pGetProperties(IndexType PropertiesId, IndexType MeshIndex = 0)
@@ -862,7 +862,7 @@ public:
      * @brief Returns the Properties::Pointer  corresponding to it's identifier
      * @details If the property is not existing it will return a warning
      * @param PropertiesId The Id of the new property
-     * @param ThisIndex The Id of the mesh (0 by default)
+     * @param MeshIndex The Id of the mesh (0 by default)
      * @return The desired properties (reference)
      */
     PropertiesType& GetProperties(IndexType PropertiesId, IndexType MeshIndex = 0)

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -797,7 +797,7 @@ public:
     void AddProperties(PropertiesType::Pointer pNewProperties, IndexType ThisIndex = 0);
 
     /** Returns if the Properties corresponding to it's identifier exists */
-    bool HasProperties(IndexType PropertiesId, IndexType ThisIndex = 0) const
+    bool HasProperties(IndexType PropertiesId, IndexType MeshIndex = 0) const
     {
         auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
         if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -852,7 +852,7 @@ public:
                 GetMesh(ThisIndex).AddProperties(pprop);
                 return pprop;
             } else {
-                KRATOS_WARNING("ModelPart") << "New property added. Please use CreateNewProperties() instead" << std::endl;
+                KRATOS_WARNING("ModelPart") << "Property " << PropertiesId << " does not exist!. Creating and adding new property. Please use CreateNewProperties() instead" << std::endl;
                 PropertiesType::Pointer pnew_property = Kratos::make_shared<PropertiesType>(PropertiesId);
                 GetMesh(ThisIndex).AddProperties(pnew_property);
                 return pnew_property;
@@ -878,7 +878,7 @@ public:
                 GetMesh(ThisIndex).AddProperties(pprop);
                 return *pprop;
             } else {
-                KRATOS_WARNING("ModelPart") << "New property added. Please use CreateNewProperties() instead" << std::endl;
+                KRATOS_WARNING("ModelPart") << "Property " << PropertiesId << " does not exist!. Creating and adding new property. Please use CreateNewProperties() instead" << std::endl;
                 PropertiesType::Pointer pnew_property = Kratos::make_shared<PropertiesType>(PropertiesId);
                 GetMesh(ThisIndex).AddProperties(pnew_property);
                 return *pnew_property;

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -814,7 +814,7 @@ public:
      * @param ThisIndex The Id of the mesh (0 by default)
      * @return The new created properties
      */
-    PropertiesType::Pointer CreateNewProperties(IndexType PropertiesId, IndexType ThisIndex = 0)
+    PropertiesType::Pointer CreateNewProperties(IndexType PropertiesId, IndexType MeshIndex = 0)
     {
         auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
         if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -800,31 +800,59 @@ public:
     bool HasProperties(IndexType PropertiesId, IndexType ThisIndex = 0) const
     {
         auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
-        if(pprop_it != GetMesh(ThisIndex).Properties().end()) { //property does exist
+        if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist
             return true;
         }
 
         return false;
     }
 
-    /** Returns the Properties::Pointer  corresponding to it's identifier */
+    /**
+     * @brief Creates a new property in the current mesh
+     * @details If the property is already existing it will crash
+     * @param PropertiesId The Id of the new property
+     * @param ThisIndex The Id of the mesh (0 by default)
+     * @return The new created properties
+     */
+    PropertiesType::Pointer CreateNewProperties(IndexType PropertiesId, IndexType ThisIndex = 0)
+    {
+        auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
+        if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist
+            KRATOS_ERROR << "Property already existing. Please use pGetProperties() instead" << std::endl;
+        } else {
+            if(IsSubModelPart()) {
+                PropertiesType::Pointer pprop =  mpParentModelPart->CreateNewProperties(PropertiesId, ThisIndex);
+                GetMesh(ThisIndex).AddProperties(pprop);
+                return pprop;
+            } else {
+                PropertiesType::Pointer pnew_property = Kratos::make_shared<PropertiesType>(PropertiesId);
+                GetMesh(ThisIndex).AddProperties(pnew_property);
+                return pnew_property;
+            }
+        }
+
+        return nullptr;
+    }
+
+    /**
+     * @brief Returns the Properties::Pointer  corresponding to it's identifier
+     * @details If the property is not existing it will return a warning
+     * @param PropertiesId The Id of the new property
+     * @param ThisIndex The Id of the mesh (0 by default)
+     * @return The desired properties (pointer)
+     */
     PropertiesType::Pointer pGetProperties(IndexType PropertiesId, IndexType ThisIndex = 0)
     {
         auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
-        if(pprop_it != GetMesh(ThisIndex).Properties().end()) //property does exist
-        {
+        if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist
             return *(pprop_it.base());
-        }
-        else
-        {
-            if(IsSubModelPart())
-            {
+        } else {
+            if(IsSubModelPart()) {
                 PropertiesType::Pointer pprop =  mpParentModelPart->pGetProperties(PropertiesId, ThisIndex);
                 GetMesh(ThisIndex).AddProperties(pprop);
                 return pprop;
-            }
-            else
-            {
+            } else {
+                KRATOS_WARNING("ModelPart") << "New property added. Please use CreateNewProperties() instead" << std::endl;
                 PropertiesType::Pointer pnew_property = Kratos::make_shared<PropertiesType>(PropertiesId);
                 GetMesh(ThisIndex).AddProperties(pnew_property);
                 return pnew_property;
@@ -832,24 +860,25 @@ public:
         }
     }
 
-    /** Returns a reference Properties corresponding to it's identifier */
+    /**
+     * @brief Returns the Properties::Pointer  corresponding to it's identifier
+     * @details If the property is not existing it will return a warning
+     * @param PropertiesId The Id of the new property
+     * @param ThisIndex The Id of the mesh (0 by default)
+     * @return The desired properties (reference)
+     */
     PropertiesType& GetProperties(IndexType PropertiesId, IndexType ThisIndex = 0)
     {
         auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
-        if(pprop_it != GetMesh(ThisIndex).Properties().end()) //property does exist
-        {
+        if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist
             return *pprop_it;
-        }
-        else
-        {
-            if(IsSubModelPart())
-            {
+        } else {
+            if(IsSubModelPart()) {
                 PropertiesType::Pointer pprop =  mpParentModelPart->pGetProperties(PropertiesId, ThisIndex);
                 GetMesh(ThisIndex).AddProperties(pprop);
                 return *pprop;
-            }
-            else
-            {
+            } else {
+                KRATOS_WARNING("ModelPart") << "New property added. Please use CreateNewProperties() instead" << std::endl;
                 PropertiesType::Pointer pnew_property = Kratos::make_shared<PropertiesType>(PropertiesId);
                 GetMesh(ThisIndex).AddProperties(pnew_property);
                 return *pnew_property;

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -799,8 +799,8 @@ public:
     /** Returns if the Properties corresponding to it's identifier exists */
     bool HasProperties(IndexType PropertiesId, IndexType MeshIndex = 0) const
     {
-        auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
-        if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist
+        auto pprop_it = GetMesh(MeshIndex).Properties().find(PropertiesId);
+        if(pprop_it != GetMesh(MeshIndex).Properties().end()) { // Property does exist
             return true;
         }
 
@@ -816,22 +816,20 @@ public:
      */
     PropertiesType::Pointer CreateNewProperties(IndexType PropertiesId, IndexType MeshIndex = 0)
     {
-        auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
-        if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist
+        auto pprop_it = GetMesh(MeshIndex).Properties().find(PropertiesId);
+        if(pprop_it != GetMesh(MeshIndex).Properties().end()) { // Property does exist
             KRATOS_ERROR << "Property already existing. Please use pGetProperties() instead" << std::endl;
         } else {
             if(IsSubModelPart()) {
-                PropertiesType::Pointer pprop =  mpParentModelPart->CreateNewProperties(PropertiesId, ThisIndex);
-                GetMesh(ThisIndex).AddProperties(pprop);
+                PropertiesType::Pointer pprop =  mpParentModelPart->CreateNewProperties(PropertiesId, MeshIndex);
+                GetMesh(MeshIndex).AddProperties(pprop);
                 return pprop;
             } else {
                 PropertiesType::Pointer pnew_property = Kratos::make_shared<PropertiesType>(PropertiesId);
-                GetMesh(ThisIndex).AddProperties(pnew_property);
+                GetMesh(MeshIndex).AddProperties(pnew_property);
                 return pnew_property;
             }
         }
-
-        return nullptr;
     }
 
     /**
@@ -848,13 +846,13 @@ public:
             return *(pprop_it.base());
         } else {
             if(IsSubModelPart()) {
-                PropertiesType::Pointer pprop =  mpParentModelPart->pGetProperties(PropertiesId, ThisIndex);
-                GetMesh(ThisIndex).AddProperties(pprop);
+                PropertiesType::Pointer pprop =  mpParentModelPart->pGetProperties(PropertiesId, MeshIndex);
+                GetMesh(MeshIndex).AddProperties(pprop);
                 return pprop;
             } else {
                 KRATOS_WARNING("ModelPart") << "Property " << PropertiesId << " does not exist!. Creating and adding new property. Please use CreateNewProperties() instead" << std::endl;
                 PropertiesType::Pointer pnew_property = Kratos::make_shared<PropertiesType>(PropertiesId);
-                GetMesh(ThisIndex).AddProperties(pnew_property);
+                GetMesh(MeshIndex).AddProperties(pnew_property);
                 return pnew_property;
             }
         }
@@ -869,18 +867,18 @@ public:
      */
     PropertiesType& GetProperties(IndexType PropertiesId, IndexType MeshIndex = 0)
     {
-        auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
-        if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist
+        auto pprop_it = GetMesh(MeshIndex).Properties().find(PropertiesId);
+        if(pprop_it != GetMesh(MeshIndex).Properties().end()) { // Property does exist
             return *pprop_it;
         } else {
             if(IsSubModelPart()) {
-                PropertiesType::Pointer pprop =  mpParentModelPart->pGetProperties(PropertiesId, ThisIndex);
-                GetMesh(ThisIndex).AddProperties(pprop);
+                PropertiesType::Pointer pprop =  mpParentModelPart->pGetProperties(PropertiesId, MeshIndex);
+                GetMesh(MeshIndex).AddProperties(pprop);
                 return *pprop;
             } else {
                 KRATOS_WARNING("ModelPart") << "Property " << PropertiesId << " does not exist!. Creating and adding new property. Please use CreateNewProperties() instead" << std::endl;
                 PropertiesType::Pointer pnew_property = Kratos::make_shared<PropertiesType>(PropertiesId);
-                GetMesh(ThisIndex).AddProperties(pnew_property);
+                GetMesh(MeshIndex).AddProperties(pnew_property);
                 return *pnew_property;
             }
         }

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -841,8 +841,8 @@ public:
      */
     PropertiesType::Pointer pGetProperties(IndexType PropertiesId, IndexType MeshIndex = 0)
     {
-        auto pprop_it = GetMesh(ThisIndex).Properties().find(PropertiesId);
-        if(pprop_it != GetMesh(ThisIndex).Properties().end()) { // Property does exist
+        auto pprop_it = GetMesh(MeshIndex).Properties().find(PropertiesId);
+        if(pprop_it != GetMesh(MeshIndex).Properties().end()) { // Property does exist
             return *(pprop_it.base());
         } else {
             if(IsSubModelPart()) {

--- a/kratos/processes/structured_mesh_generator_process.cpp
+++ b/kratos/processes/structured_mesh_generator_process.cpp
@@ -168,7 +168,7 @@ namespace Kratos
 	void StructuredMeshGeneratorProcess::GenerateTriangularElements() {
 		std::size_t element_id = mStartElementId;
 
-		Properties::Pointer p_properties = mrOutputModelPart.pGetProperties(mElementPropertiesId);
+		Properties::Pointer p_properties = mrOutputModelPart.CreateNewProperties(mElementPropertiesId);
 		std::vector<ModelPart::IndexType> element_connectivity(3);
 
 		for (std::size_t j = 0; j < mNumberOfDivisions; j++) {
@@ -183,7 +183,7 @@ namespace Kratos
 	}
 
 	void StructuredMeshGeneratorProcess::GenerateTetrahedraElements() {
-		Properties::Pointer p_properties = mrOutputModelPart.pGetProperties(mElementPropertiesId);
+		Properties::Pointer p_properties = mrOutputModelPart.CreateNewProperties(mElementPropertiesId);
 
 		for (std::size_t k = 0; k < mNumberOfDivisions; k++) {
 			for (std::size_t j = 0; j < mNumberOfDivisions; j++) {

--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -219,9 +219,24 @@ bool ModelPartHasPropertiesById2(const ModelPart& rModelPart, const unsigned int
     return rModelPart.HasProperties(PropertiesId, 0);
 }
 
-Properties::Pointer ModelPartGetPropertiesById(ModelPart& rModelPart, unsigned int PropertiesId, unsigned int MeshId)
+Properties::Pointer ModelPartCreateNewPropertiesById1(ModelPart& rModelPart, unsigned int PropertiesId, unsigned int MeshId)
+{
+    return rModelPart.CreateNewProperties(PropertiesId, MeshId);
+}
+
+Properties::Pointer ModelPartCreateNewPropertiesById2(ModelPart& rModelPart, unsigned int PropertiesId)
+{
+    return rModelPart.CreateNewProperties(PropertiesId, 0);
+}
+
+Properties::Pointer ModelPartGetPropertiesById1(ModelPart& rModelPart, unsigned int PropertiesId, unsigned int MeshId)
 {
     return rModelPart.pGetProperties(PropertiesId, MeshId);
+}
+
+Properties::Pointer ModelPartGetPropertiesById2(ModelPart& rModelPart, unsigned int PropertiesId)
+{
+    return rModelPart.pGetProperties(PropertiesId);
 }
 
 ModelPart::PropertiesContainerType::Pointer ModelPartGetProperties1(ModelPart& rModelPart)
@@ -819,7 +834,10 @@ void AddModelPartToPython(pybind11::module& m)
         .def("GetTable", &ModelPart::pGetTable)
         .def("HasProperties", ModelPartHasPropertiesById1)
         .def("HasProperties", ModelPartHasPropertiesById2)
-        .def("GetProperties", ModelPartGetPropertiesById) //new method where one asks for one specific property on one given mesh
+        .def("CreateNewProperties", ModelPartCreateNewPropertiesById1)
+        .def("CreateNewProperties", ModelPartCreateNewPropertiesById2)
+        .def("GetProperties", ModelPartGetPropertiesById1)
+//         .def("GetProperties", ModelPartGetPropertiesById2) // NOTE: This method conflicts with the other GetProperties methods
         .def_property("Properties", ModelPartGetProperties1, ModelPartSetProperties1)
         .def("AddProperties", ModelPartAddProperties1)
         .def("AddProperties", ModelPartAddProperties2)

--- a/kratos/tests/cpp_tests/processes/test_calculate_distance_to_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_distance_to_skin_process.cpp
@@ -158,7 +158,7 @@ namespace Kratos {
 			"element_name":     "Element3D4N"
 		})");
 
-    Model current_model;
+                Model current_model;
 		ModelPart &volume_part = current_model.CreateModelPart("Volume");
 		volume_part.AddNodalSolutionStepVariable(VELOCITY);
 		volume_part.AddNodalSolutionStepVariable(DISTANCE);
@@ -172,7 +172,7 @@ namespace Kratos {
 		skin_part.CreateNewNode(902, 10.0, 0.0, 2.0);
 		skin_part.CreateNewNode(903, 10.0, 10.0, 2.0);
 		skin_part.CreateNewNode(904, 0.0, 10.0, 2.0);
-		Properties::Pointer p_properties(new Properties(0));
+		Properties::Pointer p_properties = skin_part.CreateNewProperties(0);
 		skin_part.CreateNewElement("Element3D3N", 901, { 901,902,903 }, p_properties);
 		skin_part.CreateNewElement("Element3D3N", 902, { 901,903,904 }, p_properties);
 
@@ -180,8 +180,8 @@ namespace Kratos {
 		CalculateDistanceToSkinProcess<3>(volume_part, skin_part).Execute();
 
 		for (auto& node : volume_part.Nodes())
-			if (fabs(node.GetSolutionStepValue(DISTANCE)) < 1.00e16) { // There are no propagation in this version so I avoid numeric_limit::max() one
-				auto distance = fabs(node.Z() - 2.00);
+			if (std::abs(node.GetSolutionStepValue(DISTANCE)) < 1.00e16) { // There are no propagation in this version so I avoid numeric_limit::max() one
+				auto distance = std::abs(node.Z() - 2.00);
 				KRATOS_CHECK_NEAR(node.GetSolutionStepValue(DISTANCE), distance, 1e-6);
 			}
 	}
@@ -221,7 +221,7 @@ namespace Kratos {
 		skin_part.CreateNewNode(902, 10.0, 0.0, 5.0);
 		skin_part.CreateNewNode(903, 10.0, 10.0, 5.0);
 		skin_part.CreateNewNode(904, 0.0, 10.0, 5.0);
-		Properties::Pointer p_properties(new Properties(0));
+		Properties::Pointer p_properties = skin_part.CreateNewProperties(0);
 		skin_part.CreateNewElement("Element3D3N", 901, { 901,902,903 }, p_properties);
 		skin_part.CreateNewElement("Element3D3N", 902, { 901,903,904 }, p_properties);
 
@@ -229,8 +229,8 @@ namespace Kratos {
 		CalculateDistanceToSkinProcess<3>(volume_part, skin_part).Execute();
 
 		for (auto& node : volume_part.Nodes())
-			if (fabs(node.GetSolutionStepValue(DISTANCE)) < 1.00e16) { // There are no propagation in this version so I avoid numeric_limit::max() one
-				auto distance = fabs(node.Z() - 5.00);
+			if (std::abs(node.GetSolutionStepValue(DISTANCE)) < 1.00e16) { // There are no propagation in this version so I avoid numeric_limit::max() one
+				auto distance = std::abs(node.Z() - 5.00);
 				KRATOS_CHECK_NEAR(node.GetSolutionStepValue(DISTANCE), distance, 1e-6);
 			}
 

--- a/kratos/tests/cpp_tests/processes/test_calculate_nodal_area_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_nodal_area_process.cpp
@@ -59,7 +59,7 @@ namespace Kratos
 
             this_model_part.AddNodalSolutionStepVariable(NODAL_AREA);
 
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
 
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -141,7 +141,7 @@ namespace Kratos
             this_model_part.AddNodalSolutionStepVariable(DISTANCE_GRADIENT);
             this_model_part.AddNodalSolutionStepVariable(NODAL_AREA);
 
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
 
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -305,7 +305,7 @@ namespace Kratos
             
             this_model_part.AddNodalSolutionStepVariable(NODAL_AREA);
             
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
             
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -379,7 +379,7 @@ namespace Kratos
             this_model_part.AddNodalSolutionStepVariable(DISTANCE_GRADIENT);
             this_model_part.AddNodalSolutionStepVariable(NODAL_AREA);
             
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
             
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;

--- a/kratos/tests/cpp_tests/processes/test_compute_nodal_gradient_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_compute_nodal_gradient_process.cpp
@@ -62,7 +62,7 @@ namespace Kratos
             this_model_part.AddNodalSolutionStepVariable(DISTANCE);
             this_model_part.AddNodalSolutionStepVariable(DISTANCE_GRADIENT);
 
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
 
             auto& process_info = this_model_part.GetProcessInfo();
             process_info.SetValue(DOMAIN_SIZE, 2);
@@ -147,7 +147,7 @@ namespace Kratos
             this_model_part.AddNodalSolutionStepVariable(DISTANCE);
             this_model_part.AddNodalSolutionStepVariable(DISTANCE_GRADIENT);
 
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
 
             auto& process_info = this_model_part.GetProcessInfo();
             process_info.SetValue(DOMAIN_SIZE, 3);
@@ -311,7 +311,7 @@ namespace Kratos
             this_model_part.AddNodalSolutionStepVariable(DISTANCE);
             this_model_part.AddNodalSolutionStepVariable(DISTANCE_GRADIENT);
             
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
             
             auto& process_info = this_model_part.GetProcessInfo();
             process_info.SetValue(DOMAIN_SIZE, 2);
@@ -383,7 +383,7 @@ namespace Kratos
             this_model_part.AddNodalSolutionStepVariable(DISTANCE);
             this_model_part.AddNodalSolutionStepVariable(DISTANCE_GRADIENT);
 
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
 
             auto& process_info = this_model_part.GetProcessInfo();
             process_info.SetValue(DOMAIN_SIZE, 3);

--- a/kratos/tests/cpp_tests/processes/test_fast_transfer_between_model_parts_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_fast_transfer_between_model_parts_process.cpp
@@ -41,7 +41,7 @@ namespace Kratos
             ModelPart& origin_model_part = current_model.CreateModelPart("Origin");
             ModelPart& destination_model_part = current_model.CreateModelPart("Destination");
 
-            Properties::Pointer p_cond_prop = origin_model_part.pGetProperties(0);
+            Properties::Pointer p_cond_prop = origin_model_part.CreateNewProperties(0);
 
             auto& process_info = origin_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -101,7 +101,7 @@ namespace Kratos
             ModelPart& origin_model_part = current_model.CreateModelPart("Origin");
             ModelPart& destination_model_part = current_model.CreateModelPart("Destination");
 
-            Properties::Pointer p_cond_prop = origin_model_part.pGetProperties(0);
+            Properties::Pointer p_cond_prop = origin_model_part.CreateNewProperties(0);
 
             auto& process_info = origin_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -183,7 +183,7 @@ namespace Kratos
             ModelPart& origin_model_part = current_model.CreateModelPart("Origin");
             ModelPart& destination_model_part = current_model.CreateModelPart("Destination");
 
-            Properties::Pointer p_cond_prop = origin_model_part.pGetProperties(0);
+            Properties::Pointer p_cond_prop = origin_model_part.CreateNewProperties(0);
 
             auto& process_info = origin_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -243,7 +243,7 @@ namespace Kratos
             ModelPart& origin_model_part = current_model.CreateModelPart("Origin");
             ModelPart& destination_model_part = current_model.CreateModelPart("Destination");
             
-            Properties::Pointer p_cond_prop = origin_model_part.pGetProperties(0);
+            Properties::Pointer p_cond_prop = origin_model_part.CreateNewProperties(0);
             
             auto& process_info = origin_model_part.GetProcessInfo();
             process_info[STEP] = 1;

--- a/kratos/tests/cpp_tests/processes/test_find_nodal_h_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_find_nodal_h_process.cpp
@@ -57,7 +57,7 @@ namespace Kratos
             
             this_model_part.AddNodalSolutionStepVariable(NODAL_H);
             
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
             
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -128,7 +128,7 @@ namespace Kratos
             
             this_model_part.AddNodalSolutionStepVariable(NODAL_H);
             
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
             
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;

--- a/kratos/tests/cpp_tests/processes/test_mortar_mapper_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_mortar_mapper_process.cpp
@@ -63,7 +63,7 @@ namespace Kratos
             this_model_part.AddNodalSolutionStepVariable(TEMPERATURE);
             this_model_part.AddNodalSolutionStepVariable(NORMAL);
 
-            Properties::Pointer p_cond_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_cond_prop = this_model_part.CreateNewProperties(0);
 
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -154,7 +154,7 @@ namespace Kratos
             this_model_part.AddNodalSolutionStepVariable(TEMPERATURE);
             this_model_part.AddNodalSolutionStepVariable(NORMAL);
 
-            Properties::Pointer p_cond_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_cond_prop = this_model_part.CreateNewProperties(0);
 
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -248,7 +248,7 @@ namespace Kratos
             this_model_part.AddNodalSolutionStepVariable(TEMPERATURE);
             this_model_part.AddNodalSolutionStepVariable(NORMAL);
 
-            Properties::Pointer p_cond_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_cond_prop = this_model_part.CreateNewProperties(0);
 
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;

--- a/kratos/tests/cpp_tests/processes/test_replace_elements_and_condition_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_replace_elements_and_condition_process.cpp
@@ -40,7 +40,7 @@ namespace Kratos
             Model current_model;
             ModelPart& this_model_part = current_model.CreateModelPart("Main");
             
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
             
             // First we create the nodes 
             NodeType::Pointer p_node_1 = this_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
@@ -111,7 +111,7 @@ namespace Kratos
             Model current_model;
             ModelPart& this_model_part = current_model.CreateModelPart("Main");
             
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
             
             // First we create the nodes 
             NodeType::Pointer p_node_1 = this_model_part.CreateNewNode(1 , 0.0 , 1.0 , 1.0);

--- a/kratos/tests/cpp_tests/processes/test_skin_detection_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_skin_detection_process.cpp
@@ -48,7 +48,7 @@ KRATOS_TEST_CASE_IN_SUITE(SkinDetectionProcess, KratosCoreFastSuite)
     array_nodes2.push_back(p_node_3);
     array_nodes2.push_back(p_node_4);
 
-    Properties::Pointer p_elem_prop = model_part.pGetProperties(0);
+    Properties::Pointer p_elem_prop = model_part.CreateNewProperties(0);
     Element::Pointer p_elem_1 = model_part.CreateNewElement("Element2D3N", 1,PointerVector<NodeType>{array_nodes1}, p_elem_prop);
     Element::Pointer p_elem_2 = model_part.CreateNewElement("Element2D3N", 2,PointerVector<NodeType>{array_nodes2}, p_elem_prop);
 

--- a/kratos/tests/cpp_tests/sources/test_condition.cpp
+++ b/kratos/tests/cpp_tests/sources/test_condition.cpp
@@ -36,7 +36,7 @@ namespace Kratos {
             auto p_node3 = model_part.CreateNewNode(3, 1.0, 1.0, 0.0);
 
             // Definition of properties
-            auto p_prop = model_part.pGetProperties(1);
+            auto p_prop = model_part.CreateNewProperties(1);
 
             // List onf nodes
             std::vector<NodeType::Pointer> list_nodes(3);

--- a/kratos/tests/cpp_tests/sources/test_element.cpp
+++ b/kratos/tests/cpp_tests/sources/test_element.cpp
@@ -35,7 +35,7 @@ namespace Kratos {
             auto p_node3 = model_part.CreateNewNode(3, 1.0, 1.0, 0.0);
 
             // Definition of properties
-            auto p_prop = model_part.pGetProperties(1);
+            auto p_prop = model_part.CreateNewProperties(1);
 
             // List onf nodes
             std::vector<NodeType::Pointer> list_nodes(3);

--- a/kratos/tests/cpp_tests/sources/test_model_part.cpp
+++ b/kratos/tests/cpp_tests/sources/test_model_part.cpp
@@ -25,7 +25,7 @@ namespace Kratos {
 
     void GenerateGenericModelPart(ModelPart& rModelPart)
     {
-        Properties::Pointer p_elem_prop = rModelPart.pGetProperties(0);
+        Properties::Pointer p_elem_prop = rModelPart.CreateNewProperties(0);
 
         // First we create the nodes
         NodeType::Pointer p_node_1 = rModelPart.CreateNewNode(1, 0.0 , 0.0 , 0.0);

--- a/kratos/tests/cpp_tests/strategies/builder_and_solvers/test_builder_and_solver.cpp
+++ b/kratos/tests/cpp_tests/strategies/builder_and_solvers/test_builder_and_solver.cpp
@@ -87,7 +87,7 @@ namespace Kratos
             NodeType::Pointer pnode2 = rModelPart.CreateNewNode(2, 1.0, 0.0, 0.0);
             NodeType::Pointer pnode3 = rModelPart.CreateNewNode(3, 2.0, 0.0, 0.0);
 
-            auto p_prop = rModelPart.pGetProperties(1, 0);
+            auto p_prop = rModelPart.CreateNewProperties(1, 0);
             p_prop->SetValue(YOUNG_MODULUS, 206900000000.0);
             p_prop->SetValue(NODAL_AREA, 0.01);
 
@@ -152,7 +152,7 @@ namespace Kratos
             NodeType::Pointer pnode10 = rModelPart.CreateNewNode(10, 2.0, 0.0, 0.0);
             NodeType::Pointer pnode11 = rModelPart.CreateNewNode(11, 0.0, 0.0, 0.0);
 
-            auto p_prop = rModelPart.pGetProperties(1, 0);
+            auto p_prop = rModelPart.CreateNewProperties(1, 0);
             p_prop->SetValue(YOUNG_MODULUS, 206900000000.0);
             p_prop->SetValue(NODAL_AREA, 0.01);
 

--- a/kratos/tests/cpp_tests/utilities/test_assign_unique_model_part_collection_tag_utility.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_assign_unique_model_part_collection_tag_utility.cpp
@@ -47,7 +47,7 @@ namespace Kratos
             ModelPart& first_sub_modelpart_4 = first_model_part.CreateSubModelPart("YSubModelPart4");
 
             // Creating the Properties
-            Properties::Pointer p_elem_prop = first_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = first_model_part.CreateNewProperties(0);
 
             // First we create the nodes
             NodeType::Pointer p_node_1 = first_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
@@ -182,7 +182,7 @@ namespace Kratos
             ModelPart& first_sub_modelpart_4 = first_model_part.CreateSubModelPart("YSubModelPart4");
 
             // Creating the Properties
-            Properties::Pointer p_elem_prop = first_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = first_model_part.CreateNewProperties(0);
 
             // First we create the nodes
             NodeType::Pointer p_node_1 = first_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);

--- a/kratos/tests/cpp_tests/utilities/test_binbased_fast_point_locator.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_binbased_fast_point_locator.cpp
@@ -42,7 +42,7 @@ namespace Kratos
             ModelPart& this_model_part = current_model.CreateModelPart("Main");
             this_model_part.SetBufferSize(2);
             
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
             
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -123,7 +123,7 @@ namespace Kratos
             ModelPart& this_model_part = current_model.CreateModelPart("Main");
             this_model_part.SetBufferSize(2);
             
-            Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
             
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
@@ -282,7 +282,7 @@ namespace Kratos
             Model current_model;
             ModelPart& this_model_part = current_model.CreateModelPart("test_model_part",2);
             
-            Properties::Pointer p_cond_prop = this_model_part.pGetProperties(0);
+            Properties::Pointer p_cond_prop = this_model_part.CreateNewProperties(0);
             
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;


### PR DESCRIPTION
As agreed for the @KratosMultiphysics/implementation-committee , we create in a first instance the method CreateNewProperties for consistency. To keep a retro-compatibility we add a warning into pGetProperties and GetProperties.

Additionally I corrected the use in the Core cpp_tests