### PR TITLE
fixed dead load

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/cable_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cable_element_3D2N.cpp
@@ -98,10 +98,10 @@ void CableElement3D2N::CalculateLocalSystem(MatrixType &rLeftHandSideMatrix,
     rRightHandSideVector = ZeroVector(msLocalSize);
     // update Residual
     noalias(rRightHandSideVector) -= internal_forces;
-    // add bodyforces
-
-    noalias(rRightHandSideVector) += this->CalculateBodyForces();
   }
+
+  // add bodyforces
+  if (this->HasSelfWeight()) noalias(rRightHandSideVector) += this->CalculateBodyForces();
   KRATOS_CATCH("")
 }
 
@@ -121,10 +121,10 @@ void CableElement3D2N::CalculateRightHandSide(
 
 
     noalias(rRightHandSideVector) -= prod(transformation_matrix, internal_forces);
-
-    // add bodyforces
-    noalias(rRightHandSideVector) += this->CalculateBodyForces();
   }
+
+  // add bodyforces
+  if (this->HasSelfWeight()) noalias(rRightHandSideVector) += this->CalculateBodyForces();
   KRATOS_CATCH("")
 }
 


### PR DESCRIPTION
hi, the cable does only contribute to the system if it is not compressed. Until now also the dead load was then not applied, which is wrong. This is fixed now.

Another question:
As you can see I am checking if the Variable VOLUME_ACCELERATION is set to a non-zero value. Is this necessary? 