### PR TITLE
[MultilevelMonteCarloApplication] Removing compss library from the tests of the application

### DIFF
--- a/applications/MultilevelMonteCarloApplication/python_scripts/test_auxiliary_classes_utilities.py
+++ b/applications/MultilevelMonteCarloApplication/python_scripts/test_auxiliary_classes_utilities.py
@@ -3,14 +3,6 @@ from __future__ import absolute_import, division # makes KratosMultiphysics back
 # Import packages
 import numpy as np
 
-# Import exaqute
-from exaqute.ExaquteTaskPyCOMPSs import *   # to execute with pycompss
-# from exaqute.ExaquteTaskHyperLoom import *  # to execute with the IT4 scheduler
-# from exaqute.ExaquteTaskLocal import *      # to execute with python3
-'''
-get_value_from_remote is the equivalent of compss_wait_on: a synchronization point
-in future, when everything is integrated with the it4i team, importing exaqute.ExaquteTaskHyperLoom you can launch your code with their scheduler instead of BSC
-'''
 
 '''
 This utility contains the classes to perform the Continuation Multilevel Monte Carlo (CMLMC) and the Monte Carlo (MC) algorithms

--- a/applications/MultilevelMonteCarloApplication/python_scripts/test_cmlmc_utilities.py
+++ b/applications/MultilevelMonteCarloApplication/python_scripts/test_cmlmc_utilities.py
@@ -10,14 +10,6 @@ import copy
 # Import the StatisticalVariable class
 from test_auxiliary_classes_utilities import StatisticalVariable
 
-# Import exaqute
-from exaqute.ExaquteTaskPyCOMPSs import *   # to execute with pycompss
-# from exaqute.ExaquteTaskHyperLoom import *  # to execute with the IT4 scheduler
-# from exaqute.ExaquteTaskLocal import *      # to execute with python3
-'''
-get_value_from_remote is the equivalent of compss_wait_on: a synchronization point
-in future, when everything is integrated with the it4i team, importing exaqute.ExaquteTaskHyperLoom you can launch your code with their scheduler instead of BSC
-'''
 
 '''
 This utility contains the functions to perform the Continuation Multilevel Monte Carlo (CMLMC) algorithm
@@ -241,16 +233,6 @@ class MultilevelMonteCarlo(object):
         = FinalizePhase_Task(MultilevelMonteCarlo,
         serial_settings,self.mesh_parameters,self.current_number_levels,\
         self.current_iteration,self.number_samples,*synchro_elements)
-        '''synchronization point needed to compute the other functions of MLMC algorithm
-        put as in the end as possible the synchronization point'''
-        self.difference_QoI.mean = get_value_from_remote(self.difference_QoI.mean)
-        self.difference_QoI.sample_variance = get_value_from_remote(self.difference_QoI.sample_variance)
-        self.time_ML.mean = get_value_from_remote(self.time_ML.mean)
-        self.TErr = get_value_from_remote(self.TErr)
-        self.rates_error = get_value_from_remote(self.rates_error)
-        self.BayesianVariance = get_value_from_remote(self.BayesianVariance)
-        self.mean_mlmc_QoI = get_value_from_remote(self.mean_mlmc_QoI)
-        self.number_samples = get_value_from_remote(self.number_samples)
         '''start first iteration, we enter in the MLMC algorithm'''
         self.current_iteration = 1
 
@@ -313,16 +295,7 @@ class MultilevelMonteCarlo(object):
         = FinalizePhase_Task(MultilevelMonteCarlo,
         serial_settings,self.mesh_parameters,self.current_number_levels,\
         self.current_iteration,self.number_samples,*synchro_elements)
-        '''synchronization point needed to compute the other functions of MLMC algorithm
-        put as in the end as possible the synchronization point'''
-        self.difference_QoI.mean = get_value_from_remote(self.difference_QoI.mean)
-        self.difference_QoI.sample_variance = get_value_from_remote(self.difference_QoI.sample_variance)
-        self.time_ML.mean = get_value_from_remote(self.time_ML.mean)
-        self.TErr = get_value_from_remote(self.TErr)
-        self.rates_error = get_value_from_remote(self.rates_error)
-        self.BayesianVariance = get_value_from_remote(self.BayesianVariance)
-        self.mean_mlmc_QoI = get_value_from_remote(self.mean_mlmc_QoI)
-        self.number_samples = get_value_from_remote(self.number_samples)
+
         '''check convergence
         convergence reached if: i) current_iteration >= number_iterations_iE
                                ii) TErr < tolerance_i

--- a/applications/MultilevelMonteCarloApplication/python_scripts/test_mc_utilities.py
+++ b/applications/MultilevelMonteCarloApplication/python_scripts/test_mc_utilities.py
@@ -10,14 +10,6 @@ from math import *
 # Import the StatisticalVariable class
 from test_auxiliary_classes_utilities import StatisticalVariable
 
-# Import exaqute
-from exaqute.ExaquteTaskPyCOMPSs import *   # to execute with pycompss
-# from exaqute.ExaquteTaskHyperLoom import *  # to execute with the IT4 scheduler
-# from exaqute.ExaquteTaskLocal import *      # to execute with python3
-'''
-get_value_from_remote is the equivalent of compss_wait_on: a synchronization point
-in future, when everything is integrated with the it4i team, importing exaqute.ExaquteTaskHyperLoom you can launch your code with their scheduler instead of BSC
-'''
 
 '''
 This utility contains the functions to perform the Monte Carlo (CMLMC) algorithm
@@ -209,9 +201,6 @@ class MonteCarlo(object):
         self.QoI.ComputeHStatistics(level)
         self.QoI.ComputeSkewnessKurtosis(level)
         self.CheckConvergence(level)
-        '''synchronization point needed to launch new tasks, if needed
-        put as in the end as possible the synchronization point'''
-        self.convergence = get_value_from_remote(self.convergence)
 
     '''
     function printing informations about initializing MLMC phase

--- a/applications/MultilevelMonteCarloApplication/python_scripts/test_multilevel_montecarlo_analysis.py
+++ b/applications/MultilevelMonteCarloApplication/python_scripts/test_multilevel_montecarlo_analysis.py
@@ -18,7 +18,7 @@ import numpy as np
 import time
 
 # Import Continuation Multilevel Monte Carlo library
-import cmlmc_utilities as mlmc
+import test_cmlmc_utilities as mlmc
 
 # Import refinement library
 import adaptive_refinement_utilities as refinement

--- a/applications/MultilevelMonteCarloApplication/tests/test_MultilevelMonteCarloApplication.py
+++ b/applications/MultilevelMonteCarloApplication/tests/test_MultilevelMonteCarloApplication.py
@@ -1,6 +1,7 @@
 # import Kratos
 import KratosMultiphysics
 import KratosMultiphysics.MultilevelMonteCarloApplication as KratosMLMC
+import KratosMultiphysics.MeshingApplication as MeshingApplication
 
 # Import Kratos "wrapper" for unittests
 import KratosMultiphysics.KratosUnittest as KratosUnittest
@@ -12,7 +13,7 @@ from test_multilevel_montecarlo import KratosMultilevelMonteCarloGeneralTests
 def AssembleTestSuites():
     ''' Populates the test suites to run.
 
-    Populates the test suites to run. At least, it should pupulate the suites:
+    Populates the test suites to run. At least, it should populate the suites:
     "small", "nighlty" and "all"
 
     Return
@@ -26,20 +27,19 @@ def AssembleTestSuites():
 
     # Create a test suit with the selected tests (Small tests):
     # smallSuite will contain the following tests:
-    # - testSmallExample
+    # -
     smallSuite = suites['small']
-    smallSuite.addTest(KratosMultilevelMonteCarloGeneralTests('testSmallExample'))
 
     # Create a test suit with the selected tests
     # nightSuite will contain the following tests:
-    # - testSmallExample
-    # - testNightlyFirstExample
-    # - testNightlySecondExample
+    # - testMonteCarloAnalysis
+    # - testMultilevelMonteCarloAnalysis
     nightSuite = suites['nightly']
-    nightSuite.addTest(KratosMultilevelMonteCarloGeneralTests('testNightlyFirstExample'))
-    nightSuite.addTest(KratosMultilevelMonteCarloGeneralTests('testNightlySecondExample'))
-    nightSuite.addTest(KratosMultilevelMonteCarloGeneralTests('testMonteCarloAnalysis'))
-    nightSuite.addTest(KratosMultilevelMonteCarloGeneralTests('testMultilevelMonteCarloAnalysis'))
+    if(hasattr(MeshingApplication,"MmgProcess2D")):
+        nightSuite.addTest(KratosMultilevelMonteCarloGeneralTests('testMonteCarloAnalysis'))
+        nightSuite.addTest(KratosMultilevelMonteCarloGeneralTests('testMultilevelMonteCarloAnalysis'))
+    else:
+        print("MMG process is not compiled and the corresponding tests will not be executed")
 
     # Create a test suit that contains all the tests from every testCase
     # in the list:
@@ -53,4 +53,6 @@ def AssembleTestSuites():
     return suites
 
 if __name__ == '__main__':
+    KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning python tests ...")
     KratosUnittest.runTests(AssembleTestSuites())
+    KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished python tests!")


### PR DESCRIPTION
Removing compss library from the tests. Now the tests only need the mmg library installed.