### PR TITLE
Missing KratosAPI in header files

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
@@ -35,7 +35,7 @@ namespace Kratos {
 /// Short class definition.
 /** Detail class definition.
 */
-class KratosCompressiblePotentialFlowApplication : public KratosApplication {
+class KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) KratosCompressiblePotentialFlowApplication : public KratosApplication {
 public:
 	///@name Type Definitions
 	///@{

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/incompressible_adjoint_potential_wall_condition.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/incompressible_adjoint_potential_wall_condition.h
@@ -19,7 +19,7 @@ namespace Kratos
 
 
 template <class TPrimalCondition>
-class AdjointIncompressiblePotentialWallCondition : public Condition
+class KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) AdjointIncompressiblePotentialWallCondition : public Condition
 {
 public:
     ///@name Type Definitions

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
@@ -58,7 +58,7 @@ namespace Kratos
 
 /// Implements a wall condition for the potential flow formulation
 template <unsigned int TDim, unsigned int TNumNodes = TDim>
-class PotentialWallCondition : public Condition
+class KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) PotentialWallCondition : public Condition
 {
 public:
     ///@name Type Definitions

--- a/applications/CompressiblePotentialFlowApplication/custom_response_functions/adjoint_lift_response_function_coordinates_jump.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_response_functions/adjoint_lift_response_function_coordinates_jump.h
@@ -50,7 +50,7 @@ namespace Kratos
 * This is a response function which traces a chosen displacement or rotation of a single
 * node as response. It is designed to be used in adjoint sensitivity analysis.
 */
-class AdjointLiftJumpCoordinatesResponseFunction : public AdjointPotentialResponseFunction
+class KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) AdjointLiftJumpCoordinatesResponseFunction : public AdjointPotentialResponseFunction
 {
 public:
     ///@name Type Definitions

--- a/applications/CompressiblePotentialFlowApplication/custom_response_functions/adjoint_potential_response_function.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_response_functions/adjoint_potential_response_function.h
@@ -32,7 +32,7 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
-class  AdjointPotentialResponseFunction : public AdjointResponseFunction
+class KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) AdjointPotentialResponseFunction : public AdjointResponseFunction
 {
 public:
     ///@name Type Definitions


### PR DESCRIPTION
Needed to compile in Windows

@roigcarlo There were only 2 mandatory (Visual Studio was throwing 2 errors):
- compressible_potential_flow_application.h
- custom_response_functions\adjoint_lift_response_function_coordinates_jump.h

I've added it to some more