### PR TITLE
[Discussion][StructuralMechanics] defaulting to implicit time-integration

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
@@ -6,10 +6,14 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
 
     solver_type = solver_settings["solver_type"].GetString()
 
+    if solver_settings["solver_settings"].Has("time_integration_method"):
+        time_integration_method = solver_settings["solver_settings"]["time_integration_method"].GetString()
+    else:
+        time_integration_method = "implicit" # defaulting to implicit time-integration
+
     # Solvers for OpenMP parallelism
     if (parallelism == "OpenMP"):
         if (solver_type == "dynamic" or solver_type == "Dynamic"):
-            time_integration_method = solver_settings["time_integration_method"].GetString()
             if (time_integration_method == "implicit"):
                 solver_module_name = "structural_mechanics_implicit_dynamic_solver"
             elif ( time_integration_method == "explicit"):
@@ -42,7 +46,6 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
     # Solvers for MPI parallelism
     elif (parallelism == "MPI"):
         if (solver_type == "dynamic" or solver_type == "Dynamic"):
-            time_integration_method = solver_settings["time_integration_method"].GetString()
             if (time_integration_method == "implicit"):
                 solver_module_name = "trilinos_structural_mechanics_implicit_dynamic_solver"
             else:

--- a/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
@@ -6,8 +6,8 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
 
     solver_type = solver_settings["solver_type"].GetString()
 
-    if solver_settings["solver_settings"].Has("time_integration_method"):
-        time_integration_method = solver_settings["solver_settings"]["time_integration_method"].GetString()
+    if solver_settings.Has("time_integration_method"):
+        time_integration_method = solver_settings["time_integration_method"].GetString()
     else:
         time_integration_method = "implicit" # defaulting to implicit time-integration
 


### PR DESCRIPTION
same as is done in contact

Should the user have to specify the time-integration-method or not?

What do others think?