### PR TITLE
Always determining kratos paths at runtime import.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,6 @@ cmake_build/*
 packaging/*
 packaging_aux/KratosLoader.py
 packaging_aux/kratos.conf
-kratos/python_interface/KratosPaths.py
 
 # Compile and install directories
 KratosMultiphysics/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -446,20 +446,6 @@ if(${BLAS_INCLUDE_NEEDED} MATCHES ON )
 	install(FILES ${LAPACK_LIBRARIES} DESTINATION libs)
 endif(${BLAS_INCLUDE_NEEDED} MATCHES ON )
 
-# Configure and install KratosPaths.py, containing routes to installed kratos modules.
-set(KratosMultiphysics_KRATOS_INSTALL_PATH ${CMAKE_INSTALL_PREFIX})
-if (${INSTALL_PYTHON_FILES} MATCHES ON)
-  set(KratosMultiphysics_KRATOS_PYTHON_SOURCE_PATH ${CMAKE_INSTALL_PREFIX})
-else ()
-  set(KratosMultiphysics_KRATOS_PYTHON_SOURCE_PATH ${CMAKE_SOURCE_DIR})
-endif (${INSTALL_PYTHON_FILES} MATCHES ON)
-
-configure_file(
-  "${CMAKE_SOURCE_DIR}/kratos/python_interface/KratosPaths.py.in"
-  "${CMAKE_SOURCE_DIR}/kratos/python_interface/KratosPaths.py"
-)
-install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/KratosPaths.py" DESTINATION "${CMAKE_INSTALL_PREFIX}/KratosMultiphysics")
-
 ################################################################################
 if(${INSTALL_PYTHON_FILES} MATCHES ON)
   file(WRITE ${CMAKE_SOURCE_DIR}/packaging_aux/kratos.conf "${CMAKE_INSTALL_PREFIX}/libs")

--- a/kratos/mpi/python_scripts/mpi_module_init.py
+++ b/kratos/mpi/python_scripts/mpi_module_init.py
@@ -23,7 +23,7 @@ def __PathInitDetail():
     from KratosMultiphysics import KratosPaths
     import os
 
-    kratos_mpi_python_path = os.path.abspath(os.path.join(KratosPaths.kratos_python_source_path, "kratos", "mpi", "python_scripts"))
+    kratos_mpi_python_path = os.path.join(KratosPaths.kratos_install_path, "kratos", "mpi", "python_scripts")
     __path__.append(kratos_mpi_python_path)
 
 __PathInitDetail()

--- a/kratos/python_interface/KratosPaths.py.in
+++ b/kratos/python_interface/KratosPaths.py.in
@@ -1,8 +1,0 @@
-kratos_install_path = "@KratosMultiphysics_KRATOS_INSTALL_PATH@"
-kratos_python_source_path = "@KratosMultiphysics_KRATOS_PYTHON_SOURCE_PATH@"
-
-import os
-kratos_libs = os.path.abspath(os.path.join(kratos_install_path, "libs"))
-kratos_applications = os.path.abspath(os.path.join(kratos_python_source_path, "applications"))
-kratos_scripts = os.path.abspath(os.path.join(kratos_python_source_path, "kratos/python_scripts"))
-kratos_tests = os.path.abspath(os.path.join(kratos_python_source_path, "kratos/tests"))

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -3,10 +3,16 @@ import os.path
 import sys
 from . import kratos_globals
 
-from . import KratosPaths
-sys.path.append(KratosPaths.kratos_libs)
+class KratosPaths(object):
+    kratos_install_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+
+    kratos_libs = os.path.join(kratos_install_path, "libs")
+    kratos_applications = os.path.join(kratos_install_path, "applications")
+    kratos_scripts = os.path.join(kratos_install_path, "kratos", "python_scripts")
+    kratos_tests = os.path.join(kratos_install_path, "kratos", "tests")
 
 # import core library (Kratos.so)
+sys.path.append(KratosPaths.kratos_libs)
 from Kratos import *
 
 def __ModuleInitDetail():


### PR DESCRIPTION
Looks like I introduced a bug in #4156: pyhton cannot import kratos if kratos is installed and then the installed files are moved to a new path (this used to work before).

@roigcarlo and @pooyan-dadvand suggested simplifying the import mechanism so that now we can work without an extra file to be configured by cmake.

This should be pushed to the release branch too, I believe.