### PR TITLE
[Hotfix][Core][ContactStructuralMechanicsApplication] Checking condition number before invert matrix

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.h
@@ -1392,7 +1392,7 @@ private:
         const BoundedMatrix<double, 2, 2> J = prod(trans(DN),DN);
         double det_j;
         BoundedMatrix<double, 2, 2> invJ = MathUtils<double>::InvertMatrix<2>(J, det_j, -1.0);
-        const bool good_condition_number = PrivateCheckConditionNumber(J, invJ);
+        const bool good_condition_number = MathUtils<double>::CheckConditionNumber(J, invJ, std::numeric_limits<double>::epsilon(), false);
         if (!good_condition_number) // Reset in case of bad condition number
             noalias(invJ) = ZeroMatrix(2,2);
 
@@ -1412,7 +1412,7 @@ private:
 //
 //         double det_L;
 //         BoundedMatrix<double, 3, 3> invL = MathUtils<double>::InvertMatrix<3>(L, det_L, -1.0);
-//         const bool good_condition_number = PrivateCheckConditionNumber(L, invL);
+//         const bool good_condition_number = MathUtils<double>::CheckConditionNumber(L, invL, std::numeric_limits<double>::epsilon(), false);
 //         if (!good_condition_number) // Reset in case of bad condition number
 //             noalias(invL) = ZeroMatrix(3,3);
 //         array_1d<double, 3> aux = prod(invL, DeltaPoint);
@@ -1451,7 +1451,7 @@ private:
         const BoundedMatrix<double, 2, 2> J = prod(trans(DN),DN);
         double det_j;
         BoundedMatrix<double, 2, 2> invJ = MathUtils<double>::InvertMatrix<2>(J, det_j, -1.0);
-        const bool good_condition_number = PrivateCheckConditionNumber(J, invJ);
+        const bool good_condition_number = MathUtils<double>::CheckConditionNumber(J, invJ, std::numeric_limits<double>::epsilon(), false);
         if (!good_condition_number) // Reset in case of bad condition number
             noalias(invJ) = ZeroMatrix(2,2);
 
@@ -1586,37 +1586,6 @@ private:
          const double rhs = (rN2[iNode]*DX2(0, iNode)-DXa[0])*na[1] - (rN2[iNode]*DX2(1, iNode)-DXa[1])*na[0] + (rN2[iNode]*X2(0, iNode)-Xa[0])*Dna[1] - (rN2[iNode]*X2(1, iNode)-Xa[1])*Dna[0];
 
          return lhs*rhs;
-    }
-
-    /**
-     * @brief This method checks the condition number of  matrix (private method that copies the code of MathUtils)
-     * @param rInputMatrix Is the input matrix (unchanged at output)
-     * @param rInvertedMatrix Is the inverse of the input matrix
-     * @param Tolerance The maximum tolerance considered
-     * @return False of bad conditioned
-     */
-    template<class TMatrix1, class TMatrix2>
-    static inline bool PrivateCheckConditionNumber(
-        const TMatrix1& rInputMatrix,
-        TMatrix2& rInvertedMatrix,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
-        )
-    {
-        // We want at least 4 significant digits
-        const double max_condition_number = (1.0/Tolerance) * 1.0e-4;
-
-        // Find the condition number to define is inverse is OK
-        const double input_matrix_norm = norm_frobenius(rInputMatrix);
-        const double inverted_matrix_norm = norm_frobenius(rInvertedMatrix);
-
-        // Now the condition number is the product of both norms
-        const double cond_number = input_matrix_norm * inverted_matrix_norm ;
-        // Finally check if the condition number is low enough
-        if (cond_number > max_condition_number) {
-            return false;
-        }
-
-        return true;
     }
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.h
@@ -1390,12 +1390,14 @@ private:
         const BoundedMatrix<double, 3, 2> DN = prod(X, rDNDe);
 
         const BoundedMatrix<double, 2, 2> J = prod(trans(DN),DN);
-        double det_j = MathUtils<double>::DetMat<BoundedMatrix<double, 2, 2>>(J);
-        const BoundedMatrix<double, 2, 2> invJ = (std::abs(det_j) < ZeroTolerance) ? ZeroMatrix(2,2) : MathUtils<double>::InvertMatrix<2>(J, det_j);
+        double det_j;
+        BoundedMatrix<double, 2, 2> invJ = MathUtils<double>::InvertMatrix<2>(J, det_j, -1.0);
+        const bool good_condition_number = PrivateCheckConditionNumber(J, invJ);
+        if (!good_condition_number) // Reset in case of bad condition number
+            noalias(invJ) = ZeroMatrix(2,2);
 
     #ifdef KRATOS_DEBUG
-        if (std::abs(det_j) < ZeroTolerance)
-            KRATOS_WARNING("Jacobian invert") << "WARNING: CANNOT INVERT JACOBIAN TO COMPUTE DELTA COORDINATES" << std::endl;
+        KRATOS_WARNING_IF("Jacobian invert", !good_condition_number) << "WARNING:: CANNOT INVERT JACOBIAN TO COMPUTE DELTA COORDINATES" << std::endl;
     #endif
 
         const array_1d<double, 2> res = prod(trans(DN), rDeltaPoint);
@@ -1408,14 +1410,16 @@ private:
 //             L(i, 2) = ThisNormal[i];
 //         }
 //
-//         double det_L = MathUtils<double>::DetMat<BoundedMatrix<double, 3, 3>>(L);
-//         const BoundedMatrix<double, 3, 3> invL = (std::abs(det_L) < tolerance) ? ZeroMatrix(3,3) : MathUtils<double>::InvertMatrix<3>(L, det_L);
+//         double det_L;
+//         BoundedMatrix<double, 3, 3> invL = MathUtils<double>::InvertMatrix<3>(L, det_L, -1.0);
+//         const bool good_condition_number = PrivateCheckConditionNumber(L, invL);
+//         if (!good_condition_number) // Reset in case of bad condition number
+//             noalias(invL) = ZeroMatrix(3,3);
 //         array_1d<double, 3> aux = prod(invL, DeltaPoint);
 //         rResult[0] = aux[0];
 //         rResult[1] = aux[1];
 //         #ifdef KRATOS_DEBUG
-//             if (std::abs(det_L) < tolerance)
-//                 KRATOS_WARNING("Jacobian invert") << "WARNING: CANNOT INVERT JACOBIAN TO COMPUTE DELTA COORDINATES" << std::endl;
+//             KRATOS_WARNING_IF("Jacobian invert", !good_condition_number) << "WARNING: CANNOT INVERT JACOBIAN TO COMPUTE DELTA COORDINATES" << std::endl;
 //         #endif
     }
 
@@ -1445,12 +1449,14 @@ private:
         const BoundedMatrix<double, 3, 2> DN = prod(X, rDNDe);
 
         const BoundedMatrix<double, 2, 2> J = prod(trans(DN),DN);
-        double det_j = MathUtils<double>::DetMat<BoundedMatrix<double, 2, 2>>(J);
-        const BoundedMatrix<double, 2, 2> invJ = (std::abs(det_j) < ZeroTolerance) ? ZeroMatrix(2,2) : MathUtils<double>::InvertMatrix<2>(J, det_j);
+        double det_j;
+        BoundedMatrix<double, 2, 2> invJ = MathUtils<double>::InvertMatrix<2>(J, det_j, -1.0);
+        const bool good_condition_number = PrivateCheckConditionNumber(J, invJ);
+        if (!good_condition_number) // Reset in case of bad condition number
+            noalias(invJ) = ZeroMatrix(2,2);
 
     #ifdef KRATOS_DEBUG
-        if (std::abs(det_j) < ZeroTolerance)
-            KRATOS_WARNING("Jacobian invert") << "WARNING: CANNOT INVERT JACOBIAN TO COMPUTE DELTA COORDINATES" << std::endl;
+        KRATOS_WARNING_IF("Jacobian invert", !good_condition_number) << "WARNING:: CANNOT INVERT JACOBIAN TO COMPUTE DELTA COORDINATES" << std::endl;
     #endif
 
         const array_1d<double, 2> res = prod(trans(DN), rDeltaPoint);
@@ -1580,6 +1586,37 @@ private:
          const double rhs = (rN2[iNode]*DX2(0, iNode)-DXa[0])*na[1] - (rN2[iNode]*DX2(1, iNode)-DXa[1])*na[0] + (rN2[iNode]*X2(0, iNode)-Xa[0])*Dna[1] - (rN2[iNode]*X2(1, iNode)-Xa[1])*Dna[0];
 
          return lhs*rhs;
+    }
+
+    /**
+     * @brief This method checks the condition number of  matrix (private method that copies the code of MathUtils)
+     * @param rInputMatrix Is the input matrix (unchanged at output)
+     * @param rInvertedMatrix Is the inverse of the input matrix
+     * @param Tolerance The maximum tolerance considered
+     * @return False of bad conditioned
+     */
+    template<class TMatrix1, class TMatrix2>
+    static inline bool PrivateCheckConditionNumber(
+        const TMatrix1& rInputMatrix,
+        TMatrix2& rInvertedMatrix,
+        const double Tolerance = std::numeric_limits<double>::epsilon()
+        )
+    {
+        // We want at least 4 significant digits
+        const double max_condition_number = (1.0/Tolerance) * 1.0e-4;
+
+        // Find the condition number to define is inverse is OK
+        const double input_matrix_norm = norm_frobenius(rInputMatrix);
+        const double inverted_matrix_norm = norm_frobenius(rInvertedMatrix);
+
+        // Now the condition number is the product of both norms
+        const double cond_number = input_matrix_norm * inverted_matrix_norm ;
+        // Finally check if the condition number is low enough
+        if (cond_number > max_condition_number) {
+            return false;
+        }
+
+        return true;
     }
 
     ///@}

--- a/kratos/includes/mortar_classes.h
+++ b/kratos/includes/mortar_classes.h
@@ -1618,10 +1618,10 @@ public:
             const GeometryMatrixType normalized_Me = Me/norm_me;
 
             // We compute the normalized inverse
-            double aux_det = MathUtils<double>::DetMat<GeometryMatrixType>(normalized_Me);
-            if (std::abs(aux_det) >= tolerance) {
-                const GeometryMatrixType normalized_inv_Me = MathUtils<double>::InvertMatrix<TNumNodes>(normalized_Me, aux_det, tolerance);
-
+            double aux_det;
+            GeometryMatrixType normalized_inv_Me = MathUtils<double>::InvertMatrix<TNumNodes>(normalized_Me, aux_det, -1.0);
+            const bool good_condition_number = MathUtils<double>::CheckConditionNumber(normalized_Me, normalized_inv_Me, tolerance, false);
+            if (good_condition_number) {
                 noalias(Ae) = (1.0/norm_me) * prod(De, normalized_inv_Me);
                 return true;
             }
@@ -1871,7 +1871,6 @@ public:
      */
     bool CalculateDeltaAe(DerivativeDataType& rDerivativeData)
     {
-        double aux_det;
         const double tolerance = std::numeric_limits<double>::epsilon();
 
         // We compute the norm
@@ -1881,10 +1880,12 @@ public:
         const GeometryMatrixType normalized_Me = BaseClassType::Me/norm_Me;
 
         // We compute the normalized inverse
-        aux_det = MathUtils<double>::DetMat<GeometryMatrixType>(normalized_Me);
-        if (std::abs(aux_det) < tolerance) return false;
-
-        const GeometryMatrixType normalized_inv_Me = MathUtils<double>::InvertMatrix<TNumNodes>(normalized_Me, aux_det, tolerance);
+        double aux_det;
+        GeometryMatrixType normalized_inv_Me = MathUtils<double>::InvertMatrix<TNumNodes>(normalized_Me, aux_det, -1.0);
+        const bool good_condition_number = MathUtils<double>::CheckConditionNumber(normalized_Me, normalized_inv_Me, tolerance, false);
+        if (!good_condition_number) {
+            return false;
+        }
 
         // Now we compute the inverse
         const GeometryMatrixType inv_Me = normalized_inv_Me/norm_Me;

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -10,7 +10,7 @@
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
 //
-//  Collaborators:    Vicente Mataix Ferrandiz 
+//  Collaborators:    Vicente Mataix Ferrandiz
 //                    Pablo Becker
 //
 
@@ -367,10 +367,11 @@ public:
      * @param Tolerance The maximum tolerance considered
      */
     template<class TMatrix1, class TMatrix2>
-    static inline void CheckConditionNumber(
+    static inline bool CheckConditionNumber(
         const TMatrix1& rInputMatrix,
         TMatrix2& rInvertedMatrix,
-        const TDataType Tolerance = std::numeric_limits<double>::epsilon()
+        const TDataType Tolerance = std::numeric_limits<double>::epsilon(),
+        const bool ThrowError = true
         )
     {
         // We want at least 4 significant digits
@@ -384,9 +385,14 @@ public:
         const double cond_number = input_matrix_norm * inverted_matrix_norm ;
         // Finally check if the condition number is low enough
         if (cond_number > max_condition_number) {
-            KRATOS_WATCH(rInputMatrix);
-            KRATOS_ERROR << " Condition number of the matrix is too high!, cond_number = " << cond_number << std::endl;
+            if (ThrowError) {
+                KRATOS_WATCH(rInputMatrix);
+                KRATOS_ERROR << " Condition number of the matrix is too high!, cond_number = " << cond_number << std::endl;
+            }
+            return false;
         }
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
Previously the determinant was checked, now I check the condition number before instead. Without this many tests fail