### PR TITLE
Change the way singular matrices are detected in MathUtils::InvertMatrix

### DIFF
--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -355,7 +355,7 @@ public:
         // Checking condition number
         CheckConditionNumber(InputMatrix, InvertedMatrix, Tolerance);
 
-        return inverted_matrix;
+        return InvertedMatrix;
     }
 
     /**
@@ -374,21 +374,10 @@ public:
         // We want at least 4 significant digits
         const TDataType max_condition_number = (1.0/Tolerance) * 1.0e-4;
 
-        // Sizes
-        const SizeType size_1 = rInputMatrix.size1();
-        const SizeType size_2 = rInputMatrix.size2();
-
         // Find the condition number to define is inverse is OK
-        double input_matrix_norm = 0.0;
-        double inverted_matrix_norm = 0.0;
-        for(IndexType i = 0; i < size_1; ++i) {
-            for(IndexType j = 0; j < size_2; ++j) {
-                input_matrix_norm += std::pow(rInputMatrix(i,j),2);
-                inverted_matrix_norm += std::pow(rInvertedMatrix(i,j),2);
-            }
-        }
-        input_matrix_norm = std::sqrt(input_matrix_norm);
-        inverted_matrix_norm = std::sqrt(inverted_matrix_norm);
+        const double input_matrix_norm = norm_frobenius(rInputMatrix);
+        const double inverted_matrix_norm = norm_frobenius(rInvertedMatrix);
+
         // Now the condition number is the product of both norms
         const double cond_number = input_matrix_norm * inverted_matrix_norm ;
         // Finally check if the condition number is low enough

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -10,7 +10,8 @@
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
 //
-//  Collaborators:    Vicente Mataix Ferrandiz , pbecker
+//  Collaborators:    Vicente Mataix Ferrandiz 
+//                    Pablo Becker
 //
 
 #if !defined(KRATOS_MATH_UTILS )

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -353,7 +353,9 @@ public:
         }
 
         // Checking condition number
-        CheckConditionNumber(InputMatrix, InvertedMatrix, Tolerance);
+        if (Tolerance > 0.0) { // Check is skipped for negative tolerances
+            CheckConditionNumber(InputMatrix, InvertedMatrix, Tolerance);
+        }
 
         return InvertedMatrix;
     }

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -278,9 +278,9 @@ public:
 
     template<unsigned int TDim>
     static inline BoundedMatrix<TDataType, TDim, TDim> InvertMatrix(
-        const BoundedMatrix<TDataType, TDim, TDim>& rInputMatrix,
-        TDataType& rInputMatrixDet,
-        const TDataType Tolerance = std::numeric_limits<double>::epsilon()
+        const BoundedMatrix<TDataType, TDim, TDim>& InputMatrix,
+        TDataType& InputMatrixDet,
+        const TDataType Tolerance = ZeroTolerance
         )
     {
         BoundedMatrix<TDataType, TDim, TDim> InvertedMatrix;
@@ -353,7 +353,7 @@ public:
         }
 
         // Checking condition number
-        CheckConditionNumber(rInputMatrix, InvertedMatrix, Tolerance);
+        CheckConditionNumber(InputMatrix, InvertedMatrix, Tolerance);
 
         return inverted_matrix;
     }


### PR DESCRIPTION
Currently, MathUtils is attempting to detect singular matrix by simply looking at the determinant. If it is lower than approx 1e-16, it reports singular matrix and throws and error.
THIS IS INCORRECT. If a matrix has all its coeffs , for example, in the order 1e-10, the determinant will be of order (1e-10)^n , where n is the size of the matrix. 

The correct way to do it is with the condition number.
I have removed the check with the determinant and added the condition number. It only implies a cheap operation, computing the norm of the two matrices.

NOTE: I went for the norm  sqrt (sum I(i,j) ) due to simplicity and cost. If mathematically it is better to use another norm, please provide a link with the best norm / change it yourself.