### PR TITLE
[Trilinos] adding deprecation-warning to deprecated lin-solver-factory

### DIFF
--- a/applications/trilinos_application/python_scripts/deprecated_trilinos_linear_solver_factory.py
+++ b/applications/trilinos_application/python_scripts/deprecated_trilinos_linear_solver_factory.py
@@ -47,6 +47,10 @@ def ConstructPreconditioner(configuration):
 #
 def ConstructSolver(configuration):
 
+    depr_msg  = '"applications/trilinos_application/deprecated_trilinos_linear_solver_factory.py" is deprecated and will be removed\n'
+    depr_msg += 'Please use "applications/trilinos_application/trilinos_linear_solver_factory.py" instead!'
+    Logger.PrintWarning('DEPRECATION-WARNING', depr_msg)
+
     ##############################################################
     ###THIS IS A VERY DIRTY HACK TO ALLOW PARAMETERS TO BE PASSED TO THE LINEAR SOLVER FACTORY
     ###TODO: clean this up!!


### PR DESCRIPTION
To warn users before we remove it for good

(Or we remove it right away, it is only used in outdated solvers in the Fluid, up to you)