### PR TITLE
[TrilinosApplication] Missing override on mpi_normal_calculation_utilities

### DIFF
--- a/applications/TrilinosApplication/custom_utilities/mpi_normal_calculation_utilities.h
+++ b/applications/TrilinosApplication/custom_utilities/mpi_normal_calculation_utilities.h
@@ -65,7 +65,7 @@ public:
     ///@name Operations
     ///@{
 
-    int Check(ModelPart& rModelPart);
+    int Check(ModelPart& rModelPart) override;
 
     void OrientFaces(ModelPart& rModelPart,
                      bool OutwardsPositive);


### PR DESCRIPTION
BTW, this derives from a process, should be a process