### PR TITLE
Adding write nodal results non historial for integer Variables

### DIFF
--- a/kratos/includes/gid_io.h
+++ b/kratos/includes/gid_io.h
@@ -963,6 +963,25 @@ public:
     }
 
     /**
+     * writes nodal results for variables of type int
+     */
+    void WriteNodalResultsNonHistorical( Variable<int> const& rVariable, NodesContainerType& rNodes, double SolutionTag)
+    {
+
+        Timer::Start("Writing Results");
+        GiD_fBeginResult( mResultFile, (char*)(rVariable.Name().c_str()), "Kratos",
+                          SolutionTag, GiD_Scalar,
+                          GiD_OnNodes, NULL, NULL, 0, NULL );
+        for ( NodesContainerType::iterator it_node = rNodes.begin();
+              it_node != rNodes.end() ; ++it_node)
+            GiD_fWriteScalar( mResultFile, it_node->Id(), it_node->GetValue(rVariable) );
+        GiD_fEndResult(mResultFile);
+
+        Timer::Stop("Writing Results");
+
+    }
+
+    /**
      * writes nodal results for variables of type array_1d<double, 3>
      * (e.g. DISPLACEMENT)
      */

--- a/kratos/python/add_io_to_python.cpp
+++ b/kratos/python/add_io_to_python.cpp
@@ -147,6 +147,8 @@ void (GidIO<>::*pointer_to_bool_write_nodal_results_NH)( Variable<bool> const& r
 	= &GidIO<>::WriteNodalResultsNonHistorical;
 void (GidIO<>::*pointer_to_double_write_nodal_results_NH)( Variable<double> const& rVariable,  GidIO<>::NodesContainerType& rNodes, double SolutionTag)
         = &GidIO<>::WriteNodalResultsNonHistorical;
+void (GidIO<>::*pointer_to_int_write_nodal_results_NH)( Variable<int> const& rVariable,  GidIO<>::NodesContainerType& rNodes, double SolutionTag)
+        = &GidIO<>::WriteNodalResultsNonHistorical;
 void (GidIO<>::*pointer_to_array1d_write_nodal_results_NH)(Variable<array_1d<double, 3> > const& rVariable, GidIO<>::NodesContainerType& rNodes, double SolutionTag) = &GidIO<>::WriteNodalResultsNonHistorical;
 void (GidIO<>::*pointer_to_vector_write_nodal_results_NH)(Variable<Vector > const& rVariable, GidIO<>::NodesContainerType& rNodes, double SolutionTag)
         = &GidIO<>::WriteNodalResultsNonHistorical;
@@ -255,6 +257,7 @@ void  AddIOToPython(pybind11::module& m)
     .def("WriteNodalFlags",pointer_to_flags_write_nodal_results_NH)
     .def("WriteNodalResultsNonHistorical",pointer_to_bool_write_nodal_results_NH)
     .def("WriteNodalResultsNonHistorical",pointer_to_double_write_nodal_results_NH)
+    .def("WriteNodalResultsNonHistorical",pointer_to_int_write_nodal_results_NH)
     .def("WriteNodalResultsNonHistorical",pointer_to_array1d_write_nodal_results_NH)
     .def("WriteNodalResultsNonHistorical",pointer_to_vector_write_nodal_results_NH)
     .def("WriteNodalResultsNonHistorical",pointer_to_matrix_write_nodal_results_NH)


### PR DESCRIPTION
The title speaks for itself. Is there any reason why this was not done before?