### PR TITLE
refactor(HDF5): moved template functions to cpp files

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -7,6 +7,7 @@
 #include <type_traits>
 #include "includes/kratos_parameters.h"
 #include "utilities/builtin_timer.h"
+#include "input_output/logger.h"
 
 namespace Kratos
 {
@@ -314,8 +315,9 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, &Value) < 0) << "H5Awrite failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Write time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Write time \"" << rObjectPath << '/' << rName
+        << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
 }
 
@@ -336,8 +338,9 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, &rValue[0]) < 0) << "H5Awrite failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Write time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Write time \"" << rObjectPath << '/' << rName
+        << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
 }
 
@@ -361,8 +364,9 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, &rValue(0,0)) < 0) << "H5Awrite failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Write time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Write time \"" << rObjectPath << '/' << rName
+        << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
 }
 
@@ -384,8 +388,9 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, rValue.c_str()) < 0) << "H5Awrite failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Write time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Write time \"" << rObjectPath << '/' << rName
+        << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
 }
 
@@ -597,8 +602,9 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     // Read attribute.
     KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue) < 0) << "H5Aread failed." << std::endl; 
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Read time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Read time \"" << rObjectPath << '/' << rName
+        << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
 }
 
@@ -637,8 +643,9 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     // Read attribute.
     KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue[0]) < 0) << "H5Aread failed." << std::endl; 
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Read time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Read time \"" << rObjectPath << '/' << rName
+        << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
 }
 
@@ -677,8 +684,9 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     // Read attribute.
     KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue(0,0)) < 0) << "H5Aread failed." << std::endl; 
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Read time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Read time \"" << rObjectPath << '/' << rName
+        << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
 }
 
@@ -719,8 +727,9 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, buffer) < 0) << "H5Aread failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
     rValue = std::string(buffer, dims[0]);
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Read time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Read time \"" << rObjectPath << '/' << rName
+        << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
 }
 

--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -315,7 +315,7 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, &Value) < 0) << "H5Awrite failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Write time \"" << rObjectPath << '/' << rName
         << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
@@ -338,7 +338,7 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, &rValue[0]) < 0) << "H5Awrite failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Write time \"" << rObjectPath << '/' << rName
         << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
@@ -364,7 +364,7 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, &rValue(0,0)) < 0) << "H5Awrite failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Write time \"" << rObjectPath << '/' << rName
         << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
@@ -388,7 +388,7 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, rValue.c_str()) < 0) << "H5Awrite failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Write time \"" << rObjectPath << '/' << rName
         << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
@@ -602,7 +602,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     // Read attribute.
     KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue) < 0) << "H5Aread failed." << std::endl; 
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Read time \"" << rObjectPath << '/' << rName
         << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
@@ -643,7 +643,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     // Read attribute.
     KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue[0]) < 0) << "H5Aread failed." << std::endl; 
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Read time \"" << rObjectPath << '/' << rName
         << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
@@ -684,7 +684,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     // Read attribute.
     KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue(0,0)) < 0) << "H5Aread failed." << std::endl; 
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Read time \"" << rObjectPath << '/' << rName
         << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
@@ -727,7 +727,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, buffer) < 0) << "H5Aread failed." << std::endl;
     KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
     rValue = std::string(buffer, dims[0]);
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Read time \"" << rObjectPath << '/' << rName
         << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");

--- a/applications/HDF5Application/custom_io/hdf5_file.h
+++ b/applications/HDF5Application/custom_io/hdf5_file.h
@@ -16,14 +16,12 @@
 // System includes
 #include <vector>
 #include <string>
-#include <type_traits>
 
 // External includes
 
 // Project includes
 #include "includes/define.h"
 #include "containers/array_1d.h"
-#include "utilities/builtin_timer.h"
 
 // Application includes
 #include "hdf5_application_define.h"
@@ -37,23 +35,6 @@ namespace HDF5
 {
 ///@addtogroup HDF5Application
 ///@{
-
-namespace Internals
-{
-/// Check if string is a valid path.
-/**
- * Valid paths are similar to linux file system with alphanumeric names
- * and possible underscores separated by '/'. All paths are absolute.
- */
-bool IsPath(const std::string& rPath);
-
-/// Return vector of non-empty substrings separated by a delimiter.
-std::vector<std::string> Split(const std::string& rPath, char Delimiter);
-
-template <class TScalar>
-hid_t GetScalarDataType();
-
-} // namespace Internals.
 
 ///@name Kratos Classes
 ///@{
@@ -290,211 +271,41 @@ private:
     ///@}
 
 };
+
+extern template void File::WriteAttribute(const std::string& rObjectPath, const std::string& rName, int Value);
+extern template void File::WriteAttribute(const std::string& rObjectPath, const std::string& rName, double Value);
+extern template void File::WriteAttribute(const std::string& rObjectPath, const std::string& rName, const Vector<int>& rValue);
+extern template void File::WriteAttribute(const std::string& rObjectPath, const std::string& rName, const Vector<double>& rValue);
+extern template void File::WriteAttribute(const std::string& rObjectPath, const std::string& rName, const Matrix<int>& rValue);
+extern template void File::WriteAttribute(const std::string& rObjectPath, const std::string& rName, const Matrix<double>& rValue);
+
+extern template void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, int& rValue);
+extern template void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, double& rValue);
+extern template void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, Vector<int>& rValue);
+extern template void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, Vector<double>& rValue);
+extern template void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, Matrix<int>& rValue);
+extern template void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, Matrix<double>& rValue);
+
 ///@} // Kratos Classes
-
-template <class TScalar>
-void File::WriteAttribute(const std::string& rObjectPath, const std::string& rName, TScalar Value)
-{
-    KRATOS_TRY;
-    BuiltinTimer timer;
-    hid_t type_id, space_id, attr_id;
-
-    type_id = Internals::GetScalarDataType<TScalar>();
-    space_id = H5Screate(H5S_SCALAR);
-    KRATOS_ERROR_IF(space_id < 0) << "H5Screate failed." << std::endl;
-    attr_id = H5Acreate_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(), type_id,
-                                space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    KRATOS_ERROR_IF(attr_id < 0) << "H5Acreate_by_name failed." << std::endl;
-    KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, &Value) < 0) << "H5Awrite failed." << std::endl;
-    KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
-    KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Write time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
-    KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
-}
-
-template <class TScalar>
-void File::WriteAttribute(const std::string& rObjectPath, const std::string& rName, const Vector<TScalar>& rValue)
-{
-    KRATOS_TRY;
-    BuiltinTimer timer;
-    hid_t type_id, space_id, attr_id;
-
-    type_id = Internals::GetScalarDataType<TScalar>();
-    const hsize_t dim = rValue.size();
-    space_id = H5Screate_simple(1, &dim, nullptr);
-    KRATOS_ERROR_IF(space_id < 0) << "H5Screate failed." << std::endl;
-    attr_id = H5Acreate_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(), type_id,
-                                space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    KRATOS_ERROR_IF(attr_id < 0) << "H5Acreate_by_name failed." << std::endl;
-    KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, &rValue[0]) < 0) << "H5Awrite failed." << std::endl;
-    KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
-    KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Write time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
-    KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
-}
-
-template <class TScalar>
-void File::WriteAttribute(const std::string& rObjectPath, const std::string& rName, const Matrix<TScalar>& rValue)
-{
-    KRATOS_TRY;
-    BuiltinTimer timer;
-    hid_t type_id, space_id, attr_id;
-
-    type_id = Internals::GetScalarDataType<TScalar>();
-    const unsigned ndims = 2;
-    hsize_t dims[ndims];
-    dims[0] = rValue.size1();
-    dims[1] = rValue.size2();
-    space_id = H5Screate_simple(ndims, dims, nullptr);
-    KRATOS_ERROR_IF(space_id < 0) << "H5Screate failed." << std::endl;
-    attr_id = H5Acreate_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(), type_id,
-                                space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-    KRATOS_ERROR_IF(attr_id < 0) << "H5Acreate_by_name failed." << std::endl;
-    KRATOS_ERROR_IF(H5Awrite(attr_id, type_id, &rValue(0,0)) < 0) << "H5Awrite failed." << std::endl;
-    KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
-    KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Write time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
-    KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
-}
-
-template <class TScalar>
-void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, TScalar& rValue)
-{
-    KRATOS_TRY;
-    BuiltinTimer timer;
-    hid_t mem_type_id, attr_type_id, space_id, attr_id;
-    int ndims;
-
-    mem_type_id = Internals::GetScalarDataType<TScalar>();
-    attr_id = H5Aopen_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(),
-                                    H5P_DEFAULT, H5P_DEFAULT);
-    KRATOS_ERROR_IF(attr_id < 0) << "H5Aopen_by_name failed." << std::endl;
-
-    // Check data type.
-    attr_type_id = H5Aget_type(attr_id);
-    KRATOS_ERROR_IF(attr_type_id < 0) << "H5Aget_type failed." << std::endl;
-    htri_t is_valid_type = H5Tequal(mem_type_id, attr_type_id);
-    KRATOS_ERROR_IF(H5Tclose(attr_type_id) < 0) << "H5Tclose failed." << std::endl; 
-    KRATOS_ERROR_IF(is_valid_type < 0) << "H5Tequal failed." << std::endl;
-    KRATOS_ERROR_IF(is_valid_type == 0) << "Memory and file data types are different." << std::endl;
-
-    // Check dimensions.
-    space_id = H5Aget_space(attr_id);
-    KRATOS_ERROR_IF(space_id < 0) << "H5Aget_space failed." << std::endl;
-    KRATOS_ERROR_IF((ndims = H5Sget_simple_extent_ndims(space_id)) < 0)
-        << "H5Sget_simple_extent_ndims failed." << std::endl;
-    KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
-    KRATOS_ERROR_IF(ndims != 0) << "Attribute \"" << rName << "\" is not scalar." << std::endl;
-    
-    // Read attribute.
-    KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue) < 0) << "H5Aread failed." << std::endl; 
-    KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Read time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
-    KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
-}
-
-template <class TScalar>
-void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, Vector<TScalar>& rValue)
-{
-    KRATOS_TRY;
-    BuiltinTimer timer;
-    hid_t mem_type_id, attr_type_id, space_id, attr_id;
-    int ndims;
-    hsize_t dims[1];
-
-    mem_type_id = Internals::GetScalarDataType<TScalar>();
-    attr_id = H5Aopen_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(),
-                                    H5P_DEFAULT, H5P_DEFAULT);
-    KRATOS_ERROR_IF(attr_id < 0) << "H5Aopen_by_name failed." << std::endl;
-
-    // Check data type.
-    attr_type_id = H5Aget_type(attr_id);
-    KRATOS_ERROR_IF(attr_type_id < 0) << "H5Aget_type failed." << std::endl;
-    htri_t is_valid_type = H5Tequal(mem_type_id, attr_type_id);
-    KRATOS_ERROR_IF(H5Tclose(attr_type_id) < 0) << "H5Tclose failed." << std::endl; 
-    KRATOS_ERROR_IF(is_valid_type < 0) << "H5Tequal failed." << std::endl;
-    KRATOS_ERROR_IF(is_valid_type == 0) << "Memory and file data types are different." << std::endl;
-
-    // Check dimensions.
-    space_id = H5Aget_space(attr_id);
-    KRATOS_ERROR_IF(space_id < 0) << "H5Aget_space failed." << std::endl;
-    KRATOS_ERROR_IF((ndims = H5Sget_simple_extent_ndims(space_id)) < 0)
-        << "H5Sget_simple_extent_ndims failed." << std::endl;
-    KRATOS_ERROR_IF(ndims != 1) << "Attribute \"" << rName << "\" is not vector." << std::endl;
-    KRATOS_ERROR_IF(H5Sget_simple_extent_dims(space_id, dims, nullptr) < 0)
-        << "H5Sget_simple_extent_dims failed" << std::endl;
-    KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
-    rValue.resize(dims[0], false);
-    // Read attribute.
-    KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue[0]) < 0) << "H5Aread failed." << std::endl; 
-    KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Read time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
-    KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
-}
-
-template <class TScalar>
-void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, Matrix<TScalar>& rValue)
-{
-    KRATOS_TRY;
-    BuiltinTimer timer;
-    hid_t mem_type_id, attr_type_id, space_id, attr_id;
-    int ndims;
-    hsize_t dims[2];
-
-    mem_type_id = Internals::GetScalarDataType<TScalar>();
-    attr_id = H5Aopen_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(),
-                                    H5P_DEFAULT, H5P_DEFAULT);
-    KRATOS_ERROR_IF(attr_id < 0) << "H5Aopen_by_name failed." << std::endl;
-
-    // Check data type.
-    attr_type_id = H5Aget_type(attr_id);
-    KRATOS_ERROR_IF(attr_type_id < 0) << "H5Aget_type failed." << std::endl;
-    htri_t is_valid_type = H5Tequal(mem_type_id, attr_type_id);
-    KRATOS_ERROR_IF(H5Tclose(attr_type_id) < 0) << "H5Tclose failed." << std::endl; 
-    KRATOS_ERROR_IF(is_valid_type < 0) << "H5Tequal failed." << std::endl;
-    KRATOS_ERROR_IF(is_valid_type == 0) << "Memory and file data types are different." << std::endl;
-
-    // Check dimensions.
-    space_id = H5Aget_space(attr_id);
-    KRATOS_ERROR_IF(space_id < 0) << "H5Aget_space failed." << std::endl;
-    KRATOS_ERROR_IF((ndims = H5Sget_simple_extent_ndims(space_id)) < 0)
-        << "H5Sget_simple_extent_ndims failed." << std::endl;
-    KRATOS_ERROR_IF(ndims != 2) << "Attribute \"" << rName << "\" is not matrix." << std::endl;
-    KRATOS_ERROR_IF(H5Sget_simple_extent_dims(space_id, dims, nullptr) < 0)
-        << "H5Sget_simple_extent_dims failed" << std::endl;
-    KRATOS_ERROR_IF(H5Sclose(space_id) < 0) << "H5Sclose failed." << std::endl;
-    rValue.resize(dims[0], dims[1], false);
-    // Read attribute.
-    KRATOS_ERROR_IF(H5Aread(attr_id, mem_type_id, &rValue(0,0)) < 0) << "H5Aread failed." << std::endl; 
-    KRATOS_ERROR_IF(H5Aclose(attr_id) < 0) << "H5Aclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Read time \"" << rObjectPath << '/' << rName << "\": " << timer.ElapsedSeconds() << std::endl;
-    KRATOS_CATCH("Path: \"" + rObjectPath + '/' + rName + "\".");
-}
 
 namespace Internals
 {
-template <class TScalar>
-hid_t GetScalarDataType()
-{
-    hid_t type_id;
-    constexpr bool is_int_type = std::is_same<int, TScalar>::value;
-    constexpr bool is_double_type = std::is_same<double, TScalar>::value;
-    if (is_int_type)
-        type_id = H5T_NATIVE_INT;
-    else if (is_double_type)
-        type_id = H5T_NATIVE_DOUBLE;
-    else
-        static_assert(is_int_type || is_double_type,
-                      "Unsupported scalar data type.");
+/// Check if string is a valid path.
+/**
+ * Valid paths are similar to linux file system with alphanumeric names
+ * and possible underscores separated by '/'. All paths are absolute.
+ */
+bool IsPath(const std::string& rPath);
 
-    return type_id;
-}
+/// Return vector of non-empty substrings separated by a delimiter.
+std::vector<std::string> Split(const std::string& rPath, char Delimiter);
+
+template <class TScalar>
+hid_t GetScalarDataType();
+
+extern template hid_t GetScalarDataType<int>();
+extern template hid_t GetScalarDataType<double>();
+
 } // namespace Internals.
 
 ///@} addtogroup

--- a/applications/HDF5Application/custom_io/hdf5_file_parallel.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file_parallel.cpp
@@ -1,6 +1,7 @@
 #include "hdf5_file_parallel.h"
 
 #include "includes/kratos_parameters.h"
+#include "utilities/builtin_timer.h"
 
 namespace Kratos
 {
@@ -183,5 +184,434 @@ void FileParallel::ReadDataSetIndependent(const std::string& rPath,
     ReadDataSetMatrixImpl(rPath, rData, StartIndex, BlockSize, DataTransferMode::independent);
     KRATOS_CATCH("");
 }
+
+template <class T>
+void FileParallel::WriteDataSetVectorImpl(const std::string& rPath,
+                                          const Vector<T>& rData,
+                                          DataTransferMode Mode,
+                                          WriteInfo& rInfo)
+{
+    KRATOS_TRY;
+    BuiltinTimer timer;
+    // Expects a valid free path.
+    KRATOS_ERROR_IF(HasPath(rPath)) << "Path already exists: " << rPath << std::endl;
+
+    // Create any missing subpaths.
+    auto pos = rPath.find_last_of('/');
+    if (pos != 0) // Skip if last '/' is root.
+    {
+        std::string sub_path = rPath.substr(0, pos);
+        AddPath(sub_path);
+    }
+
+    // Initialize data space dimensions.
+    constexpr bool is_int_type = std::is_same<int, T>::value;
+    constexpr bool is_double_type = std::is_same<double, T>::value;
+    constexpr bool is_array_1d_type = std::is_same<array_1d<double, 3>, T>::value;
+    constexpr unsigned ndims = (!is_array_1d_type) ? 1 : 2;
+    hsize_t local_dims[ndims], global_dims[ndims];
+    // Set first data space dimension.
+    local_dims[0] = rData.size();
+    unsigned send_buf, recv_buf;
+    send_buf = local_dims[0];
+    MPI_Allreduce(&send_buf, &recv_buf, 1, MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
+    global_dims[0] = recv_buf;
+    if (Mode == DataTransferMode::independent)
+        if (local_dims[0] > 0)
+            KRATOS_ERROR_IF(local_dims[0] != global_dims[0])
+                << "Can't perform independent write with MPI. Invalid data."
+                << std::endl;
+    if (is_array_1d_type)
+        local_dims[1] = global_dims[1] = 3; // Set second data space dimension.
+
+    hsize_t local_start[ndims];
+    if (Mode == DataTransferMode::collective)
+    {
+        send_buf = local_dims[0];
+        // Get global position where local data set ends.
+        MPI_Scan(&send_buf, &recv_buf, 1, MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
+        // Set global position where local data set starts.
+        local_start[0] = recv_buf - local_dims[0];
+    }
+    else
+        local_start[0] = 0;
+
+    if (is_array_1d_type)
+        local_start[1] = 0;
+
+    // Set the data type.
+    hid_t dtype_id;
+    if (is_int_type)
+        dtype_id = H5T_NATIVE_INT;
+    else if (is_double_type)
+        dtype_id = H5T_NATIVE_DOUBLE;
+    else if (is_array_1d_type)
+        dtype_id = H5T_NATIVE_DOUBLE;
+    else
+        static_assert(is_int_type || is_double_type || is_array_1d_type,
+                      "Unsupported data type.");
+
+    // Create and write the data set.
+    hid_t file_id = GetFileId();
+    hid_t fspace_id = H5Screate_simple(ndims, global_dims, nullptr);
+    // H5Dcreate() must be called collectively for both collective and
+    // independent write.
+    hid_t dset_id = H5Dcreate(file_id, rPath.c_str(), dtype_id, fspace_id,
+                              H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    KRATOS_ERROR_IF(dset_id < 0) << "H5Dcreate failed." << std::endl;
+
+    if (Mode == DataTransferMode::collective || local_dims[0] > 0)
+    {
+        hid_t dxpl_id = H5Pcreate(H5P_DATASET_XFER);
+        if (Mode == DataTransferMode::collective)
+            H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE);
+        else
+            H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_INDEPENDENT);
+        H5Sselect_hyperslab(fspace_id, H5S_SELECT_SET, local_start, nullptr,
+                            local_dims, nullptr);
+        hid_t mspace_id = H5Screate_simple(ndims, local_dims, nullptr);
+        if (local_dims[0] > 0)
+        {
+            KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, mspace_id, fspace_id, dxpl_id, &rData[0]) < 0)
+                << "H5Dwrite failed." << std::endl;
+        }
+        else
+        {
+            KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, mspace_id, fspace_id, dxpl_id, nullptr) < 0) << "H5Dwrite failed. Please ensure global data set is non-empty."
+                                                                                                     << std::endl;
+        }
+        KRATOS_ERROR_IF(H5Pclose(dxpl_id) < 0) << "H5Pclose failed." << std::endl;
+        KRATOS_ERROR_IF(H5Sclose(mspace_id) < 0) << "H5Sclose failed." << std::endl;
+    }
+    KRATOS_ERROR_IF(H5Sclose(fspace_id) < 0) << "H5Sclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
+
+    // Set the write info.
+    rInfo.StartIndex = local_start[0];
+    rInfo.BlockSize = local_dims[0];
+    rInfo.TotalSize = global_dims[0];
+
+    if (GetEchoLevel() == 2 && GetPID() == 0)
+        std::cout << "Write time \"" << rPath
+                  << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_CATCH("Path: \"" + rPath + "\".");
+}
+
+template <class T>
+void FileParallel::WriteDataSetMatrixImpl(const std::string& rPath,
+                                          const Matrix<T>& rData,
+                                          DataTransferMode Mode,
+                                          WriteInfo& rInfo)
+{
+    KRATOS_TRY;
+    BuiltinTimer timer;
+    // Check that full path does not exist before trying to write data.
+    KRATOS_ERROR_IF(HasPath(rPath)) << "Path already exists: " << rPath << std::endl;
+
+    // Create any missing subpaths.
+    auto pos = rPath.find_last_of('/');
+    if (pos != 0) // Skip if last '/' is root.
+    {
+        std::string sub_path = rPath.substr(0, pos);
+        AddPath(sub_path);
+    }
+
+    // Initialize data space dimensions.
+    const unsigned ndims = 2;
+    hsize_t local_dims[ndims], global_dims[ndims];
+    // Set first data space dimension.
+    local_dims[0] = rData.size1();
+    unsigned send_buf, recv_buf;
+    send_buf = local_dims[0];
+    MPI_Allreduce(&send_buf, &recv_buf, 1, MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
+    global_dims[0] = recv_buf;
+    if (Mode == DataTransferMode::independent)
+        if (local_dims[0] > 0)
+            KRATOS_ERROR_IF(local_dims[0] != global_dims[0])
+                << "Can't perform independent write with MPI. Invalid data."
+                << std::endl;
+    local_dims[1] = global_dims[1] = rData.size2(); // Set second data space dimension.
+
+    hsize_t local_start[ndims] = {0};
+    if (Mode == DataTransferMode::collective)
+    {
+        send_buf = local_dims[0];
+        // Get global position where local data set ends.
+        MPI_Scan(&send_buf, &recv_buf, 1, MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
+        // Set global position where local data set starts.
+        local_start[0] = recv_buf - local_dims[0];
+    }
+    else
+        local_start[0] = 0;
+
+    // Set the data type.
+    hid_t dtype_id = Internals::GetScalarDataType<T>();
+
+    // Create and write the data set.
+    hid_t file_id = GetFileId();
+    hid_t fspace_id = H5Screate_simple(ndims, global_dims, nullptr);
+    // H5Dcreate() must be called collectively for both collective and
+    // independent write.
+    hid_t dset_id = H5Dcreate(file_id, rPath.c_str(), dtype_id, fspace_id,
+                              H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    KRATOS_ERROR_IF(dset_id < 0) << "H5Dcreate failed." << std::endl;
+
+    if (Mode == DataTransferMode::collective || local_dims[0] > 0)
+    {
+        hid_t dxpl_id = H5Pcreate(H5P_DATASET_XFER);
+        if (Mode == DataTransferMode::collective)
+            H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE);
+        else
+            H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_INDEPENDENT);
+        H5Sselect_hyperslab(fspace_id, H5S_SELECT_SET, local_start, nullptr,
+                            local_dims, nullptr);
+        hid_t mspace_id = H5Screate_simple(ndims, local_dims, nullptr);
+        if (local_dims[0] > 0)
+        {
+            KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, mspace_id, fspace_id,
+                                     dxpl_id, &rData(0, 0)) < 0)
+                << "H5Dwrite failed." << std::endl;
+        }
+        else
+        {
+            KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, mspace_id, fspace_id, dxpl_id, nullptr) < 0) << "H5Dwrite failed. Please ensure global data set is non-empty"
+                                                                                                     << " and the second matrix dimension is consistent across all processes."
+                                                                                                     << std::endl;
+        }
+        KRATOS_ERROR_IF(H5Pclose(dxpl_id) < 0) << "H5Pclose failed." << std::endl;
+        KRATOS_ERROR_IF(H5Sclose(mspace_id) < 0) << "H5Sclose failed." << std::endl;
+    }
+    KRATOS_ERROR_IF(H5Sclose(fspace_id) < 0) << "H5Sclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
+
+    // Set the write info.
+    rInfo.StartIndex = local_start[0];
+    rInfo.BlockSize = local_dims[0];
+    rInfo.TotalSize = global_dims[0];
+
+    if (GetEchoLevel() == 2 && GetPID() == 0)
+        std::cout << "Write time \"" << rPath
+                  << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_CATCH("Path: \"" + rPath + "\".");
+}
+
+template <class T>
+void FileParallel::ReadDataSetVectorImpl(const std::string& rPath,
+                                         Vector<T>& rData,
+                                         unsigned StartIndex,
+                                         unsigned BlockSize,
+                                         DataTransferMode Mode)
+{
+    KRATOS_TRY;
+    BuiltinTimer timer;
+    // Check that full path exists.
+    KRATOS_ERROR_IF_NOT(IsDataSet(rPath))
+        << "Path is not a data set: " << rPath << std::endl;
+
+    constexpr bool is_int_type = std::is_same<int, T>::value;
+    constexpr bool is_double_type = std::is_same<double, T>::value;
+    constexpr bool is_array_1d_type = std::is_same<array_1d<double, 3>, T>::value;
+    constexpr unsigned ndims = (!is_array_1d_type) ? 1 : 2;
+
+    // Check consistency of file's data set dimensions.
+    std::vector<unsigned> file_space_dims = GetDataDimensions(rPath);
+    KRATOS_ERROR_IF(file_space_dims.size() != ndims)
+        << "Invalid data set dimension." << std::endl;
+    KRATOS_ERROR_IF(StartIndex + BlockSize > file_space_dims[0])
+        << "StartIndex (" << StartIndex << ") + BlockSize (" << BlockSize
+        << ") > size of data set (" << file_space_dims[0] << ")." << std::endl;
+    hsize_t local_mem_dims[ndims];
+    // Set first memory space dimension.
+    local_mem_dims[0] = BlockSize;
+    if (is_array_1d_type)
+        local_mem_dims[1] = 3; // Set second dimension.
+    if (is_array_1d_type)
+        KRATOS_ERROR_IF(file_space_dims[1] != 3)
+            << "Invalid data set dimension." << std::endl;
+
+    if (rData.size() != BlockSize)
+        rData.resize(BlockSize, false);
+
+    // Set global position where local data set starts.
+    hsize_t local_start[ndims];
+    local_start[0] = StartIndex;
+    if (is_array_1d_type)
+        local_start[1] = 0;
+
+    // Set the data type.
+    hid_t dtype_id;
+    if (is_int_type)
+    {
+        KRATOS_ERROR_IF_NOT(HasIntDataType(rPath))
+            << "Data type is not int: " << rPath << std::endl;
+        dtype_id = H5T_NATIVE_INT;
+    }
+    else if (is_double_type)
+    {
+        KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
+            << "Data type is not float: " << rPath << std::endl;
+        dtype_id = H5T_NATIVE_DOUBLE;
+    }
+    else if (is_array_1d_type)
+    {
+        KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
+            << "Data type is not float: " << rPath << std::endl;
+        dtype_id = H5T_NATIVE_DOUBLE;
+    }
+    else
+        static_assert(is_int_type || is_double_type || is_array_1d_type,
+                      "Unsupported data type.");
+
+    hid_t file_id = GetFileId();
+    hid_t dxpl_id = H5Pcreate(H5P_DATASET_XFER);
+    if (Mode == DataTransferMode::collective)
+        H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE);
+    else
+        H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_INDEPENDENT);
+    hid_t dset_id = H5Dopen(file_id, rPath.c_str(), H5P_DEFAULT);
+    KRATOS_ERROR_IF(dset_id < 0) << "H5Dopen failed." << std::endl;
+    hid_t file_space_id = H5Dget_space(dset_id);
+    hid_t mem_space_id = H5Screate_simple(ndims, local_mem_dims, nullptr);
+    KRATOS_ERROR_IF(H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, local_start,
+                                        nullptr, local_mem_dims, nullptr) < 0)
+        << "H5Sselect_hyperslab failed." << std::endl;
+    if (local_mem_dims[0] > 0)
+    {
+        KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id, dxpl_id, &rData[0]) < 0)
+            << "H5Dread failed." << std::endl;
+    }
+    else
+    {
+        KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id, dxpl_id, nullptr) < 0)
+            << "H5Dread failed." << std::endl;
+    }
+    KRATOS_ERROR_IF(H5Pclose(dxpl_id) < 0) << "H5Pclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
+    if (GetEchoLevel() == 2 && GetPID() == 0)
+        std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds()
+                  << std::endl;
+    KRATOS_CATCH("Path: \"" + rPath + "\".");
+}
+
+template <class T>
+void FileParallel::ReadDataSetMatrixImpl(const std::string& rPath,
+                                         Matrix<T>& rData,
+                                         unsigned StartIndex,
+                                         unsigned BlockSize,
+                                         DataTransferMode Mode)
+{
+    KRATOS_TRY;
+    BuiltinTimer timer;
+    // Check that full path exists.
+    KRATOS_ERROR_IF_NOT(IsDataSet(rPath))
+        << "Path is not a data set: " << rPath << std::endl;
+
+    const unsigned ndims = 2;
+
+    // Check consistency of file's data set dimensions.
+    std::vector<unsigned> file_space_dims = GetDataDimensions(rPath);
+    KRATOS_ERROR_IF(file_space_dims.size() != ndims)
+        << "Invalid data set dimension." << std::endl;
+    KRATOS_ERROR_IF(StartIndex + BlockSize > file_space_dims[0])
+        << "StartIndex (" << StartIndex << ") + BlockSize (" << BlockSize
+        << ") > size of data set (" << file_space_dims[0] << ")." << std::endl;
+
+    if (rData.size1() != BlockSize || rData.size2() != file_space_dims[1])
+        rData.resize(BlockSize, file_space_dims[1], false);
+
+    hsize_t local_mem_dims[ndims];
+    local_mem_dims[0] = rData.size1();
+    local_mem_dims[1] = rData.size2();
+
+    // Set global position where local data set starts.
+    hsize_t local_start[ndims] = {0};
+    local_start[0] = StartIndex;
+
+    // Set the data type.
+    hid_t dtype_id = Internals::GetScalarDataType<T>();
+    if (dtype_id == H5T_NATIVE_INT)
+    {
+        KRATOS_ERROR_IF_NOT(HasIntDataType(rPath))
+            << "Data type is not int: " << rPath << std::endl;
+    }
+    else if (dtype_id == H5T_NATIVE_DOUBLE)
+    {
+        KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
+            << "Data type is not float: " << rPath << std::endl;
+    }
+
+    hid_t file_id = GetFileId();
+    hid_t dxpl_id = H5Pcreate(H5P_DATASET_XFER);
+    if (Mode == DataTransferMode::collective)
+        H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE);
+    else
+        H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_INDEPENDENT);
+    hid_t dset_id = H5Dopen(file_id, rPath.c_str(), H5P_DEFAULT);
+    KRATOS_ERROR_IF(dset_id < 0) << "H5Dopen failed." << std::endl;
+    hid_t file_space_id = H5Dget_space(dset_id);
+    hid_t mem_space_id = H5Screate_simple(ndims, local_mem_dims, nullptr);
+    KRATOS_ERROR_IF(H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, local_start,
+                                        nullptr, local_mem_dims, nullptr) < 0)
+        << "H5Sselect_hyperslab failed." << std::endl;
+    if (local_mem_dims[0] > 0)
+    {
+        KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id,
+                                dxpl_id, &rData(0, 0)) < 0)
+            << "H5Dread failed." << std::endl;
+    }
+    else
+    {
+        KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id, dxpl_id, nullptr) < 0)
+            << "H5Dread failed." << std::endl;
+    }
+    KRATOS_ERROR_IF(H5Pclose(dxpl_id) < 0) << "H5Pclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
+    if (GetEchoLevel() == 2 && GetPID() == 0)
+        std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds()
+                  << std::endl;
+    KRATOS_CATCH("Path: \"" + rPath + "\".");
+}
+
+template void FileParallel::WriteDataSetVectorImpl(const std::string& rPath,
+                                                   const Vector<int>& rData,
+                                                   DataTransferMode Mode,
+                                                   WriteInfo& rInfo);
+template void FileParallel::WriteDataSetVectorImpl(const std::string& rPath,
+                                                   const Vector<double>& rData,
+                                                   DataTransferMode Mode,
+                                                   WriteInfo& rInfo);
+template void FileParallel::WriteDataSetMatrixImpl(const std::string& rPath,
+                                                   const Matrix<int>& rData,
+                                                   DataTransferMode Mode,
+                                                   WriteInfo& rInfo);
+template void FileParallel::WriteDataSetMatrixImpl(const std::string& rPath,
+                                                   const Matrix<double>& rData,
+                                                   DataTransferMode Mode,
+                                                   WriteInfo& rInfo);
+template void FileParallel::ReadDataSetVectorImpl(const std::string& rPath,
+                                                  Vector<int>& rData,
+                                                  unsigned StartIndex,
+                                                  unsigned BlockSize,
+                                                  DataTransferMode Mode);
+template void FileParallel::ReadDataSetVectorImpl(const std::string& rPath,
+                                                  Vector<double>& rData,
+                                                  unsigned StartIndex,
+                                                  unsigned BlockSize,
+                                                  DataTransferMode Mode);
+template void FileParallel::ReadDataSetMatrixImpl(const std::string& rPath,
+                                                  Matrix<int>& rData,
+                                                  unsigned StartIndex,
+                                                  unsigned BlockSize,
+                                                  DataTransferMode Mode);
+template void FileParallel::ReadDataSetMatrixImpl(const std::string& rPath,
+                                                  Matrix<double>& rData,
+                                                  unsigned StartIndex,
+                                                  unsigned BlockSize,
+                                                  DataTransferMode Mode);
+
 } // namespace HDF5.
 } // namespace Kratos.

--- a/applications/HDF5Application/custom_io/hdf5_file_parallel.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file_parallel.cpp
@@ -292,7 +292,7 @@ void FileParallel::WriteDataSetVectorImpl(const std::string& rPath,
     rInfo.BlockSize = local_dims[0];
     rInfo.TotalSize = global_dims[0];
 
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Write time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
@@ -389,7 +389,7 @@ void FileParallel::WriteDataSetMatrixImpl(const std::string& rPath,
     rInfo.BlockSize = local_dims[0];
     rInfo.TotalSize = global_dims[0];
 
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Write time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
@@ -488,7 +488,7 @@ void FileParallel::ReadDataSetVectorImpl(const std::string& rPath,
     KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
@@ -568,7 +568,7 @@ void FileParallel::ReadDataSetMatrixImpl(const std::string& rPath,
     KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
-    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
         << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }

--- a/applications/HDF5Application/custom_io/hdf5_file_parallel.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file_parallel.cpp
@@ -2,6 +2,7 @@
 
 #include "includes/kratos_parameters.h"
 #include "utilities/builtin_timer.h"
+#include "input_output/logger.h"
 
 namespace Kratos
 {
@@ -291,9 +292,8 @@ void FileParallel::WriteDataSetVectorImpl(const std::string& rPath,
     rInfo.BlockSize = local_dims[0];
     rInfo.TotalSize = global_dims[0];
 
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Write time \"" << rPath
-                  << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Write time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
 
@@ -389,9 +389,8 @@ void FileParallel::WriteDataSetMatrixImpl(const std::string& rPath,
     rInfo.BlockSize = local_dims[0];
     rInfo.TotalSize = global_dims[0];
 
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Write time \"" << rPath
-                  << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Write time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
 
@@ -489,9 +488,8 @@ void FileParallel::ReadDataSetVectorImpl(const std::string& rPath,
     KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds()
-                  << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
 
@@ -570,9 +568,8 @@ void FileParallel::ReadDataSetMatrixImpl(const std::string& rPath,
     KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
-    if (GetEchoLevel() == 2 && GetPID() == 0)
-        std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds()
-                  << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2 && GetPID() == 0)
+        << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
 

--- a/applications/HDF5Application/custom_io/hdf5_file_parallel.h
+++ b/applications/HDF5Application/custom_io/hdf5_file_parallel.h
@@ -21,7 +21,6 @@
 #endif
 
 // Project includes
-#include "utilities/builtin_timer.h"
 
 // Application includes
 #include "custom_io/hdf5_file.h"
@@ -156,383 +155,69 @@ private:
     ///@name Private Operations
     ///@{
     template <class T>
-    void WriteDataSetVectorImpl(const std::string& rPath, const Vector<T>& rData, DataTransferMode Mode, WriteInfo& rInfo)
-    {
-        KRATOS_TRY;
-        BuiltinTimer timer;
-        // Expects a valid free path.
-        KRATOS_ERROR_IF(HasPath(rPath)) << "Path already exists: " << rPath << std::endl;
-
-        // Create any missing subpaths.
-        auto pos = rPath.find_last_of('/');
-        if (pos != 0) // Skip if last '/' is root.
-        {
-            std::string sub_path = rPath.substr(0, pos);
-            AddPath(sub_path);
-        }
-
-        // Initialize data space dimensions.
-        constexpr bool is_int_type = std::is_same<int, T>::value;
-        constexpr bool is_double_type = std::is_same<double, T>::value;
-        constexpr bool is_array_1d_type = std::is_same<array_1d<double, 3>, T>::value;
-        constexpr unsigned ndims = (!is_array_1d_type) ? 1 : 2;
-        hsize_t local_dims[ndims], global_dims[ndims];
-        // Set first data space dimension.
-        local_dims[0] = rData.size();
-        unsigned send_buf, recv_buf;
-        send_buf = local_dims[0];
-        MPI_Allreduce(&send_buf, &recv_buf, 1, MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
-        global_dims[0] = recv_buf;
-        if (Mode == DataTransferMode::independent)
-            if (local_dims[0] > 0)
-                KRATOS_ERROR_IF(local_dims[0] != global_dims[0]) << "Can't perform independent write with MPI. Invalid data." << std::endl;
-        if (is_array_1d_type)
-            local_dims[1] = global_dims[1] = 3; // Set second data space dimension.
-        
-        hsize_t local_start[ndims];
-        if (Mode == DataTransferMode::collective)
-        { 
-            send_buf = local_dims[0];
-            // Get global position where local data set ends.
-            MPI_Scan(&send_buf, &recv_buf, 1, MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
-            // Set global position where local data set starts.
-            local_start[0] = recv_buf - local_dims[0];
-        }
-        else
-            local_start[0] = 0;
- 
-        if (is_array_1d_type)
-            local_start[1] = 0;
-        
-        // Set the data type.
-        hid_t dtype_id;
-        if (is_int_type)
-            dtype_id = H5T_NATIVE_INT;
-        else if (is_double_type)
-            dtype_id = H5T_NATIVE_DOUBLE;
-        else if (is_array_1d_type)
-            dtype_id = H5T_NATIVE_DOUBLE;
-        else
-            static_assert(is_int_type || is_double_type || is_array_1d_type,
-                          "Unsupported data type.");
-
-        // Create and write the data set.
-        hid_t file_id = GetFileId();
-        hid_t fspace_id = H5Screate_simple(ndims, global_dims, nullptr);
-        // H5Dcreate() must be called collectively for both collective and
-        // independent write.
-        hid_t dset_id = H5Dcreate(file_id, rPath.c_str(), dtype_id, fspace_id,
-                                  H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        KRATOS_ERROR_IF(dset_id < 0) << "H5Dcreate failed." << std::endl;
-
-        if (Mode == DataTransferMode::collective || local_dims[0] > 0)
-        {
-            hid_t dxpl_id = H5Pcreate(H5P_DATASET_XFER);
-            if (Mode == DataTransferMode::collective)
-                H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE);
-            else
-                H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_INDEPENDENT);
-            H5Sselect_hyperslab(fspace_id, H5S_SELECT_SET, local_start, nullptr,
-                                local_dims, nullptr);
-            hid_t mspace_id = H5Screate_simple(ndims, local_dims, nullptr);
-            if (local_dims[0] > 0)
-            {
-                KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, mspace_id, fspace_id, dxpl_id, &rData[0]) < 0)
-                    << "H5Dwrite failed." << std::endl;
-            }
-            else
-            {
-                KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, mspace_id, fspace_id, dxpl_id, nullptr) < 0)
-                    << "H5Dwrite failed. Please ensure global data set is non-empty." << std::endl;
-            }
-            KRATOS_ERROR_IF(H5Pclose(dxpl_id) < 0) << "H5Pclose failed." << std::endl;
-            KRATOS_ERROR_IF(H5Sclose(mspace_id) < 0) << "H5Sclose failed." << std::endl;
-        }
-        KRATOS_ERROR_IF(H5Sclose(fspace_id) < 0) << "H5Sclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
-
-        // Set the write info.
-        rInfo.StartIndex = local_start[0];
-        rInfo.BlockSize = local_dims[0];
-        rInfo.TotalSize = global_dims[0];
-
-        if (GetEchoLevel() == 2 && GetPID() == 0)
-            std::cout << "Write time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
-        KRATOS_CATCH("Path: \"" + rPath + "\".");
-    }
+    void WriteDataSetVectorImpl(const std::string& rPath,
+                                const Vector<T>& rData,
+                                DataTransferMode Mode,
+                                WriteInfo& rInfo);
 
     template <class T>
-    void WriteDataSetMatrixImpl(const std::string& rPath, const Matrix<T>& rData, DataTransferMode Mode, WriteInfo& rInfo)
-    {
-        KRATOS_TRY;
-        BuiltinTimer timer;
-        // Check that full path does not exist before trying to write data.
-        KRATOS_ERROR_IF(HasPath(rPath)) << "Path already exists: " << rPath << std::endl;
-        
-        // Create any missing subpaths.
-        auto pos = rPath.find_last_of('/');
-        if (pos != 0) // Skip if last '/' is root.
-        {
-            std::string sub_path = rPath.substr(0, pos);
-            AddPath(sub_path);
-        }
-
-        // Initialize data space dimensions.
-        const unsigned ndims = 2;
-        hsize_t local_dims[ndims], global_dims[ndims];
-        // Set first data space dimension.
-        local_dims[0] = rData.size1();
-        unsigned send_buf, recv_buf;
-        send_buf = local_dims[0];
-        MPI_Allreduce(&send_buf, &recv_buf, 1, MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
-        global_dims[0] = recv_buf;
-        if (Mode == DataTransferMode::independent)
-            if (local_dims[0] > 0)
-                KRATOS_ERROR_IF(local_dims[0] != global_dims[0]) << "Can't perform independent write with MPI. Invalid data." << std::endl;
-        local_dims[1] = global_dims[1] = rData.size2(); // Set second data space dimension.
-        
-        hsize_t local_start[ndims] = {0};
-        if (Mode == DataTransferMode::collective)
-        { 
-            send_buf = local_dims[0];
-            // Get global position where local data set ends.
-            MPI_Scan(&send_buf, &recv_buf, 1, MPI_UNSIGNED, MPI_SUM, MPI_COMM_WORLD);
-            // Set global position where local data set starts.
-            local_start[0] = recv_buf - local_dims[0];
-        }
-        else
-            local_start[0] = 0;
- 
-        // Set the data type.
-        hid_t dtype_id = Internals::GetScalarDataType<T>();
-
-        // Create and write the data set.
-        hid_t file_id = GetFileId();
-        hid_t fspace_id = H5Screate_simple(ndims, global_dims, nullptr);
-        // H5Dcreate() must be called collectively for both collective and
-        // independent write.
-        hid_t dset_id = H5Dcreate(file_id, rPath.c_str(), dtype_id, fspace_id,
-                                  H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        KRATOS_ERROR_IF(dset_id < 0) << "H5Dcreate failed." << std::endl;
-
-        if (Mode == DataTransferMode::collective || local_dims[0] > 0)
-        {
-            hid_t dxpl_id = H5Pcreate(H5P_DATASET_XFER);
-            if (Mode == DataTransferMode::collective)
-                H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE);
-            else
-                H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_INDEPENDENT);
-            H5Sselect_hyperslab(fspace_id, H5S_SELECT_SET, local_start, nullptr,
-                                local_dims, nullptr);
-            hid_t mspace_id = H5Screate_simple(ndims, local_dims, nullptr);
-            if (local_dims[0] > 0)
-            {
-                KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, mspace_id, fspace_id,
-                    dxpl_id, &rData(0, 0)) < 0) << "H5Dwrite failed." << std::endl;
-            }
-            else
-            {
-                KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, mspace_id, fspace_id, dxpl_id, nullptr) < 0)
-                    << "H5Dwrite failed. Please ensure global data set is non-empty"
-                    << " and the second matrix dimension is consistent across all processes." << std::endl;
-            }
-            KRATOS_ERROR_IF(H5Pclose(dxpl_id) < 0) << "H5Pclose failed." << std::endl;
-            KRATOS_ERROR_IF(H5Sclose(mspace_id) < 0) << "H5Sclose failed." << std::endl;
-        }
-        KRATOS_ERROR_IF(H5Sclose(fspace_id) < 0) << "H5Sclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
-
-        // Set the write info.
-        rInfo.StartIndex = local_start[0];
-        rInfo.BlockSize = local_dims[0];
-        rInfo.TotalSize = global_dims[0];
-
-        if (GetEchoLevel() == 2 && GetPID() == 0)
-            std::cout << "Write time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
-        KRATOS_CATCH("Path: \"" + rPath + "\".");
-    }
+    void WriteDataSetMatrixImpl(const std::string& rPath,
+                                const Matrix<T>& rData,
+                                DataTransferMode Mode,
+                                WriteInfo& rInfo);
 
     template <class T>
     void ReadDataSetVectorImpl(const std::string& rPath,
-                         Vector<T>& rData,
-                         unsigned StartIndex,
-                         unsigned BlockSize,
-                         DataTransferMode Mode)
-    {
-        KRATOS_TRY;
-        BuiltinTimer timer;
-        // Check that full path exists.
-        KRATOS_ERROR_IF_NOT(IsDataSet(rPath))
-            << "Path is not a data set: " << rPath << std::endl;
-
-        constexpr bool is_int_type = std::is_same<int, T>::value;
-        constexpr bool is_double_type = std::is_same<double, T>::value;
-        constexpr bool is_array_1d_type = std::is_same<array_1d<double, 3>, T>::value;
-        constexpr unsigned ndims = (!is_array_1d_type) ? 1 : 2;
-
-        // Check consistency of file's data set dimensions.
-        std::vector<unsigned> file_space_dims = GetDataDimensions(rPath);
-        KRATOS_ERROR_IF(file_space_dims.size() != ndims) << "Invalid data set dimension." << std::endl;
-        KRATOS_ERROR_IF(StartIndex + BlockSize > file_space_dims[0])
-        << "StartIndex (" << StartIndex << ") + BlockSize (" << BlockSize
-        << ") > size of data set (" << file_space_dims[0] << ")." << std::endl;
-        hsize_t local_mem_dims[ndims];
-        // Set first memory space dimension.
-        local_mem_dims[0] = BlockSize;
-        if (is_array_1d_type)
-            local_mem_dims[1] = 3; // Set second dimension.
-        if (is_array_1d_type)
-            KRATOS_ERROR_IF(file_space_dims[1] != 3)
-                << "Invalid data set dimension." << std::endl;
-
-        if (rData.size() != BlockSize)
-            rData.resize(BlockSize, false);
-
-        // Set global position where local data set starts.
-        hsize_t local_start[ndims];
-        local_start[0] = StartIndex;
-        if (is_array_1d_type)
-            local_start[1] = 0;
-
-        // Set the data type.
-        hid_t dtype_id;
-        if (is_int_type)
-        {
-            KRATOS_ERROR_IF_NOT(HasIntDataType(rPath))
-                << "Data type is not int: " << rPath << std::endl;
-            dtype_id = H5T_NATIVE_INT;
-        }
-        else if (is_double_type)
-        {
-            KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
-                << "Data type is not float: " << rPath << std::endl;
-            dtype_id = H5T_NATIVE_DOUBLE;
-        }
-        else if (is_array_1d_type)
-        {
-            KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
-                << "Data type is not float: " << rPath << std::endl;
-            dtype_id = H5T_NATIVE_DOUBLE;
-        }
-        else
-            static_assert(is_int_type || is_double_type || is_array_1d_type,
-                          "Unsupported data type.");
-
-        hid_t file_id = GetFileId();        
-        hid_t dxpl_id = H5Pcreate(H5P_DATASET_XFER);
-        if (Mode == DataTransferMode::collective)
-            H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE);
-        else
-            H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_INDEPENDENT);
-        hid_t dset_id = H5Dopen(file_id, rPath.c_str(), H5P_DEFAULT);
-        KRATOS_ERROR_IF(dset_id < 0) << "H5Dopen failed." << std::endl;
-        hid_t file_space_id = H5Dget_space(dset_id);
-        hid_t mem_space_id = H5Screate_simple(ndims, local_mem_dims, nullptr);
-        KRATOS_ERROR_IF(H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, local_start,
-                                            nullptr, local_mem_dims, nullptr) < 0)
-            << "H5Sselect_hyperslab failed." << std::endl;
-        if (local_mem_dims[0] > 0)
-        {
-            KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id,
-                                    dxpl_id, &rData[0]) < 0)
-                << "H5Dread failed." << std::endl;
-        }
-        else
-        {
-            KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id,
-                                    dxpl_id, nullptr) < 0)
-                << "H5Dread failed." << std::endl;
-        }
-        KRATOS_ERROR_IF(H5Pclose(dxpl_id) < 0) << "H5Pclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
-        if (GetEchoLevel() == 2 && GetPID() == 0)
-            std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
-        KRATOS_CATCH("Path: \"" + rPath + "\".");
-    }
+                               Vector<T>& rData,
+                               unsigned StartIndex,
+                               unsigned BlockSize,
+                               DataTransferMode Mode);
 
     template <class T>
     void ReadDataSetMatrixImpl(const std::string& rPath,
                                Matrix<T>& rData,
                                unsigned StartIndex,
                                unsigned BlockSize,
-                               DataTransferMode Mode)
-    {
-        KRATOS_TRY;
-        BuiltinTimer timer;
-        // Check that full path exists.
-        KRATOS_ERROR_IF_NOT(IsDataSet(rPath))
-            << "Path is not a data set: " << rPath << std::endl;
-
-        const unsigned ndims = 2;
-
-        // Check consistency of file's data set dimensions.
-        std::vector<unsigned> file_space_dims = GetDataDimensions(rPath);
-        KRATOS_ERROR_IF(file_space_dims.size() != ndims) << "Invalid data set dimension." << std::endl;
-        KRATOS_ERROR_IF(StartIndex + BlockSize > file_space_dims[0])
-        << "StartIndex (" << StartIndex << ") + BlockSize (" << BlockSize
-        << ") > size of data set (" << file_space_dims[0] << ")." << std::endl;
-
-        if (rData.size1() != BlockSize || rData.size2() != file_space_dims[1])
-            rData.resize(BlockSize, file_space_dims[1], false);
-
-        hsize_t local_mem_dims[ndims];
-        local_mem_dims[0] = rData.size1();
-        local_mem_dims[1] = rData.size2();
-
-        // Set global position where local data set starts.
-        hsize_t local_start[ndims] = {0};
-        local_start[0] = StartIndex;
-
-        // Set the data type.
-        hid_t dtype_id = Internals::GetScalarDataType<T>();
-        if (dtype_id == H5T_NATIVE_INT)
-        {
-            KRATOS_ERROR_IF_NOT(HasIntDataType(rPath))
-                << "Data type is not int: " << rPath << std::endl;
-        }
-        else if (dtype_id == H5T_NATIVE_DOUBLE)
-        {
-            KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
-                << "Data type is not float: " << rPath << std::endl;
-        }
-
-        hid_t file_id = GetFileId();
-        hid_t dxpl_id = H5Pcreate(H5P_DATASET_XFER);
-        if (Mode == DataTransferMode::collective)
-            H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_COLLECTIVE);
-        else
-            H5Pset_dxpl_mpio(dxpl_id, H5FD_MPIO_INDEPENDENT);
-        hid_t dset_id = H5Dopen(file_id, rPath.c_str(), H5P_DEFAULT);
-        KRATOS_ERROR_IF(dset_id < 0) << "H5Dopen failed." << std::endl;
-        hid_t file_space_id = H5Dget_space(dset_id);
-        hid_t mem_space_id = H5Screate_simple(ndims, local_mem_dims, nullptr);
-        KRATOS_ERROR_IF(H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, local_start,
-                                            nullptr, local_mem_dims, nullptr) < 0)
-            << "H5Sselect_hyperslab failed." << std::endl;
-        if (local_mem_dims[0] > 0)
-        {
-            KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id,
-                                    dxpl_id, &rData(0,0)) < 0)
-                << "H5Dread failed." << std::endl;
-        }
-        else
-        {
-            KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id,
-                                    dxpl_id, nullptr) < 0)
-                << "H5Dread failed." << std::endl;
-        }
-        KRATOS_ERROR_IF(H5Pclose(dxpl_id) < 0) << "H5Pclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
-        if (GetEchoLevel() == 2 && GetPID() == 0)
-            std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
-        KRATOS_CATCH("Path: \"" + rPath + "\".");
-    }
+                               DataTransferMode Mode);
     ///@}
 };
+
+extern template void FileParallel::WriteDataSetVectorImpl(const std::string& rPath,
+                                                        const Vector<int>& rData,
+                                                        DataTransferMode Mode,
+                                                        WriteInfo& rInfo);
+extern template void FileParallel::WriteDataSetVectorImpl(const std::string& rPath,
+                                                        const Vector<double>& rData,
+                                                        DataTransferMode Mode,
+                                                        WriteInfo& rInfo);
+extern template void FileParallel::WriteDataSetMatrixImpl(const std::string& rPath,
+                                                        const Matrix<int>& rData,
+                                                        DataTransferMode Mode,
+                                                        WriteInfo& rInfo);
+extern template void FileParallel::WriteDataSetMatrixImpl(const std::string& rPath,
+                                                        const Matrix<double>& rData,
+                                                        DataTransferMode Mode,
+                                                        WriteInfo& rInfo);
+extern template void FileParallel::ReadDataSetVectorImpl(const std::string& rPath,
+                                                       Vector<int>& rData,
+                                                       unsigned StartIndex,
+                                                       unsigned BlockSize,
+                                                       DataTransferMode Mode);
+extern template void FileParallel::ReadDataSetVectorImpl(const std::string& rPath,
+                                                       Vector<double>& rData,
+                                                       unsigned StartIndex,
+                                                       unsigned BlockSize,
+                                                       DataTransferMode Mode);
+extern template void FileParallel::ReadDataSetMatrixImpl(const std::string& rPath,
+                                                       Matrix<int>& rData,
+                                                       unsigned StartIndex,
+                                                       unsigned BlockSize,
+                                                       DataTransferMode Mode);
+extern template void FileParallel::ReadDataSetMatrixImpl(const std::string& rPath,
+                                                       Matrix<double>& rData,
+                                                       unsigned StartIndex,
+                                                       unsigned BlockSize,
+                                                       DataTransferMode Mode);
 
 ///@} // Kratos Classes
 ///@} addtogroup

--- a/applications/HDF5Application/custom_io/hdf5_file_serial.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file_serial.cpp
@@ -2,6 +2,7 @@
 
 #include <utility>
 #include "includes/kratos_parameters.h"
+#include "utilities/builtin_timer.h"
 
 namespace Kratos
 {
@@ -170,6 +171,289 @@ void FileSerial::ReadDataSetIndependent(const std::string& rPath, Matrix<double>
     ReadDataSetMatrixImpl(rPath, rData, StartIndex, BlockSize);
     KRATOS_CATCH("");
 }
+
+template <class T>
+void FileSerial::WriteDataSetVectorImpl(const std::string& rPath,
+                                        const Vector<T>& rData,
+                                        WriteInfo& rInfo)
+{
+    KRATOS_TRY;
+    BuiltinTimer timer;
+    // Expects a valid free path.
+    KRATOS_ERROR_IF(HasPath(rPath)) << "Path already exists: " << rPath << std::endl;
+
+    // Create any missing subpaths.
+    auto pos = rPath.find_last_of('/');
+    if (pos != 0) // Skip if last '/' is root.
+    {
+        std::string sub_path = rPath.substr(0, pos);
+        AddPath(sub_path);
+    }
+
+    // Initialize data space dimensions.
+    constexpr bool is_int_type = std::is_same<int, T>::value;
+    constexpr bool is_double_type = std::is_same<double, T>::value;
+    constexpr bool is_array_1d_type = std::is_same<array_1d<double, 3>, T>::value;
+    constexpr unsigned ndims = (!is_array_1d_type) ? 1 : 2;
+    hsize_t dims[ndims] = {0};
+    dims[0] = rData.size(); // Set first data space dimension.
+    if (is_array_1d_type)
+        dims[1] = 3; // Set second data space dimension (array_1d<double,3>).
+
+    // Set the data type.
+    hid_t dtype_id;
+    if (is_int_type)
+        dtype_id = H5T_NATIVE_INT;
+    else if (is_double_type)
+        dtype_id = H5T_NATIVE_DOUBLE;
+    else if (is_array_1d_type)
+        dtype_id = H5T_NATIVE_DOUBLE;
+    else
+        static_assert(is_int_type || is_double_type || is_array_1d_type,
+                      "Unsupported data type.");
+
+    // Create and write the data set.
+    hid_t dspace_id = H5Screate_simple(ndims, dims, nullptr);
+    hid_t file_id = GetFileId();
+    hid_t dset_id = H5Dcreate(file_id, rPath.c_str(), dtype_id, dspace_id,
+                              H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    KRATOS_ERROR_IF(dset_id < 0) << "H5Dcreate failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rData[0]) < 0)
+        << "H5Dwrite failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Sclose(dspace_id) < 0) << "H5Sclose failed." << std::endl;
+
+    // Set the write info.
+    rInfo.StartIndex = 0;
+    rInfo.TotalSize = rInfo.BlockSize = rData.size();
+
+    if (GetEchoLevel() == 2)
+        std::cout << "Write time \"" << rPath
+                  << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_CATCH("Path: \"" + rPath + "\".");
+}
+
+template <class T>
+void FileSerial::WriteDataSetMatrixImpl(const std::string& rPath,
+                                        const Matrix<T>& rData,
+                                        WriteInfo& rInfo)
+{
+    KRATOS_TRY;
+    BuiltinTimer timer;
+    // Check that full path does not exist before trying to write data.
+    KRATOS_ERROR_IF(HasPath(rPath)) << "Path already exists: " << rPath << std::endl;
+
+    // Create any missing subpaths.
+    auto pos = rPath.find_last_of('/');
+    if (pos != 0) // Skip if last '/' is root.
+    {
+        std::string sub_path = rPath.substr(0, pos);
+        AddPath(sub_path);
+    }
+
+    // Initialize data space dimensions.
+    const unsigned ndims = 2;
+    hsize_t dims[ndims];
+    dims[0] = rData.size1();
+    dims[1] = rData.size2();
+
+    // Set the data type.
+    hid_t dtype_id = Internals::GetScalarDataType<T>();
+
+    // Create and write the data set.
+    hid_t dspace_id = H5Screate_simple(ndims, dims, nullptr);
+    hid_t file_id = GetFileId();
+    hid_t dset_id = H5Dcreate(file_id, rPath.c_str(), dtype_id, dspace_id,
+                              H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
+    KRATOS_ERROR_IF(dset_id < 0) << "H5Dcreate failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rData(0, 0)) < 0)
+        << "H5Dwrite failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Sclose(dspace_id) < 0) << "H5Sclose failed." << std::endl;
+
+    // Set the write info.
+    rInfo.StartIndex = 0;
+    rInfo.TotalSize = rInfo.BlockSize = rData.size1();
+
+    if (GetEchoLevel() == 2)
+        std::cout << "Write time \"" << rPath
+                  << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_CATCH("Path: \"" + rPath + "\".");
+}
+
+template <class T>
+void FileSerial::ReadDataSetVectorImpl(const std::string& rPath,
+                                       Vector<T>& rData,
+                                       unsigned StartIndex,
+                                       unsigned BlockSize)
+{
+    KRATOS_TRY;
+    BuiltinTimer timer;
+    // Check that full path exists.
+    KRATOS_ERROR_IF_NOT(IsDataSet(rPath))
+        << "Path is not a data set: " << rPath << std::endl;
+
+    constexpr bool is_int_type = std::is_same<int, T>::value;
+    constexpr bool is_double_type = std::is_same<double, T>::value;
+    constexpr bool is_array_1d_type = std::is_same<array_1d<double, 3>, T>::value;
+    constexpr unsigned ndims = (!is_array_1d_type) ? 1 : 2;
+
+    // Check consistency of file's data set dimensions.
+    std::vector<unsigned> file_space_dims = GetDataDimensions(rPath);
+    KRATOS_ERROR_IF(file_space_dims.size() != ndims)
+        << "Invalid data set dimension." << std::endl;
+    KRATOS_ERROR_IF(StartIndex + BlockSize > file_space_dims[0])
+        << "StartIndex (" << StartIndex << ") + BlockSize (" << BlockSize
+        << ") > size of data set (" << file_space_dims[0] << ")." << std::endl;
+    if (is_array_1d_type)
+        KRATOS_ERROR_IF(file_space_dims[1] != 3)
+            << "Invalid data set dimension." << std::endl;
+
+    if (rData.size() != BlockSize)
+        rData.resize(BlockSize, false);
+
+    // Initialize memory space dimensions.
+    hsize_t start[ndims] = {0}, mem_dims[ndims];
+    start[0] = StartIndex;
+    mem_dims[0] = BlockSize; // Set first dimension.
+    if (is_array_1d_type)
+        mem_dims[1] = 3; // Set second dimension.
+
+    // Set the data type.
+    hid_t dtype_id;
+    if (is_int_type)
+    {
+        KRATOS_ERROR_IF_NOT(HasIntDataType(rPath))
+            << "Data type is not int: " << rPath << std::endl;
+        dtype_id = H5T_NATIVE_INT;
+    }
+    else if (is_double_type)
+    {
+        KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
+            << "Data type is not float: " << rPath << std::endl;
+        dtype_id = H5T_NATIVE_DOUBLE;
+    }
+    else if (is_array_1d_type)
+    {
+        KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
+            << "Data type is not float: " << rPath << std::endl;
+        dtype_id = H5T_NATIVE_DOUBLE;
+    }
+    else
+        static_assert(is_int_type || is_double_type || is_array_1d_type,
+                      "Unsupported data type.");
+
+    hid_t file_id = GetFileId();
+    hid_t dset_id = H5Dopen(file_id, rPath.c_str(), H5P_DEFAULT);
+    KRATOS_ERROR_IF(dset_id < 0) << "H5Dopen failed." << std::endl;
+    hid_t file_space_id = H5Dget_space(dset_id);
+    hid_t mem_space_id = H5Screate_simple(ndims, mem_dims, nullptr);
+    KRATOS_ERROR_IF(H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, start, nullptr, mem_dims, nullptr) < 0)
+        << "H5Sselect_hyperslab failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id, H5P_DEFAULT, &rData[0]) < 0)
+        << "H5Dread failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
+
+    if (GetEchoLevel() == 2)
+        std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds()
+                  << std::endl;
+    KRATOS_CATCH("Path: \"" + rPath + "\".");
+}
+
+template <class T>
+void FileSerial::ReadDataSetMatrixImpl(const std::string& rPath,
+                                       Matrix<T>& rData,
+                                       unsigned StartIndex,
+                                       unsigned BlockSize)
+{
+    KRATOS_TRY;
+    BuiltinTimer timer;
+    // Check that full path exists.
+    KRATOS_ERROR_IF_NOT(IsDataSet(rPath))
+        << "Path is not a data set: " << rPath << std::endl;
+
+    const unsigned ndims = 2;
+
+    // Check consistency of file's data set dimensions.
+    std::vector<unsigned> file_space_dims = GetDataDimensions(rPath);
+    KRATOS_ERROR_IF(file_space_dims.size() != ndims)
+        << "Invalid data set dimension." << std::endl;
+    KRATOS_ERROR_IF(StartIndex + BlockSize > file_space_dims[0])
+        << "StartIndex (" << StartIndex << ") + BlockSize (" << BlockSize
+        << ") > size of data set (" << file_space_dims[0] << ")." << std::endl;
+
+    if (rData.size1() != BlockSize || rData.size2() != file_space_dims[1])
+        rData.resize(BlockSize, file_space_dims[1], false);
+
+    // Initialize memory space dimensions.
+    hsize_t start[ndims] = {0}, mem_dims[ndims];
+    start[0] = StartIndex;
+    mem_dims[0] = rData.size1(); // Set first dimension.
+    mem_dims[1] = rData.size2(); // Set second dimension.
+
+    // Set the data type.
+    hid_t dtype_id = Internals::GetScalarDataType<T>();
+    if (dtype_id == H5T_NATIVE_INT)
+    {
+        KRATOS_ERROR_IF_NOT(HasIntDataType(rPath))
+            << "Data type is not int: " << rPath << std::endl;
+    }
+    else if (dtype_id == H5T_NATIVE_DOUBLE)
+    {
+        KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
+            << "Data type is not float: " << rPath << std::endl;
+    }
+
+    hid_t file_id = GetFileId();
+    hid_t dset_id = H5Dopen(file_id, rPath.c_str(), H5P_DEFAULT);
+    KRATOS_ERROR_IF(dset_id < 0) << "H5Dopen failed." << std::endl;
+    hid_t file_space_id = H5Dget_space(dset_id);
+    hid_t mem_space_id = H5Screate_simple(ndims, mem_dims, nullptr);
+    KRATOS_ERROR_IF(H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, start, nullptr, mem_dims, nullptr) < 0)
+        << "H5Sselect_hyperslab failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id,
+                            H5P_DEFAULT, &rData(0, 0)) < 0)
+        << "H5Dread failed." << std::endl;
+    KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
+    KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
+
+    if (GetEchoLevel() == 2)
+        std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds()
+                  << std::endl;
+    KRATOS_CATCH("Path: \"" + rPath + "\".");
+}
+
+template void FileSerial::WriteDataSetVectorImpl(const std::string& rPath,
+                                                 const Vector<int>& rData,
+                                                 WriteInfo& rInfo);
+template void FileSerial::WriteDataSetVectorImpl(const std::string& rPath,
+                                                 const Vector<double>& rData,
+                                                 WriteInfo& rInfo);
+template void FileSerial::WriteDataSetMatrixImpl(const std::string& rPath,
+                                                 const Matrix<int>& rData,
+                                                 WriteInfo& rInfo);
+template void FileSerial::WriteDataSetMatrixImpl(const std::string& rPath,
+                                                 const Matrix<double>& rData,
+                                                 WriteInfo& rInfo);
+template void FileSerial::ReadDataSetVectorImpl(const std::string& rPath,
+                                                Vector<int>& rData,
+                                                unsigned StartIndex,
+                                                unsigned BlockSize);
+template void FileSerial::ReadDataSetVectorImpl(const std::string& rPath,
+                                                Vector<double>& rData,
+                                                unsigned StartIndex,
+                                                unsigned BlockSize);
+template void FileSerial::ReadDataSetMatrixImpl(const std::string& rPath,
+                                                Matrix<int>& rData,
+                                                unsigned StartIndex,
+                                                unsigned BlockSize);
+template void FileSerial::ReadDataSetMatrixImpl(const std::string& rPath,
+                                                Matrix<double>& rData,
+                                                unsigned StartIndex,
+                                                unsigned BlockSize);
 
 } // namespace HDF5.
 } // namespace Kratos.

--- a/applications/HDF5Application/custom_io/hdf5_file_serial.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file_serial.cpp
@@ -3,6 +3,7 @@
 #include <utility>
 #include "includes/kratos_parameters.h"
 #include "utilities/builtin_timer.h"
+#include "input_output/logger.h"
 
 namespace Kratos
 {
@@ -227,9 +228,8 @@ void FileSerial::WriteDataSetVectorImpl(const std::string& rPath,
     rInfo.StartIndex = 0;
     rInfo.TotalSize = rInfo.BlockSize = rData.size();
 
-    if (GetEchoLevel() == 2)
-        std::cout << "Write time \"" << rPath
-                  << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
+        << "Write time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
 
@@ -275,9 +275,8 @@ void FileSerial::WriteDataSetMatrixImpl(const std::string& rPath,
     rInfo.StartIndex = 0;
     rInfo.TotalSize = rInfo.BlockSize = rData.size1();
 
-    if (GetEchoLevel() == 2)
-        std::cout << "Write time \"" << rPath
-                  << "\": " << timer.ElapsedSeconds() << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
+        << "Write time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
 
@@ -356,9 +355,8 @@ void FileSerial::ReadDataSetVectorImpl(const std::string& rPath,
     KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
 
-    if (GetEchoLevel() == 2)
-        std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds()
-                  << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
+        << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
 
@@ -420,9 +418,8 @@ void FileSerial::ReadDataSetMatrixImpl(const std::string& rPath,
     KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
     KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
 
-    if (GetEchoLevel() == 2)
-        std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds()
-                  << std::endl;
+    KRATOS_INFO_IF("HDF5Application", GetEchoLevel() == 2)
+        << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
     KRATOS_CATCH("Path: \"" + rPath + "\".");
 }
 

--- a/applications/HDF5Application/custom_io/hdf5_file_serial.h
+++ b/applications/HDF5Application/custom_io/hdf5_file_serial.h
@@ -18,7 +18,6 @@
 // External includes
 
 // Project includes
-#include "utilities/builtin_timer.h"
 
 // Application includes
 #include "custom_io/hdf5_file.h"
@@ -153,248 +152,53 @@ private:
     ///@name Private Operations
     ///@{
     template <class T>
-    void WriteDataSetVectorImpl(const std::string& rPath, const Vector<T>& rData, WriteInfo& rInfo)
-    {
-        KRATOS_TRY;
-        BuiltinTimer timer;
-        // Expects a valid free path.
-        KRATOS_ERROR_IF(HasPath(rPath)) << "Path already exists: " <<rPath << std::endl;
-
-        // Create any missing subpaths.
-        auto pos =rPath.find_last_of('/');
-        if (pos != 0) // Skip if last '/' is root.
-        {
-            std::string sub_path =rPath.substr(0, pos);
-            AddPath(sub_path);
-        }
-
-        // Initialize data space dimensions.
-        constexpr bool is_int_type = std::is_same<int, T>::value;
-        constexpr bool is_double_type = std::is_same<double, T>::value;
-        constexpr bool is_array_1d_type = std::is_same<array_1d<double, 3>, T>::value;
-        constexpr unsigned ndims = (!is_array_1d_type) ? 1 : 2;
-        hsize_t dims[ndims] = {0};
-        dims[0] = rData.size(); // Set first data space dimension.
-        if (is_array_1d_type)
-            dims[1] = 3; // Set second data space dimension (array_1d<double,3>).
-
-        // Set the data type.
-        hid_t dtype_id;
-        if (is_int_type)
-            dtype_id = H5T_NATIVE_INT;
-        else if (is_double_type)
-            dtype_id = H5T_NATIVE_DOUBLE;
-        else if (is_array_1d_type)
-            dtype_id = H5T_NATIVE_DOUBLE;
-        else
-            static_assert(is_int_type || is_double_type || is_array_1d_type,
-                          "Unsupported data type.");
-
-        // Create and write the data set.
-        hid_t dspace_id = H5Screate_simple(ndims, dims, nullptr);
-        hid_t file_id = GetFileId();
-        hid_t dset_id = H5Dcreate(file_id, rPath.c_str(), dtype_id, dspace_id,
-                                  H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        KRATOS_ERROR_IF(dset_id < 0) << "H5Dcreate failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rData[0]) < 0)
-            << "H5Dwrite failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Sclose(dspace_id) < 0) << "H5Sclose failed." << std::endl;
-
-        // Set the write info.
-        rInfo.StartIndex = 0;
-        rInfo.TotalSize = rInfo.BlockSize = rData.size();
-
-        if (GetEchoLevel() == 2)
-            std::cout << "Write time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
-        KRATOS_CATCH("Path: \"" + rPath + "\".");
-    }
+    void WriteDataSetVectorImpl(const std::string& rPath, const Vector<T>& rData, WriteInfo& rInfo);
 
     template <class T>
-    void WriteDataSetMatrixImpl(const std::string& rPath, const Matrix<T>& rData, WriteInfo& rInfo)
-    {
-        KRATOS_TRY;
-        BuiltinTimer timer;
-        // Check that full path does not exist before trying to write data.
-        KRATOS_ERROR_IF(HasPath(rPath)) << "Path already exists: " << rPath << std::endl;
-
-        // Create any missing subpaths.
-        auto pos = rPath.find_last_of('/');
-        if (pos != 0) // Skip if last '/' is root.
-        {
-            std::string sub_path = rPath.substr(0, pos);
-            AddPath(sub_path);
-        }
-
-        // Initialize data space dimensions.
-        const unsigned ndims = 2;
-        hsize_t dims[ndims];
-        dims[0] = rData.size1();
-        dims[1] = rData.size2();
-
-        // Set the data type.
-        hid_t dtype_id = Internals::GetScalarDataType<T>();
-
-        // Create and write the data set.
-        hid_t dspace_id = H5Screate_simple(ndims, dims, nullptr);
-        hid_t file_id = GetFileId();
-        hid_t dset_id = H5Dcreate(file_id, rPath.c_str(), dtype_id, dspace_id,
-                                  H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
-        KRATOS_ERROR_IF(dset_id < 0) << "H5Dcreate failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dwrite(dset_id, dtype_id, H5S_ALL, H5S_ALL, H5P_DEFAULT, &rData(0, 0)) < 0)
-            << "H5Dwrite failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Sclose(dspace_id) < 0) << "H5Sclose failed." << std::endl;
-
-        // Set the write info.
-        rInfo.StartIndex = 0;
-        rInfo.TotalSize = rInfo.BlockSize = rData.size1();
-
-        if (GetEchoLevel() == 2)
-            std::cout << "Write time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
-        KRATOS_CATCH("Path: \"" + rPath + "\".");
-    }
+    void WriteDataSetMatrixImpl(const std::string& rPath, const Matrix<T>& rData, WriteInfo& rInfo);
 
     template <class T>
-    void ReadDataSetVectorImpl(const std::string& rPath, Vector<T>& rData, unsigned StartIndex, unsigned BlockSize)
-    {
-        KRATOS_TRY;
-        BuiltinTimer timer;
-        // Check that full path exists.
-        KRATOS_ERROR_IF_NOT(IsDataSet(rPath))
-            << "Path is not a data set: " << rPath << std::endl;
-
-        constexpr bool is_int_type = std::is_same<int, T>::value;
-        constexpr bool is_double_type = std::is_same<double, T>::value;
-        constexpr bool is_array_1d_type = std::is_same<array_1d<double, 3>, T>::value;
-        constexpr unsigned ndims = (!is_array_1d_type) ? 1 : 2;
-
-        // Check consistency of file's data set dimensions.
-        std::vector<unsigned> file_space_dims = GetDataDimensions(rPath);
-        KRATOS_ERROR_IF(file_space_dims.size() != ndims)
-            << "Invalid data set dimension." << std::endl;
-        KRATOS_ERROR_IF(StartIndex + BlockSize > file_space_dims[0])
-            << "StartIndex (" << StartIndex << ") + BlockSize (" << BlockSize
-            << ") > size of data set (" << file_space_dims[0] << ")." << std::endl;
-        if (is_array_1d_type)
-            KRATOS_ERROR_IF(file_space_dims[1] != 3)
-                << "Invalid data set dimension." << std::endl;
-
-        if (rData.size() != BlockSize)
-            rData.resize(BlockSize, false);
-
-        // Initialize memory space dimensions.
-        hsize_t start[ndims] = {0}, mem_dims[ndims];
-        start[0] = StartIndex;
-        mem_dims[0] = BlockSize; // Set first dimension.
-        if (is_array_1d_type)
-            mem_dims[1] = 3; // Set second dimension.
-
-        // Set the data type.
-        hid_t dtype_id;
-        if (is_int_type)
-        {
-            KRATOS_ERROR_IF_NOT(HasIntDataType(rPath))
-                << "Data type is not int: " << rPath << std::endl;
-            dtype_id = H5T_NATIVE_INT;
-        }
-        else if (is_double_type)
-        {
-            KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
-                << "Data type is not float: " << rPath << std::endl;
-            dtype_id = H5T_NATIVE_DOUBLE;
-        }
-        else if (is_array_1d_type)
-        {
-            KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
-                << "Data type is not float: " << rPath << std::endl;
-            dtype_id = H5T_NATIVE_DOUBLE;
-        }
-        else
-            static_assert(is_int_type || is_double_type || is_array_1d_type,
-                          "Unsupported data type.");
-
-        hid_t file_id = GetFileId();
-        hid_t dset_id = H5Dopen(file_id, rPath.c_str(), H5P_DEFAULT);
-        KRATOS_ERROR_IF(dset_id < 0) << "H5Dopen failed." << std::endl;
-        hid_t file_space_id = H5Dget_space(dset_id);
-        hid_t mem_space_id =
-            H5Screate_simple(ndims, mem_dims, nullptr);
-        KRATOS_ERROR_IF(H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, start, nullptr, mem_dims, nullptr) < 0)
-            << "H5Sselect_hyperslab failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id, H5P_DEFAULT, &rData[0]) < 0)
-            << "H5Dread failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
-
-        if (GetEchoLevel() == 2)
-            std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
-        KRATOS_CATCH("Path: \"" + rPath + "\".");
-    }
+    void ReadDataSetVectorImpl(const std::string& rPath,
+                               Vector<T>& rData,
+                               unsigned StartIndex,
+                               unsigned BlockSize);
 
     template <class T>
-    void ReadDataSetMatrixImpl(const std::string& rPath, Matrix<T>& rData, unsigned StartIndex, unsigned BlockSize)
-    {
-        KRATOS_TRY;
-        BuiltinTimer timer;
-        // Check that full path exists.
-        KRATOS_ERROR_IF_NOT(IsDataSet(rPath))
-            << "Path is not a data set: " << rPath << std::endl;
-
-        const unsigned ndims = 2;
-
-        // Check consistency of file's data set dimensions.
-        std::vector<unsigned> file_space_dims = GetDataDimensions(rPath);
-        KRATOS_ERROR_IF(file_space_dims.size() != ndims)
-            << "Invalid data set dimension." << std::endl;
-        KRATOS_ERROR_IF(StartIndex + BlockSize > file_space_dims[0])
-            << "StartIndex (" << StartIndex << ") + BlockSize (" << BlockSize
-            << ") > size of data set (" << file_space_dims[0] << ")." << std::endl;
-
-        if (rData.size1() != BlockSize || rData.size2() != file_space_dims[1])
-            rData.resize(BlockSize, file_space_dims[1], false);
-
-        // Initialize memory space dimensions.
-        hsize_t start[ndims] = {0}, mem_dims[ndims];
-        start[0] = StartIndex;
-        mem_dims[0] = rData.size1(); // Set first dimension.
-        mem_dims[1] = rData.size2(); // Set second dimension.
-
-        // Set the data type.
-        hid_t dtype_id = Internals::GetScalarDataType<T>();
-        if (dtype_id == H5T_NATIVE_INT)
-        {
-            KRATOS_ERROR_IF_NOT(HasIntDataType(rPath))
-                << "Data type is not int: " << rPath << std::endl;
-        }
-        else if (dtype_id == H5T_NATIVE_DOUBLE)
-        {
-            KRATOS_ERROR_IF_NOT(HasFloatDataType(rPath))
-                << "Data type is not float: " << rPath << std::endl;
-        }
-
-        hid_t file_id = GetFileId();
-        hid_t dset_id = H5Dopen(file_id, rPath.c_str(), H5P_DEFAULT);
-        KRATOS_ERROR_IF(dset_id < 0) << "H5Dopen failed." << std::endl;
-        hid_t file_space_id = H5Dget_space(dset_id);
-        hid_t mem_space_id =
-            H5Screate_simple(ndims, mem_dims, nullptr);
-        KRATOS_ERROR_IF(H5Sselect_hyperslab(file_space_id, H5S_SELECT_SET, start, nullptr, mem_dims, nullptr) < 0)
-            << "H5Sselect_hyperslab failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dread(dset_id, dtype_id, mem_space_id, file_space_id, H5P_DEFAULT, &rData(0,0)) < 0)
-            << "H5Dread failed." << std::endl;
-        KRATOS_ERROR_IF(H5Dclose(dset_id) < 0) << "H5Dclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Sclose(file_space_id) < 0) << "H5Sclose failed." << std::endl;
-        KRATOS_ERROR_IF(H5Sclose(mem_space_id) < 0) << "H5Sclose failed." << std::endl;
-
-        if (GetEchoLevel() == 2)
-            std::cout << "Read time \"" << rPath << "\": " << timer.ElapsedSeconds() << std::endl;
-        KRATOS_CATCH("Path: \"" + rPath + "\".");
-    }
+    void ReadDataSetMatrixImpl(const std::string& rPath,
+                               Matrix<T>& rData,
+                               unsigned StartIndex,
+                               unsigned BlockSize);
     ///@}
-
 };
+
+extern template void FileSerial::WriteDataSetVectorImpl(const std::string& rPath,
+                                                        const Vector<int>& rData,
+                                                        WriteInfo& rInfo);
+extern template void FileSerial::WriteDataSetVectorImpl(const std::string& rPath,
+                                                        const Vector<double>& rData,
+                                                        WriteInfo& rInfo);
+extern template void FileSerial::WriteDataSetMatrixImpl(const std::string& rPath,
+                                                        const Matrix<int>& rData,
+                                                        WriteInfo& rInfo);
+extern template void FileSerial::WriteDataSetMatrixImpl(const std::string& rPath,
+                                                        const Matrix<double>& rData,
+                                                        WriteInfo& rInfo);
+extern template void FileSerial::ReadDataSetVectorImpl(const std::string& rPath,
+                                                       Vector<int>& rData,
+                                                       unsigned StartIndex,
+                                                       unsigned BlockSize);
+extern template void FileSerial::ReadDataSetVectorImpl(const std::string& rPath,
+                                                       Vector<double>& rData,
+                                                       unsigned StartIndex,
+                                                       unsigned BlockSize);
+extern template void FileSerial::ReadDataSetMatrixImpl(const std::string& rPath,
+                                                       Matrix<int>& rData,
+                                                       unsigned StartIndex,
+                                                       unsigned BlockSize);
+extern template void FileSerial::ReadDataSetMatrixImpl(const std::string& rPath,
+                                                       Matrix<double>& rData,
+                                                       unsigned StartIndex,
+                                                       unsigned BlockSize);
 
 ///@} // Kratos Classes
 ///@} addtogroup

--- a/applications/HDF5Application/custom_io/hdf5_model_part_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_model_part_io.cpp
@@ -8,6 +8,7 @@
 #include "custom_utilities/factor_elements_and_conditions_utility.h"
 #include "utilities/builtin_timer.h"
 #include "utilities/openmp_utils.h"
+#include "input_output/logger.h"
 
 namespace Kratos
 {
@@ -206,8 +207,9 @@ void ModelPartIO::WriteModelPart(ModelPart& rModelPart)
     WriteConditions(rModelPart.Conditions());
     WriteSubModelParts(rModelPart);
 
-    if (mpFile->GetEchoLevel() == 1 && mpFile->GetPID() == 0)
-        std::cout << "Time to write model part \"" << rModelPart.Name() << "\": " << timer.ElapsedSeconds() << " seconds." << std::endl;
+    KRATOS_INFO_IF("HDF5Application", mpFile->GetEchoLevel() == 1 && mpFile->GetPID() == 0)
+        << "Time to write model part \"" << rModelPart.Name()
+        << "\": " << timer.ElapsedSeconds() << " seconds." << std::endl;
 
     KRATOS_CATCH("");
 }
@@ -226,8 +228,9 @@ void ModelPartIO::ReadModelPart(ModelPart& rModelPart)
     Internals::ReadAndAssignBufferSize(*mpFile, mPrefix, rModelPart);
     ReadSubModelParts(rModelPart);
 
-    if (mpFile->GetEchoLevel() == 1 && mpFile->GetPID() == 0)
-        std::cout << "Time to read model part \"" << rModelPart.Name() << "\": " << timer.ElapsedSeconds() << " seconds." << std::endl;
+    KRATOS_INFO_IF("HDF5Application", mpFile->GetEchoLevel() == 1 && mpFile->GetPID() == 0)
+        << "Time to read model part \"" << rModelPart.Name()
+        << "\": " << timer.ElapsedSeconds() << " seconds." << std::endl;
 
     KRATOS_CATCH("");
 }

--- a/applications/HDF5Application/custom_io/hdf5_model_part_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_model_part_io.cpp
@@ -207,7 +207,7 @@ void ModelPartIO::WriteModelPart(ModelPart& rModelPart)
     WriteConditions(rModelPart.Conditions());
     WriteSubModelParts(rModelPart);
 
-    KRATOS_INFO_IF("HDF5Application", mpFile->GetEchoLevel() == 1 && mpFile->GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", mpFile->GetEchoLevel() == 1)
         << "Time to write model part \"" << rModelPart.Name()
         << "\": " << timer.ElapsedSeconds() << " seconds." << std::endl;
 
@@ -228,7 +228,7 @@ void ModelPartIO::ReadModelPart(ModelPart& rModelPart)
     Internals::ReadAndAssignBufferSize(*mpFile, mPrefix, rModelPart);
     ReadSubModelParts(rModelPart);
 
-    KRATOS_INFO_IF("HDF5Application", mpFile->GetEchoLevel() == 1 && mpFile->GetPID() == 0)
+    KRATOS_INFO_IF("HDF5Application", mpFile->GetEchoLevel() == 1)
         << "Time to read model part \"" << rModelPart.Name()
         << "\": " << timer.ElapsedSeconds() << " seconds." << std::endl;
 


### PR DESCRIPTION
This PR cleans up the hdf5 file headers by moving template bodies to cpp files.