### PR TITLE
Adding bool to check if the search structure has valid iterators

### DIFF
--- a/kratos/spatial_containers/search_structure.h
+++ b/kratos/spatial_containers/search_structure.h
@@ -321,12 +321,14 @@ public:
     typedef SearchStructure<IndexType,SizeType,CoordinateType,IteratorType,IteratorIteratorType,Dimension> ThisType;
 
 public:
+
     // Bin
-    //SubBinAxis<IndexType,SizeType> Axis[Dimension];
+    bool hasIterators;
     SubBinAxis<IndexType,SizeType> Axis[3];
     IteratorIteratorType RowBegin;
     IteratorIteratorType RowEnd;
     IteratorIteratorType DataBegin;
+
     // KDTree
     CoordinateType distance_to_partition;
     CoordinateType distance_to_partition2;
@@ -374,6 +376,8 @@ public:
             Axis[i].Set(Min_[i],Max_[i],MaxSize_[i],Block);
         }
         
+        hasIterators = true;
+
         DataBegin = IteratorBegin;
         
         RowBegin = DataBegin + Axis[0].Min;
@@ -394,36 +398,45 @@ public:
             Block *= MaxSize_[i-1];
             Axis[i].Set(Min_[i],Max_[i],MaxSize_[i],Block);
         }
+
+        hasIterators = false;
     }
 
     IndexType BeginRow(IndexType const& Idx)
     {
         return Idx + Axis[0].Min;
     }
+
     IndexType EndRow(IndexType const& Idx)
     {
         return Idx + Axis[0].Max+1;
     }
-
 
     SearchStructure const& operator++()
     {
         for(SizeType i = 0; i < Dimension; i++)
             ++(Axis[i]);
         
-        RowBegin = DataBegin + Axis[0].Min;
-        RowEnd   = DataBegin + Axis[0].Max + 1;
+        // Update the row iterators only if the DataBegin iterator exists
+        if(hasIterators) {
+            RowBegin = DataBegin + Axis[0].Min;
+            RowEnd   = DataBegin + Axis[0].Max + 1;
+        }
         
         return *this;
     }
+
     SearchStructure const& operator--()
     {
         for(SizeType i = 0; i < Dimension; i++)
             (Axis[i])--;
         
-        RowBegin = DataBegin + Axis[0].Min;
-        RowEnd   = DataBegin + Axis[0].Max + 1;
-        
+        // Update the row iterators only if the DataBegin iterator exists
+        if(hasIterators) {
+            RowBegin = DataBegin + Axis[0].Min;
+            RowEnd   = DataBegin + Axis[0].Max + 1;
+        }
+
         return *this;
     }
 


### PR DESCRIPTION
This fixes the bins test in #3597.

The problem is, search structure ++ and -- operators assume that the internal iterators of the class are always defined and increment/decrement them, which is not the case if certain constructors are used.

I added a check to see if the iterators are valid.
The solution is a little bit "basic" but I did not found any other mechanism to check the validity of an iterator without having access to the container it should iterate.

fixes #3597 and fixes #3254 