### PR TITLE
[core] Add mesh container for point2D

### DIFF
--- a/kratos/includes/gid_io.h
+++ b/kratos/includes/gid_io.h
@@ -198,6 +198,9 @@ public:
         mGidMeshContainers.push_back( TMeshContainer(
                                           GeometryData::Kratos_Point3D,
                                           GiD_Point, "Kratos_Point3D_Mesh" ) );
+        mGidMeshContainers.push_back( TMeshContainer(
+                                          GeometryData::Kratos_Point2D,
+                                          GiD_Point, "Kratos_Point2D_Mesh" ) );
 
 
     }//SetUpMeshContainers

--- a/kratos/includes/gid_io.h
+++ b/kratos/includes/gid_io.h
@@ -196,11 +196,11 @@ public:
                                           GeometryData::Kratos_Line3D3,
                                           GiD_Linear, "Kratos_Line3D3_Mesh" ) );
         mGidMeshContainers.push_back( TMeshContainer(
-                                          GeometryData::Kratos_Point3D,
-                                          GiD_Point, "Kratos_Point3D_Mesh" ) );
-        mGidMeshContainers.push_back( TMeshContainer(
                                           GeometryData::Kratos_Point2D,
                                           GiD_Point, "Kratos_Point2D_Mesh" ) );
+        mGidMeshContainers.push_back( TMeshContainer(
+                                          GeometryData::Kratos_Point3D,
+                                          GiD_Point, "Kratos_Point3D_Mesh" ) );
 
 
     }//SetUpMeshContainers


### PR DESCRIPTION
Adding a missing mesh container in order to write elements with 2D point geometries.