### PR TITLE
Minor CMake cleanup and KratosMultiphysics install logic.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -445,22 +445,3 @@ if(${BLAS_INCLUDE_NEEDED} MATCHES ON )
 	message("installed lapack = " ${LAPACK_LIBRARIES})
 	install(FILES ${LAPACK_LIBRARIES} DESTINATION libs)
 endif(${BLAS_INCLUDE_NEEDED} MATCHES ON )
-
-################################################################################
-if(${INSTALL_PYTHON_FILES} MATCHES ON)
-  file(WRITE ${CMAKE_SOURCE_DIR}/packaging_aux/kratos.conf "${CMAKE_INSTALL_PREFIX}/libs")
-
-  install(FILES ${CMAKE_SOURCE_DIR}/packaging_aux/kratos.conf DESTINATION packaging )
-  install(FILES ${CMAKE_SOURCE_DIR}/packaging_aux/script.py DESTINATION . )
-
-  SET(CPACK_GENERATOR "DEB")
-  SET(CPACK_DEBIAN_PACKAGE_MAINTAINER "Kratos Team") #required
-  set(CPACK_PACKAGE_FILE_NAME  "Kratos_${KratosMultiphysics_VERSION_MAJOR}_${KratosMultiphysics_VERSION_MINOR}")
-  #SET(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
-  SET(CPACK_DEBIAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS} "libc6, libgcc1, libgfortran3, libgomp1, libopenmpi1.3, libparmetis3.1, libstdc++6, openmpi-bin, ${KRATOS_EXTRA_PACKAGE_DEPENDS} " )
-  #    SET(CPACK_DEBIAN_PACKAGE_DEPENDS ${CPACK_DEBIAN_PACKAGE_DEPENDS} " openmpi-bin, ${KRATOS_EXTRA_PACKAGE_DEPENDS}" )
-  Set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
-  set(CPACK_DEBIAN_PACKAGE_CONTROL_EXTRA "${CMAKE_SOURCE_DIR}/packaging_aux/postinst;${CMAKE_SOURCE_DIR}/packaging_aux/prerm;")
-
-  INCLUDE(CPack)
-endif(${INSTALL_PYTHON_FILES} MATCHES ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,8 +423,10 @@ else(DEFINED KRATOS_INSTALL_PREFIX)
   message(STATUS "Standard install dir ${CMAKE_INSTALL_PREFIX}")
 endif(DEFINED KRATOS_INSTALL_PREFIX)
 
+# Clean the Module install directory
+install(CODE "message(STATUS \"Deleting: ${CMAKE_INSTALL_PREFIX}/KratosMultiphysics\")")
+install(CODE "file(REMOVE_RECURSE \"${CMAKE_INSTALL_PREFIX}/KratosMultiphysics\")")
 
-################################################################################
 # install core files for the KratosMultiphysics python module
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/__init__.py" DESTINATION KratosMultiphysics )
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/kratos_globals.py" DESTINATION KratosMultiphysics )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -430,10 +430,6 @@ install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/__init__.py" DESTINAT
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/kratos_globals.py" DESTINATION KratosMultiphysics )
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/application_importer.py" DESTINATION KratosMultiphysics )
 
-# Remove the tags in the event of multiple versions of boost being found
-# in the same directory
-# list(REMOVE_ITEM Boost_LIBRARIES "debug" "optimized")
-
 # Install the libraries in the libs folder
 install(FILES ${Boost_LIBRARIES} DESTINATION libs)
 install(FILES ${EXTRA_INSTALL_LIBS} DESTINATION libs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -423,9 +423,11 @@ else(DEFINED KRATOS_INSTALL_PREFIX)
   message(STATUS "Standard install dir ${CMAKE_INSTALL_PREFIX}")
 endif(DEFINED KRATOS_INSTALL_PREFIX)
 
-# Clean the Module install directory
+# Clean the Module and libs install directories
 install(CODE "message(STATUS \"Deleting: ${CMAKE_INSTALL_PREFIX}/KratosMultiphysics\")")
 install(CODE "file(REMOVE_RECURSE \"${CMAKE_INSTALL_PREFIX}/KratosMultiphysics\")")
+install(CODE "message(STATUS \"Deleting: ${CMAKE_INSTALL_PREFIX}/libs\")")
+install(CODE "file(REMOVE_RECURSE \"${CMAKE_INSTALL_PREFIX}/libs\")")
 
 # install core files for the KratosMultiphysics python module
 install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/__init__.py" DESTINATION KratosMultiphysics )


### PR DESCRIPTION
A couple of changes to the CMakeFile:
- Temporally removing the packaging as it was not working anyway. The aim is to enable it again in the new version
- KratosMultiphysics folder has a custom install script now which deletes the folder on "make install" (not on configure) so changes in the python modules and old applications not compiled should no longer give problems.

This should fix #4296 and... another one, sorry don't remember the number (@philbucher is the one with the problem with the FluidDynamicsApplication from @armingeiser I think ?)