### PR TITLE
Fixing check for periodic boundary conditions in fractional step solver.

### DIFF
--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
@@ -869,7 +869,7 @@ protected:
      */
      void PeriodicConditionProjectionCorrection(ModelPart& rModelPart)
      {
-         if (mrPeriodicIdVar.Key() != 0)
+         if (mrPeriodicIdVar.Key() != Kratos::Variable<int>::StaticObject().Key())
          {
              int GlobalNodesNum = rModelPart.GetCommunicator().LocalMesh().Nodes().size();
              rModelPart.GetCommunicator().SumAll(GlobalNodesNum);
@@ -954,7 +954,7 @@ protected:
 
      void PeriodicConditionVelocityCorrection(ModelPart& rModelPart)
      {
-         if (mrPeriodicIdVar.Key() != 0)
+         if (mrPeriodicIdVar.Key() != Kratos::Variable<int>::StaticObject().Key())
          {
              int GlobalNodesNum = rModelPart.GetCommunicator().LocalMesh().Nodes().size();
              rModelPart.GetCommunicator().SumAll(GlobalNodesNum);


### PR DESCRIPTION
The check relied on the fact that the `NONE` variable always had `Key() == 0` in the old variable key assignment strategy, which is no longer true for hash-based keys. I'm actually surprised this has been wrong for so long.

@philbucher this should fix the issue you reported from the MeshMovingApplication tests (at least tests pass in debug for me now in master).

@roigcarlo this should go into the release branch :(
