### PR TITLE
Style-Guide conforming names for Linear-Solvers

### DIFF
--- a/applications/EigenSolversApplication/custom_python/add_custom_solvers_to_python.cpp
+++ b/applications/EigenSolversApplication/custom_python/add_custom_solvers_to_python.cpp
@@ -113,12 +113,10 @@ EigenSolversApplicationRegisterLinearSolvers::EigenSolversApplicationRegisterLin
     static auto SparseQRFactory= StandardLinearSolverFactory<SpaceType,LocalSpaceType,SparseQRType>();
     static auto ComplexSparseQRFactory= StandardLinearSolverFactory<ComplexSpaceType,ComplexLocalSpaceType,ComplexSparseQRType>();
 
-    KRATOS_REGISTER_LINEAR_SOLVER("SparseLUSolver", SparseLUFactory);
-    KRATOS_REGISTER_LINEAR_SOLVER("eigen_sparse_lu", SparseLUFactory);  // NOTE: Retrocompatibility name
-    KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("ComplexSparseLUSolver", ComplexSparseLUFactory);
-    KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("complex_eigen_sparse_lu", ComplexSparseLUFactory);  // NOTE: Retrocompatibility name
-    KRATOS_REGISTER_LINEAR_SOLVER("SparseQRSolver", SparseQRFactory);
-    KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("ComplexSparseQRSolver", ComplexSparseQRFactory);
+    KRATOS_REGISTER_LINEAR_SOLVER("sparse_lu", SparseLUFactory);
+    KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("sparse_lu_complex", ComplexSparseLUFactory);
+    KRATOS_REGISTER_LINEAR_SOLVER("sparse_qr", SparseQRFactory);
+    KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("sparse_qr_complex", ComplexSparseQRFactory);
 
 #ifdef USE_EIGEN_MKL
     typedef EigenDirectSolver<PardisoLLT<double>> PardisoLLTSolver;
@@ -135,16 +133,12 @@ EigenSolversApplicationRegisterLinearSolvers::EigenSolversApplicationRegisterLin
     static auto PardisoLUFactory= StandardLinearSolverFactory<SpaceType,LocalSpaceType,PardisoLUType>();
     static auto ComplexPardisoLUFactory= StandardLinearSolverFactory<ComplexSpaceType,ComplexLocalSpaceType,ComplexPardisoLUType>();
 
-    KRATOS_REGISTER_LINEAR_SOLVER("PardisoLLTSolver", PardisoLLTFactor);
-    KRATOS_REGISTER_LINEAR_SOLVER("eigen_pardiso_llt", PardisoLLTFactor); // NOTE: Retrocompatibility name
-//     KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("ComplexPardisoLLTSolver", ComplexPardisoLLTFactory);
-    KRATOS_REGISTER_LINEAR_SOLVER("PardisoLDLTSolver", PardisoLDLTFactory);
-    KRATOS_REGISTER_LINEAR_SOLVER("eigen_pardiso_ldlt", PardisoLDLTFactory); // NOTE: Retrocompatibility name
-//     KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("ComplexPardisoLDLTSolver", ComplexPardisoLDLTFactory);
-    KRATOS_REGISTER_LINEAR_SOLVER("PardisoLUSolver", PardisoLUFactory);
-    KRATOS_REGISTER_LINEAR_SOLVER("eigen_pardiso_lu", PardisoLUFactory); // NOTE: Retrocompatibility name
-    KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("ComplexPardisoLUSolver", ComplexPardisoLUFactory);
-    KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("complex_eigen_pardiso_lu", ComplexPardisoLUFactory); // NOTE: Retrocompatibility name
+    KRATOS_REGISTER_LINEAR_SOLVER("pardiso_llt", PardisoLLTFactor);
+//     KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("pardiso_llt_complex", ComplexPardisoLLTFactory);
+    KRATOS_REGISTER_LINEAR_SOLVER("pardiso_ldlt", PardisoLDLTFactory);
+//     KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("pardiso_ldlt_complex", ComplexPardisoLDLTFactory);
+    KRATOS_REGISTER_LINEAR_SOLVER("pardiso_lu", PardisoLUFactory);
+    KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("pardiso_lu_complex", ComplexPardisoLUFactory);
 #endif
 }
 

--- a/applications/EigenSolversApplication/tests/test_eigen_direct_solver.py
+++ b/applications/EigenSolversApplication/tests/test_eigen_direct_solver.py
@@ -5,7 +5,7 @@ import KratosMultiphysics
 
 import KratosMultiphysics.EigenSolversApplication as EigenSolversApplication
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-from new_linear_solver_factory import ConstructSolver
+from KratosMultiphysics.python_linear_solver_factory import ConstructSolver
 
 class TestEigenDirectSolver(KratosUnittest.TestCase):
     def _execute_eigen_direct_solver_test(self, class_name, solver_type):
@@ -15,7 +15,7 @@ class TestEigenDirectSolver(KratosUnittest.TestCase):
 
         space = KratosMultiphysics.UblasSparseSpace()
 
-        settings = KratosMultiphysics.Parameters('{ "solver_type" : "' + solver_type + '" }')
+        settings = KratosMultiphysics.Parameters('{ "solver_type" : "EigenSolversApplication.' + solver_type + '" }')
 
         solver = ConstructSolver(settings)
 
@@ -47,16 +47,16 @@ class TestEigenDirectSolver(KratosUnittest.TestCase):
             self.assertAlmostEqual(b_act[i], b_exp[i], 7)
 
     def test_eigen_sparse_lu(self):
-        self._execute_eigen_direct_solver_test('SparseLUSolver', 'eigen_sparse_lu')
+        self._execute_eigen_direct_solver_test('SparseLUSolver', 'sparse_lu')
 
     def test_eigen_pardiso_lu(self):
-        self._execute_eigen_direct_solver_test('PardisoLUSolver', 'eigen_pardiso_lu')
+        self._execute_eigen_direct_solver_test('PardisoLUSolver', 'pardiso_lu')
 
     def test_eigen_pardiso_ldlt(self):
-        self._execute_eigen_direct_solver_test('PardisoLDLTSolver', 'eigen_pardiso_ldlt')
+        self._execute_eigen_direct_solver_test('PardisoLDLTSolver', 'pardiso_ldlt')
 
     def test_eigen_pardiso_llt(self):
-        self._execute_eigen_direct_solver_test('PardisoLLTSolver', 'eigen_pardiso_llt')
+        self._execute_eigen_direct_solver_test('PardisoLLTSolver', 'pardiso_llt')
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/ExternalSolversApplication/custom_python/add_linear_solvers_to_python.cpp
+++ b/applications/ExternalSolversApplication/custom_python/add_linear_solvers_to_python.cpp
@@ -138,26 +138,25 @@ ExternalSolversApplicationRegisterLinearSolvers::ExternalSolversApplicationRegis
     static auto SuperLUSolverFactory= StandardLinearSolverFactory<SpaceType,LocalSpaceType,SuperLUSolverType>();
     static auto SuperLUIterativeSolverFactory= StandardLinearSolverFactory<SpaceType,LocalSpaceType,SuperLUIterativeSolverType>();
 
-    KRATOS_REGISTER_LINEAR_SOLVER("GMRESSolver", GMRESSolverFactory);
-    KRATOS_REGISTER_LINEAR_SOLVER("Super_LU", SuperLUSolverFactory); // NOTE: This is duplicated by retrocompatibility
-    KRATOS_REGISTER_LINEAR_SOLVER("SuperLUSolver", SuperLUSolverFactory);
-    KRATOS_REGISTER_LINEAR_SOLVER("SuperLUIterativeSolver", SuperLUIterativeSolverFactory);
+    KRATOS_REGISTER_LINEAR_SOLVER("gmres", GMRESSolverFactory);
+    KRATOS_REGISTER_LINEAR_SOLVER("super_lu", SuperLUSolverFactory);
+    KRATOS_REGISTER_LINEAR_SOLVER("super_lu_iterative", SuperLUIterativeSolverFactory);
 
 #ifdef INCLUDE_PASTIX
     typedef TUblasSparseSpace<std::complex<double>> ComplexSpaceType;
     typedef TUblasDenseSpace<std::complex<double>> ComplexLocalSpaceType;
     typedef PastixSolver<SpaceType,  LocalSpaceType> PastixSolverType;
     static auto PastixSolverFactory = StandardLinearSolverFactory<SpaceType,LocalSpaceType,PastixSolverType>();
-    KRATOS_REGISTER_LINEAR_SOLVER("PastixSolver", PastixSolverFactory);
+    KRATOS_REGISTER_LINEAR_SOLVER("pastix", PastixSolverFactory);
     typedef PastixComplexSolver<ComplexSpaceType, ComplexLocalSpaceType> PastixComplexSolverType;
     static auto PastixComplexSolverFactory = StandardLinearSolverFactory<ComplexSpaceType, ComplexLocalSpaceType, PastixComplexSolverType>();
-    KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("PastixComplexSolver", PastixComplexSolverFactory);
+    KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("pastix_complex", PastixComplexSolverFactory);
 #endif
 
 #ifdef INCLUDE_FEAST
     typedef FEASTSolver<SpaceType, LocalSpaceType> FEASTSolverType;
     static auto FEASTSolverFactory= StandardLinearSolverFactory<SpaceType,LocalSpaceType,FEASTSolverType>();
-    KRATOS_REGISTER_LINEAR_SOLVER("FEASTSolver", FEASTSolverFactory);
+    KRATOS_REGISTER_LINEAR_SOLVER("feast", FEASTSolverFactory);
 #endif
 }
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -421,11 +421,11 @@ class MechanicalSolver(PythonSolver):
                 from KratosMultiphysics import ExternalSolversApplication
 
             linear_solvers_by_speed = [
-                "PardisoLUSolver", # EigenSolversApplication (if compiled with Intel-support)
-                "SparseLUSolver",  # EigenSolversApplication
-                "PastixSolver",    # ExternalSolversApplication (if Pastix is included in compilation)
-                "SuperLUSolver",   # ExternalSolversApplication
-                "SkylineLUFactorizationSolver" # in Core, always available, but slow
+                "pardiso_lu", # EigenSolversApplication (if compiled with Intel-support)
+                "sparse_lu",  # EigenSolversApplication
+                "pastix",     # ExternalSolversApplication (if Pastix is included in compilation)
+                "super_lu",   # ExternalSolversApplication
+                "skyline_lu_factorization" # in Core, always available, but slow
             ]
 
             for solver_name in linear_solvers_by_speed:

--- a/applications/StructuralMechanicsApplication/tests/structural_mechanics_test_factory.py
+++ b/applications/StructuralMechanicsApplication/tests/structural_mechanics_test_factory.py
@@ -40,7 +40,7 @@ class StructuralMechanicsTestFactory(KratosUnittest.TestCase):
             # the previous default linear-solver is set
             if not ProjectParameters["solver_settings"].Has("linear_solver_settings"):
                 default_lin_solver_settings = KratosMultiphysics.Parameters("""{
-                "solver_type": "ExternalSolversApplication.SuperLUSolver",
+                "solver_type": "ExternalSolversApplication.super_lu",
                     "max_iteration": 500,
                     "tolerance": 1e-9,
                     "scaling": false,

--- a/kratos/python_scripts/linear_solver_factory.py
+++ b/kratos/python_scripts/linear_solver_factory.py
@@ -33,8 +33,8 @@ def ConstructSolver(configuration):
     ###THIS IS A VERY DIRTY HACK TO ALLOW PARAMETERS TO BE PASSED TO THE LINEAR SOLVER FACTORY
     ###TODO: clean this up!!
     if(type(configuration) == Parameters):
-        import new_linear_solver_factory
-        return new_linear_solver_factory.ConstructSolver(configuration)
+        from KratosMultiphysics import python_linear_solver_factory
+        return python_linear_solver_factory.ConstructSolver(configuration)
         #solver_type = configuration["solver_type"].GetString()
 
         #import json

--- a/kratos/python_scripts/new_linear_solver_factory.py
+++ b/kratos/python_scripts/new_linear_solver_factory.py
@@ -7,10 +7,5 @@ def ConstructSolver(configuration):
     depr_msg += 'Please use "kratos/python_scripts/python_linear_solver_factory.py" instead!'
     KratosMultiphysics.Logger.PrintWarning('DEPRECATION-WARNING', depr_msg)
 
-    if(type(configuration) != KratosMultiphysics.Parameters):
-        raise Exception("input is expected to be provided as a Kratos Parameters object")
-
-    if KratosMultiphysics.ComplexLinearSolverFactory().Has(configuration["solver_type"].GetString()):
-        return KratosMultiphysics.ComplexLinearSolverFactory().Create(configuration)
-    else:
-        return KratosMultiphysics.LinearSolverFactory().Create(configuration)
+    from KratosMultiphysics import python_linear_solver_factory
+    return python_linear_solver_factory.ConstructSolver(configuration)

--- a/kratos/python_scripts/python_linear_solver_factory.py
+++ b/kratos/python_scripts/python_linear_solver_factory.py
@@ -9,45 +9,36 @@ def __DeprecatedApplicationImport(solver_type):
     # and hence cannot be created by the C-linear-solver-factory
     # NOTE: this is only for backwards-compatibility!!!
     # the correct way is to specify the application in which the linear solver
-    # is defined, e.g. "solver_type" : "ExternalSolversApplication.SuperLUSolver"
+    # is defined, e.g. "solver_type" : "ExternalSolversApplication.super_lu"
 
     linear_solver_apps = {
         "ExternalSolversApplication" : [
-            "GMRESSolver",
-            "SuperLUSolver",
-            "Super_LU",
-            "SuperLUIterativeSolver",
-            "PastixSolver",
-            "PastixComplexSolver",
-            "FEASTSolver"
+            "gmres",
+            "super_lu",
+            "super_lu_iterative",
+            "pastix",
+            "pastix_complex",
+            "feast"
         ],
         "EigenSolversApplication" : [
-            "SparseLUSolver",
-            "eigen_sparse_lu",
-            "SparseQRSolver",
-            "ComplexSparseLUSolver",
-            "ComplexSparseQRSolver",
-            "PardisoLLTSolver",
-            "eigen_pardiso_llt",
-            "ComplexPardisoLLTSolver",
-            "PardisoLDLTSolver",
-            "eigen_pardiso_ldlt",
-            "eigen_pardiso_lu",
-            "ComplexPardisoLDLTSolver",
-            "complex_eigen_sparse_lu",
-            "complex_eigen_pardiso_lu"
-            "ComplexPardisoLUSolver"
-            "PardisoLUSolver"
+            "sparse_lu",
+            "sparse_lu_complex",
+            "sparse_qr",
+            "sparse_qr_complex",
+            "pardiso_llt",
+            "pardiso_ldlt",
+            "pardiso_lu",
+            "pardiso_lu_complex"
         ]
     }
 
     for app_name, linear_solver_names in linear_solver_apps.items():
         if solver_type in linear_solver_names:
-            depr_msg  = 'The linear-solver "' + solver_type + '" is defined in the "' + app_name +  '"\n'
+            depr_msg  = 'DEPRECATION-WARNING:\nThe linear-solver "' + solver_type + '" is defined in the "' + app_name +  '"\n'
             depr_msg += 'Please specify the "solver_type" including the name of the application:\n'
             depr_msg += '"' + app_name + '.' + solver_type + '"'
             depr_msg += '\nPlease update your settings accordingly, the current settings are deprecated!'
-            KM.Logger.PrintWarning('DEPRECATION-WARNING', depr_msg)
+            KM.Logger.PrintWarning('Linear-Solver-Factory', depr_msg)
 
             from KratosMultiphysics import kratos_utilities as kratos_utils
             if not kratos_utils.IsApplicationAvailable(app_name):
@@ -59,10 +50,96 @@ def __DeprecatedApplicationImport(solver_type):
             __import__("KratosMultiphysics." + app_name)
             break
 
+def __CheckIfSolverTypeIsDeprecated(config):
+    '''function to translate old/deprecated solver-names to new names
+    needed for backwards-compatibility
+    '''
+
+    solver_type = config["solver_type"].GetString()
+    splitted_solver_type = solver_type.split(".") # in case the name of the solver is "EigenSolversApp.SparseLUSolver"
+
+    real_solver_type = splitted_solver_type[-1]
+
+    # solvers from Core
+    old_new_name_map = {
+        "CGSolver"                     : "cg",
+        "BICGSTABSolver"               : "bicgstab",
+        "DeflatedCGSolver"             : "deflated_cg",
+        "TFQMRSolver"                  : "tfqmr",
+        "SkylineLUFactorizationSolver" : "skyline_lu_factorization",
+        "AMGCL"                        : "amgcl",
+        "AMGCLSolver"                  : "amgcl",
+        "AMGCL_NS_Solver"              : "amgcl_ns",
+        "ScalingSolver"                : "scaling",
+        "SkylineLUComplexSolver"       : "skyline_lu_complex",
+        "complex_skyline_lu_solver"    : "skyline_lu_complex"
+    }
+
+    # solvers from ExternalSolversApp
+    old_new_name_map.update({
+        "GMRESSolver"            : "gmres",
+        "Super_LU"               : "super_lu",
+        "SuperLUSolver"          : "super_lu",
+        "SuperLUIterativeSolver" : "super_lu_iterative",
+        "PastixSolver"           : "pastix",
+        "PastixComplexSolver"    : "pastix_complex",
+        "FEASTSolver"            : "feast"
+    })
+
+    # solvers from EigenSolversApp
+    old_new_name_map.update({
+        "SparseLUSolver"           : "sparse_lu",
+        "eigen_sparse_lu"          : "sparse_lu",
+        "ComplexSparseLUSolver"    : "sparse_lu_complex",
+        "complex_eigen_sparse_lu"  : "sparse_lu_complex",
+        "SparseQRSolver"           : "sparse_qr",
+        "ComplexSparseQRSolver"    : "sparse_qr_complex",
+        "PardisoLLTSolver"         : "pardiso_llt",
+        "eigen_pardiso_llt"        : "pardiso_llt",
+        "PardisoLDLTSolver"        : "pardiso_ldlt",
+        "eigen_pardiso_ldlt"       : "pardiso_ldlt",
+        "PardisoLUSolver"          : "pardiso_lu",
+        "eigen_pardiso_lu"         : "pardiso_lu",
+        "ComplexPardisoLUSolver"   : "pardiso_lu_complex",
+        "complex_eigen_pardiso_lu" : "pardiso_lu_complex"
+    })
+
+    if real_solver_type in old_new_name_map:
+        new_name = old_new_name_map[real_solver_type]
+        depr_msg  = 'DEPRECATION-WARNING: \nUsing a deprecated "solver_type"!\n'
+        depr_msg += 'Replace "' + real_solver_type + '" with "' + new_name + '"'
+        KM.Logger.PrintWarning("Linear-Solver-Factory", depr_msg)
+        splitted_solver_type[-1] = new_name
+        config["solver_type"].SetString(".".join(splitted_solver_type))
+
+def __CheckIfPreconditionerTypeIsDeprecated(config):
+    '''function to translate old/deprecated preconditioner-names to new names
+    needed for backwards-compatibility
+    '''
+
+    if config.Has("preconditioner_type"):
+        preconditioner_type = config["preconditioner_type"]
+
+        old_new_name_map = {
+            "None"                   : "none",
+            "DiagonalPreconditioner" : "diagonal",
+            "ILU0Preconditioner"     : "ilu0",
+            "ILUPreconditioner"      : "ilu"
+        }
+
+        if preconditioner_type in old_new_name_map:
+            new_name = old_new_name_map[preconditioner_type]
+            depr_msg  = 'DEPRECATION-WARNING: \nUsing a deprecated "preconditioner_type"!\n'
+            depr_msg += 'Replace "' + preconditioner_type + '" with "' + new_name + '"'
+            KM.Logger.PrintWarning("Linear-Solver-Factory", depr_msg)
+            config["preconditioner_type"].SetString(new_name)
 
 def ConstructSolver(configuration):
     if(type(configuration) != KM.Parameters):
         raise Exception("input is expected to be provided as a Kratos Parameters object")
+
+    __CheckIfSolverTypeIsDeprecated(configuration)
+    __CheckIfPreconditionerTypeIsDeprecated(configuration)
 
     solver_type = configuration["solver_type"].GetString()
 

--- a/kratos/sources/standard_linear_solver_factory.cpp
+++ b/kratos/sources/standard_linear_solver_factory.cpp
@@ -66,17 +66,15 @@ namespace Kratos
 
         //registration of linear solvers
 //         KRATOS_REGISTER_LINEAR_SOLVER("LinearSolver", StandardLinearSolverFactory<SpaceType,LocalSpaceType,LinearSolverType>());
-        KRATOS_REGISTER_LINEAR_SOLVER("CGSolver", CGSolverFactory);
-        KRATOS_REGISTER_LINEAR_SOLVER("BICGSTABSolver", BICGSTABSolverFactory);
-        KRATOS_REGISTER_LINEAR_SOLVER("DeflatedCGSolver", DeflatedCGSolverFactory);
-        KRATOS_REGISTER_LINEAR_SOLVER("TFQMRSolver", TFQMRSolverFactory);
-        KRATOS_REGISTER_LINEAR_SOLVER("SkylineLUFactorizationSolver",SkylineLUFactorizationSolverFactory );
-        KRATOS_REGISTER_LINEAR_SOLVER("AMGCL", AMGCLSolverFactory);
-        KRATOS_REGISTER_LINEAR_SOLVER("AMGCLSolver", AMGCLSolverFactory); //registered with two different names
-        KRATOS_REGISTER_LINEAR_SOLVER("AMGCL_NS_Solver",AMGCL_NS_SolverFactory );
-        KRATOS_REGISTER_LINEAR_SOLVER("ScalingSolver",ScalingSolverFactory );
-        KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("SkylineLUComplexSolver", SkylineLUComplexSolverFactory);
-        KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("complex_skyline_lu_solver", SkylineLUComplexSolverFactory); // NOTE: Name duplicated for retrocompatibility
+        KRATOS_REGISTER_LINEAR_SOLVER("cg", CGSolverFactory);
+        KRATOS_REGISTER_LINEAR_SOLVER("bicgstab", BICGSTABSolverFactory);
+        KRATOS_REGISTER_LINEAR_SOLVER("deflated_cg", DeflatedCGSolverFactory);
+        KRATOS_REGISTER_LINEAR_SOLVER("tfqmr", TFQMRSolverFactory);
+        KRATOS_REGISTER_LINEAR_SOLVER("skyline_lu_factorization",SkylineLUFactorizationSolverFactory );
+        KRATOS_REGISTER_LINEAR_SOLVER("amgcl", AMGCLSolverFactory);
+        KRATOS_REGISTER_LINEAR_SOLVER("amgcl_ns",AMGCL_NS_SolverFactory );
+        KRATOS_REGISTER_LINEAR_SOLVER("scaling",ScalingSolverFactory );
+        KRATOS_REGISTER_COMPLEX_LINEAR_SOLVER("skyline_lu_complex", SkylineLUComplexSolverFactory);
 
     };
 } // Namespace Kratos

--- a/kratos/sources/standard_preconditioner_factory.cpp
+++ b/kratos/sources/standard_preconditioner_factory.cpp
@@ -44,10 +44,10 @@ namespace Kratos
         static auto ILUPreconditionerFactory= StandardPreconditionerFactory<SpaceType,LocalSpaceType,ILUPreconditionerType>();
 
         //registration of linear solvers
-        KRATOS_REGISTER_PRECONDITIONER("None", PreconditionerFactory);
-        KRATOS_REGISTER_PRECONDITIONER("DiagonalPreconditioner", DiagonalPreconditionerFactory);
-        KRATOS_REGISTER_PRECONDITIONER("ILU0Preconditioner", ILU0PreconditionerFactory);
-        KRATOS_REGISTER_PRECONDITIONER("ILUPreconditioner",ILUPreconditionerFactory );
+        KRATOS_REGISTER_PRECONDITIONER("none", PreconditionerFactory);
+        KRATOS_REGISTER_PRECONDITIONER("diagonal", DiagonalPreconditionerFactory);
+        KRATOS_REGISTER_PRECONDITIONER("ilu0", ILU0PreconditionerFactory);
+        KRATOS_REGISTER_PRECONDITIONER("ilu",ILUPreconditionerFactory );
     };
 } // Namespace Kratos
 

--- a/kratos/tests/test_levelset_convection.py
+++ b/kratos/tests/test_levelset_convection.py
@@ -43,9 +43,9 @@ class TestLevelSetConvection(KratosUnittest.TestCase):
             if node.X < 0.001:
                 node.Fix(KratosMultiphysics.DISTANCE)
 
-        import new_linear_solver_factory
-        linear_solver = new_linear_solver_factory.ConstructSolver(
-            KratosMultiphysics.Parameters("""{"solver_type" : "SkylineLUFactorizationSolver"}"""))
+        from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
+        linear_solver = linear_solver_factory.ConstructSolver(
+            KratosMultiphysics.Parameters("""{"solver_type" : "skyline_lu_factorization"}"""))
 
         model_part.CloneTimeStep(40.0)
 

--- a/kratos/tests/test_linear_solvers.py
+++ b/kratos/tests/test_linear_solvers.py
@@ -42,8 +42,8 @@ class TestLinearSolvers(KratosUnittest.TestCase):
         #space.UnaliasedAdd(boriginal, 1.0, b) #boriginal=1*bs
 
         #construct the solver
-        import new_linear_solver_factory
-        linear_solver = new_linear_solver_factory.ConstructSolver(settings)
+        from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
+        linear_solver = linear_solver_factory.ConstructSolver(settings)
 
         #solve
         linear_solver.Solve(A,x,b)
@@ -75,22 +75,22 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "TFQMRSolver",
+                        "solver_type" : "tfqmr",
                         "tolerance" : 1.0e-6,
                         "max_iteration" : 500,
-                        "preconditioner_type" : "ILU0Preconditioner"
+                        "preconditioner_type" : "ilu0"
                     },
                     {
-                        "solver_type" : "TFQMRSolver",
+                        "solver_type" : "tfqmr",
                         "tolerance" : 1.0e-6,
                         "max_iteration" : 500,
-                        "preconditioner_type" : "DiagonalPreconditioner"
+                        "preconditioner_type" : "diagonal"
                     },
                     {
-                        "solver_type" : "TFQMRSolver",
+                        "solver_type" : "tfqmr",
                         "tolerance" : 1.0e-6,
                         "max_iteration" : 1000,
-                        "preconditioner_type" : "None"
+                        "preconditioner_type" : "none"
                     }
                 ]
             }
@@ -101,16 +101,16 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "CGSolver",
+                        "solver_type" : "cg",
                         "tolerance" : 1.0e-6,
                         "max_iteration" : 500,
-                        "preconditioner_type" : "DiagonalPreconditioner"
+                        "preconditioner_type" : "diagonal"
                     },
                     {
-                        "solver_type" : "CGSolver",
+                        "solver_type" : "cg",
                         "tolerance" : 1.0e-6,
                         "max_iteration" : 1000,
-                        "preconditioner_type" : "None"
+                        "preconditioner_type" : "none"
                     }
                 ]
             }
@@ -121,7 +121,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "DeflatedCGSolver"
+                        "solver_type" : "deflated_cg"
                     }
                 ]
             }
@@ -132,30 +132,30 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "BICGSTABSolver",
+                        "solver_type" : "bicgstab",
                         "tolerance" : 1.0e-6,
                         "max_iteration" : 500,
-                        "preconditioner_type" : "ILU0Preconditioner",
+                        "preconditioner_type" : "ilu0",
                         "scaling": false
                     },
                     {
-                        "solver_type" : "BICGSTABSolver",
+                        "solver_type" : "bicgstab",
                         "tolerance" : 1.0e-6,
                         "max_iteration" : 500,
-                        "preconditioner_type" : "ILU0Preconditioner",
+                        "preconditioner_type" : "ilu0",
                         "scaling": false
                     },
                     {
-                        "solver_type" : "BICGSTABSolver",
+                        "solver_type" : "bicgstab",
                         "tolerance" : 1.0e-6,
                         "max_iteration" : 500,
-                        "preconditioner_type" : "DiagonalPreconditioner"
+                        "preconditioner_type" : "diagonal"
                     },
                     {
-                        "solver_type" : "BICGSTABSolver",
+                        "solver_type" : "bicgstab",
                         "tolerance" : 1.0e-6,
                         "max_iteration" : 500,
-                        "preconditioner_type" : "None"
+                        "preconditioner_type" : "none"
                     }
                 ]
             }
@@ -166,7 +166,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "SkylineLUFactorizationSolver",
+                        "solver_type" : "skyline_lu_factorization",
                         "scaling": false
                     }
                 ]
@@ -183,15 +183,15 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "SuperLUSolver",
+                        "solver_type" : "ExternalSolversApplication.super_lu",
                         "scaling": false
                     },
                     {
-                        "solver_type" : "SuperLUIterativeSolver",
+                        "solver_type" : "ExternalSolversApplication.super_lu_iterative",
                         "scaling": false
                     },
                     {
-                        "solver_type" : "SuperLUIterativeSolver",
+                        "solver_type" : "ExternalSolversApplication.super_lu_iterative",
                         "scaling": true
                     }
                 ]
@@ -212,7 +212,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "PastixSolver",
+                        "solver_type" : "ExternalSolversApplication.pastix",
                         "solution_method": "Direct",
                             "tolerance":1e-6,
                             "max_iteration":100,
@@ -234,7 +234,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
                 "test_list" : [
                     {
 
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "smoother_type":"iluk",
                         "krylov_type": "bicgstab",
                         "coarsening_type": "aggregation",
@@ -258,7 +258,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
                 "test_list" : [
                     {
 
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "smoother_type":"iluk",
                         "krylov_type": "lgmres",
                         "coarsening_type": "aggregation",
@@ -281,19 +281,19 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "krylov_type": "bicgstab",
                         "preconditioner_type": "dummy",
                         "verbosity" : 1
                     },
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "krylov_type": "gmres",
                         "preconditioner_type": "dummy",
                         "verbosity" : 1
                     },
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "krylov_type": "lgmres",
                         "preconditioner_type": "dummy",
                         "verbosity" : 1
@@ -307,14 +307,14 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "krylov_type": "lgmres",
                         "smoother_type":"ilu0",
                         "preconditioner_type": "relaxation",
                         "verbosity" : 1
                     },
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "krylov_type": "lgmres",
                         "smoother_type":"ilu0",
                         "preconditioner_type": "relaxation",
@@ -322,35 +322,35 @@ class TestLinearSolvers(KratosUnittest.TestCase):
                         "block_size" : 2
                     },
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "krylov_type": "lgmres",
                         "smoother_type":"iluk",
                         "preconditioner_type": "relaxation",
                         "verbosity" : 1
                     },
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "krylov_type": "lgmres",
                         "smoother_type":"spai0",
                         "preconditioner_type": "relaxation",
                         "verbosity" : 1
                     },
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "krylov_type": "lgmres",
                         "smoother_type":"damped_jacobi",
                         "preconditioner_type": "relaxation",
                         "verbosity" : 1
                     },
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "krylov_type": "lgmres",
                         "smoother_type":"gauss_seidel",
                         "preconditioner_type": "relaxation",
                         "verbosity" : 1
                     },
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "krylov_type": "lgmres",
                         "smoother_type":"chebyshev",
                         "preconditioner_type": "relaxation",
@@ -365,7 +365,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "smoother_type":"ilu0",
                         "krylov_type": "bicgstab",
                         "coarsening_type": "aggregation",
@@ -388,7 +388,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "smoother_type":"ilu0",
                         "krylov_type": "idrs",
                         "coarsening_type": "aggregation",
@@ -411,7 +411,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
             {
                 "test_list" : [
                     {
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "smoother_type":"spai0",
                         "krylov_type": "bicgstab",
                         "coarsening_type": "aggregation",
@@ -435,7 +435,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
                 "test_list" : [
                     {
 
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "smoother_type":"spai0",
                         "krylov_type": "cg",
                         "coarsening_type": "ruge_stuben",
@@ -460,7 +460,7 @@ class TestLinearSolvers(KratosUnittest.TestCase):
                 "test_list" : [
                 {
 
-                        "solver_type" : "AMGCL",
+                        "solver_type" : "amgcl",
                         "smoother_type":"iluk",
                         "krylov_type": "bicgstabl",
                         "coarsening_type": "aggregation",

--- a/kratos/tests/test_redistance.py
+++ b/kratos/tests/test_redistance.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
+from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
 import math
 import os
 
@@ -32,7 +33,6 @@ class TestRedistance(KratosUnittest.TestCase):
         for node in model_part.Nodes:
             node.SetSolutionStepValue(KratosMultiphysics.DISTANCE,0, self._ExpectedDistance(node.X,node.Y,node.Z)  )
 
-        from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
         linear_solver = linear_solver_factory.ConstructSolver( KratosMultiphysics.Parameters( """ { "solver_type" : "skyline_lu_factorization" } """ ) )
 
         model_part.CloneTimeStep(1.0)
@@ -71,7 +71,7 @@ class TestRedistance(KratosUnittest.TestCase):
         for node in model_part.Nodes:
             node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, node.Y - free_surface_level)
 
-        from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
+
         linear_solver = linear_solver_factory.ConstructSolver( KratosMultiphysics.Parameters( """ { "solver_type" : "skyline_lu_factorization" } """ ) )
 
         model_part.CloneTimeStep(1.0)
@@ -108,7 +108,6 @@ class TestRedistance(KratosUnittest.TestCase):
         for node in model_part.Nodes:
             node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, node.Y - free_surface_level)
 
-        from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
         linear_solver = linear_solver_factory.ConstructSolver( KratosMultiphysics.Parameters( """ { "solver_type" : "skyline_lu_factorization" } """ ) )
 
         model_part.CloneTimeStep(1.0)

--- a/kratos/tests/test_redistance.py
+++ b/kratos/tests/test_redistance.py
@@ -32,8 +32,8 @@ class TestRedistance(KratosUnittest.TestCase):
         for node in model_part.Nodes:
             node.SetSolutionStepValue(KratosMultiphysics.DISTANCE,0, self._ExpectedDistance(node.X,node.Y,node.Z)  )
 
-        import new_linear_solver_factory
-        linear_solver = new_linear_solver_factory.ConstructSolver( KratosMultiphysics.Parameters( """ { "solver_type" : "SkylineLUFactorizationSolver" } """ ) )
+        from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
+        linear_solver = linear_solver_factory.ConstructSolver( KratosMultiphysics.Parameters( """ { "solver_type" : "skyline_lu_factorization" } """ ) )
 
         model_part.CloneTimeStep(1.0)
 
@@ -71,8 +71,8 @@ class TestRedistance(KratosUnittest.TestCase):
         for node in model_part.Nodes:
             node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, node.Y - free_surface_level)
 
-        import new_linear_solver_factory
-        linear_solver = new_linear_solver_factory.ConstructSolver( KratosMultiphysics.Parameters( """ { "solver_type" : "SkylineLUFactorizationSolver" } """ ) )
+        from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
+        linear_solver = linear_solver_factory.ConstructSolver( KratosMultiphysics.Parameters( """ { "solver_type" : "skyline_lu_factorization" } """ ) )
 
         model_part.CloneTimeStep(1.0)
 
@@ -108,8 +108,8 @@ class TestRedistance(KratosUnittest.TestCase):
         for node in model_part.Nodes:
             node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, node.Y - free_surface_level)
 
-        import new_linear_solver_factory
-        linear_solver = new_linear_solver_factory.ConstructSolver( KratosMultiphysics.Parameters( """ { "solver_type" : "SkylineLUFactorizationSolver" } """ ) )
+        from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
+        linear_solver = linear_solver_factory.ConstructSolver( KratosMultiphysics.Parameters( """ { "solver_type" : "skyline_lu_factorization" } """ ) )
 
         model_part.CloneTimeStep(1.0)
 


### PR DESCRIPTION
With this PR I am updating the names of the linear-solvers in json 
e.g. `"solver_type" : "SuperLUSolver"` => `"solver_type" : "super_lu"`

Previously it was not consistent with the style-guide, now I unified everything

Also now it is consistent btw mpi and non-mpi

The tests are updated and running

Backwards-compatibility is ensured, by replacing the old names with the new names (and giving a deprecation-warning)

I am quite happy that I could finally unify this! This is a part of Kratos that I have been struggling with since the beginning: I never new what names the linear-solvers had.
Now this is quite intuitive and consistent with the rest of the code :D