### PR TITLE
[Hotfix] Properly assignment of solver_type after string splitting in linear solver factory

### DIFF
--- a/kratos/python_scripts/python_linear_solver_factory.py
+++ b/kratos/python_scripts/python_linear_solver_factory.py
@@ -155,6 +155,7 @@ def ConstructSolver(configuration):
         # the following is only needed for the check in the ComplexLinearSolverFactory
         # note that the solver-configuration is NOT modified
         solver_type = splitted_name[1]
+        configuration["solver_type"].SetString(solver_type)
         __import__("KratosMultiphysics." + app_name)
     else:
         __DeprecatedApplicationImport(solver_type)


### PR DESCRIPTION
Hi,

The definition of solvers as "KratosApplication.solver_name" in the parameters is not working, since the whole string "KratosApplication.solver_name" is given to the linear_solver_factory.h file instead of only "solver_name". I think this solves the issue. Is it correct?

You can check the potential flow unit tests as an example.