### PR TITLE
[StructuralMechanicsApplications] Not computing tangent tensor in CL during RHS only computations in solid elements

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement.cpp
@@ -142,7 +142,11 @@ void SmallDisplacement::CalculateAll(
     Flags& ConstitutiveLawOptions=Values.GetOptions();
     ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
     ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    if ( CalculateStiffnessMatrixFlag ) {
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    } else {
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+    }
 
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -100,7 +100,7 @@ void SmallDisplacementBbar::CalculateAll(
     // Resizing as needed the LHS
     const SizeType mat_size = number_of_nodes * dimension;
 
-    if ( CalculateStiffnessMatrixFlag == true ) { //calculation of the matrix is required
+    if ( CalculateStiffnessMatrixFlag ) { //calculation of the matrix is required
         if ( rLeftHandSideMatrix.size1() != mat_size )
             rLeftHandSideMatrix.resize( mat_size, mat_size, false );
 
@@ -108,7 +108,7 @@ void SmallDisplacementBbar::CalculateAll(
     }
 
     // Resizing as needed the RHS
-    if ( CalculateResidualVectorFlag == true ) { //calculation of the matrix is required
+    if ( CalculateResidualVectorFlag ) { //calculation of the matrix is required
         if ( rRightHandSideVector.size() != mat_size )
             rRightHandSideVector.resize( mat_size, false );
 
@@ -125,7 +125,11 @@ void SmallDisplacementBbar::CalculateAll(
     Flags& ConstitutiveLawOptions=Values.GetOptions();
     ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
     ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    if ( CalculateStiffnessMatrixFlag ) {
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    } else {
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+    }
 
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input parameter
@@ -153,13 +157,13 @@ void SmallDisplacementBbar::CalculateAll(
         if ( dimension == 2 && GetProperties().Has( THICKNESS ))
             int_to_reference_weight *= GetProperties()[THICKNESS];
 
-        if ( CalculateStiffnessMatrixFlag == true ) { //calculation of the matrix is required
+        if ( CalculateStiffnessMatrixFlag ) { //calculation of the matrix is required
             // Contributions to stiffness matrix calculated on the reference config
             this->CalculateAndAddKm( rLeftHandSideMatrix, this_kinematic_variables.B,
                                      this_constitutive_variables.D, int_to_reference_weight );
         }
 
-        if ( CalculateResidualVectorFlag == true ) { //calculation of the matrix is required
+        if ( CalculateResidualVectorFlag ) { //calculation of the matrix is required
             this->CalculateAndAddResidualVector(rRightHandSideVector, this_kinematic_variables,
                                                 rCurrentProcessInfo, body_force,
                                                 this_constitutive_variables.StressVector, int_to_reference_weight);

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -100,7 +100,7 @@ void SmallDisplacementBbar::CalculateAll(
     // Resizing as needed the LHS
     const SizeType mat_size = number_of_nodes * dimension;
 
-    if ( CalculateStiffnessMatrixFlag ) { //calculation of the matrix is required
+    if ( CalculateStiffnessMatrixFlag ) { // Calculation of the matrix is required
         if ( rLeftHandSideMatrix.size1() != mat_size )
             rLeftHandSideMatrix.resize( mat_size, mat_size, false );
 
@@ -108,7 +108,7 @@ void SmallDisplacementBbar::CalculateAll(
     }
 
     // Resizing as needed the RHS
-    if ( CalculateResidualVectorFlag ) { //calculation of the matrix is required
+    if ( CalculateResidualVectorFlag ) { // Calculation of the matrix is required
         if ( rRightHandSideVector.size() != mat_size )
             rRightHandSideVector.resize( mat_size, false );
 

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -197,7 +197,11 @@ void TotalLagrangian::CalculateAll(
     Flags& ConstitutiveLawOptions=Values.GetOptions();
     ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
     ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    if ( CalculateStiffnessMatrixFlag ) {
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    } else {
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+    }
 
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -244,7 +244,11 @@ void UpdatedLagrangian::CalculateAll(
     Flags& ConstitutiveLawOptions=Values.GetOptions();
     ConstitutiveLawOptions.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, UseElementProvidedStrain());
     ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
-    ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    if ( CalculateStiffnessMatrixFlag ) {
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, true);
+    } else {
+        ConstitutiveLawOptions.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+    }
 
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter


### PR DESCRIPTION
The tangent tensor is not used on the RHS computation, its removal can reduce significantly the explicit simulations