### PR TITLE
[Core] Missing sqrt in displacement criteria

### DIFF
--- a/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/displacement_criteria.h
@@ -367,13 +367,13 @@ private:
             if (it_dof->IsFree()) {
                 dof_id = it_dof->EquationId();
                 variation_dof_value = Dx[dof_id];
-                final_correction_norm += variation_dof_value * variation_dof_value;
+                final_correction_norm += std::pow(variation_dof_value, 2);
                 dof_num++;
             }
         }
 
         rDofNum = dof_num;
-        return final_correction_norm;
+        return std::sqrt(final_correction_norm);
     }
 
     ///@}

--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -313,7 +313,7 @@ protected:
             if (it_dof->IsFree()) {
                 dof_id = it_dof->EquationId();
                 residual_dof_value = TSparseSpace::GetValue(b,dof_id);
-                residual_solution_norm += residual_dof_value * residual_dof_value;
+                residual_solution_norm += std::pow(residual_dof_value, 2);
                 dof_num++;
             }
         }


### PR DESCRIPTION
This was removed by an error, restoring.

@marandra and @ddiezrod noticed. Sorry for the change