### PR TITLE
Structural/sensitivity domain integration

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
@@ -71,8 +71,8 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
         self.element_sensitivity_variables = self.__GenerateVariableListFromInput(parameter["element_sensitivity_variables"])
 
 
-    def ExecuteInitialize(self):
-        """ This method is executed at the begining to initialize the process
+    def Check(self):
+        """ This method is executed at the begining to verify that the input is correct.
         Keyword arguments:
         self -- It signifies an instance of a class.
         """
@@ -80,6 +80,7 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
         for sub_mp_i in self.sensitivity_sub_model_parts:
             if len(sub_mp_i.Elements) < 1:
                 raise Exception("sensitivity sub model part has no elements!")
+        return 0
 
 
     def ExecuteFinalizeSolutionStep(self):

--- a/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
@@ -20,6 +20,7 @@ def CheckAvailabilityOfSensitivities(variable, model_part):
     else: # python2 syntax
         return model_part.Elements.__iter__().next().Has(variable)
 
+
 class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
     """
         This class integrates scalar element sensitivities (material and cross-section
@@ -70,14 +71,23 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
         self.element_sensitivity_variables = self.__GenerateVariableListFromInput(parameter["element_sensitivity_variables"])
 
 
-    def ExecuteFinalizeSolutionStep(self):
-        """ This method is executed in order to finalize the current step
-
-        Here the dictionary containing the solution is filled
-
+    def ExecuteInitialize(self):
+        """ This method is executed at the begining to initialize the process
         Keyword arguments:
         self -- It signifies an instance of a class.
         """
+        # Check integration domains
+        for sub_mp_i in self.sensitivity_sub_model_parts:
+            if len(sub_mp_i.Elements) < 1:
+                raise Exception("sensitivity sub model part has no elements!")
+
+
+    def ExecuteFinalizeSolutionStep(self):
+        """ This method is executed in order to finalize the current step
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        """
+
         # loop over sensitivty variables for which integration should performed
         for variable_i in self.element_sensitivity_variables:
             if CheckAvailabilityOfSensitivities(variable_i, self.sensitivity_model_part):

--- a/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
@@ -78,7 +78,7 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
         """
         # Check integration domains
         for sub_mp_i in self.sensitivity_sub_model_parts:
-            if len(sub_mp_i.Elements) < 1:
+            if sub_mp_i.NumberOfElements() < 1:
                 raise Exception("sensitivity sub model part has no elements!")
         return 0
 

--- a/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
@@ -1,18 +1,13 @@
 from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
-from KratosMultiphysics.json_utilities import read_external_json
-
-# Import KratosUnittest
-import KratosMultiphysics.KratosUnittest as KratosUnittest
-from KratosMultiphysics.KratosUnittest import isclose as t_isclose
 
 def Factory(settings, model):
     if not isinstance(settings, KratosMultiphysics.Parameters):
         raise Exception("Expected input shall be a Parameters object, encapsulating a json string")
     return ElementSensitivityDomainIntegrationProcess(model, settings["Parameters"])
 
-class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process, KratosUnittest.TestCase):
+class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
     """
         This class integrates scalar element sensitivities (material and cross-section
         properties like CROSS_AREA or YOUNGS_MODULUS) within defined domains.

--- a/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
@@ -1,0 +1,124 @@
+from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
+# Importing the Kratos Library
+import KratosMultiphysics
+from KratosMultiphysics.json_utilities import read_external_json
+
+# Import KratosUnittest
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+from KratosMultiphysics.KratosUnittest import isclose as t_isclose
+
+def Factory(settings, model):
+    if not isinstance(settings, KratosMultiphysics.Parameters):
+        raise Exception("Expected input shall be a Parameters object, encapsulating a json string")
+    return ElementSensitivityDomainIntegrationProcess(model, settings["Parameters"])
+
+class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process, KratosUnittest.TestCase):
+    """
+        This class integrates scalar element sensitivities (material and cross-section
+        properties like CROSS_AREA or YOUNGS_MODULUS) within defined domains.
+        The integration domains are defined by sub model parts of the sensitivity model part.
+    """
+
+    def __init__(self, model, params):
+        """ The default constructor of the class
+
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        model -- the model contaning the model_parts
+        settings -- Kratos parameters containing solver settings.
+        """
+        KratosMultiphysics.Process.__init__(self)
+
+        ## Settings string in json format
+        default_parameters = KratosMultiphysics.Parameters("""{
+            "help"                             : "This class integrates element sensitivities within domains defined by sub model parts",
+            "element_sensitivity_variables"    : [],
+            "model_part_name"                  : "",
+            "sensitivity_model_part_name"      : "",
+            "sensitivity_sub_model_part_list"  : [],
+            "time_frequency"                   : 1.00
+        }""")
+
+        ## Overwrite the default settings with user-provided parameters
+        params.ValidateAndAssignDefaults(default_parameters)
+        self.params = params
+        self.model  = model
+
+    def ExecuteInitialize(self):
+        """ This method is executed at the begining to initialize the process
+
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        """
+
+        model_part_name = self.params["model_part_name"].GetString()
+        sensitivity_model_part_name = self.params["sensitivity_model_part_name"].GetString()
+        sensitivity_sub_model_part_names = [ self.params["sensitivity_sub_model_part_list"][i].GetString() for i in range( 0,self.params["sensitivity_sub_model_part_list"].size() ) ]
+
+        # Get sensitivity model part
+        if (sensitivity_model_part_name != ""):
+            self.sensitivity_model_part = self.model[model_part_name].GetSubModelPart(sensitivity_model_part_name)
+        else:
+            self.sensitivity_model_part = self.model[model_part_name]
+
+        # Get defined sub model parts of sensitivity model part as integration domains
+        self.sensitivity_sub_model_parts = []
+        if len(sensitivity_sub_model_part_names) is 0:
+            self.sensitivity_sub_model_parts.append(self.sensitivity_model_part)
+        else:
+            for mp_name in sensitivity_sub_model_part_names:
+                self.sensitivity_sub_model_parts.append(self.sensitivity_model_part.GetSubModelPart(mp_name))
+
+        self.element_sensitivity_variables = self.__generate_variable_list_from_input(self.params["element_sensitivity_variables"])
+        self.frequency = self.params["time_frequency"].GetDouble()
+
+        # Initialize counter
+        self.time_counter = 0.0
+
+    def ExecuteFinalizeSolutionStep(self):
+        """ This method is executed in order to finalize the current step
+
+        Here the dictionary containing the solution is filled
+
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        """
+        dt = self.sensitivity_model_part.ProcessInfo.GetValue(KratosMultiphysics.DELTA_TIME)
+        self.time_counter += dt
+
+        if self.time_counter > self.frequency:
+            self.time_counter = 0.0
+            # loop over integration domains
+            for sub_mp_i in self.sensitivity_sub_model_parts:
+                # loop over sensitivty variables for which integration should performed
+                for variable_i in self.element_sensitivity_variables:
+                    value = 0.0
+                    # loop over elements in sensitivity sub model parts
+                    if next(sub_mp_i.Elements.__iter__() ).Has(variable_i):
+                        for elem_i in sub_mp_i.Elements:
+                            value += elem_i.GetValue(variable_i)
+                        for elem_i in sub_mp_i.Elements:
+                            elem_i.SetValue(variable_i, value)
+                    else:
+                        raise Exception(variable_i.Name() + " is not available for domain integration!")
+
+    def __generate_variable_list_from_input(self,param):
+        """ Parse a list of variables from input.
+
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        value -- The Kratos vector to transform
+        """
+
+        if not param.IsArray():
+            raise Exception("{0} Error: Variable list is unreadable".format(self.__class__.__name__))
+
+        variable_list = []
+        for i in range(0, param.size()):
+            variable_type = KratosMultiphysics.KratosGlobals.GetVariableType(param[i].GetString())
+            if (variable_type == "Double"):
+                variable_list.append(KratosMultiphysics.KratosGlobals.GetVariable( param[i].GetString() ))
+            else:
+                raise Exception("sensitivity domain integration is only available for variables of data type 'Double' but " + param[i].GetString() + " is of type '" + variable_type + "'.")
+
+        return variable_list

--- a/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
@@ -55,7 +55,7 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
             for mp_name in sensitivity_sub_model_part_names:
                 self.sensitivity_sub_model_parts.append(self.sensitivity_model_part.GetSubModelPart(mp_name))
 
-        self.element_sensitivity_variables = self.__generate_variable_list_from_input(parameter["element_sensitivity_variables"])
+        self.element_sensitivity_variables = self.__GenerateVariableListFromInput(parameter["element_sensitivity_variables"])
 
 
     def ExecuteFinalizeSolutionStep(self):
@@ -66,19 +66,18 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
         Keyword arguments:
         self -- It signifies an instance of a class.
         """
-        # loop over integration domains
-        for sub_mp_i in self.sensitivity_sub_model_parts:
-            # loop over sensitivty variables for which integration should performed
-            for variable_i in self.element_sensitivity_variables:
-                domain_sensitivity = 0.0
-                if self.__check_availability_of_sensitivities(variable_i, sub_mp_i):
+        # loop over sensitivty variables for which integration should performed
+        for variable_i in self.element_sensitivity_variables:
+            if self.__CheckAvailabilityOfSensitivities(variable_i, self.sensitivity_model_part):
+                # loop over integration domains
+                for sub_mp_i in self.sensitivity_sub_model_parts:
                     domain_sensitivity = KratosMultiphysics.VariableUtils().SumElementScalarVariable(variable_i, sub_mp_i)
-                    KratosMultiphysics.VariableUtils().SetNonHistoricalVariable(variable_i, domain_sensitivity, sub_mp_i.Elements )
-                else:
-                    raise Exception(variable_i.Name() + " is not available for domain integration!")
+                    KratosMultiphysics.VariableUtils().SetNonHistoricalVariable(variable_i, domain_sensitivity, sub_mp_i.Elements)
+            else:
+                raise Exception(variable_i.Name() + " is not available for domain integration!")
 
 
-    def __generate_variable_list_from_input(self, parameter):
+    def __GenerateVariableListFromInput(self, parameter):
         """ Parse a list of variables from input.
 
         Keyword arguments:
@@ -100,7 +99,7 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
         return variable_list
 
 
-    def __check_availability_of_sensitivities(self, variable, model_part):
+    def __CheckAvailabilityOfSensitivities(self, variable, model_part):
         """ Check if element sensitivities w.r.t. given variable are available.
 
         Keyword arguments:
@@ -109,10 +108,8 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
         model_part -- sub model part of the sensitivity model part.
         """
 
-        has_sensitivities = False
         if sys.version_info[0] >= 3: # python3 syntax
-            has_sensitivities = model_part.Elements.__iter__().__next__().Has(variable)
+            return model_part.Elements.__iter__().__next__().Has(variable)
         else: # python2 syntax
-            has_sensitivities = model_part.Elements.__iter__().next().Has(variable)
+            return model_part.Elements.__iter__().next().Has(variable)
 
-        return has_sensitivities

--- a/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
@@ -8,6 +8,18 @@ def Factory(settings, model):
         raise Exception("Expected input shall be a Parameters object, encapsulating a json string")
     return ElementSensitivityDomainIntegrationProcess(model, settings["Parameters"])
 
+def CheckAvailabilityOfSensitivities(variable, model_part):
+    """ Check if element sensitivities w.r.t. given variable are available.
+    Keyword arguments:
+    variable -- traced variable within sensitivity analysis.
+    model_part -- sub model part of the sensitivity model part.
+    """
+
+    if sys.version_info[0] >= 3: # python3 syntax
+        return model_part.Elements.__iter__().__next__().Has(variable)
+    else: # python2 syntax
+        return model_part.Elements.__iter__().next().Has(variable)
+
 class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
     """
         This class integrates scalar element sensitivities (material and cross-section
@@ -68,7 +80,7 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
         """
         # loop over sensitivty variables for which integration should performed
         for variable_i in self.element_sensitivity_variables:
-            if self.__CheckAvailabilityOfSensitivities(variable_i, self.sensitivity_model_part):
+            if CheckAvailabilityOfSensitivities(variable_i, self.sensitivity_model_part):
                 # loop over integration domains
                 for sub_mp_i in self.sensitivity_sub_model_parts:
                     domain_sensitivity = KratosMultiphysics.VariableUtils().SumElementScalarVariable(variable_i, sub_mp_i)
@@ -79,7 +91,6 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
 
     def __GenerateVariableListFromInput(self, parameter):
         """ Parse a list of variables from input.
-
         Keyword arguments:
         self -- It signifies an instance of a class.
         parameter -- Kratos parameters containing process settings.
@@ -99,17 +110,7 @@ class ElementSensitivityDomainIntegrationProcess(KratosMultiphysics.Process):
         return variable_list
 
 
-    def __CheckAvailabilityOfSensitivities(self, variable, model_part):
-        """ Check if element sensitivities w.r.t. given variable are available.
 
-        Keyword arguments:
-        self -- It signifies an instance of a class.
-        variable -- traced variable within sensitivity analysis.
-        model_part -- sub model part of the sensitivity model part.
-        """
 
-        if sys.version_info[0] >= 3: # python3 syntax
-            return model_part.Elements.__iter__().__next__().Has(variable)
-        else: # python2 syntax
-            return model_part.Elements.__iter__().next().Has(variable)
+
 

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/Beam_structure.mdpa
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/Beam_structure.mdpa
@@ -85,9 +85,6 @@ Begin SubModelPart  ROTATION_support // Group DIRICH_BC // Subtree ROTATION
     End SubModelPartConditions
 End SubModelPart
 
-
-
-
 Begin SubModelPart PointLoad3D_load // Group load // Subtree PointLoad3D
     Begin SubModelPartNodes
         6
@@ -109,4 +106,48 @@ Begin SubModelPart  test_model_part
     End SubModelPartElements
     Begin SubModelPartConditions
     End SubModelPartConditions
+End SubModelPart
+
+Begin SubModelPart sensitivity_mp // Group Beam // Subtree Parts
+    Begin SubModelPartNodes
+       1
+       2
+       3
+       4
+       5
+       6
+       7
+       8
+       9
+       10
+       11
+    End SubModelPartNodes
+    Begin SubModelPartElements
+         1
+         2
+         3
+         4
+         5
+         6
+         7
+         8
+         9
+         10
+    End SubModelPartElements
+    Begin SubModelPartConditions
+        1
+    End SubModelPartConditions
+
+    Begin SubModelPart sensitivity_mp_1 // Group Beam // Subtree Parts
+        Begin SubModelPartNodes
+        End SubModelPartNodes
+        Begin SubModelPartElements
+             2
+             3
+             4
+             5
+        End SubModelPartElements
+        Begin SubModelPartConditions
+        End SubModelPartConditions
+    End SubModelPart
 End SubModelPart

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
@@ -38,7 +38,7 @@
             },
         "echo_level"                   : 0,
         "problem_domain_sub_model_part_list" : ["Parts_Beam"],
-        "processes_sub_model_part_list"      : ["DISPLACEMENT_support","ROTATION_support"],
+        "processes_sub_model_part_list"      : ["Structure","DISPLACEMENT_support","ROTATION_support","PointLoad3D_load"],
         "computing_model_part_name" : "computing_domain",
         "rotation_dofs"                      : true,
         "linear_solver_settings"       : {
@@ -60,7 +60,7 @@
         "process_name"  : "AssignVectorVariableProcess",
         "Parameters"    : {
             "mesh_id"         : 0,
-            "model_part_name" : "DISPLACEMENT_support",
+            "model_part_name" : "Structure.DISPLACEMENT_support",
             "variable_name"   : "ADJOINT_DISPLACEMENT",
             "constrained"     : [true,true,true],
             "value"           : [0.0,0.0,0.0],
@@ -74,7 +74,7 @@
         "process_name"  : "AssignVectorVariableProcess",
         "Parameters"    : {
             "mesh_id"         : 0,
-            "model_part_name" : "ROTATION_support",
+            "model_part_name" : "Structure.ROTATION_support",
             "variable_name"   : "ADJOINT_ROTATION",
             "constrained"     : [true,true,true],
             "value"           : [0.0,0.0,0.0],
@@ -90,7 +90,7 @@
         "process_name"          : "ApplyConstantVectorValueProcess",
         "Parameters"            : {
             "mesh_id"         : 0,
-            "model_part_name" : "PointLoad3D_load",
+            "model_part_name" : "Structure.PointLoad3D_load",
             "variable_name"   : "POINT_LOAD",
             "modulus"          :40,
             "direction"       : [0.0,0.0,1.0]

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
@@ -111,21 +111,18 @@
             }
         }
     }],
-    "element_sensitivity_domain_integration" : [
-        {
-            "python_module"   : "element_sensitivity_domain_integration_process",
-            "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
-            "help"                  : "",
-            "process_name"          : "ElementSensitivityDomainIntegrationProcess",
-            "Parameters"            : {
-                "element_sensitivity_variables"    : ["I22_SENSITIVITY"],
-                "model_part_name"                  : "Structure",
-                "sensitivity_model_part_name"      : "sensitivity_mp",
-                "sensitivity_sub_model_part_list"  : ["sensitivity_mp_1"],
-                "time_frequency"                   : -2.0
-            }
+    "element_sensitivity_domain_integration" : [{
+        "python_module"   : "element_sensitivity_domain_integration_process",
+        "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+        "help"                  : "",
+        "process_name"          : "ElementSensitivityDomainIntegrationProcess",
+        "Parameters"            : {
+            "element_sensitivity_variables"    : ["I22_SENSITIVITY"],
+            "model_part_name"                  : "Structure",
+            "sensitivity_model_part_name"      : "sensitivity_mp",
+            "sensitivity_sub_model_part_list"  : ["sensitivity_mp_1"]
         }
-        ],
+    }],
     "json_check_process" : [
         {
             "python_module"   : "from_json_check_result_process",

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
@@ -30,7 +30,7 @@
                 "stress_location"   : 1
             },
         "sensitivity_settings" : {
-                "sensitivity_model_part_name" : "Parts_Beam",
+                "sensitivity_model_part_name" : "sensitivity_mp",
                 "nodal_sensitivity_variables"  : ["SHAPE"],
                 "element_sensitivity_variables"  : ["I22"],
                 "condition_sensitivity_variables"  : ["POINT_LOAD"],
@@ -111,6 +111,21 @@
             }
         }
     }],
+    "element_sensitivity_domain_integration" : [
+        {
+            "python_module"   : "element_sensitivity_domain_integration_process",
+            "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
+            "help"                  : "",
+            "process_name"          : "ElementSensitivityDomainIntegrationProcess",
+            "Parameters"            : {
+                "element_sensitivity_variables"    : ["I22_SENSITIVITY"],
+                "model_part_name"                  : "Structure",
+                "sensitivity_model_part_name"      : "sensitivity_mp",
+                "sensitivity_sub_model_part_list"  : ["sensitivity_mp_1"],
+                "time_frequency"                   : -2.0
+            }
+        }
+        ],
     "json_check_process" : [
         {
             "python_module"   : "from_json_check_result_process",

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_local_stress_adjoint_parameters.json
@@ -110,8 +110,8 @@
                 "list_of_variables": ["DISPLACEMENT", "ROTATION"]
             }
         }
-    }],
-    "element_sensitivity_domain_integration" : [{
+    },
+    {
         "python_module"   : "element_sensitivity_domain_integration_process",
         "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
         "help"                  : "",

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_nodal_disp_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_nodal_disp_adjoint_parameters.json
@@ -36,7 +36,7 @@
             },
         "echo_level"                   : 0,
         "problem_domain_sub_model_part_list" : ["Parts_Beam"],
-        "processes_sub_model_part_list"      : ["DISPLACEMENT_support","ROTATION_support"],
+        "processes_sub_model_part_list"      : ["Structure","DISPLACEMENT_support","ROTATION_support","PointLoad3D_load"],
         "computing_model_part_name" : "computing_domain",
         "rotation_dofs"                      : true,
         "linear_solver_settings"       : {
@@ -58,7 +58,7 @@
         "process_name"  : "AssignVectorVariableProcess",
         "Parameters"    : {
             "mesh_id"         : 0,
-            "model_part_name" : "DISPLACEMENT_support",
+            "model_part_name" : "Structure.DISPLACEMENT_support",
             "variable_name"   : "ADJOINT_DISPLACEMENT",
             "constrained"     : [true,true,true],
             "value"           : [0.0,0.0,0.0],
@@ -72,7 +72,7 @@
         "process_name"  : "AssignVectorVariableProcess",
         "Parameters"    : {
             "mesh_id"         : 0,
-            "model_part_name" : "ROTATION_support",
+            "model_part_name" : "Structure.ROTATION_support",
             "variable_name"   : "ADJOINT_ROTATION",
             "constrained"     : [true,true,true],
             "value"           : [0.0,0.0,0.0],
@@ -88,7 +88,7 @@
         "process_name"          : "ApplyConstantVectorValueProcess",
         "Parameters"            : {
             "mesh_id"         : 0,
-            "model_part_name" : "PointLoad3D_load",
+            "model_part_name" : "Structure.PointLoad3D_load",
             "variable_name"   : "POINT_LOAD",
             "modulus"          :40,
             "direction"       : [0.0,0.0,1.0]

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_parameters.json
@@ -35,7 +35,7 @@
             "solver_type" : "ExternalSolversApplication.super_lu"
         },
         "problem_domain_sub_model_part_list" : ["Parts_Beam"],
-        "processes_sub_model_part_list"      : ["DISPLACEMENT_support", "ROTATION_support","PointLoad3D_load"],
+        "processes_sub_model_part_list"      : ["Structure","DISPLACEMENT_support", "ROTATION_support","PointLoad3D_load"],
         "rotation_dofs"                      : true
 
     },
@@ -47,7 +47,7 @@
         "process_name"  : "AssignVectorVariableProcess",
         "Parameters"    : {
             "mesh_id"         : 0,
-            "model_part_name" : "DISPLACEMENT_support",
+            "model_part_name" : "Structure.DISPLACEMENT_support",
             "variable_name"   : "DISPLACEMENT",
             "constrained"     : [true,true,true],
             "value"           : [0.0,0.0,0.0],
@@ -61,7 +61,7 @@
         "process_name"  : "AssignVectorVariableProcess",
         "Parameters"    : {
             "mesh_id"         : 0,
-            "model_part_name" : "ROTATION_support",
+            "model_part_name" : "Structure.ROTATION_support",
             "variable_name"   : "ROTATION",
             "constrained"     : [true,true,true],
             "value"           : [0.0,0.0,0.0],
@@ -95,7 +95,7 @@
         "process_name"          : "ApplyConstantVectorValueProcess",
         "Parameters"            : {
             "mesh_id"         : 0,
-            "model_part_name" : "PointLoad3D_load",
+            "model_part_name" : "Structure.PointLoad3D_load",
             "variable_name"   : "POINT_LOAD",
             "modulus"          :40,
             "direction"       : [0.0,0.0,1.0]

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_strain_energy_adjoint_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/beam_test_strain_energy_adjoint_parameters.json
@@ -34,7 +34,7 @@
             },
         "echo_level"                   : 0,
         "problem_domain_sub_model_part_list" : ["Parts_Beam"],
-        "processes_sub_model_part_list"      : ["DISPLACEMENT_support","ROTATION_support"],
+        "processes_sub_model_part_list"      : ["Structure","DISPLACEMENT_support","ROTATION_support","PointLoad3D_load"],
         "computing_model_part_name" : "computing_domain",
         "rotation_dofs"                      : true,
         "linear_solver_settings"       : {
@@ -56,7 +56,7 @@
         "process_name"  : "AssignVectorVariableProcess",
         "Parameters"    : {
             "mesh_id"         : 0,
-            "model_part_name" : "DISPLACEMENT_support",
+            "model_part_name" : "Structure.DISPLACEMENT_support",
             "variable_name"   : "ADJOINT_DISPLACEMENT",
             "constrained"     : [true,true,true],
             "value"           : [0.0,0.0,0.0],
@@ -70,7 +70,7 @@
         "process_name"  : "AssignVectorVariableProcess",
         "Parameters"    : {
             "mesh_id"         : 0,
-            "model_part_name" : "ROTATION_support",
+            "model_part_name" : "Structure.ROTATION_support",
             "variable_name"   : "ADJOINT_ROTATION",
             "constrained"     : [true,true,true],
             "value"           : [0.0,0.0,0.0],
@@ -86,7 +86,7 @@
         "process_name"          : "ApplyConstantVectorValueProcess",
         "Parameters"            : {
             "mesh_id"         : 0,
-            "model_part_name" : "PointLoad3D_load",
+            "model_part_name" : "Structure.PointLoad3D_load",
             "variable_name"   : "POINT_LOAD",
             "modulus"          :40,
             "direction"       : [0.0,0.0,1.0]

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/materials_beam.json
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_tests/adjoint_beam_structure_3d2n/materials_beam.json
@@ -1,6 +1,6 @@
 {
     "properties": [{
-            "model_part_name": "Parts_Beam",
+            "model_part_name": "Structure.Parts_Beam",
             "properties_id": 1,
             "Material": {
                     "constitutive_law": {

--- a/applications/StructuralMechanicsApplication/tests/test_adjoint_sensitity_analysis_beam_3d2n_structure.py
+++ b/applications/StructuralMechanicsApplication/tests/test_adjoint_sensitity_analysis_beam_3d2n_structure.py
@@ -64,17 +64,21 @@ class TestAdjointSensitivityAnalysisBeamStructure(KratosUnittest.TestCase):
             adjoint_analysis.Run()
 
             # Check sensitivities for the parameter I22
-            reference_values = [-87.62277093392399, 38.125186783868, 0.6250049974719261, 0.15624887499699122]
+            reference_values = [-87.62277093392399, 9.497391494932984, 38.125186783868, 0.6250049974719261, 0.15624887499699122]
             sensitivities_to_check = []
-            element_list = [1,6,10]
+            element_list = [1,2,3,4,5,6,10]
             for element_id in element_list:
                 sensitivities_to_check.append(model_adjoint.GetModelPart(model_part_name).Elements[element_id].GetValue(I22_SENSITIVITY))
             sensitivities_to_check.append(model_adjoint.GetModelPart(model_part_name).Conditions[1].GetValue(POINT_LOAD_SENSITIVITY)[2])
 
         self.assertAlmostEqual(sensitivities_to_check[0], reference_values[0], 3)
         self.assertAlmostEqual(sensitivities_to_check[1], reference_values[1], 3)
-        self.assertAlmostEqual(sensitivities_to_check[2], reference_values[2], 3)
-        self.assertAlmostEqual(sensitivities_to_check[3], reference_values[3], 5)
+        self.assertAlmostEqual(sensitivities_to_check[2], reference_values[1], 3)
+        self.assertAlmostEqual(sensitivities_to_check[3], reference_values[1], 3)
+        self.assertAlmostEqual(sensitivities_to_check[4], reference_values[1], 3)
+        self.assertAlmostEqual(sensitivities_to_check[5], reference_values[2], 3)
+        self.assertAlmostEqual(sensitivities_to_check[6], reference_values[3], 3)
+        self.assertAlmostEqual(sensitivities_to_check[7], reference_values[4], 5)
 
     def test_nodal_displacement_response(self):
         # Create the adjoint solver


### PR DESCRIPTION
Within this PR I add a python process to integrate elemental sensitivities over given domains. Since in discrete sensitivity analysis the sensitivity of a element w.r.t. to a stiffness related property is already the variational sensitivity integrated over the element domain, the integration over more elements boils down to the summation of the element sensitivities. The integration domains I simply define with sub model parts of the sensitivity model part.
To test the new process I call it within a already existing sensitivity analysis test case. I also cleaned the respective test case within this PR.
 