### PR TITLE
[HotFix][Core] Embedded skin utility minor correction

### DIFF
--- a/kratos/utilities/embedded_skin_utility.cpp
+++ b/kratos/utilities/embedded_skin_utility.cpp
@@ -82,9 +82,9 @@ namespace Kratos
         VariableUtils().SetFlag<ModelPart::ConditionsContainerType>(TO_ERASE, true, mrSkinModelPart.Conditions());
 
         // Remove all the skin model part geometrical entities
-        mrSkinModelPart.RemoveNodes(TO_ERASE);
-        mrSkinModelPart.RemoveElements(TO_ERASE);
-        mrSkinModelPart.RemoveConditions(TO_ERASE);
+        mrSkinModelPart.RemoveNodesFromAllLevels(TO_ERASE);
+        mrSkinModelPart.RemoveElementsFromAllLevels(TO_ERASE);
+        mrSkinModelPart.RemoveConditionsFromAllLevels(TO_ERASE);
     }
 
     template<std::size_t TDim>


### PR DESCRIPTION
In case the embedded skin model part is a submodelpart, remove the nodes, conditions and elements from all levels when calling the `Clear()` method.