### PR TITLE
Cleanup/trilinos builder and solver shadowing

### DIFF
--- a/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
+++ b/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_block_builder_and_solver.h
@@ -312,7 +312,7 @@ public:
     //**************************************************************************
     /** Solve the linear problem.
      */
-    virtual void SystemSolve(
+    void SystemSolveWithPhysics(
         TSystemMatrixType& A,
         TSystemVectorType& Dx,
         TSystemVectorType& b,
@@ -404,7 +404,7 @@ public:
 
         boost::timer solve_time;
 
-        SystemSolve(A,Dx,b,r_model_part);
+        SystemSolveWithPhysics(A,Dx,b,r_model_part);
 
         if(BaseType::GetEchoLevel()>0)
         {
@@ -436,7 +436,7 @@ public:
         KRATOS_TRY
 
         BuildRHS(pScheme,r_model_part,b);
-        SystemSolve(A,Dx,b,r_model_part);
+        SystemSolveWithPhysics(A,Dx,b,r_model_part);
 
         KRATOS_CATCH("")
     }

--- a/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_elimination_builder_and_solver.h
+++ b/applications/trilinos_application/custom_strategies/builder_and_solvers/trilinos_elimination_builder_and_solver.h
@@ -317,11 +317,12 @@ public:
 
     //**************************************************************************
     //**************************************************************************
-    void SystemSolve(
+    void SystemSolveWithPhysics(
         TSystemMatrixType& A,
         TSystemVectorType& Dx,
-        TSystemVectorType& b
-    ) override
+        TSystemVectorType& b,
+        ModelPart& rModelPart
+    )
     {
         KRATOS_TRY
 
@@ -336,6 +337,9 @@ public:
         {
             if (this->GetEchoLevel()>1)
                 if (mrComm.MyPID() == 0) KRATOS_WATCH("entering in the solver");
+
+            if(BaseType::mpLinearSystemSolver->AdditionalPhysicalDataIsNeeded() )
+                BaseType::mpLinearSystemSolver->ProvideAdditionalData(A, Dx, b, BaseType::mDofSet, rModelPart);
 
             this->mpLinearSystemSolver->Solve(A,Dx,b);
 
@@ -394,7 +398,7 @@ public:
 
         boost::timer solve_time;
 
-        SystemSolve(A,Dx,b);
+        SystemSolveWithPhysics(A,Dx,b, r_model_part);
 
         if (BaseType::GetEchoLevel()>0)
         {
@@ -426,7 +430,7 @@ public:
         KRATOS_TRY
 
         BuildRHS(pScheme,r_model_part,b);
-        SystemSolve(A,Dx,b);
+        SystemSolveWithPhysics(A,Dx,b, r_model_part);
 
         KRATOS_CATCH("")
     }


### PR DESCRIPTION
Updating the function signatures in TrilinosBlockBuilderAndSolver to match the serial implementation and updating the TrilinosEliminationBuilderAndSolver to provide additional data to the solver when needed.

This closes #1502.

Please note that I could not test the elimination version because it is currently not working with the fluid (also in master). I would be grateful if someone could run a case with that one.