### PR TITLE
[MeshMovingApp] cleaning mesh-moving analysis

### DIFF
--- a/applications/MeshMovingApplication/python_scripts/mesh_moving_analysis.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_moving_analysis.py
@@ -10,84 +10,13 @@ from KratosMultiphysics.analysis_stage import AnalysisStage
 class MeshMovingAnalysis(AnalysisStage):
     """
     This class is the main-script of the MeshMovingApplication put in a class
-
     It can be imported and used as "black-box"
     """
-    def __init__(self, model, project_parameters):
-        # Making sure that older cases still work by properly initalizing the parameters
-        solver_settings = project_parameters["solver_settings"]
-        if not solver_settings.Has("time_stepping"):
-            KratosMultiphysics.Logger.PrintWarning("MeshMovingAnalysis", "Using the old way to pass the time_step, this will be removed!")
-            time_stepping_params = KratosMultiphysics.Parameters("{}")
-            time_stepping_params.AddValue("time_step", project_parameters["problem_data"]["time_step"])
-            solver_settings.AddValue("time_stepping", time_stepping_params)
-
-        if not solver_settings.Has("domain_size"):
-            KratosMultiphysics.Logger.PrintWarning("MeshMovingAnalysis", "Using the old way to pass the domain_size, this will be removed!")
-            solver_settings.AddEmptyValue("domain_size")
-            solver_settings["domain_size"].SetInt(project_parameters["problem_data"]["domain_size"].GetInt())
-
-        if not solver_settings.Has("model_part_name"):
-            KratosMultiphysics.Logger.PrintWarning("MeshMovingAnalysis", "Using the old way to pass the model_part_name, this will be removed!")
-            solver_settings.AddEmptyValue("model_part_name")
-            solver_settings["model_part_name"].SetString(project_parameters["problem_data"]["model_part_name"].GetString())
-
-        if not solver_settings.Has("echo_level"): # this is done to remain backwards-compatible
-            KratosMultiphysics.Logger.PrintWarning("MeshMovingAnalysis", '"solver_settings" does not have "echo_level", please add it!')
-            solver_settings.AddEmptyValue("echo_level")
-            solver_settings["echo_level"].SetInt(0)
-
-        super(MeshMovingAnalysis, self).__init__(model, project_parameters)
 
     #### Internal functions ####
     def _CreateSolver(self):
         """ Create the Solver (and create and import the ModelPart if it is not alread in the model) """
-        ## Solver construction
         return mesh_mothion_solvers.CreateSolver(self.model, self.project_parameters)
-
-    def _CreateProcesses(self, parameter_name, initialization_order):
-        """Create a list of Processes
-        This method is TEMPORARY to not break existing code
-        It will be removed in the future
-        """
-        list_of_processes = super(MeshMovingAnalysis, self)._CreateProcesses(parameter_name, initialization_order)
-
-        if parameter_name == "processes":
-            processes_block_names = ["boundary_conditions_process_list", "list_other_processes", "json_output_process",
-                "json_check_process", "check_analytic_results_process"]
-            if len(list_of_processes) == 0: # Processes are given in the old format
-                KratosMultiphysics.Logger.PrintWarning("MeshMovingAnalysis", "Using the old way to create the processes, this will be removed!")
-                from process_factory import KratosProcessFactory
-                factory = KratosProcessFactory(self.model)
-                for process_name in processes_block_names:
-                    if (self.project_parameters.Has(process_name) is True):
-                        list_of_processes += factory.ConstructListOfProcesses(self.project_parameters[process_name])
-            else: # Processes are given in the new format
-                for process_name in processes_block_names:
-                    if (self.project_parameters.Has(process_name) is True):
-                        raise Exception("Mixing of process initialization is not alowed!")
-        elif parameter_name == "output_processes":
-            if self.project_parameters.Has("output_configuration"):
-                KratosMultiphysics.Logger.PrintWarning("MeshMovingAnalysis", "Using the old way to create the gid-output, this will be removed!")
-                gid_output= self._SetUpGiDOutput()
-                list_of_processes += [gid_output,]
-        else:
-            raise NameError("wrong parameter name")
-
-        return list_of_processes
-
-    def _SetUpGiDOutput(self):
-        '''Initialize a GiD output instance'''
-        if self.parallel_type == "OpenMP":
-            from gid_output_process import GiDOutputProcess as OutputProcess
-        elif self.parallel_type == "MPI":
-            from gid_output_process_mpi import GiDOutputProcessMPI as OutputProcess
-
-        gid_output = OutputProcess(self._GetSolver().GetComputingModelPart(),
-                                   self.project_parameters["problem_data"]["problem_name"].GetString() ,
-                                   self.project_parameters["output_configuration"])
-
-        return gid_output
 
     def _GetSimulationName(self):
         return "::[Mesh Moving Simulation]:: "

--- a/applications/MeshMovingApplication/python_scripts/mesh_moving_analysis.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_moving_analysis.py
@@ -12,11 +12,53 @@ class MeshMovingAnalysis(AnalysisStage):
     This class is the main-script of the MeshMovingApplication put in a class
     It can be imported and used as "black-box"
     """
+    def __init__(self, model, project_parameters):
+        # Making sure that older cases fail with a meaningful error message
+        solver_settings = project_parameters["solver_settings"]
+        if not solver_settings.Has("time_stepping"):
+            raise Exception("Using the old way to pass the time_step, this was removed!")
+
+        if not solver_settings.Has("domain_size"):
+            raise Exception("Using the old way to pass the domain_size, this was removed!")
+
+        if not solver_settings.Has("model_part_name"):
+            raise Exception("Using the old way to pass the model_part_name, this was removed!")
+
+        if not solver_settings.Has("echo_level"): # this is done to remain backwards-compatible
+            raise Exception('"solver_settings" does not have "echo_level", please add it!')
+
+        super(MeshMovingAnalysis, self).__init__(model, project_parameters)
 
     #### Internal functions ####
     def _CreateSolver(self):
         """ Create the Solver (and create and import the ModelPart if it is not alread in the model) """
         return mesh_mothion_solvers.CreateSolver(self.model, self.project_parameters)
+
+    def _CreateProcesses(self, parameter_name, initialization_order):
+        """Create a list of Processes
+        This method is TEMPORARY to not break existing code
+        It was removed, now throwing errors to avoid silent failures
+        """
+        list_of_processes = super(MeshMovingAnalysis, self)._CreateProcesses(parameter_name, initialization_order)
+
+        if parameter_name == "processes":
+            processes_block_names = ["boundary_conditions_process_list", "list_other_processes", "json_output_process",
+                "json_check_process", "check_analytic_results_process"]
+            if len(list_of_processes) == 0: # Processes are given in the old format (or no processes are specified)
+                for process_name in processes_block_names:
+                    if self.project_parameters.Has(process_name):
+                        raise Exception("Using the old way to create the processes, this was removed!")
+            else: # Processes are given in the new format
+                for process_name in processes_block_names:
+                    if self.project_parameters.Has(process_name):
+                        raise Exception("Mixing of process initialization is not alowed!")
+        elif parameter_name == "output_processes":
+            if self.project_parameters.Has("output_configuration"):
+                raise Exception("Using the old way to create the gid-output, this was removed!")
+        else:
+            raise NameError("wrong parameter name")
+
+        return list_of_processes
 
     def _GetSimulationName(self):
         return "::[Mesh Moving Simulation]:: "

--- a/applications/ShapeOptimizationApplication/python_scripts/mesh_controller_with_solver.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/mesh_controller_with_solver.py
@@ -28,17 +28,18 @@ class MeshControllerWithSolver(MeshController) :
         {
             "apply_mesh_solver" : true,
             "solver_settings" : {
-                "solver_type" : "structural_similarity",
-                "model_part_name"       : "",
+                "domain_size"     : 3,
+                "echo_level"      : 0,
+                "solver_type"     : "structural_similarity",
+                "model_part_name" : "NONE",
                 "model_import_settings"              : {
                     "input_type"     : "use_input_model_part"
                 },
                 "time_stepping" : {
                     "time_step"       : 1.0
                 },
-                "domain_size"     : 3,
                 "mesh_motion_linear_solver_settings" : {
-                    "solver_type" : "AMGCL",
+                    "solver_type" : "amgcl",
                     "smoother_type":"ilu0",
                     "krylov_type": "gmres",
                     "coarsening_type": "aggregation",
@@ -49,10 +50,14 @@ class MeshControllerWithSolver(MeshController) :
                 "compute_reactions"         : false,
                 "calculate_mesh_velocities" : false
             },
-            "boundary_conditions_process_list" : []
+            "processes" : {
+                "boundary_conditions_process_list" : []
+            }
         }""")
         self.MeshSolverSettings = MeshSolverSettings
         self.MeshSolverSettings.ValidateAndAssignDefaults(default_settings)
+        self.MeshSolverSettings["solver_settings"].ValidateAndAssignDefaults(default_settings["solver_settings"])
+        self.MeshSolverSettings["processes"].ValidateAndAssignDefaults(default_settings["processes"])
 
         if not self.MeshSolverSettings["solver_settings"].Has("mesh_motion_linear_solver_settings"):
             MeshSolverSettings.AddValue("mesh_motion_linear_solver_settings", default_settings["solver_settings"]["mesh_motion_linear_solver_settings"])
@@ -65,7 +70,7 @@ class MeshControllerWithSolver(MeshController) :
 
         self.OptimizationModelPart = model[self.MeshSolverSettings["solver_settings"]["model_part_name"].GetString()]
 
-        if self.MeshSolverSettings["boundary_conditions_process_list"].size() == 0:
+        if self.MeshSolverSettings["processes"]["boundary_conditions_process_list"].size() == 0:
             self.__FixWholeSurface(self.OptimizationModelPart, self.MeshSolverSettings)
             self.has_automatic_boundary_process = True
         else:
@@ -116,9 +121,9 @@ class MeshControllerWithSolver(MeshController) :
     @staticmethod
     def __AddDefaultProblemData(mesh_solver_settings):
         problem_data = Parameters("""{
-            "echo_level" : 0,
-            "start_time" : 0.0,
-            "end_time" : 1.0,
+            "echo_level"    : 0,
+            "start_time"    : 0.0,
+            "end_time"      : 1.0,
             "parallel_type" : "OpenMP"
         }""")
 
@@ -145,6 +150,6 @@ class MeshControllerWithSolver(MeshController) :
             """)
 
         print("> Add automatic process to fix the whole surface to mesh motion solver:")
-        mesh_solver_settings["boundary_conditions_process_list"].Append(auto_process_settings)
+        mesh_solver_settings["processes"]["boundary_conditions_process_list"].Append(auto_process_settings)
 
 # ==============================================================================

--- a/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
@@ -41,12 +41,13 @@ class ModelPartController:
             "mesh_motion" : {
                 "apply_mesh_solver" : false,
                 "solver_settings" : { },
-                "boundary_conditions_process_list" : []
+                "processes" : {}
             }
         }""")
 
         self.model_settings.ValidateAndAssignDefaults(default_settings)
         self.model_settings["model_import_settings"].ValidateAndAssignDefaults(default_settings["model_import_settings"])
+        self.model_settings["mesh_motion"].ValidateAndAssignDefaults(default_settings["mesh_motion"])
 
         self.model = model
 

--- a/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
@@ -39,15 +39,12 @@ class ModelPartController:
                 "damping_regions" : []
             },
             "mesh_motion" : {
-                "apply_mesh_solver" : false,
-                "solver_settings" : { },
-                "processes" : {}
+                "apply_mesh_solver" : false
             }
         }""")
 
         self.model_settings.ValidateAndAssignDefaults(default_settings)
         self.model_settings["model_import_settings"].ValidateAndAssignDefaults(default_settings["model_import_settings"])
-        self.model_settings["mesh_motion"].ValidateAndAssignDefaults(default_settings["mesh_motion"])
 
         self.model = model
 

--- a/applications/ShapeOptimizationApplication/test_examples/01_Strain_Energy_Minimization_3D_Hook/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/test_examples/01_Strain_Energy_Minimization_3D_Hook/optimization_parameters.json
@@ -57,8 +57,7 @@
                         "verbosity"           : 1
                     },
                     "compute_reactions"     : false
-                },
-                "boundary_conditions_process_list" : []
+                }
             }
         },
         "objectives" : [{

--- a/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/run_test.py
@@ -6,8 +6,9 @@ from KratosMultiphysics import *
 from KratosMultiphysics.ShapeOptimizationApplication import *
 
 # Additional imports
+from KratosMultiphysics.KratosUnittest import TestCase
 import KratosMultiphysics.kratos_utilities as kratos_utilities
-import os
+import os, csv
 
 # Read parameters
 with open("optimization_parameters.json",'r') as parameter_file:
@@ -23,13 +24,35 @@ optimizer.Optimize()
 # =======================================================================================================
 # Test results and clean directory
 # =======================================================================================================
-
-# Testing is done using the "json_output_process" & "json_check_process" within the structural analysis
-
-# Cleaning
 original_directory = os.getcwd()
 output_directory = parameters["optimization_settings"]["output"]["output_directory"].GetString()
 optimization_model_part_name = parameters["optimization_settings"]["model_settings"]["model_part_name"].GetString()
+optimization_log_filename = parameters["optimization_settings"]["output"]["optimization_log_filename"].GetString() + ".csv"
+
+# Testing by
+# 1) using the "json_output_process" & "json_check_process" within the structural analysis
+# 2) additionally checking some process output
+os.chdir(output_directory)
+
+with open(optimization_log_filename, 'r') as csvfile:
+    reader = csv.reader(csvfile, delimiter=',')
+    last_line = None
+    for line in reader:
+        if not line:
+            continue
+        else:
+            last_line = line
+
+    resulting_iteration = float(last_line[0].strip())
+    resulting_abs_improvement = float(last_line[2].strip())
+
+    # Check against specifications
+    TestCase().assertEqual(resulting_iteration, 5)
+    TestCase().assertAlmostEqual(resulting_abs_improvement, 290.094, 3)
+
+os.chdir(original_directory)
+
+# Cleaning
 kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
 kratos_utilities.DeleteDirectoryIfExisting(output_directory)
 kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")

--- a/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/run_test.py
@@ -6,8 +6,9 @@ from KratosMultiphysics import *
 from KratosMultiphysics.ShapeOptimizationApplication import *
 
 # Additional imports
+from KratosMultiphysics.KratosUnittest import TestCase
 import KratosMultiphysics.kratos_utilities as kratos_utilities
-import os
+import os, csv
 
 # Read parameters
 with open("optimization_parameters.json",'r') as parameter_file:
@@ -23,13 +24,35 @@ optimizer.Optimize()
 # =======================================================================================================
 # Test results and clean directory
 # =======================================================================================================
-
-# Testing is done using the "json_output_process" & "json_check_process" within the structural analysis
-
-# Cleaning
 original_directory = os.getcwd()
 output_directory = parameters["optimization_settings"]["output"]["output_directory"].GetString()
 optimization_model_part_name = parameters["optimization_settings"]["model_settings"]["model_part_name"].GetString()
+optimization_log_filename = parameters["optimization_settings"]["output"]["optimization_log_filename"].GetString() + ".csv"
+
+# Testing by
+# 1) using the "json_output_process" & "json_check_process" within the structural analysis
+# 2) additionally checking some process output
+os.chdir(output_directory)
+
+with open(optimization_log_filename, 'r') as csvfile:
+    reader = csv.reader(csvfile, delimiter=',')
+    last_line = None
+    for line in reader:
+        if not line:
+            continue
+        else:
+            last_line = line
+
+    resulting_iteration = float(last_line[0].strip())
+    resulting_abs_improvement = float(last_line[2].strip())
+
+    # Check against specifications
+    TestCase().assertEqual(resulting_iteration, 7)
+    TestCase().assertAlmostEqual(resulting_abs_improvement, -98.843, 3)
+
+os.chdir(original_directory)
+
+# Cleaning
 kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
 kratos_utilities.DeleteDirectoryIfExisting(output_directory)
 kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
@@ -14,15 +14,15 @@
             "mesh_motion" : {
                 "apply_mesh_solver" : true,
                 "solver_settings" : {
-                    "solver_type": "mesh_solver_structural_similarity",
-                    "model_part_name"    : "structure",
-                    "model_import_settings"              : {
+                    "domain_size"     : 3,
+                    "solver_type"     : "structural_similarity",
+                    "model_part_name" : "structure",
+                    "model_import_settings" : {
                         "input_type"     : "use_input_model_part"
                     },
                     "time_stepping" : {
                         "time_step"       : 1.0
                     },
-                    "domain_size"     : 3,
                     "mesh_motion_linear_solver_settings"  : {
                         "solver_type"         : "AMGCL",
                         "max_iteration"       : 500,
@@ -33,8 +33,7 @@
                         "coarsening_type"     : "aggregation",
                         "scaling"             : false,
                         "verbosity"           : 1
-                    },
-                    "compute_reactions"     : false
+                    }
                 }
             }
         },

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/primal_parameters.json
@@ -29,7 +29,7 @@
         "residual_absolute_tolerance"        : 1e-9,
         "max_iteration"                      : 10,
         "problem_domain_sub_model_part_list" : ["Parts_structure"],
-        "processes_sub_model_part_list"      : ["DISPLACEMENT_support","PointLoad3D_load_point"],
+        "processes_sub_model_part_list"      : ["DISPLACEMENT_support","PointLoad3D_load_point", "structure"],
         "rotation_dofs"                      : false
     },
     "processes": {

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/run_test.py
@@ -6,8 +6,9 @@ from KratosMultiphysics import *
 from KratosMultiphysics.ShapeOptimizationApplication import *
 
 # Additional imports
+from KratosMultiphysics.KratosUnittest import TestCase
 import KratosMultiphysics.kratos_utilities as kratos_utilities
-import os
+import os, csv
 
 # Read parameters
 with open("optimization_parameters.json",'r') as parameter_file:
@@ -23,13 +24,35 @@ optimizer.Optimize()
 # =======================================================================================================
 # Test results and clean directory
 # =======================================================================================================
-
-# Testing is done using the "json_output_process" & "json_check_process" within the structural analysis
-
-# Cleaning
 original_directory = os.getcwd()
 output_directory = parameters["optimization_settings"]["output"]["output_directory"].GetString()
 optimization_model_part_name = parameters["optimization_settings"]["model_settings"]["model_part_name"].GetString()
+optimization_log_filename = parameters["optimization_settings"]["output"]["optimization_log_filename"].GetString() + ".csv"
+
+# Testing by
+# 1) using the "json_output_process" & "json_check_process" within the structural analysis
+# 2) additionally checking some process output
+os.chdir(output_directory)
+
+with open(optimization_log_filename, 'r') as csvfile:
+    reader = csv.reader(csvfile, delimiter=',')
+    last_line = None
+    for line in reader:
+        if not line:
+            continue
+        else:
+            last_line = line
+
+    resulting_iteration = float(last_line[0].strip())
+    resulting_abs_improvement = float(last_line[2].strip())
+
+    # Check against specifications
+    TestCase().assertEqual(resulting_iteration, 6)
+    TestCase().assertAlmostEqual(resulting_abs_improvement, -92.846, 3)
+
+os.chdir(original_directory)
+
+# Cleaning
 kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
 kratos_utilities.DeleteDirectoryIfExisting(output_directory)
 kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")

--- a/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/run_test.py
@@ -6,8 +6,9 @@ from KratosMultiphysics import *
 from KratosMultiphysics.ShapeOptimizationApplication import *
 
 # Additional imports
+from KratosMultiphysics.KratosUnittest import TestCase
 import KratosMultiphysics.kratos_utilities as kratos_utilities
-import os
+import os, csv
 
 # Read parameters
 with open("optimization_parameters.json",'r') as parameter_file:
@@ -23,13 +24,35 @@ optimizer.Optimize()
 # =======================================================================================================
 # Test results and clean directory
 # =======================================================================================================
-
-# Testing is done using the "json_output_process" & "json_check_process" within the structural analysis
-
-# Cleaning
 original_directory = os.getcwd()
 output_directory = parameters["optimization_settings"]["output"]["output_directory"].GetString()
 optimization_model_part_name = parameters["optimization_settings"]["model_settings"]["model_part_name"].GetString()
+optimization_log_filename = parameters["optimization_settings"]["output"]["optimization_log_filename"].GetString() + ".csv"
+
+# Testing by
+# 1) using the "json_output_process" & "json_check_process" within the structural analysis
+# 2) additionally checking some process output
+os.chdir(output_directory)
+
+with open(optimization_log_filename, 'r') as csvfile:
+    reader = csv.reader(csvfile, delimiter=',')
+    last_line = None
+    for line in reader:
+        if not line:
+            continue
+        else:
+            last_line = line
+
+    resulting_iteration = float(last_line[0].strip())
+    resulting_abs_improvement = float(last_line[2].strip())
+
+    # Check against specifications
+    TestCase().assertEqual(resulting_iteration, 5)
+    TestCase().assertAlmostEqual(resulting_abs_improvement, 229.167, 3)
+
+os.chdir(original_directory)
+
+# Cleaning
 kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
 kratos_utilities.DeleteDirectoryIfExisting(output_directory)
 kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")


### PR DESCRIPTION
This cleans the `MeshMovingAnalysis` and removes the backwards-compatibility of the "old-style" project-parameters (which was anyway never really used)

@dbaumgaertner is the only user of this afaik

@dbaumgaertner I don't know, but maybe you will have to update your things after this PR.
I am doing it this way since you explicitly told me that you will act AFTER things have changed