### PR TITLE
[Core] Adding methods to constraints to recover the dofs vectors

### DIFF
--- a/kratos/includes/linear_master_slave_constraint.h
+++ b/kratos/includes/linear_master_slave_constraint.h
@@ -370,6 +370,24 @@ public:
     }
 
     /**
+     * @brief This method returns the slave dof vector
+     * @return The vector containing the slave dofs
+     */
+    const DofPointerVectorType& GetSlaveDofsVector() const override
+    {
+        return mSlaveDofsVector;
+    }
+
+    /**
+     * @brief This method returns the slave dof vector
+     * @return The vector containing the slave dofs
+     */
+    const DofPointerVectorType& GetMasterDofsVector() const override
+    {
+        return mMasterDofsVector;
+    }
+
+    /**
      * @brief This is called during the assembling process in order
      * @details To calculate the relation between the master and slave.
      * @param rTransformationMatrix the matrix which relates the master and slave degree of freedom

--- a/kratos/includes/master_slave_constraint.h
+++ b/kratos/includes/master_slave_constraint.h
@@ -338,6 +338,24 @@ public:
     }
 
     /**
+     * @brief This method returns the slave dof vector
+     * @return The vector containing the slave dofs
+     */
+    virtual const DofPointerVectorType& GetSlaveDofsVector() const
+    {
+        KRATOS_ERROR << "GetSlaveDofsVector not implemented in MasterSlaveConstraintBaseClass" << std::endl;
+    }
+
+    /**
+     * @brief This method returns the slave dof vector
+     * @return The vector containing the slave dofs
+     */
+    virtual const DofPointerVectorType& GetMasterDofsVector() const
+    {
+        KRATOS_ERROR << "GetMasterDofsVector not implemented in MasterSlaveConstraintBaseClass" << std::endl;
+    }
+
+    /**
      * @brief This is called during the assembling process in order
      * @details To calculate the relation between the master and slave.
      * @param rTransformationMatrix the matrix which relates the master and slave degree of freedom


### PR DESCRIPTION
I add this methods in order to be able to access to the vector of dofs from the constraints, this could be used in order compute the MPC in a explicit way