### PR TITLE
[MeshingApplication] Compilation error when not MMG is included

### DIFF
--- a/applications/MeshingApplication/CMakeLists.txt
+++ b/applications/MeshingApplication/CMakeLists.txt
@@ -56,7 +56,6 @@ set( KRATOS_MESHING_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/metrics_hessian_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/metrics_error_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/nodal_values_interpolation_process.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/integration_values_extrapolation_to_nodes_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/multiscale_refining_process.cpp
 )
 endif(${INCLUDE_MMG} MATCHES ON)


### PR DESCRIPTION
Just that, hotfix