### PR TITLE
[Core][Hotfix] GetParentModelPart returns itself in case of root model part

### DIFF
--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -1353,7 +1353,11 @@ public:
 
     ModelPart* GetParentModelPart() const
     {
-        return mpParentModelPart;
+        if (IsSubModelPart()) {
+            return mpParentModelPart;
+        } else {
+            return const_cast<ModelPart*>(this);
+        }
     }
 
     bool HasSubModelPart(std::string const& ThisSubModelPartName) const
@@ -1651,5 +1655,3 @@ KRATOS_API(KRATOS_CORE) inline std::ostream & operator <<(std::ostream& rOStream
 } // namespace Kratos.
 
 #endif // KRATOS_MODEL_PART_H_INCLUDED  defined
-
-

--- a/kratos/tests/test_model_part.py
+++ b/kratos/tests/test_model_part.py
@@ -17,12 +17,12 @@ class TestModelPart(KratosUnittest.TestCase):
         model_part= current_model.CreateModelPart("Main")
 
         parent_model_part_0 = model_part.GetParentModelPart()
-        self.assertEqual(parent_model_part_0.Name(), "Main") # Itself as it is the RootModelPart
+        self.assertEqual(parent_model_part_0.Name, "Main") # Itself as it is the RootModelPart
 
         inlet_model_part = model_part.CreateSubModelPart("Inlets")
 
         parent_model_part_1 = inlet_model_part.GetParentModelPart()
-        self.assertEqual(parent_model_part_1.Name(), "Main")
+        self.assertEqual(parent_model_part_1.Name, "Main")
 
         self.assertTrue(model_part.HasSubModelPart("Inlets"))
         self.assertEqual(model_part.NumberOfSubModelParts(), 1)

--- a/kratos/tests/test_model_part.py
+++ b/kratos/tests/test_model_part.py
@@ -1,4 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
+from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics import *
@@ -16,9 +16,13 @@ class TestModelPart(KratosUnittest.TestCase):
 
         model_part= current_model.CreateModelPart("Main")
 
-        self.assertEqual(model_part.NumberOfSubModelParts(), 0)
+        parent_model_part_0 = model_part.GetParentModelPart()
+        self.assertEqual(parent_model_part_0.Name(), "Main") # Itself as it is the RootModelPart
 
-        model_part.CreateSubModelPart("Inlets")
+        inlet_model_part = model_part.CreateSubModelPart("Inlets")
+
+        parent_model_part_1 = inlet_model_part.GetParentModelPart()
+        self.assertEqual(parent_model_part_1.Name(), "Main")
 
         self.assertTrue(model_part.HasSubModelPart("Inlets"))
         self.assertEqual(model_part.NumberOfSubModelParts(), 1)


### PR DESCRIPTION
This is the same that happens in case of GetRootModelPart