### PR TITLE
[Core] enhance time discretization

### DIFF
--- a/applications/MeshMovingApplication/custom_utilities/mesh_velocity_calculation.cpp
+++ b/applications/MeshMovingApplication/custom_utilities/mesh_velocity_calculation.cpp
@@ -16,6 +16,8 @@
 // External includes
 
 // Project includes
+#include "includes/model_part.h"
+#include "includes/mesh_moving_variables.h"
 #include "mesh_velocity_calculation.h"
 
 namespace Kratos {
@@ -59,9 +61,7 @@ void CalculateMeshVelocities(ModelPart& rModelPart,
     const int num_local_nodes = rModelPart.GetCommunicator().LocalMesh().NumberOfNodes();
     const auto nodes_begin = rModelPart.GetCommunicator().LocalMesh().NodesBegin();
 
-    const double delta_time = rModelPart.GetProcessInfo()[DELTA_TIME];
-
-    const auto coeffs = rBDF.ComputeBDFCoefficients(delta_time);
+    const auto coeffs = rBDF.ComputeBDFCoefficients(rModelPart.GetProcessInfo());
 
     #pragma omp parallel for
     for (int i=0; i<num_local_nodes; i++) {
@@ -80,12 +80,7 @@ void CalculateMeshVelocities(ModelPart& rModelPart,
     const int num_local_nodes = rModelPart.GetCommunicator().LocalMesh().NumberOfNodes();
     const auto nodes_begin = rModelPart.GetCommunicator().LocalMesh().NodesBegin();
 
-    const auto& r_current_process_info = rModelPart.GetProcessInfo();
-
-    const double delta_time = r_current_process_info[DELTA_TIME];
-    const double previous_delta_time = r_current_process_info.GetPreviousTimeStepInfo(1)[DELTA_TIME];
-
-    const auto coeffs = rBDF.ComputeBDFCoefficients(delta_time, previous_delta_time);
+    const auto coeffs = rBDF.ComputeBDFCoefficients(rModelPart.GetProcessInfo());
 
     #pragma omp parallel for
     for (int i=0; i<num_local_nodes; i++) {

--- a/applications/MeshMovingApplication/custom_utilities/mesh_velocity_calculation.h
+++ b/applications/MeshMovingApplication/custom_utilities/mesh_velocity_calculation.h
@@ -19,12 +19,10 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
-#include "includes/model_part.h"
-#include "includes/mesh_moving_variables.h"
 #include "utilities/time_discretization.h"
 
 namespace Kratos {
+class ModelPart; // forward-declaring to not having to include it here
 namespace MeshVelocityCalculation {
 
 void CalculateMeshVelocities(ModelPart& rModelPart,

--- a/kratos/python/add_utilities_to_python.cpp
+++ b/kratos/python/add_utilities_to_python.cpp
@@ -175,7 +175,7 @@ void CalculateDistancesDefault2D(ParallelDistanceCalculator<2>& rParallelDistanc
 {
     rParallelDistanceCalculator.CalculateDistances(rModelPart, rDistanceVar, rAreaVar, max_levels, max_distance);
 }
-    
+
 void CalculateDistancesFlag2D(ParallelDistanceCalculator<2>& rParallelDistanceCalculator, ModelPart& rModelPart, const Variable<double>& rDistanceVar, const Variable<double>& rAreaVar, const unsigned int max_levels, const double max_distance, Flags Options)
 {
     rParallelDistanceCalculator.CalculateDistances(rModelPart, rDistanceVar, rAreaVar, max_levels, max_distance, Options);
@@ -185,7 +185,7 @@ void CalculateDistancesDefault3D(ParallelDistanceCalculator<3>& rParallelDistanc
 {
     rParallelDistanceCalculator.CalculateDistances(rModelPart, rDistanceVar, rAreaVar, max_levels, max_distance);
 }
-    
+
 void CalculateDistancesFlag3D(ParallelDistanceCalculator<3>& rParallelDistanceCalculator, ModelPart& rModelPart, const Variable<double>& rDistanceVar, const Variable<double>& rAreaVar, const unsigned int max_levels, const double max_distance, Flags Options)
 {
     rParallelDistanceCalculator.CalculateDistances(rModelPart, rDistanceVar, rAreaVar, max_levels, max_distance, Options);
@@ -791,29 +791,36 @@ void AddUtilitiesToPython(pybind11::module& m)
         .def("RemoveConditionsAndBelongingsFromAllLevels", &Kratos::AuxiliarModelPartUtilities::RemoveConditionsAndBelongingsFromAllLevels)
         ;
 
+    // TimeDiscretization
     py::class_<TimeDiscretization::BDF1>(m, "BDF1")
         .def(py::init<>())
-        .def("ComputeBDFCoefficients", &TimeDiscretization::BDF1::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 2> (TimeDiscretization::BDF1::*)(double) const) &TimeDiscretization::BDF1::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 2> (TimeDiscretization::BDF1::*)(const ProcessInfo&) const) &TimeDiscretization::BDF1::ComputeBDFCoefficients)
         ;
     py::class_<TimeDiscretization::BDF2>(m, "BDF2")
         .def(py::init<>())
-        .def("ComputeBDFCoefficients", &TimeDiscretization::BDF2::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 3> (TimeDiscretization::BDF2::*)(double, double) const) &TimeDiscretization::BDF2::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 3> (TimeDiscretization::BDF2::*)(const ProcessInfo&) const) &TimeDiscretization::BDF2::ComputeBDFCoefficients)
         ;
     py::class_<TimeDiscretization::BDF3>(m, "BDF3")
         .def(py::init<>())
-        .def("ComputeBDFCoefficients", &TimeDiscretization::BDF3::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 4> (TimeDiscretization::BDF3::*)(double) const) &TimeDiscretization::BDF3::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 4> (TimeDiscretization::BDF3::*)(const ProcessInfo&) const) &TimeDiscretization::BDF3::ComputeBDFCoefficients)
         ;
     py::class_<TimeDiscretization::BDF4>(m, "BDF4")
         .def(py::init<>())
-        .def("ComputeBDFCoefficients", &TimeDiscretization::BDF4::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 5> (TimeDiscretization::BDF4::*)(double) const) &TimeDiscretization::BDF4::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 5> (TimeDiscretization::BDF4::*)(const ProcessInfo&) const) &TimeDiscretization::BDF4::ComputeBDFCoefficients)
         ;
     py::class_<TimeDiscretization::BDF5>(m, "BDF5")
         .def(py::init<>())
-        .def("ComputeBDFCoefficients", &TimeDiscretization::BDF5::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 6> (TimeDiscretization::BDF5::*)(double) const) &TimeDiscretization::BDF5::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 6> (TimeDiscretization::BDF5::*)(const ProcessInfo&) const) &TimeDiscretization::BDF5::ComputeBDFCoefficients)
         ;
     py::class_<TimeDiscretization::BDF6>(m, "BDF6")
         .def(py::init<>())
-        .def("ComputeBDFCoefficients", &TimeDiscretization::BDF6::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 7> (TimeDiscretization::BDF6::*)(double) const) &TimeDiscretization::BDF6::ComputeBDFCoefficients)
+        .def("ComputeBDFCoefficients", (std::array<double, 7> (TimeDiscretization::BDF6::*)(const ProcessInfo&) const) &TimeDiscretization::BDF6::ComputeBDFCoefficients)
         ;
 
     py::class_<TimeDiscretization::Newmark>(m, "Newmark")

--- a/kratos/tests/test_time_discretization.py
+++ b/kratos/tests/test_time_discretization.py
@@ -9,7 +9,6 @@ class TestTimeDiscretization(KratosUnittest.TestCase):
         test_model = KM.Model()
         model_part = test_model.CreateModelPart("test_mp")
         for dt in reversed(delta_times):
-            print(dt)
             model_part.CloneTimeStep(model_part.ProcessInfo[KM.TIME] + dt) # filling the time-step-info
 
         exp_size = len(exp_results)

--- a/kratos/utilities/time_discretization.cpp
+++ b/kratos/utilities/time_discretization.cpp
@@ -17,6 +17,8 @@
 
 // Project includes
 #include "includes/checks.h"
+#include "includes/process_info.h"
+#include "includes/variables.h"
 #include "input_output/logger.h"
 #include "time_discretization.h"
 
@@ -34,6 +36,13 @@ std::array<double, 2> BDF1::ComputeBDFCoefficients(const double DeltaTime) const
     coefficients[1] = -1.0/DeltaTime;
 
     return coefficients;
+}
+
+std::array<double, 2> BDF1::ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const
+{
+    KRATOS_ERROR_IF_NOT(rProcessInfo.Has(DELTA_TIME)) << "No DELTA_TIME "
+        << "defined in the ProcessInfo!" << std::endl;
+    return ComputeBDFCoefficients(rProcessInfo[DELTA_TIME]);
 }
 
 std::array<double, 3> BDF2::ComputeBDFCoefficients(const double DeltaTime, const double PreviousDeltaTime) const
@@ -62,6 +71,14 @@ std::array<double, 3> BDF2::ComputeBDFCoefficients(const double DeltaTime, const
     return coefficients;
 }
 
+std::array<double, 3> BDF2::ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const
+{
+    KRATOS_ERROR_IF_NOT(rProcessInfo.Has(DELTA_TIME)) << "No DELTA_TIME "
+        << "defined in the ProcessInfo!" << std::endl;
+    return ComputeBDFCoefficients(rProcessInfo[DELTA_TIME],
+                                  rProcessInfo.GetPreviousTimeStepInfo(1)[DELTA_TIME]);
+}
+
 std::array<double, 4> BDF3::ComputeBDFCoefficients(const double DeltaTime) const
 {
     KRATOS_ERROR_IF(DeltaTime < std::numeric_limits<double>::epsilon())
@@ -77,6 +94,13 @@ std::array<double, 4> BDF3::ComputeBDFCoefficients(const double DeltaTime) const
     coefficients[3] =  -2.0 / denom;
 
     return coefficients;
+}
+
+std::array<double, 4> BDF3::ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const
+{
+    KRATOS_ERROR_IF_NOT(rProcessInfo.Has(DELTA_TIME)) << "No DELTA_TIME "
+        << "defined in the ProcessInfo!" << std::endl;
+    return ComputeBDFCoefficients(rProcessInfo[DELTA_TIME]);
 }
 
 std::array<double, 5> BDF4::ComputeBDFCoefficients(const double DeltaTime) const
@@ -95,6 +119,13 @@ std::array<double, 5> BDF4::ComputeBDFCoefficients(const double DeltaTime) const
     coefficients[4] =   3.0 / denom;
 
     return coefficients;
+}
+
+std::array<double, 5> BDF4::ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const
+{
+    KRATOS_ERROR_IF_NOT(rProcessInfo.Has(DELTA_TIME)) << "No DELTA_TIME "
+        << "defined in the ProcessInfo!" << std::endl;
+    return ComputeBDFCoefficients(rProcessInfo[DELTA_TIME]);
 }
 
 std::array<double, 6> BDF5::ComputeBDFCoefficients(const double DeltaTime) const
@@ -116,6 +147,13 @@ std::array<double, 6> BDF5::ComputeBDFCoefficients(const double DeltaTime) const
     return coefficients;
 }
 
+std::array<double, 6> BDF5::ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const
+{
+    KRATOS_ERROR_IF_NOT(rProcessInfo.Has(DELTA_TIME)) << "No DELTA_TIME "
+        << "defined in the ProcessInfo!" << std::endl;
+    return ComputeBDFCoefficients(rProcessInfo[DELTA_TIME]);
+}
+
 std::array<double, 7> BDF6::ComputeBDFCoefficients(const double DeltaTime) const
 {
     KRATOS_ERROR_IF(DeltaTime < std::numeric_limits<double>::epsilon())
@@ -134,6 +172,13 @@ std::array<double, 7> BDF6::ComputeBDFCoefficients(const double DeltaTime) const
     coefficients[6] =   10.0 / denom;
 
     return coefficients;
+}
+
+std::array<double, 7> BDF6::ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const
+{
+    KRATOS_ERROR_IF_NOT(rProcessInfo.Has(DELTA_TIME)) << "No DELTA_TIME "
+        << "defined in the ProcessInfo!" << std::endl;
+    return ComputeBDFCoefficients(rProcessInfo[DELTA_TIME]);
 }
 
 } // namespace TimeDiscretization.

--- a/kratos/utilities/time_discretization.h
+++ b/kratos/utilities/time_discretization.h
@@ -21,12 +21,15 @@
 // Project includes
 
 namespace Kratos {
+class ProcessInfo; // forward-declaring to not having to include it here
+
 namespace TimeDiscretization {
 
 class KRATOS_API(KRATOS_CORE) BDF1
 {
 public:
     std::array<double, 2> ComputeBDFCoefficients(double DeltaTime) const;
+    std::array<double, 2> ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const;
 };
 
 class KRATOS_API(KRATOS_CORE) BDF2
@@ -34,30 +37,35 @@ class KRATOS_API(KRATOS_CORE) BDF2
 public:
     std::array<double, 3> ComputeBDFCoefficients(double DeltaTime,
                                                  double PreviousDeltaTime) const;
+    std::array<double, 3> ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const;
 };
 
 class KRATOS_API(KRATOS_CORE) BDF3
 {
 public:
     std::array<double, 4> ComputeBDFCoefficients(double DeltaTime) const;
+    std::array<double, 4> ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const;
 };
 
 class KRATOS_API(KRATOS_CORE) BDF4
 {
 public:
     std::array<double, 5> ComputeBDFCoefficients(double DeltaTime) const;
+    std::array<double, 5> ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const;
 };
 
 class KRATOS_API(KRATOS_CORE) BDF5
 {
 public:
     std::array<double, 6> ComputeBDFCoefficients(double DeltaTime) const;
+    std::array<double, 6> ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const;
 };
 
 class KRATOS_API(KRATOS_CORE) BDF6
 {
 public:
     std::array<double, 7> ComputeBDFCoefficients(double DeltaTime) const;
+    std::array<double, 7> ComputeBDFCoefficients(const ProcessInfo& rProcessInfo) const;
 };
 
 class Newmark


### PR DESCRIPTION
This PR enhances the TimeDiscretization towards accepting a ProcessInfo instead of directly passing the delta_time as asked for by @rubenzorrilla 

I used the new features in the MeshMovingApp

Tests are running, also new tests were added and refactored

No additional includes were added to `time_discretization.h` to keep it as lightweight as possible