### PR TITLE
[ConvDiff] CHT apply heat transfer interface process

### DIFF
--- a/applications/convection_diffusion_application/python_scripts/apply_thermal_interface_process.py
+++ b/applications/convection_diffusion_application/python_scripts/apply_thermal_interface_process.py
@@ -1,0 +1,49 @@
+import KratosMultiphysics
+import KratosMultiphysics.ConvectionDiffusionApplication as KratosConvDiff
+
+def Factory(settings, Model):
+    if(type(settings) != KratosMultiphysics.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    return ApplyInletProcess(Model, settings["Parameters"])
+
+
+class ApplyThermalInterfaceProcess(KratosMultiphysics.Process):
+    def __init__(self, Model, settings):
+        KratosMultiphysics.Process.__init__(self)
+
+        # Compare against default settings
+        default_settings = KratosMultiphysics.Parameters(r'''{
+            "model_part_name" : ""
+        }''')
+        settings.ValidateAndAssignDefaults(default_settings)
+
+        # Check input data
+        if (settings["model_part_name"].GetString() == ""):
+            raise Exception("Empty thermal interface model part name string. Set a valid model part name.")
+
+        # Set the INLET flag in the thermal interface nodes and conditions
+        interface_model_part = Model[settings["model_part_name"].GetString()]
+        KratosMultiphysics.VariableUtils().SetFlag(KratosMultiphysics.INTERFACE, True, interface_model_part.Nodes)
+        KratosMultiphysics.VariableUtils().SetFlag(KratosMultiphysics.INTERFACE, True, interface_model_part.Conditions)
+
+        # Search for the maximum property id in the current model
+        # Note that this operation is required to be performed after
+        # the properties have been already set by reading the materials.json
+        max_prop_id = -1
+        model_part_names = Model.GetModelPartNames()
+        model_part = Model.GetModelPart(settings["model_part_name"].GetString())
+        for model_part_name in model_part_names:
+            for prop in Model.GetModelPart(model_part_name).Properties:
+                if prop.Id > max_prop_id:
+                    max_prop_id = prop.Id
+        model_part.GetCommunicator().MaxAll(max_prop_id)
+
+        # Create a new property with the user defined interface parameters
+        thermal_interface_prop = KratosMultiphysics.Properties(max_prop_id + 1)
+        thermal_interface_prop.SetValue(KratosMultiphysics.EMISSIVITY, 0.0)
+        thermal_interface_prop.SetValue(KratosMultiphysics.CONVECTION_COEFFICIENT, 0.0)
+
+        # Set the property in the interface model part
+        model_part.AddProperties(thermal_interface_prop)
+        for condition in model_part.Conditions:
+            condition.Properties = thermal_interface_prop

--- a/applications/convection_diffusion_application/tests/test_ConvectionDiffusionApplication.py
+++ b/applications/convection_diffusion_application/tests/test_ConvectionDiffusionApplication.py
@@ -22,6 +22,7 @@ except ImportError as e:
 ##### SELF-CONTAINED TESTS #####
 from source_term_test import SourceTermTest
 from thermal_coupling_test import ThermalCouplingTest
+from test_apply_thermal_interface_process import ApplyThermalInterfaceProcessTest
 
 ##### SMALL TESTS #####
 from convection_diffusion_test_factory import BasicConvectionDiffusionStationaryTest as TBasicConvectionDiffusionStationaryTest
@@ -40,20 +41,21 @@ def AssembleTestSuites():
         The set of suites with its test_cases added.
     '''
     suites = KratosUnittest.KratosSuites
-    
+
     # Create a test suit with the selected tests (Small tests):
     # These tests are executed by the continuous integration tool, so they have to be very fast!
     # Execution time << 1 sec on a regular PC !!!
     # If the tests in the smallSuite take too long then merging to master will not be possible!
     smallSuite = suites['small'] # These tests are executed by the continuous integration tool
     nightSuite = suites['nightly'] # These tests are executed in the nightly build
-    
+
     ### Adding the self-contained tests
     smallSuite.addTest(SourceTermTest('testPureDiffusion'))
     smallSuite.addTest(SourceTermTest('testDiffusionDominated'))
     smallSuite.addTest(SourceTermTest('testConvectionDominated'))
     smallSuite.addTest(SourceTermTest('testReaction'))
     smallSuite.addTest(ThermalCouplingTest('testDirichletNeumann'))
+    smallSuite.addTest(ApplyThermalInterfaceProcessTest('testThermalInterfaceProcess'))
 
     ### Adding Small Tests
     smallSuite.addTest(TBasicConvectionDiffusionStationaryTest('test_execution'))
@@ -77,7 +79,7 @@ if __name__ == '__main__':
     KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning cpp unit tests ...")
     run_cpp_unit_tests.run()
     KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished running cpp unit tests!")
-    
+
     KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning python tests ...")
     KratosUnittest.runTests(AssembleTestSuites())
     KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished python tests!")

--- a/applications/convection_diffusion_application/tests/test_apply_thermal_interface_process.py
+++ b/applications/convection_diffusion_application/tests/test_apply_thermal_interface_process.py
@@ -1,0 +1,53 @@
+from __future__ import print_function, absolute_import, division
+import KratosMultiphysics
+import KratosMultiphysics.KratosUnittest as UnitTest
+import KratosMultiphysics.ConvectionDiffusionApplication as ConvectionDiffusionApplication
+
+import os
+
+class ApplyThermalInterfaceProcessTest(UnitTest.TestCase):
+    def runTest(self):
+        # Create a model part containing some properties
+        self.model = KratosMultiphysics.Model()
+        root_model_part = self.model.CreateModelPart("MainModelPart")
+        for i in range(5):
+            sub_model_part = root_model_part.CreateSubModelPart("SubModelPart" + str(i))
+            new_property_i = KratosMultiphysics.Properties(i)
+            sub_model_part.AddProperties(new_property_i)
+
+        # Create a fake interface condition
+        root_model_part.CreateNewNode(1, 0.0, 0.0, 0.0)
+        root_model_part.CreateNewNode(2, 1.0, 0.0, 0.0)
+        root_model_part.CreateNewNode(3, 2.0, 0.0, 0.0)
+        root_model_part.CreateNewCondition("ThermalFace2D2N", 1, [1,2], root_model_part.GetProperties()[1])
+        root_model_part.CreateNewCondition("ThermalFace2D2N", 2, [2,3], root_model_part.GetProperties()[2])
+
+        # Create a fake interface model part
+        interface_model_part = root_model_part.CreateSubModelPart("InterfaceModelPart")
+        interface_model_part.AddCondition(root_model_part.GetCondition(1))
+        interface_model_part.AddCondition(root_model_part.GetCondition(2))
+
+        # Call the apply_thermal_interface_process
+        interface_model_part = self.model.GetModelPart("InterfaceModelPart")
+        import apply_thermal_interface_process
+        settings = KratosMultiphysics.Parameters(r'''{
+            "model_part_name": "InterfaceModelPart"
+        }''')
+        thermal_int_proc = apply_thermal_interface_process.ApplyThermalInterfaceProcess(self.model, settings)
+
+    def checkResults(self):
+        # Check the interface properties
+        interface_model_part = self.model.GetModelPart("InterfaceModelPart")
+        self.assertEqual(interface_model_part.NumberOfProperties(), 1)
+        self.assertEqual(interface_model_part.GetRootModelPart().NumberOfProperties(), 6)
+        self.assertAlmostEqual(interface_model_part.GetCondition(1).Properties.GetValue(KratosMultiphysics.EMISSIVITY), 0.0, 1e-12)
+        self.assertAlmostEqual(interface_model_part.GetCondition(1).Properties.GetValue(KratosMultiphysics.CONVECTION_COEFFICIENT), 0.0, 1e-12)
+
+    def testThermalInterfaceProcess(self):
+        self.runTest()
+        self.checkResults()
+
+if __name__ == '__main__':
+    test = ApplyThermalInterfaceProcessTest()
+    test.runTest()
+    test.checkResults()

--- a/kratos/python/add_model_to_python.cpp
+++ b/kratos/python/add_model_to_python.cpp
@@ -26,19 +26,18 @@ namespace Python {
 void  AddModelToPython(pybind11::module& m)
 {
     namespace py = pybind11;
-    py::class_<Model >(m,"Model")
-    .def(py::init<>())
-    .def("Reset", &Model::Reset)
-    .def("CreateModelPart", [&](Model& self, const std::string& Name){return &self.CreateModelPart(Name);}, py::return_value_policy::reference_internal )
-    .def("CreateModelPart", [&](Model& self, const std::string& Name, unsigned int BufferSize){return &self.CreateModelPart(Name, BufferSize);}, py::return_value_policy::reference_internal )
-    .def("DeleteModelPart", &Model::DeleteModelPart)
-    .def("GetModelPart", &Model::GetModelPart, py::return_value_policy::reference_internal)
-    .def("HasModelPart", &Model::HasModelPart)
-    .def("__getitem__", &Model::GetModelPart, py::return_value_policy::reference_internal)
-    .def("__str__", PrintObject<Model>)
-    ;
+    py::class_<Model>(m, "Model")
+        .def(py::init<>())
+        .def("Reset", &Model::Reset)
+        .def("CreateModelPart", [&](Model &self, const std::string &Name) { return &self.CreateModelPart(Name); }, py::return_value_policy::reference_internal)
+        .def("CreateModelPart", [&](Model &self, const std::string &Name, unsigned int BufferSize) { return &self.CreateModelPart(Name, BufferSize); }, py::return_value_policy::reference_internal)
+        .def("DeleteModelPart", &Model::DeleteModelPart)
+        .def("GetModelPart", &Model::GetModelPart, py::return_value_policy::reference_internal)
+        .def("HasModelPart", &Model::HasModelPart)
+        .def("GetModelPartNames", &Model::GetModelPartNames)
+        .def("__getitem__", &Model::GetModelPart, py::return_value_policy::reference_internal)
+        .def("__str__", PrintObject<Model>);
 }
 
 }  // namespace Python.
 } // Namespace Kratos
-


### PR DESCRIPTION
This PR adds a new process to set the heat transfer interface properties in thermal coupled problems. Since there is no model part iterator in the Model container yet (and probably needs a deep discussion...), I've exported the GetModelPartNames() method to Python. By doing this we can iterate all the model parts.


@jginternational this is just a reminder to add it in the GUI.