### PR TITLE
Support for conditional expressions in KRATOS_CHECK_EQUAL macros

### DIFF
--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -24,8 +24,8 @@
 #define KRATOS_CHECK(IsTrue) if(!(IsTrue)) KRATOS_ERROR << "Check failed because " << #IsTrue << " is not true"
 #define KRATOS_CHECK_IS_FALSE(IsFalse) if(IsFalse) KRATOS_ERROR  << "Check failed because " << #IsFalse << " is not false"
 
-#define KRATOS_CHECK_EQUAL(a,b) if(!(a == b)) KRATOS_ERROR << "Check failed because " << #a << " is not equal to " << #b
-#define KRATOS_CHECK_NOT_EQUAL(a,b) if(a == b) KRATOS_ERROR << "Check failed because " << #a << " is equal to " << #b
+#define KRATOS_CHECK_EQUAL(a,b) if(!((a) == (b))) KRATOS_ERROR << "Check failed because " << #a << " is not equal to " << #b
+#define KRATOS_CHECK_NOT_EQUAL(a,b) if((a) == (b)) KRATOS_ERROR << "Check failed because " << #a << " is equal to " << #b
 
 #define KRATOS_CHECK_STRING_EQUAL(a,b) if(a.compare(b) != 0) KRATOS_ERROR << "Check failed because \"" << a << "\" is not equal to \"" << b << "\""
 #define KRATOS_CHECK_STRING_NOT_EQUAL(a,b) if(a.compare(b) == 0) KRATOS_ERROR << "Check failed because \"" << a << "\" is equal to \"" << b << "\""


### PR DESCRIPTION
Writing tests for flag synchronization in MPI, I sometimes end up with checks where the expected result depends on the rank:
```C++
KRATOS_CHECK_EQUAL(node.IsDefined(INLET), rank == root); // defined only on root
```
This produces a (correct) compilation warning, since the macro expands to
```C++
if (node.IsDefined(INLET) == rank == root) {...}
```
I am adding parentheses to the macros to suppress the warning and make sure that we do not introduce bugs in this way:
```C++
if ( (node.IsDefined(INLET)) == (rank == root) ) {...}
```