### PR TITLE
Mpi/feature data communicator get

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -65,6 +65,7 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/prime_numbers.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/connectivity_preserve_modeler.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/parallel_environment.cpp;
+    ${CMAKE_CURRENT_SOURCE_DIR}/sources/data_communicator.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/divide_geometry.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/divide_triangle_2d_3.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/divide_tetrahedra_3d_4.cpp;

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -1179,7 +1179,7 @@ class DataCommunicator
      *  Failing on the Root rank is left to the caller, so that a detailed error message can be
      *  produced.
      *
-     *  @note: This method should be called from all ranks, it will deadlock if called within
+     *  @note This method should be called from all ranks, it will deadlock if called within
      *  an if(rank == some_rank) statement.
      *  @see MPIDataCommunicator.
      *  @param Condition The condition to check.
@@ -1204,7 +1204,7 @@ class DataCommunicator
      *  Failing on the Root rank is left to the caller, so that a detailed error message can be
      *  produced.
      *
-     *  @note: This method should be called from all ranks, it will deadlock if called within
+     *  @note This method should be called from all ranks, it will deadlock if called within
      *  an if(rank == some_rank) statement.
      *  @see MPIDataCommunicator.
      *  @param Condition The condition to check.
@@ -1229,7 +1229,7 @@ class DataCommunicator
      *  Failing on the ranks where the condition is true is left to the caller,
      *  so that a detailed error message can be produced.
      *
-     *  @note: This method should be called from all ranks, it will deadlock if called within
+     *  @note This method should be called from all ranks, it will deadlock if called within
      *  an if(rank == some_rank) statement.
      *  @see MPIDataCommunicator.
      *  @param Condition The condition to check.
@@ -1253,7 +1253,7 @@ class DataCommunicator
      *  Failing on the ranks where the condition is false is left to the caller,
      *  so that a detailed error message can be produced.
      *
-     *  @note: This method should be called from all ranks, it will deadlock if called within
+     *  @note This method should be called from all ranks, it will deadlock if called within
      *  an if(rank == some_rank) statement.
      *  @see MPIDataCommunicator.
      *  @param Condition The condition to check.

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -34,7 +34,7 @@ namespace Kratos
 /// Serial (do-nothing) version of a wrapper class for MPI communication.
 /** @see MPIDataCommunicator for a working distributed memory implementation.
   */
-class DataCommunicator
+class KRATOS_API(KRATOS_CORE) DataCommunicator
 {
   public:
     ///@name Type Definitions

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -1154,6 +1154,12 @@ class DataCommunicator
     }
 
     ///@}
+    ///@name Access
+    ///@{
+
+    static DataCommunicator& GetDefault();
+
+    ///@}
     ///@name Helper functions for error checking in MPI
     ///@{
 

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -1157,6 +1157,9 @@ class DataCommunicator
     ///@name Access
     ///@{
 
+    /// Convenience function to retireve the current default DataCommunicator.
+    /** @return A reference to the DataCommunicator instance registered as default in ParallelEnvironment.
+     */
     static DataCommunicator& GetDefault();
 
     ///@}

--- a/kratos/mpi/tests/sources/test_data_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_data_communicator.cpp
@@ -15,7 +15,6 @@
 
 #include "includes/data_communicator.h"
 #include "includes/kratos_components.h"
-#include "includes/parallel_environment.h"
 
 #include "testing/testing.h"
 
@@ -43,7 +42,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorFromKratosComponents, KratosMPICoreFas
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -59,7 +58,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -75,7 +74,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumDouble, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumArray1d, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -97,7 +96,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorSumArray1d, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumIntVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -130,7 +129,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumIntVector, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumDoubleVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -165,7 +164,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumDoubleVector, KratosMPICoreFastSuit
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -181,7 +180,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -197,7 +196,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinDouble, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinArray1d, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -219,7 +218,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMinArray1d, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinIntVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -252,7 +251,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinIntVector, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinDoubleVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -287,7 +286,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinDoubleVector, KratosMPICoreFastSuit
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -303,7 +302,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -319,7 +318,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxDouble, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxArray1d, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -341,7 +340,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommuniactorMaxArray1d, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxIntVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -374,7 +373,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxIntVector, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxDoubleVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     constexpr int root = 0;
 
     const int world_rank = r_world.Rank();
@@ -718,7 +717,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScanSumDoubleVector, KratosMPICoreFast
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
 
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
@@ -755,7 +754,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
 
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
@@ -792,7 +791,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvDouble, KratosMPICoreFastSuite
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvString, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
 
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
@@ -825,7 +824,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSendRecvString, KratosMPICoreFastSuite
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_rank = r_world.Rank();
     const int send_rank = 0;
 
@@ -837,7 +836,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_rank = r_world.Rank();
     const int send_rank = 0;
 
@@ -849,7 +848,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastDouble, KratosMPICoreFastSuit
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastIntVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_rank = r_world.Rank();
     const int send_rank = 0;
 
@@ -862,7 +861,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastIntVector, KratosMPICoreFastS
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastDoubleVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_rank = r_world.Rank();
     const int send_rank = 0;
 
@@ -877,7 +876,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastDoubleVector, KratosMPICoreFa
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScatterIntVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
     const int send_rank = 0;
@@ -920,7 +919,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScatterIntVector, KratosMPICoreFastSui
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScatterDoubleVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
     const int send_rank = 0;
@@ -969,7 +968,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScattervInt, KratosMPICoreFastSuite)
      * message containing doubles is double of message containing ints
      */
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
     const int send_rank = world_size-1;
@@ -1053,7 +1052,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScattervDouble, KratosMPICoreFastSuite
      * message containing doubles is double of message containing ints
      */
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
     const int send_rank = world_size-1;
@@ -1135,7 +1134,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScattervDouble, KratosMPICoreFastSuite
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGatherInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
     const int recv_rank = 0;
@@ -1181,7 +1180,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGatherInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGatherDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
     const int recv_rank = 0;
@@ -1229,7 +1228,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGatherDouble, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGathervInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
     const int recv_rank = world_size-1;
@@ -1294,7 +1293,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGathervInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGathervDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
     const int recv_rank = world_size-1;
@@ -1361,7 +1360,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGathervDouble, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorAllGatherInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
 
@@ -1389,7 +1388,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorAllGatherInt, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorAllGatherDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = ParallelEnvironment::GetDefaultDataCommunicator();
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
     const int world_size = r_world.Size();
     const int world_rank = r_world.Rank();
 

--- a/kratos/mpi/tests/sources/test_mpi_coloring_utilities.cpp
+++ b/kratos/mpi/tests/sources/test_mpi_coloring_utilities.cpp
@@ -14,7 +14,6 @@
 #include "mpi.h"
 #include "mpi/mpi_environment.h"
 #include "mpi/utilities/mpi_coloring_utilities.h"
-#include "includes/parallel_environment.h"
 
 #include "testing/testing.h"
 

--- a/kratos/mpi/tests/test_mpi_data_communicator_python.py
+++ b/kratos/mpi/tests/test_mpi_data_communicator_python.py
@@ -6,17 +6,23 @@ import KratosMultiphysics.KratosUnittest as UnitTest
 class TestMPIDataCommunicatorPython(UnitTest.TestCase):
 
     def setUp(self):
-        self.world = Kratos.ParallelEnvironment.GetDefaultDataCommunicator()
+        self.world = Kratos.DataCommunicator.GetDefault()
         self.rank = self.world.Rank()
         self.size = self.world.Size()
 
     def tearDown(self):
         pass
 
-    def testDataCommunicatorRetrieval(self):
+    def testDataCommunicatorRetrievalFromParallelEnvironment(self):
         default_comm = Kratos.ParallelEnvironment.GetDefaultDataCommunicator()
 
         self.assertTrue(Kratos.ParallelEnvironment.HasDataCommunicator("World"))
+
+        # if we imported mpi, default should be "World" (wrapping MPI_COMM_WORLD)
+        self.assertTrue(default_comm.IsDistributed())
+
+    def testDataCommunicatorRetrievalFromDataCommunicator(self):
+        default_comm = Kratos.DataCommunicator.GetDefault()
 
         # if we imported mpi, default should be "World" (wrapping MPI_COMM_WORLD)
         self.assertTrue(default_comm.IsDistributed())

--- a/kratos/python/add_data_communicator_to_python.cpp
+++ b/kratos/python/add_data_communicator_to_python.cpp
@@ -133,6 +133,7 @@ void AddDataCommunicatorToPython(pybind11::module &m)
     .def("Rank", &DataCommunicator::Rank)
     .def("Size", &DataCommunicator::Size)
     .def("IsDistributed", &DataCommunicator::IsDistributed)
+    .def_static("GetDefault", &DataCommunicator::GetDefault)
     .def("__str__", PrintObject<DataCommunicator>);
 }
 

--- a/kratos/sources/data_communicator.cpp
+++ b/kratos/sources/data_communicator.cpp
@@ -1,0 +1,23 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main author:     Jordi Cotela
+//
+
+#include "includes/data_communicator.h"
+#include "includes/parallel_environment.h"
+
+namespace Kratos {
+
+DataCommunicator& DataCommunicator::GetDefault()
+{
+    return ParallelEnvironment::GetDefaultDataCommunicator();
+}
+
+}


### PR DESCRIPTION
Adding a convenience function `DataCommunicator::GetDefault()` that should avoid having to include the `parallel_environment.h` header in most cases (except in very specific cases, users should only need it to get the default data_communicator).

Thanks to @msandre for the suggestion.