### PR TITLE
[Core] Hotfix - missing ublas_space in amgcl_solver

### DIFF
--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -35,6 +35,7 @@
 #include "includes/kratos_parameters.h"
 #include "linear_solvers/iterative_solver.h"
 #include "includes/ublas_interface.h"
+#include "spaces/ublas_space.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
I get the following error in windows if I do not add that include 
![error](https://user-images.githubusercontent.com/25667299/53026421-2f363880-3463-11e9-9916-0fadabcf7737.JPG)
