### PR TITLE
[Fldyn] remove enrichment in almost full/empty two fluid element

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.cpp
@@ -234,12 +234,12 @@ void TwoFluidNavierStokes<TElementData>::Calculate(
     const ProcessInfo& rCurrentProcessInfo )
 {
     noalias( rOutput ) = ZeroVector( StrainSize );
-
+    
     if (rVariable == FLUID_STRESS) {
 
         // creating a new data container that goes out of scope after the function is left
         TElementData dataLocal;
-
+        
         // transferring the velocity (among other variables)
         dataLocal.Initialize(*this, rCurrentProcessInfo);
 
@@ -247,7 +247,7 @@ void TwoFluidNavierStokes<TElementData>::Calculate(
         Matrix shape_functions;
         ShapeFunctionDerivativesArrayType shape_derivatives;
 
-        // computing DN_DX values for the strain rate
+        // computing DN_DX values for the strain rate         
         this->CalculateGeometryData(gauss_weights, shape_functions, shape_derivatives);
         const unsigned int number_of_gauss_points = gauss_weights.size();
 
@@ -1960,65 +1960,50 @@ void TwoFluidNavierStokes<TElementData>::CondenseEnrichment(
         negative_volume += rData.w_gauss_neg_side[igauss_neg];
     }
     const double Vol = positive_volume + negative_volume;
+    
+    //We only enrich elements which are not almost empty/full
+    if (positive_volume / Vol > min_area_ratio && negative_volume / Vol > min_area_ratio) {
 
-    // Compute the maximum diagonal value in the enrichment stiffness matrix
-    double max_diag = 0.0;
-    for (unsigned int k = 0; k < NumNodes; ++k){
-        if (std::abs(rKeeTot(k, k)) > max_diag){
-            max_diag = std::abs(rKeeTot(k, k));
-        }
-    }
-    if (max_diag == 0){
-        max_diag = 1.0;
-    }
-
-    // Check that positive and negative volumes ratios are larger than the minimum
-    // If not, substitute the enrichment term by
-    if (positive_volume / Vol < min_area_ratio){
-        for (unsigned int i = 0; i < NumNodes; ++i){
-            if (rData.Distance[i] >= 0.0){
-                rKeeTot(i, i) += 1000.0 * max_diag;
+        // Compute the maximum diagonal value in the enrichment stiffness matrix
+        double max_diag = 0.0;
+        for (unsigned int k = 0; k < NumNodes; ++k){
+            if (std::abs(rKeeTot(k, k)) > max_diag){
+                max_diag = std::abs(rKeeTot(k, k));
             }
         }
-    }
-
-    if (negative_volume / Vol < min_area_ratio){
-        for (unsigned int i = 0; i < NumNodes; ++i){
-            if (rData.Distance[i] < 0.0){
-                rKeeTot(i, i) += 1000.0 * max_diag;
+        if (max_diag == 0.0){
+            max_diag = 1.0;
+        }
+        // "weakly" impose continuity
+        for (unsigned int i = 0; i < Dim; ++i){
+            const double di = std::abs(rData.Distance[i]);
+            for (unsigned int j = i + 1; j < NumNodes; j++){
+                const double dj = std::abs(rData.Distance[j]);
+                // Check if the edge is cut, if it is, set the penalty constraint
+                if (rData.Distance[i] * rData.Distance[j] < 0.0){
+                    double sum_d = di + dj;
+                    double Ni = dj / sum_d;
+                    double Nj = di / sum_d;
+                    double penalty_coeff = max_diag * 0.001; // h/BDFVector[0];
+                    rKeeTot(i, i) += penalty_coeff * Ni * Ni;
+                    rKeeTot(i, j) -= penalty_coeff * Ni * Nj;
+                    rKeeTot(j, i) -= penalty_coeff * Nj * Ni;
+                    rKeeTot(j, j) += penalty_coeff * Nj * Nj;
+                }
             }
         }
+
+        // Enrichment condensation (add to LHS and RHS the enrichment contributions)
+        double det;
+        MatrixType inverse_diag(NumNodes, NumNodes);
+        MathUtils<double>::InvertMatrix(rKeeTot, inverse_diag, det);
+
+        const Matrix tmp = prod(inverse_diag, rHtot);
+        noalias(rLeftHandSideMatrix) -= prod(rVtot, tmp);
+
+        const Vector tmp2 = prod(inverse_diag, rRHSeeTot);
+        noalias(rRightHandSideVector) -= prod(rVtot, tmp2);
     }
-
-    // "weakly" impose continuity
-    for (unsigned int i = 0; i < Dim; ++i){
-        const double di = std::abs(rData.Distance[i]);
-        for (unsigned int j = i + 1; j < NumNodes; j++){
-            const double dj = std::abs(rData.Distance[j]);
-            // Check if the edge is cut, if it is, set the penalty constraint
-            if (rData.Distance[i] * rData.Distance[j] < 0.0){
-                double sum_d = di + dj;
-                double Ni = dj / sum_d;
-                double Nj = di / sum_d;
-                double penalty_coeff = max_diag * 0.001; // h/BDFVector[0];
-                rKeeTot(i, i) += penalty_coeff * Ni * Ni;
-                rKeeTot(i, j) -= penalty_coeff * Ni * Nj;
-                rKeeTot(j, i) -= penalty_coeff * Nj * Ni;
-                rKeeTot(j, j) += penalty_coeff * Nj * Nj;
-            }
-        }
-    }
-
-    // Enrichment condensation (add to LHS and RHS the enrichment contributions)
-    double det;
-    MatrixType inverse_diag(NumNodes, NumNodes);
-    MathUtils<double>::InvertMatrix(rKeeTot, inverse_diag, det);
-
-    const Matrix tmp = prod(inverse_diag, rHtot);
-    noalias(rLeftHandSideMatrix) -= prod(rVtot, tmp);
-
-    const Vector tmp2 = prod(inverse_diag, rRHSeeTot);
-    noalias(rRightHandSideVector) -= prod(rVtot, tmp2);
 }
 
 template <class TElementData>

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.cpp
@@ -1947,7 +1947,7 @@ void TwoFluidNavierStokes<TElementData>::CondenseEnrichment(
     MatrixType &rKeeTot,
     const VectorType &rRHSeeTot)
 {
-    const double min_area_ratio = -1e-6;
+    const double min_area_ratio = 1e-7;
 
     // Compute positive side, negative side and total volumes
     double positive_volume = 0.0;

--- a/applications/FluidDynamicsApplication/symbolic_generation/two_fluid_navier_stokes/two_fluid_navier_stokes_template.cpp
+++ b/applications/FluidDynamicsApplication/symbolic_generation/two_fluid_navier_stokes/two_fluid_navier_stokes_template.cpp
@@ -701,7 +701,7 @@ void TwoFluidNavierStokes<TElementData>::CondenseEnrichment(
     MatrixType &rKeeTot,
     const VectorType &rRHSeeTot)
 {
-    const double min_area_ratio = -1e-6;
+    const double min_area_ratio = 1e-7;
 
     // Compute positive side, negative side and total volumes
     double positive_volume = 0.0;


### PR DESCRIPTION
After latest changes in math utils, we have found that when an element is cut by the interface very close to a node, diagonal enrichment matrix is almost singular and math utils throws an error.

Solution proposed here is not to apply the enrichment for such elements. If you find this ok, I will apply this same change to the other two fluids elements.

PD: sorry for the "chosmetic" changes, I can remove them if you prefer so.