### PR TITLE
[Core] Removing deprecated warnings on compilation because InvertMatrix

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/derivatives_utilities.h
@@ -1391,7 +1391,8 @@ private:
 
         const BoundedMatrix<double, 2, 2> J = prod(trans(DN),DN);
         double det_j;
-        BoundedMatrix<double, 2, 2> invJ = MathUtils<double>::InvertMatrix<2>(J, det_j, -1.0);
+        BoundedMatrix<double, 2, 2> invJ;
+        MathUtils<double>::InvertMatrix(J, invJ, det_j, -1.0);
         const bool good_condition_number = MathUtils<double>::CheckConditionNumber(J, invJ, std::numeric_limits<double>::epsilon(), false);
         if (!good_condition_number) // Reset in case of bad condition number
             noalias(invJ) = ZeroMatrix(2,2);
@@ -1411,7 +1412,8 @@ private:
 //         }
 //
 //         double det_L;
-//         BoundedMatrix<double, 3, 3> invL = MathUtils<double>::InvertMatrix<3>(L, det_L, -1.0);
+//         BoundedMatrix<double, 3, 3> invL;
+//         MathUtils<double>::InvertMatrix(L, invL, det_L, -1.0);
 //         const bool good_condition_number = MathUtils<double>::CheckConditionNumber(L, invL, std::numeric_limits<double>::epsilon(), false);
 //         if (!good_condition_number) // Reset in case of bad condition number
 //             noalias(invL) = ZeroMatrix(3,3);
@@ -1450,7 +1452,8 @@ private:
 
         const BoundedMatrix<double, 2, 2> J = prod(trans(DN),DN);
         double det_j;
-        BoundedMatrix<double, 2, 2> invJ = MathUtils<double>::InvertMatrix<2>(J, det_j, -1.0);
+        BoundedMatrix<double, 2, 2> invJ;
+        MathUtils<double>::InvertMatrix(J, invJ, det_j, -1.0);
         const bool good_condition_number = MathUtils<double>::CheckConditionNumber(J, invJ, std::numeric_limits<double>::epsilon(), false);
         if (!good_condition_number) // Reset in case of bad condition number
             noalias(invJ) = ZeroMatrix(2,2);

--- a/applications/FluidDynamicsApplication/custom_elements/stokes_3D_twofluid.h
+++ b/applications/FluidDynamicsApplication/custom_elements/stokes_3D_twofluid.h
@@ -378,27 +378,27 @@ public:
                 ConstitutiveLaw::Parameters Values(GetGeometry(),r_properties,rCurrentProcessInfo);
                 Output = mp_constitutive_law->CalculateValue(Values,rVariable, Output);
                 // std::cout <<"StrainRate: "<<Output <<std::endl;
-        } 
+        }
         else if(rVariable == EFFECTIVE_VISCOSITY) //compute the heat flux per unit volume induced by the shearing
         {
             double distance_center = 0.0;
             for(unsigned int i=0; i<GetGeometry().size(); i++)
                 distance_center += GetGeometry()[i].FastGetSolutionStepValue(DISTANCE);
             distance_center/=static_cast<double>(GetGeometry().size());
-            
-            if(distance_center > 0) //AIR 
+
+            if(distance_center > 0) //AIR
             {
                 const Properties& r_properties = GetProperties();
-                Output = r_properties[DYNAMIC_VISCOSITY]; 
+                Output = r_properties[DYNAMIC_VISCOSITY];
             }
             else //OTHER MATERIAL
             {
                 const Properties& r_properties = GetProperties();
                 ConstitutiveLaw::Parameters Values(GetGeometry(),r_properties,rCurrentProcessInfo);
                 Output = mp_constitutive_law->CalculateValue(Values,rVariable, Output);
-                //std::cout <<"Viscosity: "<< Output <<std::endl; 
-            }         
-                        
+                //std::cout <<"Viscosity: "<< Output <<std::endl;
+            }
+
         }
 
         KRATOS_CATCH("")
@@ -792,7 +792,8 @@ public:
 
         //add to LHS enrichment contributions
         double det;
-        BoundedMatrix<double,4,4> inverse_diag = MathUtils<double>::InvertMatrix<4>(Kee_tot,det);
+        BoundedMatrix<double,4,4> inverse_diag;
+        MathUtils<double>::InvertMatrix(Kee_tot, inverse_diag,det);
 
         const BoundedMatrix<double,4,16> tmp = prod(inverse_diag,Htot);
         noalias(rLeftHandSideMatrix) -= prod(Vtot,tmp);

--- a/applications/MeshingApplication/custom_utilities/metrics_math_utils.h
+++ b/applications/MeshingApplication/custom_utilities/metrics_math_utils.h
@@ -88,7 +88,8 @@ public:
         MatrixType auxmat, emat;
 
         double auxdet;
-        const MatrixType& inv_metric1_matrix = MathUtils<double>::InvertMatrix<TDim>(metric1_matrix, auxdet);
+        MatrixType inv_metric1_matrix;
+        MathUtils<double>::InvertMatrix(metric1_matrix, inv_metric1_matrix, auxdet);
         const MatrixType n_matrix = prod(inv_metric1_matrix, metric2_matrix);
 
         MathUtils<double>::EigenSystem<TDim>(n_matrix, emat, auxmat, 1e-18, 20);
@@ -100,7 +101,8 @@ public:
         for (std::size_t i = 0; i < TDim; ++i)
             auxmat(i, i) = MathUtils<double>::Max(lambdamat(i, i), mumat(i, i));
 
-        const MatrixType& invemat = MathUtils<double>::InvertMatrix<TDim>(emat, auxdet);
+        MatrixType invemat;
+        MathUtils<double>::InvertMatrix(emat, invemat, auxdet);
 
         MatrixType IntersectionMatrix =  prod(trans(invemat), prod<temp_type>(auxmat, invemat));
 

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
@@ -238,7 +238,8 @@ void SPRErrorProcess<TDim>::CalculatePatch(
     }
 
     double det;
-    BoundedMatrix<double, TDim + 1, TDim + 1> invA = MathUtils<double>::InvertMatrix<TDim + 1>(A, det, -1.0); // We consider a negative tolerance in order to avoid error
+    BoundedMatrix<double, TDim + 1, TDim + 1> invA;
+    MathUtils<double>::InvertMatrix(A, invA, det, -1.0); // We consider a negative tolerance in order to avoid error
 
     KRATOS_INFO_IF("SPRErrorProcess", mEchoLevel > 3) << A << std::endl << invA << std::endl << det<< std::endl;
 
@@ -250,7 +251,7 @@ void SPRErrorProcess<TDim>::CalculatePatch(
             for( IndexType j = 0; j < TDim + 1; j++)
                 A(i,j) += 0.001;
         }
-        invA = MathUtils<double>::InvertMatrix<TDim + 1>(A,det);
+        MathUtils<double>::InvertMatrix(A, invA, det);
         KRATOS_WARNING_IF("SPRErrorProcess", mEchoLevel > 0) << "det: " << det << std::endl;
     }
 

--- a/kratos/includes/mortar_classes.h
+++ b/kratos/includes/mortar_classes.h
@@ -1182,7 +1182,8 @@ public:
     {
         // We calculate the inverse of D operator
         double auxdet;
-        const GeometryMatrixSlaveType inv_D_operator = MathUtils<double>::InvertMatrix<TNumNodes>(DOperator, auxdet);
+        GeometryMatrixSlaveType inv_D_operator;
+        MathUtils<double>::InvertMatrix(DOperator, inv_D_operator, auxdet);
 
         // We calculate the P operator
         const GeometryMatrixMasterType POperator = prod(inv_D_operator, MOperator);
@@ -1619,7 +1620,8 @@ public:
 
             // We compute the normalized inverse
             double aux_det;
-            GeometryMatrixType normalized_inv_Me = MathUtils<double>::InvertMatrix<TNumNodes>(normalized_Me, aux_det, -1.0);
+            GeometryMatrixType normalized_inv_Me;
+            MathUtils<double>::InvertMatrix(normalized_Me, normalized_inv_Me, aux_det, -1.0);
             const bool good_condition_number = MathUtils<double>::CheckConditionNumber(normalized_Me, normalized_inv_Me, tolerance, false);
             if (good_condition_number) {
                 noalias(Ae) = (1.0/norm_me) * prod(De, normalized_inv_Me);
@@ -1881,7 +1883,8 @@ public:
 
         // We compute the normalized inverse
         double aux_det;
-        GeometryMatrixType normalized_inv_Me = MathUtils<double>::InvertMatrix<TNumNodes>(normalized_Me, aux_det, -1.0);
+        GeometryMatrixType normalized_inv_Me;
+        MathUtils<double>::InvertMatrix(normalized_Me, normalized_inv_Me, aux_det, -1.0);
         const bool good_condition_number = MathUtils<double>::CheckConditionNumber(normalized_Me, normalized_inv_Me, tolerance, false);
         if (!good_condition_number) {
             return false;

--- a/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
@@ -210,7 +210,8 @@ namespace Kratos
             mat11(0,0) = 0.896308;
 
             double det;
-            const BoundedMatrix<double, 1, 1> inv11 = MathUtils<double>::InvertMatrix<1>(mat11, det);
+            BoundedMatrix<double, 1, 1> inv11;
+            MathUtils<double>::InvertMatrix(mat11, inv11, det);
             const BoundedMatrix<double, 1, 1> I11 = prod(inv11, mat11);
 
             KRATOS_CHECK_NEAR(I11(0,0), 1.0, tolerance);
@@ -221,19 +222,15 @@ namespace Kratos
             mat22(1,0) = 1.47006;
             mat22(1,1) = 1.00029;
 
-            const BoundedMatrix<double, 2, 2> inv22 = MathUtils<double>::InvertMatrix<2>(mat22, det);
+            BoundedMatrix<double, 2, 2> inv22;
+            MathUtils<double>::InvertMatrix(mat22, inv22, det);
             const BoundedMatrix<double, 2, 2> I22 = prod(inv22, mat22);
 
-            for (unsigned int i = 0; i < 2; i++)
-            {
-                for (unsigned int j = 0; j < 2; j++)
-                {
-                    if (i == j)
-                    {
+            for (unsigned int i = 0; i < 2; i++) {
+                for (unsigned int j = 0; j < 2; j++) {
+                    if (i == j) {
                         KRATOS_CHECK_NEAR(I22(i,j), 1.0, tolerance);
-                    }
-                    else
-                    {
+                    } else {
                         KRATOS_CHECK_NEAR(I22(i,j), 0.0, tolerance);
                     }
                 }
@@ -250,19 +247,15 @@ namespace Kratos
             mat33(2,1) = 1.08225;
             mat33(2,2) = 0.972831;
 
-            const BoundedMatrix<double, 3, 3> inv33 = MathUtils<double>::InvertMatrix<3>(mat33, det);
+            BoundedMatrix<double, 3, 3> inv33;
+            MathUtils<double>::InvertMatrix(mat33, inv33, det);
             const BoundedMatrix<double, 3, 3> I33 = prod(inv33, mat33);
 
-            for (unsigned int i = 0; i < 3; i++)
-            {
-                for (unsigned int j = 0; j < 3; j++)
-                {
-                    if (i == j)
-                    {
+            for (unsigned int i = 0; i < 3; i++) {
+                for (unsigned int j = 0; j < 3; j++) {
+                    if (i == j) {
                         KRATOS_CHECK_NEAR(I33(i,j), 1.0, tolerance);
-                    }
-                    else
-                    {
+                    } else {
                         KRATOS_CHECK_NEAR(I33(i,j), 0.0, tolerance);
                     }
                 }
@@ -286,19 +279,15 @@ namespace Kratos
             mat44(3,2) = 2.58081;
             mat44(3,3) = 3.3083;
 
-            const BoundedMatrix<double, 4, 4> inv44 = MathUtils<double>::InvertMatrix<4>(mat44, det);
+            BoundedMatrix<double, 4, 4> inv44;
+            MathUtils<double>::InvertMatrix(mat44, inv44, det);
             const BoundedMatrix<double, 4, 4> I44 = prod(inv44, mat44);
 
-            for (unsigned int i = 0; i < 4; i++)
-            {
-                for (unsigned int j = 0; j < 4; j++)
-                {
-                    if (i == j)
-                    {
+            for (unsigned int i = 0; i < 4; i++) {
+                for (unsigned int j = 0; j < 4; j++) {
+                    if (i == j) {
                         KRATOS_CHECK_NEAR(I44(i,j), 1.0, tolerance);
-                    }
-                    else
-                    {
+                    } else {
                         KRATOS_CHECK_NEAR(I44(i,j), 0.0, tolerance);
                     }
                 }

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -76,7 +76,7 @@ public:
 
     typedef boost::numeric::ublas::indirect_array<DenseVector<std::size_t>> IndirectArrayType;
 
-    static constexpr double ZeroTolerance = std::numeric_limits<double>::epsilon();
+    static constexpr TDataType ZeroTolerance = std::numeric_limits<TDataType>::epsilon();
 
     ///@}
     ///@name Life Cycle
@@ -418,7 +418,7 @@ public:
         const TMatrix1& rInputMatrix,
         TMatrix2& rInvertedMatrix,
         TDataType& rInputMatrixDet,
-        const TDataType Tolerance = std::numeric_limits<double>::epsilon()
+        const TDataType Tolerance = ZeroTolerance
         )
     {
         const SizeType size = rInputMatrix.size2();


### PR DESCRIPTION
After last changes, removing deprecated method