### PR TITLE
using python3 in nightly

### DIFF
--- a/scripts/build/nightly_build.sh
+++ b/scripts/build/nightly_build.sh
@@ -121,7 +121,7 @@ make install -j2 -k > ${LOG_DIR}/compile_clang.log 2>&1
 
 # UnitTesting
 cd ${HOME}/Kratos/kratos/python_scripts
-python3 run_tests.py -l nightly > ${LOG_DIR}/unittest_clang.log 2>&1
+python3 run_tests.py -l nightly -c python3 > ${LOG_DIR}/unittest_clang.log 2>&1
 
 # # Benchmarking
 # cd ${HOME}/Kratos/benchmarking


### PR DESCRIPTION
otherwise the modules that are not included in `runkratos` are not available (e.g. numpy)