### PR TITLE
Making the SerialCommunicator default if MPI is finalized.

### DIFF
--- a/kratos/mpi/python/kratos_mpi_python.cpp
+++ b/kratos/mpi/python/kratos_mpi_python.cpp
@@ -20,6 +20,8 @@
 #include "add_mpi_data_communicator_to_python.h"
 #include "add_mpi_utilities_to_python.h"
 
+#include "includes/parallel_environment.h"
+
 namespace Kratos {
 namespace Python {
 
@@ -35,6 +37,7 @@ PYBIND11_MODULE(KratosMPI, m)
     // Define a callback to finalize MPI on module cleanup
     auto cleanup_callback = []() {
         MPIEnvironment::Finalize();
+        ParallelEnvironment::SetDefaultDataCommunicator("Serial");
     };
 
     m.add_object("_cleanup", py::capsule(cleanup_callback));


### PR DESCRIPTION
@rubenzorrilla has encountered that the python tests for the FluidApplication try to call the mpi DataCommunicator after MPI Finalization (the calls originate from the logger, which tries to use the MPI_COMM_WORLD wrapper to check on which ranks to print). To prevent this, I am resetting the default communicator to serial as soon as MPI is finalized.

One would hope that this situation should never happen (MPI should only be finalized on exit), but I believe this is happening here due to the way MPI tests are spawned on independent processes (FYI @philbucher). I do not believe this should be relevant in most other cases, but better safe than sorry.

I will try to figure out a cleaner solution, but I wanted to provide a fix before release.