### PR TITLE
Revert "[TrilinosApplication] Missing override on mpi_normal_calculation_utilities"

### DIFF
--- a/applications/TrilinosApplication/custom_utilities/mpi_normal_calculation_utilities.h
+++ b/applications/TrilinosApplication/custom_utilities/mpi_normal_calculation_utilities.h
@@ -65,7 +65,7 @@ public:
     ///@name Operations
     ///@{
 
-    int Check(ModelPart& rModelPart) override;
+    int Check(ModelPart& rModelPart);
 
     void OrientFaces(ModelPart& rModelPart,
                      bool OutwardsPositive);


### PR DESCRIPTION
Reverts KratosMultiphysics/Kratos#4570

this does not override, it does not compile like this!