### PR TITLE
[PfemFluid] Fixing InvertMatrix check error and tests warnings

### DIFF
--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_element.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_V_P_implicit_nodally_integrated_element.cpp
@@ -287,13 +287,15 @@ namespace Kratos {
     rElementalVariables.DetFgrad=1;
     MathUtils<double>::InvertMatrix(rElementalVariables.Fgrad,
 				    rElementalVariables.InvFgrad,
-				    rElementalVariables.DetFgrad);
+				    rElementalVariables.DetFgrad,
+                    -1.0);
 
     // rElementalVariables.InvFgradVel=ZeroMatrix(dimension,dimension);
     // rElementalVariables.DetFgradVel=1;
     // MathUtils<double>::InvertMatrix(rElementalVariables.FgradVel,
     // 				    rElementalVariables.InvFgradVel,
-    // 				    rElementalVariables.DetFgradVel);
+    // 				    rElementalVariables.DetFgradVel,
+    //                  -1.0);
 
     //it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
     rElementalVariables.SpatialVelocityGrad.resize(dimension,dimension);
@@ -365,13 +367,15 @@ namespace Kratos {
     rElementalVariables.DetFgrad=1;
     MathUtils<double>::InvertMatrix(rElementalVariables.Fgrad,
 				    rElementalVariables.InvFgrad,
-				    rElementalVariables.DetFgrad);
+				    rElementalVariables.DetFgrad,
+                    -1.0);
 
     // rElementalVariables.InvFgradVel=ZeroMatrix(dimension,dimension);
     // rElementalVariables.DetFgradVel=1;
     // MathUtils<double>::InvertMatrix(rElementalVariables.FgradVel,
     // 				    rElementalVariables.InvFgradVel,
-    // 				    rElementalVariables.DetFgradVel);
+    // 				    rElementalVariables.DetFgradVel,
+    //                  -1.0);
 
 
     //it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj

--- a/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_element.cpp
+++ b/applications/PfemFluidDynamicsApplication/custom_elements/two_step_updated_lagrangian_element.cpp
@@ -671,13 +671,15 @@ namespace Kratos {
     rElementalVariables.DetFgrad=1;
     MathUtils<double>::InvertMatrix(rElementalVariables.Fgrad,
 				    rElementalVariables.InvFgrad,
-				    rElementalVariables.DetFgrad);
+				    rElementalVariables.DetFgrad,
+                    -1.0);
 
     rElementalVariables.InvFgradVel=ZeroMatrix(dimension,dimension);
     rElementalVariables.DetFgradVel=1;
     MathUtils<double>::InvertMatrix(rElementalVariables.FgradVel,
 				    rElementalVariables.InvFgradVel,
-				    rElementalVariables.DetFgradVel);
+				    rElementalVariables.DetFgradVel,
+                    -1.0);
 
 
     //it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
@@ -783,13 +785,15 @@ namespace Kratos {
     rElementalVariables.DetFgrad=1;
     MathUtils<double>::InvertMatrix(rElementalVariables.Fgrad,
 				    rElementalVariables.InvFgrad,
-				    rElementalVariables.DetFgrad);
+				    rElementalVariables.DetFgrad,
+                    -1.0);
 
     rElementalVariables.InvFgradVel=ZeroMatrix(dimension,dimension);
     rElementalVariables.DetFgradVel=1;
     MathUtils<double>::InvertMatrix(rElementalVariables.FgradVel,
 				    rElementalVariables.InvFgradVel,
-				    rElementalVariables.DetFgradVel);
+				    rElementalVariables.DetFgradVel,
+                    -1.0);
 
 
     //it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
@@ -1012,7 +1016,7 @@ namespace Kratos {
     FJacobian=1;
 
 
-    MathUtils<double>::InvertMatrix( Fgrad, invFgrad, FJacobian );
+    MathUtils<double>::InvertMatrix( Fgrad, invFgrad, FJacobian, -1.0);
 
     // Fgrad.resize(2,2);
 
@@ -1087,7 +1091,7 @@ namespace Kratos {
     invFgradVel=ZeroMatrix(TDim,TDim);
     FVelJacobian=1;
 
-    MathUtils<double>::InvertMatrix( FgradVel, invFgradVel, FVelJacobian );
+    MathUtils<double>::InvertMatrix( FgradVel, invFgradVel, FVelJacobian, -1.0);
 
 
   }
@@ -1345,34 +1349,34 @@ namespace Kratos {
   }
 
 
-  template < >  
-  double TwoStepUpdatedLagrangianElement<2>::CalcNormalProjectionDefRate(const VectorType &SpatialDefRate, 
-									 const array_1d<double, 3> NormalVector) 
-  { 
-   
-    double NormalProjSpatialDefRate=NormalVector[0]*SpatialDefRate[0]*NormalVector[0]+ 
-      NormalVector[1]*SpatialDefRate[1]*NormalVector[1]+ 
-      2*NormalVector[0]*SpatialDefRate[2]*NormalVector[1]; 
- 
-    return NormalProjSpatialDefRate; 
-  } 
- 
-  template < >  
-  double TwoStepUpdatedLagrangianElement<3>::CalcNormalProjectionDefRate(const VectorType &SpatialDefRate, 
-									 const array_1d<double, 3> NormalVector) 
-  { 
-   
-    double  NormalProjSpatialDefRate=NormalVector[0]*SpatialDefRate[0]*NormalVector[0]+ 
-      NormalVector[1]*SpatialDefRate[1]*NormalVector[1]+ 
-      NormalVector[2]*SpatialDefRate[2]*NormalVector[2]+ 
-      2*NormalVector[0]*SpatialDefRate[3]*NormalVector[1]+ 
-      2*NormalVector[0]*SpatialDefRate[4]*NormalVector[2]+ 
-      2*NormalVector[1]*SpatialDefRate[5]*NormalVector[2]; 
-   
-    return NormalProjSpatialDefRate; 
+  template < >
+  double TwoStepUpdatedLagrangianElement<2>::CalcNormalProjectionDefRate(const VectorType &SpatialDefRate,
+									 const array_1d<double, 3> NormalVector)
+  {
+
+    double NormalProjSpatialDefRate=NormalVector[0]*SpatialDefRate[0]*NormalVector[0]+
+      NormalVector[1]*SpatialDefRate[1]*NormalVector[1]+
+      2*NormalVector[0]*SpatialDefRate[2]*NormalVector[1];
+
+    return NormalProjSpatialDefRate;
   }
 
-  
+  template < >
+  double TwoStepUpdatedLagrangianElement<3>::CalcNormalProjectionDefRate(const VectorType &SpatialDefRate,
+									 const array_1d<double, 3> NormalVector)
+  {
+
+    double  NormalProjSpatialDefRate=NormalVector[0]*SpatialDefRate[0]*NormalVector[0]+
+      NormalVector[1]*SpatialDefRate[1]*NormalVector[1]+
+      NormalVector[2]*SpatialDefRate[2]*NormalVector[2]+
+      2*NormalVector[0]*SpatialDefRate[3]*NormalVector[1]+
+      2*NormalVector[0]*SpatialDefRate[4]*NormalVector[2]+
+      2*NormalVector[1]*SpatialDefRate[5]*NormalVector[2];
+
+    return NormalProjSpatialDefRate;
+  }
+
+
   template < >
   double TwoStepUpdatedLagrangianElement<2>::CalcNormalProjectionDefRate(VectorType &SpatialDefRate)
   {
@@ -1612,9 +1616,9 @@ namespace Kratos {
     return std::sqrt(2.0*NormS);
   }
 
-  
 
-  
+
+
 
   template< unsigned int TDim >
   void TwoStepUpdatedLagrangianElement<TDim>::ComputeLumpedMassMatrix(Matrix& rMassMatrix,
@@ -1804,7 +1808,7 @@ namespace Kratos {
   }
 
 
- 
+
   template< unsigned int TDim >
   void TwoStepUpdatedLagrangianElement<TDim>::ComputeBulkMatrix(Matrix& BulkMatrix,
 								const ShapeFunctionsType& rN,

--- a/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/nodal_two_step_v_p_strategy.h
+++ b/applications/PfemFluidDynamicsApplication/custom_strategies/strategies/nodal_two_step_v_p_strategy.h
@@ -859,7 +859,7 @@ namespace Kratos {
 	      Matrix SpatialVelocityGrad=ZeroMatrix(dimension,dimension);
 	      //Inverse
 
-	      MathUtils<double>::InvertMatrix(Fgrad,InvFgrad,detFgrad);
+	      MathUtils<double>::InvertMatrix(Fgrad,InvFgrad,detFgrad,-1.0);
 
 	      //it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
 	      SpatialVelocityGrad=prod(FgradVel,InvFgrad);
@@ -1162,7 +1162,7 @@ namespace Kratos {
 	    //Inverse
 
 
-	    MathUtils<double>::InvertMatrix(Fgrad,InvFgrad,detFgrad);
+	    MathUtils<double>::InvertMatrix(Fgrad,InvFgrad,detFgrad,-1.0);
 
 	    //it computes the spatial velocity gradient tensor --> [L_ij]=dF_ik*invF_kj
 	    SpatialVelocityGrad=prod(FgradVel,InvFgrad);

--- a/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_explicit_solver.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_explicit_solver.py
@@ -43,7 +43,7 @@ class PfemFluidExplicitSolver(BaseSolver.PfemFluidSolver):
             "velocity_tolerance": 1e-5,
             "pressure_tolerance": 1e-5,
             "pressure_linear_solver_settings":  {
-                "solver_type"                    : "AMGCL",
+                "solver_type"                    : "amgcl",
                 "max_iteration"                  : 5000,
                 "tolerance"                      : 1e-9,
                 "provide_coordinates"            : false,
@@ -54,10 +54,10 @@ class PfemFluidExplicitSolver(BaseSolver.PfemFluidSolver):
                 "verbosity"                      : 0
             },
             "velocity_linear_solver_settings": {
-                "solver_type"                    : "BICGSTABSolver",
+                "solver_type"                    : "bicgstab",
                 "max_iteration"                  : 5000,
                 "tolerance"                      : 1e-9,
-                "preconditioner_type"            : "None",
+                "preconditioner_type"            : "none",
                 "scaling"                        : false
             },
             "solving_strategy_settings":{

--- a/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_nodal_integration_solver.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_nodal_integration_solver.py
@@ -44,7 +44,7 @@ class PfemFluidNodalIntegrationSolver(BaseSolver.PfemFluidSolver):
             "velocity_tolerance": 1e-5,
             "pressure_tolerance": 1e-5,
             "pressure_linear_solver_settings":  {
-                "solver_type"                    : "AMGCL",
+                "solver_type"                    : "amgcl",
                 "max_iteration"                  : 5000,
                 "tolerance"                      : 1e-9,
                 "provide_coordinates"            : false,
@@ -55,10 +55,10 @@ class PfemFluidNodalIntegrationSolver(BaseSolver.PfemFluidSolver):
                 "verbosity"                      : 0
             },
             "velocity_linear_solver_settings": {
-                "solver_type"                    : "BICGSTABSolver",
+                "solver_type"                    : "bicgstab",
                 "max_iteration"                  : 5000,
                 "tolerance"                      : 1e-9,
-                "preconditioner_type"            : "None",
+                "preconditioner_type"            : "none",
                 "scaling"                        : false
             },
             "solving_strategy_settings":{

--- a/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_solver.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_solver.py
@@ -42,7 +42,7 @@ class PfemFluidSolver:
             "velocity_tolerance": 1e-5,
             "pressure_tolerance": 1e-5,
             "pressure_linear_solver_settings":  {
-                "solver_type"                    : "AMGCL",
+                "solver_type"                    : "amgcl",
                 "max_iteration"                  : 5000,
                 "tolerance"                      : 1e-9,
                 "provide_coordinates"            : false,
@@ -53,10 +53,10 @@ class PfemFluidSolver:
                 "verbosity"                      : 0
             },
             "velocity_linear_solver_settings": {
-                "solver_type"                    : "BICGSTABSolver",
+                "solver_type"                    : "bicgstab",
                 "max_iteration"                  : 5000,
                 "tolerance"                      : 1e-9,
-                "preconditioner_type"            : "None",
+                "preconditioner_type"            : "none",
                 "scaling"                        : false
             },
             "solving_strategy_settings":{

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Dam_Break_2D/Mu_Rheology/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Dam_Break_2D/Mu_Rheology/ProjectParameters.json
@@ -22,14 +22,14 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "AMGCL",
+            "solver_type"         : "amgcl",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
             "provide_coordinates" : false,

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Dam_Break_2D/Newtonian_fluid/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Dam_Break_2D/Newtonian_fluid/ProjectParameters.json
@@ -22,14 +22,14 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "AMGCL",
+            "solver_type"         : "amgcl",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
             "provide_coordinates" : false,
@@ -369,5 +369,5 @@
         }
     }
     ]
-    
+
 }

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Dam_Break_2D/Non_Newtonian_fluid/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Dam_Break_2D/Non_Newtonian_fluid/ProjectParameters.json
@@ -22,14 +22,14 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "AMGCL",
+            "solver_type"         : "amgcl",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
             "provide_coordinates" : false,

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Bingham/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Bingham/ProjectParameters.json
@@ -22,17 +22,17 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "ILU0Preconditioner",
+            "preconditioner_type" : "ilu0",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "ILU0Preconditioner",
+            "preconditioner_type" : "ilu0",
             "scaling"             : false
         },
         "bodies_list"                        : [{

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_FSI/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_FSI/ProjectParameters.json
@@ -22,14 +22,14 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "AMGCL",
+            "solver_type"         : "amgcl",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
             "provide_coordinates" : false,

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Newtonian_Sloshing/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Newtonian_Sloshing/ProjectParameters.json
@@ -22,14 +22,14 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "AMGCL",
+            "solver_type"         : "amgcl",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
             "provide_coordinates" : false,

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_muIrheology/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_muIrheology/ProjectParameters.json
@@ -22,17 +22,17 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "ILU0Preconditioner",
+            "preconditioner_type" : "ilu0",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "ILU0Preconditioner",
+            "preconditioner_type" : "ilu0",
             "scaling"             : false
         },
         "bodies_list"                        : [{

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_3D_Newtonian_Sloshing/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_3D_Newtonian_Sloshing/ProjectParameters.json
@@ -22,14 +22,14 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "AMGCL",
+            "solver_type"         : "amgcl",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
             "provide_coordinates" : false,

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Water_sloshing_2D/Mu_Rheology/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Water_sloshing_2D/Mu_Rheology/ProjectParameters.json
@@ -22,17 +22,17 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-5,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-5,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "bodies_list"                        : [{
@@ -229,5 +229,5 @@
         }
     }
     ]
-    
+
 }

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Water_sloshing_2D/Newtonian_fluid/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Water_sloshing_2D/Newtonian_fluid/ProjectParameters.json
@@ -22,17 +22,17 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-5,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-5,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "bodies_list"                        : [{

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Water_sloshing_2D/Non_Newtonian_fluid/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Water_sloshing_2D/Non_Newtonian_fluid/ProjectParameters.json
@@ -22,17 +22,17 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 0,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-5,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-5,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "bodies_list"                        : [{

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Water_sloshing_Box/Newtonian_fluid/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Water_sloshing_Box/Newtonian_fluid/ProjectParameters.json
@@ -22,14 +22,14 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 1,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "AMGCL",
+            "solver_type"         : "amgcl",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
             "provide_coordinates" : false,

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Water_sloshing_Box/Non_Newtonian_fluid/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Water_sloshing_Box/Non_Newtonian_fluid/ProjectParameters.json
@@ -22,14 +22,14 @@
         "pressure_tolerance"                 : 1e-5,
         "echo_level"                         : 1,
         "velocity_linear_solver_settings"    : {
-            "solver_type"         : "BICGSTABSolver",
+            "solver_type"         : "bicgstab",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
-            "preconditioner_type" : "None",
+            "preconditioner_type" : "none",
             "scaling"             : false
         },
         "pressure_linear_solver_settings"    : {
-            "solver_type"         : "AMGCL",
+            "solver_type"         : "amgcl",
             "max_iteration"       : 5000,
             "tolerance"           : 1e-9,
             "provide_coordinates" : false,


### PR DESCRIPTION
Summary of changes:
- We avoid checking the inverted matrix because, in PFEM, elements can be eventually distorted and then they are eliminated through the remeshing process if necessary
- Tests are updated with the current linear solver names