### PR TITLE
[Core] Setting value on Parameters when AddValue sets already existing entry

### DIFF
--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -360,7 +360,7 @@ void Parameters::AddValue(
         (*mpValue)[rEntry] = *(rOtherValue.mpValue);
     } else {
         KRATOS_WARNING("Parameters") << "WARNING:: Entry " << rEntry << " already defined. Overriding it" << std::endl;
-        SetValue(rEntry, rEntry);
+        SetValue(rEntry, rOtherValue);
     }
 }
 

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -358,6 +358,9 @@ void Parameters::AddValue(
 {
     if(mpValue->find(rEntry) == mpValue->end()) {
         (*mpValue)[rEntry] = *(rOtherValue.mpValue);
+    } else {
+        KRATOS_WARNING("Parameters") << "WARNING:: Entry " << rEntry << " already defined. Overriding it" << std::endl;
+        SetValue(rEntry, rEntry);
     }
 }
 

--- a/kratos/sources/kratos_parameters.cpp
+++ b/kratos/sources/kratos_parameters.cpp
@@ -359,7 +359,7 @@ void Parameters::AddValue(
     if(mpValue->find(rEntry) == mpValue->end()) {
         (*mpValue)[rEntry] = *(rOtherValue.mpValue);
     } else {
-        KRATOS_WARNING("Parameters") << "WARNING:: Entry " << rEntry << " already defined. Overriding it" << std::endl;
+        KRATOS_WARNING("Parameters") << "WARNING:: Entry " << rEntry << " already defined. Overwriting it" << std::endl;
         SetValue(rEntry, rOtherValue);
     }
 }


### PR DESCRIPTION
Fixes #3965

BTW: I checked this change in no time thanks to the new implementation of cpp instead of header only. We should move more code to cpp particularly in classes included everywhere.