### PR TITLE
[Fluid] Distance modification process model constructor and Execute method addition

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -16,6 +16,7 @@
 // External includes
 
 // Project includes
+#include "containers/model.h"
 #include "includes/checks.h"
 #include "utilities/openmp_utils.h"
 #include "processes/find_nodal_h_process.h"
@@ -46,15 +47,28 @@ DistanceModificationProcess::DistanceModificationProcess(
 DistanceModificationProcess::DistanceModificationProcess(
     ModelPart& rModelPart,
     Parameters& rParameters)
-    : Process(), mrModelPart(rModelPart) {
+    : Process(), mrModelPart(rModelPart)
+{
+    this->CheckDefaultsAndProcessSettings(rParameters);
+}
 
+DistanceModificationProcess::DistanceModificationProcess(
+    Model &rModel,
+    Parameters &rParameters)
+    : Process(), mrModelPart(rModel.GetModelPart(rParameters["model_part_name"].GetString()))
+{
+    this->CheckDefaultsAndProcessSettings(rParameters);
+}
+
+void DistanceModificationProcess::CheckDefaultsAndProcessSettings(Parameters &rParameters)
+{
     Parameters default_parameters( R"(
     {
-        "model_part_name"                        : "default_model_part_name",
+        "model_part_name"                        : "",
         "distance_factor"                        : 2.0,
         "distance_threshold"                     : 0.001,
         "continuous_distance"                    : true,
-        "check_at_each_time_step"                : false,
+        "check_at_each_time_step"                : true,
         "avoid_almost_empty_elements"            : true,
         "deactivate_full_negative_elements"      : true,
         "recover_original_distance_at_each_step" : false
@@ -69,6 +83,12 @@ DistanceModificationProcess::DistanceModificationProcess(
     mAvoidAlmostEmptyElements = rParameters["avoid_almost_empty_elements"].GetBool();
     mNegElemDeactivation = rParameters["deactivate_full_negative_elements"].GetBool();
     mRecoverOriginalDistance = rParameters["recover_original_distance_at_each_step"].GetBool();
+}
+
+void DistanceModificationProcess::Execute()
+{
+    this->ExecuteInitialize();
+    this->ExecuteInitializeSolutionStep();
 }
 
 void DistanceModificationProcess::ExecuteInitialize() {
@@ -304,7 +324,7 @@ void DistanceModificationProcess::RecoverDeactivationPreviousState(){
     for (int i_node = 0; i_node < static_cast<int>(mrModelPart.NumberOfNodes()); ++i_node){
         auto it_node = mrModelPart.NodesBegin() + i_node;
         if (it_node->GetValue(EMBEDDED_IS_ACTIVE) == 0){
-            // Fix the nodal DOFs
+            // Free the nodal DOFs that were fixed
             it_node->Free(PRESSURE);
             it_node->Free(VELOCITY_X);
             it_node->Free(VELOCITY_Y);

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -69,16 +69,21 @@ public:
 
     /// Constructor.
     DistanceModificationProcess(
-        ModelPart& rModelPart, 
+        ModelPart& rModelPart,
         const double FactorCoeff, //TODO: Remove it (here for legacy reasons)
         const double DistanceThreshold,
-        const bool CheckAtEachStep, 
+        const bool CheckAtEachStep,
         const bool NegElemDeactivation,
         const bool RecoverOriginalDistance);
 
     /// Constructor with Kratos parameters.
     DistanceModificationProcess(
         ModelPart& rModelPart,
+        Parameters& rParameters);
+
+    /// Constructor with Kratos model
+    DistanceModificationProcess(
+        Model& rModel,
         Parameters& rParameters);
 
     /// Destructor.
@@ -88,13 +93,7 @@ public:
     ///@name Operators
     ///@{
 
-    ///@}
-    ///@name Operations
-    ///@{
-
-    ///@}
-    ///@name Access
-    ///@{
+    void Execute() override;
 
     void ExecuteInitialize() override;
 
@@ -103,6 +102,14 @@ public:
     void ExecuteInitializeSolutionStep() override;
 
     void ExecuteFinalizeSolutionStep() override;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    ///@}
+    ///@name Access
+    ///@{
 
     ///@}
     ///@name Inquiry
@@ -161,6 +168,8 @@ private:
     ///@name Private Operations
     ///@{
 
+    void CheckDefaultsAndProcessSettings(Parameters &rParameters);
+
     void ModifyDistance();
 
     void ModifyDiscontinuousDistance();
@@ -168,7 +177,7 @@ private:
     void RecoverDeactivationPreviousState();
 
     void RecoverOriginalDistance();
-    
+
     void RecoverOriginalDiscontinuousDistance();
 
     void DeactivateFullNegativeElements();

--- a/applications/FluidDynamicsApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/FluidDynamicsApplication/custom_python/add_custom_processes_to_python.cpp
@@ -87,6 +87,7 @@ void AddCustomProcessesToPython(pybind11::module& m)
     (m,"DistanceModificationProcess")
     .def(py::init < ModelPart&, const double, const double, const bool, const bool, const bool >())
     .def(py::init< ModelPart&, Parameters& >())
+    .def(py::init< Model&, Parameters& >())
     ;
 
     py::class_<EmbeddedNodesInitializationProcess, EmbeddedNodesInitializationProcess::Pointer, Process>


### PR DESCRIPTION
This PR adds a new constructor with the model as argument and an Execute method. To avoid changing the entire process to use a pointer to the model part instead of a reference, I've decided to assign the member reference variable `mrModelPart` before checking the defaults. Since it is assigned according to the model part name, which must be always provided by the user, I though that it was enough with the Parameters and Model internal checks.