### PR TITLE
Clean up and fixing Calculate for eq_strain_rate and viscosity

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/stokes_3D_twofluid.h
+++ b/applications/FluidDynamicsApplication/custom_elements/stokes_3D_twofluid.h
@@ -330,13 +330,6 @@ public:
 
                 Vector strain = CalculateStrain();
                 Values.SetStrainVector(strain);
-                //MODIFICATION: Add limits to the strain. In order to do so, we call the consitutive model of the element:
-                const double gamma_dot = std::sqrt(2.*strain[0] * strain[0] + 2.*strain[1] * strain[1] + 2.*strain[2] * strain[2]
-                    + strain[3] * strain[3] + strain[4] * strain[4] + strain[5] * strain[5]); 
-                double gamma_dot_from_constitutive_law = mp_constitutive_law->GetValue(EQ_STRAIN_RATE, gamma_dot_from_constitutive_law);
-                double ratio = fabs(gamma_dot_from_constitutive_law/gamma_dot);
-                if(ratio>1.0 || ratio<1e-20) ratio = 1.0;
-                strain*=ratio; 
 
                 Vector stress(strain_size);
                 Values.SetStressVector(stress); //this is an ouput parameter
@@ -737,7 +730,7 @@ public:
 
         double max_diag = 0.0;
         for(unsigned int k=0; k<Dim+1; k++)
-            if(fabs(Kee_tot(k,k) ) > max_diag) max_diag = fabs(Kee_tot(k,k) );
+            if(std::abs(Kee_tot(k,k) ) > max_diag) max_diag = std::abs(Kee_tot(k,k) );
         if(max_diag == 0) max_diag = 1.0;
 
         if(positive_volume/Vol < min_area_ratio)
@@ -764,11 +757,11 @@ public:
         //"weakly" impose continuity
         for(unsigned int i=0; i<Dim; i++)
         {
-            const double di = fabs(distances[i]);
+            const double di = std::abs(distances[i]);
 
             for(unsigned int j=i+1; j<Dim+1; j++)
             {
-                const double dj =  fabs(distances[j]);
+                const double dj =  std::abs(distances[j]);
 
                 if( distances[i]*distances[j] < 0.0) //cut edge
                 {

--- a/applications/FluidDynamicsApplication/custom_elements/stokes_3D_twofluid.h
+++ b/applications/FluidDynamicsApplication/custom_elements/stokes_3D_twofluid.h
@@ -885,17 +885,16 @@ private:
 
         //getting data for the given geometry
         double Volume;
-        GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, Volume);
+        BoundedMatrix<double,NumNodes,Dim> v, DN;
+        array_1d<double,NumNodes> N;
+        GeometryUtils::CalculateGeometryData(GetGeometry(), DN, N, Volume);
 
         for (unsigned int i = 0; i < NumNodes; i++)
         {
             const array_1d<double,3>& vel = GetGeometry()[i].FastGetSolutionStepValue(VELOCITY);
             for(unsigned int k=0; k<Dim; k++)
-                data.v(i,k)   = vel[k];
+                v(i,k)   = vel[k];
         }
-
-        const BoundedMatrix<double,NumNodes,Dim>& v = data.v;
-        const BoundedMatrix<double,NumNodes,Dim>& DN = data.DN_DX;
 
         Vector strain(strain_size);
         strain[0] = DN(0,0)*v(0,0) + DN(1,0)*v(1,0) + DN(2,0)*v(2,0) + DN(3,0)*v(3,0);


### PR DESCRIPTION
previos merge was incomplete; the const:law::Calculate was being called without setting the strain tensor.
This PR fixes this and adds some clean up to the element, computing the strain in a different function