### PR TITLE
[AnalysisStage] adding call to solver.Clear() in Finalize

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_fractionalstep.py
@@ -194,7 +194,3 @@ class TrilinosNavierStokesSolverFractionalStep(navier_stokes_solver_fractionalst
         if self._IsPrintingRank():
             #TODO: CHANGE THIS ONCE THE MPI LOGGER IS IMPLEMENTED
             KratosMultiphysics.Logger.PrintInfo("TrilinosNavierStokesSolverFractionalStep","Initialization TrilinosNavierStokesSolverFractionalStep finished")
-
-    def Finalize(self):
-        self.solver.Clear()
-

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
@@ -201,6 +201,3 @@ class TrilinosNavierStokesSolverMonolithic(navier_stokes_solver_vmsmonolithic.Na
         if self._IsPrintingRank():
             #TODO: CHANGE THIS ONCE THE MPI LOGGER IS IMPLEMENTED
             KratosMultiphysics.Logger.Print("Monolithic MPI solver initialization finished.")
-
-    def Finalize(self):
-        self.solver.Clear()

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -110,6 +110,8 @@ class AnalysisStage(object):
 
         self._GetSolver().Finalize()
 
+        # clearing the solver to avoid deallocation-problems in MPI
+        # and to free memory
         self._GetSolver().Clear()
 
         if self.is_printing_rank:

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -110,6 +110,8 @@ class AnalysisStage(object):
 
         self._GetSolver().Finalize()
 
+        self._GetSolver().Clear()
+
         if self.is_printing_rank:
             KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "Analysis -END- ")
 


### PR DESCRIPTION
based on the problems we have in #3885 :
>@KratosMultiphysics/technical-committee how about we add a call to solver.Clear() in the finalization of the analysis-stage? (in a separate PR ofc)
>This would have two benefits:
>1. If Clear is properly implemented in the solvers then the fix from this PR will automatically be applied too
>2. In a multi-stage-analysis it might be good to clear the previous stages to free some memory.

what do you think?