### PR TITLE
[Core] improve restart utility

### DIFF
--- a/applications/trilinos_application/python_scripts/trilinos_restart_utility.py
+++ b/applications/trilinos_application/python_scripts/trilinos_restart_utility.py
@@ -34,8 +34,3 @@ class TrilinosRestartUtility(restart_utility.RestartUtility):
     def _ExecuteAfterLoad(self):
         if self.set_mpi_communicator:
             KratosTrilinos.ParallelFillCommunicator(self.main_model_part.GetRootModelPart()).Execute()
-
-    def _PrintOnRankZero(self, *args):
-        KratosMPI.mpi.world.barrier()
-        if KratosMPI.mpi.rank == 0:
-            KratosMultiphysics.Logger.PrintInfo(" ".join(map(str,args)))

--- a/applications/trilinos_application/python_scripts/trilinos_restart_utility.py
+++ b/applications/trilinos_application/python_scripts/trilinos_restart_utility.py
@@ -18,14 +18,15 @@ class TrilinosRestartUtility(RestartUtility):
         super(TrilinosRestartUtility, self).__init__(model_part, settings)
 
         self.set_mpi_communicator = settings["set_mpi_communicator"].GetBool()
+        self.rank = Kratos.DataCommunicator.GetDefault().Rank()
 
     #### Protected functions ####
 
     def _GetFileLabelLoad(self):
-        return str(Kratos.DataCommunicator.GetDefault().Rank()) + '_' + self.input_file_label
+        return str(self.rank) + '_' + self.input_file_label
 
     def _GetFileLabelSave(self, file_label):
-        return str(Kratos.DataCommunicator.GetDefault().Rank()) + '_' + str(file_label)
+        return str(self.rank) + '_' + str(file_label)
 
     def _ExecuteAfterLoad(self):
         if self.set_mpi_communicator:

--- a/applications/trilinos_application/python_scripts/trilinos_restart_utility.py
+++ b/applications/trilinos_application/python_scripts/trilinos_restart_utility.py
@@ -2,15 +2,11 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 
 # Importing the Kratos Library
 import KratosMultiphysics
-import KratosMultiphysics.mpi as KratosMPI
-
-# Import applications
-import KratosMultiphysics.TrilinosApplication as KratosTrilinos
 
 # Other imports
-import restart_utility
+from KratosMultiphysics.restart_utility import RestartUtility
 
-class TrilinosRestartUtility(restart_utility.RestartUtility):
+class TrilinosRestartUtility(RestartUtility):
     """
     This class overwrites the methods that are different
     in MPI parallel execution
@@ -26,11 +22,12 @@ class TrilinosRestartUtility(restart_utility.RestartUtility):
     #### Protected functions ####
 
     def _GetFileLabelLoad(self):
-        return str(KratosMPI.mpi.rank) + '_' + self.input_file_label
+        return str(Kratos.DataCommunicator.GetDefault().Rank()) + '_' + self.input_file_label
 
     def _GetFileLabelSave(self, file_label):
-        return str(KratosMPI.mpi.rank) + '_' + str(file_label)
+        return str(Kratos.DataCommunicator.GetDefault().Rank()) + '_' + str(file_label)
 
     def _ExecuteAfterLoad(self):
         if self.set_mpi_communicator:
+            import KratosMultiphysics.TrilinosApplication as KratosTrilinos
             KratosTrilinos.ParallelFillCommunicator(self.main_model_part.GetRootModelPart()).Execute()

--- a/kratos/python_scripts/restart_utility.py
+++ b/kratos/python_scripts/restart_utility.py
@@ -112,17 +112,13 @@ class RestartUtility(object):
         This function saves the restart file. It should be called at the end of a time-step.
         Use "IsRestartOutputStep" to check if a restart file should be written in this time-step
         """
-        if self.save_restart_files_in_folder:
-            folder_path = self.__GetFolderPathSave()
-            if not os.path.isdir(folder_path) and self.model_part.GetCommunicator().MyPID() == 0:
-                os.makedirs(folder_path)
-            self.model_part.GetCommunicator().Barrier()
-
         if self.restart_control_type_is_time:
             time = self.model_part.ProcessInfo[KratosMultiphysics.TIME]
             control_label = self.__GetPrettyTime(time)
         else:
             control_label = self.model_part.ProcessInfo[KratosMultiphysics.STEP]
+
+        self.CreateOutputFolder()
 
         if not os.path.isdir(self.__GetFolderPathSave()):
             err_msg  = 'The directory for saving the restart-files of modelpart "'
@@ -153,6 +149,14 @@ class RestartUtility(object):
             return (self.model_part.ProcessInfo[KratosMultiphysics.TIME] > self.next_output)
         else:
             return (self.model_part.ProcessInfo[KratosMultiphysics.STEP] >= self.next_output)
+
+    def CreateOutputFolder(self):
+        if self.save_restart_files_in_folder:
+            folder_path = self.__GetFolderPathSave()
+            if not os.path.isdir(folder_path) and self.model_part.GetCommunicator().MyPID() == 0:
+                os.makedirs(folder_path)
+            self.model_part.GetCommunicator().Barrier()
+
 
     #### Protected functions ####
 

--- a/kratos/python_scripts/restart_utility.py
+++ b/kratos/python_scripts/restart_utility.py
@@ -124,6 +124,14 @@ class RestartUtility(object):
         else:
             control_label = self.model_part.ProcessInfo[KratosMultiphysics.STEP]
 
+        if not os.path.isdir(self.__GetFolderPathSave()):
+            err_msg  = 'The directory for saving the restart-files of modelpart "'
+            err_msg += self.model_part_name + '" does not exist!\n'
+            if self.save_restart_files_in_folder:
+                err_msg += 'Something went wrong with the creation of the folder "'
+                err_msg += self.__GetFolderPathSave()+ '"!'
+            raise Exception(err_msg)
+
         file_name = self.__GetFileNameSave(control_label)
 
         # Save the ModelPart

--- a/kratos/python_scripts/restart_utility.py
+++ b/kratos/python_scripts/restart_utility.py
@@ -91,8 +91,8 @@ class RestartUtility(object):
             restart_path = restart_file_name
 
         # Check path
-        if (os.path.exists(restart_path+".rest") == False):
-            raise Exception("Restart file not found: " + restart_path + ".rest")
+        if not os.path.exists(restart_path+".rest"):
+            raise FileNotFoundError("Restart file not found: " + restart_path + ".rest")
         self._PrintOnRankZero("::[Restart Utility]::", "Loading restart file:", restart_path + ".rest")
 
         # Load the ModelPart

--- a/kratos/python_scripts/restart_utility.py
+++ b/kratos/python_scripts/restart_utility.py
@@ -93,7 +93,7 @@ class RestartUtility(object):
         # Check path
         if not os.path.exists(restart_path+".rest"):
             raise FileNotFoundError("Restart file not found: " + restart_path + ".rest")
-        self._PrintOnRankZero("::[Restart Utility]::", "Loading restart file:", restart_path + ".rest")
+        KratosMultiphysics.Logger.PrintInfo("Restart Utility", "Loading restart file:", restart_path + ".rest")
 
         # Load the ModelPart
         serializer = KratosMultiphysics.FileSerializer(restart_path, self.serializer_flag)
@@ -105,7 +105,7 @@ class RestartUtility(object):
         load_step = self.model_part.ProcessInfo[KratosMultiphysics.STEP] + 1
         self.model_part.ProcessInfo[KratosMultiphysics.LOAD_RESTART] = load_step
 
-        self._PrintOnRankZero("::[Restart Utility]::", "Finished loading model part from restart file.")
+        KratosMultiphysics.Logger.PrintInfo("Restart Utility", "Finished loading model part from restart file.")
 
     def SaveRestart(self):
         """
@@ -134,7 +134,7 @@ class RestartUtility(object):
         serializer = KratosMultiphysics.FileSerializer(file_name, self.serializer_flag)
         serializer.Save(self.model_part.Name, self.model_part)
         if self.echo_level > 0:
-            self._PrintOnRankZero("::[Restart Utility]::", "Saved restart file", file_name + ".rest")
+            KratosMultiphysics.Logger.PrintInfo("Restart Utility", "Saved restart file", file_name + ".rest")
 
         # Schedule next output
         if self.restart_save_frequency > 0.0: # Note: if == 0, we'll just always print
@@ -169,10 +169,6 @@ class RestartUtility(object):
     def _ExecuteAfterLoad(self):
         """This function creates the communicators in MPI/trilinos"""
         pass
-
-    def _PrintOnRankZero(self, *args):
-        # This function will be overridden in the trilinos-version
-        KratosMultiphysics.Logger.PrintInfo(" ".join(map(str,args)))
 
     #### Private functions ####
 

--- a/kratos/python_scripts/save_restart_process.py
+++ b/kratos/python_scripts/save_restart_process.py
@@ -18,8 +18,8 @@ class SaveRestartProcess(KratosMultiphysics.Process):
         KratosMultiphysics.Process.__init__(self)
         ## Settings string in json format
         default_settings = KratosMultiphysics.Parameters("""{
-            "help"                         : "This process is used in order to save/load the problem databse with the serializer the current problem",
-            "model_part_name"              : "",
+            "help"                         : "This process is used in order to save the problem databse with the serializer the current problem",
+            "model_part_name"              : "SPECIFY_MODEL_PART_NAME",
             "echo_level"                   : 0,
             "serializer_trace"             : "no_trace",
             "restart_save_frequency"       : 0.0,
@@ -30,14 +30,8 @@ class SaveRestartProcess(KratosMultiphysics.Process):
         ## Overwrite the default settings with user-provided parameters
         params.ValidateAndAssignDefaults(default_settings)
         params.RemoveValue("help")
-        self.params = params
-        self.model = model
 
-        if self.params["model_part_name"].GetString() == "":
-            raise Exception('No "model_part_name" was specified!')
-
-    def ExecuteInitialize(self):
-        model_part = self.model[self.params["model_part_name"].GetString()]
+        model_part = model[params["model_part_name"].GetString()]
 
         is_mpi_execution = (model_part.GetCommunicator().TotalProcesses() > 1)
 

--- a/kratos/python_scripts/save_restart_process.py
+++ b/kratos/python_scripts/save_restart_process.py
@@ -33,18 +33,15 @@ class SaveRestartProcess(KratosMultiphysics.Process):
 
         model_part = model[params["model_part_name"].GetString()]
 
-        is_mpi_execution = (model_part.GetCommunicator().TotalProcesses() > 1)
-
-        if is_mpi_execution:
-            import KratosMultiphysics.TrilinosApplication
-            from trilinos_restart_utility import TrilinosRestartUtility as Restart
+        if model_part.GetCommunicator().TotalProcesses() > 1: # mpi-execution
+            from KratosMultiphysics.TrilinosApplication.trilinos_restart_utility import TrilinosRestartUtility as RestartUtility
         else:
-            from restart_utility import RestartUtility as Restart
+            from KratosMultiphysics.restart_utility import RestartUtility
 
-        self.params.AddValue("input_filename", self.params["model_part_name"])
-        self.params.RemoveValue("model_part_name")
+        params.AddValue("input_filename", params["model_part_name"])
+        params.RemoveValue("model_part_name")
 
-        self.restart_utility = Restart(model_part, self.params)
+        self.restart_utility = RestartUtility(model_part, params)
 
     def IsOutputStep(self):
         return self.restart_utility.IsRestartOutputStep()

--- a/kratos/python_scripts/save_restart_process.py
+++ b/kratos/python_scripts/save_restart_process.py
@@ -52,26 +52,8 @@ class SaveRestartProcess(KratosMultiphysics.Process):
 
         self.restart_utility = Restart(model_part, self.params)
 
-    def ExecuteBeforeSolutionLoop(self):
-        pass
-
-    def ExecuteInitializeSolutionStep(self):
-        pass
-
-    def ExecuteFinalizeSolutionStep(self):
-        pass
-
-    def ExecuteBeforeOutputStep(self):
-        pass
-
     def IsOutputStep(self):
         return self.restart_utility.IsRestartOutputStep()
 
     def PrintOutput(self):
         self.restart_utility.SaveRestart()
-
-    def ExecuteAfterOutputStep(self):
-        pass
-
-    def ExecuteFinalize(self):
-        pass

--- a/kratos/python_scripts/save_restart_process.py
+++ b/kratos/python_scripts/save_restart_process.py
@@ -43,6 +43,9 @@ class SaveRestartProcess(KratosMultiphysics.Process):
 
         self.restart_utility = RestartUtility(model_part, params)
 
+        # already create the folder now to avoid problems on slow file-systems
+        self.restart_utility.CreateOutputFolder()
+
     def IsOutputStep(self):
         return self.restart_utility.IsRestartOutputStep()
 

--- a/kratos/tests/test_restart.py
+++ b/kratos/tests/test_restart.py
@@ -156,7 +156,7 @@ class TestRestart(KratosUnittest.TestCase):
 
         serializer_save = KratosMultiphysics.FileSerializer(file_name, serializer_flag)
         serializer_save.Save(model_part.Name, model_part)
-        
+
 
     def __execute_restart_load(self, current_model, file_name, serializer_flag):
         model_part_name = "MainRestart"
@@ -220,7 +220,7 @@ class TestRestart(KratosUnittest.TestCase):
 
         rest_utility = restart_utility.RestartUtility(loaded_model_part, restart_parameters)
 
-        rest_utility.LoadRestart() #TODO: it would be best to return the loaded_modelpart from this... 
+        rest_utility.LoadRestart() #TODO: it would be best to return the loaded_modelpart from this...
 
         return loaded_model_part #rest_utility.model_part
 
@@ -236,7 +236,7 @@ class TestRestart(KratosUnittest.TestCase):
         self.__execute_restart_test(KratosMultiphysics.SerializerTraceType.SERIALIZER_TRACE_ALL)
 
     def test_restart_utility(self):
-        
+
 
         # Here we only test SERIALIZER_NO_TRACE since the others are tested in the simple tests
         model_part_name = "MainRestart"
@@ -269,19 +269,17 @@ class TestRestart(KratosUnittest.TestCase):
         end_time = 17.1
 
         save_restart_process = save_rest_proc.Factory(save_restart_process_params, model)
-        save_restart_process.ExecuteInitialize()
-        save_restart_process.ExecuteBeforeSolutionLoop()
+
+        base_path = "MainRestart__restart_files"
+        self.assertTrue(os.path.isdir(base_path)) # make sure the folder gets created right away
+
         while model_part.ProcessInfo[KratosMultiphysics.TIME] < end_time:
             model_part.ProcessInfo[KratosMultiphysics.TIME] += delta_time
             model_part.ProcessInfo[KratosMultiphysics.STEP] += 1
-            save_restart_process.ExecuteInitializeSolutionStep()
             if save_restart_process.IsOutputStep():
                 save_restart_process.PrintOutput()
-            save_restart_process.ExecuteFinalizeSolutionStep()
-        save_restart_process.ExecuteFinalize()
 
         # Checking if the files exist
-        base_path = "MainRestart__restart_files"
         base_file_name = os.path.join(base_path, "MainRestart_")
         for i in range(2,50,2):
             self.assertTrue(os.path.isfile(base_file_name + str(i) + ".rest"))

--- a/kratos/tests/test_restart.py
+++ b/kratos/tests/test_restart.py
@@ -302,4 +302,5 @@ class TestRestart(KratosUnittest.TestCase):
 
 
 if __name__ == '__main__':
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
     KratosUnittest.main()


### PR DESCRIPTION
This PR refactors a bit and simplifies the restart-utiltity

Also it gives a proper error-message now if the output-folder could not be created (which is a problem on our clusters)
For the same reason I also create the folder now right away to give the file-system more time to make it available for being used