### PR TITLE
Structural/move update sensitivity call

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/adjoint_nodal_displacement_response_function.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/adjoint_nodal_displacement_response_function.cpp
@@ -182,9 +182,7 @@ namespace Kratos
         const VariableComponentType& r_traced_dof =
             KratosComponents<VariableComponentType>::Get(mTracedDofLabel);
 
-        const auto& r_primal_traced_node = rModelPart.GetNode(mpTracedNode->Id());
-
-        return r_primal_traced_node.FastGetSolutionStepValue(r_traced_dof, 0);
+        return rModelPart.GetNode(mpTracedNode->Id()).FastGetSolutionStepValue(r_traced_dof, 0);
 
         KRATOS_CATCH("");
     }

--- a/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/adjoint_nodal_displacement_response_function.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/adjoint_nodal_displacement_response_function.cpp
@@ -182,7 +182,9 @@ namespace Kratos
         const VariableComponentType& r_traced_dof =
             KratosComponents<VariableComponentType>::Get(mTracedDofLabel);
 
-        return mpTracedNode->FastGetSolutionStepValue(r_traced_dof, 0);
+        const auto& r_primal_traced_node = rModelPart.GetNode(mpTracedNode->Id());
+
+        return r_primal_traced_node.FastGetSolutionStepValue(r_traced_dof, 0);
 
         KRATOS_CATCH("");
     }

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
@@ -86,14 +86,13 @@ class StructuralMechanicsAdjointStaticSolver(structural_mechanics_solver.Mechani
     def FinalizeSolutionStep(self):
         super(StructuralMechanicsAdjointStaticSolver, self).FinalizeSolutionStep()
         self.response_function.FinalizeSolutionStep()
+        self.adjoint_postprocess.UpdateSensitivities()
 
     def SolveSolutionStep(self):
         if self.response_function_settings["response_type"].GetString() == "adjoint_linear_strain_energy":
             self._SolveSolutionStepSpecialLinearStrainEnergy()
         else:
             super(StructuralMechanicsAdjointStaticSolver, self).SolveSolutionStep()
-        #after adjoint solution, calculate sensitivities
-        self.adjoint_postprocess.UpdateSensitivities() # TODO call postprocess here or in FinalizeSolutionStep ?
 
     def _SolveSolutionStepSpecialLinearStrainEnergy(self):
         for node in self.main_model_part.Nodes:

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
@@ -297,7 +297,6 @@ class AdjointResponseFunction(ResponseFunctionBase):
         self.adjoint_analysis.Initialize()
 
     def InitializeSolutionStep(self):
-
         # Run the primal analysis.
         # TODO if primal_analysis.status==solved: return
         Logger.PrintInfo("\n> Starting primal analysis for response:", self.identifier)
@@ -307,16 +306,6 @@ class AdjointResponseFunction(ResponseFunctionBase):
         self.primal_analysis.RunSolutionLoop()
         Logger.PrintInfo("> Time needed for solving the primal analysis = ",round(timer.time() - startTime,2),"s")
 
-        # TODO the response value calculation for stresses currently only works on the adjoint modelpart
-        # this needs to be improved, also the response value should be calculated on the PRIMAL modelpart!!
-        self.adjoint_analysis.time = self.adjoint_analysis._GetSolver().AdvanceInTime(self.adjoint_analysis.time)
-
-        # synchronize the modelparts
-        self._SynchronizeAdjointFromPrimal()
-
-        self.adjoint_analysis.InitializeSolutionStep()
-
-
     def CalculateValue(self):
         startTime = timer.time()
         value = self._GetResponseFunctionUtility().CalculateValue(self.primal_model_part)
@@ -324,18 +313,18 @@ class AdjointResponseFunction(ResponseFunctionBase):
 
         self.primal_model_part.ProcessInfo[StructuralMechanicsApplication.RESPONSE_VALUE] = value
 
-
     def CalculateGradient(self):
-        Logger.PrintInfo("\n> Starting adjoint analysis for response:", self.identifier)
+        # synchronize the modelparts
+        self._SynchronizeAdjointFromPrimal()
         startTime = timer.time()
-        self.adjoint_analysis._GetSolver().Predict()
-        self.adjoint_analysis._GetSolver().SolveSolutionStep()
+        Logger.PrintInfo("\n> Starting adjoint analysis for response:", self.identifier)
+        if not self.adjoint_analysis.time < self.adjoint_analysis.end_time:
+            self.adjoint_analysis.end_time += 1
+        self.adjoint_analysis.RunSolutionLoop()
         Logger.PrintInfo("> Time needed for solving the adjoint analysis = ",round(timer.time() - startTime,2),"s")
-
 
     def GetValue(self):
         return self.primal_model_part.ProcessInfo[StructuralMechanicsApplication.RESPONSE_VALUE]
-
 
     def GetShapeGradient(self):
         gradient = {}
@@ -343,20 +332,12 @@ class AdjointResponseFunction(ResponseFunctionBase):
             gradient[node.Id] = node.GetSolutionStepValue(KratosMultiphysics.SHAPE_SENSITIVITY)
         return gradient
 
-
-    def FinalizeSolutionStep(self):
-        self.adjoint_analysis.FinalizeSolutionStep()
-        self.adjoint_analysis.OutputSolutionStep()
-
-
     def Finalize(self):
         self.primal_analysis.Finalize()
         self.adjoint_analysis.Finalize()
 
-
     def _GetResponseFunctionUtility(self):
         return self.adjoint_analysis._GetSolver().response_function
-
 
     def _SynchronizeAdjointFromPrimal(self):
         Logger.PrintInfo("\n> Synchronize primal and adjoint modelpart for response:", self.identifier)


### PR DESCRIPTION
Within this PR I move  `UpdateSensitivities` from `SolveSolutionStep` to `FinalizeSolutionStep` of the adjoint structural python solver. Therefor I had to modifiy `structural_response.py` and `CalculateValue`of `AdjointNodalDisplacementResponseFunction`.