### PR TITLE
[StructuralMechanics] nonlin-shells fix serialization

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
@@ -2154,17 +2154,17 @@ ShellCrossSection::SectionBehaviorType ShellThickElement3D3N::GetSectionBehavior
 void ShellThickElement3D3N::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseShellElement);
-    bool is_derived = (nullptr != dynamic_cast<ShellT3_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
-    rSerializer.save("is_derived", is_derived);
+    bool is_corotational = (nullptr != dynamic_cast<ShellT3_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
+    rSerializer.save("is_corotational", is_corotational);
     rSerializer.save("CTr", *mpCoordinateTransformation);
 }
 
 void ShellThickElement3D3N::load(Serializer& rSerializer)
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseShellElement);
-    bool is_derived;
-    rSerializer.load("is_derived", is_derived);
-    if (is_derived) {
+    bool is_corotational;
+    rSerializer.load("is_corotational", is_corotational);
+    if (is_corotational) {
         mpCoordinateTransformation = Kratos::make_shared<ShellT3_CorotationalCoordinateTransformation>(pGetGeometry());
     } else {
         mpCoordinateTransformation = Kratos::make_shared<ShellT3_CoordinateTransformation>(pGetGeometry());

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
@@ -2154,13 +2154,22 @@ ShellCrossSection::SectionBehaviorType ShellThickElement3D3N::GetSectionBehavior
 void ShellThickElement3D3N::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseShellElement);
-    rSerializer.save("CTr", mpCoordinateTransformation);
+    bool is_derived = (nullptr != dynamic_cast<ShellT3_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
+    rSerializer.save("en", is_derived);
+    rSerializer.save("CTr", *mpCoordinateTransformation);
 }
 
 void ShellThickElement3D3N::load(Serializer& rSerializer)
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseShellElement);
-    rSerializer.load("CTr", mpCoordinateTransformation);
+    bool is_derived;
+    rSerializer.load("en", is_derived);
+    if (is_derived) {
+        mpCoordinateTransformation = Kratos::make_shared<ShellT3_CorotationalCoordinateTransformation>(pGetGeometry());
+    } else {
+        mpCoordinateTransformation = Kratos::make_shared<ShellT3_CoordinateTransformation>(pGetGeometry());
+    }
+    rSerializer.load("CTr", *mpCoordinateTransformation);
 }
 
 } // namespace Kratos

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D3N.cpp
@@ -2155,7 +2155,7 @@ void ShellThickElement3D3N::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseShellElement);
     bool is_derived = (nullptr != dynamic_cast<ShellT3_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
-    rSerializer.save("en", is_derived);
+    rSerializer.save("is_derived", is_derived);
     rSerializer.save("CTr", *mpCoordinateTransformation);
 }
 
@@ -2163,7 +2163,7 @@ void ShellThickElement3D3N::load(Serializer& rSerializer)
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseShellElement);
     bool is_derived;
-    rSerializer.load("en", is_derived);
+    rSerializer.load("is_derived", is_derived);
     if (is_derived) {
         mpCoordinateTransformation = Kratos::make_shared<ShellT3_CorotationalCoordinateTransformation>(pGetGeometry());
     } else {

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
@@ -1906,15 +1906,24 @@ ShellCrossSection::SectionBehaviorType ShellThickElement3D4N::GetSectionBehavior
 
 void ShellThickElement3D4N::save(Serializer& rSerializer) const
 {
-    KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer,  BaseShellElement );
-    rSerializer.save("CTr", mpCoordinateTransformation);
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseShellElement);
+    bool is_derived = (nullptr != dynamic_cast<ShellQ4_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
+    rSerializer.save("is_derived", is_derived);
+    rSerializer.save("CTr", *mpCoordinateTransformation);
     rSerializer.save("EAS", mEASStorage);
 }
 
 void ShellThickElement3D4N::load(Serializer& rSerializer)
 {
-    KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer,  BaseShellElement );
-    rSerializer.load("CTr", mpCoordinateTransformation);
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseShellElement);
+    bool is_derived;
+    rSerializer.load("is_derived", is_derived);
+    if (is_derived) {
+        mpCoordinateTransformation = Kratos::make_shared<ShellQ4_CorotationalCoordinateTransformation>(pGetGeometry());
+    } else {
+        mpCoordinateTransformation = Kratos::make_shared<ShellQ4_CoordinateTransformation>(pGetGeometry());
+    }
+    rSerializer.load("CTr", *mpCoordinateTransformation);
     rSerializer.load("EAS", mEASStorage);
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thick_element_3D4N.cpp
@@ -1907,8 +1907,8 @@ ShellCrossSection::SectionBehaviorType ShellThickElement3D4N::GetSectionBehavior
 void ShellThickElement3D4N::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseShellElement);
-    bool is_derived = (nullptr != dynamic_cast<ShellQ4_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
-    rSerializer.save("is_derived", is_derived);
+    bool is_corotational = (nullptr != dynamic_cast<ShellQ4_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
+    rSerializer.save("is_corotational", is_corotational);
     rSerializer.save("CTr", *mpCoordinateTransformation);
     rSerializer.save("EAS", mEASStorage);
 }
@@ -1916,9 +1916,9 @@ void ShellThickElement3D4N::save(Serializer& rSerializer) const
 void ShellThickElement3D4N::load(Serializer& rSerializer)
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseShellElement);
-    bool is_derived;
-    rSerializer.load("is_derived", is_derived);
-    if (is_derived) {
+    bool is_corotational;
+    rSerializer.load("is_corotational", is_corotational);
+    if (is_corotational) {
         mpCoordinateTransformation = Kratos::make_shared<ShellQ4_CorotationalCoordinateTransformation>(pGetGeometry());
     } else {
         mpCoordinateTransformation = Kratos::make_shared<ShellQ4_CoordinateTransformation>(pGetGeometry());

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
@@ -1662,17 +1662,17 @@ ShellCrossSection::SectionBehaviorType ShellThinElement3D3N::GetSectionBehavior(
 void ShellThinElement3D3N::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseShellElement);
-    bool is_derived = (nullptr != dynamic_cast<ShellT3_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
-    rSerializer.save("is_derived", is_derived);
+    bool is_corotational = (nullptr != dynamic_cast<ShellT3_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
+    rSerializer.save("is_corotational", is_corotational);
     rSerializer.save("CTr", *mpCoordinateTransformation);
 }
 
 void ShellThinElement3D3N::load(Serializer& rSerializer)
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseShellElement);
-    bool is_derived;
-    rSerializer.load("is_derived", is_derived);
-    if (is_derived) {
+    bool is_corotational;
+    rSerializer.load("is_corotational", is_corotational);
+    if (is_corotational) {
         mpCoordinateTransformation = Kratos::make_shared<ShellT3_CorotationalCoordinateTransformation>(pGetGeometry());
     } else {
         mpCoordinateTransformation = Kratos::make_shared<ShellT3_CoordinateTransformation>(pGetGeometry());

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D3N.cpp
@@ -1661,14 +1661,23 @@ ShellCrossSection::SectionBehaviorType ShellThinElement3D3N::GetSectionBehavior(
 
 void ShellThinElement3D3N::save(Serializer& rSerializer) const
 {
-    KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer,  BaseShellElement );
-    rSerializer.save("CTr", mpCoordinateTransformation);
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseShellElement);
+    bool is_derived = (nullptr != dynamic_cast<ShellT3_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
+    rSerializer.save("is_derived", is_derived);
+    rSerializer.save("CTr", *mpCoordinateTransformation);
 }
 
 void ShellThinElement3D3N::load(Serializer& rSerializer)
 {
-    KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer,  BaseShellElement );
-    rSerializer.load("CTr", mpCoordinateTransformation);
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseShellElement);
+    bool is_derived;
+    rSerializer.load("is_derived", is_derived);
+    if (is_derived) {
+        mpCoordinateTransformation = Kratos::make_shared<ShellT3_CorotationalCoordinateTransformation>(pGetGeometry());
+    } else {
+        mpCoordinateTransformation = Kratos::make_shared<ShellT3_CoordinateTransformation>(pGetGeometry());
+    }
+    rSerializer.load("CTr", *mpCoordinateTransformation);
 }
 
 }

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
@@ -2421,17 +2421,17 @@ ShellCrossSection::SectionBehaviorType ShellThinElement3D4N::GetSectionBehavior(
 void ShellThinElement3D4N::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseShellElement);
-    bool is_derived = (nullptr != dynamic_cast<ShellQ4_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
-    rSerializer.save("is_derived", is_derived);
+    bool is_corotational = (nullptr != dynamic_cast<ShellQ4_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
+    rSerializer.save("is_corotational", is_corotational);
     rSerializer.save("CTr", *mpCoordinateTransformation);
 }
 
 void ShellThinElement3D4N::load(Serializer& rSerializer)
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseShellElement);
-    bool is_derived;
-    rSerializer.load("is_derived", is_derived);
-    if (is_derived) {
+    bool is_corotational;
+    rSerializer.load("is_corotational", is_corotational);
+    if (is_corotational) {
         mpCoordinateTransformation = Kratos::make_shared<ShellQ4_CorotationalCoordinateTransformation>(pGetGeometry());
     } else {
         mpCoordinateTransformation = Kratos::make_shared<ShellQ4_CoordinateTransformation>(pGetGeometry());

--- a/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/shell_thin_element_3D4N.cpp
@@ -2421,12 +2421,21 @@ ShellCrossSection::SectionBehaviorType ShellThinElement3D4N::GetSectionBehavior(
 void ShellThinElement3D4N::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseShellElement);
-    rSerializer.save("CTr", mpCoordinateTransformation);
+    bool is_derived = (nullptr != dynamic_cast<ShellQ4_CorotationalCoordinateTransformation*>(mpCoordinateTransformation.get()));
+    rSerializer.save("is_derived", is_derived);
+    rSerializer.save("CTr", *mpCoordinateTransformation);
 }
 
 void ShellThinElement3D4N::load(Serializer& rSerializer)
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseShellElement);
-    rSerializer.load("CTr", mpCoordinateTransformation);
+    bool is_derived;
+    rSerializer.load("is_derived", is_derived);
+    if (is_derived) {
+        mpCoordinateTransformation = Kratos::make_shared<ShellQ4_CorotationalCoordinateTransformation>(pGetGeometry());
+    } else {
+        mpCoordinateTransformation = Kratos::make_shared<ShellQ4_CoordinateTransformation>(pGetGeometry());
+    }
+    rSerializer.load("CTr", *mpCoordinateTransformation);
 }
 }


### PR DESCRIPTION
by serializing the object itself and not the pointer it is possible to avoid the registration of the coordinate-transformations in the Serializer