### PR TITLE
check if cable is compressed in explicit

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/cable_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cable_element_3D2N.cpp
@@ -174,6 +174,48 @@ void CableElement3D2N::UpdateInternalForces(
 }
 
 
+BoundedVector<double,TrussElement3D2N::msLocalSize>
+  CableElement3D2N::GetConstitutiveLawTrialResponse(
+   const ProcessInfo& rCurrentProcessInfo, const bool rSaveInternalVariables)
+{
+    KRATOS_TRY;
+    const double numerical_limit = std::numeric_limits<double>::epsilon();
+    Vector strain_vector = ZeroVector(this->mpConstitutiveLaw->GetStrainSize());
+    Vector stress_vector = ZeroVector(this->mpConstitutiveLaw->GetStrainSize());
+    strain_vector[0] = this->CalculateGreenLagrangeStrain();
+
+    Matrix temp_matrix;
+    Vector temp_vector;
+
+    this->mpConstitutiveLaw->CalculateMaterialResponse(strain_vector,
+    temp_matrix,stress_vector,temp_matrix,rCurrentProcessInfo,this->GetProperties(),
+    this->GetGeometry(),temp_vector,true,true,rSaveInternalVariables);
+
+    BoundedVector<double,msLocalSize> internal_forces = ZeroVector(msLocalSize);
+    const double l = StructuralMechanicsElementUtilities::CalculateCurrentLength3D2N(*this);
+    const double L0 = StructuralMechanicsElementUtilities::CalculateReferenceLength3D2N(*this);
+    const double A = this->GetProperties()[CROSS_AREA];
+    double prestress = 0.00;
+    if (this->GetProperties().Has(TRUSS_PRESTRESS_PK2)) {
+      prestress = this->GetProperties()[TRUSS_PRESTRESS_PK2];
+    }
+
+    const double normal_force =
+        ((stress_vector[0] + prestress) * l * A) / L0;
+
+    this->mIsCompressed = false;
+    if ((normal_force < 0.00)&&(std::abs(l-L0)>numerical_limit)) this->mIsCompressed = true;
+
+    internal_forces[0] = -1.0 * normal_force;
+    internal_forces[3] = +1.0 * normal_force;
+
+    return internal_forces;
+    KRATOS_CATCH("");
+}
+
+
+
+
 void CableElement3D2N::save(Serializer &rSerializer) const {
   KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, TrussElement3D2N);
   rSerializer.save("mIscompressed", this->mIsCompressed);

--- a/applications/StructuralMechanicsApplication/custom_elements/cable_element_3D2N.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cable_element_3D2N.hpp
@@ -94,6 +94,16 @@ namespace Kratos
          */
         void UpdateInternalForces(BoundedVector<double,msLocalSize>& rinternalForces) override;
 
+        /**
+         * @brief This function calls the constitutive law to get stresses
+         * @param rCurrentProcessInfo Current process info
+         * @param rSaveInternalVariables Boolean to save internal constit. law variables
+         */
+
+        BoundedVector<double,msLocalSize> GetConstitutiveLawTrialResponse(
+            const ProcessInfo& rCurrentProcessInfo,
+            const bool rSaveInternalVariables) override;
+
     private:
         // boolean for the cable --> does not resist to compression
         bool mIsCompressed;


### PR DESCRIPTION
@loumalouomega and @philbucher the pr #4035 caused some problems for me which I just noticed.
The main problem is fixed with this pr as calling only `CalculateRightHandSide` did not check if the cable is compressed or not. There is still another problem which I will describe in a seperate issue