### PR TITLE
deriving python interface of MasterSlaveConstraints from flags

### DIFF
--- a/kratos/python/add_constraint_to_python.cpp
+++ b/kratos/python/add_constraint_to_python.cpp
@@ -44,7 +44,7 @@ typename TVariableType::Type GetValueHelperFunctionMasterSlaveConstraint(MasterS
 
 void AddConstraintToPython(pybind11::module &m)
 {
-    pybind11::class_<MasterSlaveConstraint, MasterSlaveConstraint::Pointer, MasterSlaveConstraint::BaseType>(m, "MasterSlaveConstraint")
+    pybind11::class_<MasterSlaveConstraint, MasterSlaveConstraint::Pointer, MasterSlaveConstraint::BaseType, Flags>(m, "MasterSlaveConstraint")
     .def(pybind11::init<>())
     .def(pybind11::init<int>())
 


### PR DESCRIPTION
as of now MasterSlaveConstraints do not have interface of flags.

this PR corrects this