### PR TITLE
[Core] Element/Condition: removing deprecated functions

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/solid_shell_element_sprism_3D6N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/solid_shell_element_sprism_3D6N.cpp
@@ -474,62 +474,6 @@ void SolidShellElementSprism3D6N::CalculateLocalSystem(
 /***********************************************************************************/
 /***********************************************************************************/
 
-void SolidShellElementSprism3D6N::CalculateLocalSystem(
-    std::vector< MatrixType >& rLeftHandSideMatrices,
-    const std::vector< Variable< MatrixType > >& rLHSVariables,
-    std::vector< VectorType >& rRightHandSideVectors,
-    const std::vector< Variable< VectorType > >& rRHSVariables,
-    ProcessInfo& rCurrentProcessInfo
-    )
-{
-    KRATOS_TRY;
-
-    /* Create local system components */
-    LocalSystemComponents local_system;
-
-    /* Calculation flags*/
-    local_system.CalculationFlags.Set(SolidShellElementSprism3D6N::COMPUTE_LHS_MATRIX_WITH_COMPONENTS);
-    local_system.CalculationFlags.Set(SolidShellElementSprism3D6N::COMPUTE_RHS_VECTOR_WITH_COMPONENTS);
-
-    /* Initialize sizes for the system components: */
-    if( rLHSVariables.size() != rLeftHandSideMatrices.size() ) {
-        rLeftHandSideMatrices.resize(rLHSVariables.size());
-    }
-
-    if( rRHSVariables.size() != rRightHandSideVectors.size() ) {
-        rRightHandSideVectors.resize(rRHSVariables.size());
-    }
-
-    local_system.CalculationFlags.Set(SolidShellElementSprism3D6N::COMPUTE_LHS_MATRIX);
-    for( IndexType i = 0; i < rLeftHandSideMatrices.size(); ++i ) {
-        this->InitializeSystemMatrices( rLeftHandSideMatrices[i], rRightHandSideVectors[0], local_system.CalculationFlags );
-    }
-
-    local_system.CalculationFlags.Set(SolidShellElementSprism3D6N::COMPUTE_RHS_VECTOR, true);
-    local_system.CalculationFlags.Set(SolidShellElementSprism3D6N::COMPUTE_LHS_MATRIX, false);
-
-    for( IndexType i = 0; i < rRightHandSideVectors.size(); ++i ) {
-        this->InitializeSystemMatrices( rLeftHandSideMatrices[0], rRightHandSideVectors[i], local_system.CalculationFlags );
-    }
-
-    local_system.CalculationFlags.Set(SolidShellElementSprism3D6N::COMPUTE_LHS_MATRIX, true);
-
-    /* Set general_variables to Local system components */
-    local_system.SetLeftHandSideMatrices(rLeftHandSideMatrices);
-    local_system.SetRightHandSideVectors(rRightHandSideVectors);
-
-    local_system.SetLeftHandSideVariables(rLHSVariables);
-    local_system.SetRightHandSideVariables(rRHSVariables);
-
-    /* Calculate elemental system */
-    CalculateElementalSystem( local_system, rCurrentProcessInfo );
-
-    KRATOS_CATCH("");
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
 void SolidShellElementSprism3D6N::CalculateMassMatrix(
     MatrixType& rMassMatrix,
     ProcessInfo& rCurrentProcessInfo

--- a/applications/StructuralMechanicsApplication/custom_elements/solid_shell_element_sprism_3D6N.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/solid_shell_element_sprism_3D6N.h
@@ -293,23 +293,6 @@ public:
         ProcessInfo& rCurrentProcessInfo
         ) override;
 
-     /**
-      * @brief This function provides a more general interface to the element.
-      * it is designed so that rLHSvariables and rRHSvariables are passed TO the element
-      * thus telling what is the desired output
-      * @param rLHSVariables paramter describing the expected LHSs
-      * @param rRightHandSideVectors container for the desired RHS output
-      * @param rRHSVariables parameter describing the expected RHSs
-      */
-
-     void CalculateLocalSystem(
-        std::vector< MatrixType >& rLeftHandSideMatrices,
-        const std::vector< Variable< MatrixType > >& rLHSVariables,
-        std::vector< VectorType >& rRightHandSideVectors,
-        const std::vector< Variable< VectorType > >& rRHSVariables,
-        ProcessInfo& rCurrentProcessInfo
-        ) override;
-
     /**
       * @brief This is called during the assembling process in order
       * to calculate the elemental mass matrix

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -193,21 +193,6 @@ public:
         return *this;
     }
 
-
-    ///@}
-    ///@name Informations
-    ///@{
-
-    /** Dimensional space of the element geometry
-    @return SizeType, working space dimension of this geometry.
-    */
-
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please ask directly the Geometry") SizeType WorkingSpaceDimension() const
-    {
-        return pGetGeometry()->WorkingSpaceDimension();
-    }
-
-
     ///@}
     ///@name Operations
     ///@{
@@ -431,23 +416,6 @@ public:
       rLeftHandSideMatrix.resize(0, 0, false);
         if (rRightHandSideVector.size() != 0)
       rRightHandSideVector.resize(0, false);
-    }
-
-    /**
-     * this function provides a more general interface to the condition.
-     * it is designed so that rLHSvariables and rRHSvariables are passed TO the condition
-     * thus telling what is the desired output
-     * @param rLeftHandSideMatrices container with the output left hand side matrices
-     * @param rLHSVariables paramter describing the expected LHSs
-     * @param rRightHandSideVectors container for the desired RHS output
-     * @param rRHSVariables parameter describing the expected RHSs
-     */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function") virtual void CalculateLocalSystem(std::vector< MatrixType >& rLeftHandSideMatrices,
-                                      const std::vector< Variable< MatrixType > >& rLHSVariables,
-                                      std::vector< VectorType >& rRightHandSideVectors,
-                                      const std::vector< Variable< VectorType > >& rRHSVariables,
-                                      ProcessInfo& rCurrentProcessInfo)
-    {
     }
 
     /**
@@ -992,8 +960,6 @@ public:
         if (rOutput.size1() != 0)
             rOutput.resize(0, 0, false);
     }
-
-    //METHODS TO BE CLEANED: DEPRECATED end
 
     ///@}
     ///@name Access

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -190,19 +190,6 @@ public:
     }
 
     ///@}
-    ///@name Informations
-    ///@{
-
-    /** Dimensional space of the element geometry
-	@return SizeType, working space dimension of this geometry.
-    */
-
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please ask directly the Geometry") SizeType WorkingSpaceDimension() const
-    {
-         return pGetGeometry()->WorkingSpaceDimension();
-    }
-
-    ///@}
     ///@name Operations
     ///@{
 
@@ -430,23 +417,6 @@ public:
 	  rLeftHandSideMatrix.resize(0, 0, false);
         if (rRightHandSideVector.size() != 0)
 	  rRightHandSideVector.resize(0, false);
-    }
-
-    /**
-     * this function provides a more general interface to the element.
-     * it is designed so that rLHSvariables and rRHSvariables are passed TO the element
-     * thus telling what is the desired output
-     * @param rLeftHandSideMatrices container with the output left hand side matrices
-     * @param rLHSVariables paramter describing the expected LHSs
-     * @param rRightHandSideVectors container for the desired RHS output
-     * @param rRHSVariables parameter describing the expected RHSs
-     */
-    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function") virtual void CalculateLocalSystem(std::vector< MatrixType >& rLeftHandSideMatrices,
-                                      const std::vector< Variable< MatrixType > >& rLHSVariables,
-                                      std::vector< VectorType >& rRightHandSideVectors,
-                                      const std::vector< Variable< VectorType > >& rRHSVariables,
-                                      ProcessInfo& rCurrentProcessInfo)
-    {
     }
 
     /**
@@ -1016,9 +986,6 @@ public:
         if (rOutput.size1() != 0)
             rOutput.resize(0, 0, false);
     }
-
-
-    //METHODS TO BE CLEANED: DEPRECATED end
 
     ///@}
     ///@name Access


### PR DESCRIPTION
removing the functions that were deprecated some time ago

@loumalouomega apparently the deprecated version of `CalculateLocalSystem` is still being used (though I don't think it is ever called) in the SolidShellElement. No clue why it did not give the deprecation-warning. Can you have a look please?