### PR TITLE
[Core][NR-Strategy] adding iteration-number print

### DIFF
--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -1072,7 +1072,7 @@ class ResidualBasedNewtonRaphsonStrategy
     virtual void MaxIterationsExceeded()
     {
         KRATOS_INFO_IF("NR-Strategy", this->GetEchoLevel() > 0)
-            << " ATTENTION: max iterations ( " << mMaxIterationNumber
+            << "ATTENTION: max iterations ( " << mMaxIterationNumber
             << " ) exceeded!" << std::endl;
     }
 

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -790,6 +790,10 @@ class ResidualBasedNewtonRaphsonStrategy
             MaxIterationsExceeded();
         }
 
+        if (this->GetEchoLevel() > 0){
+            KRATOS_INFO("NR-Strategy") << "Iteration " << IterationNumber << " / " << mMaxIterationNumber << std::endl;
+        }
+
         //recalculate residual if needed
         //(note that some convergence criteria need it to be recalculated)
         if (residual_is_updated == false)
@@ -1037,10 +1041,6 @@ class ResidualBasedNewtonRaphsonStrategy
         TSystemMatrixType& rA  = *mpA;
         TSystemVectorType& rDx = *mpDx;
         TSystemVectorType& rb  = *mpb;
-
-        if (this->GetEchoLevel() != 0){
-            KRATOS_INFO("NR-Strategy") << "Iteration " << IterationNumber << " / " << mMaxIterationNumber << std::endl;
-        }
 
         if (this->GetEchoLevel() == 2) //if it is needed to print the debug info
         {

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -788,10 +788,10 @@ class ResidualBasedNewtonRaphsonStrategy
         //plots a warning if the maximum number of iterations is exceeded
         if (iteration_number >= mMaxIterationNumber) {
             MaxIterationsExceeded();
-        }
-
-        if (this->GetEchoLevel() > 0){
-            KRATOS_INFO("NR-Strategy") << "Iteration " << IterationNumber << " / " << mMaxIterationNumber << std::endl;
+        } else {
+            KRATOS_INFO_IF("NR-Strategy", this->GetEchoLevel() > 0)
+                << "Convergence achieved after " << iteration_number << " / "
+                << mMaxIterationNumber << " iterations" << std::endl;
         }
 
         //recalculate residual if needed
@@ -1071,11 +1071,11 @@ class ResidualBasedNewtonRaphsonStrategy
 
     virtual void MaxIterationsExceeded()
     {
-        if (this->GetEchoLevel() != 0) {
-            KRATOS_INFO("NR-Strategy") << "\n***************************************************\n"
-                                       << "******* ATTENTION: max iterations exceeded ********\n"
-                                       << "***************************************************" << std::endl;
-        }
+        KRATOS_INFO_IF("NR-Strategy", this->GetEchoLevel() > 0)
+            << "\n***************************************************\n"
+            << "******* ATTENTION: max iterations ( " << mMaxIterationNumber
+            << " ) exceeded ********\n"
+            << "***************************************************" << std::endl;
     }
 
     ///@}

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -432,10 +432,10 @@ class ResidualBasedNewtonRaphsonStrategy
             #pragma omp parallel for firstprivate(it_begin)
             for(int i=0; i<static_cast<int>(BaseType::GetModelPart().MasterSlaveConstraints().size()); ++i)
                  (it_begin+i)->Apply(rProcessInfo);
-            
 
-            
-            //the following is needed since we need to eventually compute time derivatives after applying 
+
+
+            //the following is needed since we need to eventually compute time derivatives after applying
             //Master slave relations
             TSparseSpace::SetToZero(rDx);
             this->GetScheme()->Update(BaseType::GetModelPart(), r_dof_set, rA, rDx, rb);
@@ -563,8 +563,6 @@ class ResidualBasedNewtonRaphsonStrategy
             typename TBuilderAndSolverType::Pointer p_builder_and_solver = GetBuilderAndSolver();
             ModelPart& r_model_part = BaseType::GetModelPart();
 
-            const int rank = r_model_part.GetCommunicator().MyPID();
-
             //set up the system, operation performed just once unless it is required
             //to reform the dof set at each iteration
             BuiltinTimer system_construction_time;
@@ -574,24 +572,24 @@ class ResidualBasedNewtonRaphsonStrategy
                 //setting up the list of the DOFs to be solved
                 BuiltinTimer setup_dofs_time;
                 p_builder_and_solver->SetUpDofSet(p_scheme, r_model_part);
-                KRATOS_INFO_IF("Setup Dofs Time", BaseType::GetEchoLevel() > 0 && rank == 0)
+                KRATOS_INFO_IF("Setup Dofs Time", BaseType::GetEchoLevel() > 0)
                     << setup_dofs_time.ElapsedSeconds() << std::endl;
 
                 //shaping correctly the system
                 BuiltinTimer setup_system_time;
                 p_builder_and_solver->SetUpSystem(r_model_part);
-                KRATOS_INFO_IF("Setup System Time", BaseType::GetEchoLevel() > 0 && rank == 0)
+                KRATOS_INFO_IF("Setup System Time", BaseType::GetEchoLevel() > 0)
                     << setup_system_time.ElapsedSeconds() << std::endl;
 
                 //setting up the Vectors involved to the correct size
                 BuiltinTimer system_matrix_resize_time;
                 p_builder_and_solver->ResizeAndInitializeVectors(p_scheme, mpA, mpDx, mpb,
                                                                  r_model_part);
-                KRATOS_INFO_IF("System Matrix Resize Time", BaseType::GetEchoLevel() > 0 && rank == 0)
+                KRATOS_INFO_IF("System Matrix Resize Time", BaseType::GetEchoLevel() > 0)
                     << system_matrix_resize_time.ElapsedSeconds() << std::endl;
             }
 
-            KRATOS_INFO_IF("System Construction Time", BaseType::GetEchoLevel() > 0 && rank == 0)
+            KRATOS_INFO_IF("System Construction Time", BaseType::GetEchoLevel() > 0)
                 << system_construction_time.ElapsedSeconds() << std::endl;
 
             TSystemMatrixType& rA  = *mpA;
@@ -788,8 +786,9 @@ class ResidualBasedNewtonRaphsonStrategy
         }
 
         //plots a warning if the maximum number of iterations is exceeded
-        if (iteration_number >= mMaxIterationNumber && BaseType::GetModelPart().GetCommunicator().MyPID() == 0)
+        if (iteration_number >= mMaxIterationNumber) {
             MaxIterationsExceeded();
+        }
 
         //recalculate residual if needed
         //(note that some convergence criteria need it to be recalculated)
@@ -1039,6 +1038,10 @@ class ResidualBasedNewtonRaphsonStrategy
         TSystemVectorType& rDx = *mpDx;
         TSystemVectorType& rb  = *mpb;
 
+        if (this->GetEchoLevel() != 0){
+            KRATOS_INFO("NR-Strategy") << "Iteration " << IterationNumber << " / " << mMaxIterationNumber << std::endl;
+        }
+
         if (this->GetEchoLevel() == 2) //if it is needed to print the debug info
         {
             KRATOS_INFO("Dx")  << "Solution obtained = " << rDx << std::endl;
@@ -1064,16 +1067,14 @@ class ResidualBasedNewtonRaphsonStrategy
 
     /**
      * @brief This method prints information after reach the max number of iterations
-     * @todo Replace by logger
      */
 
     virtual void MaxIterationsExceeded()
     {
-        if (this->GetEchoLevel() != 0 && BaseType::GetModelPart().GetCommunicator().MyPID() == 0)
-        {
-            std::cout << "***************************************************" << std::endl;
-            std::cout << "******* ATTENTION: max iterations exceeded ********" << std::endl;
-            std::cout << "***************************************************" << std::endl;
+        if (this->GetEchoLevel() != 0) {
+            KRATOS_INFO("NR-Strategy") << "\n***************************************************\n"
+                                       << "******* ATTENTION: max iterations exceeded ********\n"
+                                       << "***************************************************" << std::endl;
         }
     }
 

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -1072,10 +1072,8 @@ class ResidualBasedNewtonRaphsonStrategy
     virtual void MaxIterationsExceeded()
     {
         KRATOS_INFO_IF("NR-Strategy", this->GetEchoLevel() > 0)
-            << "\n***************************************************\n"
-            << "******* ATTENTION: max iterations ( " << mMaxIterationNumber
-            << " ) exceeded ********\n"
-            << "***************************************************" << std::endl;
+            << " ATTENTION: max iterations ( " << mMaxIterationNumber
+            << " ) exceeded!" << std::endl;
     }
 
     ///@}


### PR DESCRIPTION
I think this is really handy, no clue why it was not there before

additionally removing the rank-checks since now the MPI-Logger is implemented 