### PR TITLE
Core/adding standard check near

### DIFF
--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -42,6 +42,18 @@
 #define KRATOS_CHECK_STRING_CONTAIN_SUB_STRING(TheString, SubString) if (TheString.find(SubString) == std::string::npos ) \
 KRATOS_ERROR << "The string \"" << SubString << "\" was not found in the given string"
 
+// To be used as a default check, when the characteristic units of the problem
+// are not expected to be too many orders of magnitude smaller than 1, since otherwise
+// the check would become trivial (e.g., if one is comparing distances when the characteristic length
+// of the problem is represented by a number smaller than 10-7 in the assumed units).
+//
+// Similarly, when the numerical errors associated with finite-point arithmetic
+// are not expected to be especially large, due to the particularities of the operation
+// being performed, since in the latter case the condition for equality might become too
+// rigorous.
+//
+// In the above-mentioned cases, and in other exceptional ones it is best to use 'KRATOS_CHECK_NEAR', where the
+// tolerance is explicitly set.
 #define KRATOS_STANDARD_CHECK_NEAR(a,b) if(std::abs(a - b) > Globals::Epsilon * (1 + std::abs(a) + std::abs(b))) KRATOS_ERROR << "Check failed because " << #a << " = " << a << \
 " is not near to " << #b << " = " << b << " within the standard Kratos tolerance."
 

--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -42,7 +42,7 @@
 #define KRATOS_CHECK_STRING_CONTAIN_SUB_STRING(TheString, SubString) if (TheString.find(SubString) == std::string::npos ) \
 KRATOS_ERROR << "The string \"" << SubString << "\" was not found in the given string"
 
-#define KRATOS_STANDARD_CHECK_NEAR(a,b) if(std::abs(a - b) > 1e4 * std::numeric_limits<double>::epsilon() * (1 + std::abs(a) + std::abs(b))) KRATOS_ERROR << "Check failed because " << #a << " = " << a << \
+#define KRATOS_STANDARD_CHECK_NEAR(a,b) if(std::abs(a - b) > Globals::Epsilon * (1 + std::abs(a) + std::abs(b))) KRATOS_ERROR << "Check failed because " << #a << " = " << a << \
 " is not near to " << #b << " = " << b << " within the standard Kratos tolerance " << 1e4 * std::numeric_limits<double>::epsilon()
 
 #define KRATOS_CHECK_NEAR(a,b, tolerance) if(std::abs(a - b) > tolerance) KRATOS_ERROR << "Check failed because " << #a << " = " << a << \

--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -43,7 +43,7 @@
 KRATOS_ERROR << "The string \"" << SubString << "\" was not found in the given string"
 
 #define KRATOS_STANDARD_CHECK_NEAR(a,b) if(std::abs(a - b) > Globals::Epsilon * (1 + std::abs(a) + std::abs(b))) KRATOS_ERROR << "Check failed because " << #a << " = " << a << \
-" is not near to " << #b << " = " << b << " within the standard Kratos tolerance " << 1e4 * std::numeric_limits<double>::epsilon()
+" is not near to " << #b << " = " << b << " within the standard Kratos tolerance."
 
 #define KRATOS_CHECK_NEAR(a,b, tolerance) if(std::abs(a - b) > tolerance) KRATOS_ERROR << "Check failed because " << #a << " = " << a << \
 " is not near to " << #b << " = " << b << " within the tolerance " << tolerance

--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -42,6 +42,9 @@
 #define KRATOS_CHECK_STRING_CONTAIN_SUB_STRING(TheString, SubString) if (TheString.find(SubString) == std::string::npos ) \
 KRATOS_ERROR << "The string \"" << SubString << "\" was not found in the given string"
 
+#define KRATOS_STANDARD_CHECK_NEAR(a,b) if(std::abs(a - b) > 1e4 * std::numeric_limits<double>::epsilon() * (1 + std::abs(a) + std::abs(b))) KRATOS_ERROR << "Check failed because " << #a << " = " << a << \
+" is not near to " << #b << " = " << b << " within the standard Kratos tolerance " << 1e4 * std::numeric_limits<double>::epsilon()
+
 #define KRATOS_CHECK_NEAR(a,b, tolerance) if(std::abs(a - b) > tolerance) KRATOS_ERROR << "Check failed because " << #a << " = " << a << \
 " is not near to " << #b << " = " << b << " within the tolerance " << tolerance
 #define KRATOS_CHECK_DOUBLE_EQUAL(a,b) KRATOS_CHECK_NEAR(a,b,std::numeric_limits<double>::epsilon())

--- a/kratos/includes/global_variables.h
+++ b/kratos/includes/global_variables.h
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
-//                    
+//
 //
 
 
@@ -21,7 +21,7 @@
 // System includes
 #include <string>
 #include <iostream>
-
+#include <limits>
 
 // External includes
 
@@ -34,6 +34,7 @@ namespace Kratos
 namespace Globals
 {
 	constexpr double Pi   = 3.14159265358979323846264338327950288419716939937510582097494459230781640628620899862803482534211706798214808651L;
+	constexpr double Epsilon = 1e4 * std::numeric_limits<double>::epsilon();
 /*		class VariableData;
 		class Element;
 		class Condition;

--- a/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
@@ -35,11 +35,9 @@ namespace Kratos
 
         KRATOS_TEST_CASE_IN_SUITE(MathUtilsHeron, KratosCoreFastSuite)
         {
-            constexpr double tolerance = 1e-6;
-
             const double area = MathUtils<double>::Heron<false>(std::sqrt(2.0), 1.0, 1.0);
 
-            KRATOS_CHECK_NEAR(area, 0.5, tolerance);
+            KRATOS_STANDARD_CHECK_NEAR(area, 0.5);
         }
 
         /** Checks if it gives you the absolute value of a given value
@@ -81,14 +79,12 @@ namespace Kratos
 
         KRATOS_TEST_CASE_IN_SUITE(MathUtilsDetMat, KratosCoreFastSuite)
         {
-            constexpr double tolerance = 1e-6;
-
             BoundedMatrix<double, 1, 1> mat11 = ZeroMatrix(1, 1);
             mat11(0,0) = 1.0;
 
             double det = MathUtils<double>::DetMat(mat11);
 
-            KRATOS_CHECK_NEAR(det, 1.0, tolerance);
+            KRATOS_STANDARD_CHECK_NEAR(det, 1.0);
 
             BoundedMatrix<double, 2, 2> mat22 = ZeroMatrix(2, 2);
             mat22(0,0) = 1.0;
@@ -96,7 +92,7 @@ namespace Kratos
 
             det = MathUtils<double>::DetMat(mat22);
 
-            KRATOS_CHECK_NEAR(det, 1.0, tolerance);
+            KRATOS_STANDARD_CHECK_NEAR(det, 1.0);
 
             BoundedMatrix<double, 3, 3> mat33 = ZeroMatrix(3, 3);
             mat33(0,0) = 1.0;
@@ -105,7 +101,7 @@ namespace Kratos
 
             det = MathUtils<double>::DetMat(mat33);
 
-            KRATOS_CHECK_NEAR(det, 1.0, tolerance);
+            KRATOS_STANDARD_CHECK_NEAR(det, 1.0);
 
             BoundedMatrix<double, 4, 4> mat44 = ZeroMatrix(4, 4);
             mat44(0,0) = 1.0;
@@ -115,13 +111,11 @@ namespace Kratos
 
             det = MathUtils<double>::DetMat(mat44);
 
-            KRATOS_CHECK_NEAR(det, 1.0, tolerance);
+            KRATOS_STANDARD_CHECK_NEAR(det, 1.0);
         }
 
         KRATOS_TEST_CASE_IN_SUITE(MathUtilsCofactor, KratosCoreFastSuite)
         {
-            constexpr double tolerance = 1e-6;
-
             BoundedMatrix<double, 1, 1> mat11 = ZeroMatrix(1, 1);
             mat11(0,0) = 2.0;
 
@@ -145,13 +139,11 @@ namespace Kratos
             mat33(2,0) = 2.0; mat33(2,1) = 0.0; mat33(2,2) = -1.0;
 
             cofactor = MathUtils<double>::Cofactor(mat33, 2, 1);
-            KRATOS_CHECK_NEAR(cofactor, 9.0, tolerance);
+            KRATOS_STANDARD_CHECK_NEAR(cofactor, 9.0);
         }
 
         KRATOS_TEST_CASE_IN_SUITE(MathUtilsCofactorMatrix, KratosCoreFastSuite)
         {
-            constexpr double tolerance = 1e-6;
-
             BoundedMatrix<double, 3, 3> mat33 = ZeroMatrix(3, 3);
             mat33(0,0) = 2.0; mat33(0,1) = 0.0; mat33(0,2) = 2.0;
             mat33(1,0) = 2.0; mat33(1,1) = 0.0; mat33(1,2) =-2.0;
@@ -165,7 +157,7 @@ namespace Kratos
             MathUtils<double>::MatrixType cof_mat = MathUtils<double>::CofactorMatrix(mat33);
             for (unsigned i = 0; i < ref33.size1(); ++i)
                 for (unsigned j = 0; j < ref33.size2(); ++j)
-                    KRATOS_CHECK_NEAR(cof_mat(i,j), ref33(i,j), tolerance);
+                    KRATOS_STANDARD_CHECK_NEAR(cof_mat(i,j), ref33(i,j));
         }
 
         /** Checks if it calculates the generalized determinant of a non-square matrix
@@ -174,15 +166,13 @@ namespace Kratos
 
         KRATOS_TEST_CASE_IN_SUITE(MathUtilsGenDetMat, KratosCoreFastSuite)
         {
-            constexpr double tolerance = 1e-6;
-
             Matrix mat23 = ZeroMatrix(2, 3);
             mat23(0,0) = 1.0;
             mat23(1,1) = 1.0;
 
             double det = MathUtils<double>::GeneralizedDet(mat23);
 
-            KRATOS_CHECK_NEAR(det, 1.0, tolerance);
+            KRATOS_STANDARD_CHECK_NEAR(det, 1.0);
 
             Matrix mat55 = ZeroMatrix(5, 5);
             mat55(0,0) =   1.0;
@@ -195,7 +185,7 @@ namespace Kratos
 
             det = MathUtils<double>::Det(mat55);
 
-            KRATOS_CHECK_NEAR(det, 4.0, tolerance);
+            KRATOS_STANDARD_CHECK_NEAR(det, 4.0);
         }
 
         /** Checks if it calculates the inverse of a 1x1, 2x2, 3x3 and 4x4 matrix
@@ -204,8 +194,6 @@ namespace Kratos
 
         KRATOS_TEST_CASE_IN_SUITE(MathUtilsInvMat, KratosCoreFastSuite)
         {
-            constexpr double tolerance = 1e-6;
-
             BoundedMatrix<double, 1, 1> mat11;
             mat11(0,0) = 0.896308;
 
@@ -214,7 +202,7 @@ namespace Kratos
             MathUtils<double>::InvertMatrix(mat11, inv11, det);
             const BoundedMatrix<double, 1, 1> I11 = prod(inv11, mat11);
 
-            KRATOS_CHECK_NEAR(I11(0,0), 1.0, tolerance);
+            KRATOS_STANDARD_CHECK_NEAR(I11(0,0), 1.0);
 
             BoundedMatrix<double, 2, 2> mat22;
             mat22(0,0) = 0.670005;
@@ -229,9 +217,9 @@ namespace Kratos
             for (unsigned int i = 0; i < 2; i++) {
                 for (unsigned int j = 0; j < 2; j++) {
                     if (i == j) {
-                        KRATOS_CHECK_NEAR(I22(i,j), 1.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I22(i,j), 1.0);
                     } else {
-                        KRATOS_CHECK_NEAR(I22(i,j), 0.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I22(i,j), 0.0);
                     }
                 }
             }
@@ -254,9 +242,9 @@ namespace Kratos
             for (unsigned int i = 0; i < 3; i++) {
                 for (unsigned int j = 0; j < 3; j++) {
                     if (i == j) {
-                        KRATOS_CHECK_NEAR(I33(i,j), 1.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I33(i,j), 1.0);
                     } else {
-                        KRATOS_CHECK_NEAR(I33(i,j), 0.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I33(i,j), 0.0);
                     }
                 }
             }
@@ -286,9 +274,9 @@ namespace Kratos
             for (unsigned int i = 0; i < 4; i++) {
                 for (unsigned int j = 0; j < 4; j++) {
                     if (i == j) {
-                        KRATOS_CHECK_NEAR(I44(i,j), 1.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I44(i,j), 1.0);
                     } else {
-                        KRATOS_CHECK_NEAR(I44(i,j), 0.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I44(i,j), 0.0);
                     }
                 }
             }
@@ -300,8 +288,6 @@ namespace Kratos
 
         KRATOS_TEST_CASE_IN_SUITE(MathUtilsInvertMatrix, KratosCoreFastSuite)
         {
-            constexpr double tolerance = 1e-6;
-
             double det;
             Matrix inv(1,1);
             Matrix I(1,1);
@@ -319,9 +305,9 @@ namespace Kratos
             for (unsigned int i = 0; i < i_dim; i++) {
                 for (unsigned int j = 0; j < i_dim; j++) {
                     if (i == j) {
-                        KRATOS_CHECK_NEAR(I(i,j), 1.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 1.0);
                     } else {
-                        KRATOS_CHECK_NEAR(I(i,j), 0.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 0.0);
                     }
                 }
             }
@@ -343,9 +329,9 @@ namespace Kratos
             for (unsigned int i = 0; i < i_dim; i++) {
                 for (unsigned int j = 0; j < i_dim; j++) {
                     if (i == j) {
-                        KRATOS_CHECK_NEAR(I(i,j), 1.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 1.0);
                     } else {
-                        KRATOS_CHECK_NEAR(I(i,j), 0.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 0.0);
                     }
                 }
             }
@@ -372,9 +358,9 @@ namespace Kratos
             for (unsigned int i = 0; i < i_dim; i++) {
                 for (unsigned int j = 0; j < i_dim; j++) {
                     if (i == j) {
-                        KRATOS_CHECK_NEAR(I(i,j), 1.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 1.0);
                     } else {
-                        KRATOS_CHECK_NEAR(I(i,j), 0.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 0.0);
                     }
                 }
             }
@@ -408,9 +394,9 @@ namespace Kratos
             for (unsigned int i = 0; i < i_dim; i++) {
                 for (unsigned int j = 0; j < i_dim; j++) {
                     if (i == j) {
-                        KRATOS_CHECK_NEAR(I(i,j), 1.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 1.0);
                     } else {
-                        KRATOS_CHECK_NEAR(I(i,j), 0.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 0.0);
                     }
                 }
             }
@@ -431,16 +417,16 @@ namespace Kratos
 
             MathUtils<double>::InvertMatrix(mat,inv, det);
 
-            KRATOS_CHECK_NEAR(det, 4.0, tolerance);
+            KRATOS_STANDARD_CHECK_NEAR(det, 4.0);
 
             I = prod(inv, mat);
 
             for (unsigned int i = 0; i < i_dim; i++) {
                 for (unsigned int j = 0; j < i_dim; j++) {
                     if (i == j) {
-                        KRATOS_CHECK_NEAR(I(i,j), 1.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 1.0);
                     } else {
-                        KRATOS_CHECK_NEAR(I(i,j), 0.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 0.0);
                     }
                 }
             }
@@ -452,8 +438,6 @@ namespace Kratos
 
         KRATOS_TEST_CASE_IN_SUITE(MathUtilsSolve, KratosCoreFastSuite)
         {
-            constexpr double tolerance = 1e-6;
-
             const std::size_t i_dim = 4;
             double det;
             Matrix A(i_dim, i_dim);
@@ -490,7 +474,7 @@ namespace Kratos
             MathUtils<double>::Solve(A,x,b);
 
             for (std::size_t i = 0; i < i_dim; i++) {
-                KRATOS_CHECK_NEAR(ref_x[i], x[i], tolerance);
+                KRATOS_STANDARD_CHECK_NEAR(ref_x[i], x[i]);
             }
         }
 
@@ -500,8 +484,6 @@ namespace Kratos
 
         KRATOS_TEST_CASE_IN_SUITE(MathUtilsGeneralizedInvertMatrix, KratosCoreFastSuite)
         {
-            constexpr double tolerance = 1e-6;
-
             // We check the Left inverse
 
             const unsigned int i_dim = 2;
@@ -529,11 +511,11 @@ namespace Kratos
                 {
                     if (i == j)
                     {
-                        KRATOS_CHECK_NEAR(I(i,j), 1.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 1.0);
                     }
                     else
                     {
-                        KRATOS_CHECK_NEAR(I(i,j), 0.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 0.0);
                     }
                 }
             }
@@ -559,11 +541,11 @@ namespace Kratos
                 {
                     if (i == j)
                     {
-                        KRATOS_CHECK_NEAR(I(i,j), 1.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 1.0);
                     }
                     else
                     {
-                        KRATOS_CHECK_NEAR(I(i,j), 0.0, tolerance);
+                        KRATOS_STANDARD_CHECK_NEAR(I(i,j), 0.0);
                     }
                 }
             }
@@ -590,8 +572,6 @@ namespace Kratos
 
         KRATOS_TEST_CASE_IN_SUITE(MathUtilsEigen, KratosCoreFastSuite)
         {
-            constexpr double tolerance = 1e-6;
-
             BoundedMatrix<double, 3, 3> mat33;
             BoundedMatrix<double, 3, 3> eigenmat33;
             BoundedMatrix<double, 3, 3> vectormat33;
@@ -613,7 +593,7 @@ namespace Kratos
 
             for (std::size_t i = 0; i < 3; i++) {
                 for (std::size_t j = i; j < 3; j++) {
-                    KRATOS_CHECK_NEAR(auxmat33(i,j), mat33(i,j), tolerance);
+                    KRATOS_STANDARD_CHECK_NEAR(auxmat33(i,j), mat33(i,j));
                 }
             }
 


### PR DESCRIPTION
This pull request adresses #4305. I have used the definition of the tolerance that I proposed there, although I am open to change it to that proposed by @msandre in the same issue.

The advantages of `KRATOS_STANDARD_CHECK_NEAR` are:

- We avoid the proliferation of too many arbitrary tolerances
- We scale the numbers being compared for the user
- We make the instances where the standard check does not work much more conspicuous, implying that the loss of accuracy perhaps cannot be ignored there.

The latter point is obviously dependent upon a generalized used of `KRATOS_STANDARD_CHECK_NEAR.`

I have included a variable Globals::Epsilon ~ 1e-12. The idea is to have it accessible from everywhere and to facilitate a centralized control of this variable. I have also included a first example of use of the new check in test_math_utils.cpp, where all the tolerances where previously set to 1e-6. I have not checked, but I believe it is likely that all checks have become substantially tighter (unless tiny quantities where being compared in some example)