### PR TITLE
[ParticleMechanics] Adding neglect check for CamClay

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_constitutive/flow_rules/borja_cam_clay_plastic_flow_rule.cpp
+++ b/applications/ParticleMechanicsApplication/custom_constitutive/flow_rules/borja_cam_clay_plastic_flow_rule.cpp
@@ -261,7 +261,7 @@ bool BorjaCamClayPlasticFlowRule::CalculateConsistencyCondition(RadialReturnVari
 
         // Compute Inverse LHS Matrix
         double det_lhs = MathUtils<double>::Det(lhs_matrix);
-        MathUtils<double>::InvertMatrix( lhs_matrix, inv_lhs_matrix, det_lhs);
+        MathUtils<double>::InvertMatrix( lhs_matrix, inv_lhs_matrix, det_lhs, -1.0);
 
         // Update delta_unknown_vector
         delta_unknown_vector = prod(inv_lhs_matrix, rhs_vector);


### PR DESCRIPTION
Just to avoid check condition number during matrix inversion in CamClay.