### PR TITLE
[core][geometry] Fixing quadrilateral_interface_2d_4 for AMatrix port

### DIFF
--- a/kratos/geometries/quadrilateral_interface_2d_4.h
+++ b/kratos/geometries/quadrilateral_interface_2d_4.h
@@ -1122,7 +1122,7 @@ public:
 
         for ( IndexType i = 0; i < rResult.size(); i++ )
         {
-            vector<Matrix> temp( this->PointsNumber() );
+            DenseVector<Matrix> temp( this->PointsNumber() );
             rResult[i].swap( temp );
         }
 


### PR DESCRIPTION
I just replaced a "vector<Matrix>" by a "DenseVector<Matrix>"