### PR TITLE
[HotFix][Core]fix a small bug in the residualbased_builder_and_solver

### DIFF
--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -1097,7 +1097,7 @@ protected:
 
             TSystemVectorType bmodified(rb.size());
             TSparseSpace::Mult(T_transpose_matrix, rb, bmodified);
-            noalias(rb) = bmodified;
+            TSparseSpace::Copy(bmodified, rb);
             bmodified.resize(0, false); //free memory
 
             TSystemMatrixType auxiliar_A_matrix(mT.size2(), rA.size2());


### PR DESCRIPTION
to avoid using noalias and to use optimized routine in the linear algebra space
