### PR TITLE
Atempting to solve cascade-enables of non cotired items in win

### DIFF
--- a/applications/CMakeLists.txt
+++ b/applications/CMakeLists.txt
@@ -186,6 +186,18 @@ if(${EXTERNAL_SOLVERS_APPLICATION} MATCHES ON)
   add_subdirectory(ExternalSolversApplication)
 endif(${EXTERNAL_SOLVERS_APPLICATION} MATCHES ON)
 
+if(${DELAUNAY_MESHING_APPLICATION} MATCHES ON)
+  add_subdirectory(DelaunayMeshingApplication)
+endif(${DELAUNAY_MESHING_APPLICATION} MATCHES ON)
+
+if(${CONSTITUTIVE_MODELS_APPLICATION} MATCHES ON)
+  add_subdirectory(ConstitutiveModelsApplication)
+endif(${CONSTITUTIVE_MODELS_APPLICATION} MATCHES ON)
+
+if(${CONTACT_MECHANICS_APPLICATION} MATCHES ON)
+  add_subdirectory(ContactMechanicsApplication)
+endif(${CONTACT_MECHANICS_APPLICATION} MATCHES ON)
+
 if(${SOLID_MECHANICS_APPLICATION} MATCHES ON)
   add_subdirectory(SolidMechanicsApplication)
 endif(${SOLID_MECHANICS_APPLICATION} MATCHES ON)
@@ -201,14 +213,6 @@ endif(${PFEM_SOLID_MECHANICS_APPLICATION} MATCHES ON)
 if(${PFEM_FLUID_DYNAMICS_APPLICATION} MATCHES ON)
   add_subdirectory(PfemFluidDynamicsApplication)
 endif(${PFEM_FLUID_DYNAMICS_APPLICATION} MATCHES ON)
-
-if(${CONTACT_MECHANICS_APPLICATION} MATCHES ON)
-  add_subdirectory(ContactMechanicsApplication)
-endif(${CONTACT_MECHANICS_APPLICATION} MATCHES ON)
-
-if(${CONSTITUTIVE_MODELS_APPLICATION} MATCHES ON)
-  add_subdirectory(ConstitutiveModelsApplication)
-endif(${CONSTITUTIVE_MODELS_APPLICATION} MATCHES ON)
 
 if(${UMAT_APPLICATION} MATCHES ON)
   add_subdirectory(UmatApplication)
@@ -381,10 +385,6 @@ endif(${EIGEN_SOLVERS_APPLICATION} MATCHES ON)
 if(${STABILIZED_CFD_APPLICATION} MATCHES ON)
   add_subdirectory(StabilizedCFDApplication)
 endif(${STABILIZED_CFD_APPLICATION} MATCHES ON)
-
-if(${DELAUNAY_MESHING_APPLICATION} MATCHES ON)
-  add_subdirectory(DelaunayMeshingApplication)
-endif(${DELAUNAY_MESHING_APPLICATION} MATCHES ON)
 
 if(${FREE_SURFACE_APPLICATION} MATCHES ON)
   add_subdirectory(FreeSurfaceApplication)


### PR DESCRIPTION
After some investigation I've discovered that either cmake or cotire work a bit different in win, and targeting projects as dependencies of other projects before cotiring the dependencies may cause the non-cotired project to trigger its compilation, and of every non-cotire dependencie of the former. 

In it is possible that appveyor is compiling some items twice, most notably, the core since its a dependency of everything.