### PR TITLE
[Fluid] New temperature dependent Newtonian laws

### DIFF
--- a/applications/FluidDynamicsApplication/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/CMakeLists.txt
@@ -63,6 +63,7 @@ set( KRATOS_FLUID_DYNAMICS_APPLICATION_CORE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/euler_3d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_2d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_temperature_dependent_2d_law.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_temperature_dependent_3d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_3d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_two_fluid_2d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_two_fluid_3d_law.cpp

--- a/applications/FluidDynamicsApplication/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/CMakeLists.txt
@@ -62,6 +62,7 @@ set( KRATOS_FLUID_DYNAMICS_APPLICATION_CORE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/euler_2d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/euler_3d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_2d_law.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_temperature_dependent_2d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_3d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_two_fluid_2d_law.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/newtonian_two_fluid_3d_law.cpp
@@ -138,4 +139,3 @@ if(${INSTALL_TESTING_FILES} MATCHES ON)
   get_filename_component (CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
   install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests DESTINATION applications/${CURRENT_DIR_NAME} FILES_MATCHING PATTERN "*.py" PATTERN  "*.json" PATTERN "*.mdpa" PATTERN ".svn" EXCLUDE)
 endif(${INSTALL_TESTING_FILES} MATCHES ON)
-

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_2d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_2d_law.cpp
@@ -84,12 +84,12 @@ int Newtonian2DLaw::Check(
     const GeometryType& rElementGeometry,
     const ProcessInfo& rCurrentProcessInfo)
 {
+    // Check DYNAMIC_VISCOSITY variable
     KRATOS_CHECK_VARIABLE_KEY(DYNAMIC_VISCOSITY);
 
-    // If the viscosity is not table provided, check its value
-    if (rMaterialProperties[DYNAMIC_VISCOSITY] <= 0.0) {
-        KRATOS_ERROR << "Incorrect or missing DYNAMIC_VISCOSITY provided in process info for Newtonian2DLaw: " << rMaterialProperties[DYNAMIC_VISCOSITY] << std::endl;
-    }
+    // Check viscosity value
+    KRATOS_ERROR_IF(rMaterialProperties[DYNAMIC_VISCOSITY] <= 0.0)
+        << "Incorrect or missing DYNAMIC_VISCOSITY provided in process info for Newtonian2DLaw: " << rMaterialProperties[DYNAMIC_VISCOSITY] << std::endl;
 
     return 0;
 }

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_2d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_2d_law.cpp
@@ -58,7 +58,7 @@ ConstitutiveLaw::SizeType Newtonian2DLaw::GetStrainSize() {
 }
 
 void  Newtonian2DLaw::CalculateMaterialResponseCauchy(Parameters& rValues)
-{    
+{
     const Flags& options = rValues.GetOptions();
     const Vector& r_strain_rate = rValues.GetStrainVector();
     Vector& r_viscous_stress = rValues.GetStressVector();
@@ -87,10 +87,8 @@ int Newtonian2DLaw::Check(
     KRATOS_CHECK_VARIABLE_KEY(DYNAMIC_VISCOSITY);
 
     // If the viscosity is not table provided, check its value
-    if (!rMaterialProperties.HasTable(TEMPERATURE, DYNAMIC_VISCOSITY)) {
-        if (rMaterialProperties[DYNAMIC_VISCOSITY] <= 0.0) {
-            KRATOS_ERROR << "Incorrect or missing DYNAMIC_VISCOSITY provided in process info for Newtonian2DLaw: " << rMaterialProperties[DYNAMIC_VISCOSITY] << std::endl;
-        }
+    if (rMaterialProperties[DYNAMIC_VISCOSITY] <= 0.0) {
+        KRATOS_ERROR << "Incorrect or missing DYNAMIC_VISCOSITY provided in process info for Newtonian2DLaw: " << rMaterialProperties[DYNAMIC_VISCOSITY] << std::endl;
     }
 
     return 0;
@@ -102,17 +100,8 @@ std::string Newtonian2DLaw::Info() const {
 
 double Newtonian2DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters& rParameters) const
 {
-    double effective_viscosity;
     const Properties &r_prop = rParameters.GetMaterialProperties();
-
-    if (r_prop.HasTable(TEMPERATURE, DYNAMIC_VISCOSITY)) {
-        // Temperature dependent viscosity
-        effective_viscosity = this->GetValueFromTable(TEMPERATURE, DYNAMIC_VISCOSITY, rParameters);
-    } else {
-        // Constant viscosity value
-        effective_viscosity = r_prop[DYNAMIC_VISCOSITY];
-    }
-
+    const double effective_viscosity = r_prop[DYNAMIC_VISCOSITY];
     return effective_viscosity;
 }
 

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_3d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_3d_law.cpp
@@ -58,7 +58,7 @@ ConstitutiveLaw::SizeType Newtonian3DLaw::GetStrainSize() {
 }
 
 void  Newtonian3DLaw::CalculateMaterialResponseCauchy (Parameters& rValues)
-{    
+{
     const Flags& options = rValues.GetOptions();
     const Vector& r_strain_rate = rValues.GetStrainVector();
     Vector& r_viscous_stress = rValues.GetStressVector();
@@ -87,14 +87,12 @@ int Newtonian3DLaw::Check(
     const GeometryType& rElementGeometry,
     const ProcessInfo& rCurrentProcessInfo)
 {
+    // Check DYNAMIC_VISCOSITY variable
     KRATOS_CHECK_VARIABLE_KEY(DYNAMIC_VISCOSITY);
 
-    // If the viscosity is not table provided, check its value
-    if (!rMaterialProperties.HasTable(TEMPERATURE, DYNAMIC_VISCOSITY)) {
-        if (rMaterialProperties[DYNAMIC_VISCOSITY] <= 0.0) {
-            KRATOS_ERROR << "Incorrect or missing DYNAMIC_VISCOSITY provided in process info for Newtonian2DLaw: " << rMaterialProperties[DYNAMIC_VISCOSITY] << std::endl;
-        }
-    }
+    // Check viscosity value
+    KRATOS_ERROR_IF(rMaterialProperties[DYNAMIC_VISCOSITY] <= 0.0)
+        << "Incorrect or missing DYNAMIC_VISCOSITY provided in process info for Newtonian2DLaw: " << rMaterialProperties[DYNAMIC_VISCOSITY] << std::endl;
 
     return 0;
 }
@@ -105,17 +103,8 @@ std::string Newtonian3DLaw::Info() const {
 
 double Newtonian3DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters& rParameters) const
 {
-    double effective_viscosity;
     const Properties &r_prop = rParameters.GetMaterialProperties();
-
-    if (r_prop.HasTable(TEMPERATURE, DYNAMIC_VISCOSITY)) {
-        // Temperature dependent viscosity
-        effective_viscosity = this->GetValueFromTable(TEMPERATURE, DYNAMIC_VISCOSITY, rParameters);
-    } else {
-        // Constant viscosity value
-        effective_viscosity = r_prop[DYNAMIC_VISCOSITY];
-    }
-
+    const double effective_viscosity = r_prop[DYNAMIC_VISCOSITY];
     return effective_viscosity;
 }
 

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_temperature_dependent_2d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_temperature_dependent_2d_law.cpp
@@ -1,0 +1,85 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+// System includes
+#include <iostream>
+
+// External includes
+
+// Project includes
+#include "includes/cfd_variables.h"
+#include "includes/checks.h"
+#include "custom_constitutive/newtonian_temperature_dependent_2d_law.h"
+
+namespace Kratos
+{
+
+//******************************CONSTRUCTOR*******************************************
+//************************************************************************************
+
+NewtonianTemperatureDependent2DLaw::NewtonianTemperatureDependent2DLaw()
+    : Newtonian2DLaw()
+{}
+
+//******************************COPY CONSTRUCTOR**************************************
+//************************************************************************************
+
+NewtonianTemperatureDependent2DLaw::NewtonianTemperatureDependent2DLaw(const NewtonianTemperatureDependent2DLaw& rOther)
+    : Newtonian2DLaw(rOther)
+{}
+
+//********************************CLONE***********************************************
+//************************************************************************************
+
+ConstitutiveLaw::Pointer NewtonianTemperatureDependent2DLaw::Clone() const {
+    return Kratos::make_shared<NewtonianTemperatureDependent2DLaw>(*this);
+}
+
+//*******************************DESTRUCTOR*******************************************
+//************************************************************************************
+
+NewtonianTemperatureDependent2DLaw::~NewtonianTemperatureDependent2DLaw() {}
+
+int NewtonianTemperatureDependent2DLaw::Check(
+    const Properties& rMaterialProperties,
+    const GeometryType& rElementGeometry,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_CHECK_VARIABLE_KEY(DYNAMIC_VISCOSITY);
+
+    // If the viscosity is not table provided, check its value
+    if (!rMaterialProperties.HasTable(TEMPERATURE, DYNAMIC_VISCOSITY)) {
+        KRATOS_ERROR << "TEMPERATURE - DYNAMICS_VISCOSITY table is missing in NewtonianTemperatureDependent2DLaw" << std::endl;
+    }
+
+    return 0;
+}
+
+std::string NewtonianTemperatureDependent2DLaw::Info() const {
+    return "NewtonianTemperatureDependent2DLaw";
+}
+
+double NewtonianTemperatureDependent2DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters &rParameters) const
+{
+    const double effective_viscosity = this->GetValueFromTable(TEMPERATURE, DYNAMIC_VISCOSITY, rParameters);
+    return effective_viscosity;
+}
+
+void NewtonianTemperatureDependent2DLaw::save(Serializer& rSerializer) const {
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Newtonian2DLaw )
+}
+
+void NewtonianTemperatureDependent2DLaw::load(Serializer& rSerializer) {
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Newtonian2DLaw )
+}
+
+} // Namespace Kratos

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_temperature_dependent_2d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_temperature_dependent_2d_law.h
@@ -1,0 +1,147 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#if !defined (KRATOS_NEWTONIAN_TEMPERATURE_DEPENDENT_LAW_2D_H_INCLUDED)
+#define  KRATOS_NEWTONIAN_TEMPERATURE_DEPENDENT_LAW_2D_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "newtonian_2d_law.h"
+
+namespace Kratos
+{
+/**
+ * Defines a Newtonian constitutive law for 2D
+ * This material law is defined by the parameters:
+ * 1) DYNAMIC_VISCOSITY
+ */
+
+class KRATOS_API(FLUID_DYNAMICS_APPLICATION) NewtonianTemperatureDependent2DLaw : public Newtonian2DLaw
+{
+public:
+    /**
+     * Type Definitions
+     */
+    typedef ProcessInfo      ProcessInfoType;
+    typedef ConstitutiveLaw         BaseType;
+    typedef std::size_t             SizeType;
+    /**
+     * Counted pointer of Newtonian3DLaw
+     */
+
+    KRATOS_CLASS_POINTER_DEFINITION(NewtonianTemperatureDependent2DLaw);
+
+    /**
+     * Life Cycle
+     */
+
+    /**
+     * Default constructor.
+     */
+    NewtonianTemperatureDependent2DLaw();
+
+    /**
+     * Clone function (has to be implemented by any derived class)
+     * @return a pointer to a new instance of this constitutive law
+     */
+    ConstitutiveLaw::Pointer Clone() const override;
+
+    /**
+     * Copy constructor.
+     */
+    NewtonianTemperatureDependent2DLaw (const NewtonianTemperatureDependent2DLaw& rOther);
+
+    /**
+     * Destructor.
+     */
+    ~NewtonianTemperatureDependent2DLaw() override;
+
+    /**
+     * This function is designed to be called once to perform all the checks needed
+     * on the input provided. Checks can be "expensive" as the function is designed
+     * to catch user's errors.
+     * @param rMaterialProperties
+     * @param rElementGeometry
+     * @param rCurrentProcessInfo
+     * @return
+     */
+    int Check(const Properties& rMaterialProperties, const GeometryType& rElementGeometry, const ProcessInfo& rCurrentProcessInfo) override;
+
+    /**
+     * Input and output
+     */
+    /**
+     * Turn back information as a string.
+     */
+    std::string Info() const override;
+
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+    double GetEffectiveViscosity(ConstitutiveLaw::Parameters &rParameters) const override;
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    ///@}
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Serialization
+    ///@{
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override;
+
+    void load(Serializer& rSerializer) override;
+    ///@}
+}; // Class NewtonianTemperatureDependent2DLaw
+}  // namespace Kratos.
+#endif // KRATOS_NEWTONIAN_TEMPERATURE_DEPENDENT_LAW_2D_H_INCLUDED  defined

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_temperature_dependent_3d_law.cpp
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_temperature_dependent_3d_law.cpp
@@ -20,7 +20,7 @@
 #include "includes/cfd_variables.h"
 
 // Application includes
-#include "custom_constitutive/newtonian_temperature_dependent_2d_law.h"
+#include "custom_constitutive/newtonian_temperature_dependent_3d_law.h"
 
 namespace Kratos
 {
@@ -28,32 +28,32 @@ namespace Kratos
 //******************************CONSTRUCTOR*******************************************
 //************************************************************************************
 
-NewtonianTemperatureDependent2DLaw::NewtonianTemperatureDependent2DLaw()
-    : Newtonian2DLaw()
+NewtonianTemperatureDependent3DLaw::NewtonianTemperatureDependent3DLaw()
+    : Newtonian3DLaw()
 {}
 
 //******************************COPY CONSTRUCTOR**************************************
 //************************************************************************************
 
-NewtonianTemperatureDependent2DLaw::NewtonianTemperatureDependent2DLaw(const NewtonianTemperatureDependent2DLaw& rOther)
-    : Newtonian2DLaw(rOther)
+NewtonianTemperatureDependent3DLaw::NewtonianTemperatureDependent3DLaw(const NewtonianTemperatureDependent3DLaw& rOther)
+    : Newtonian3DLaw(rOther)
 {}
 
 //********************************CLONE***********************************************
 //************************************************************************************
 
-ConstitutiveLaw::Pointer NewtonianTemperatureDependent2DLaw::Clone() const
+ConstitutiveLaw::Pointer NewtonianTemperatureDependent3DLaw::Clone() const
 {
-    return Kratos::make_shared<NewtonianTemperatureDependent2DLaw>(*this);
+    return Kratos::make_shared<NewtonianTemperatureDependent3DLaw>(*this);
 }
 
 //*******************************DESTRUCTOR*******************************************
 //************************************************************************************
 
-NewtonianTemperatureDependent2DLaw::~NewtonianTemperatureDependent2DLaw()
+NewtonianTemperatureDependent3DLaw::~NewtonianTemperatureDependent3DLaw()
 {}
 
-int NewtonianTemperatureDependent2DLaw::Check(
+int NewtonianTemperatureDependent3DLaw::Check(
     const Properties& rMaterialProperties,
     const GeometryType& rElementGeometry,
     const ProcessInfo& rCurrentProcessInfo)
@@ -62,31 +62,31 @@ int NewtonianTemperatureDependent2DLaw::Check(
 
     // If the viscosity is not table provided, check its value
     if (!rMaterialProperties.HasTable(TEMPERATURE, DYNAMIC_VISCOSITY)) {
-        KRATOS_ERROR << "TEMPERATURE - DYNAMICS_VISCOSITY table is missing in NewtonianTemperatureDependent2DLaw" << std::endl;
+        KRATOS_ERROR << "TEMPERATURE - DYNAMICS_VISCOSITY table is missing in NewtonianTemperatureDependent3DLaw" << std::endl;
     }
 
     return 0;
 }
 
-std::string NewtonianTemperatureDependent2DLaw::Info() const
+std::string NewtonianTemperatureDependent3DLaw::Info() const
 {
-    return "NewtonianTemperatureDependent2DLaw";
+    return "NewtonianTemperatureDependent3DLaw";
 }
 
-double NewtonianTemperatureDependent2DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters &rParameters) const
+double NewtonianTemperatureDependent3DLaw::GetEffectiveViscosity(ConstitutiveLaw::Parameters &rParameters) const
 {
     const double effective_viscosity = this->GetValueFromTable(TEMPERATURE, DYNAMIC_VISCOSITY, rParameters);
     return effective_viscosity;
 }
 
-void NewtonianTemperatureDependent2DLaw::save(Serializer& rSerializer) const
+void NewtonianTemperatureDependent3DLaw::save(Serializer& rSerializer) const
 {
-    KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Newtonian2DLaw )
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Newtonian3DLaw )
 }
 
-void NewtonianTemperatureDependent2DLaw::load(Serializer& rSerializer)
+void NewtonianTemperatureDependent3DLaw::load(Serializer& rSerializer)
 {
-    KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Newtonian2DLaw )
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Newtonian3DLaw )
 }
 
 } // Namespace Kratos

--- a/applications/FluidDynamicsApplication/custom_constitutive/newtonian_temperature_dependent_3d_law.h
+++ b/applications/FluidDynamicsApplication/custom_constitutive/newtonian_temperature_dependent_3d_law.h
@@ -10,25 +10,26 @@
 //  Main authors:    Ruben Zorrilla
 //
 
-#if !defined (KRATOS_NEWTONIAN_TEMPERATURE_DEPENDENT_LAW_2D_H_INCLUDED)
-#define  KRATOS_NEWTONIAN_TEMPERATURE_DEPENDENT_LAW_2D_H_INCLUDED
+#if !defined (KRATOS_NEWTONIAN_TEMPERATURE_DEPENDENT_LAW_3D_H_INCLUDED)
+#define  KRATOS_NEWTONIAN_TEMPERATURE_DEPENDENT_LAW_3D_H_INCLUDED
 
 // System includes
 
 // External includes
 
 // Project includes
-#include "newtonian_2d_law.h"
+#include "newtonian_3d_law.h"
 
 namespace Kratos
 {
+
 /**
- * Defines a Newtonian constitutive law for 2D
+ * Defines a Newtonian constitutive law in 3D.
  * This material law is defined by the parameters:
  * 1) DYNAMIC_VISCOSITY
  */
+class KRATOS_API(FLUID_DYNAMICS_APPLICATION) NewtonianTemperatureDependent3DLaw : public Newtonian3DLaw
 
-class KRATOS_API(FLUID_DYNAMICS_APPLICATION) NewtonianTemperatureDependent2DLaw : public Newtonian2DLaw
 {
 public:
     /**
@@ -38,10 +39,10 @@ public:
     typedef std::size_t             SizeType;
 
     /**
-     * Counted pointer of Newtonian3DLaw
+     * Counted pointer of NewtonianTemperatureDependent3DLaw
      */
 
-    KRATOS_CLASS_POINTER_DEFINITION(NewtonianTemperatureDependent2DLaw);
+    KRATOS_CLASS_POINTER_DEFINITION(NewtonianTemperatureDependent3DLaw);
 
     /**
      * Life Cycle
@@ -50,7 +51,7 @@ public:
     /**
      * Default constructor.
      */
-    NewtonianTemperatureDependent2DLaw();
+    NewtonianTemperatureDependent3DLaw();
 
     /**
      * Clone function (has to be implemented by any derived class)
@@ -61,12 +62,17 @@ public:
     /**
      * Copy constructor.
      */
-    NewtonianTemperatureDependent2DLaw (const NewtonianTemperatureDependent2DLaw& rOther);
+    NewtonianTemperatureDependent3DLaw (const NewtonianTemperatureDependent3DLaw& rOther);
+
 
     /**
      * Destructor.
      */
-    ~NewtonianTemperatureDependent2DLaw() override;
+    ~NewtonianTemperatureDependent3DLaw() override;
+
+    /**
+     * Operations needed by the base class:
+     */
 
     /**
      * This function is designed to be called once to perform all the checks needed
@@ -85,6 +91,7 @@ public:
     /**
      * Input and output
      */
+
     /**
      * Turn back information as a string.
      */
@@ -104,11 +111,13 @@ protected:
     ///@name Protected Operators
     ///@{
 
-    double GetEffectiveViscosity(ConstitutiveLaw::Parameters &rParameters) const override;
 
     ///@}
     ///@name Protected Operations
     ///@{
+
+    /// Get the effective viscosity (in dynamic units -- Pa s) for the fluid.
+    double GetEffectiveViscosity(ConstitutiveLaw::Parameters& rParameters) const override;
 
     ///@}
 private:
@@ -144,7 +153,7 @@ private:
     void save(Serializer& rSerializer) const override;
 
     void load(Serializer& rSerializer) override;
-    ///@}
-}; // Class NewtonianTemperatureDependent2DLaw
+
+}; // Class NewtonianTemperatureDependent3DLaw
 }  // namespace Kratos.
-#endif // KRATOS_NEWTONIAN_TEMPERATURE_DEPENDENT_LAW_2D_H_INCLUDED  defined
+#endif // KRATOS_NEWTONIAN_TEMPERATURE_DEPENDENT_LAW_3D_H_INCLUDED  defined

--- a/applications/FluidDynamicsApplication/custom_python/add_custom_constitutive_laws_to_python.cpp
+++ b/applications/FluidDynamicsApplication/custom_python/add_custom_constitutive_laws_to_python.cpp
@@ -30,11 +30,13 @@
 #include "custom_constitutive/newtonian_3d_law.h"
 #include "custom_constitutive/herschel_bulkley_3d_law.h"
 #include "custom_constitutive/newtonian_two_fluid_3d_law.h"
+#include "custom_constitutive/newtonian_temperature_dependent_3d_law.h"
 
 // 2D constitutive laws
 #include "custom_constitutive/euler_2d_law.h"
 #include "custom_constitutive/newtonian_2d_law.h"
 #include "custom_constitutive/newtonian_two_fluid_2d_law.h"
+#include "custom_constitutive/newtonian_temperature_dependent_2d_law.h"
 
 namespace Kratos
 {
@@ -68,6 +70,12 @@ void  AddCustomConstitutiveLawsToPython(pybind11::module& m)
     .def( py::init<>() );
 
     py::class_< NewtonianTwoFluid3DLaw, NewtonianTwoFluid3DLaw::Pointer, ConstitutiveLaw >(m,"NewtonianTwoFluid3DLaw")
+    .def( py::init<>() );
+
+    py::class_< NewtonianTemperatureDependent2DLaw, NewtonianTemperatureDependent2DLaw::Pointer, Newtonian2DLaw >(m,"NewtonianTemperatureDependent2DLaw")
+    .def( py::init<>() );
+
+    py::class_< NewtonianTemperatureDependent3DLaw, NewtonianTemperatureDependent3DLaw::Pointer, Newtonian3DLaw >(m,"NewtonianTemperatureDependent3DLaw")
     .def( py::init<>() );
 
 }

--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
@@ -288,10 +288,11 @@ void KratosFluidDynamicsApplication::Register() {
     KRATOS_REGISTER_CONSTITUTIVE_LAW("Euler3DLaw", mEuler3DLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("HerschelBulkley3DLaw", mHerschelBulkley3DLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("Newtonian2DLaw", mNewtonian2DLaw);
-    KRATOS_REGISTER_CONSTITUTIVE_LAW("NewtonianTemperatureDependent2DLaw", mNewtonianTemperatureDependent2DLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("Newtonian3DLaw", mNewtonian3DLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("NewtonianTwoFluid2DLaw", mNewtonianTwoFluid2DLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("NewtonianTwoFluid3DLaw", mNewtonianTwoFluid3DLaw);
+    KRATOS_REGISTER_CONSTITUTIVE_LAW("NewtonianTemperatureDependent2DLaw", mNewtonianTemperatureDependent2DLaw);
+    KRATOS_REGISTER_CONSTITUTIVE_LAW("NewtonianTemperatureDependent3DLaw", mNewtonianTemperatureDependent3DLaw);
 }
 
 }  // namespace Kratos.

--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
@@ -288,6 +288,7 @@ void KratosFluidDynamicsApplication::Register() {
     KRATOS_REGISTER_CONSTITUTIVE_LAW("Euler3DLaw", mEuler3DLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("HerschelBulkley3DLaw", mHerschelBulkley3DLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("Newtonian2DLaw", mNewtonian2DLaw);
+    KRATOS_REGISTER_CONSTITUTIVE_LAW("NewtonianTemperatureDependent2DLaw", mNewtonianTemperatureDependent2DLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("Newtonian3DLaw", mNewtonian3DLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("NewtonianTwoFluid2DLaw", mNewtonianTwoFluid2DLaw);
     KRATOS_REGISTER_CONSTITUTIVE_LAW("NewtonianTwoFluid3DLaw", mNewtonianTwoFluid3DLaw);

--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.h
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.h
@@ -84,10 +84,11 @@
 #include "custom_constitutive/euler_3d_law.h"
 #include "custom_constitutive/herschel_bulkley_3d_law.h"
 #include "custom_constitutive/newtonian_2d_law.h"
-#include "custom_constitutive/newtonian_temperature_dependent_2d_law.h"
 #include "custom_constitutive/newtonian_3d_law.h"
 #include "custom_constitutive/newtonian_two_fluid_2d_law.h"
 #include "custom_constitutive/newtonian_two_fluid_3d_law.h"
+#include "custom_constitutive/newtonian_temperature_dependent_2d_law.h"
+#include "custom_constitutive/newtonian_temperature_dependent_3d_law.h"
 
 
 namespace Kratos
@@ -389,10 +390,11 @@ private:
     const Euler3DLaw mEuler3DLaw;
     const HerschelBulkley3DLaw mHerschelBulkley3DLaw;
     const Newtonian2DLaw mNewtonian2DLaw;
-    const NewtonianTemperatureDependent2DLaw mNewtonianTemperatureDependent2DLaw;
     const Newtonian3DLaw mNewtonian3DLaw;
     const NewtonianTwoFluid2DLaw mNewtonianTwoFluid2DLaw;
     const NewtonianTwoFluid3DLaw mNewtonianTwoFluid3DLaw;
+    const NewtonianTemperatureDependent2DLaw mNewtonianTemperatureDependent2DLaw;
+    const NewtonianTemperatureDependent3DLaw mNewtonianTemperatureDependent3DLaw;
 
     ///@}
     ///@name Private Operators

--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.h
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.h
@@ -84,6 +84,7 @@
 #include "custom_constitutive/euler_3d_law.h"
 #include "custom_constitutive/herschel_bulkley_3d_law.h"
 #include "custom_constitutive/newtonian_2d_law.h"
+#include "custom_constitutive/newtonian_temperature_dependent_2d_law.h"
 #include "custom_constitutive/newtonian_3d_law.h"
 #include "custom_constitutive/newtonian_two_fluid_2d_law.h"
 #include "custom_constitutive/newtonian_two_fluid_3d_law.h"
@@ -276,7 +277,7 @@ private:
     const EmbeddedFluidElement< QSVMS< TimeIntegratedQSVMSData<3,4> > > mEmbeddedQSVMS3D4N;
     const EmbeddedFluidElementDiscontinuous< QSVMS< TimeIntegratedQSVMSData<2,3> > > mEmbeddedQSVMSDiscontinuous2D3N;
     const EmbeddedFluidElementDiscontinuous< QSVMS< TimeIntegratedQSVMSData<3,4> > > mEmbeddedQSVMSDiscontinuous3D4N;
-    
+
     /// 3D instance of the two-fluid VMS element
     const TwoFluidVMS<3,4> mTwoFluidVMS3D;
     const TwoFluidVMSLinearizedDarcy<3,4> mTwoFluidVMSLinearizedDarcy3D;
@@ -388,6 +389,7 @@ private:
     const Euler3DLaw mEuler3DLaw;
     const HerschelBulkley3DLaw mHerschelBulkley3DLaw;
     const Newtonian2DLaw mNewtonian2DLaw;
+    const NewtonianTemperatureDependent2DLaw mNewtonianTemperatureDependent2DLaw;
     const Newtonian3DLaw mNewtonian3DLaw;
     const NewtonianTwoFluid2DLaw mNewtonianTwoFluid2DLaw;
     const NewtonianTwoFluid3DLaw mNewtonianTwoFluid3DLaw;

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_dynamics_constitutive_laws.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_dynamics_constitutive_laws.cpp
@@ -32,6 +32,7 @@
 #include "custom_constitutive/newtonian_3d_law.h"
 #include "custom_constitutive/newtonian_two_fluid_3d_law.h"
 #include "custom_constitutive/newtonian_temperature_dependent_2d_law.h"
+#include "custom_constitutive/newtonian_temperature_dependent_3d_law.h"
 
 namespace Kratos {
 	namespace Testing {

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_dynamics_constitutive_laws.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_dynamics_constitutive_laws.cpp
@@ -31,6 +31,7 @@
 #include "custom_constitutive/newtonian_2d_law.h"
 #include "custom_constitutive/newtonian_3d_law.h"
 #include "custom_constitutive/newtonian_two_fluid_3d_law.h"
+#include "custom_constitutive/newtonian_temperature_dependent_2d_law.h"
 
 namespace Kratos {
 	namespace Testing {
@@ -54,7 +55,7 @@ namespace Kratos {
 
         /**
          * @brief Set the Table Properties object
-         * This function sets a temperature dependent viscosity table 
+         * This function sets a temperature dependent viscosity table
          * and a constitutive law pointer for a properties container
          * @param rModelPart model part owning the properties
          * @param pConstitutiveLaw pointer to the constitutive law to be set
@@ -193,7 +194,7 @@ namespace Kratos {
 		{
             // Declare the constitutive law pointer as well as its required arrays
             const unsigned int strain_size = 3;
-            Newtonian2DLaw::Pointer p_cons_law(new Newtonian2DLaw());
+            Newtonian2DLaw::Pointer p_cons_law(new NewtonianTemperatureDependent2DLaw());
             Vector stress_vector = ZeroVector(strain_size);
             Vector strain_vector = ZeroVector(strain_size);
             Matrix c_matrix = ZeroMatrix(strain_size, strain_size);

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_dynamics_constitutive_laws.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_fluid_dynamics_constitutive_laws.cpp
@@ -258,6 +258,75 @@ namespace Kratos {
 	    }
 
 	    /**
+	     * Checks the Newtonian fluid temperature dependent viscosity 3D constitutive law.
+	     */
+	    KRATOS_TEST_CASE_IN_SUITE(NewtonianTemperatureDependent3DConstitutiveLaw, FluidDynamicsApplicationFastSuite)
+		{
+            // Declare the constitutive law pointer as well as its required arrays
+            const unsigned int strain_size = 6;
+            Newtonian3DLaw::Pointer p_cons_law(new NewtonianTemperatureDependent3DLaw());
+            Vector stress_vector = ZeroVector(strain_size);
+            Vector strain_vector = ZeroVector(strain_size);
+            Matrix c_matrix = ZeroMatrix(strain_size, strain_size);
+
+            // Get the trial element
+            Model model;
+            ModelPart& model_part = model.CreateModelPart("Main", 3);
+            GenerateTetrahedron(model_part, p_cons_law, SetTableProperties);
+            Element::Pointer p_element = model_part.pGetElement(1);
+
+            // Set the constitutive law values
+            ConstitutiveLaw::Parameters cons_law_values(
+                p_element->GetGeometry(),
+                p_element->GetProperties(),
+                model_part.GetProcessInfo());
+
+            // Set constitutive law flags:
+            Flags& constitutive_law_options = cons_law_values.GetOptions();
+            constitutive_law_options.Set(ConstitutiveLaw::COMPUTE_STRESS);
+            constitutive_law_options.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR);
+
+            // Set the constitutive arrays
+            strain_vector(0) =  3.0;
+            strain_vector(1) =  6.0;
+            strain_vector(2) =  1.0;
+            strain_vector(3) = -1.0;
+            strain_vector(4) = -6.0;
+            strain_vector(5) = -3.0;
+            cons_law_values.SetStrainVector(strain_vector);  // Input strain values
+            cons_law_values.SetStressVector(stress_vector);  // Output stress values
+            cons_law_values.SetConstitutiveMatrix(c_matrix); // Output constitutive tensor
+            cons_law_values.SetShapeFunctionsValues(row((p_element->GetGeometry()).ShapeFunctionsValues(),0)); // Centered Gauss pt. shape functions
+
+            // Check first temperature field
+            const double tolerance = 1e-8;
+            for (auto &r_node : model_part.Nodes()) {
+                r_node.FastGetSolutionStepValue(TEMPERATURE) = r_node.Id() * 5.0;
+            }
+            p_cons_law->CalculateMaterialResponseCauchy(cons_law_values);
+
+            std::vector<double> expected_c_1_diag = {0.00169048,0.00169048,0.00169048,0.00126786,0.00126786,0.00126786};
+            std::vector<double> expected_stress_1 = {-0.000845242,0.00676193,-0.00591669,-0.00126786,-0.00760717,-0.00380359};
+            for (unsigned int i = 0; i < strain_size; ++i) {
+                KRATOS_CHECK_NEAR(c_matrix(i,i), expected_c_1_diag[i], tolerance);
+                KRATOS_CHECK_NEAR(stress_vector(i), expected_stress_1[i], tolerance);
+            }
+
+            // Set second temperature field
+            for (auto &r_node : model_part.Nodes()) {
+                r_node.FastGetSolutionStepValue(TEMPERATURE) = r_node.Id() * 10.0;
+            }
+            p_cons_law->CalculateMaterialResponseCauchy(cons_law_values);
+
+            std::vector<double> expected_c_2_diag = {0.00126734,0.00126734,0.00126734,0.000950505,0.000950505,0.000950505};
+            std::vector<double> expected_stress_2 = {-0.00063367,0.00506936,-0.00443569,-0.000950505,-0.00570303,-0.00285152};
+            for (unsigned int i = 0; i < strain_size; ++i) {
+                KRATOS_CHECK_NEAR(c_matrix(i,i), expected_c_2_diag[i], tolerance);
+                KRATOS_CHECK_NEAR(stress_vector(i), expected_stress_2[i], tolerance);
+            }
+	    }
+
+	    /**
 	     * Checks the Newtonian fluid 3D constitutive law.
 	     */
 	    KRATOS_TEST_CASE_IN_SUITE(Newtonian3DConstitutiveLaw, FluidDynamicsApplicationFastSuite)


### PR DESCRIPTION
This PR modifies the current Newtonian constitutive laws to always get the dynamic viscosity from the properties inside the `GetEffectiveViscosity`. In the past, we used to to that by getting the viscosity value from the constitutive tensor, which is not needed in all the cases. Besides, to compute or not compute the constitutive tensor is set from outside the constitutive law, meaning that the `GetEffectiveViscosity` method might fail in some cases. Even though the properties accessing is computationally expensive, this change shouldn't introduce any overhead, since this accessing is performed once as used to be in the past (I didn't found any element computing the viscosity by means of the constitutive laws `GetEffectiveViscosity`). 

For the temperature dependent viscosity case, two new constitutive laws (derived from the Newtonian ones) have been created. The unique method that needs to be override is the `GetEffectiveViscosity`, which in this case takes the value from the table. 