### PR TITLE
Core/data communicator serial defaults

### DIFF
--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -1160,7 +1160,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void AllGather(
         const std::vector<int>& rSendValues,
         std::vector<int>& rRecvValues) const
-    {}
+    {
+        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"AllGather");
+        rRecvValues = AllGather(rSendValues);
+    }
 
     /// Wrapper for MPI_Allgather calls (double version).
     /** @param rSendValues[in] Values to be gathered from this rank.
@@ -1170,7 +1173,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void AllGather(
         const std::vector<double>& rSendValues,
         std::vector<double>& rRecvValues) const
-    {}
+    {
+        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"AllGather");
+        rRecvValues = AllGather(rSendValues);
+    }
 
     ///@}
     ///@name Inquiry

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -651,14 +651,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const int SendDestination,
         const int RecvSource) const
     {
-        if (SendDestination == RecvSource)
-        {
-            return rSendValues;
-        }
-        else
-        {
-            return std::vector<int>(0);
-        }
+        KRATOS_ERROR_IF(SendDestination != RecvSource)
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+
+        return rSendValues;
     }
 
     /// Exchange data with other ranks (double version).
@@ -678,14 +674,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const int SendDestination,
         const int RecvSource) const
     {
-        if (SendDestination == RecvSource)
-        {
-            return rSendValues;
-        }
-        else
-        {
-            return std::vector<double>(0);
-        }
+        KRATOS_ERROR_IF(SendDestination != RecvSource)
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+
+        return rSendValues;
     }
 
     /// Exchange data with other ranks (string version).
@@ -705,14 +697,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const int SendDestination,
         const int RecvSource) const
     {
-        if (SendDestination == RecvSource)
-        {
-            return rSendValues;
-        }
-        else
-        {
-            return std::string("");
-        }
+        KRATOS_ERROR_IF(SendDestination != RecvSource)
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+
+        return rSendValues;
     }
 
     /// Exchange data with other ranks (int version).
@@ -727,7 +715,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void SendRecv(
         const std::vector<int>& rSendValues, const int SendDestination, const int SendTag,
         std::vector<int>& rRecvValues, const int RecvSource, const int RecvTag) const
-    {}
+    {
+        DebugSizeCheck(rSendValues.size(), rRecvValues.size(), "SendRecv");
+        rRecvValues = SendRecv(rSendValues, SendDestination, RecvSource);
+    }
 
     /// Exchange data with other ranks (double version).
     /** This is a wrapper for MPI_Sendrecv.
@@ -741,7 +732,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void SendRecv(
         const std::vector<double>& rSendValues, const int SendDestination, const int SendTag,
         std::vector<double>& rRecvValues, const int RecvSource, const int RecvTag) const
-    {}
+    {
+        DebugSizeCheck(rSendValues.size(), rRecvValues.size(), "SendRecv");
+        rRecvValues = SendRecv(rSendValues, SendDestination, RecvSource);
+    }
 
     /// Exchange data with other ranks (string version).
     /** This is a wrapper for MPI_Sendrecv.
@@ -755,7 +749,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void SendRecv(
         const std::string& rSendValues, const int SendDestination, const int SendTag,
         std::string& rRecvValues, const int RecvSource, const int RecvTag) const
-    {}
+    {
+        DebugSizeCheck(rSendValues.size(), rRecvValues.size(), "SendRecv");
+        rRecvValues = SendRecv(rSendValues, SendDestination, RecvSource);
+    }
 
     // Broadcast
 

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -651,7 +651,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const int SendDestination,
         const int RecvSource) const
     {
-        KRATOS_ERROR_IF(SendDestination != RecvSource)
+        KRATOS_ERROR_IF( (Rank() != SendDestination) || (Rank() != RecvSource))
         << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
 
         return rSendValues;
@@ -674,7 +674,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const int SendDestination,
         const int RecvSource) const
     {
-        KRATOS_ERROR_IF(SendDestination != RecvSource)
+        KRATOS_ERROR_IF( (Rank() != SendDestination) || (Rank() != RecvSource))
         << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
 
         return rSendValues;
@@ -697,7 +697,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const int SendDestination,
         const int RecvSource) const
     {
-        KRATOS_ERROR_IF(SendDestination != RecvSource)
+        KRATOS_ERROR_IF( (Rank() != SendDestination) || (Rank() != RecvSource))
         << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
 
         return rSendValues;

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -1050,13 +1050,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rSendValues,
         const int DestinationRank) const
     {
-        std::vector<std::vector<int>> output(0);
-        if (Rank() == DestinationRank)
-        {
-            output.resize(1);
-            output[0] = rSendValues;
-        }
-        return output;
+        KRATOS_ERROR_IF( Rank() != DestinationRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        return std::vector<std::vector<int>>{rSendValues};
     }
 
     /// Wrapper for MPI_Gatherv calls (double version).
@@ -1075,13 +1071,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rSendValues,
         const int DestinationRank) const
     {
-        std::vector<std::vector<double>> output(0);
-        if (Rank() == DestinationRank)
-        {
-            output.resize(1);
-            output[0] = rSendValues;
-        }
-        return output;
+        KRATOS_ERROR_IF( Rank() != DestinationRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        return std::vector<std::vector<double>>{rSendValues};
     }
 
     /// Wrapper for MPI_Gatherv calls (int version).
@@ -1098,7 +1090,14 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rRecvCounts,
         const std::vector<int>& rRecvOffsets,
         const int DestinationRank) const
-    {}
+    {
+        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Gatherv (values check)");
+        DebugSizeCheck(rRecvCounts.size(), 1, "Gatherv (counts check)");
+        DebugSizeCheck(rRecvOffsets.size(), 1, "Gatherv (offset check)");
+        KRATOS_ERROR_IF( Rank() != DestinationRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        rRecvValues = rSendValues;
+    }
 
     /// Wrapper for MPI_Gatherv calls (int version).
     /** @param[in] rSendValues Values to be gathered from this rank.
@@ -1114,7 +1113,14 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rRecvCounts,
         const std::vector<int>& rRecvOffsets,
         const int DestinationRank) const
-    {}
+    {
+        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Gatherv (values check)");
+        DebugSizeCheck(rRecvCounts.size(), 1, "Gatherv (counts check)");
+        DebugSizeCheck(rRecvOffsets.size(), 1, "Gatherv (offset check)");
+        KRATOS_ERROR_IF( Rank() != DestinationRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        rRecvValues = rSendValues;
+    }
 
     // Allgather operations
 

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -23,6 +23,14 @@
 #include "containers/array_1d.h"
 #include "includes/define.h"
 
+// Using a macro instead of a function to get the correct line in the error message.
+#ifndef KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK
+#define KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(Size1, Size2, CheckedFunction) \
+    KRATOS_DEBUG_ERROR_IF(Size1 != Size2) \
+    << "Input error in call to DataCommunicator::" << CheckedFunction \
+    << ": The sizes of the local and distributed buffers do not match." << std::endl;
+#endif
+
 namespace Kratos
 {
 ///@addtogroup Kratos Core
@@ -139,7 +147,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<int>& rGlobalValues,
         const int Root) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Sum");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "Sum");
         rGlobalValues = Sum(rLocalValues, Root);
     }
 
@@ -154,7 +162,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<double>& rGlobalValues,
         const int Root) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Sum");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "Sum");
         rGlobalValues = Sum(rLocalValues, Root);
     }
 
@@ -224,7 +232,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<int>& rGlobalValues,
         const int Root) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Min");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "Min");
         rGlobalValues = Min(rLocalValues, Root);
     }
 
@@ -239,7 +247,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<double>& rGlobalValues,
         const int Root) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Min");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "Min");
         rGlobalValues = Min(rLocalValues, Root);
     }
 
@@ -309,7 +317,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<int>& rGlobalValues,
         const int Root) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Max");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "Max");
         rGlobalValues = Max(rLocalValues, Root);
     }
 
@@ -324,7 +332,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<double>& rGlobalValues,
         const int Root) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Max");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "Max");
         rGlobalValues = Max(rLocalValues, Root);
     }
 
@@ -389,7 +397,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rLocalValues,
         std::vector<int>& rGlobalValues) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "SumAll");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "SumAll");
         rGlobalValues = SumAll(rLocalValues);
     }
 
@@ -402,7 +410,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rLocalValues,
         std::vector<double>& rGlobalValues) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "SumAll");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "SumAll");
         rGlobalValues = SumAll(rLocalValues);
     }
 
@@ -465,7 +473,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rLocalValues,
         std::vector<int>& rGlobalValues) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "MinAll");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "MinAll");
         rGlobalValues = MinAll(rLocalValues);
     }
 
@@ -478,7 +486,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rLocalValues,
         std::vector<double>& rGlobalValues) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "MinAll");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "MinAll");
         rGlobalValues = MinAll(rLocalValues);
     }
 
@@ -541,7 +549,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rLocalValues,
         std::vector<int>& rGlobalValues) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "MaxAll");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "MaxAll");
         rGlobalValues = MaxAll(rLocalValues);
     }
 
@@ -554,7 +562,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rLocalValues,
         std::vector<double>& rGlobalValues) const
     {
-        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "MaxAll");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rGlobalValues.size(), "MaxAll");
         rGlobalValues = MaxAll(rLocalValues);
     }
 
@@ -614,7 +622,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rLocalValues,
         std::vector<int>& rPartialSums) const
     {
-        DebugSizeCheck(rLocalValues.size(), rPartialSums.size(), "ScanSum");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rPartialSums.size(), "ScanSum");
         rPartialSums = ScanSum(rLocalValues);
     }
 
@@ -628,7 +636,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rLocalValues,
         std::vector<double>& rPartialSums) const
     {
-        DebugSizeCheck(rLocalValues.size(), rPartialSums.size(), "ScanSum");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rLocalValues.size(), rPartialSums.size(), "ScanSum");
         rPartialSums = ScanSum(rLocalValues);
     }
 
@@ -716,7 +724,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rSendValues, const int SendDestination, const int SendTag,
         std::vector<int>& rRecvValues, const int RecvSource, const int RecvTag) const
     {
-        DebugSizeCheck(rSendValues.size(), rRecvValues.size(), "SendRecv");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendValues.size(), rRecvValues.size(), "SendRecv");
         rRecvValues = SendRecv(rSendValues, SendDestination, RecvSource);
     }
 
@@ -733,7 +741,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rSendValues, const int SendDestination, const int SendTag,
         std::vector<double>& rRecvValues, const int RecvSource, const int RecvTag) const
     {
-        DebugSizeCheck(rSendValues.size(), rRecvValues.size(), "SendRecv");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendValues.size(), rRecvValues.size(), "SendRecv");
         rRecvValues = SendRecv(rSendValues, SendDestination, RecvSource);
     }
 
@@ -750,7 +758,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::string& rSendValues, const int SendDestination, const int SendTag,
         std::string& rRecvValues, const int RecvSource, const int RecvTag) const
     {
-        DebugSizeCheck(rSendValues.size(), rRecvValues.size(), "SendRecv");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendValues.size(), rRecvValues.size(), "SendRecv");
         rRecvValues = SendRecv(rSendValues, SendDestination, RecvSource);
     }
 
@@ -847,7 +855,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<int>& rRecvValues,
         const int SourceRank) const
     {
-        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"Scatter");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendValues.size(),rRecvValues.size(),"Scatter");
         rRecvValues = Scatter(rSendValues, SourceRank);
     }
 
@@ -862,7 +870,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<double>& rRecvValues,
         const int SourceRank) const
     {
-        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"Scatter");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendValues.size(),rRecvValues.size(),"Scatter");
         rRecvValues = Scatter(rSendValues, SourceRank);
     }
 
@@ -929,9 +937,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<int>& rRecvValues,
         const int SourceRank) const
     {
-        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Scatterv (values check)");
-        DebugSizeCheck(rSendCounts.size(), 1, "Scatterv (counts check)");
-        DebugSizeCheck(rSendOffsets.size(), 1, "Scatterv (offsets check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rRecvValues.size(), rSendValues.size(), "Scatterv (values check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendCounts.size(), 1, "Scatterv (counts check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendOffsets.size(), 1, "Scatterv (offsets check)");
         KRATOS_ERROR_IF( Rank() != SourceRank )
         << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
         rRecvValues = rSendValues;
@@ -952,9 +960,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<double>& rRecvValues,
         const int SourceRank) const
     {
-        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Scatterv (values check)");
-        DebugSizeCheck(rSendCounts.size(), 1, "Scatterv (counts check)");
-        DebugSizeCheck(rSendOffsets.size(), 1, "Scatterv (offsets check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rRecvValues.size(), rSendValues.size(), "Scatterv (values check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendCounts.size(), 1, "Scatterv (counts check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendOffsets.size(), 1, "Scatterv (offsets check)");
         KRATOS_ERROR_IF( Rank() != SourceRank )
         << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
         rRecvValues = rSendValues;
@@ -1012,7 +1020,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<int>& rRecvValues,
         const int DestinationRank) const
     {
-        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"Gather");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendValues.size(),rRecvValues.size(),"Gather");
         rRecvValues = Gather(rSendValues, DestinationRank);
     }
 
@@ -1028,7 +1036,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<double>& rRecvValues,
         const int DestinationRank) const
     {
-        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"Gather");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendValues.size(),rRecvValues.size(),"Gather");
         rRecvValues = Gather(rSendValues, DestinationRank);
     }
 
@@ -1091,9 +1099,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rRecvOffsets,
         const int DestinationRank) const
     {
-        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Gatherv (values check)");
-        DebugSizeCheck(rRecvCounts.size(), 1, "Gatherv (counts check)");
-        DebugSizeCheck(rRecvOffsets.size(), 1, "Gatherv (offset check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rRecvValues.size(), rSendValues.size(), "Gatherv (values check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rRecvCounts.size(), 1, "Gatherv (counts check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rRecvOffsets.size(), 1, "Gatherv (offset check)");
         KRATOS_ERROR_IF( Rank() != DestinationRank )
         << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
         rRecvValues = rSendValues;
@@ -1114,9 +1122,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rRecvOffsets,
         const int DestinationRank) const
     {
-        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Gatherv (values check)");
-        DebugSizeCheck(rRecvCounts.size(), 1, "Gatherv (counts check)");
-        DebugSizeCheck(rRecvOffsets.size(), 1, "Gatherv (offset check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rRecvValues.size(), rSendValues.size(), "Gatherv (values check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rRecvCounts.size(), 1, "Gatherv (counts check)");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rRecvOffsets.size(), 1, "Gatherv (offset check)");
         KRATOS_ERROR_IF( Rank() != DestinationRank )
         << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
         rRecvValues = rSendValues;
@@ -1161,7 +1169,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rSendValues,
         std::vector<int>& rRecvValues) const
     {
-        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"AllGather");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendValues.size(),rRecvValues.size(),"AllGather");
         rRecvValues = AllGather(rSendValues);
     }
 
@@ -1174,7 +1182,7 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rSendValues,
         std::vector<double>& rRecvValues) const
     {
-        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"AllGather");
+        KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK(rSendValues.size(),rRecvValues.size(),"AllGather");
         rRecvValues = AllGather(rSendValues);
     }
 
@@ -1343,17 +1351,6 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
 
   private:
 
-    ///@name Private operations
-    ///@{
-
-    void DebugSizeCheck(std::size_t Size1, std::size_t Size2, const std::string& CallName) const
-    {
-        KRATOS_DEBUG_ERROR_IF(Size1 != Size2)
-        << "Input error in call to DataCommunicator::" << CallName
-        << ": The sizes of the local and distributed buffers do not match." << std::endl;
-    }
-
-    ///@}
     ///@name Un accessible methods
     ///@{
 
@@ -1398,5 +1395,7 @@ inline std::ostream &operator<<(std::ostream &rOStream,
 ///@} addtogroup block
 
 } // namespace Kratos.
+
+#undef KRATOS_DATA_COMMUNICATOR_DEBUG_SIZE_CHECK
 
 #endif // KRATOS_DATA_COMMUNICATOR_H_INCLUDED  defined

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -929,9 +929,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<int>& rRecvValues,
         const int SourceRank) const
     {
-        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Scatterv");
-        DebugSizeCheck(rSendCounts.size(), 1, "Scatterv");
-        DebugSizeCheck(rSendOffsets.size(), 1, "Scatterv");
+        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Scatterv (values check)");
+        DebugSizeCheck(rSendCounts.size(), 1, "Scatterv (counts check)");
+        DebugSizeCheck(rSendOffsets.size(), 1, "Scatterv (offsets check)");
         KRATOS_ERROR_IF( Rank() != SourceRank )
         << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
         rRecvValues = rSendValues;
@@ -952,9 +952,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         std::vector<double>& rRecvValues,
         const int SourceRank) const
     {
-        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Scatterv");
-        DebugSizeCheck(rSendCounts.size(), 1, "Scatterv");
-        DebugSizeCheck(rSendOffsets.size(), 1, "Scatterv");
+        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Scatterv (values check)");
+        DebugSizeCheck(rSendCounts.size(), 1, "Scatterv (counts check)");
+        DebugSizeCheck(rSendOffsets.size(), 1, "Scatterv (offsets check)");
         KRATOS_ERROR_IF( Rank() != SourceRank )
         << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
         rRecvValues = rSendValues;

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -884,15 +884,11 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<std::vector<int>>& rSendValues,
         const int SourceRank) const
     {
-        int rank = Rank();
-        if (rank == SourceRank && rank < static_cast<int>(rSendValues.size()) )
-        {
-            return rSendValues[rank];
-        }
-        else
-        {
-            return std::vector<int>(0);
-        }
+        KRATOS_ERROR_IF( Rank() != SourceRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        KRATOS_ERROR_IF( static_cast<unsigned int>(Size()) != rSendValues.size() )
+        << "Unexpected number of sends in DataCommuncatior::Scatterv (serial DataCommunicator always assumes a single process)." << std::endl;
+        return rSendValues[0];
     }
 
     /// Wrapper for MPI_Scatterv calls (double version).
@@ -911,15 +907,11 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<std::vector<double>>& rSendValues,
         const int SourceRank) const
     {
-        int rank = Rank();
-        if (rank == SourceRank && rank < static_cast<int>(rSendValues.size()) )
-        {
-            return rSendValues[rank];
-        }
-        else
-        {
-            return std::vector<double>(0);
-        }
+        KRATOS_ERROR_IF( Rank() != SourceRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        KRATOS_ERROR_IF( static_cast<unsigned int>(Size()) != rSendValues.size() )
+        << "Unexpected number of sends in DataCommuncatior::Scatterv (serial DataCommunicator always assumes a single process)." << std::endl;
+        return rSendValues[0];
     }
 
     /// Wrapper for MPI_Scatterv calls (int version).
@@ -936,7 +928,14 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rSendOffsets,
         std::vector<int>& rRecvValues,
         const int SourceRank) const
-    {}
+    {
+        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Scatterv");
+        DebugSizeCheck(rSendCounts.size(), 1, "Scatterv");
+        DebugSizeCheck(rSendOffsets.size(), 1, "Scatterv");
+        KRATOS_ERROR_IF( Rank() != SourceRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        rRecvValues = rSendValues;
+    }
 
     /// Wrapper for MPI_Scatterv calls (double version).
     /** @param[in] rSendValues Values to be scattered (meaningul only on SourceRank).
@@ -952,7 +951,14 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rSendOffsets,
         std::vector<double>& rRecvValues,
         const int SourceRank) const
-    {}
+    {
+        DebugSizeCheck(rRecvValues.size(), rSendValues.size(), "Scatterv");
+        DebugSizeCheck(rSendCounts.size(), 1, "Scatterv");
+        DebugSizeCheck(rSendOffsets.size(), 1, "Scatterv");
+        KRATOS_ERROR_IF( Rank() != SourceRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        rRecvValues = rSendValues;
+    }
 
     // Gather operations
 

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -812,14 +812,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rSendValues,
         const int SourceRank) const
     {
-        if (Rank() == SourceRank)
-        {
-            return rSendValues;
-        }
-        else
-        {
-            return std::vector<int>(0);
-        }
+        KRATOS_ERROR_IF( Rank() != SourceRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        return rSendValues;
     }
 
     /// Wrapper for MPI_Scatter calls (double version).
@@ -836,14 +831,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rSendValues,
         const int SourceRank) const
     {
-        if (Rank() == SourceRank)
-        {
-            return rSendValues;
-        }
-        else
-        {
-            return std::vector<double>(0);
-        }
+        KRATOS_ERROR_IF( Rank() != SourceRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        return rSendValues;
     }
 
     /// Wrapper for MPI_Scatter calls (int version).
@@ -856,7 +846,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rSendValues,
         std::vector<int>& rRecvValues,
         const int SourceRank) const
-    {}
+    {
+        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"Scatter");
+        rRecvValues = Scatter(rSendValues, SourceRank);
+    }
 
     /// Wrapper for MPI_Scatter calls (double version).
     /** @param[in] rSendValues Values to be scattered (meaningful only on SourceRank).
@@ -868,7 +861,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rSendValues,
         std::vector<double>& rRecvValues,
         const int SourceRank) const
-    {}
+    {
+        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"Scatter");
+        rRecvValues = Scatter(rSendValues, SourceRank);
+    }
 
     // Scatterv operations
 

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -976,14 +976,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rSendValues,
         const int DestinationRank) const
     {
-        if (Rank() == DestinationRank)
-        {
-            return rSendValues;
-        }
-        else
-        {
-            return std::vector<int>();
-        }
+        KRATOS_ERROR_IF( Rank() != DestinationRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        return rSendValues;
     }
 
     /// Wrapper for MPI_Gather calls (double version).
@@ -1000,14 +995,9 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rSendValues,
         const int DestinationRank) const
     {
-        if (Rank() == DestinationRank)
-        {
-            return rSendValues;
-        }
-        else
-        {
-            return std::vector<double>();
-        }
+        KRATOS_ERROR_IF( Rank() != DestinationRank )
+        << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;
+        return rSendValues;
     }
 
     /// Wrapper for MPI_Gather calls (int version).
@@ -1021,7 +1011,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rSendValues,
         std::vector<int>& rRecvValues,
         const int DestinationRank) const
-    {}
+    {
+        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"Gather");
+        rRecvValues = Gather(rSendValues, DestinationRank);
+    }
 
     /// Wrapper for MPI_Gather calls (double version).
     /** @param[in] rSendValues Values to be gathered from this rank.
@@ -1034,7 +1027,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rSendValues,
         std::vector<double>& rRecvValues,
         const int DestinationRank) const
-    {}
+    {
+        DebugSizeCheck(rSendValues.size(),rRecvValues.size(),"Gather");
+        rRecvValues = Gather(rSendValues, DestinationRank);
+    }
 
     // Gatherv operations
 

--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -138,7 +138,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rLocalValues,
         std::vector<int>& rGlobalValues,
         const int Root) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Sum");
+        rGlobalValues = Sum(rLocalValues, Root);
+    }
 
     /// Sum rLocalValues across all ranks in the Communicator (double version).
     /** This is a wrapper to MPI_Reduce.
@@ -150,7 +153,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rLocalValues,
         std::vector<double>& rGlobalValues,
         const int Root) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Sum");
+        rGlobalValues = Sum(rLocalValues, Root);
+    }
 
     /// Obtain the minimum of rLocalValue across all ranks in the Communicator (int version).
     /** This is a wrapper to MPI_Reduce.
@@ -217,7 +223,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rLocalValues,
         std::vector<int>& rGlobalValues,
         const int Root) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Min");
+        rGlobalValues = Min(rLocalValues, Root);
+    }
 
     /// Obtain the minimum (for each term) of rLocalValues across all ranks in the Communicator (double version).
     /** This is a wrapper to MPI_Reduce.
@@ -229,7 +238,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rLocalValues,
         std::vector<double>& rGlobalValues,
         const int Root) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Min");
+        rGlobalValues = Min(rLocalValues, Root);
+    }
 
     /// Obtain the maximum of rLocalValue across all ranks in the Communicator (int version).
     /** This is a wrapper to MPI_Reduce.
@@ -296,7 +308,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<int>& rLocalValues,
         std::vector<int>& rGlobalValues,
         const int Root) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Max");
+        rGlobalValues = Max(rLocalValues, Root);
+    }
 
     /// Obtain the maximum (for each term) of rLocalValues across all ranks in the Communicator (double version).
     /** This is a wrapper to MPI_Reduce.
@@ -308,7 +323,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
         const std::vector<double>& rLocalValues,
         std::vector<double>& rGlobalValues,
         const int Root) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "Max");
+        rGlobalValues = Max(rLocalValues, Root);
+    }
 
     // Allreduce operations
 
@@ -370,7 +388,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void SumAll(
         const std::vector<int>& rLocalValues,
         std::vector<int>& rGlobalValues) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "SumAll");
+        rGlobalValues = SumAll(rLocalValues);
+    }
 
     /// Sum rLocalValues across all ranks in the Communicator (double version).
     /** This is a wrapper to MPI_Allreduce.
@@ -380,7 +401,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void SumAll(
         const std::vector<double>& rLocalValues,
         std::vector<double>& rGlobalValues) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "SumAll");
+        rGlobalValues = SumAll(rLocalValues);
+    }
 
     /// Obtain the minimum of rLocalValue across all ranks in the Communicator (int version).
     /** This is a wrapper to MPI_Allreduce.
@@ -440,7 +464,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void MinAll(
         const std::vector<int>& rLocalValues,
         std::vector<int>& rGlobalValues) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "MinAll");
+        rGlobalValues = MinAll(rLocalValues);
+    }
 
     /// Obtain the minimum (for each term) of rLocalValues across all ranks in the Communicator (double version).
     /** This is a wrapper to MPI_Allreduce.
@@ -450,7 +477,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void MinAll(
         const std::vector<double>& rLocalValues,
         std::vector<double>& rGlobalValues) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "MinAll");
+        rGlobalValues = MinAll(rLocalValues);
+    }
 
     /// Obtain the maximum of rLocalValue across all ranks in the Communicator (int version).
     /** This is a wrapper to MPI_Allreduce.
@@ -510,7 +540,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void MaxAll(
         const std::vector<int>& rLocalValues,
         std::vector<int>& rGlobalValues) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "MaxAll");
+        rGlobalValues = MaxAll(rLocalValues);
+    }
 
     /// Obtain the maximum (for each term) of rLocalValues across all ranks in the Communicator (double version).
     /** This is a wrapper to MPI_Allreduce.
@@ -520,7 +553,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void MaxAll(
         const std::vector<double>& rLocalValues,
         std::vector<double>& rGlobalValues) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rGlobalValues.size(), "MaxAll");
+        rGlobalValues = MaxAll(rLocalValues);
+    }
 
     // Scan operations
 
@@ -577,7 +613,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void ScanSum(
         const std::vector<int>& rLocalValues,
         std::vector<int>& rPartialSums) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rPartialSums.size(), "ScanSum");
+        rPartialSums = ScanSum(rLocalValues);
+    }
 
     /// Compute the partial sums of rLocalValues across all ranks in the Communicator (double version).
     /** The partial sum is the sum of a quantity from rank 0 to the current rank (included).
@@ -588,7 +627,10 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
     virtual void ScanSum(
         const std::vector<double>& rLocalValues,
         std::vector<double>& rPartialSums) const
-    {}
+    {
+        DebugSizeCheck(rLocalValues.size(), rPartialSums.size(), "ScanSum");
+        rPartialSums = ScanSum(rLocalValues);
+    }
 
     // Sendrecv operations
 
@@ -1294,6 +1336,17 @@ class KRATOS_API(KRATOS_CORE) DataCommunicator
 
   private:
 
+    ///@name Private operations
+    ///@{
+
+    void DebugSizeCheck(std::size_t Size1, std::size_t Size2, const std::string& CallName) const
+    {
+        KRATOS_DEBUG_ERROR_IF(Size1 != Size2)
+        << "Input error in call to DataCommunicator::" << CallName
+        << ": The sizes of the local and distributed buffers do not match." << std::endl;
+    }
+
+    ///@}
     ///@name Un accessible methods
     ///@{
 

--- a/kratos/mpi/includes/mpi_data_communicator.h
+++ b/kratos/mpi/includes/mpi_data_communicator.h
@@ -409,7 +409,7 @@ class MPIDataCommunicator: public DataCommunicator
     ///@name Operations
     ///@{
 
-    void CheckMPIErrorCode(const int ierr, const std::string MPICallName) const;
+    void CheckMPIErrorCode(const int ierr, const std::string& MPICallName) const;
 
     template<class TDataType> void ReduceDetail(
         const TDataType& rLocalValues,

--- a/kratos/mpi/sources/mpi_data_communicator.cpp
+++ b/kratos/mpi/sources/mpi_data_communicator.cpp
@@ -795,7 +795,7 @@ void MPIDataCommunicator::PrintData(std::ostream &rOStream) const
 
 // Error checking
 
-void MPIDataCommunicator::CheckMPIErrorCode(const int ierr, const std::string MPICallName) const
+void MPIDataCommunicator::CheckMPIErrorCode(const int ierr, const std::string& MPICallName) const
 {
     KRATOS_ERROR_IF_NOT(ierr == MPI_SUCCESS) << MPICallName << " failed with error code " << ierr << "." << std::endl;
 }

--- a/kratos/mpi/tests/sources/test_data_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_data_communicator.cpp
@@ -1127,170 +1127,134 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScatterDoubleVector, KratosMPICoreFast
 
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScattervInt, KratosMPICoreFastSuite)
 {
-    /* send message for ints is {0, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, ...} (max 6 values per rank)
-     * read only first <rank> values of the message per rank (up to 5 values per rank)
-     * message containing doubles is double of message containing ints
-     */
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
-    const int world_size = r_world.Size();
-    const int world_rank = r_world.Rank();
-    const int send_rank = world_size-1;
 
-    std::vector<int> send_buffer(0);
-    std::vector<int> send_sizes(0);
-    std::vector<int> send_offsets(0);
+    // the serial version of scatterv only works for the trivial case (from 0 to 0)
+    std::vector<int> send_buffer_single = {1, 1};
 
-    auto make_message_size = [](int rank) { return rank < 5 ? rank : 5; };
-    auto make_message_distance = [](int rank, int padding) {
-        return rank < 5 ? ((rank-1)*rank)/2 + rank*padding : rank*(5+padding) - 15;
-    };
+    std::vector<std::vector<int>> send_buffer_multiple = {send_buffer_single};
+    std::vector<int> send_offsets = {0};
+    std::vector<int> send_counts = {2};
 
-    const int recv_size = make_message_size(world_rank);
-    std::vector<int> recv_buffer(recv_size, -1);
-
-    const int message_padding = 1;
-    if (world_rank == send_rank)
-    {
-        const int send_size = make_message_distance(world_size, message_padding);
-        send_buffer.resize(send_size);
-        send_sizes.resize(world_size);
-        send_offsets.resize(world_size);
-        int counter = 0;
-        for (int rank = 0; rank < world_size; rank++)
-        {
-            send_sizes[rank] = make_message_size(rank);
-            send_offsets[rank] = make_message_distance(rank, message_padding);
-            for (int i = 0; i < send_sizes[rank] + message_padding; i++, counter++)
-            {
-                send_buffer[counter] = rank;
-            }
-        }
-    }
+    std::vector<int> recv_buffer = {-1, -1};
+    int send_rank = 0;
 
     // two-buffer version
-    serial_communicator.Scatterv(send_buffer, send_sizes, send_offsets, recv_buffer, send_rank);
-
-    for (int i = 0; i < recv_size; i++)
+    serial_communicator.Scatterv(send_buffer_single, send_counts, send_offsets, recv_buffer, send_rank);
+    for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(recv_buffer[i], -1);
+        KRATOS_CHECK_EQUAL(recv_buffer[i], send_buffer_single[i]);
     }
 
-    // return buffer version
+    // return version
+    std::vector<int> return_buffer = serial_communicator.Scatterv(send_buffer_multiple, send_rank);
+    KRATOS_CHECK_EQUAL(return_buffer.size(), send_buffer_single.size());
+    for (int i = 0; i < 2; i++)
+    {
+        KRATOS_CHECK_EQUAL(return_buffer[i], send_buffer_single[i]);
+    }
 
-    // pre-process: prepare input vector-of-vectors
-    std::vector<std::vector<int>> scatterv_message;
-    if (serial_communicator.Rank() == send_rank)
-    {
-        scatterv_message.resize(world_size);
-        for (int rank = 0; rank < world_size; rank++)
-        {
-            // note: single-buffer version does not support padding, entire message is sent.
-            scatterv_message[rank].resize(make_message_size(rank));
-            for (int i = 0; i < send_sizes[rank]; i++)
-            {
-                scatterv_message[rank][i] = rank;
-            }
-        }
+    // remote calls are not supported
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const int world_size = r_world.Size();
+
+    if (world_size > 1) {
+        send_rank = world_size - 1;
+
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(
+            serial_communicator.Scatterv(send_buffer_single, send_counts, send_offsets, recv_buffer, send_rank),
+            "Communication between different ranks is not possible with a serial DataCommunicator."
+        );
+
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(
+            return_buffer = serial_communicator.Scatterv(send_buffer_multiple, send_rank),
+            "Communication between different ranks is not possible with a serial DataCommunicator."
+        );
     }
-    std::vector<int> result = serial_communicator.Scatterv(scatterv_message, send_rank);
-    if (serial_communicator.Rank() == send_rank)
-    {
-        unsigned int expected_size = make_message_size(send_rank);
-        KRATOS_CHECK_EQUAL(result.size(), expected_size);
-        for (unsigned int i = 0; i < expected_size; i++)
-        {
-            KRATOS_CHECK_EQUAL(result[i], send_rank);
-        }
-    }
-    else
-    {
-        KRATOS_CHECK_EQUAL(result.size(), 0);
-    }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<int> wrong_size_recv = {-1, -1, -1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Scatterv(send_buffer_single, send_counts, send_offsets, wrong_size_recv, send_rank),
+        "Input error in call to DataCommunicator::Scatterv"
+    );
+    std::vector<int> wrong_counts = {2, 3};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Scatterv(send_buffer_single, wrong_counts, send_offsets, recv_buffer, send_rank),
+        "Input error in call to DataCommunicator::Scatterv"
+    );
+    std::vector<int> wrong_offsets = {0, 1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Scatterv(send_buffer_single, send_counts, wrong_offsets, recv_buffer, send_rank),
+        "Input error in call to DataCommunicator::Scatterv"
+    );
+    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScattervDouble, KratosMPICoreFastSuite)
 {
-    /* send message for ints is {0, 1, 1, 2, 2, 2, 3, 3, 3, 3, 4, 4, 4, 4, 4, ...} (max 6 values per rank)
-     * read only first <rank> values of the message per rank (up to 5 values per rank)
-     * message containing doubles is double of message containing ints
-     */
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
-    const int world_size = r_world.Size();
-    const int world_rank = r_world.Rank();
-    const int send_rank = world_size-1;
 
-    std::vector<double> send_buffer(0);
-    std::vector<int> send_sizes(0);
-    std::vector<int> send_offsets(0);
+    // the serial version of scatterv only works for the trivial case (from 0 to 0)
+    std::vector<double> send_buffer_single = {2.0, 2.0};
 
-    auto make_message_size = [](int rank) { return rank < 5 ? rank : 5; };
-    auto make_message_distance = [](int rank, int padding) {
-        return rank < 5 ? ((rank-1)*rank)/2 + rank*padding : rank*(5+padding) - 15;
-    };
+    std::vector<std::vector<double>> send_buffer_multiple = {send_buffer_single};
+    std::vector<int> send_offsets = {0};
+    std::vector<int> send_counts = {2};
 
-    const int recv_size = make_message_size(world_rank);
-    std::vector<double> recv_buffer(recv_size, -1.0);
-
-    const int message_padding = 1;
-    if (world_rank == send_rank)
-    {
-        const int send_size = make_message_distance(world_size, message_padding);
-        send_buffer.resize(send_size);
-        send_sizes.resize(world_size);
-        send_offsets.resize(world_size);
-        int counter = 0;
-        for (int rank = 0; rank < world_size; rank++)
-        {
-            send_sizes[rank] = make_message_size(rank);
-            send_offsets[rank] = make_message_distance(rank, message_padding);
-            for (int i = 0; i < send_sizes[rank] + message_padding; i++, counter++)
-            {
-                send_buffer[counter] = 2.0*rank;
-            }
-        }
-    }
+    std::vector<double> recv_buffer = {-1.0, -1.0};
+    int send_rank = 0;
 
     // two-buffer version
-    serial_communicator.Scatterv(send_buffer, send_sizes, send_offsets, recv_buffer, send_rank);
-
-    for (int i = 0; i < recv_size; i++)
+    serial_communicator.Scatterv(send_buffer_single, send_counts, send_offsets, recv_buffer, send_rank);
+    for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(recv_buffer[i], -1.0);
+        KRATOS_CHECK_EQUAL(recv_buffer[i], send_buffer_single[i]);
     }
 
-    // return buffer version
+    // return version
+    std::vector<double> return_buffer = serial_communicator.Scatterv(send_buffer_multiple, send_rank);
+    KRATOS_CHECK_EQUAL(return_buffer.size(), send_buffer_single.size());
+    for (int i = 0; i < 2; i++)
+    {
+        KRATOS_CHECK_EQUAL(return_buffer[i], send_buffer_single[i]);
+    }
 
-    // pre-process: prepare input vector-of-vectors
-    std::vector<std::vector<double>> scatterv_message;
-    if (serial_communicator.Rank() == send_rank)
-    {
-        scatterv_message.resize(world_size);
-        for (int rank = 0; rank < world_size; rank++)
-        {
-            // note: single-buffer version does not support padding, entire message is sent.
-            scatterv_message[rank].resize(make_message_size(rank));
-            for (int i = 0; i < send_sizes[rank]; i++)
-            {
-                scatterv_message[rank][i] = 2.0*rank;
-            }
-        }
+    // remote calls are not supported
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const int world_size = r_world.Size();
+
+    if (world_size > 1) {
+        send_rank = world_size - 1;
+
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(
+            serial_communicator.Scatterv(send_buffer_single, send_counts, send_offsets, recv_buffer, send_rank),
+            "Communication between different ranks is not possible with a serial DataCommunicator."
+        );
+
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(
+            return_buffer = serial_communicator.Scatterv(send_buffer_multiple, send_rank),
+            "Communication between different ranks is not possible with a serial DataCommunicator."
+        );
     }
-    std::vector<double> result = serial_communicator.Scatterv(scatterv_message, send_rank);
-    if (serial_communicator.Rank() == send_rank)
-    {
-        unsigned int expected_size = make_message_size(send_rank);
-        KRATOS_CHECK_EQUAL(result.size(), expected_size);
-        for (unsigned int i = 0; i < expected_size; i++)
-        {
-            KRATOS_CHECK_EQUAL(result[i], 2.0*send_rank);
-        }
-    }
-    else
-    {
-        KRATOS_CHECK_EQUAL(result.size(), 0);
-    }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<double> wrong_size_recv = {-1.0, -1.0, -1.0};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Scatterv(send_buffer_single, send_counts, send_offsets, wrong_size_recv, send_rank),
+        "Input error in call to DataCommunicator::Scatterv"
+    );
+    std::vector<int> wrong_counts = {2, 3};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Scatterv(send_buffer_single, wrong_counts, send_offsets, recv_buffer, send_rank),
+        "Input error in call to DataCommunicator::Scatterv"
+    );
+    std::vector<int> wrong_offsets = {0, 1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Scatterv(send_buffer_single, send_counts, wrong_offsets, recv_buffer, send_rank),
+        "Input error in call to DataCommunicator::Scatterv"
+    );
+    #endif
 }
 
 // Gather /////////////////////////////////////////////////////////////////////

--- a/kratos/mpi/tests/sources/test_data_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_data_communicator.cpp
@@ -110,7 +110,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumIntVector, KratosMPICoreFastSuite)
     {
         for (int i = 0; i < 2; i++)
         {
-            KRATOS_CHECK_EQUAL(output[i], -1);
+            KRATOS_CHECK_EQUAL(output[i], local[i]);
         }
     }
 
@@ -143,7 +143,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumDoubleVector, KratosMPICoreFastSuit
     {
         for (int i = 0; i < 2; i++)
         {
-            KRATOS_CHECK_EQUAL(output[i], -1.0);
+            KRATOS_CHECK_EQUAL(output[i], local[i]);
         }
     }
 
@@ -232,7 +232,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinIntVector, KratosMPICoreFastSuite)
     {
         for (int i = 0; i < 2; i++)
         {
-            KRATOS_CHECK_EQUAL(output[i], -1);
+            KRATOS_CHECK_EQUAL(output[i], local[i]);
         }
     }
 
@@ -265,7 +265,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinDoubleVector, KratosMPICoreFastSuit
     {
         for (int i = 0; i < 2; i++)
         {
-            KRATOS_CHECK_EQUAL(output[i], -1.0);
+            KRATOS_CHECK_EQUAL(output[i], local[i]);
         }
     }
 
@@ -354,7 +354,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxIntVector, KratosMPICoreFastSuite)
     {
         for (int i = 0; i < 2; i++)
         {
-            KRATOS_CHECK_EQUAL(output[i], -1);
+            KRATOS_CHECK_EQUAL(output[i], local[i]);
         }
     }
 
@@ -387,7 +387,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxDoubleVector, KratosMPICoreFastSuit
     {
         for (int i = 0; i < 2; i++)
         {
-            KRATOS_CHECK_EQUAL(output[i], -1.0);
+            KRATOS_CHECK_EQUAL(output[i], local[i]);
         }
     }
 
@@ -449,7 +449,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumAllIntVector, KratosMPICoreFastSuit
     serial_communicator.SumAll(local, output);
     for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(output[i], -1);
+        KRATOS_CHECK_EQUAL(output[i], local[i]);
     }
 
     // return buffer version
@@ -472,7 +472,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumAllDoubleVector, KratosMPICoreFastS
     serial_communicator.SumAll(local, output);
     for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(output[i], -1.0);
+        KRATOS_CHECK_EQUAL(output[i], local[i]);
     }
 
     // return buffer version
@@ -530,7 +530,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinAllIntVector, KratosMPICoreFastSuit
     serial_communicator.MinAll(local, output);
     for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(output[i], -1);
+        KRATOS_CHECK_EQUAL(output[i], local[i]);
     }
 
     // return buffer version
@@ -553,7 +553,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinAllDoubleVector, KratosMPICoreFastS
     serial_communicator.MinAll(local, output);
     for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(output[i], -1.0);
+        KRATOS_CHECK_EQUAL(output[i], local[i]);
     }
 
     // return buffer version
@@ -611,7 +611,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxAllIntVector, KratosMPICoreFastSuit
     serial_communicator.MaxAll(local, output);
     for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(output[i], -1);
+        KRATOS_CHECK_EQUAL(output[i], local[i]);
     }
 
     // return buffer version
@@ -634,7 +634,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxAllDoubleVector, KratosMPICoreFastS
     serial_communicator.MaxAll(local, output);
     for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(output[i], -1.0);
+        KRATOS_CHECK_EQUAL(output[i], local[i]);
     }
 
     // return buffer version
@@ -677,7 +677,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScanSumIntVector, KratosMPICoreFastSui
     serial_communicator.ScanSum(local, output);
     for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(output[i], -1);
+        KRATOS_CHECK_EQUAL(output[i], local[i]);
     }
 
     // return buffer version
@@ -700,7 +700,7 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScanSumDoubleVector, KratosMPICoreFast
     serial_communicator.ScanSum(local, output);
     for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(output[i], -1.0);
+        KRATOS_CHECK_EQUAL(output[i], local[i]);
     }
 
     // return buffer version

--- a/kratos/mpi/tests/sources/test_data_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_data_communicator.cpp
@@ -1500,57 +1500,65 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorGathervDouble, KratosMPICoreFastSuite)
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorAllGatherInt, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
-    const int world_size = r_world.Size();
-    const int world_rank = r_world.Rank();
 
-    std::vector<int> send_buffer{world_rank, world_rank};
+    // the serial version of scatter only works for the trivial case (from 0 to 0)
+    const std::vector<int> send_buffer = {1, 1};
+    std::vector<int> recv_buffer = {-1, -1};
 
     // two-buffer version
-    std::vector<int> recv_buffer(2*world_size, -1);
     serial_communicator.AllGather(send_buffer, recv_buffer);
-
-    for (int i = 0; i < 2*world_size; i++)
+    for (unsigned int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(recv_buffer[i], -1);
+        KRATOS_CHECK_EQUAL(recv_buffer[i], send_buffer[i]);
     }
 
     // return buffer version
     std::vector<int> return_buffer = serial_communicator.AllGather(send_buffer);
-
     KRATOS_CHECK_EQUAL(return_buffer.size(), send_buffer.size());
-    for (unsigned int i = 0; i < return_buffer.size(); i++)
+    for (unsigned int i = 0; i < 2; i++)
     {
         KRATOS_CHECK_EQUAL(return_buffer[i], send_buffer[i]);
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<int> wrong_size_recv = {-1, -1, -1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.AllGather(send_buffer, wrong_size_recv),
+        "Input error in call to DataCommunicator::AllGather"
+    );
+    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorAllGatherDouble, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
-    const int world_size = r_world.Size();
-    const int world_rank = r_world.Rank();
 
-    std::vector<double> send_buffer{2.0*world_rank, 2.0*world_rank};
+    // the serial version of scatter only works for the trivial case (from 0 to 0)
+    const std::vector<double> send_buffer = {2.0, 2.0};
+    std::vector<double> recv_buffer = {-1.0, -1.0};
 
     // two-buffer version
-    std::vector<double> recv_buffer(2*world_size, -1.0);
     serial_communicator.AllGather(send_buffer, recv_buffer);
-
-    for (int i = 0; i < 2*world_size; i++)
+    for (unsigned int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(recv_buffer[i], -1.0);
+        KRATOS_CHECK_EQUAL(recv_buffer[i], send_buffer[i]);
     }
 
     // return buffer version
     std::vector<double> return_buffer = serial_communicator.AllGather(send_buffer);
-
     KRATOS_CHECK_EQUAL(return_buffer.size(), send_buffer.size());
-    for (unsigned int i = 0; i < return_buffer.size(); i++)
+    for (unsigned int i = 0; i < 2; i++)
     {
         KRATOS_CHECK_EQUAL(return_buffer[i], send_buffer[i]);
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<double> wrong_size_recv = {-1.0, -1.0, -1.0};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.AllGather(send_buffer, wrong_size_recv),
+        "Input error in call to DataCommunicator::AllGather"
+    );
+    #endif
 }
 
 // Error broadcasting methods /////////////////////////////////////////////////

--- a/kratos/mpi/tests/sources/test_data_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_data_communicator.cpp
@@ -124,6 +124,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumIntVector, KratosMPICoreFastSuite)
             KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
         }
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<int> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Sum(local, wrong_size_global, root),
+        "Input error in call to DataCommunicator::Sum"
+    );
+    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumDoubleVector, KratosMPICoreFastSuite)
@@ -157,6 +165,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumDoubleVector, KratosMPICoreFastSuit
             KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
         }
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<double> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Sum(local, wrong_size_global, root),
+        "Input error in call to DataCommunicator::Sum"
+    );
+    #endif
 }
 
 // Min ////////////////////////////////////////////////////////////////////////
@@ -246,6 +262,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinIntVector, KratosMPICoreFastSuite)
             KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
         }
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<int> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Min(local, wrong_size_global, root),
+        "Input error in call to DataCommunicator::Min"
+    );
+    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinDoubleVector, KratosMPICoreFastSuite)
@@ -279,6 +303,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinDoubleVector, KratosMPICoreFastSuit
             KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
         }
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<double> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Min(local, wrong_size_global, root),
+        "Input error in call to DataCommunicator::Min"
+    );
+    #endif
 }
 
 // Max ////////////////////////////////////////////////////////////////////////
@@ -368,6 +400,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxIntVector, KratosMPICoreFastSuite)
             KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
         }
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<int> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Max(local, wrong_size_global, root),
+        "Input error in call to DataCommunicator::Max"
+    );
+    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxDoubleVector, KratosMPICoreFastSuite)
@@ -401,6 +441,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMaxDoubleVector, KratosMPICoreFastSuit
             KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
         }
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<double> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Max(local, wrong_size_global, root),
+        "Input error in call to DataCommunicator::Max"
+    );
+    #endif
 }
 
 // SumAll /////////////////////////////////////////////////////////////////////
@@ -459,6 +507,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumAllIntVector, KratosMPICoreFastSuit
     {
         KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<int> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.SumAll(local, wrong_size_global),
+        "Input error in call to DataCommunicator::SumAll"
+    );
+    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumAllDoubleVector, KratosMPICoreFastSuite)
@@ -482,6 +538,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorSumAllDoubleVector, KratosMPICoreFastS
     {
         KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<double> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.SumAll(local, wrong_size_global),
+        "Input error in call to DataCommunicator::SumAll"
+    );
+    #endif
 }
 
 // MinAll /////////////////////////////////////////////////////////////////////
@@ -540,6 +604,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinAllIntVector, KratosMPICoreFastSuit
     {
         KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<int> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.MinAll(local, wrong_size_global),
+        "Input error in call to DataCommunicator::MinAll"
+    );
+    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinAllDoubleVector, KratosMPICoreFastSuite)
@@ -563,6 +635,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorMinAllDoubleVector, KratosMPICoreFastS
     {
         KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<double> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.MinAll(local, wrong_size_global),
+        "Input error in call to DataCommunicator::MinAll"
+    );
+    #endif
 }
 
 // MaxAll /////////////////////////////////////////////////////////////////////
@@ -687,6 +767,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScanSumIntVector, KratosMPICoreFastSui
     {
         KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<int> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.ScanSum(local, wrong_size_global),
+        "Input error in call to DataCommunicator::ScanSum"
+    );
+    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScanSumDoubleVector, KratosMPICoreFastSuite)
@@ -710,6 +798,14 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScanSumDoubleVector, KratosMPICoreFast
     {
         KRATOS_CHECK_EQUAL(returned_result[i], local[i]);
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<double> wrong_size_global{-1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.ScanSum(local, wrong_size_global),
+        "Input error in call to DataCommunicator::ScanSum"
+    );
+    #endif
 }
 
 // SendRecv ///////////////////////////////////////////////////////////////////

--- a/kratos/mpi/tests/sources/test_data_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_data_communicator.cpp
@@ -1024,87 +1024,103 @@ KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorBroadcastDoubleVector, KratosMPICoreFa
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScatterIntVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
-    const int world_size = r_world.Size();
-    const int world_rank = r_world.Rank();
-    const int send_rank = 0;
 
-    std::vector<int> send_buffer(0);
+    // the serial version of scatter only works for the trivial case (from 0 to 0)
+    std::vector<int> send_buffer = {1, 1};
     std::vector<int> recv_buffer = {-1, -1};
-
-    if (world_rank == send_rank)
-    {
-        send_buffer.resize(2*world_size);
-        for (int i = 0; i < 2*world_size; i++)
-        {
-            send_buffer[i] = 1;
-        }
-    }
+    int send_rank = 0;
 
     // two-buffer version
     serial_communicator.Scatter(send_buffer, recv_buffer, send_rank);
     for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(recv_buffer[i], -1);
+        KRATOS_CHECK_EQUAL(recv_buffer[i], send_buffer[i]);
     }
 
     // return version
     std::vector<int> return_buffer = serial_communicator.Scatter(send_buffer, send_rank);
-    if (world_rank == send_rank)
+    KRATOS_CHECK_EQUAL(return_buffer.size(), send_buffer.size());
+    for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(return_buffer.size(), send_buffer.size());
-        for (int i = 0; i < 2; i++)
-        {
-            KRATOS_CHECK_EQUAL(return_buffer[i], send_buffer[i]);
-        }
+        KRATOS_CHECK_EQUAL(return_buffer[i], send_buffer[i]);
     }
-    else
-    {
-        KRATOS_CHECK_EQUAL(return_buffer.size(), 0);
+
+    // remote calls are not supported
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const int world_size = r_world.Size();
+
+    if (world_size > 1) {
+        send_rank = world_size - 1;
+
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(
+            serial_communicator.Scatter(send_buffer, recv_buffer, send_rank),
+            "Communication between different ranks is not possible with a serial DataCommunicator."
+        );
+
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(
+            return_buffer = serial_communicator.Scatter(send_buffer, send_rank),
+            "Communication between different ranks is not possible with a serial DataCommunicator."
+        );
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<int> wrong_size_recv = {-1, -1, -1};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Scatter(send_buffer, wrong_size_recv, send_rank),
+        "Input error in call to DataCommunicator::Scatter"
+    );
+    #endif
 }
 
 KRATOS_TEST_CASE_IN_SUITE(DataCommunicatorScatterDoubleVector, KratosMPICoreFastSuite)
 {
     DataCommunicator serial_communicator;
-    const DataCommunicator& r_world = DataCommunicator::GetDefault();
-    const int world_size = r_world.Size();
-    const int world_rank = r_world.Rank();
-    const int send_rank = 0;
 
-    std::vector<double> send_buffer(0);
-    std::vector<double> recv_buffer{-1.0, -1.0};
-
-    if (world_rank == send_rank)
-    {
-        send_buffer.resize(2*world_size);
-        for (int i = 0; i < 2*world_size; i++)
-        {
-            send_buffer[i] = 2.0;
-        }
-    }
+    // the serial version of scatter only works for the trivial case (from 0 to 0)
+    std::vector<double> send_buffer = {2.0, 2.0};
+    std::vector<double> recv_buffer = {-1.0, -1.0};
+    int send_rank = 0;
 
     // two-buffer version
     serial_communicator.Scatter(send_buffer, recv_buffer, send_rank);
     for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(recv_buffer[i], -1.0);
+        KRATOS_CHECK_EQUAL(recv_buffer[i], send_buffer[i]);
     }
 
     // return version
     std::vector<double> return_buffer = serial_communicator.Scatter(send_buffer, send_rank);
-    if (world_rank == send_rank)
+    KRATOS_CHECK_EQUAL(return_buffer.size(), send_buffer.size());
+    for (int i = 0; i < 2; i++)
     {
-        KRATOS_CHECK_EQUAL(return_buffer.size(), send_buffer.size());
-        for (int i = 0; i < 2; i++)
-        {
-            KRATOS_CHECK_EQUAL(return_buffer[i], send_buffer[i]);
-        }
+        KRATOS_CHECK_EQUAL(return_buffer[i], send_buffer[i]);
     }
-    else
-    {
-        KRATOS_CHECK_EQUAL(return_buffer.size(), 0);
+
+    // remote calls are not supported
+    const DataCommunicator& r_world = DataCommunicator::GetDefault();
+    const int world_size = r_world.Size();
+
+    if (world_size > 1) {
+        send_rank = world_size - 1;
+
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(
+            serial_communicator.Scatter(send_buffer, recv_buffer, send_rank),
+            "Communication between different ranks is not possible with a serial DataCommunicator."
+        );
+
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(
+            return_buffer = serial_communicator.Scatter(send_buffer, send_rank),
+            "Communication between different ranks is not possible with a serial DataCommunicator."
+        );
     }
+
+    #ifdef KRATOS_DEBUG
+    std::vector<double> wrong_size_recv = {-1.0, -1.0, -1.0};
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        serial_communicator.Scatter(send_buffer, wrong_size_recv, send_rank),
+        "Input error in call to DataCommunicator::Scatter"
+    );
+    #endif
 }
 
 // Scatterv ///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Improving the default behavior of the DataCommunicator in non-MPI runs to be consistent with the MPI implementation. The idea is that DataCommunicator methods should behave as the MPI equivalents if those were run with a single process. This allows MPI-parallel algorithms that "reduce" nicely to the single-process case to work independently of the specifics of the run and the type of DataCommunicator (serial/distributed).
In short, everything should work nice as long as the single-process case never explicitly requires out-of-process data. If out-of-process data is explicitly requested, the method will throw an error.

Tests have been updated accordingly.

This closes #3646