### PR TITLE
[Core] fix linear-solver naming issue with recursive solvers

### DIFF
--- a/kratos/includes/linear_solver_factory.h
+++ b/kratos/includes/linear_solver_factory.h
@@ -105,14 +105,14 @@ public:
         // e.g. "ExternalSolversApplication.super_lu" => "super_lu"
         solver_name = solver_name.substr(solver_name.find(".") + 1);
 
-        KRATOS_ERROR_IF_NOT(KratosComponents< FactoryType >::Has(solver_name))
+        KRATOS_ERROR_IF_NOT(Has(solver_name))
             << "Trying to construct a Linear solver with solver_type:\n\""
             << solver_name << "\" which does not exist.\n"
             << "The list of available options (for currently loaded applications) is:\n"
             << KratosComponents< FactoryType >() << std::endl;
 
-        const auto& r_aux_solver = KratosComponents< FactoryType >::Get(solver_name);
-        return r_aux_solver.CreateSolver( Settings );
+        const auto& aux = KratosComponents< FactoryType >::Get(solver_name);
+        return aux.CreateSolver( Settings );
     }
 
     ///@}

--- a/kratos/includes/linear_solver_factory.h
+++ b/kratos/includes/linear_solver_factory.h
@@ -100,14 +100,19 @@ public:
      */
     virtual typename LinearSolver<TSparseSpace,TLocalSpace>::Pointer Create(Kratos::Parameters Settings)
     {
-        if(KratosComponents< FactoryType >::Has( Settings["solver_type"].GetString())== false) {
+        std::string solver_name = Settings["solver_type"].GetString();
+        // remove name of the application (if passed)
+        // e.g. "ExternalSolversApplication.super_lu" => "super_lu"
+        solver_name = solver_name.substr(solver_name.find(".") + 1);
+
+        if (!KratosComponents< FactoryType >::Has(solver_name)) {
             KRATOS_ERROR << "Trying to construct a Linear solver with solver_type:\n\""
-                << Settings["solver_type"].GetString() << "\" which does not exist.\n"
+                << solver_name << "\" which does not exist.\n"
                 << "The list of available options (for currently loaded applications) is:\n"
                 << KratosComponents< FactoryType >() << std::endl;
         }
-        const auto& aux = KratosComponents< FactoryType >::Get( Settings["solver_type"].GetString()  );
-        return aux.CreateSolver( Settings );
+        const auto& r_aux_solver = KratosComponents< FactoryType >::Get(solver_name);
+        return r_aux_solver.CreateSolver( Settings );
     }
 
     ///@}

--- a/kratos/includes/linear_solver_factory.h
+++ b/kratos/includes/linear_solver_factory.h
@@ -105,12 +105,12 @@ public:
         // e.g. "ExternalSolversApplication.super_lu" => "super_lu"
         solver_name = solver_name.substr(solver_name.find(".") + 1);
 
-        if (!KratosComponents< FactoryType >::Has(solver_name)) {
-            KRATOS_ERROR << "Trying to construct a Linear solver with solver_type:\n\""
-                << solver_name << "\" which does not exist.\n"
-                << "The list of available options (for currently loaded applications) is:\n"
-                << KratosComponents< FactoryType >() << std::endl;
-        }
+        KRATOS_ERROR_IF_NOT(KratosComponents< FactoryType >::Has(solver_name))
+            << "Trying to construct a Linear solver with solver_type:\n\""
+            << solver_name << "\" which does not exist.\n"
+            << "The list of available options (for currently loaded applications) is:\n"
+            << KratosComponents< FactoryType >() << std::endl;
+
         const auto& r_aux_solver = KratosComponents< FactoryType >::Get(solver_name);
         return r_aux_solver.CreateSolver( Settings );
     }

--- a/kratos/includes/preconditioner_factory.h
+++ b/kratos/includes/preconditioner_factory.h
@@ -112,8 +112,8 @@ public:
             << raw_precond_name << "\" which does not exist.\n"
             << "The list of available options (for currently loaded applications) is:\n"
             << KratosComponents< FactoryType >() << std::endl;
-        }
-        const auto& aux = KratosComponents< FactoryType >::Get( raw_precond_name );
+
+        const auto& aux = KratosComponents< FactoryType >::Get(raw_precond_name);
         return aux.CreatePreconditioner();
     }
     ///@}

--- a/kratos/includes/preconditioner_factory.h
+++ b/kratos/includes/preconditioner_factory.h
@@ -103,12 +103,17 @@ public:
      */
     virtual typename PreconditionerType::Pointer Create(const std::string& rPreconditionerType)
     {
-        if(Has( rPreconditionerType ) == false) {
-            KRATOS_ERROR << "Trying to construct a preconditioner with type preconditioner_type= " << rPreconditionerType << std::endl <<
-                            "Which does not exist. The list of available options (for currently loaded applications) is: " << std::endl <<
-                         KratosComponents< FactoryType >() << std::endl;
+        // remove name of the application (if passed)
+        // e.g. "ExternalSolversApplication.super_lu" => "super_lu"
+        const std::string raw_precond_name = rPreconditionerType.substr(rPreconditionerType.find(".") + 1);
+
+        KRATOS_ERROR_IF_NOT(Has(raw_precond_name))
+            << "Trying to construct a preconditioner with preconditioner_type:\n\""
+            << raw_precond_name << "\" which does not exist.\n"
+            << "The list of available options (for currently loaded applications) is:\n"
+            << KratosComponents< FactoryType >() << std::endl;
         }
-        const auto& aux = KratosComponents< FactoryType >::Get( rPreconditionerType );
+        const auto& aux = KratosComponents< FactoryType >::Get( raw_precond_name );
         return aux.CreatePreconditioner();
     }
     ///@}

--- a/kratos/python_scripts/python_linear_solver_factory.py
+++ b/kratos/python_scripts/python_linear_solver_factory.py
@@ -150,10 +150,11 @@ def ConstructSolver(configuration):
     if "Application." in solver_type: # the module in which the solver is implemented was specified
         splitted_name = solver_type.split(".")
         if len(splitted_name) != 2:
-            raise NameError('The "solver_type" has to consist in "ApplicationName.SolverType"')
+            raise NameError('The "solver_type" has to consist in "ApplicationName.solver_type"')
         app_name = splitted_name[0]
+        # the following is only needed for the check in the ComplexLinearSolverFactory
+        # note that the solver-configuration is NOT modified
         solver_type = splitted_name[1]
-        configuration["solver_type"].SetString(solver_type)
         __import__("KratosMultiphysics." + app_name)
     else:
         __DeprecatedApplicationImport(solver_type)


### PR DESCRIPTION
fixes #4244 

@miguelmaso has a problem with the way the factory currently handles the imports for solvers that are defined in an application.
So far I remove the name of the application and then modify the settings. This way it gives a problem when reusing the same settings

Long story short, this PR fixes this, the incoming configuration is no longer modified

A more detailed description of the problem and also my answer is in #4244 