### PR TITLE
[StructuralMechanicsApplication] Reducing small bottleneck on lumped damping matrix

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1659,25 +1659,29 @@ double BaseSolidElement::CalculateDerivativesOnCurrentConfiguration(
 /***********************************************************************************/
 /***********************************************************************************/
 
-Vector BaseSolidElement::GetBodyForce(
+array_1d<double, 3> BaseSolidElement::GetBodyForce(
     const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
     const IndexType PointNumber
     ) const
 {
-    Vector body_force = ZeroVector(3);
+    array_1d<double, 3> body_force;
+    for (IndexType i = 0; i < 3; ++i)
+        body_force[i] = 0.0;
 
+    const auto& r_properties = GetProperties();
     double density = 0.0;
-    if (GetProperties().Has( DENSITY ) == true)
-        density = GetProperties()[DENSITY];
+    if (r_properties.Has( DENSITY ))
+        density = r_properties[DENSITY];
 
-    if (GetProperties().Has( VOLUME_ACCELERATION ) == true)
-        body_force += density * GetProperties()[VOLUME_ACCELERATION];
+    if (r_properties.Has( VOLUME_ACCELERATION ))
+        noalias(body_force) += density * r_properties[VOLUME_ACCELERATION];
 
-    if( GetGeometry()[0].SolutionStepsDataHas(VOLUME_ACCELERATION) ) {
+    const auto& r_geometry = this->GetGeometry();
+    if( r_geometry[0].SolutionStepsDataHas(VOLUME_ACCELERATION) ) {
         Vector N;
-        N = GetGeometry().ShapeFunctionsValues(N, IntegrationPoints[PointNumber].Coordinates());
-        for (IndexType i_node = 0; i_node < this->GetGeometry().size(); ++i_node)
-            noalias(body_force) += N[i_node] * density * GetGeometry()[i_node].FastGetSolutionStepValue(VOLUME_ACCELERATION);
+        N = r_geometry.ShapeFunctionsValues(N, IntegrationPoints[PointNumber].Coordinates());
+        for (IndexType i_node = 0; i_node < r_geometry.size(); ++i_node)
+            noalias(body_force) += N[i_node] * density * r_geometry[i_node].FastGetSolutionStepValue(VOLUME_ACCELERATION);
     }
 
     return body_force;
@@ -1727,7 +1731,7 @@ void BaseSolidElement::CalculateAndAddResidualVector(
     VectorType& rRightHandSideVector,
     const KinematicVariables& rThisKinematicVariables,
     const ProcessInfo& rCurrentProcessInfo,
-    const Vector& rBodyForce,
+    const array_1d<double, 3>& rBodyForce,
     const Vector& rStressVector,
     const double IntegrationWeight
     ) const
@@ -1749,7 +1753,7 @@ void BaseSolidElement::CalculateAndAddResidualVector(
 void BaseSolidElement::CalculateAndAddExtForceContribution(
     const Vector& rN,
     const ProcessInfo& rCurrentProcessInfo,
-    const Vector& rBodyForce,
+    const array_1d<double, 3>& rBodyForce,
     VectorType& rRightHandSideVector,
     const double Weight
     ) const

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -408,23 +408,6 @@ void BaseSolidElement::GetSecondDerivativesVector(
 /***********************************************************************************/
 /***********************************************************************************/
 
-void BaseSolidElement::CalculateRightHandSide(
-    VectorType& rRightHandSideVector,
-    ProcessInfo& rCurrentProcessInfo
-    )
-{
-    // Calculation flags
-    const bool CalculateStiffnessMatrixFlag = false;
-    const bool CalculateResidualVectorFlag = true;
-    MatrixType temp = Matrix();
-
-    CalculateAll( temp, rRightHandSideVector, rCurrentProcessInfo, CalculateStiffnessMatrixFlag, CalculateResidualVectorFlag );
-}
-
-
-/***********************************************************************************/
-/***********************************************************************************/
-
 void BaseSolidElement::AddExplicitContribution(
     const VectorType& rRHSVector,
     const Variable<VectorType>& rRHSVariable,
@@ -530,6 +513,22 @@ void BaseSolidElement::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
     VectorType RHS;
     CalculateLocalSystem(rLeftHandSideMatrix, RHS, rCurrentProcessInfo);
     KRATOS_CATCH("");
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void BaseSolidElement::CalculateRightHandSide(
+    VectorType& rRightHandSideVector,
+    ProcessInfo& rCurrentProcessInfo
+    )
+{
+    // Calculation flags
+    const bool CalculateStiffnessMatrixFlag = false;
+    const bool CalculateResidualVectorFlag = true;
+    MatrixType temp = Matrix();
+
+    CalculateAll( temp, rRightHandSideVector, rCurrentProcessInfo, CalculateStiffnessMatrixFlag, CalculateResidualVectorFlag );
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -1846,13 +1846,10 @@ void BaseSolidElement::CalculateDampingMatrixWithLumpedMass(
 
     // 2.-Calculate mass matrix:
     if (alpha > std::numeric_limits<double>::epsilon()) {
-        MatrixType mass_matrix = ZeroMatrix( mat_size, mat_size );
         VectorType temp_vector(mat_size);
         CalculateLumpedMassVector(temp_vector);
         for (IndexType i = 0; i < mat_size; ++i)
-            mass_matrix(i, i) = temp_vector[i];
-
-        noalias( rDampingMatrix ) += alpha * mass_matrix;
+            rDampingMatrix(i, i) += alpha * temp_vector[i];
     }
 
     // 3.-Calculate StiffnessMatrix:

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -480,7 +480,7 @@ void BaseSolidElement::AddExplicitContribution(
         Vector current_nodal_velocities = ZeroVector(element_size);
         this->GetFirstDerivativesVector(current_nodal_velocities);
 
-        Matrix damping_matrix = ZeroMatrix(element_size, element_size);
+        Matrix damping_matrix(element_size, element_size);
         this->CalculateDampingMatrixWithLumpedMass(damping_matrix, rCurrentProcessInfo);
 
         // Current residual contribution due to damping

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -865,7 +865,7 @@ protected:
      * @param PointNumber The id of the integration point considered
      * @return The vector of body forces
      */
-    Vector GetBodyForce(
+    array_1d<double, 3> GetBodyForce(
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const IndexType PointNumber
         ) const;
@@ -911,7 +911,7 @@ protected:
         VectorType& rRightHandSideVector,
         const KinematicVariables& rThisKinematicVariables,
         const ProcessInfo& rCurrentProcessInfo,
-        const Vector& rBodyForce,
+        const array_1d<double, 3>& rBodyForce,
         const Vector& rStressVector,
         const double IntegrationWeight
         ) const;
@@ -927,7 +927,7 @@ protected:
     void CalculateAndAddExtForceContribution(
         const Vector& rN,
         const ProcessInfo& rCurrentProcessInfo,
-        const Vector& rBodyForce,
+        const array_1d<double, 3>& rBodyForce,
         VectorType& rRightHandSideVector,
         const double IntegrationWeight
         ) const;

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.cpp
@@ -137,10 +137,14 @@ void SmallDisplacementBbar::CalculateAll(
     // compute Hydrostatic B-Matrix
     this->SmallDisplacementBbar::CalculateHydrostaticDeformationMatrix(this_kinematic_variables);
 
-    for ( IndexType point_number = 0; point_number < integration_points.size(); point_number++ )
-    {
+    // Some declarations
+    array_1d<double, 3> body_force;
+    double int_to_reference_weight;
+
+    // Computing in all integrations points
+    for ( IndexType point_number = 0; point_number < integration_points.size(); ++point_number ) {
         // Contribution to external forces
-        const Vector body_force = this->GetBodyForce(integration_points, point_number);
+        noalias(body_force) = this->GetBodyForce(integration_points, point_number);
 
         // Compute element kinematics B, F, DN_DX ...
         CalculateKinematicVariablesBbar(this_kinematic_variables, point_number, integration_points);
@@ -151,7 +155,7 @@ void SmallDisplacementBbar::CalculateAll(
                                        GetStressMeasure());
 
         // Calculating weights for integration on the reference configuration
-        double int_to_reference_weight = GetIntegrationWeight(integration_points, point_number,
+        int_to_reference_weight = GetIntegrationWeight(integration_points, point_number,
                                                               this_kinematic_variables.detJ0);
 
         if ( dimension == 2 && GetProperties().Has( THICKNESS ))
@@ -889,7 +893,7 @@ void SmallDisplacementBbar::CalculateAndAddResidualVector(
         VectorType& rRightHandSideVector,
         const KinematicVariables& rThisKinematicVariables,
         const ProcessInfo& rCurrentProcessInfo,
-        const Vector& rBodyForce,
+        const array_1d<double, 3>& rBodyForce,
         const Vector& rStressVector,
         const double IntegrationWeight
     ) const

--- a/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/small_displacement_bbar.h
@@ -218,7 +218,7 @@ protected:
             VectorType& rRightHandSideVector,
             const KinematicVariables& rThisKinematicVariables,
             const ProcessInfo& rCurrentProcessInfo,
-            const Vector& rBodyForce,
+            const array_1d<double, 3>& rBodyForce,
             const Vector& rStressVector,
             const double IntegrationWeight
             ) const override;

--- a/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/total_lagrangian.cpp
@@ -206,9 +206,14 @@ void TotalLagrangian::CalculateAll(
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter
 
-    for ( IndexType point_number = 0; point_number < integration_points.size(); ++point_number ){
+    // Some declarations
+    array_1d<double, 3> body_force;
+    double int_to_reference_weight;
+
+    // Computing in all integrations points
+    for ( IndexType point_number = 0; point_number < integration_points.size(); ++point_number ) {
         // Contribution to external forces
-        const Vector body_force = this->GetBodyForce(integration_points, point_number);
+        noalias(body_force) = this->GetBodyForce(integration_points, point_number);
 
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
@@ -217,7 +222,7 @@ void TotalLagrangian::CalculateAll(
         this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure());
 
         // Calculating weights for integration on the reference configuration
-        double int_to_reference_weight = GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);
+        int_to_reference_weight = GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);
 
         if ( dimension == 2 && this->GetProperties().Has( THICKNESS ))
             int_to_reference_weight *= this->GetProperties()[THICKNESS];

--- a/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/updated_lagrangian.cpp
@@ -253,9 +253,14 @@ void UpdatedLagrangian::CalculateAll(
     // If strain has to be computed inside of the constitutive law with PK2
     Values.SetStrainVector(this_constitutive_variables.StrainVector); //this is the input  parameter
 
+    // Some declarations
+    array_1d<double, 3> body_force;
+    double int_to_reference_weight;
+
+    // Computing in all integrations points
     for ( IndexType point_number = 0; point_number < integration_points.size(); ++point_number ) {
         // Contribution to external forces
-        const Vector body_force = this->GetBodyForce(integration_points, point_number);
+        noalias(body_force) = this->GetBodyForce(integration_points, point_number);
 
         // Compute element kinematics B, F, DN_DX ...
         this->CalculateKinematicVariables(this_kinematic_variables, point_number, this->GetIntegrationMethod());
@@ -264,7 +269,7 @@ void UpdatedLagrangian::CalculateAll(
         this->CalculateConstitutiveVariables(this_kinematic_variables, this_constitutive_variables, Values, point_number, integration_points, this->GetStressMeasure());
 
         // Calculating weights for integration on the reference configuration
-        double int_to_reference_weight = this->GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);
+        int_to_reference_weight = this->GetIntegrationWeight(integration_points, point_number, this_kinematic_variables.detJ0);
 
         if ( dimension == 2 && GetProperties().Has( THICKNESS ))
             int_to_reference_weight *= this->GetProperties()[THICKNESS];


### PR DESCRIPTION
This is a small bottleneck, the mass matrix is created and destroyed, so better directly assign the values