### PR TITLE
[WIP][StructMech] move lenght calculation to utilities

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/cable_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cable_element_3D2N.cpp
@@ -138,8 +138,8 @@ void CableElement3D2N::UpdateInternalForces(
 
   this->CreateTransformationMatrix(transformation_matrix);
 
-  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
-  const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
+  const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
   const double A = this->GetProperties()[CROSS_AREA];
 
   double prestress = 0.00;

--- a/applications/StructuralMechanicsApplication/custom_elements/cable_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cable_element_3D2N.cpp
@@ -19,6 +19,7 @@
 #include "custom_elements/cable_element_3D2N.hpp"
 #include "includes/define.h"
 #include "structural_mechanics_application_variables.h"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 
 namespace Kratos {
 CableElement3D2N::CableElement3D2N(IndexType NewId,
@@ -137,8 +138,8 @@ void CableElement3D2N::UpdateInternalForces(
 
   this->CreateTransformationMatrix(transformation_matrix);
 
-  const double l = this->CalculateCurrentLength();
-  const double L0 = this->CalculateReferenceLength();
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
+  const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
   const double A = this->GetProperties()[CROSS_AREA];
 
   double prestress = 0.00;

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -446,35 +446,7 @@ double CrBeamElement2D2N::CalculateDeformedElementAngle() {
 
 double CrBeamElement2D2N::CalculateLength() const {
   KRATOS_TRY;
-  const double numerical_limit = std::numeric_limits<double>::epsilon();
-  const double du =
-      this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
-      this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
-  const double dv =
-      this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
-      this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
-
-  const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
-  const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
-
-  const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy));
-
-  KRATOS_ERROR_IF(l < numerical_limit) << "length 0 for element " << this->Id()
-                                       << std::endl;
-  return l;
-  KRATOS_CATCH("")
-}
-
-double CrBeamElement2D2N::CalculateReferenceLength() const {
-  KRATOS_TRY;
-  const double numerical_limit = std::numeric_limits<double>::epsilon();
-  const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
-  const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
-  const double L = std::sqrt((dx * dx) + (dy * dy));
-
-  KRATOS_ERROR_IF(L < numerical_limit) << "length 0 for element " << this->Id()
-                                       << std::endl;
-  return L;
+  return StructuralMechanicsElementUtilities::CalculateCurrentLength2D2N(*this);
   KRATOS_CATCH("")
 }
 
@@ -616,7 +588,7 @@ CrBeamElement2D2N::CalculateDeformationParameters() {
   BoundedVector<double, msLocalSize> deformation_parameters =
       ZeroVector(msLocalSize);
   deformation_parameters[0] =
-      this->CalculateLength() - this->CalculateReferenceLength();
+      this->CalculateLength() - StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(*this);
   deformation_parameters[1] = current_displacement[5] - current_displacement[2];
   deformation_parameters[2] = current_displacement[5] + current_displacement[2];
   deformation_parameters[2] -= 2.00 * (this->CalculateDeformedElementAngle() -

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.cpp
@@ -923,6 +923,11 @@ int CrBeamElement2D2N::Check(const ProcessInfo &rCurrentProcessInfo) {
     KRATOS_ERROR << "I33 not provided for this element" << this->Id()
                  << std::endl;
   }
+
+    KRATOS_ERROR_IF(StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(*this)
+         < std::numeric_limits<double>::epsilon())
+        << "Element #" << this->Id() << " has a length of zero!" << std::endl;
+
   return 0;
 
   KRATOS_CATCH("")

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_2D2N.hpp
@@ -199,12 +199,6 @@ namespace Kratos
         virtual double CalculateLength() const;
 
         /**
-         * @brief This function calculates the reference length
-         */
-        double CalculateReferenceLength() const;
-
-
-        /**
          * @brief This function calculates the elastic part of the total stiffness matrix
          */
         BoundedMatrix<double,msLocalSize,msLocalSize> CreateElementStiffnessMatrix_Kd_mat() const;

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -178,7 +178,7 @@ CrBeamElement3D2N::CalculateBodyForces() const {
       ZeroVector(msElementSize);
 
   const double A = this->GetProperties()[CROSS_AREA];
-  const double l = this->CalculateCurrentLength();
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
   const double rho = this->GetProperties()[DENSITY];
 
   // calculating equivalent line load
@@ -313,7 +313,7 @@ CrBeamElement3D2N::CreateElementStiffnessMatrix_Material() const {
   const double E = this->GetProperties()[YOUNG_MODULUS];
   const double G = this->CalculateShearModulus();
   const double A = this->GetProperties()[CROSS_AREA];
-  const double L = this->CalculateReferenceLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
 
   const double J = this->GetProperties()[TORSIONAL_INERTIA];
   const double Iy = this->GetProperties()[I22];
@@ -402,7 +402,7 @@ CrBeamElement3D2N::CreateElementStiffnessMatrix_Geometry() const {
   const double my_B = this->mNodalForces[10];
   const double mz_B = this->mNodalForces[11];
 
-  const double L = this->CalculateCurrentLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
   const double Qy = -1.00 * (mz_A + mz_B) / L;
   const double Qz = (my_A + my_B) / L;
 
@@ -522,7 +522,7 @@ CrBeamElement3D2N::CalculateDeformationStiffness() const {
   const double E = this->GetProperties()[YOUNG_MODULUS];
   const double G = this->CalculateShearModulus();
   const double A = this->GetProperties()[CROSS_AREA];
-  const double L = this->CalculateReferenceLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
 
   const double J = this->GetProperties()[TORSIONAL_INERTIA];
   const double Iy = this->GetProperties()[I22];
@@ -547,7 +547,7 @@ CrBeamElement3D2N::CalculateDeformationStiffness() const {
   Kd(4, 4) = 3.0 * E * Iy * Psi_y / L;
   Kd(5, 5) = 3.0 * E * Iz * Psi_z / L;
 
-  const double l = this->CalculateCurrentLength();
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
   const double N = this->mNodalForces[6];
 
   const double Qy =
@@ -908,7 +908,7 @@ BoundedMatrix<double, CrBeamElement3D2N::msElementSize,
 CrBeamElement3D2N::CalculateTransformationS() const {
 
   KRATOS_TRY
-  const double L = this->CalculateCurrentLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
   BoundedMatrix<double, msElementSize, msLocalSize> S =
       ZeroMatrix(msElementSize, msLocalSize);
   S(0, 3) = -1.00;
@@ -1049,8 +1049,8 @@ CrBeamElement3D2N::CalculateElementForces(const Vector &Bisectrix,
   KRATOS_TRY;
   BoundedVector<double, msLocalSize> deformation_modes_total_v =
       ZeroVector(msLocalSize);
-  const double L = this->CalculateReferenceLength();
-  const double l = this->CalculateCurrentLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
 
   Vector phi_s = CalculateSymmetricDeformationMode(VectorDifference);
   Vector phi_a = CalculateAntiSymmetricDeformationMode(Bisectrix);
@@ -1078,7 +1078,7 @@ double CrBeamElement3D2N::CalculatePsi(const double I, const double A_eff) const
 
   KRATOS_TRY;
   const double E = this->GetProperties()[YOUNG_MODULUS];
-  const double L = this->CalculateCurrentLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
   const double G = this->CalculateShearModulus();
 
   const double phi = (12.0 * E * I) / (L * L * G * A_eff);
@@ -1093,37 +1093,6 @@ double CrBeamElement3D2N::CalculatePsi(const double I, const double A_eff) const
   KRATOS_CATCH("")
 }
 
-double CrBeamElement3D2N::CalculateReferenceLength() const {
-
-  KRATOS_TRY;
-  const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
-  const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
-  const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-  const double L = std::sqrt(dx * dx + dy * dy + dz * dz);
-  return L;
-  KRATOS_CATCH("")
-}
-
-double CrBeamElement3D2N::CalculateCurrentLength() const {
-
-  KRATOS_TRY;
-  const double du =
-      this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
-      this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
-  const double dv =
-      this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
-      this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
-  const double dw =
-      this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Z) -
-      this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Z);
-  const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
-  const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
-  const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-  const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy) +
-                             (dw + dz) * (dw + dz));
-  return l;
-  KRATOS_CATCH("")
-}
 
 BoundedVector<double, CrBeamElement3D2N::msLocalSize>
 CrBeamElement3D2N::GetCurrentNodalPosition() const {
@@ -1344,7 +1313,7 @@ void CrBeamElement3D2N::CalculateConsistentMassMatrix(
   }
   rMassMatrix = ZeroMatrix(msElementSize, msElementSize);
 
-  const double L = this->CalculateReferenceLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
   const double L2 = L * L;
   const double rho = this->GetProperties()[DENSITY];
   const double A = this->GetProperties()[CROSS_AREA];
@@ -1447,7 +1416,7 @@ void CrBeamElement3D2N::CalculateLumpedMassMatrix(
   }
   rMassMatrix = ZeroMatrix(msElementSize, msElementSize);
   const double A = this->GetProperties()[CROSS_AREA];
-  const double L = this->CalculateReferenceLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
   const double rho = this->GetProperties()[DENSITY];
 
   const double total_mass = A * L * rho;

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -1646,8 +1646,9 @@ int CrBeamElement3D2N::Check(const ProcessInfo &rCurrentProcessInfo) {
       << "LOCAL_AXIS_1 is not perpendicular to LOCAL_AXIS_2 for element " << this->Id() << std::endl;
   }
 
-
-
+    KRATOS_ERROR_IF(StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this)
+         < std::numeric_limits<double>::epsilon())
+        << "Element #" << this->Id() << " has a length of zero!" << std::endl;
 
   return 0;
 

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.hpp
@@ -249,16 +249,6 @@ namespace Kratos
         double CalculateShearModulus() const;
 
         /**
-         * @brief This function calculates the reference length
-         */
-        double CalculateReferenceLength() const;
-
-        /**
-         * @brief This function calculates the current length
-         */
-        double CalculateCurrentLength() const;
-
-        /**
          * @brief This function updates incremental deformation w.r.t. to current and previous deformations
          */
         Vector UpdateIncrementDeformation();

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_2D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_2D2N.cpp
@@ -19,6 +19,7 @@
 #include "custom_utilities/static_condensation_utility.h"
 #include "includes/define.h"
 #include "structural_mechanics_application_variables.h"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 
 namespace Kratos {
 
@@ -211,7 +212,7 @@ void CrBeamElementLinear2D2N::GetValueOnIntegrationPoints(
 
 double CrBeamElementLinear2D2N::CalculateLength() const {
   KRATOS_TRY;
-  return this->CalculateReferenceLength();
+  return StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(*this);
   KRATOS_CATCH("")
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_linear_3D2N.cpp
@@ -19,6 +19,7 @@
 #include "custom_utilities/static_condensation_utility.h"
 #include "includes/define.h"
 #include "structural_mechanics_application_variables.h"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 
 namespace Kratos {
 
@@ -155,7 +156,7 @@ CrBeamElementLinear3D2N::CalculateDeformationStiffness() const {
   const double E = this->GetProperties()[YOUNG_MODULUS];
   const double G = this->CalculateShearModulus();
   const double A = this->GetProperties()[CROSS_AREA];
-  const double L = this->CalculateReferenceLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
 
   const double J = this->GetProperties()[TORSIONAL_INERTIA];
   const double Iy = this->GetProperties()[I22];

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -155,7 +155,7 @@ TrussElement3D2N::CalculateBodyForces() {
 
   // creating necessary values
   const double A = this->GetProperties()[CROSS_AREA];
-  const double L = this->CalculateReferenceLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
   const double rho = this->GetProperties()[DENSITY];
 
   double total_mass = A * L * rho;
@@ -362,8 +362,8 @@ void TrussElement3D2N::CalculateOnIntegrationPoints(
       prestress = this->GetProperties()[TRUSS_PRESTRESS_PK2];
     }
 
-    const double L0 = this->CalculateReferenceLength();
-    const double l = this->CalculateCurrentLength();
+    const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
 
 
     array_1d<double, msDimension> temp_internal_stresses = ZeroVector(msDimension);
@@ -459,51 +459,13 @@ int TrussElement3D2N::Check(const ProcessInfo &rCurrentProcessInfo) {
 double TrussElement3D2N::CalculateGreenLagrangeStrain() {
 
   KRATOS_TRY
-  const double l = this->CalculateCurrentLength();
-  const double L = this->CalculateReferenceLength();
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
   const double e = ((l * l - L * L) / (2.00 * L * L));
   return e;
   KRATOS_CATCH("")
 }
 
-double TrussElement3D2N::CalculateReferenceLength() {
-
-  KRATOS_TRY;
-  const double numerical_limit = std::numeric_limits<double>::epsilon();
-  const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
-  const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
-  const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-  const double L = std::sqrt(dx * dx + dy * dy + dz * dz);
-
-  KRATOS_ERROR_IF(L<=numerical_limit)
-   << "Reference Length of element" << this->Id() << "~ 0" << std::endl;
-  return L;
-  KRATOS_CATCH("")
-}
-double TrussElement3D2N::CalculateCurrentLength() {
-
-  KRATOS_TRY;
-  const double numerical_limit = std::numeric_limits<double>::epsilon();
-  const double du =
-      this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
-      this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
-  const double dv =
-      this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
-      this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
-  const double dw =
-      this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Z) -
-      this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Z);
-  const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
-  const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
-  const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-  const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy) +
-                             (dw + dz) * (dw + dz));
-
-  KRATOS_ERROR_IF(l<=numerical_limit)
-   << "Current Length of element" << this->Id() << "~ 0" << std::endl;
-  return l;
-  KRATOS_CATCH("")
-}
 void TrussElement3D2N::UpdateInternalForces(
     BoundedVector<double, TrussElement3D2N::msLocalSize> &rInternalForces) {
 
@@ -513,8 +475,8 @@ void TrussElement3D2N::UpdateInternalForces(
 
   this->CreateTransformationMatrix(transformation_matrix);
 
-  const double l = this->CalculateCurrentLength();
-  const double L0 = this->CalculateReferenceLength();
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
+  const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
   const double A = this->GetProperties()[CROSS_AREA];
 
   double prestress = 0.00;
@@ -748,8 +710,8 @@ void TrussElement3D2N::CalculateGeometricStiffnessMatrix(
   const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
   const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
   const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-  const double L = this->CalculateReferenceLength();
-  const double l = this->CalculateCurrentLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
   double e_gL = (l * l - L * L) / (2.00 * L * L);
   const double L3 = L * L * L;
 
@@ -829,7 +791,7 @@ void TrussElement3D2N::CalculateElasticStiffnessMatrix(
   const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
   const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
   const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-  const double L = this->CalculateReferenceLength();
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
   const double L3 = L * L * L;
 
   const double EA = E * A;
@@ -925,8 +887,8 @@ BoundedVector<double,TrussElement3D2N::msLocalSize>
     this->GetGeometry(),temp_vector,true,true,rSaveInternalVariables);
 
     BoundedVector<double,msLocalSize> internal_forces = ZeroVector(msLocalSize);
-    const double l = this->CalculateCurrentLength();
-    const double L0 = this->CalculateReferenceLength();
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
+    const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
     const double A = this->GetProperties()[CROSS_AREA];
     double prestress = 0.00;
     if (this->GetProperties().Has(TRUSS_PRESTRESS_PK2)) {
@@ -986,7 +948,7 @@ void TrussElement3D2N::CalculateLumpedMassVector(VectorType &rMassVector)
         rMassVector.resize( msLocalSize );
 
     const double A = this->GetProperties()[CROSS_AREA];
-    const double L = this->CalculateReferenceLength();
+    const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
     const double rho = this->GetProperties()[DENSITY];
 
     const double total_mass = A * L * rho;

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -452,6 +452,10 @@ int TrussElement3D2N::Check(const ProcessInfo &rCurrentProcessInfo) {
                  << std::endl;
   }
 
+    KRATOS_ERROR_IF(StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this)
+         < std::numeric_limits<double>::epsilon())
+        << "Element #" << this->Id() << " has a length of zero!" << std::endl;
+
   return 0;
 
   KRATOS_CATCH("")

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -155,7 +155,7 @@ TrussElement3D2N::CalculateBodyForces() {
 
   // creating necessary values
   const double A = this->GetProperties()[CROSS_AREA];
-  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
   const double rho = this->GetProperties()[DENSITY];
 
   double total_mass = A * L * rho;
@@ -362,8 +362,8 @@ void TrussElement3D2N::CalculateOnIntegrationPoints(
       prestress = this->GetProperties()[TRUSS_PRESTRESS_PK2];
     }
 
-    const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
-    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
+    const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
 
 
     array_1d<double, msDimension> temp_internal_stresses = ZeroVector(msDimension);
@@ -459,8 +459,8 @@ int TrussElement3D2N::Check(const ProcessInfo &rCurrentProcessInfo) {
 double TrussElement3D2N::CalculateGreenLagrangeStrain() {
 
   KRATOS_TRY
-  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
-  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
   const double e = ((l * l - L * L) / (2.00 * L * L));
   return e;
   KRATOS_CATCH("")
@@ -475,8 +475,8 @@ void TrussElement3D2N::UpdateInternalForces(
 
   this->CreateTransformationMatrix(transformation_matrix);
 
-  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
-  const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
+  const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
   const double A = this->GetProperties()[CROSS_AREA];
 
   double prestress = 0.00;
@@ -710,8 +710,8 @@ void TrussElement3D2N::CalculateGeometricStiffnessMatrix(
   const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
   const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
   const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
-  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
+  const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
   double e_gL = (l * l - L * L) / (2.00 * L * L);
   const double L3 = L * L * L;
 
@@ -791,7 +791,7 @@ void TrussElement3D2N::CalculateElasticStiffnessMatrix(
   const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
   const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
   const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+  const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
   const double L3 = L * L * L;
 
   const double EA = E * A;
@@ -887,8 +887,8 @@ BoundedVector<double,TrussElement3D2N::msLocalSize>
     this->GetGeometry(),temp_vector,true,true,rSaveInternalVariables);
 
     BoundedVector<double,msLocalSize> internal_forces = ZeroVector(msLocalSize);
-    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
-    const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
+    const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
     const double A = this->GetProperties()[CROSS_AREA];
     double prestress = 0.00;
     if (this->GetProperties().Has(TRUSS_PRESTRESS_PK2)) {
@@ -948,7 +948,7 @@ void TrussElement3D2N::CalculateLumpedMassVector(VectorType &rMassVector)
         rMassVector.resize( msLocalSize );
 
     const double A = this->GetProperties()[CROSS_AREA];
-    const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+    const double L = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
     const double rho = this->GetProperties()[DENSITY];
 
     const double total_mass = A * L * rho;

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.hpp
@@ -228,16 +228,6 @@ namespace Kratos
         double CalculateGreenLagrangeStrain();
 
         /**
-         * @brief This function calculates the reference length
-         */
-        double CalculateReferenceLength();
-
-        /**
-         * @brief This function calculates the current length
-         */
-        double CalculateCurrentLength();
-
-        /**
          * @brief This function calculates self-weight forces
          */
         BoundedVector<double,msLocalSize> CalculateBodyForces();

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_linear_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_linear_3D2N.cpp
@@ -19,6 +19,7 @@
 #include "custom_elements/truss_element_linear_3D2N.hpp"
 #include "includes/define.h"
 #include "structural_mechanics_application_variables.h"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 
 namespace Kratos {
 TrussElementLinear3D2N::TrussElementLinear3D2N(IndexType NewId,
@@ -227,7 +228,7 @@ double TrussElementLinear3D2N::CalculateLinearStrain()  {
   this->CreateTransformationMatrix(transformation_matrix);
 
   current_disp = prod(Matrix(trans(transformation_matrix)),current_disp);
-  const double length_0 = this->CalculateReferenceLength();
+  const double length_0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
   const double e = (current_disp[3]-current_disp[0])/length_0;
 
   return e;

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_linear_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_linear_3D2N.cpp
@@ -228,7 +228,7 @@ double TrussElementLinear3D2N::CalculateLinearStrain()  {
   this->CreateTransformationMatrix(transformation_matrix);
 
   current_disp = prod(Matrix(trans(transformation_matrix)),current_disp);
-  const double length_0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+  const double length_0 = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
   const double e = (current_disp[3]-current_disp[0])/length_0;
 
   return e;

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_3D2N.cpp
@@ -13,6 +13,7 @@
 #include "adjoint_finite_difference_truss_element_3D2N.h"
 #include "structural_mechanics_application_variables.h"
 #include "custom_response_functions/response_utilities/stress_response_definitions.h"
+#include "custom_utilities/structural_mechanics_element_utilities.h"
 #include "includes/checks.h"
 
 
@@ -133,46 +134,6 @@ void AdjointFiniteDifferenceTrussElement::CheckProperties(const ProcessInfo& rCu
     cl->Check(r_properties ,this->GetGeometry(),rCurrentProcessInfo);
 }
 
-double AdjointFiniteDifferenceTrussElement::CalculateReferenceLength()
-{
-  KRATOS_TRY;
-  const double numerical_limit = std::numeric_limits<double>::epsilon();
-  const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
-  const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
-  const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-  const double L = std::sqrt(dx * dx + dy * dy + dz * dz);
-
-  KRATOS_DEBUG_ERROR_IF(L <= numerical_limit)
-   << "Reference Length of element" << this->Id() << "~ 0" << std::endl;
-  return L;
-  KRATOS_CATCH("")
-}
-
-double AdjointFiniteDifferenceTrussElement::CalculateCurrentLength()
-{
-    KRATOS_TRY;
-    const double numerical_limit = std::numeric_limits<double>::epsilon();
-    const double du =
-        this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
-        this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
-    const double dv =
-        this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
-        this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
-    const double dw =
-        this->GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Z) -
-        this->GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Z);
-    const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
-    const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
-    const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
-    const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy) +
-                               (dw + dz) * (dw + dz));
-
-    KRATOS_DEBUG_ERROR_IF(l <= numerical_limit)
-        << "Current Length of element" << this->Id() << "~ 0" << std::endl;
-    return l;
-    KRATOS_CATCH("")
-}
-
 void AdjointFiniteDifferenceTrussElement::CalculateCurrentLengthDisplacementDerivative(Vector& rDerivativeVector)
 {
     KRATOS_TRY;
@@ -184,7 +145,7 @@ void AdjointFiniteDifferenceTrussElement::CalculateCurrentLengthDisplacementDeri
     if (rDerivativeVector.size() != num_dofs)
         rDerivativeVector.resize(num_dofs, false);
 
-    const double l = CalculateCurrentLength();
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
     const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
     const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
     const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
@@ -231,8 +192,8 @@ double AdjointFiniteDifferenceTrussElement::CalculateDerivativePreFactorFX(const
     const double numerical_limit = std::numeric_limits<double>::epsilon();
     const double E = mpPrimalElement->GetProperties()[YOUNG_MODULUS];
     const double A = mpPrimalElement->GetProperties()[CROSS_AREA];
-    const double l_0 = CalculateReferenceLength();
-    const double l = CalculateCurrentLength();
+    const double l_0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
     double prestress = 0.0;
     if (mpPrimalElement->GetProperties().Has(TRUSS_PRESTRESS_PK2))
         prestress = mpPrimalElement->GetProperties()[TRUSS_PRESTRESS_PK2];
@@ -252,8 +213,8 @@ double AdjointFiniteDifferenceTrussElement::CalculateDerivativePreFactorPK2(cons
 {
     const double numerical_limit = std::numeric_limits<double>::epsilon();
     const double E = mpPrimalElement->GetProperties()[YOUNG_MODULUS];
-    const double l = CalculateCurrentLength();
-    const double l_0 = CalculateReferenceLength();
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
+    const double l_0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
     double derivative_pre_factor = E * l / (l_0 * l_0);
 
     KRATOS_DEBUG_ERROR_IF(derivative_pre_factor<=numerical_limit)

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_3D2N.cpp
@@ -78,7 +78,8 @@ int AdjointFiniteDifferenceTrussElement::Check(const ProcessInfo& rCurrentProces
     CheckDofs();
     CheckProperties(rCurrentProcessInfo);
 
-    KRATOS_ERROR_IF(this->GetGeometry().Length() < std::numeric_limits<double>::epsilon())
+    KRATOS_ERROR_IF(StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this)
+         < std::numeric_limits<double>::epsilon())
         << "Element #" << this->Id() << " has a length of zero!" << std::endl;
 
     return return_value;

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_truss_element_3D2N.cpp
@@ -145,7 +145,7 @@ void AdjointFiniteDifferenceTrussElement::CalculateCurrentLengthDisplacementDeri
     if (rDerivativeVector.size() != num_dofs)
         rDerivativeVector.resize(num_dofs, false);
 
-    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
     const double dx = this->GetGeometry()[1].X0() - this->GetGeometry()[0].X0();
     const double dy = this->GetGeometry()[1].Y0() - this->GetGeometry()[0].Y0();
     const double dz = this->GetGeometry()[1].Z0() - this->GetGeometry()[0].Z0();
@@ -192,8 +192,8 @@ double AdjointFiniteDifferenceTrussElement::CalculateDerivativePreFactorFX(const
     const double numerical_limit = std::numeric_limits<double>::epsilon();
     const double E = mpPrimalElement->GetProperties()[YOUNG_MODULUS];
     const double A = mpPrimalElement->GetProperties()[CROSS_AREA];
-    const double l_0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
-    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
+    const double l_0 = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
     double prestress = 0.0;
     if (mpPrimalElement->GetProperties().Has(TRUSS_PRESTRESS_PK2))
         prestress = mpPrimalElement->GetProperties()[TRUSS_PRESTRESS_PK2];
@@ -213,8 +213,8 @@ double AdjointFiniteDifferenceTrussElement::CalculateDerivativePreFactorPK2(cons
 {
     const double numerical_limit = std::numeric_limits<double>::epsilon();
     const double E = mpPrimalElement->GetProperties()[YOUNG_MODULUS];
-    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength(*this);
-    const double l_0 = StructuralMechanicsElementUtilities::CalculateReferenceLength(*this);
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
+    const double l_0 = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
     double derivative_pre_factor = E * l / (l_0 * l_0);
 
     KRATOS_DEBUG_ERROR_IF(derivative_pre_factor<=numerical_limit)

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -133,7 +133,7 @@ double CalculateCurrentLength2D2N(const Element& rElement) {
   const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy));
 
   KRATOS_ERROR_IF(l < numerical_limit)
-   << "Current Length of element " << rElement.Id() << " ~0" << std::endl;
+   << "Current length of element " << rElement.Id() << " ~0" << std::endl;
   return l;
   KRATOS_CATCH("")
 }
@@ -146,7 +146,7 @@ double CalculateReferenceLength2D2N(const Element& rElement) {
   const double L = std::sqrt((dx * dx) + (dy * dy));
 
   KRATOS_ERROR_IF(L < numerical_limit)
-   << "Reference Length of element " << rElement.Id() << " ~0" << std::endl;
+   << "Reference length of element " << rElement.Id() << " ~0" << std::endl;
   return L;
   KRATOS_CATCH("")
 }
@@ -162,7 +162,7 @@ double CalculateReferenceLength3D2N(const Element& rElement) {
   const double L = std::sqrt(dx * dx + dy * dy + dz * dz);
 
   KRATOS_ERROR_IF(L<=numerical_limit)
-   << "Reference Length of element " << rElement.Id() << " ~0" << std::endl;
+   << "Reference length of element " << rElement.Id() << " ~0" << std::endl;
   return L;
   KRATOS_CATCH("")
 }
@@ -187,7 +187,7 @@ double CalculateCurrentLength3D2N(const Element& rElement) {
                              (dw + dz) * (dw + dz));
 
   KRATOS_ERROR_IF(l<=numerical_limit)
-   << "Current Length of element " << rElement.Id() << " ~0" << std::endl;
+   << "Current length of element " << rElement.Id() << " ~0" << std::endl;
   return l;
   KRATOS_CATCH("")
 }

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -116,12 +116,26 @@ void CalculateRayleighDampingMatrix(
     KRATOS_CATCH( "CalculateRayleighDampingMatrix" )
 }
 
+double CalculateReferenceLength2D2N(const Element& rElement)
+{
+    KRATOS_TRY;
+
+    const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
+    const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
+    const double L = std::sqrt((dx * dx) + (dy * dy));
+
+    KRATOS_ERROR_IF(L <= std::numeric_limits<double>::epsilon())
+        << "Reference length of element " << rElement.Id() << ": ~0" << std::endl;
+
+    return L;
+
+    KRATOS_CATCH("")
+}
 
 double CalculateCurrentLength2D2N(const Element& rElement)
 {
     KRATOS_TRY;
 
-    const double numerical_limit = std::numeric_limits<double>::epsilon();
     const double du =
         rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
         rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
@@ -134,42 +148,26 @@ double CalculateCurrentLength2D2N(const Element& rElement)
 
     const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy));
 
-    KRATOS_ERROR_IF(l < numerical_limit)
-    << "Current length of element " << rElement.Id() << " ~0" << std::endl;
+    KRATOS_ERROR_IF(l <= std::numeric_limits<double>::epsilon())
+        << "Current length of element " << rElement.Id() << ": ~0" << std::endl;
+
     return l;
 
     KRATOS_CATCH("")
 }
 
-double CalculateReferenceLength2D2N(const Element& rElement)
-{
-    KRATOS_TRY;
-
-    const double numerical_limit = std::numeric_limits<double>::epsilon();
-    const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
-    const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
-    const double L = std::sqrt((dx * dx) + (dy * dy));
-
-    KRATOS_ERROR_IF(L < numerical_limit)
-    << "Reference length of element " << rElement.Id() << " ~0" << std::endl;
-    return L;
-
-    KRATOS_CATCH("")
-}
-
-
 double CalculateReferenceLength3D2N(const Element& rElement)
 {
     KRATOS_TRY;
 
-    const double numerical_limit = std::numeric_limits<double>::epsilon();
     const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
     const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
     const double dz = rElement.GetGeometry()[1].Z0() - rElement.GetGeometry()[0].Z0();
     const double L = std::sqrt(dx * dx + dy * dy + dz * dz);
 
-    KRATOS_ERROR_IF(L<=numerical_limit)
-    << "Reference length of element " << rElement.Id() << " ~0" << std::endl;
+    KRATOS_ERROR_IF(L <= std::numeric_limits<double>::epsilon())
+        << "Reference length of element " << rElement.Id() << ": ~0" << std::endl;
+
     return L;
 
     KRATOS_CATCH("")
@@ -179,7 +177,6 @@ double CalculateCurrentLength3D2N(const Element& rElement)
 {
     KRATOS_TRY;
 
-    const double numerical_limit = std::numeric_limits<double>::epsilon();
     const double du =
         rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
         rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
@@ -195,13 +192,13 @@ double CalculateCurrentLength3D2N(const Element& rElement)
     const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy) +
                                 (dw + dz) * (dw + dz));
 
-    KRATOS_ERROR_IF(l<=numerical_limit)
-    << "Current length of element " << rElement.Id() << " ~0" << std::endl;
+    KRATOS_ERROR_IF(l <= std::numeric_limits<double>::epsilon())
+        << "Current length of element " << rElement.Id() << ": ~0" << std::endl;
+
     return l;
 
     KRATOS_CATCH("")
 }
-
 
 } // namespace StructuralMechanicsElementUtilities.
 }  // namespace Kratos.

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -125,13 +125,8 @@ double CalculateReferenceLength2D2N(const Element& rElement)
         rElement.GetGeometry()[1].GetInitialPosition().Coordinates() -
         rElement.GetGeometry()[0].GetInitialPosition().Coordinates();
 
-    const double L = std::sqrt((delta_pos[0] * delta_pos[0]) +
-                               (delta_pos[1] * delta_pos[1]));
-
-    KRATOS_ERROR_IF(L <= std::numeric_limits<double>::epsilon())
-        << "Reference length of element " << rElement.Id() << ": ~0" << std::endl;
-
-    return L;
+    return std::sqrt((delta_pos[0] * delta_pos[0]) +
+                     (delta_pos[1] * delta_pos[1]));
 
     KRATOS_CATCH("")
 }
@@ -165,12 +160,7 @@ double CalculateReferenceLength3D2N(const Element& rElement)
         rElement.GetGeometry()[1].GetInitialPosition().Coordinates() -
         rElement.GetGeometry()[0].GetInitialPosition().Coordinates();
 
-    const double L = MathUtils<double>::Norm3(delta_pos);
-
-    KRATOS_ERROR_IF(L <= std::numeric_limits<double>::epsilon())
-        << "Reference length of element " << rElement.Id() << ": ~0" << std::endl;
-
-    return L;
+    return MathUtils<double>::Norm3(delta_pos);
 
     KRATOS_CATCH("")
 }

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -17,6 +17,7 @@
 // Project includes
 #include "structural_mechanics_element_utilities.h"
 #include "structural_mechanics_application_variables.h"
+#include "utilities/math_utils.h"
 
 namespace Kratos {
 namespace StructuralMechanicsElementUtilities {
@@ -120,9 +121,12 @@ double CalculateReferenceLength2D2N(const Element& rElement)
 {
     KRATOS_TRY;
 
-    const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
-    const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
-    const double L = std::sqrt((dx * dx) + (dy * dy));
+    const array_1d<double, 3> delta_pos =
+        rElement.GetGeometry()[1].GetInitialPosition().Coordinates() -
+        rElement.GetGeometry()[0].GetInitialPosition().Coordinates();
+
+    const double L = std::sqrt((delta_pos[0] * delta_pos[0]) +
+                               (delta_pos[1] * delta_pos[1]));
 
     KRATOS_ERROR_IF(L <= std::numeric_limits<double>::epsilon())
         << "Reference length of element " << rElement.Id() << ": ~0" << std::endl;
@@ -136,17 +140,14 @@ double CalculateCurrentLength2D2N(const Element& rElement)
 {
     KRATOS_TRY;
 
-    const double du =
-        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
-        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
-    const double dv =
-        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
-        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
+    const array_1d<double, 3> delta_pos =
+        rElement.GetGeometry()[1].GetInitialPosition().Coordinates() -
+        rElement.GetGeometry()[0].GetInitialPosition().Coordinates() +
+        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT) -
+        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT);
 
-    const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
-    const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
-
-    const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy));
+    const double l = std::sqrt((delta_pos[0] * delta_pos[0]) +
+                               (delta_pos[1] * delta_pos[1]));
 
     KRATOS_ERROR_IF(l <= std::numeric_limits<double>::epsilon())
         << "Current length of element " << rElement.Id() << ": ~0" << std::endl;
@@ -160,10 +161,11 @@ double CalculateReferenceLength3D2N(const Element& rElement)
 {
     KRATOS_TRY;
 
-    const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
-    const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
-    const double dz = rElement.GetGeometry()[1].Z0() - rElement.GetGeometry()[0].Z0();
-    const double L = std::sqrt(dx * dx + dy * dy + dz * dz);
+    const array_1d<double, 3> delta_pos =
+        rElement.GetGeometry()[1].GetInitialPosition().Coordinates() -
+        rElement.GetGeometry()[0].GetInitialPosition().Coordinates();
+
+    const double L = MathUtils<double>::Norm3(delta_pos);
 
     KRATOS_ERROR_IF(L <= std::numeric_limits<double>::epsilon())
         << "Reference length of element " << rElement.Id() << ": ~0" << std::endl;
@@ -177,20 +179,13 @@ double CalculateCurrentLength3D2N(const Element& rElement)
 {
     KRATOS_TRY;
 
-    const double du =
-        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
-        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
-    const double dv =
-        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
-        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
-    const double dw =
-        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Z) -
-        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Z);
-    const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
-    const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
-    const double dz = rElement.GetGeometry()[1].Z0() - rElement.GetGeometry()[0].Z0();
-    const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy) +
-                                (dw + dz) * (dw + dz));
+    const array_1d<double, 3> delta_pos =
+        rElement.GetGeometry()[1].GetInitialPosition().Coordinates() -
+        rElement.GetGeometry()[0].GetInitialPosition().Coordinates() +
+        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT) -
+        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT);
+
+    const double l = MathUtils<double>::Norm3(delta_pos);
 
     KRATOS_ERROR_IF(l <= std::numeric_limits<double>::epsilon())
         << "Current length of element " << rElement.Id() << ": ~0" << std::endl;

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -145,7 +145,7 @@ double CalculateCurrentLength2D2N(const Element& rElement)
                                (delta_pos[1] * delta_pos[1]));
 
     KRATOS_ERROR_IF(l <= std::numeric_limits<double>::epsilon())
-        << "Current length of element " << rElement.Id() << ": ~0" << std::endl;
+        << "Element #" << rElement.Id() << " has a current length of zero!" << std::endl;
 
     return l;
 
@@ -178,7 +178,7 @@ double CalculateCurrentLength3D2N(const Element& rElement)
     const double l = MathUtils<double>::Norm3(delta_pos);
 
     KRATOS_ERROR_IF(l <= std::numeric_limits<double>::epsilon())
-        << "Current length of element " << rElement.Id() << ": ~0" << std::endl;
+        << "Element #" << rElement.Id() << " has a current length of zero!" << std::endl;
 
     return l;
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -117,7 +117,42 @@ void CalculateRayleighDampingMatrix(
 }
 
 
-double CalculateReferenceLength(const Element& rElement) {
+double CalculateCurrentLength2D2N(const Element& rElement) {
+  KRATOS_TRY;
+  const double numerical_limit = std::numeric_limits<double>::epsilon();
+  const double du =
+      rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
+      rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
+  const double dv =
+      rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
+      rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
+
+  const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
+  const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
+
+  const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy));
+
+  KRATOS_ERROR_IF(l < numerical_limit) << "length 0 for element " << rElement.Id()
+                                       << std::endl;
+  return l;
+  KRATOS_CATCH("")
+}
+
+double CalculateReferenceLength2D2N(const Element& rElement) {
+  KRATOS_TRY;
+  const double numerical_limit = std::numeric_limits<double>::epsilon();
+  const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
+  const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
+  const double L = std::sqrt((dx * dx) + (dy * dy));
+
+  KRATOS_ERROR_IF(L < numerical_limit) << "length 0 for element " << rElement.Id()
+                                       << std::endl;
+  return L;
+  KRATOS_CATCH("")
+}
+
+
+double CalculateReferenceLength3D2N(const Element& rElement) {
 
   KRATOS_TRY;
   const double numerical_limit = std::numeric_limits<double>::epsilon();
@@ -132,7 +167,7 @@ double CalculateReferenceLength(const Element& rElement) {
   KRATOS_CATCH("")
 }
 
-double CalculateCurrentLength(const Element& rElement) {
+double CalculateCurrentLength3D2N(const Element& rElement) {
 
   KRATOS_TRY;
   const double numerical_limit = std::numeric_limits<double>::epsilon();

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -132,8 +132,8 @@ double CalculateCurrentLength2D2N(const Element& rElement) {
 
   const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy));
 
-  KRATOS_ERROR_IF(l < numerical_limit) << "length 0 for element " << rElement.Id()
-                                       << std::endl;
+  KRATOS_ERROR_IF(l < numerical_limit)
+   << "Current Length of element " << rElement.Id() << " ~0" << std::endl;
   return l;
   KRATOS_CATCH("")
 }
@@ -145,8 +145,8 @@ double CalculateReferenceLength2D2N(const Element& rElement) {
   const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
   const double L = std::sqrt((dx * dx) + (dy * dy));
 
-  KRATOS_ERROR_IF(L < numerical_limit) << "length 0 for element " << rElement.Id()
-                                       << std::endl;
+  KRATOS_ERROR_IF(L < numerical_limit)
+   << "Reference Length of element " << rElement.Id() << " ~0" << std::endl;
   return L;
   KRATOS_CATCH("")
 }
@@ -162,7 +162,7 @@ double CalculateReferenceLength3D2N(const Element& rElement) {
   const double L = std::sqrt(dx * dx + dy * dy + dz * dz);
 
   KRATOS_ERROR_IF(L<=numerical_limit)
-   << "Reference Length of element" << rElement.Id() << "~ 0" << std::endl;
+   << "Reference Length of element " << rElement.Id() << " ~0" << std::endl;
   return L;
   KRATOS_CATCH("")
 }
@@ -187,7 +187,7 @@ double CalculateCurrentLength3D2N(const Element& rElement) {
                              (dw + dz) * (dw + dz));
 
   KRATOS_ERROR_IF(l<=numerical_limit)
-   << "Current Length of element" << rElement.Id() << "~ 0" << std::endl;
+   << "Current Length of element " << rElement.Id() << " ~0" << std::endl;
   return l;
   KRATOS_CATCH("")
 }

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -116,6 +116,48 @@ void CalculateRayleighDampingMatrix(
     KRATOS_CATCH( "CalculateRayleighDampingMatrix" )
 }
 
+
+double CalculateReferenceLength(const Element& rElement) {
+
+  KRATOS_TRY;
+  const double numerical_limit = std::numeric_limits<double>::epsilon();
+  const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
+  const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
+  const double dz = rElement.GetGeometry()[1].Z0() - rElement.GetGeometry()[0].Z0();
+  const double L = std::sqrt(dx * dx + dy * dy + dz * dz);
+
+  KRATOS_ERROR_IF(L<=numerical_limit)
+   << "Reference Length of element" << rElement.Id() << "~ 0" << std::endl;
+  return L;
+  KRATOS_CATCH("")
+}
+
+double CalculateCurrentLength(const Element& rElement) {
+
+  KRATOS_TRY;
+  const double numerical_limit = std::numeric_limits<double>::epsilon();
+  const double du =
+      rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
+      rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
+  const double dv =
+      rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
+      rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
+  const double dw =
+      rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Z) -
+      rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Z);
+  const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
+  const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
+  const double dz = rElement.GetGeometry()[1].Z0() - rElement.GetGeometry()[0].Z0();
+  const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy) +
+                             (dw + dz) * (dw + dz));
+
+  KRATOS_ERROR_IF(l<=numerical_limit)
+   << "Current Length of element" << rElement.Id() << "~ 0" << std::endl;
+  return l;
+  KRATOS_CATCH("")
+}
+
+
 } // namespace StructuralMechanicsElementUtilities.
 }  // namespace Kratos.
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.cpp
@@ -117,79 +117,89 @@ void CalculateRayleighDampingMatrix(
 }
 
 
-double CalculateCurrentLength2D2N(const Element& rElement) {
-  KRATOS_TRY;
-  const double numerical_limit = std::numeric_limits<double>::epsilon();
-  const double du =
-      rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
-      rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
-  const double dv =
-      rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
-      rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
+double CalculateCurrentLength2D2N(const Element& rElement)
+{
+    KRATOS_TRY;
 
-  const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
-  const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
+    const double numerical_limit = std::numeric_limits<double>::epsilon();
+    const double du =
+        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
+        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
+    const double dv =
+        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
+        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
 
-  const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy));
+    const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
+    const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
 
-  KRATOS_ERROR_IF(l < numerical_limit)
-   << "Current length of element " << rElement.Id() << " ~0" << std::endl;
-  return l;
-  KRATOS_CATCH("")
+    const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy));
+
+    KRATOS_ERROR_IF(l < numerical_limit)
+    << "Current length of element " << rElement.Id() << " ~0" << std::endl;
+    return l;
+
+    KRATOS_CATCH("")
 }
 
-double CalculateReferenceLength2D2N(const Element& rElement) {
-  KRATOS_TRY;
-  const double numerical_limit = std::numeric_limits<double>::epsilon();
-  const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
-  const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
-  const double L = std::sqrt((dx * dx) + (dy * dy));
+double CalculateReferenceLength2D2N(const Element& rElement)
+{
+    KRATOS_TRY;
 
-  KRATOS_ERROR_IF(L < numerical_limit)
-   << "Reference length of element " << rElement.Id() << " ~0" << std::endl;
-  return L;
-  KRATOS_CATCH("")
+    const double numerical_limit = std::numeric_limits<double>::epsilon();
+    const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
+    const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
+    const double L = std::sqrt((dx * dx) + (dy * dy));
+
+    KRATOS_ERROR_IF(L < numerical_limit)
+    << "Reference length of element " << rElement.Id() << " ~0" << std::endl;
+    return L;
+
+    KRATOS_CATCH("")
 }
 
 
-double CalculateReferenceLength3D2N(const Element& rElement) {
+double CalculateReferenceLength3D2N(const Element& rElement)
+{
+    KRATOS_TRY;
 
-  KRATOS_TRY;
-  const double numerical_limit = std::numeric_limits<double>::epsilon();
-  const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
-  const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
-  const double dz = rElement.GetGeometry()[1].Z0() - rElement.GetGeometry()[0].Z0();
-  const double L = std::sqrt(dx * dx + dy * dy + dz * dz);
+    const double numerical_limit = std::numeric_limits<double>::epsilon();
+    const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
+    const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
+    const double dz = rElement.GetGeometry()[1].Z0() - rElement.GetGeometry()[0].Z0();
+    const double L = std::sqrt(dx * dx + dy * dy + dz * dz);
 
-  KRATOS_ERROR_IF(L<=numerical_limit)
-   << "Reference length of element " << rElement.Id() << " ~0" << std::endl;
-  return L;
-  KRATOS_CATCH("")
+    KRATOS_ERROR_IF(L<=numerical_limit)
+    << "Reference length of element " << rElement.Id() << " ~0" << std::endl;
+    return L;
+
+    KRATOS_CATCH("")
 }
 
-double CalculateCurrentLength3D2N(const Element& rElement) {
+double CalculateCurrentLength3D2N(const Element& rElement)
+{
+    KRATOS_TRY;
 
-  KRATOS_TRY;
-  const double numerical_limit = std::numeric_limits<double>::epsilon();
-  const double du =
-      rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
-      rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
-  const double dv =
-      rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
-      rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
-  const double dw =
-      rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Z) -
-      rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Z);
-  const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
-  const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
-  const double dz = rElement.GetGeometry()[1].Z0() - rElement.GetGeometry()[0].Z0();
-  const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy) +
-                             (dw + dz) * (dw + dz));
+    const double numerical_limit = std::numeric_limits<double>::epsilon();
+    const double du =
+        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_X) -
+        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_X);
+    const double dv =
+        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Y) -
+        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Y);
+    const double dw =
+        rElement.GetGeometry()[1].FastGetSolutionStepValue(DISPLACEMENT_Z) -
+        rElement.GetGeometry()[0].FastGetSolutionStepValue(DISPLACEMENT_Z);
+    const double dx = rElement.GetGeometry()[1].X0() - rElement.GetGeometry()[0].X0();
+    const double dy = rElement.GetGeometry()[1].Y0() - rElement.GetGeometry()[0].Y0();
+    const double dz = rElement.GetGeometry()[1].Z0() - rElement.GetGeometry()[0].Z0();
+    const double l = std::sqrt((du + dx) * (du + dx) + (dv + dy) * (dv + dy) +
+                                (dw + dz) * (dw + dz));
 
-  KRATOS_ERROR_IF(l<=numerical_limit)
-   << "Current length of element " << rElement.Id() << " ~0" << std::endl;
-  return l;
-  KRATOS_CATCH("")
+    KRATOS_ERROR_IF(l<=numerical_limit)
+    << "Current length of element " << rElement.Id() << " ~0" << std::endl;
+    return l;
+
+    KRATOS_CATCH("")
 }
 
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
@@ -76,6 +76,20 @@ void CalculateRayleighDampingMatrix(
     /*const*/ ProcessInfo& rCurrentProcessInfo,
     const std::size_t MatrixSize);
 
+/**
+ * @brief This function calculates the reference length for 3D2N elements
+ * @param rElement The Element for which the reference length should be computed
+ * @return reference length
+ */
+double CalculateReferenceLength(const Element& rElement);
+
+/**
+ * @brief This function calculates the current length for 3D2N elements
+ * @param rElement The Element for which the current length should be computed
+ * @return current length
+ */
+double CalculateCurrentLength(const Element& rElement);
+
 } // namespace StructuralMechanicsElementUtilities.
 }  // namespace Kratos.
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/structural_mechanics_element_utilities.h
@@ -77,18 +77,32 @@ void CalculateRayleighDampingMatrix(
     const std::size_t MatrixSize);
 
 /**
+ * @brief This function calculates the reference length for 2D2N elements
+ * @param rElement The Element for which the reference length should be computed
+ * @return reference length
+ */
+double CalculateReferenceLength2D2N(const Element& rElement);
+
+/**
+ * @brief This function calculates the current length for 2D2N elements
+ * @param rElement The Element for which the current length should be computed
+ * @return current length
+ */
+double CalculateCurrentLength2D2N(const Element& rElement);
+
+/**
  * @brief This function calculates the reference length for 3D2N elements
  * @param rElement The Element for which the reference length should be computed
  * @return reference length
  */
-double CalculateReferenceLength(const Element& rElement);
+double CalculateReferenceLength3D2N(const Element& rElement);
 
 /**
  * @brief This function calculates the current length for 3D2N elements
  * @param rElement The Element for which the current length should be computed
  * @return current length
  */
-double CalculateCurrentLength(const Element& rElement);
+double CalculateCurrentLength3D2N(const Element& rElement);
 
 } // namespace StructuralMechanicsElementUtilities.
 }  // namespace Kratos.

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
@@ -98,56 +98,50 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateElementLength, KratosStructuralMechanicsFastS
     Model current_model;
 
     // Generate a model part with the previous
-    ModelPart& model_part = current_model.CreateModelPart("Tetrahedra");
+    ModelPart& model_part = current_model.CreateModelPart("test_model_part");
     model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
 
     // Fill the model part geometry data
     model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-    model_part.CreateNewNode(2, 1.0, 1.0, 1.0);
+    auto p_node_2 = model_part.CreateNewNode(2, 1.0, 1.0, 1.0);
     model_part.CreateNewNode(3, 0.0, 0.0, 0.0);
 
-
-    // Set the DISTANCE field
-    model_part.Nodes()[2].FastGetSolutionStepValue(DISPLACEMENT_X) = 1.0;
-    model_part.Nodes()[2].FastGetSolutionStepValue(DISPLACEMENT_Y) = 1.0;
-    model_part.Nodes()[2].FastGetSolutionStepValue(DISPLACEMENT_Z) = 1.0;
+    // Set the DISPLACEMENT
+    p_node_2->FastGetSolutionStepValue(DISPLACEMENT_X) = 1.0;
+    p_node_2->FastGetSolutionStepValue(DISPLACEMENT_Y) = 1.0;
+    p_node_2->FastGetSolutionStepValue(DISPLACEMENT_Z) = 1.0;
 
     Properties::Pointer p_properties(new Properties(0));
-    std::vector<ModelPart::IndexType> nodes1{1,2};
-    std::vector<ModelPart::IndexType> nodes2{1,3};
-    model_part.CreateNewElement("Element3D2N", 1, nodes1, p_properties);
-    model_part.CreateNewElement("Element3D2N", 2, nodes2, p_properties);
-    model_part.CreateNewElement("Element2D2N", 3, nodes1, p_properties);
-    model_part.CreateNewElement("Element2D2N", 4, nodes2, p_properties);
-
+    const std::vector<ModelPart::IndexType> nodes1{1,2};
+    const std::vector<ModelPart::IndexType> nodes2{1,3};
+    auto p_element_1 = model_part.CreateNewElement("Element3D2N", 1, nodes1, p_properties);
+    auto p_element_2 = model_part.CreateNewElement("Element3D2N", 2, nodes2, p_properties);
+    auto p_element_3 = model_part.CreateNewElement("Element2D2N", 3, nodes1, p_properties);
+    auto p_element_4 = model_part.CreateNewElement("Element2D2N", 4, nodes2, p_properties);
 
     // length 3D
-    Element& r_element_1 = model_part.GetElement(1);
-    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(r_element_1), sqrt(3.0));
-    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(r_element_1), sqrt(12.0));
+    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*p_element_1), std::sqrt(3.0));
+    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*p_element_1), std::sqrt(12.0));
 
     // 0 length throws ERROR  3D
-    Element& r_element_2 = model_part.GetElement(2);
     KRATOS_CHECK_EXCEPTION_IS_THROWN(
-        StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(r_element_2),
-        "Error: Reference length of element 2 ~0");
+        StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*p_element_2),
+        "Error: Reference length of element 2: ~0");
     KRATOS_CHECK_EXCEPTION_IS_THROWN(
-        StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(r_element_2),
-        "Error: Current length of element 2 ~0");
+        StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*p_element_2),
+        "Error: Current length of element 2: ~0");
 
     // length 2D
-    Element& r_element_3 = model_part.GetElement(3);
-    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(r_element_3), sqrt(2.0));
-    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateCurrentLength2D2N(r_element_3), sqrt(8.0));
+    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(*p_element_3), std::sqrt(2.0));
+    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateCurrentLength2D2N(*p_element_3), std::sqrt(8.0));
 
     // 0 length throws ERROR 2D
-    Element& r_element_4 = model_part.GetElement(4);
     KRATOS_CHECK_EXCEPTION_IS_THROWN(
-        StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(r_element_4),
-        "Error: Reference length of element 4 ~0");
+        StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(*p_element_4),
+        "Error: Reference length of element 4: ~0");
     KRATOS_CHECK_EXCEPTION_IS_THROWN(
-        StructuralMechanicsElementUtilities::CalculateCurrentLength2D2N(r_element_4),
-        "Error: Current length of element 4 ~0");
+        StructuralMechanicsElementUtilities::CalculateCurrentLength2D2N(*p_element_4),
+        "Error: Current length of element 4: ~0");
 }
 
 } // namespace Testing

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
@@ -130,9 +130,6 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateElementLength, KratosStructuralMechanicsFastS
 
     // 0 length throws ERROR  3D
     KRATOS_CHECK_EXCEPTION_IS_THROWN(
-        StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*p_element_2),
-        "Error: Reference length of element 2: ~0");
-    KRATOS_CHECK_EXCEPTION_IS_THROWN(
         StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*p_element_2),
         "Error: Current length of element 2: ~0");
 
@@ -141,9 +138,6 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateElementLength, KratosStructuralMechanicsFastS
     KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateCurrentLength2D2N(*p_element_3), std::sqrt(8.0));
 
     // 0 length throws ERROR 2D
-    KRATOS_CHECK_EXCEPTION_IS_THROWN(
-        StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(*p_element_4),
-        "Error: Reference length of element 4: ~0");
     KRATOS_CHECK_EXCEPTION_IS_THROWN(
         StructuralMechanicsElementUtilities::CalculateCurrentLength2D2N(*p_element_4),
         "Error: Current length of element 4: ~0");

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
@@ -131,7 +131,7 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateElementLength, KratosStructuralMechanicsFastS
     // 0 length throws ERROR  3D
     KRATOS_CHECK_EXCEPTION_IS_THROWN(
         StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*p_element_2),
-        "Error: Current length of element 2: ~0");
+        "Error: Element #2 has a current length of zero!");
 
     // length 2D
     KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(*p_element_3), std::sqrt(2.0));
@@ -140,7 +140,7 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateElementLength, KratosStructuralMechanicsFastS
     // 0 length throws ERROR 2D
     KRATOS_CHECK_EXCEPTION_IS_THROWN(
         StructuralMechanicsElementUtilities::CalculateCurrentLength2D2N(*p_element_4),
-        "Error: Current length of element 4: ~0");
+        "Error: Element #4 has a current length of zero!");
 }
 
 } // namespace Testing

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
@@ -106,6 +106,11 @@ KRATOS_TEST_CASE_IN_SUITE(CalculateElementLength, KratosStructuralMechanicsFastS
     auto p_node_2 = model_part.CreateNewNode(2, 1.0, 1.0, 1.0);
     model_part.CreateNewNode(3, 0.0, 0.0, 0.0);
 
+    // Set the updated node-position (due to MOVE-MESH)
+    p_node_2->X() = 0.5;
+    p_node_2->Y() = 0.5;
+    p_node_2->Z() = 0.5;
+
     // Set the DISPLACEMENT
     p_node_2->FastGetSolutionStepValue(DISPLACEMENT_X) = 1.0;
     p_node_2->FastGetSolutionStepValue(DISPLACEMENT_Y) = 1.0;

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_structural_mechanics_element_utilities.cpp
@@ -17,6 +17,7 @@
 #include "testing/testing.h"
 #include "custom_utilities/structural_mechanics_element_utilities.h"
 #include "structural_mechanics_application_variables.h"
+#include "containers/model.h"
 
 namespace Kratos {
 namespace Testing {
@@ -89,6 +90,64 @@ KRATOS_TEST_CASE_IN_SUITE(RayleighDampingSelection, KratosStructuralMechanicsFas
 
     const double beta_1 = StructuralMechanicsElementUtilities::GetRayleighBeta(aux_props_2, aux_process_info_2);
     KRATOS_CHECK_DOUBLE_EQUAL(val_beta, beta_1);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(CalculateElementLength, KratosStructuralMechanicsFastSuite)
+{
+    // create model part
+    Model current_model;
+
+    // Generate a model part with the previous
+    ModelPart& model_part = current_model.CreateModelPart("Tetrahedra");
+    model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+
+    // Fill the model part geometry data
+    model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    model_part.CreateNewNode(2, 1.0, 1.0, 1.0);
+    model_part.CreateNewNode(3, 0.0, 0.0, 0.0);
+
+
+    // Set the DISTANCE field
+    model_part.Nodes()[2].FastGetSolutionStepValue(DISPLACEMENT_X) = 1.0;
+    model_part.Nodes()[2].FastGetSolutionStepValue(DISPLACEMENT_Y) = 1.0;
+    model_part.Nodes()[2].FastGetSolutionStepValue(DISPLACEMENT_Z) = 1.0;
+
+    Properties::Pointer p_properties(new Properties(0));
+    std::vector<ModelPart::IndexType> nodes1{1,2};
+    std::vector<ModelPart::IndexType> nodes2{1,3};
+    model_part.CreateNewElement("Element3D2N", 1, nodes1, p_properties);
+    model_part.CreateNewElement("Element3D2N", 2, nodes2, p_properties);
+    model_part.CreateNewElement("Element2D2N", 3, nodes1, p_properties);
+    model_part.CreateNewElement("Element2D2N", 4, nodes2, p_properties);
+
+
+    // length 3D
+    Element& r_element_1 = model_part.GetElement(1);
+    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(r_element_1), sqrt(3.0));
+    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(r_element_1), sqrt(12.0));
+
+    // 0 length throws ERROR  3D
+    Element& r_element_2 = model_part.GetElement(2);
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(r_element_2),
+        "Error: Reference length of element 2 ~0");
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(r_element_2),
+        "Error: Current length of element 2 ~0");
+
+    // length 2D
+    Element& r_element_3 = model_part.GetElement(3);
+    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(r_element_3), sqrt(2.0));
+    KRATOS_CHECK_DOUBLE_EQUAL(StructuralMechanicsElementUtilities::CalculateCurrentLength2D2N(r_element_3), sqrt(8.0));
+
+    // 0 length throws ERROR 2D
+    Element& r_element_4 = model_part.GetElement(4);
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        StructuralMechanicsElementUtilities::CalculateReferenceLength2D2N(r_element_4),
+        "Error: Reference length of element 4 ~0");
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        StructuralMechanicsElementUtilities::CalculateCurrentLength2D2N(r_element_4),
+        "Error: Current length of element 4 ~0");
 }
 
 } // namespace Testing


### PR DESCRIPTION
The length calculation is moved to element utilities, where it can be used by several elements.

@philbucher i could reuse this function now also in the beam elements, what do you think?
The only difference that currently in the beam functions there is no check for `l==0`.

Part of #3727