### PR TITLE
[Poromechanics] Fixing arc length strategy

### DIFF
--- a/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_newton_raphson_strategy.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_newton_raphson_strategy.hpp
@@ -174,9 +174,8 @@ protected:
         int ierr = MotherType::Check();
         if(ierr != 0) return ierr;
         
-        if(IS_CONVERGED.Key() == 0)
-            KRATOS_THROW_ERROR( std::invalid_argument,"IS_CONVERGED Key is 0. Check if all applications were correctly registered.", "" )
-        
+        KRATOS_CHECK_VARIABLE_KEY(IS_CONVERGED);
+
         return ierr;
 
         KRATOS_CATCH( "" )

--- a/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_ramm_arc_length_strategy.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_ramm_arc_length_strategy.hpp
@@ -78,8 +78,10 @@ public:
             mDesiredIterations = rParameters["desired_iterations"].GetInt();
             mMaxRadiusFactor = rParameters["max_radius_factor"].GetDouble();
             mMinRadiusFactor = rParameters["min_radius_factor"].GetDouble();
+
+            mInitializeArcLengthWasPerformed = false;
         }
-    
+
     //------------------------------------------------------------------------------------
 
     ///Destructor
@@ -94,46 +96,51 @@ public:
         if (mInitializeWasPerformed == false)
 		{
             MotherType::Initialize();
-                        
-            //set up the system
-            if (mpBuilderAndSolver->GetDofSetIsInitializedFlag() == false)
+
+            if (mInitializeArcLengthWasPerformed == false)
             {
-                //setting up the list of the DOFs to be solved
-                mpBuilderAndSolver->SetUpDofSet(mpScheme, BaseType::GetModelPart());
+                //set up the system
+                if (mpBuilderAndSolver->GetDofSetIsInitializedFlag() == false)
+                {
+                    //setting up the list of the DOFs to be solved
+                    mpBuilderAndSolver->SetUpDofSet(mpScheme, BaseType::GetModelPart());
 
-                //shaping correctly the system
-                mpBuilderAndSolver->SetUpSystem(BaseType::GetModelPart());
+                    //shaping correctly the system
+                    mpBuilderAndSolver->SetUpSystem(BaseType::GetModelPart());
+                }
+
+                // Compute initial radius (mRadius_0)
+                mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, mpA, mpDx, mpb, BaseType::GetModelPart());
+                TSystemMatrixType& mA = *mpA;
+                TSystemVectorType& mDx = *mpDx;
+                TSystemVectorType& mb = *mpb;
+                TSparseSpace::SetToZero(mA);
+                TSparseSpace::SetToZero(mDx);
+                TSparseSpace::SetToZero(mb);
+
+                mpBuilderAndSolver->BuildAndSolve(mpScheme, BaseType::GetModelPart(), mA, mDx, mb);
+
+                mRadius_0 = TSparseSpace::TwoNorm(mDx);
+                mRadius = mRadius_0;
+
+                // Compute vector of reference external force (mf)
+                this->InitializeSystemVector(mpf);
+                TSystemVectorType& mf = *mpf;
+                TSparseSpace::SetToZero(mf);
+
+                mpBuilderAndSolver->BuildRHS(mpScheme, BaseType::GetModelPart(), mf);
+
+                //Initialize the loading factor Lambda
+                mLambda = 0.0;
+                mLambda_old = 1.0;
+
+                // Initialize Norm of solution
+                mNormxEquilibrium = 0.0;
+
+                mInitializeArcLengthWasPerformed = true;
+
+                KRATOS_INFO("Ramm's Arc Length Strategy") << "Strategy Initialized" << std::endl;
             }
-            
-            // Compute initial radius (mRadius_0)
-            mpBuilderAndSolver->ResizeAndInitializeVectors(mpScheme, mpA, mpDx, mpb, BaseType::GetModelPart());
-            TSystemMatrixType& mA = *mpA;
-            TSystemVectorType& mDx = *mpDx;
-            TSystemVectorType& mb = *mpb;
-            TSparseSpace::SetToZero(mA);
-            TSparseSpace::SetToZero(mDx);
-            TSparseSpace::SetToZero(mb);
-
-            mpBuilderAndSolver->BuildAndSolve(mpScheme, BaseType::GetModelPart(), mA, mDx, mb);
-            
-            mRadius_0 = TSparseSpace::TwoNorm(mDx);
-            mRadius = mRadius_0;
-
-            // Compute vector of reference external force (mf)
-            this->InitializeSystemVector(mpf);
-            TSystemVectorType& mf = *mpf;
-            TSparseSpace::SetToZero(mf);
-
-            mpBuilderAndSolver->BuildRHS(mpScheme, BaseType::GetModelPart(), mf);
-            
-            //Initialize the loading factor Lambda
-            mLambda = 0.0;
-            mLambda_old = 1.0;
-            
-            // Initialize Norm of solution
-            mNormxEquilibrium = 0.0;
-            
-            KRATOS_INFO("Ramm's Arc Length Strategy") << "Strategy Initialized" << std::endl;
         }
 
         KRATOS_CATCH( "" )
@@ -148,14 +155,14 @@ public:
 		if (mSolutionStepIsInitialized == false)
 		{
             GrandMotherType::InitializeSolutionStep();
-            
+
             this->SaveInitializeSystemVector(mpf);
             this->InitializeSystemVector(mpDxf);
             this->InitializeSystemVector(mpDxb);
             this->InitializeSystemVector(mpDxPred);
             this->InitializeSystemVector(mpDxStep);
         }
-        
+
         KRATOS_CATCH( "" )
     }
 
@@ -164,9 +171,9 @@ public:
 	bool SolveSolutionStep() override
 	{
         // ********** Prediction phase **********
-                
+
         KRATOS_INFO("Ramm's Arc Length Strategy") << "ARC-LENGTH RADIUS: " << mRadius/mRadius_0 << " X initial radius" << std::endl;
-        
+
         // Initialize variables
 		DofsArrayType& rDofSet = mpBuilderAndSolver->GetDofSet();
         TSystemMatrixType& mA = *mpA;
@@ -177,13 +184,19 @@ public:
         TSystemVectorType& mDxf = *mpDxf;
         TSystemVectorType& mDxPred = *mpDxPred;
         TSystemVectorType& mDxStep = *mpDxStep;
-        
+
+        //initializing the parameters of the iteration loop
+        double NormDx;
+        unsigned int iteration_number = 1;
+        BaseType::GetModelPart().GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
+        bool is_converged = false;
         mpScheme->InitializeNonLinIteration(BaseType::GetModelPart(), mA, mDx, mb);
-                
+        is_converged = mpConvergenceCriteria->PreCriteria(BaseType::GetModelPart(), rDofSet, mA, mDx, mb);
+
         TSparseSpace::SetToZero(mA);
         TSparseSpace::SetToZero(mb);
         TSparseSpace::SetToZero(mDxf);
-        
+
         // Note: This is not so efficient, but I want to solve mA*mDxf=mf without losing mf
         this->BuildWithDirichlet(mA, mDxf, mb);
         noalias(mb) = mf;
@@ -199,34 +212,32 @@ public:
 
         //move the mesh if needed
         if(BaseType::MoveMeshFlag() == true) BaseType::MoveMesh();
-        
+
         // ********** Correction phase (iteration cicle) **********
-
-        //initializing the parameters of the iteration loop
-        bool is_converged = false;
-        mpConvergenceCriteria->InitializeSolutionStep(BaseType::GetModelPart(), rDofSet, mA, mDxf, mb);
-        if (mpConvergenceCriteria->GetActualizeRHSflag() == true)
+        if (is_converged == true)
         {
-            TSparseSpace::SetToZero(mb);
-            mpBuilderAndSolver->BuildRHS(mpScheme, BaseType::GetModelPart(), mb);
+            mpConvergenceCriteria->InitializeSolutionStep(BaseType::GetModelPart(), rDofSet, mA, mDxf, mb);
+            if (mpConvergenceCriteria->GetActualizeRHSflag() == true)
+            {
+                TSparseSpace::SetToZero(mb);
+                mpBuilderAndSolver->BuildRHS(mpScheme, BaseType::GetModelPart(), mb);
+            }
+            is_converged = mpConvergenceCriteria->PostCriteria(BaseType::GetModelPart(), rDofSet, mA, mDxf, mb);
         }
-        is_converged = mpConvergenceCriteria->PostCriteria(BaseType::GetModelPart(), rDofSet, mA, mDxf, mb);
 
-        unsigned int iteration_number = 0;
-        double NormDx;
-        
-        while (is_converged == false && iteration_number < mMaxIterationNumber)
+        while (is_converged == false && iteration_number++ < mMaxIterationNumber)
         {
             //setting the number of iteration
-            iteration_number += 1;
             BaseType::GetModelPart().GetProcessInfo()[NL_ITERATION_NUMBER] = iteration_number;
-            
+
             mpScheme->InitializeNonLinIteration(BaseType::GetModelPart(), mA, mDx, mb);
+
+            is_converged = mpConvergenceCriteria->PreCriteria(BaseType::GetModelPart(), rDofSet, mA, mDx, mb);
 
             TSparseSpace::SetToZero(mA);
             TSparseSpace::SetToZero(mb);
             TSparseSpace::SetToZero(mDxf);
-            
+
             // Note: This is not so efficient, but I want to solve mA*mDxf=mf without losing mf
             this->BuildWithDirichlet(mA, mDxf, mb);
             noalias(mb) = mf;
@@ -235,25 +246,25 @@ public:
             TSparseSpace::SetToZero(mA);
             TSparseSpace::SetToZero(mb);
             TSparseSpace::SetToZero(mDxb);
-            
+
             mpBuilderAndSolver->BuildAndSolve(mpScheme, BaseType::GetModelPart(), mA, mDxb, mb);
-            
+
             DLambda = -TSparseSpace::Dot(mDxPred, mDxb)/TSparseSpace::Dot(mDxPred, mDxf);
-            
+
             noalias(mDx) = mDxb + DLambda*mDxf;
-            
+
             //Check solution before update
             if( mNormxEquilibrium > 1.0e-10 )
             {
                 NormDx = TSparseSpace::TwoNorm(mDx);
-                
+
                 if( (NormDx/mNormxEquilibrium) > 1.0e3 || (std::abs(DLambda)/std::abs(mLambda-mDLambdaStep)) > 1.0e3 )
                 {
                     is_converged = false;
                     break;
                 }
             }
-            
+
             //update results
             mDLambdaStep += DLambda;
             mLambda += DLambda;
@@ -262,20 +273,24 @@ public:
 
             //move the mesh if needed
             if(BaseType::MoveMeshFlag() == true) BaseType::MoveMesh();
-            
+
             mpScheme->FinalizeNonLinIteration(BaseType::GetModelPart(), mA, mDx, mb);
-            
+
             // *** Check Convergence ***
-            
-            if (mpConvergenceCriteria->GetActualizeRHSflag() == true)
+
+            if (is_converged == true)
             {
-                TSparseSpace::SetToZero(mb);
-                mpBuilderAndSolver->BuildRHS(mpScheme, BaseType::GetModelPart(), mb);
+                if (mpConvergenceCriteria->GetActualizeRHSflag() == true)
+                {
+                    TSparseSpace::SetToZero(mb);
+                    mpBuilderAndSolver->BuildRHS(mpScheme, BaseType::GetModelPart(), mb);
+                }
+                is_converged = mpConvergenceCriteria->PostCriteria(BaseType::GetModelPart(), rDofSet, mA, mDx, mb);
             }
-            is_converged = mpConvergenceCriteria->PostCriteria(BaseType::GetModelPart(), rDofSet, mA, mDx, mb);
+
         }//While
-        
-        // Check iteration_number 
+
+        // Check iteration_number
         if (iteration_number >= mMaxIterationNumber)
         {
             is_converged = true;
@@ -285,15 +300,15 @@ public:
                 this->MaxIterationsExceeded();
             }
         }
-        
+
         //calculate reactions if required
         if (mCalculateReactionsFlag == true)
         {
             mpBuilderAndSolver->CalculateReactions(mpScheme, BaseType::GetModelPart(), mA, mDx, mb);
         }
-        
+
         BaseType::GetModelPart().GetProcessInfo()[IS_CONVERGED] = is_converged;
-        
+
 		return is_converged;
     }
 
@@ -302,12 +317,12 @@ public:
 	void FinalizeSolutionStep() override
 	{
 		KRATOS_TRY
-        
+
         unsigned int iteration_number = BaseType::GetModelPart().GetProcessInfo()[NL_ITERATION_NUMBER];
-        
+
         // Update the radius
         mRadius = mRadius*sqrt(double(mDesiredIterations)/double(iteration_number));
-        
+
         DofsArrayType& rDofSet = mpBuilderAndSolver->GetDofSet();
         TSystemMatrixType& mA = *mpA;
         TSystemVectorType& mDx = *mpDx;
@@ -320,16 +335,16 @@ public:
                 mRadius = mMaxRadiusFactor*mRadius_0;
             else if(mRadius < mMinRadiusFactor*mRadius_0)
                 mRadius = mMinRadiusFactor*mRadius_0;
-            
+
             // Update Norm of x
             mNormxEquilibrium = this->CalculateReferenceDofsNorm(rDofSet);
         }
         else
         {
             std::cout << "************ NO CONVERGENCE: restoring equilibrium path ************" << std::endl;
-            
+
             TSystemVectorType& mDxStep = *mpDxStep;
-            
+
             //update results
             mLambda -= mDLambdaStep;
             noalias(mDx) = -mDxStep;
@@ -358,33 +373,33 @@ public:
 
 		KRATOS_CATCH("")
 	}
-    
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void Clear() override
     {
         KRATOS_TRY
-        
+
         SparseSpaceType::Clear(mpf);
         SparseSpaceType::Clear(mpDxf);
         SparseSpaceType::Clear(mpDxb);
         SparseSpaceType::Clear(mpDxPred);
         SparseSpaceType::Clear(mpDxStep);
-        
+
         TSystemVectorType& mf = *mpf;
         TSystemVectorType& mDxf = *mpDxf;
         TSystemVectorType& mDxb = *mpDxb;
         TSystemVectorType& mDxPred = *mpDxPred;
         TSystemVectorType& mDxStep = *mpDxStep;
-        
+
         SparseSpaceType::Resize(mf, 0);
         SparseSpaceType::Resize(mDxf, 0);
         SparseSpaceType::Resize(mDxb, 0);
         SparseSpaceType::Resize(mDxPred, 0);
         SparseSpaceType::Resize(mDxStep, 0);
-        
+
         GrandMotherType::Clear();
-        
+
         KRATOS_CATCH( "" )
     }
 
@@ -393,22 +408,22 @@ public:
     bool IsConverged() override
     {
         KRATOS_TRY
-        
+
         bool IsConverged = true;
-                
+
         // Note: Initialize() needs to be called beforehand
-        
+
 		this->InitializeSolutionStep();
-        
+
 		this->Predict();
-        
+
         // Solve the problem with constant load
 		IsConverged = this->CheckConvergence();
-        
+
 		this->FinalizeSolutionStep();
-        
+
         return IsConverged;
-        
+
         KRATOS_CATCH("")
     }
 
@@ -417,13 +432,13 @@ public:
     virtual void UpdateLoads()
     {
         KRATOS_TRY
-                
+
         mLambda = BaseType::GetModelPart().GetProcessInfo()[ARC_LENGTH_LAMBDA];
         mRadius = (BaseType::GetModelPart().GetProcessInfo()[ARC_LENGTH_RADIUS_FACTOR])*mRadius_0;
-        
-        // Update External Loads        
+
+        // Update External Loads
         this->UpdateExternalLoads();
-        
+
         KRATOS_CATCH("")
     }
 
@@ -437,9 +452,11 @@ protected:
     TSystemVectorPointerType mpDxb; /// Delta x of A*Dxb=b
     TSystemVectorPointerType mpDxPred; /// Delta x of prediction phase
     TSystemVectorPointerType mpDxStep; /// Delta x of the current step
-    
+
     unsigned int mDesiredIterations; /// This is used to calculate the radius of the next step
-    
+
+    bool mInitializeArcLengthWasPerformed;
+
     double mMaxRadiusFactor, mMinRadiusFactor; /// Used to limit the radius of the arc length strategy
     double mRadius, mRadius_0; /// Radius of the arc length strategy
     double mLambda, mLambda_old; /// Loading factor
@@ -451,10 +468,10 @@ protected:
     int Check() override
     {
         KRATOS_TRY
-        
+
         int ierr = MotherType::Check();
         if(ierr != 0) return ierr;
-        
+
         if(ARC_LENGTH_LAMBDA.Key() == 0)
             KRATOS_THROW_ERROR( std::invalid_argument,"ARC_LENGTH_LAMBDA Key is 0. Check if all applications were correctly registered.", "" )
         if(ARC_LENGTH_RADIUS_FACTOR.Key() == 0)
@@ -509,14 +526,14 @@ protected:
     }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    
+
     virtual void Update(DofsArrayType& rDofSet, TSystemMatrixType& mA, TSystemVectorType& mDx, TSystemVectorType& mb)
     {
         KRATOS_TRY
-        
+
         // Update scheme
         mpScheme->Update(BaseType::GetModelPart(), rDofSet, mA, mDx, mb);
-        
+
         // Update External Loads
         this->UpdateExternalLoads();
 
@@ -558,17 +575,17 @@ protected:
         {
             ModelPart& rSubModelPart = *(mSubModelPartList[i]);
             const std::string& VariableName = mVariableNames[i];
-            
+
             if( KratosComponents< Variable<double> >::Has( VariableName ) )
             {
                 Variable<double> var = KratosComponents< Variable<double> >::Get( VariableName );
-                
+
                 #pragma omp parallel
                 {
                     ModelPart::NodeIterator NodesBegin;
                     ModelPart::NodeIterator NodesEnd;
                     OpenMPUtils::PartitionedIterators(rSubModelPart.Nodes(),NodesBegin,NodesEnd);
-                    
+
                     for (ModelPart::NodeIterator itNode = NodesBegin; itNode != NodesEnd; ++itNode)
                     {
                         double& rvalue = itNode->FastGetSolutionStepValue(var);
@@ -582,13 +599,13 @@ protected:
                 component_type varx = KratosComponents< component_type >::Get(VariableName+std::string("_X"));
                 component_type vary = KratosComponents< component_type >::Get(VariableName+std::string("_Y"));
                 component_type varz = KratosComponents< component_type >::Get(VariableName+std::string("_Z"));
-                
+
                 #pragma omp parallel
                 {
                     ModelPart::NodeIterator NodesBegin;
                     ModelPart::NodeIterator NodesEnd;
                     OpenMPUtils::PartitionedIterators(rSubModelPart.Nodes(),NodesBegin,NodesEnd);
-                    
+
                     for (ModelPart::NodeIterator itNode = NodesBegin; itNode != NodesEnd; ++itNode)
                     {
                         double& rvaluex = itNode->FastGetSolutionStepValue(varx);
@@ -605,7 +622,7 @@ protected:
                 KRATOS_THROW_ERROR( std::logic_error, "One variable of the applied loads has a non supported type. Variable: ", VariableName )
             }
         }
-        
+
         // Save the applied Lambda factor
         mLambda_old = mLambda;
     }

--- a/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_ramm_arc_length_strategy.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_ramm_arc_length_strategy.hpp
@@ -472,10 +472,9 @@ protected:
         int ierr = MotherType::Check();
         if(ierr != 0) return ierr;
 
-        if(ARC_LENGTH_LAMBDA.Key() == 0)
-            KRATOS_THROW_ERROR( std::invalid_argument,"ARC_LENGTH_LAMBDA Key is 0. Check if all applications were correctly registered.", "" )
-        if(ARC_LENGTH_RADIUS_FACTOR.Key() == 0)
-            KRATOS_THROW_ERROR( std::invalid_argument,"ARC_LENGTH_RADIUS_FACTOR Key is 0. Check if all applications were correctly registered.", "" )
+        KRATOS_CHECK_VARIABLE_KEY(ARC_LENGTH_LAMBDA);
+        KRATOS_CHECK_VARIABLE_KEY(ARC_LENGTH_RADIUS_FACTOR);
+
         return ierr;
 
         KRATOS_CATCH( "" )


### PR DESCRIPTION
Summary of problems addressed:

- The number of iterations were not properly computed. Important for the estimation of the arc length radius.
- We were repeatedly calling the Initialize() method when dofs were reformed. That was problematic because important member variables for the arc length were deleted.