### PR TITLE
[DEM] Important bugfix for dem continuum due to a resize with 'false' argument

### DIFF
--- a/applications/DEMApplication/custom_constitutive/DEM_Dempack_dev_CL.cpp
+++ b/applications/DEMApplication/custom_constitutive/DEM_Dempack_dev_CL.cpp
@@ -30,8 +30,12 @@ namespace Kratos {
         double a = 0.0;
         CalculateContactArea(radius, other_radius, a);
         unsigned int old_size = v.size();
+        Vector backup = v;
         v.resize(old_size + 1, false);
-        v[old_size]=a;
+        v[old_size] = a;
+        for (unsigned int i=0; i<old_size; i++) {
+            v[i] = backup[i];
+        }
         return a;
     }
 

--- a/applications/DEMApplication/custom_constitutive/DEM_KDEM_CL.cpp
+++ b/applications/DEMApplication/custom_constitutive/DEM_KDEM_CL.cpp
@@ -39,8 +39,12 @@ namespace Kratos {
         double a = 0.0;
         CalculateContactArea(radius, other_radius, a);
         unsigned int old_size = v.size();
+        Vector backup = v;
         v.resize(old_size + 1, false);
         v[old_size] = a;
+        for (unsigned int i=0; i<old_size; i++) {
+            v[i] = backup[i];
+        }
         return a;
     }
 


### PR DESCRIPTION
The error slipped in when porting to AMatrix, sorry guys.
resize(new_size,false) was destroying all the information.