### PR TITLE
Structural/fix tests

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/beam_test/dynamic_3D2NBeamCr_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/beam_test/dynamic_3D2NBeamCr_test_parameters.json
@@ -26,8 +26,8 @@
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,
-        "residual_relative_tolerance"        : 0.0001,
-        "residual_absolute_tolerance"        : 1e-9,
+        "residual_relative_tolerance"        : 1e-5,
+        "residual_absolute_tolerance"        : 1e-7,
         "max_iteration"                      : 100,
         "linear_solver_settings"             : {
             "solver_type" : "ExternalSolversApplication.super_lu",

--- a/applications/StructuralMechanicsApplication/tests/beam_test/nonlinear_3D2NBeamCr_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/beam_test/nonlinear_3D2NBeamCr_test_parameters.json
@@ -24,8 +24,8 @@
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 1e-12,
         "displacement_absolute_tolerance"    : 1e-12,
-        "residual_relative_tolerance"        : 1e-12,
-        "residual_absolute_tolerance"        : 1e-12,
+        "residual_relative_tolerance"        : 1e-4,
+        "residual_absolute_tolerance"        : 1e-6,
         "max_iteration"                      : 100,
         "linear_solver_settings"             : {
             "solver_type" : "ExternalSolversApplication.super_lu",

--- a/applications/StructuralMechanicsApplication/tests/formfinding_test/Fofi_4Point_Tent_Cable_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/formfinding_test/Fofi_4Point_Tent_Cable_test_parameters.json
@@ -25,12 +25,12 @@
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,
         "displacement_absolute_tolerance"    : 1e-9,
-        "residual_relative_tolerance"        : 0.0001,
-        "residual_absolute_tolerance"        : 1e-9,
+        "residual_relative_tolerance"        : 1e-14,
+        "residual_absolute_tolerance"        : 1e-15,
         "max_iteration"                      : 10,
         "problem_domain_sub_model_part_list" : ["Parts_membrane","Parts_cable"],
         "processes_sub_model_part_list"      : ["DISPLACEMENT_supports", "Structure"],
-        "rotation_dofs"                      : true,
+        "rotation_dofs"                      : false,
         "linear_solver_settings"             : {
             "solver_type" : "ExternalSolversApplication.super_lu",
             "scaling"     : false

--- a/applications/StructuralMechanicsApplication/tests/truss_test/nonlinear_3D2NTruss_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/truss_test/nonlinear_3D2NTruss_test_parameters.json
@@ -26,12 +26,12 @@
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 1e-9,
         "displacement_absolute_tolerance"    : 1e-9,
-        "residual_relative_tolerance"        : 1e-9,
+        "residual_relative_tolerance"        : 1e-11,
         "residual_absolute_tolerance"        : 1e-9,
         "max_iteration"                      : 1000,
         "problem_domain_sub_model_part_list" : ["Parts_structure"],
         "processes_sub_model_part_list"      : ["Structure", "DISPLACEMENT_dirichletXYZ","DISPLACEMENT_dirichletXZ","PointLoad3D_neumann"],
-        "rotation_dofs"                      : true
+        "rotation_dofs"                      : false
     },
     "processes" : {
     "constraints_process_list" : [{


### PR DESCRIPTION
tightning the tolerances after the updates in the convcrit
closes #4493 

@loumalouomega @KlausBSautter #4482 broke this test:
~~~
======================================================================
FAIL: test_execution (structural_mechanics_test_factory.RigidSphereFailingExplicit)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/philippb/software/Kratos_Master/applications/StructuralMechanicsApplication/tests/structural_mechanics_test_factory.py", line 55, in test_execution
    self.test.RunSolutionLoop()
  File "/home/philippb/software/Kratos_Master/kratos/python_scripts/analysis_stage.py", line 66, in RunSolutionLoop
    self.FinalizeSolutionStep()
  File "/home/philippb/software/Kratos_Master/kratos/python_scripts/analysis_stage.py", line 141, in FinalizeSolutionStep
    process.ExecuteFinalizeSolutionStep()
  File "/home/philippb/software/Kratos_Master/kratos/python_scripts/check_scalar_to_nodes_process.py", line 124, in ExecuteFinalizeSolutionStep
    self.assertAlmostEqual(self.value, value, self.tolerance_rank)
AssertionError: -0.000981 != -0.1428274976744769 within 8 places
~~~

@MFusseder @armingeiser also this test broke, probably bcs the PR was made at the same time:
~~~
======================================================================
FAIL: test_nodal_reaction_response (test_adjoint_sensitity_analysis_beam_3d2n_structure.TestAdjointSensitivityAnalysisBeamStructure)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/philippb/software/Kratos_Master/applications/StructuralMechanicsApplication/tests/test_adjoint_sensitity_analysis_beam_3d2n_structure.py", line 145, in test_nodal_reaction_response
    adjoint_analysis.Run()
  File "/home/philippb/software/Kratos_Master/kratos/python_scripts/analysis_stage.py", line 48, in Run
    self.RunSolutionLoop()
  File "/home/philippb/software/Kratos_Master/kratos/python_scripts/analysis_stage.py", line 66, in RunSolutionLoop
    self.FinalizeSolutionStep()
  File "/home/philippb/software/Kratos_Master/kratos/python_scripts/analysis_stage.py", line 141, in FinalizeSolutionStep
    process.ExecuteFinalizeSolutionStep()
  File "/home/philippb/software/Kratos_Master/kratos/python_scripts/from_json_check_result_process.py", line 180, in ExecuteFinalizeSolutionStep
    self.assertTrue(isclosethis, msg=(str(value[gp]) + " != " + str(value_json) + ", rel_tol = " + str(reltol) + ", abs_tol = " + str(tol) + " : Error checking elem " + str(elem.Id) + " " + variable_name + " results."))
AssertionError: False is not true : -1.250007002727898 != -1.249994220896042, rel_tol = 1e-06, abs_tol = 1e-05 : Error checking elem 10 I22_SENSITIVITY results.
~~~