### PR TITLE
fix(core): fixed error for some compilers in sensitivity builder

### DIFF
--- a/kratos/utilities/sensitivity_builder.cpp
+++ b/kratos/utilities/sensitivity_builder.cpp
@@ -150,7 +150,7 @@ void ParallelForEach(TContainer& rContainer, TCallable&& Fun)
 {
 #pragma omp parallel
     {
-        auto local_fun{Fun};
+        auto local_fun(Fun);
 #pragma omp for
         for (int i = 0; i < static_cast<int>(rContainer.size()); ++i)
         {


### PR DESCRIPTION
Fixes #4512. The curly braces caused the auto-deduced type to generate an initializer list of callable instead of callable.