### PR TITLE
[PotentialFlow] fix abs

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.cpp
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.cpp
@@ -27,8 +27,8 @@ namespace Kratos {
 KratosCompressiblePotentialFlowApplication::KratosCompressiblePotentialFlowApplication():
     KratosApplication("CompressiblePotentialFlowApplication"),
     mCompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-    mIncompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mCompressiblePotentialFlowElement3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+    mIncompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mPotentialWallCondition2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
     mPotentialWallCondition3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3))))
   {}

--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
@@ -10,10 +10,8 @@
 //  Main authors:    Riccardo Rossi
 //
 
-
 #if !defined(KRATOS_COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION_H_INCLUDED )
 #define  KRATOS_COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION_H_INCLUDED
-
 
 // System includes
 
@@ -29,22 +27,6 @@
 
 namespace Kratos {
 
-///@name Kratos Globals
-///@{
-
-///@}
-///@name Type Definitions
-///@{
-
-///@}
-///@name  Enum's
-///@{
-
-///@}
-///@name  Functions
-///@{
-
-///@}
 ///@name Kratos Classes
 ///@{
 
@@ -55,7 +37,6 @@ class KratosCompressiblePotentialFlowApplication : public KratosApplication {
 public:
 	///@name Type Definitions
 	///@{
-
 
 	/// Pointer definition of KratosCompressiblePotentialFlowApplication
 	KRATOS_CLASS_POINTER_DEFINITION(KratosCompressiblePotentialFlowApplication);
@@ -70,47 +51,32 @@ public:
 	/// Destructor.
 	~KratosCompressiblePotentialFlowApplication() override{}
 
-
-	///@}
-	///@name Operators
-	///@{
-
-
 	///@}
 	///@name Operations
 	///@{
 
 	void Register() override;
 
-
-
-	///@}
-	///@name Access
-	///@{
-
-
-	///@}
-	///@name Inquiry
-	///@{
-
-
 	///@}
 	///@name Input and output
 	///@{
 
 	/// Turn back information as a string.
-	std::string Info() const override {
+	std::string Info() const override
+    {
 		return "KratosCompressiblePotentialFlowApplication";
 	}
 
 	/// Print information about this object.
-	void PrintInfo(std::ostream& rOStream) const override {
+	void PrintInfo(std::ostream& rOStream) const override
+    {
 		rOStream << Info();
 		PrintData(rOStream);
 	}
 
 	///// Print object's data.
-	void PrintData(std::ostream& rOStream) const override {
+	void PrintData(std::ostream& rOStream) const override
+    {
   		KRATOS_WATCH("in my application");
   		KRATOS_WATCH(KratosComponents<VariableData>::GetComponents().size() );
 
@@ -124,116 +90,35 @@ public:
 		KratosComponents<Condition>().PrintData(rOStream);
     }
 
-
-	///@}
-	///@name Friends
-	///@{
-
-
-	///@}
-
-protected:
-	///@name Protected static Member Variables
-	///@{
-
-
-	///@}
-	///@name Protected member Variables
-	///@{
-
-
-	///@}
-	///@name Protected Operators
-	///@{
-
-
-	///@}
-	///@name Protected Operations
-	///@{
-
-
-	///@}
-	///@name Protected  Access
-	///@{
-
-
-	///@}
-	///@name Protected Inquiry
-	///@{
-
-
-	///@}
-	///@name Protected LifeCycle
-	///@{
-
-
 	///@}
 
 private:
-	///@name Static Member Variables
-	///@{
+    ///@name Member Variables
+    ///@{
 
-	// static const ApplicationCondition  msApplicationCondition;
+    const CompressiblePotentialFlowElement<2,3> mCompressiblePotentialFlowElement2D3N;
+    const CompressiblePotentialFlowElement<3,4> mCompressiblePotentialFlowElement3D4N;
 
-	///@}
-	///@name Member Variables
-	///@{
-        const CompressiblePotentialFlowElement<2,3> mCompressiblePotentialFlowElement2D3N;
-        const CompressiblePotentialFlowElement<3,4> mCompressiblePotentialFlowElement3D4N;
-        const PotentialWallCondition<2,2> mPotentialWallCondition2D2N;
-        const PotentialWallCondition<3,3> mPotentialWallCondition3D3N;
+    const IncompressiblePotentialFlowElement<2,3> mIncompressiblePotentialFlowElement2D3N;
 
-		const IncompressiblePotentialFlowElement<2,3> mIncompressiblePotentialFlowElement2D3N;
+    const PotentialWallCondition<2,2> mPotentialWallCondition2D2N;
+    const PotentialWallCondition<3,3> mPotentialWallCondition3D3N;
 
+    ///@}
+    ///@name Un accessible methods
+    ///@{
 
-	///@}
-	///@name Private Operators
-	///@{
+    /// Assignment operator.
+    KratosCompressiblePotentialFlowApplication& operator=(KratosCompressiblePotentialFlowApplication const& rOther);
 
+    /// Copy constructor.
+    KratosCompressiblePotentialFlowApplication(KratosCompressiblePotentialFlowApplication const& rOther);
 
-	///@}
-	///@name Private Operations
-	///@{
-
-
-	///@}
-	///@name Private  Access
-	///@{
-
-
-	///@}
-	///@name Private Inquiry
-	///@{
-
-
-	///@}
-	///@name Un accessible methods
-	///@{
-
-	/// Assignment operator.
-	KratosCompressiblePotentialFlowApplication& operator=(KratosCompressiblePotentialFlowApplication const& rOther);
-
-	/// Copy constructor.
-	KratosCompressiblePotentialFlowApplication(KratosCompressiblePotentialFlowApplication const& rOther);
-
-
-	///@}
+    ///@}
 
 }; // Class KratosCompressiblePotentialFlowApplication
 
 ///@}
-
-
-///@name Type Definitions
-///@{
-
-
-///@}
-///@name Input and output
-///@{
-
-///@}
-
 
 }  // namespace Kratos.
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
@@ -598,7 +598,7 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::ComputeElementInternalEn
         ComputeVelocityUpperWakeElement(velocity);
 
     internal_energy = 0.5 * inner_prod(velocity, velocity);
-    this->SetValue(INTERNAL_ENERGY, abs(internal_energy));
+    this->SetValue(INTERNAL_ENERGY, std::abs(internal_energy));
 }
 
 template <int Dim, int NumNodes>


### PR DESCRIPTION
this is a bug, in Linux the outcome of `abs` is an integer!
In windows it would work though :)

=> always use `std::abs` (not `fabs` or `abs`)

I am just reporting, haven't run the tests and have no clue abt the consequences :)