### PR TITLE
structural/masonry_damage_cl_2d_error in function corrected

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/plane_stress_d_plus_d_minus_damage_masonry_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/plane_stress_d_plus_d_minus_damage_masonry_2d.cpp
@@ -708,7 +708,7 @@ double DamageDPlusDMinusMasonry2DLaw::EvaluateBezierCurve(
     double C = x1 - Xi;
     if (std::abs(A) < 1.0e-12) {
         x2 = x2 + 1.0E-6 * (x3-x1);
-        A =  x1 - 2.0 * x2 + x2;
+        A =  x1 - 2.0 * x2 + x3;
         B = 2.0 * (x2 - x1);
         C = x1 - Xi;
     }


### PR DESCRIPTION
found a mistake in my implementation. now it is corrected!
cpp test doesn't need to be changed. Should still work