### PR TITLE
[Core] Update process-factory to work with python-module-only applications

### DIFF
--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -17,9 +17,10 @@ class KratosProcessFactory(object):
             python_module_name = item["python_module"].GetString()
 
             if item.Has("kratos_module"): # for Kratos-processes
-                '''Location of the process in Kratos; e.g.:
+                """Location of the process in Kratos; e.g.:
                 - KratosMultiphysics
-                - KratosMultiphysics.FluidDynamicsApplication'''
+                - KratosMultiphysics.FluidDynamicsApplication
+                """
                 
                 kratos_module_name = item["kratos_module"].GetString()
                 if not kratos_module_name.startswith("KratosMultiphysics"):

--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -19,8 +19,8 @@ class KratosProcessFactory(object):
             if item.Has("kratos_module"): # for Kratos-processes
                 '''Location of the process in Kratos; e.g.:
                 - KratosMultiphysics
-                - KratosMultiphysics.FluidDynamicsApplication
-                '''
+                - KratosMultiphysics.FluidDynamicsApplication'''
+                
                 kratos_module_name = item["kratos_module"].GetString()
                 if not kratos_module_name.startswith("KratosMultiphysics"):
                     kratos_module_name = "KratosMultiphysics." + kratos_module_name


### PR DESCRIPTION
New applications are python-modules-only, they need the new import-mechanism

The changes here are fully backwards-compatible and were also tested with the new python-import mechanism (by @tteschemacher with the IgaApplication that uses the new import-mechanism)

@jcotela this is finally the implementation that we were already discussing

after this is merged I will tackle #3673