### PR TITLE
renewed and added tests, minor changes in codes of masonry_cl

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/plane_stress_d_plus_d_minus_damage_masonry_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/plane_stress_d_plus_d_minus_damage_masonry_2d.cpp
@@ -516,11 +516,9 @@ void DamageDPlusDMinusMasonry2DLaw::CalculateEquivalentStressCompression(
 	const double alpha_factor = 1.0 / (1.0 - alpha);
 	const double beta = (yield_compression / yield_tension) * (1.0 - alpha) - (1.0 + alpha);
 	
-	double I1,I2,J2;
+	double I1,J2;
 	ConstitutiveLawUtilities<3>::CalculateI1Invariant(rPredictiveStressVector, I1);
 	array_1d<double, 3> deviator = ZeroVector(VoigtSize);
-    ConstitutiveLawUtilities<3>::CalculateI2Invariant(rPredictiveStressVector, I2);
-    //double J2_temp = (1.0 / 3.0) * std::pow(I1,2) - I2;
 	ConstitutiveLawUtilities<3>::CalculateJ2Invariant(rPredictiveStressVector, I1, deviator, J2);
 	
 	array_1d<double, 2> rPrincipalStressVector;
@@ -528,11 +526,9 @@ void DamageDPlusDMinusMasonry2DLaw::CalculateEquivalentStressCompression(
 	const double principal_stress_1 = rPrincipalStressVector[0];
 	const double principal_stress_2 = rPrincipalStressVector[1];
 	const double smax_macaulay = std::max(principal_stress_1, 0.0);
-	
 	if (principal_stress_2 < 0.0){
 		rEquivalentStress = alpha_factor * (alpha*I1 + std::sqrt(3.0 * J2) + beta * shear_compression_reductor * smax_macaulay);
 	}
-	
 }
 /***********************************************************************************/
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_constitutive/plane_stress_d_plus_d_minus_damage_masonry_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/plane_stress_d_plus_d_minus_damage_masonry_2d.h
@@ -623,10 +623,10 @@ private:
      *          Control nodes:  K=(e_k,s_k); R=(e_r,s_r); U=(e_u,s_u)
      *  {V}   Residual Strength
      *
-     *   STRESS                 
-     *      ^
-     *     /|\
-     *      |                     (P)
+     *    STRESS                 
+     *       ^
+     *      /|\
+     *       |                     (P)
      * s_p = |------------(I)+----#####--+(J) 
      * s_i = |               ' ###  ' ####
      * s_j   |              ###     '    ####

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_d+d-damage_law_masonry_2d.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_d+d-damage_law_masonry_2d.cpp
@@ -37,7 +37,7 @@ typedef Node<3> NodeType;
 /**
     * Check the correct calculation of the integrated stress with the CL's
     */
-KRATOS_TEST_CASE_IN_SUITE(DamageDPlusDMinusMasonry2DLaw, KratosStructuralMechanicsFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(DPlusDMinusMasonry2DPureTensionTest, KratosStructuralMechanicsFastSuite)
 {
     ConstitutiveLaw::Parameters cl_parameters;
     Properties material_properties;
@@ -55,7 +55,7 @@ KRATOS_TEST_CASE_IN_SUITE(DamageDPlusDMinusMasonry2DLaw, KratosStructuralMechani
 
     stress_vector = ZeroVector(3);
     strain_vector = ZeroVector(3);
-    strain_vector[0] = -0.05882;
+    strain_vector[0] = 0.000787;
     strain_vector[1] = 0.0;
     strain_vector[2] = 0.0;
 
@@ -95,7 +95,7 @@ KRATOS_TEST_CASE_IN_SUITE(DamageDPlusDMinusMasonry2DLaw, KratosStructuralMechani
     DamageDPlusDMinusMasonry2DLaw masonry2d_cl = DamageDPlusDMinusMasonry2DLaw();
 
     std::vector<double> masonry2d_res;
-    masonry2d_res = {-2.72231e+07, -5.44462e+06, 0};
+    masonry2d_res = {926316.0, 185263.0, 0};
 
     Vector test_masonry2d_stress;
     masonry2d_cl.CalculateMaterialResponseCauchy(cl_parameters);
@@ -106,5 +106,147 @@ KRATOS_TEST_CASE_IN_SUITE(DamageDPlusDMinusMasonry2DLaw, KratosStructuralMechani
         KRATOS_CHECK_NEAR(test_masonry2d_stress[comp], masonry2d_res[comp], 0.0001e6);
     }
 }
+
+KRATOS_TEST_CASE_IN_SUITE(DPlusDMinusMasonry2DPureCompressionTest, KratosStructuralMechanicsFastSuite)
+{
+    ConstitutiveLaw::Parameters cl_parameters;
+    Properties material_properties;
+    ProcessInfo process_info;
+    Vector stress_vector, strain_vector;
+
+    Model current_model;
+    ModelPart& test_model_part = current_model.CreateModelPart("Main");
+
+    NodeType::Pointer p_node_1 = test_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    NodeType::Pointer p_node_2 = test_model_part.CreateNewNode(2, 1.0, 0.5, 0.0);
+    NodeType::Pointer p_node_3 = test_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+
+    Triangle2D3<NodeType> Geom = Triangle2D3<NodeType>(p_node_1, p_node_2, p_node_3);
+
+    stress_vector = ZeroVector(3);
+    strain_vector = ZeroVector(3);
+    strain_vector[0] = -0.02227;
+    strain_vector[1] = 0.0;
+    strain_vector[2] = 0.0;
+ 
+    material_properties.SetValue(YOUNG_MODULUS, 3718.0e+6);
+    material_properties.SetValue(POISSON_RATIO, 0.2);
+    material_properties.SetValue(YIELD_STRESS_TENSION, 1.559e+6);
+    material_properties.SetValue(FRACTURE_ENERGY_TENSION, 10.0e+2);
+    material_properties.SetValue(DAMAGE_ONSET_STRESS_COMPRESSION, 10.0e+6);
+    material_properties.SetValue(YIELD_STRESS_COMPRESSION, 17.99e+6);
+    material_properties.SetValue(YIELD_STRAIN_COMPRESSION, 0.02);
+    material_properties.SetValue(RESIDUAL_STRESS_COMPRESSION, 2.00e+6);
+    material_properties.SetValue(BIAXIAL_COMPRESSION_MULTIPLIER, 1.20);
+    material_properties.SetValue(FRACTURE_ENERGY_COMPRESSION, 8.0e+5);
+    material_properties.SetValue(SHEAR_COMPRESSION_REDUCTOR, 0.16);
+    material_properties.SetValue(BEZIER_CONTROLLER_C1, 0.65);
+    material_properties.SetValue(BEZIER_CONTROLLER_C2,  0.45);
+    material_properties.SetValue(BEZIER_CONTROLLER_C3, 1.5);
+    material_properties.SetValue(DELAY_TIME, 1.0);
+
+    Flags cl_options;
+    cl_options.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+    cl_options.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, true);
+    cl_options.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+
+    //process_info.SetValue(DELTA_TIME, 0.1);
+
+    cl_parameters.SetElementGeometry(Geom);
+    cl_parameters.SetMaterialProperties(material_properties);
+    cl_parameters.SetStrainVector(strain_vector);
+    cl_parameters.SetStressVector(stress_vector);
+    cl_parameters.SetProcessInfo(process_info);
+    cl_parameters.SetOptions(cl_options);
+    Matrix const_matrix;
+    cl_parameters.SetConstitutiveMatrix(const_matrix);
+
+    // Create the CL
+    DamageDPlusDMinusMasonry2DLaw masonry2d_cl = DamageDPlusDMinusMasonry2DLaw();
+
+    std::vector<double> masonry2d_res;
+    masonry2d_res = {-2.06954e+07,  -4.13908e+06, 0};
+
+    Vector test_masonry2d_stress;
+    masonry2d_cl.CalculateMaterialResponseCauchy(cl_parameters);
+    test_masonry2d_stress = cl_parameters.GetStressVector();
+
+    // Check the results
+    for (int comp = 0; comp < 3; comp++) {
+        KRATOS_CHECK_NEAR(test_masonry2d_stress[comp], masonry2d_res[comp], 0.0001e6);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(DPlusDMinusMasonry2DPMixedStateTest, KratosStructuralMechanicsFastSuite)
+{
+    ConstitutiveLaw::Parameters cl_parameters;
+    Properties material_properties;
+    ProcessInfo process_info;
+    Vector stress_vector, strain_vector;
+
+    Model current_model;
+    ModelPart& test_model_part = current_model.CreateModelPart("Main");
+
+    NodeType::Pointer p_node_1 = test_model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+    NodeType::Pointer p_node_2 = test_model_part.CreateNewNode(2, 1.0, 0.5, 0.0);
+    NodeType::Pointer p_node_3 = test_model_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+
+    Triangle2D3<NodeType> Geom = Triangle2D3<NodeType>(p_node_1, p_node_2, p_node_3);
+
+    stress_vector = ZeroVector(3);
+    strain_vector = ZeroVector(3);
+    strain_vector[0] = 0.0;
+    strain_vector[1] = 0.0;
+    strain_vector[2] = -0.005218;
+ 
+    material_properties.SetValue(YOUNG_MODULUS, 3718.0e+6);
+    material_properties.SetValue(POISSON_RATIO, 0.2);
+    material_properties.SetValue(YIELD_STRESS_TENSION, 1.559e+6);
+    material_properties.SetValue(FRACTURE_ENERGY_TENSION, 10.0e+3);
+    material_properties.SetValue(DAMAGE_ONSET_STRESS_COMPRESSION, 10.0e+6);
+    material_properties.SetValue(YIELD_STRESS_COMPRESSION, 17.99e+6);
+    material_properties.SetValue(YIELD_STRAIN_COMPRESSION, 0.02);
+    material_properties.SetValue(RESIDUAL_STRESS_COMPRESSION, 2.00e+6);
+    material_properties.SetValue(BIAXIAL_COMPRESSION_MULTIPLIER, 1.20);
+    material_properties.SetValue(FRACTURE_ENERGY_COMPRESSION, 8.0e+5);
+    material_properties.SetValue(SHEAR_COMPRESSION_REDUCTOR, 0.16);
+    material_properties.SetValue(BEZIER_CONTROLLER_C1, 0.65);
+    material_properties.SetValue(BEZIER_CONTROLLER_C2,  0.45);
+    material_properties.SetValue(BEZIER_CONTROLLER_C3, 1.5);
+    material_properties.SetValue(DELAY_TIME, 1.0);
+
+    Flags cl_options;
+    cl_options.Set(ConstitutiveLaw::COMPUTE_STRESS, true);
+    cl_options.Set(ConstitutiveLaw::USE_ELEMENT_PROVIDED_STRAIN, true);
+    cl_options.Set(ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR, false);
+
+    //process_info.SetValue(DELTA_TIME, 0.1);
+
+    cl_parameters.SetElementGeometry(Geom);
+    cl_parameters.SetMaterialProperties(material_properties);
+    cl_parameters.SetStrainVector(strain_vector);
+    cl_parameters.SetStressVector(stress_vector);
+    cl_parameters.SetProcessInfo(process_info);
+    cl_parameters.SetOptions(cl_options);
+    Matrix const_matrix;
+    cl_parameters.SetConstitutiveMatrix(const_matrix);
+
+    // Create the CL
+    DamageDPlusDMinusMasonry2DLaw masonry2d_cl = DamageDPlusDMinusMasonry2DLaw();
+
+    std::vector<double> masonry2d_res;
+    masonry2d_res = {-1.57685e+06, -1.57685e+06, -5.93494e+06};
+
+    Vector test_masonry2d_stress;
+    masonry2d_cl.CalculateMaterialResponseCauchy(cl_parameters);
+    test_masonry2d_stress = cl_parameters.GetStressVector();
+
+    // Check the results
+    for (int comp = 0; comp < 3; comp++) {
+        KRATOS_CHECK_NEAR(test_masonry2d_stress[comp], masonry2d_res[comp], 0.0001e6);
+    }
+}
+
+
 } // namespace Testing
 } // namespace Kratos


### PR DESCRIPTION
Repaired the masonry 2d test,
@AlejandroCornejo and me, we changed an equation in constitutive_law_utilities.cpp, so the reference values of the test were computed with the "old" equation of cl_utilities. 
Thanks for advice @philbucher.
And sorry for travis compile problems @rubenzorrilla 
Also some minor changes to the files of the cl were done.
closes #4292 