### PR TITLE
fix(StructuralMechanics): fixed kirchhoff plane stress calculation

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
@@ -106,7 +106,7 @@ void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculatePK2Stress(
 {
     Matrix D;
     this->CalculateConstitutiveMatrixPK2(D, YoungModulus, PoissonCoefficient);
-    rStressVector = prod(D, rStrainVector);
+    noalias(rStressVector) = prod(D, rStrainVector);
 }
 
 /***********************************************************************************/

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.cpp
@@ -98,6 +98,17 @@ void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculateConstitutiveMatrixPK2
     rConstitutiveMatrix(2,2) = c3;
 }
 
+void HyperElasticIsotropicKirchhoffPlaneStress2D::CalculatePK2Stress(
+    const Vector& rStrainVector,
+    Vector& rStressVector,
+    const double YoungModulus,
+    const double PoissonCoefficient)
+{
+    Matrix D;
+    this->CalculateConstitutiveMatrixPK2(D, YoungModulus, PoissonCoefficient);
+    rStressVector = prod(D, rStrainVector);
+}
+
 /***********************************************************************************/
 /***********************************************************************************/
 

--- a/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/hyper_elastic_isotropic_kirchhoff_plane_stress_2d.h
@@ -162,6 +162,13 @@ protected:
         const double YoungModulus,
         const double PoissonCoefficient
         ) override;
+    
+    void CalculatePK2Stress(
+        const Vector& rStrainVector,
+        Vector& rStressVector,
+        double YoungModulus,
+        double PoissonCoefficient
+        ) override;
 
     /**
      * @brief It calculates the strain vector


### PR DESCRIPTION
The kirchhoff plane stress law was computing PK2 stresses incorrectly from the base class implementation. This bug caused incorrect stresses to be computed when the flag COMPUTE_CONSTITUTIVE_TENSOR was set to false.

This resulted in the correct stresses in BuildAndSolve() but incorrect stresses in BuildRHS() for the TotalLagrangian element, which caused the convergence criteria to behave incorrectly.