### PR TITLE
Shape opt/updates

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/mesh_controller_with_solver.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/mesh_controller_with_solver.py
@@ -13,13 +13,12 @@ from __future__ import print_function, absolute_import, division
 
 # Kratos Core and Apps
 from KratosMultiphysics import *
-from KratosMultiphysics.MeshMovingApplication import *
 from KratosMultiphysics.ShapeOptimizationApplication import *
 
 # Additional imports
 import time as timer
 from mesh_controller_base import MeshController
-from mesh_moving_analysis import MeshMovingAnalysis
+from KratosMultiphysics.MeshMovingApplication.mesh_moving_analysis import MeshMovingAnalysis
 
 # # ==============================================================================
 class MeshControllerWithSolver(MeshController) :
@@ -29,7 +28,7 @@ class MeshControllerWithSolver(MeshController) :
         {
             "apply_mesh_solver" : true,
             "solver_settings" : {
-                "solver_type" : "mesh_solver_structural_similarity",
+                "solver_type" : "structural_similarity",
                 "model_part_name"       : "",
                 "model_import_settings"              : {
                     "input_type"     : "use_input_model_part"

--- a/applications/ShapeOptimizationApplication/test_examples/04_Eigenfrequency_Maximization_3D_Cantilever/materials.json
+++ b/applications/ShapeOptimizationApplication/test_examples/04_Eigenfrequency_Maximization_3D_Cantilever/materials.json
@@ -5,7 +5,7 @@
             "Material": {
                     "name": "Material",
                     "constitutive_law": {
-                            "name": "StructuralMechanicsApplication.LinearElastic3DLaw"
+                            "name": "LinearElastic3DLaw"
                     },
                     "Variables": {
                             "DENSITY": 7.85000E+3,

--- a/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
+++ b/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
@@ -7,26 +7,23 @@ from __future__ import print_function, absolute_import, division
 
 # Import Kratos core and apps
 from KratosMultiphysics import *
-from KratosMultiphysics import ShapeOptimizationApplication
-from KratosMultiphysics import StructuralMechanicsApplication
-from KratosMultiphysics import ExternalSolversApplication
 
 # Import Kratos "wrapper" for unittests
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 
-# Import necessary external applications
-try:
-    from KratosMultiphysics import EigenSolversApplication
+from KratosMultiphysics.kratos_utilities import IsApplicationAvailable
+
+# Check if external Apps are available
+if IsApplicationAvailable("EigenSolversApplication"):
     is_eigen_app_missing = False
-except ImportError as e:
-    print("WARNING: EigenSolversApplication is not available, skip related tests!")
+else:
+    print("WARNING: EigenSolversApplication is not available, skipping related tests!")
     is_eigen_app_missing = True
 
-try:
-    from KratosMultiphysics import MeshMovingApplication
+if IsApplicationAvailable("MeshMovingApplication"):
     is_mesh_moving_app_missing = False
-except ImportError as e:
-    print("WARNING: MeshMovingApplication is not available, skip related tests!")
+else:
+    print("WARNING: MeshMovingApplication is not available, skipping related tests!")
     is_mesh_moving_app_missing = True
 
 # ==============================================================================


### PR DESCRIPTION
Some updates to match recent developments in Kratos

BTW you should really think abt using the logger. Your tests are super-verbose, no way of figuring out if there are some actual relevant warnings (I think there are, such as still using the deprecated model-part-constructor which will be removed very soon!)

BTW how do you use StructuralMechanics? I saw it being imported only once but from what I could see none of the features from it were used