### PR TITLE
fix(StructuralMechanics): updated mpi test parameters

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/structural_mechanics_test_factory_mpi.py
+++ b/applications/StructuralMechanicsApplication/tests/structural_mechanics_test_factory_mpi.py
@@ -24,7 +24,9 @@ class StructuralMechanicsTestFactoryMPI(StructuralMechanicsTestFactory):
         # Here we append "_mpi" to the name of the results file
         # e.g. "test_results.json" => "test_results_mpi.json"
         # This is necessary becs the node numbering changes with the partitioning
-        results_file_param = project_parameters["json_check_process"][0]["Parameters"]["input_file_name"]
+        if project_parameters["solver_settings"].Has("linear_solver_settings"):
+            project_parameters["solver_settings"].RemoveValue("linear_solver_settings")
+        results_file_param = project_parameters["processes"]["json_check_process"][0]["Parameters"]["input_file_name"]
         results_file_name = results_file_param.GetString()
         raw_path, file_name = os.path.split(results_file_name)
         raw_file_name, file_ext = os.path.splitext(file_name)


### PR DESCRIPTION
The mpi test in structural mechanics application was failing. Two modifications were needed to fix the test.

- The first problem was caused by a change in the json format which was not propogated to the test.
- The second problem was caused by the base (serial) class StructuralMechanicsTestFactory setting the linear_solver_settings and then trying to create the derived solver (trilinos) with these settings. Use of inheritance for code re-use is making this code really messy and should be refactored in a future PR. 