### PR TITLE
[ParticleMechanics] Remove jacobian storage from MP element

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -1605,39 +1605,6 @@ Vector& UpdatedLagrangian::MPMShapeFunctionPointValues( Vector& rResult, const a
 }
 
 
-Vector& UpdatedLagrangian::MPMLocalCoordinates(Vector& rResult, array_1d<double,3>& rPoint)
-{
-    KRATOS_TRY
-
-    GeometryType& rGeom = GetGeometry();
-
-    // Only local coordinated of a point in a tetrahedron is computed
-    rResult.resize(4,false);
-
-    double x10 = rGeom[1].Coordinates()[0]-rGeom[0].Coordinates()[0];
-    double x20 = rGeom[2].Coordinates()[0]-rGeom[0].Coordinates()[0];
-    double x30 = rGeom[3].Coordinates()[0]-rGeom[0].Coordinates()[0];
-    double y10 = rGeom[1].Coordinates()[1]-rGeom[0].Coordinates()[1];
-    double y20 = rGeom[2].Coordinates()[1]-rGeom[0].Coordinates()[1];
-    double y30 = rGeom[3].Coordinates()[1]-rGeom[0].Coordinates()[1];
-    double z10 = rGeom[1].Coordinates()[2]-rGeom[0].Coordinates()[2];
-    double z20 = rGeom[2].Coordinates()[2]-rGeom[0].Coordinates()[2];
-    double z30 = rGeom[3].Coordinates()[2]-rGeom[0].Coordinates()[2];
-
-    rResult[3] = (rPoint[0] - rGeom[0].Coordinates()[0])*(y10*z20 - z10*y20) - (rPoint[1] - rGeom[0].Coordinates()[1])*(x10*z20-x20*z10) + (rPoint[2] - rGeom[0].Coordinates()[2])*(y20*x10 - y10*x20)/mDeterminantJ0;
-
-    rResult[2] = (rPoint[0] - rGeom[0].Coordinates()[0])*(y30*z10-y10*z30) + (rPoint[1] - rGeom[0].Coordinates()[1])*(x10*z30-x30*z10) + (rPoint[2] - rGeom[0].Coordinates()[2])*(y10*x30 - y30*x10)/mDeterminantJ0;
-
-    rResult[1] = (rPoint[0] - rGeom[0].Coordinates()[0])*(y20*z30-y30*z20) + (rPoint[1] - rGeom[0].Coordinates()[1])*(x30*z20-x20*z30) + (rPoint[2] - rGeom[0].Coordinates()[2])*(y30*x20 - x30*y20)/mDeterminantJ0;
-
-    rResult[0] = 1 - rResult[1] - rResult[2] -rResult[3];
-
-    return rResult;
-
-    KRATOS_CATCH( "" )
-}
-
-
 // Function which return dN/de
 Matrix& UpdatedLagrangian::MPMShapeFunctionsLocalGradients( Matrix& rResult )
 {

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -127,9 +127,6 @@ void UpdatedLagrangian::Initialize()
 {
     KRATOS_TRY
 
-    // Initial position of the particle
-    const array_1d<double,3>& xg = this->GetValue(MP_COORD);
-
     // Initialize parameters
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
     mDeterminantF0 = 1;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -68,7 +68,6 @@ UpdatedLagrangian::UpdatedLagrangian( UpdatedLagrangian const& rOther)
     :Element(rOther)
     ,mDeformationGradientF0(rOther.mDeformationGradientF0)
     ,mDeterminantF0(rOther.mDeterminantF0)
-    ,mDeterminantJ0(rOther.mDeterminantJ0)
     ,mConstitutiveLawVector(rOther.mConstitutiveLawVector)
     ,mFinalizedStep(rOther.mFinalizedStep)
 {
@@ -85,7 +84,6 @@ UpdatedLagrangian&  UpdatedLagrangian::operator=(UpdatedLagrangian const& rOther
     mDeformationGradientF0 = rOther.mDeformationGradientF0;
 
     mDeterminantF0 = rOther.mDeterminantF0;
-    mDeterminantJ0 = rOther.mDeterminantJ0;
     mConstitutiveLawVector = rOther.mConstitutiveLawVector;
 
     return *this;
@@ -111,7 +109,6 @@ Element::Pointer UpdatedLagrangian::Clone( IndexType NewId, NodesArrayType const
     NewElement.mDeformationGradientF0 = mDeformationGradientF0;
 
     NewElement.mDeterminantF0 = mDeterminantF0;
-    NewElement.mDeterminantJ0 = mDeterminantJ0;
 
     return Element::Pointer( new UpdatedLagrangian(NewElement) );
 }
@@ -1818,8 +1815,6 @@ void UpdatedLagrangian::save( Serializer& rSerializer ) const
     rSerializer.save("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.save("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.save("DeterminantF0",mDeterminantF0);
-    rSerializer.save("DeterminantJ0",mDeterminantJ0);
-
 }
 
 void UpdatedLagrangian::load( Serializer& rSerializer )
@@ -1828,7 +1823,6 @@ void UpdatedLagrangian::load( Serializer& rSerializer )
     rSerializer.load("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.load("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.load("DeterminantF0",mDeterminantF0);
-    rSerializer.load("DeterminantJ0",mDeterminantJ0);
 }
 
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -157,8 +157,6 @@ void UpdatedLagrangian::InitializeGeneralVariables (GeneralVariables& rVariables
 
     rVariables.detFT = 1;
 
-    rVariables.detJ = 1;
-
     rVariables.B.resize( voigtsize, number_of_nodes * dimension, false );
 
     rVariables.F.resize( dimension, dimension, false );
@@ -357,11 +355,12 @@ void UpdatedLagrangian::CalculateKinematics(GeneralVariables& rVariables, Proces
 
     // Calculating the inverse of the jacobian and the parameters needed [d£/dx_n]
     Matrix InvJ;
-    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, rVariables.detJ);
+    double detJ;
+    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, detJ);
 
     // Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;
-    MathUtils<double>::InvertMatrix( rVariables.j, Invj, rVariables.detJ ); //overwrites detJ
+    MathUtils<double>::InvertMatrix( rVariables.j, Invj, detJ); //overwrites detJ
 
     // Compute cartesian derivatives [dN/dx_n+1]
     rVariables.DN_DX = prod( rVariables.DN_De, Invj); //overwrites DX now is the current position dx

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -186,9 +186,6 @@ void UpdatedLagrangian::InitializeGeneralVariables (GeneralVariables& rVariables
 
     // Calculating the current jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n+1/d£]
     rVariables.j = this->MPMJacobianDelta( rVariables.j, xg, rVariables.CurrentDisp);
-
-    // Calculating the reference jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n/d£]
-    rVariables.J = this->MPMJacobian( rVariables.J, xg);
 }
 //************************************************************************************
 //************************************************************************************
@@ -353,10 +350,15 @@ void UpdatedLagrangian::CalculateKinematics(GeneralVariables& rVariables, Proces
     // Define the stress measure
     rVariables.StressMeasure = ConstitutiveLaw::StressMeasure_Cauchy;
 
+    // Calculating the reference jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n/d£]
+    const array_1d<double,3>& xg = this->GetValue(MP_COORD);
+    Matrix Jacobian;
+    Jacobian = this->MPMJacobian( Jacobian, xg);
+
     // Calculating the inverse of the jacobian and the parameters needed [d£/dx_n]
     Matrix InvJ;
     double detJ;
-    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, detJ);
+    MathUtils<double>::InvertMatrix( Jacobian, InvJ, detJ);
 
     // Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;
@@ -800,13 +802,9 @@ void UpdatedLagrangian::Calculate(const Variable<double>& rVariable,
     if (rVariable == DENSITY)
     {
         GeometryType& rGeom = GetGeometry();
-        const unsigned int dimension = rGeom.WorkingSpaceDimension();
         const unsigned int number_of_nodes = rGeom.PointsNumber();
         const array_1d<double,3>& xg = this->GetValue(MP_COORD);
         GeneralVariables Variables;
-        Matrix J0 = ZeroMatrix(dimension, dimension);
-
-        J0 = this->MPMJacobian(J0, xg);
 
         Variables.N = this->MPMShapeFunctionPointValues(Variables.N, xg);
         const double & MP_Mass = this->GetValue(MP_MASS);
@@ -836,9 +834,6 @@ void UpdatedLagrangian::Calculate(const Variable<array_1d<double, 3 > >& rVariab
         const unsigned int number_of_nodes = rGeom.PointsNumber();
         const array_1d<double,3>& xg = this->GetValue(MP_COORD);
         GeneralVariables Variables;
-        Matrix J0 = ZeroMatrix(dimension, dimension);
-
-        J0 = this->MPMJacobian(J0, xg);
 
         Variables.N = this->MPMShapeFunctionPointValues(Variables.N, xg);
         const array_1d<double,3>& MP_Velocity = this->GetValue(MP_VELOCITY);
@@ -865,9 +860,6 @@ void UpdatedLagrangian::Calculate(const Variable<array_1d<double, 3 > >& rVariab
         const unsigned int number_of_nodes = rGeom.PointsNumber();
         const array_1d<double,3>& xg = this->GetValue(MP_COORD);
         GeneralVariables Variables;
-        Matrix J0 = ZeroMatrix(dimension, dimension);
-
-        J0 = this->MPMJacobian(J0, xg);
 
         Variables.N = this->MPMShapeFunctionPointValues(Variables.N, xg);
         const array_1d<double,3>& MP_Acceleration = this->GetValue(MP_ACCELERATION);

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -68,7 +68,6 @@ UpdatedLagrangian::UpdatedLagrangian( UpdatedLagrangian const& rOther)
     :Element(rOther)
     ,mDeformationGradientF0(rOther.mDeformationGradientF0)
     ,mDeterminantF0(rOther.mDeterminantF0)
-    ,mInverseJ(rOther.mInverseJ)
     ,mDeterminantJ0(rOther.mDeterminantJ0)
     ,mConstitutiveLawVector(rOther.mConstitutiveLawVector)
     ,mFinalizedStep(rOther.mFinalizedStep)
@@ -84,9 +83,6 @@ UpdatedLagrangian&  UpdatedLagrangian::operator=(UpdatedLagrangian const& rOther
 
     mDeformationGradientF0.clear();
     mDeformationGradientF0 = rOther.mDeformationGradientF0;
-
-    mInverseJ.clear();
-    mInverseJ = rOther.mInverseJ;
 
     mDeterminantF0 = rOther.mDeterminantF0;
     mDeterminantJ0 = rOther.mDeterminantJ0;
@@ -113,8 +109,6 @@ Element::Pointer UpdatedLagrangian::Clone( IndexType NewId, NodesArrayType const
     NewElement.mConstitutiveLawVector = mConstitutiveLawVector->Clone();
 
     NewElement.mDeformationGradientF0 = mDeformationGradientF0;
-
-    NewElement.mInverseJ = mInverseJ;
 
     NewElement.mDeterminantF0 = mDeterminantF0;
     NewElement.mDeterminantJ0 = mDeterminantJ0;
@@ -143,12 +137,6 @@ void UpdatedLagrangian::Initialize()
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
     mDeterminantF0 = 1;
     mDeformationGradientF0 = IdentityMatrix(dimension);
-
-    // Compute current jacobian matrix and inverses
-    Matrix j = ZeroMatrix(dimension, dimension);
-    j = this->MPMJacobian(j,xg);
-    double detj;
-    MathUtils<double>::InvertMatrix( j, mInverseJ, detj );
 
     // Initialize constitutive law and materials
     InitializeMaterial();
@@ -1057,8 +1045,6 @@ void UpdatedLagrangian::FinalizeStepVariables( GeneralVariables & rVariables, co
 
     double AccumulatedPlasticDeviatoricStrain = mConstitutiveLawVector->GetValue(MP_ACCUMULATED_PLASTIC_DEVIATORIC_STRAIN, AccumulatedPlasticDeviatoricStrain);
     this->SetValue(MP_ACCUMULATED_PLASTIC_DEVIATORIC_STRAIN, AccumulatedPlasticDeviatoricStrain);
-
-    MathUtils<double>::InvertMatrix( rVariables.j, mInverseJ, rVariables.detJ );
 
     this->UpdateGaussPoint(rVariables, rCurrentProcessInfo);
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -68,7 +68,6 @@ UpdatedLagrangian::UpdatedLagrangian( UpdatedLagrangian const& rOther)
     :Element(rOther)
     ,mDeformationGradientF0(rOther.mDeformationGradientF0)
     ,mDeterminantF0(rOther.mDeterminantF0)
-    ,mInverseJ0(rOther.mInverseJ0)
     ,mInverseJ(rOther.mInverseJ)
     ,mDeterminantJ0(rOther.mDeterminantJ0)
     ,mConstitutiveLawVector(rOther.mConstitutiveLawVector)
@@ -86,8 +85,6 @@ UpdatedLagrangian&  UpdatedLagrangian::operator=(UpdatedLagrangian const& rOther
     mDeformationGradientF0.clear();
     mDeformationGradientF0 = rOther.mDeformationGradientF0;
 
-    mInverseJ0.clear();
-    mInverseJ0 = rOther.mInverseJ0;
     mInverseJ.clear();
     mInverseJ = rOther.mInverseJ;
 
@@ -117,7 +114,6 @@ Element::Pointer UpdatedLagrangian::Clone( IndexType NewId, NodesArrayType const
 
     NewElement.mDeformationGradientF0 = mDeformationGradientF0;
 
-    NewElement.mInverseJ0 = mInverseJ0;
     NewElement.mInverseJ = mInverseJ;
 
     NewElement.mDeterminantF0 = mDeterminantF0;
@@ -147,11 +143,6 @@ void UpdatedLagrangian::Initialize()
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
     mDeterminantF0 = 1;
     mDeformationGradientF0 = IdentityMatrix(dimension);
-
-    // Compute initial jacobian matrix and inverses
-    Matrix J0 = ZeroMatrix(dimension, dimension);
-    J0 = this->MPMJacobian(J0, xg);
-    MathUtils<double>::InvertMatrix( J0, mInverseJ0, mDeterminantJ0 );
 
     // Compute current jacobian matrix and inverses
     Matrix j = ZeroMatrix(dimension, dimension);
@@ -836,9 +827,6 @@ void UpdatedLagrangian::Calculate(const Variable<double>& rVariable,
 
         J0 = this->MPMJacobian(J0, xg);
 
-        //calculating and storing inverse and the determinant of the jacobian
-        MathUtils<double>::InvertMatrix( J0, mInverseJ0, mDeterminantJ0 );
-
         Variables.N = this->MPMShapeFunctionPointValues(Variables.N, xg);
         const double & MP_Mass = this->GetValue(MP_MASS);
 
@@ -871,9 +859,6 @@ void UpdatedLagrangian::Calculate(const Variable<array_1d<double, 3 > >& rVariab
 
         J0 = this->MPMJacobian(J0, xg);
 
-        // Calculating and storing inverse and the determinant of the jacobian
-        MathUtils<double>::InvertMatrix( J0, mInverseJ0, mDeterminantJ0 );
-
         Variables.N = this->MPMShapeFunctionPointValues(Variables.N, xg);
         const array_1d<double,3>& MP_Velocity = this->GetValue(MP_VELOCITY);
         const double & MP_Mass = this->GetValue(MP_MASS);
@@ -902,9 +887,6 @@ void UpdatedLagrangian::Calculate(const Variable<array_1d<double, 3 > >& rVariab
         Matrix J0 = ZeroMatrix(dimension, dimension);
 
         J0 = this->MPMJacobian(J0, xg);
-
-        //calculating and storing inverse and the determinant of the jacobian
-        MathUtils<double>::InvertMatrix( J0, mInverseJ0, mDeterminantJ0 );
 
         Variables.N = this->MPMShapeFunctionPointValues(Variables.N, xg);
         const array_1d<double,3>& MP_Acceleration = this->GetValue(MP_ACCELERATION);
@@ -939,11 +921,6 @@ void UpdatedLagrangian::InitializeSolutionStep( ProcessInfo& rCurrentProcessInfo
     const unsigned int number_of_nodes = rGeom.PointsNumber();
     const array_1d<double,3> & xg = this->GetValue(MP_COORD);
     GeneralVariables Variables;
-
-    // Calculating and storing inverse and the determinant of the jacobian
-    Matrix J0 = ZeroMatrix(dimension, dimension);
-    J0 = this->MPMJacobian(J0, xg);
-    MathUtils<double>::InvertMatrix( J0, mInverseJ0, mDeterminantJ0 );
 
     // Calculating shape function
     Variables.N = this->MPMShapeFunctionPointValues(Variables.N, xg);
@@ -1888,7 +1865,6 @@ void UpdatedLagrangian::save( Serializer& rSerializer ) const
     rSerializer.save("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.save("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.save("DeterminantF0",mDeterminantF0);
-    rSerializer.save("InverseJ0",mInverseJ0);
     rSerializer.save("DeterminantJ0",mDeterminantJ0);
 
 }
@@ -1899,7 +1875,6 @@ void UpdatedLagrangian::load( Serializer& rSerializer )
     rSerializer.load("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.load("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.load("DeterminantF0",mDeterminantF0);
-    rSerializer.load("InverseJ0",mInverseJ0);
     rSerializer.load("DeterminantJ0",mDeterminantJ0);
 }
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
@@ -105,7 +105,6 @@ protected:
         double  detF;
         double  detF0;
         double  detFT;
-        double  detJ;
         Vector  StrainVector;
         Vector  StressVector;
         Vector  N;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
@@ -502,10 +502,6 @@ protected:
      * Container for the total deformation gradient determinants
      */
     double mDeterminantF0;
-    /**
-     * Container for historical inverse of Jacobian at reference configuration invJ0
-     */
-    Matrix mInverseJ;
 
     /**
      * Container for the total Jacobian determinants

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
@@ -505,7 +505,6 @@ protected:
     /**
      * Container for historical inverse of Jacobian at reference configuration invJ0
      */
-    Matrix mInverseJ0;
     Matrix mInverseJ;
 
     /**

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
@@ -504,11 +504,6 @@ protected:
     double mDeterminantF0;
 
     /**
-     * Container for the total Jacobian determinants
-     */
-    double mDeterminantJ0;
-
-    /**
      * Container for constitutive law instances on each integration point
      */
     ConstitutiveLaw::Pointer mConstitutiveLawVector;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
@@ -705,10 +705,6 @@ protected:
      * Calculate Shape Function grandient local Values in a given point in 3 dimension
      */
     virtual Matrix& MPMShapeFunctionsLocalGradients(Matrix& rResult);
-    /**
-     * Calculate local coordinated of a given point in 3 dimension
-     */
-    virtual Vector& MPMLocalCoordinates(Vector& rResult, array_1d<double,3>& rPoint);
 
     /**
      * Calculation of the Volume Change of the Element

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
@@ -117,8 +117,6 @@ protected:
         Matrix  ConstitutiveMatrix;
 
         // Variables including all integration points
-        Matrix j;
-        Matrix DeltaPosition;
         Matrix CurrentDisp;
         Matrix PreviousDisp;
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian.hpp
@@ -117,7 +117,6 @@ protected:
         Matrix  ConstitutiveMatrix;
 
         // Variables including all integration points
-        Matrix J;
         Matrix j;
         Matrix DeltaPosition;
         Matrix CurrentDisp;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
@@ -117,9 +117,6 @@ void UpdatedLagrangianUP::Initialize()
 {
     KRATOS_TRY
 
-    // Initial position of the particle
-    const array_1d<double,3>& xg = this->GetValue(MP_COORD);
-
     // Initialize parameters
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
     mDeterminantF0 = 1;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
@@ -265,11 +265,12 @@ void UpdatedLagrangianUP::CalculateKinematics(GeneralVariables& rVariables, Proc
 
     // Calculating the inverse of the jacobian and the parameters needed [d£/dx_n]
     Matrix InvJ;
-    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, rVariables.detJ);
+    double detJ;
+    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, detJ);
 
     // Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;
-    MathUtils<double>::InvertMatrix( rVariables.j, Invj, rVariables.detJ ); //overwrites detJ
+    MathUtils<double>::InvertMatrix( rVariables.j, Invj, detJ); //overwrites detJ
 
     // Compute cartesian derivatives [dN/dx_n+1]
     rVariables.DN_DX = prod( rVariables.DN_De, Invj); //overwrites DX now is the current position dx

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
@@ -273,9 +273,13 @@ void UpdatedLagrangianUP::CalculateKinematics(GeneralVariables& rVariables, Proc
     double detJ;
     MathUtils<double>::InvertMatrix( Jacobian, InvJ, detJ);
 
+    // Calculating the current jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n+1/d£]
+    Matrix jacobian;
+    jacobian = this->MPMJacobianDelta( jacobian, xg, rVariables.CurrentDisp);
+
     // Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;
-    MathUtils<double>::InvertMatrix( rVariables.j, Invj, detJ); //overwrites detJ
+    MathUtils<double>::InvertMatrix( jacobian, Invj, detJ); //overwrites detJ
 
     // Compute cartesian derivatives [dN/dx_n+1]
     rVariables.DN_DX = prod( rVariables.DN_De, Invj); //overwrites DX now is the current position dx
@@ -283,14 +287,14 @@ void UpdatedLagrangianUP::CalculateKinematics(GeneralVariables& rVariables, Proc
     /* NOTE::
     Deformation Gradient F [(dx_n+1 - dx_n)/dx_n] is to be updated in constitutive law parameter as total deformation gradient.
     The increment of total deformation gradient can be evaluated in 2 ways, which are:
-    1. By: noalias( rVariables.F ) = prod( rVariables.j, InvJ);
+    1. By: noalias( rVariables.F ) = prod( jacobian, InvJ);
     2. By means of the gradient of nodal displacement: using this second expression quadratic convergence is not guarantee
 
     (NOTICE: Here, we are using method no. 1)
     */
 
     // Update Deformation gradient
-    noalias( rVariables.F ) = prod( rVariables.j, InvJ);
+    noalias( rVariables.F ) = prod( jacobian, InvJ);
 
     // Determinant of the previous Deformation Gradient F_n
     rVariables.detF0 = mDeterminantF0;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
@@ -125,11 +125,6 @@ void UpdatedLagrangianUP::Initialize()
     mDeterminantF0 = 1;
     mDeformationGradientF0 = IdentityMatrix(dimension);
 
-    // Compute initial jacobian matrix and inverses
-    Matrix J0 = ZeroMatrix(dimension,dimension);
-    J0 = this->MPMJacobian(J0, xg);
-    MathUtils<double>::InvertMatrix( J0, mInverseJ0, mDeterminantJ0 );
-
     // Compute current jacobian matrix and inverses
     Matrix j = ZeroMatrix(dimension,dimension);
     j = this->MPMJacobian(j,xg);
@@ -375,11 +370,6 @@ void UpdatedLagrangianUP::InitializeSolutionStep( ProcessInfo& rCurrentProcessIn
     const unsigned int number_of_nodes = rGeom.PointsNumber();
     const array_1d<double,3>& xg = this->GetValue(MP_COORD);
     GeneralVariables Variables;
-
-    // Calculating and storing inverse and the determinant of the jacobian
-    Matrix J0 = ZeroMatrix(dimension, dimension);
-    J0 = this->MPMJacobian(J0, xg);
-    MathUtils<double>::InvertMatrix( J0, mInverseJ0, mDeterminantJ0 );
 
     // Calculating shape function
     Variables.N = this->MPMShapeFunctionPointValues(Variables.N, xg);

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
@@ -125,12 +125,6 @@ void UpdatedLagrangianUP::Initialize()
     mDeterminantF0 = 1;
     mDeformationGradientF0 = IdentityMatrix(dimension);
 
-    // Compute current jacobian matrix and inverses
-    Matrix j = ZeroMatrix(dimension,dimension);
-    j = this->MPMJacobian(j,xg);
-    double detj;
-    MathUtils<double>::InvertMatrix( j, mInverseJ, detj );
-
     // Initialize constitutive law and materials
     InitializeMaterial();
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_UP.cpp
@@ -263,10 +263,15 @@ void UpdatedLagrangianUP::CalculateKinematics(GeneralVariables& rVariables, Proc
     // Define the stress measure
     rVariables.StressMeasure = ConstitutiveLaw::StressMeasure_Cauchy;
 
+    // Calculating the reference jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n/d£]
+    const array_1d<double,3>& xg = this->GetValue(MP_COORD);
+    Matrix Jacobian;
+    Jacobian = this->MPMJacobian( Jacobian, xg);
+
     // Calculating the inverse of the jacobian and the parameters needed [d£/dx_n]
     Matrix InvJ;
     double detJ;
-    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, detJ);
+    MathUtils<double>::InvertMatrix( Jacobian, InvJ, detJ);
 
     // Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
@@ -151,9 +151,6 @@ void UpdatedLagrangianAxisymmetry::InitializeGeneralVariables (GeneralVariables&
 
     // CurrentDisp is the unknown variable. It represents the nodal delta displacement. When it is predicted is equal to zero.
     rVariables.CurrentDisp = CalculateCurrentDisp(rVariables.CurrentDisp, rCurrentProcessInfo);
-
-    // Calculating the current jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n+1/d£]
-    rVariables.j = this->MPMJacobianDelta( rVariables.j, xg, rVariables.CurrentDisp);
 }
 
 //*********************************COMPUTE KINEMATICS*********************************
@@ -176,9 +173,13 @@ void UpdatedLagrangianAxisymmetry::CalculateKinematics(GeneralVariables& rVariab
     double detJ;
     MathUtils<double>::InvertMatrix( Jacobian, InvJ, detJ);
 
+    // Calculating the current jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n+1/d£]
+    Matrix jacobian;
+    jacobian = this->MPMJacobianDelta( jacobian, xg, rVariables.CurrentDisp);
+
     //Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;
-    MathUtils<double>::InvertMatrix( rVariables.j, Invj, detJ); //overwrites detJ
+    MathUtils<double>::InvertMatrix( jacobian, Invj, detJ); //overwrites detJ
 
     // Compute cartesian derivatives [dN/dx_n]
     rVariables.DN_DX = prod( rVariables.DN_De, InvJ);

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
@@ -189,7 +189,7 @@ void UpdatedLagrangianAxisymmetry::CalculateKinematics(GeneralVariables& rVariab
     const double initial_radius = ParticleMechanicsMathUtilities<double>::CalculateRadius(rVariables.N, GetGeometry(), Initial);
 
     rVariables.CurrentDisp = CalculateCurrentDisp(rVariables.CurrentDisp, rCurrentProcessInfo);
-    CalculateDeformationGradient (rVariables.DN_DX, rVariables.F, rVariables.CurrentDisp, current_radius, initial_radius);
+    this->CalculateDeformationGradient (rVariables.DN_DX, rVariables.F, rVariables.CurrentDisp, current_radius, initial_radius);
 
     // Compute cartesian derivatives [dN/dx_n+1]
     rVariables.DN_DX = prod( rVariables.DN_De, Invj); //overwrites DX now is the current position dx

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
@@ -331,11 +331,6 @@ void UpdatedLagrangianAxisymmetry::InitializeSolutionStep( ProcessInfo& rCurrent
     const array_1d<double,3>& xg = this->GetValue(MP_COORD);
     GeneralVariables Variables;
 
-    // Calculating and storing inverse and the determinant of the jacobian
-    Matrix J0 = ZeroMatrix(dimension, dimension);
-    J0 = this->MPMJacobian(J0, xg);
-    MathUtils<double>::InvertMatrix( J0, mInverseJ0, mDeterminantJ0 );
-
     // Calculating shape function
     Variables.N = this->MPMShapeFunctionPointValues(Variables.N, xg);
 
@@ -730,7 +725,6 @@ void UpdatedLagrangianAxisymmetry::save( Serializer& rSerializer ) const
     rSerializer.save("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.save("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.save("DeterminantF0",mDeterminantF0);
-    rSerializer.save("InverseJ0",mInverseJ0);
     rSerializer.save("DeterminantJ0",mDeterminantJ0);
 
 }
@@ -741,7 +735,6 @@ void UpdatedLagrangianAxisymmetry::load( Serializer& rSerializer )
     rSerializer.load("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.load("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.load("DeterminantF0",mDeterminantF0);
-    rSerializer.load("InverseJ0",mInverseJ0);
     rSerializer.load("DeterminantJ0",mDeterminantJ0);
 }
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
@@ -725,8 +725,6 @@ void UpdatedLagrangianAxisymmetry::save( Serializer& rSerializer ) const
     rSerializer.save("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.save("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.save("DeterminantF0",mDeterminantF0);
-    rSerializer.save("DeterminantJ0",mDeterminantJ0);
-
 }
 
 void UpdatedLagrangianAxisymmetry::load( Serializer& rSerializer )
@@ -735,7 +733,6 @@ void UpdatedLagrangianAxisymmetry::load( Serializer& rSerializer )
     rSerializer.load("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.load("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.load("DeterminantF0",mDeterminantF0);
-    rSerializer.load("DeterminantJ0",mDeterminantJ0);
 }
 
 } // Namespace Kratos

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
@@ -154,10 +154,6 @@ void UpdatedLagrangianAxisymmetry::InitializeGeneralVariables (GeneralVariables&
 
     // Calculating the current jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n+1/d£]
     rVariables.j = this->MPMJacobianDelta( rVariables.j, xg, rVariables.CurrentDisp);
-
-    // Calculating the reference jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n/d£]
-    rVariables.J = this->MPMJacobian( rVariables.J, xg);
-
 }
 
 //*********************************COMPUTE KINEMATICS*********************************
@@ -170,10 +166,15 @@ void UpdatedLagrangianAxisymmetry::CalculateKinematics(GeneralVariables& rVariab
     // Define the stress measure
     rVariables.StressMeasure = ConstitutiveLaw::StressMeasure_Cauchy;
 
+    // Calculating the reference jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n/d£]
+    const array_1d<double,3>& xg = this->GetValue(MP_COORD);
+    Matrix Jacobian;
+    Jacobian = this->MPMJacobian( Jacobian, xg);
+
     // Calculating the inverse of the jacobian and the parameters needed [d£/dx_n]
     Matrix InvJ;
     double detJ;
-    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, detJ);
+    MathUtils<double>::InvertMatrix( Jacobian, InvJ, detJ);
 
     //Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_axisymmetry.cpp
@@ -122,8 +122,6 @@ void UpdatedLagrangianAxisymmetry::InitializeGeneralVariables (GeneralVariables&
 
     rVariables.detFT = 1;
 
-    rVariables.detJ = 1;
-
     rVariables.B.resize( strain_size , number_of_nodes * dimension, false );
 
     rVariables.F.resize( 3, 3, false );
@@ -174,11 +172,12 @@ void UpdatedLagrangianAxisymmetry::CalculateKinematics(GeneralVariables& rVariab
 
     // Calculating the inverse of the jacobian and the parameters needed [d£/dx_n]
     Matrix InvJ;
-    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, rVariables.detJ);
+    double detJ;
+    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, detJ);
 
     //Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;
-    MathUtils<double>::InvertMatrix( rVariables.j, Invj, rVariables.detJ ); //overwrites detJ
+    MathUtils<double>::InvertMatrix( rVariables.j, Invj, detJ); //overwrites detJ
 
     // Compute cartesian derivatives [dN/dx_n]
     rVariables.DN_DX = prod( rVariables.DN_De, InvJ);

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
@@ -68,7 +68,6 @@ UpdatedLagrangianQuadrilateral::UpdatedLagrangianQuadrilateral( UpdatedLagrangia
     :Element(rOther)
     ,mDeformationGradientF0(rOther.mDeformationGradientF0)
     ,mDeterminantF0(rOther.mDeterminantF0)
-    ,mDeterminantJ0(rOther.mDeterminantJ0)
     ,mConstitutiveLawVector(rOther.mConstitutiveLawVector)
     ,mFinalizedStep(rOther.mFinalizedStep)
 {
@@ -85,7 +84,6 @@ UpdatedLagrangianQuadrilateral&  UpdatedLagrangianQuadrilateral::operator=(Updat
     mDeformationGradientF0 = rOther.mDeformationGradientF0;
 
     mDeterminantF0 = rOther.mDeterminantF0;
-    mDeterminantJ0 = rOther.mDeterminantJ0;
     mConstitutiveLawVector = rOther.mConstitutiveLawVector;
 
     return *this;
@@ -111,7 +109,6 @@ Element::Pointer UpdatedLagrangianQuadrilateral::Clone( IndexType NewId, NodesAr
     NewElement.mDeformationGradientF0 = mDeformationGradientF0;
 
     NewElement.mDeterminantF0 = mDeterminantF0;
-    NewElement.mDeterminantJ0 = mDeterminantJ0;
 
     return Element::Pointer( new UpdatedLagrangianQuadrilateral(NewElement) );
 }
@@ -1827,8 +1824,6 @@ void UpdatedLagrangianQuadrilateral::save( Serializer& rSerializer ) const
     rSerializer.save("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.save("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.save("DeterminantF0",mDeterminantF0);
-    rSerializer.save("DeterminantJ0",mDeterminantJ0);
-
 }
 
 void UpdatedLagrangianQuadrilateral::load( Serializer& rSerializer )
@@ -1837,7 +1832,6 @@ void UpdatedLagrangianQuadrilateral::load( Serializer& rSerializer )
     rSerializer.load("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.load("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.load("DeterminantF0",mDeterminantF0);
-    rSerializer.load("DeterminantJ0",mDeterminantJ0);
 }
 
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
@@ -68,7 +68,6 @@ UpdatedLagrangianQuadrilateral::UpdatedLagrangianQuadrilateral( UpdatedLagrangia
     :Element(rOther)
     ,mDeformationGradientF0(rOther.mDeformationGradientF0)
     ,mDeterminantF0(rOther.mDeterminantF0)
-    ,mInverseJ(rOther.mInverseJ)
     ,mDeterminantJ0(rOther.mDeterminantJ0)
     ,mConstitutiveLawVector(rOther.mConstitutiveLawVector)
     ,mFinalizedStep(rOther.mFinalizedStep)
@@ -84,10 +83,6 @@ UpdatedLagrangianQuadrilateral&  UpdatedLagrangianQuadrilateral::operator=(Updat
 
     mDeformationGradientF0.clear();
     mDeformationGradientF0 = rOther.mDeformationGradientF0;
-
-    mInverseJ.clear();
-    mInverseJ = rOther.mInverseJ;
-
 
     mDeterminantF0 = rOther.mDeterminantF0;
     mDeterminantJ0 = rOther.mDeterminantJ0;
@@ -114,8 +109,6 @@ Element::Pointer UpdatedLagrangianQuadrilateral::Clone( IndexType NewId, NodesAr
     NewElement.mConstitutiveLawVector = mConstitutiveLawVector->Clone();
 
     NewElement.mDeformationGradientF0 = mDeformationGradientF0;
-
-    NewElement.mInverseJ = mInverseJ;
 
     NewElement.mDeterminantF0 = mDeterminantF0;
     NewElement.mDeterminantJ0 = mDeterminantJ0;
@@ -144,12 +137,6 @@ void UpdatedLagrangianQuadrilateral::Initialize()
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
     mDeterminantF0 = 1;
     mDeformationGradientF0 = IdentityMatrix(dimension);
-
-    // Compute current jacobian matrix and inverses
-    Matrix j = ZeroMatrix(dimension, dimension);
-    j = this->MPMJacobian(j,xg);
-    double detj;
-    MathUtils<double>::InvertMatrix( j, mInverseJ, detj );
 
     // Initialize constitutive law and materials
     InitializeMaterial();
@@ -989,8 +976,6 @@ void UpdatedLagrangianQuadrilateral::FinalizeStepVariables( GeneralVariables & r
 
     double AccumulatedPlasticDeviatoricStrain = mConstitutiveLawVector->GetValue(MP_ACCUMULATED_PLASTIC_DEVIATORIC_STRAIN, AccumulatedPlasticDeviatoricStrain);
     this->SetValue(MP_ACCUMULATED_PLASTIC_DEVIATORIC_STRAIN, AccumulatedPlasticDeviatoricStrain);
-
-    MathUtils<double>::InvertMatrix( rVariables.j, mInverseJ, rVariables.detJ );
 
     this->UpdateGaussPoint(rVariables, rCurrentProcessInfo);
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
@@ -180,8 +180,6 @@ void UpdatedLagrangianQuadrilateral::InitializeGeneralVariables (GeneralVariable
 
     rVariables.detFT = 1;
 
-    rVariables.detJ = 1;
-
     rVariables.B.resize( voigtsize, number_of_nodes * dimension, false );
 
     rVariables.F.resize( dimension, dimension, false );
@@ -384,11 +382,12 @@ void UpdatedLagrangianQuadrilateral::CalculateKinematics(GeneralVariables& rVari
 
     // Calculating the inverse of the jacobian and the parameters needed [d£/dx_n]
     Matrix InvJ;
-    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, rVariables.detJ);
+    double detJ;
+    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, detJ);
 
     // Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;
-    MathUtils<double>::InvertMatrix( rVariables.j, Invj, rVariables.detJ ); //overwrites detJ
+    MathUtils<double>::InvertMatrix( rVariables.j, Invj, detJ); //overwrites detJ
 
     // Compute cartesian derivatives [dN/dx_n+1]
     rVariables.DN_DX = prod( rVariables.DN_De, Invj); //overwrites DX now is the current position dx

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
@@ -213,9 +213,6 @@ void UpdatedLagrangianQuadrilateral::InitializeGeneralVariables (GeneralVariable
 
     // Calculating the current jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n+1/d£]
     rVariables.j = this->MPMJacobianDelta( rVariables.j, xg, rVariables.CurrentDisp);
-
-    // Calculating the reference jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n/d£]
-    rVariables.J = this->MPMJacobian( rVariables.J, xg);
 }
 //************************************************************************************
 //************************************************************************************
@@ -380,10 +377,15 @@ void UpdatedLagrangianQuadrilateral::CalculateKinematics(GeneralVariables& rVari
     // Define the stress measure
     rVariables.StressMeasure = ConstitutiveLaw::StressMeasure_Cauchy;
 
+    // Calculating the reference jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n/d£]
+    const array_1d<double,3>& xg = this->GetValue(MP_COORD);
+    Matrix Jacobian;
+    Jacobian = this->MPMJacobian( Jacobian, xg);
+
     // Calculating the inverse of the jacobian and the parameters needed [d£/dx_n]
     Matrix InvJ;
     double detJ;
-    MathUtils<double>::InvertMatrix( rVariables.J, InvJ, detJ);
+    MathUtils<double>::InvertMatrix( Jacobian, InvJ, detJ);
 
     // Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
@@ -127,9 +127,6 @@ void UpdatedLagrangianQuadrilateral::Initialize()
 {
     KRATOS_TRY
 
-    // Initial position of the particle
-    const array_1d<double,3>& xg = this->GetValue(MP_COORD);
-
     // Initialize parameters
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
     mDeterminantF0 = 1;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
@@ -210,9 +210,6 @@ void UpdatedLagrangianQuadrilateral::InitializeGeneralVariables (GeneralVariable
 
     // CurrentDisp is the variable unknown. It represents the nodal delta displacement. When it is predicted is equal to zero.
     rVariables.CurrentDisp = CalculateCurrentDisp(rVariables.CurrentDisp, rCurrentProcessInfo);
-
-    // Calculating the current jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n+1/d£]
-    rVariables.j = this->MPMJacobianDelta( rVariables.j, xg, rVariables.CurrentDisp);
 }
 //************************************************************************************
 //************************************************************************************
@@ -387,9 +384,13 @@ void UpdatedLagrangianQuadrilateral::CalculateKinematics(GeneralVariables& rVari
     double detJ;
     MathUtils<double>::InvertMatrix( Jacobian, InvJ, detJ);
 
+    // Calculating the current jacobian from cartesian coordinates to parent coordinates for the MP element [dx_n+1/d£]
+    Matrix jacobian;
+    jacobian = this->MPMJacobianDelta( jacobian, xg, rVariables.CurrentDisp);
+
     // Calculating the inverse of the jacobian and the parameters needed [d£/(dx_n+1)]
     Matrix Invj;
-    MathUtils<double>::InvertMatrix( rVariables.j, Invj, detJ); //overwrites detJ
+    MathUtils<double>::InvertMatrix( jacobian, Invj, detJ); //overwrites detJ
 
     // Compute cartesian derivatives [dN/dx_n+1]
     rVariables.DN_DX = prod( rVariables.DN_De, Invj); //overwrites DX now is the current position dx
@@ -397,13 +398,13 @@ void UpdatedLagrangianQuadrilateral::CalculateKinematics(GeneralVariables& rVari
     /* NOTE::
     Deformation Gradient F [(dx_n+1 - dx_n)/dx_n] is to be updated in constitutive law parameter as total deformation gradient.
     The increment of total deformation gradient can be evaluated in 2 ways, which are:
-    1. By: noalias( rVariables.F ) = prod( rVariables.j, InvJ);
+    1. By: noalias( rVariables.F ) = prod( jacobian, InvJ);
     2. By means of the gradient of nodal displacement: using this second expression quadratic convergence is not guarantee
 
     (NOTICE: Here, we are using method no. 2)*/
 
     // METHOD 1: Update Deformation gradient: F [dx_n+1/dx_n] = [dx_n+1/d£] [d£/dx_n]
-    // noalias( rVariables.F ) = prod( rVariables.j, InvJ);
+    // noalias( rVariables.F ) = prod( jacobian, InvJ);
 
     // METHOD 2: Update Deformation gradient: F_ij = δ_ij + u_i,j
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
@@ -190,13 +190,9 @@ void UpdatedLagrangianQuadrilateral::InitializeGeneralVariables (GeneralVariable
 
     rVariables.ConstitutiveMatrix.resize( voigtsize, voigtsize, false );
 
-    rVariables.Normal.resize( voigtsize, voigtsize, false );
-
     rVariables.StrainVector.resize( voigtsize, false );
 
     rVariables.StressVector.resize( voigtsize, false );
-
-    rVariables.IsoStressVector.resize( voigtsize, false );
 
     rVariables.DN_DX.resize( number_of_nodes, dimension, false );
     rVariables.DN_De.resize( number_of_nodes, dimension, false );

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.cpp
@@ -68,7 +68,6 @@ UpdatedLagrangianQuadrilateral::UpdatedLagrangianQuadrilateral( UpdatedLagrangia
     :Element(rOther)
     ,mDeformationGradientF0(rOther.mDeformationGradientF0)
     ,mDeterminantF0(rOther.mDeterminantF0)
-    ,mInverseJ0(rOther.mInverseJ0)
     ,mInverseJ(rOther.mInverseJ)
     ,mDeterminantJ0(rOther.mDeterminantJ0)
     ,mConstitutiveLawVector(rOther.mConstitutiveLawVector)
@@ -86,8 +85,6 @@ UpdatedLagrangianQuadrilateral&  UpdatedLagrangianQuadrilateral::operator=(Updat
     mDeformationGradientF0.clear();
     mDeformationGradientF0 = rOther.mDeformationGradientF0;
 
-    mInverseJ0.clear();
-    mInverseJ0 = rOther.mInverseJ0;
     mInverseJ.clear();
     mInverseJ = rOther.mInverseJ;
 
@@ -118,7 +115,6 @@ Element::Pointer UpdatedLagrangianQuadrilateral::Clone( IndexType NewId, NodesAr
 
     NewElement.mDeformationGradientF0 = mDeformationGradientF0;
 
-    NewElement.mInverseJ0 = mInverseJ0;
     NewElement.mInverseJ = mInverseJ;
 
     NewElement.mDeterminantF0 = mDeterminantF0;
@@ -148,11 +144,6 @@ void UpdatedLagrangianQuadrilateral::Initialize()
     const unsigned int dimension = GetGeometry().WorkingSpaceDimension();
     mDeterminantF0 = 1;
     mDeformationGradientF0 = IdentityMatrix(dimension);
-
-    // Compute initial jacobian matrix and inverses
-    Matrix J0 = ZeroMatrix(dimension, dimension);
-    J0 = this->MPMJacobian(J0, xg);
-    MathUtils<double>::InvertMatrix( J0, mInverseJ0, mDeterminantJ0 );
 
     // Compute current jacobian matrix and inverses
     Matrix j = ZeroMatrix(dimension, dimension);
@@ -864,11 +855,6 @@ void UpdatedLagrangianQuadrilateral::InitializeSolutionStep( ProcessInfo& rCurre
     const unsigned int number_of_nodes = rGeom.PointsNumber();
     const array_1d<double,3>& xg = this->GetValue(MP_COORD);
     GeneralVariables Variables;
-
-    // Calculating and storing inverse and the determinant of the jacobian
-    Matrix J0 = ZeroMatrix(dimension, dimension);
-    J0 = this->MPMJacobian(J0, xg);
-    MathUtils<double>::InvertMatrix( J0, mInverseJ0, mDeterminantJ0 );
 
     // Calculating shape function
     Variables.N = this->MPMShapeFunctionPointValues(Variables.N, xg);
@@ -1856,7 +1842,6 @@ void UpdatedLagrangianQuadrilateral::save( Serializer& rSerializer ) const
     rSerializer.save("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.save("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.save("DeterminantF0",mDeterminantF0);
-    rSerializer.save("InverseJ0",mInverseJ0);
     rSerializer.save("DeterminantJ0",mDeterminantJ0);
 
 }
@@ -1867,7 +1852,6 @@ void UpdatedLagrangianQuadrilateral::load( Serializer& rSerializer )
     rSerializer.load("ConstitutiveLawVector",mConstitutiveLawVector);
     rSerializer.load("DeformationGradientF0",mDeformationGradientF0);
     rSerializer.load("DeterminantF0",mDeterminantF0);
-    rSerializer.load("InverseJ0",mInverseJ0);
     rSerializer.load("DeterminantJ0",mDeterminantJ0);
 }
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
@@ -506,7 +506,6 @@ protected:
     /**
      * Container for historical inverse of Jacobian at reference configuration invJ0
      */
-    Matrix mInverseJ0;
     Matrix mInverseJ;
     /**
      * Container for the total Jacobian determinants

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
@@ -503,10 +503,7 @@ protected:
      * Container for the total deformation gradient determinants
      */
     double mDeterminantF0;
-    /**
-     * Container for historical inverse of Jacobian at reference configuration invJ0
-     */
-    Matrix mInverseJ;
+
     /**
      * Container for the total Jacobian determinants
      */

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
@@ -105,7 +105,6 @@ protected:
         double  detF;
         double  detF0;
         double  detFT;
-        double  detJ;
         Vector  StrainVector;
         Vector  StressVector;
         Vector  IsoStressVector;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
@@ -505,11 +505,6 @@ protected:
     double mDeterminantF0;
 
     /**
-     * Container for the total Jacobian determinants
-     */
-    double mDeterminantJ0;
-
-    /**
      * Container for constitutive law instances on each integration point
      */
     ConstitutiveLaw::Pointer mConstitutiveLawVector;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
@@ -97,11 +97,11 @@ protected:
 
         StressMeasureType StressMeasure;
 
-        //for axisymmetric use only
+        // For axisymmetric use only
         double  CurrentRadius;
         double  ReferenceRadius;
 
-        //general variables for large displacement use
+        // General variables for large displacement use
         double  detF;
         double  detF0;
         double  detFT;
@@ -118,10 +118,7 @@ protected:
         Matrix  ConstitutiveMatrix;
         Matrix Normal;
 
-        //variables including all integration points
-        //GeometryType::JacobiansType J;
-        //GeometryType::JacobiansType j;
-        Matrix J;
+        // Variables including all integration points
         Matrix j;
         Matrix  DeltaPosition;
         Matrix CurrentDisp;

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
@@ -119,8 +119,6 @@ protected:
         Matrix Normal;
 
         // Variables including all integration points
-        Matrix j;
-        Matrix  DeltaPosition;
         Matrix CurrentDisp;
         Matrix PreviousDisp;
 

--- a/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
+++ b/applications/ParticleMechanicsApplication/custom_elements/updated_lagrangian_quadrilateral.hpp
@@ -107,7 +107,6 @@ protected:
         double  detFT;
         Vector  StrainVector;
         Vector  StressVector;
-        Vector  IsoStressVector;
         Vector  N;
         Matrix  B;
         Matrix  F;
@@ -116,7 +115,6 @@ protected:
         Matrix  DN_DX;
         Matrix  DN_De;
         Matrix  ConstitutiveMatrix;
-        Matrix Normal;
 
         // Variables including all integration points
         Matrix CurrentDisp;


### PR DESCRIPTION
I am removing the variables to store jacobian in MP element as it is not needed for integration purpose. I am not sure why it is there, as they are quite expensive memory wise. Including its initial condition, inverse, and determinant, there are a lot of memory being wasted. 
Maybe @iiaconeta can ellaborate this? All tests are running okay, btw.