### PR TITLE
[StructuralMechanicsApplication][Release] Clean up cpp warnings

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_prism_neighbours_process.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_prism_neighbours_process.cpp
@@ -46,7 +46,7 @@ namespace Kratos
             const std::size_t NumberNeighbours
             )
         {
-            Properties::Pointer p_elem_prop = ThisModelPart.pGetProperties(0);
+            Properties::Pointer p_elem_prop = ThisModelPart.CreateNewProperties(0);
 
             // First we create the nodes
             NodeType::Pointer p_node_1  = ThisModelPart.CreateNewNode( 1,  0.0 ,  0.0 , 0.0);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_shell_to_solid_shell_process.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_shell_to_solid_shell_process.cpp
@@ -48,7 +48,7 @@ namespace Kratos
 
         void ShellToSolidShellProcessCreateModelPart(ModelPart& ThisModelPart)
         {
-            Properties::Pointer p_elem_prop = ThisModelPart.pGetProperties(0);
+            Properties::Pointer p_elem_prop = ThisModelPart.CreateNewProperties(0);
 
             p_elem_prop->SetValue(THICKNESS, 0.2);
 

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_shell_thickness_compute_process.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_shell_thickness_compute_process.cpp
@@ -31,7 +31,7 @@ namespace Kratos
 
         void SolidShellProcessCreateModelPart(ModelPart& ThisModelPart)
         {
-            Properties::Pointer p_elem_prop = ThisModelPart.pGetProperties(0);
+            Properties::Pointer p_elem_prop = ThisModelPart.CreateNewProperties(0);
 
             // First we create the nodes
             NodeType::Pointer p_node_1 = ThisModelPart.CreateNewNode(1, 0.0 , 0.0 , 0.0);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_static_sensitivity.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_static_sensitivity.cpp
@@ -97,8 +97,7 @@ KRATOS_TEST_CASE_IN_SUITE(TotalLagrangian2D3_StaticSensitivity, KratosStructural
     smtsss::PrimalTestSolver solver{&primal_model_part, response_node_id};
     const double delta = 1e-7;
     const double response_value0 = solver.CalculateResponseValue();
-    ModelPart& adjoint_model_part =
-        CreateStructuralMechanicsAdjointTestModelPart(&primal_model_part);
+    ModelPart& adjoint_model_part = CreateStructuralMechanicsAdjointTestModelPart(&primal_model_part);
     smtsss::AdjointTestSolver adjoint_solver{&adjoint_model_part, response_node_id};
     for (unsigned i_node : {1, 2, 3})
     {

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_transient_sensitivity.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_transient_sensitivity.cpp
@@ -134,7 +134,7 @@ SolvingStrategyType::Pointer CreatePrimalSolvingStrategy(ModelPart* pModelPart)
     SchemeType::Pointer p_scheme =
         Kratos::make_shared<ResidualBasedBossakDisplacementScheme<SparseSpaceType, LocalSpaceType>>(0.0);
     ConvergenceCriteriaType::Pointer p_conv_criteria =
-        Kratos::make_shared<ResidualCriteria<SparseSpaceType, LocalSpaceType>>(1e-24, 1e-25);
+        Kratos::make_shared<ResidualCriteria<SparseSpaceType, LocalSpaceType>>(1e-12, 1e-14);
     return Kratos::make_shared<ResidualBasedNewtonRaphsonStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType>>(
         *pModelPart, p_scheme, p_linear_solver, p_conv_criteria, 30, true, false, true);
 }

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_transient_sensitivity.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_solid_transient_sensitivity.cpp
@@ -134,7 +134,7 @@ SolvingStrategyType::Pointer CreatePrimalSolvingStrategy(ModelPart* pModelPart)
     SchemeType::Pointer p_scheme =
         Kratos::make_shared<ResidualBasedBossakDisplacementScheme<SparseSpaceType, LocalSpaceType>>(0.0);
     ConvergenceCriteriaType::Pointer p_conv_criteria =
-        Kratos::make_shared<ResidualCriteria<SparseSpaceType, LocalSpaceType>>(1e-12, 1e-14);
+        Kratos::make_shared<ResidualCriteria<SparseSpaceType, LocalSpaceType>>(1e-6, 1e-10);
     return Kratos::make_shared<ResidualBasedNewtonRaphsonStrategy<SparseSpaceType, LocalSpaceType, LinearSolverType>>(
         *pModelPart, p_scheme, p_linear_solver, p_conv_criteria, 30, true, false, true);
 }

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_spr_error_process.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_spr_error_process.cpp
@@ -33,7 +33,7 @@ namespace Kratos
         
         void Create2DGeometry(ModelPart& ThisModelPart, const std::string& ElementName)
         {
-            Properties::Pointer p_elem_prop = ThisModelPart.pGetProperties(0);
+            Properties::Pointer p_elem_prop = ThisModelPart.CreateNewProperties(0);
 
             // First we create the nodes
             NodeType::Pointer p_node_1 = ThisModelPart.CreateNewNode(1, 0.0 , 0.0 , 0.0);
@@ -76,7 +76,7 @@ namespace Kratos
 
         void Create3DGeometry(ModelPart& ThisModelPart, const std::string& ElementName)
         {
-            Properties::Pointer p_elem_prop = ThisModelPart.pGetProperties(0);
+            Properties::Pointer p_elem_prop = ThisModelPart.CreateNewProperties(0);
 
             // First we create the nodes
             NodeType::Pointer p_node_1 = ThisModelPart.CreateNewNode(1 , 0.0 , 1.0 , 1.0);
@@ -209,6 +209,8 @@ namespace Kratos
             process_info[STEP] = 1;
             process_info[NL_ITERATION_NUMBER] = 1;
             
+            Testing::Create2DGeometry(this_model_part, "SmallDisplacementElement2D3N");
+
             // In case the StructuralMechanicsApplciation is not compiled we skip the test
             Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
             if (!KratosComponents<ConstitutiveLaw>::Has("LinearElasticPlaneStrain2DLaw"))
@@ -218,8 +220,6 @@ namespace Kratos
             p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_this_law);
             p_elem_prop->SetValue(YOUNG_MODULUS, 1.0);
             p_elem_prop->SetValue(POISSON_RATIO, 0.0);
-
-            Testing::Create2DGeometry(this_model_part, "SmallDisplacementElement2D3N");
 
             for (auto& node : this_model_part.Nodes()) {
                 if (node.X() > 0.9) {
@@ -257,7 +257,9 @@ namespace Kratos
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
             process_info[NL_ITERATION_NUMBER] = 1;
-            
+
+            Testing::Create3DGeometry(this_model_part, "SmallDisplacementElement3D4N");
+
             // In case the StructuralMechanicsApplciation is not compiled we skip the test
             Properties::Pointer p_elem_prop = this_model_part.pGetProperties(0);
             if (!KratosComponents<ConstitutiveLaw>::Has("LinearElastic3DLaw"))
@@ -267,8 +269,6 @@ namespace Kratos
             p_elem_prop->SetValue(CONSTITUTIVE_LAW, p_this_law);
             p_elem_prop->SetValue(YOUNG_MODULUS, 1.0);
             p_elem_prop->SetValue(POISSON_RATIO, 0.0);
-
-            Testing::Create3DGeometry(this_model_part, "SmallDisplacementElement3D4N");
 
             for (auto& node : this_model_part.Nodes()) {
                 if (node.X() > 0.9) {

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_tangent_tensor_numerical_derivation_utility.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_tangent_tensor_numerical_derivation_utility.cpp
@@ -414,11 +414,11 @@ KRATOS_TEST_CASE_IN_SUITE(LinearElasticCasePertubationTensorUtility, KratosStruc
     ModelPart& r_model_part = this_model.CreateModelPart("Main");
 
     ConstitutiveLaw::Parameters cl_configuration_values;
-    Properties material_properties = r_model_part.GetProperties(1);
+    Properties::Pointer p_material_properties = r_model_part.CreateNewProperties(1);
     Vector stress_vector, strain_vector;
     Matrix tangent_moduli, deformation_gradient_F;
     double det_deformation_gradient_F;
-    SettingBasicCase(r_model_part, cl_configuration_values, material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F);
+    SettingBasicCase(r_model_part, cl_configuration_values, *p_material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F);
 
     auto p_constitutive_law = KratosComponents<ConstitutiveLaw>().Get("LinearElastic3DLaw").Clone();
     p_constitutive_law->CalculateMaterialResponse(cl_configuration_values, ConstitutiveLaw::StressMeasure::StressMeasure_Cauchy);
@@ -449,11 +449,11 @@ KRATOS_TEST_CASE_IN_SUITE(HyperElasticCasePertubationTensorUtility, KratosStruct
     ModelPart& r_model_part = this_model.CreateModelPart("Main");
 
     ConstitutiveLaw::Parameters cl_configuration_values;
-    Properties material_properties = r_model_part.GetProperties(1);
+    Properties::Pointer p_material_properties = r_model_part.CreateNewProperties(1);
     Vector stress_vector, strain_vector;
     Matrix tangent_moduli, deformation_gradient_F;
     double det_deformation_gradient_F;
-    SettingBasicCase(r_model_part, cl_configuration_values, material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F, false);
+    SettingBasicCase(r_model_part, cl_configuration_values, *p_material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F, false);
 
     auto p_constitutive_law = KratosComponents<ConstitutiveLaw>().Get("KirchhoffSaintVenant3DLaw").Clone();
     p_constitutive_law->CalculateMaterialResponse(cl_configuration_values, ConstitutiveLaw::StressMeasure::StressMeasure_PK2);
@@ -484,11 +484,11 @@ KRATOS_TEST_CASE_IN_SUITE(QuadraticLinearElasticCasePertubationTensorUtility, Kr
     ModelPart& r_model_part = this_model.CreateModelPart("Main");
 
     ConstitutiveLaw::Parameters cl_configuration_values;
-    Properties material_properties = r_model_part.GetProperties(1);
+    Properties::Pointer p_material_properties = r_model_part.CreateNewProperties(1);
     Vector stress_vector, strain_vector;
     Matrix tangent_moduli, deformation_gradient_F;
     double det_deformation_gradient_F;
-    SettingBasicCase(r_model_part, cl_configuration_values, material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F);
+    SettingBasicCase(r_model_part, cl_configuration_values, *p_material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F);
 
     auto p_constitutive_law = KratosComponents<ConstitutiveLaw>().Get("LinearElastic3DLaw").Clone();
     p_constitutive_law->CalculateMaterialResponse(cl_configuration_values, ConstitutiveLaw::StressMeasure::StressMeasure_PK2);
@@ -505,11 +505,11 @@ KRATOS_TEST_CASE_IN_SUITE(QuadraticKirchhoffHyperElasticCasePertubationTensorUti
     ModelPart& r_model_part = this_model.CreateModelPart("Main");
 
     ConstitutiveLaw::Parameters cl_configuration_values;
-    Properties material_properties = r_model_part.GetProperties(1);
+    Properties::Pointer p_material_properties = r_model_part.CreateNewProperties(1);
     Vector stress_vector, strain_vector;
     Matrix tangent_moduli, deformation_gradient_F;
     double det_deformation_gradient_F;
-    SettingBasicCase(r_model_part, cl_configuration_values, material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F, false);
+    SettingBasicCase(r_model_part, cl_configuration_values, *p_material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F, false);
 
     auto p_constitutive_law = KratosComponents<ConstitutiveLaw>().Get("KirchhoffSaintVenant3DLaw").Clone();
     p_constitutive_law->CalculateMaterialResponse(cl_configuration_values, ConstitutiveLaw::StressMeasure::StressMeasure_PK2);
@@ -528,15 +528,15 @@ KRATOS_TEST_CASE_IN_SUITE(QuadraticSmallStrainIsotropicPlasticity3DVonMisesVonMi
     r_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
 
     ConstitutiveLaw::Parameters cl_configuration_values;
-    Properties& r_material_properties = r_model_part.GetProperties(1);
+    Properties::Pointer p_material_properties = r_model_part.CreateNewProperties(1);
     Vector stress_vector, strain_vector;
     Matrix tangent_moduli, deformation_gradient_F;
     double det_deformation_gradient_F;
-    SettingBasicCase(r_model_part, cl_configuration_values, r_material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F, true, 2);
+    SettingBasicCase(r_model_part, cl_configuration_values, *p_material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F, true, 2);
 
     // Creating constitutive law
     auto p_constitutive_law = KratosComponents<ConstitutiveLaw>().Get("SmallStrainIsotropicPlasticity3DVonMisesVonMises").Clone();
-    r_material_properties.SetValue(CONSTITUTIVE_LAW, p_constitutive_law);
+    p_material_properties->SetValue(CONSTITUTIVE_LAW, p_constitutive_law);
 
     // Creating geometry
     Create3DGeometryHexahedra(r_model_part);
@@ -564,15 +564,15 @@ KRATOS_TEST_CASE_IN_SUITE(QuadraticSmallStrainIsotropicPlasticity3DVonMisesVonMi
     r_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
 
     ConstitutiveLaw::Parameters cl_configuration_values;
-    Properties& r_material_properties = r_model_part.GetProperties(1);
+    Properties::Pointer p_material_properties = r_model_part.CreateNewProperties(1);
     Vector stress_vector, strain_vector;
     Matrix tangent_moduli, deformation_gradient_F;
     double det_deformation_gradient_F;
-    SettingBasicCase(r_model_part, cl_configuration_values, r_material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F, true, 2);
+    SettingBasicCase(r_model_part, cl_configuration_values, *p_material_properties, stress_vector, strain_vector, tangent_moduli, deformation_gradient_F, det_deformation_gradient_F, true, 2);
 
     // Creating constitutive law
     auto p_constitutive_law = KratosComponents<ConstitutiveLaw>().Get("SmallStrainIsotropicPlasticity3DVonMisesVonMises").Clone();
-    r_material_properties.SetValue(CONSTITUTIVE_LAW, p_constitutive_law);
+    p_material_properties->SetValue(CONSTITUTIVE_LAW, p_constitutive_law);
 
     // Creating geometry
     Create3DGeometryHexahedra(r_model_part);

--- a/applications/StructuralMechanicsApplication/tests/cpp_tests/test_total_lagrangian_element_matrices.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_tests/test_total_lagrangian_element_matrices.cpp
@@ -124,7 +124,7 @@ void CreateTotalLagrangianTestModelPart(std::string const& rElementName, ModelPa
     std::vector<ModelPart::IndexType> node_ids(r_elem.GetGeometry().PointsNumber());
     for (std::size_t i = 0; i < r_elem.GetGeometry().PointsNumber(); ++i)
         node_ids.at(i) = i + 1;
-    auto p_prop = rModelPart.pGetProperties(1);
+    auto p_prop = rModelPart.CreateNewProperties(1);
     rModelPart.CreateNewElement(rElementName, 1, node_ids, p_prop);
     rModelPart.SetBufferSize(2);
     for (auto& r_node : rModelPart.Nodes())

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -260,7 +260,7 @@ def AssembleTestSuites():
     # Trusses
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestTruss3D2N]))
     # Beams
-    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestCrBeam3D2N]))
+    nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestCrBeam3D2N]))
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestCrBeam2D2N])) # TODO should be in smallSuite but is too slow
     # Loading Conditions
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestLoadingConditionsPoint]))

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -232,7 +232,7 @@ def AssembleTestSuites():
     ### Adding the self-contained tests
     # Constitutive Law tests
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestConstitutiveLaw]))
-    smallSuite.addTest(TSimpleSmallDeformationPlasticityMCTest('test_execution'))
+    nightSuite.addTest(TSimpleSmallDeformationPlasticityMCTest('test_execution'))
     smallSuite.addTest(TSimpleSmallDeformationPlasticityVMTest('test_execution'))
     smallSuite.addTest(TSimpleSmallDeformationPlasticityDPTest('test_execution'))
     smallSuite.addTest(TSimpleSmallDeformationPlasticityTTest('test_execution'))


### PR DESCRIPTION
This PR removes several warnings from cpp tests in StructuralMechanicsApplication

Migrates #4197 to the Release-7.0