### PR TITLE
[Core] Small fix in reorder elements and nodes

### DIFF
--- a/kratos/processes/reorder_and_optimize_modelpart_process.cpp
+++ b/kratos/processes/reorder_and_optimize_modelpart_process.cpp
@@ -252,7 +252,7 @@ namespace Kratos
                     node_id = std::min(node_id, r_node.Id());
                 node_ids.at(it->Id() - 1) = node_id;
             }
-            std::sort(element_ids.begin(), element_ids.end(),
+            std::stable_sort(element_ids.begin(), element_ids.end(),
                       [&node_ids](const std::size_t& i, const std::size_t& j) {
                           return node_ids[i - 1] < node_ids[j - 1];
                       });


### PR DESCRIPTION
There is a small problem with the reorder and optimize model part process.

In the line 255, it sorts the list of elements ids with respect of another list called node_ids. This last list contains the lowest id of the nodes that are part of each element.

As many elements share nodes, there are repeated values in the node_ids list. The problem is then that as it has no preference between these elements, the order becomes random and you end up with different reorderings for different compilers. This specially painful when you try to debug between different versions.

std::stable_sort does the following: if there are elements with the same node_id then they maintain the same order as they had before sorting. In this way, the solution becomes unique for all compilers.