### PR TITLE
[Core] Enhanced calculate embedded variable from skin

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -58,7 +58,7 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/find_nodal_h_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/calculate_nodal_area_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/skin_detection_process.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/processes/replace_elements_and_condition_process.cpp 
+    ${CMAKE_CURRENT_SOURCE_DIR}/processes/replace_elements_and_condition_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/tetrahedral_mesh_orientation_check.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/integration_values_extrapolation_to_nodes_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/bounding_volume_tree.cpp;
@@ -91,6 +91,7 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modified_shape_functions/tetrahedra_3d_4_ausas_modified_shape_functions.cpp;
+    ${CMAKE_CURRENT_SOURCE_DIR}/elements/embedded_nodal_variable_calculation_element_simplex.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/elements/mesh_element.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/conditions/mesh_condition.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/apply_periodic_boundary_condition_process.cpp;

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
@@ -131,7 +131,7 @@ void EmbeddedNodalVariableCalculationElementSimplex<double>::CalculateRightHandS
     }
 
     // Get the element shape function values from the normalized distance to node 0
-    const auto &rData = this->GetValue(NODAL_MAUX);
+    const double &rData = this->GetValue(NODAL_MAUX);
     const auto &rN = this->GetDistanceBasedShapeFunctionValues();
 
     // Compute the Gramm matrix
@@ -151,7 +151,7 @@ void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double, 3>>::Calcul
     }
 
     // Get the element shape function values from the normalized distance to node 0
-    const auto &rData = this->GetValue(NODAL_VAUX);
+    const array_1d<double,3> &rData = this->GetValue(NODAL_VAUX);
     const auto &rN = this->GetDistanceBasedShapeFunctionValues();
 
     // Compute the Gramm matrix
@@ -171,7 +171,7 @@ void EmbeddedNodalVariableCalculationElementSimplex<double>::EquationIdVector(
         rResult.resize(2, false);
     }
 
-    const auto pos = (this->GetGeometry())[0].GetDofPosition(NODAL_MAUX);
+    const unsigned int pos = (this->GetGeometry())[0].GetDofPosition(NODAL_MAUX);
     for (unsigned int i = 0; i < 2; i++) {
         rResult[i] = (this->GetGeometry())[i].GetDof(NODAL_MAUX, pos).EquationId();
     }
@@ -186,7 +186,7 @@ void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double, 3>>::Equati
         rResult.resize(6, false);
     }
 
-    const auto x_pos = (this->GetGeometry())[0].GetDofPosition(NODAL_VAUX_X);
+    const unsigned int x_pos = (this->GetGeometry())[0].GetDofPosition(NODAL_VAUX_X);
     for (unsigned int i = 0; i < 2; i++) {
         rResult[i * 3] = GetGeometry()[i].GetDof(NODAL_VAUX_X, x_pos).EquationId();
         rResult[i * 3 + 1] = GetGeometry()[i].GetDof(NODAL_VAUX_Y, x_pos + 1).EquationId();
@@ -227,7 +227,7 @@ void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double, 3>>::GetDof
 template <class TVarType>
 const array_1d<double, 2> EmbeddedNodalVariableCalculationElementSimplex<TVarType>::GetDistanceBasedShapeFunctionValues()
 {
-    const auto d = this->GetValue(DISTANCE);
+    const double d = this->GetValue(DISTANCE);
     array_1d<double, 2> N;
     N[0] = 1.0 - d;
     N[1] = d;

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
@@ -4,7 +4,7 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
+//  License:         BSD License
 //                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
@@ -5,7 +5,7 @@
 //                   Multi-Physics
 //
 //  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla
 //

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
@@ -35,6 +35,64 @@ void EmbeddedNodalVariableCalculationElementSimplex<TVarType>::CalculateLocalSys
 }
 
 template <>
+int EmbeddedNodalVariableCalculationElementSimplex<double>::Check(const ProcessInfo &rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    // Perform basic element checks
+    int ErrorCode = Kratos::Element::Check(rCurrentProcessInfo);
+    if(ErrorCode != 0) {
+        return ErrorCode;
+    }
+
+    // Check that all required variables have been registered
+    if(DISTANCE.Key() == 0) {
+        KRATOS_ERROR << "DISTANCE Key is 0. Check if the application was correctly registered.";
+    }
+    if(NODAL_MAUX.Key() == 0) {
+        KRATOS_ERROR << "NODAL_MAUX Key is 0. Check if the application was correctly registered.";
+    }
+
+    // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom
+    for(auto &r_node : this->GetGeometry()) {
+        KRATOS_ERROR_IF(!r_node.SolutionStepsDataHas(NODAL_MAUX)) << "Missing NODAL_MAUX variable on solution step data for node " << r_node.Id() << std::endl;;
+    }
+
+    return 0;
+
+    KRATOS_CATCH("");
+}
+
+template <>
+int EmbeddedNodalVariableCalculationElementSimplex<array_1d<double,3>>::Check(const ProcessInfo &rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    // Perform basic element checks
+    int ErrorCode = Kratos::Element::Check(rCurrentProcessInfo);
+    if(ErrorCode != 0) {
+        return ErrorCode;
+    }
+
+    // Check that all required variables have been registered
+    if(DISTANCE.Key() == 0) {
+        KRATOS_ERROR << "DISTANCE Key is 0. Check if the application was correctly registered.";
+    }
+    if(NODAL_VAUX.Key() == 0) {
+        KRATOS_ERROR << "NODAL_VAUX Key is 0. Check if the application was correctly registered.";
+    }
+
+    // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom
+    for(auto &r_node : this->GetGeometry()) {
+        KRATOS_ERROR_IF(!r_node.SolutionStepsDataHas(NODAL_VAUX)) << "Missing NODAL_VAUX variable on solution step data for node " << r_node.Id() << std::endl;;
+    }
+
+    return 0;
+
+    KRATOS_CATCH("");
+}
+
+template <>
 void EmbeddedNodalVariableCalculationElementSimplex<double>::CalculateLeftHandSide(
     MatrixType &rLeftHandSideMatrix,
     ProcessInfo &rCurrentProcessInfo)
@@ -44,16 +102,13 @@ void EmbeddedNodalVariableCalculationElementSimplex<double>::CalculateLeftHandSi
         rLeftHandSideMatrix.resize(2, 2, false);
     }
 
-    // Initialize Left Hand Side matrix
-    noalias(rLeftHandSideMatrix) = ZeroMatrix(2,2);
-
     // Get the element shape function values from the normalized distance to node 0
-    const auto N = this->GetDistanceBasedShapeFunctionValues();
+    const auto &rN = this->GetDistanceBasedShapeFunctionValues();
 
     // Compute the Gramm matrix
     for (unsigned int i = 0; i < 2; ++i) {
         for (unsigned int j = 0; j < 2; ++j) {
-            rLeftHandSideMatrix(i, j) = N[i] * N[j];
+            rLeftHandSideMatrix(i, j) = rN[i] * rN[j];
         }
     }
 }
@@ -68,17 +123,14 @@ void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double,3>>::Calcula
         rLeftHandSideMatrix.resize(6, 6, false);
     }
 
-    // Initialize Left Hand Side matrix
-    noalias(rLeftHandSideMatrix) = ZeroMatrix(6,6);
-
     // Get the element shape function values from the normalized distance to node 0
-    const auto N = this->GetDistanceBasedShapeFunctionValues();
+    const auto &rN = this->GetDistanceBasedShapeFunctionValues();
 
     // Compute the Gramm matrix
     for (unsigned int i = 0; i < 2; ++i) {
         for (unsigned int j = 0; j < 2; ++j) {
             for (unsigned int k = 0; k < 3; ++k) {
-                rLeftHandSideMatrix(i * 3 + k, j * 3 + k) = N[i] * N[j];
+                rLeftHandSideMatrix(i * 3 + k, j * 3 + k) = rN[i] * rN[j];
             }
         }
     }
@@ -94,16 +146,13 @@ void EmbeddedNodalVariableCalculationElementSimplex<double>::CalculateRightHandS
         rRigthHandSideVector.resize(2, false);
     }
 
-    // Initialize Left Hand Side matrix
-    noalias(rRigthHandSideVector) = ZeroVector(2);
-
     // Get the element shape function values from the normalized distance to node 0
-    const auto data = this->GetValue(NODAL_MAUX);
-    const auto N = this->GetDistanceBasedShapeFunctionValues();
+    const auto &rData = this->GetValue(NODAL_MAUX);
+    const auto &rN = this->GetDistanceBasedShapeFunctionValues();
 
     // Compute the Gramm matrix
     for (unsigned int i = 0; i < 2; ++i) {
-        rRigthHandSideVector(i) = N[i] * data;
+        rRigthHandSideVector(i) = rN[i] * rData;
     }
 }
 
@@ -117,17 +166,14 @@ void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double, 3>>::Calcul
         rRigthHandSideVector.resize(6, false);
     }
 
-    // Initialize Left Hand Side matrix
-    noalias(rRigthHandSideVector) = ZeroVector(6);
-
     // Get the element shape function values from the normalized distance to node 0
-    const auto data = this->GetValue(NODAL_VAUX);
-    const auto N = this->GetDistanceBasedShapeFunctionValues();
+    const auto &rData = this->GetValue(NODAL_VAUX);
+    const auto &rN = this->GetDistanceBasedShapeFunctionValues();
 
     // Compute the Gramm matrix
     for (unsigned int i = 0; i < 2; ++i) {
         for (unsigned int k = 0; k < 3; ++k) {
-            rRigthHandSideVector(i * 3 + k) = N[i] * data[k];
+            rRigthHandSideVector(i * 3 + k) = rN[i] * rData(k);
         }
     }
 }
@@ -155,7 +201,6 @@ void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double, 3>>::Equati
     if (rResult.size() != 6) {
         rResult.resize(6, false);
     }
-
 
     const auto x_pos = (this->GetGeometry())[0].GetDofPosition(NODAL_VAUX_X);
     for (unsigned int i = 0; i < 2; i++) {

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
@@ -83,6 +83,7 @@ void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double,3>>::Calcula
         }
     }
 }
+
 template <>
 void EmbeddedNodalVariableCalculationElementSimplex<double>::CalculateRightHandSide(
     VectorType &rRigthHandSideVector,

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
@@ -45,14 +45,6 @@ int EmbeddedNodalVariableCalculationElementSimplex<double>::Check(const ProcessI
         return ErrorCode;
     }
 
-    // Check that all required variables have been registered
-    if(DISTANCE.Key() == 0) {
-        KRATOS_ERROR << "DISTANCE Key is 0. Check if the application was correctly registered.";
-    }
-    if(NODAL_MAUX.Key() == 0) {
-        KRATOS_ERROR << "NODAL_MAUX Key is 0. Check if the application was correctly registered.";
-    }
-
     // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom
     for(auto &r_node : this->GetGeometry()) {
         KRATOS_ERROR_IF(!r_node.SolutionStepsDataHas(NODAL_MAUX)) << "Missing NODAL_MAUX variable on solution step data for node " << r_node.Id() << std::endl;;
@@ -72,14 +64,6 @@ int EmbeddedNodalVariableCalculationElementSimplex<array_1d<double,3>>::Check(co
     int ErrorCode = Kratos::Element::Check(rCurrentProcessInfo);
     if(ErrorCode != 0) {
         return ErrorCode;
-    }
-
-    // Check that all required variables have been registered
-    if(DISTANCE.Key() == 0) {
-        KRATOS_ERROR << "DISTANCE Key is 0. Check if the application was correctly registered.";
-    }
-    if(NODAL_VAUX.Key() == 0) {
-        KRATOS_ERROR << "NODAL_VAUX Key is 0. Check if the application was correctly registered.";
     }
 
     // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.cpp
@@ -1,0 +1,185 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+//
+
+// System includes
+
+
+// External includes
+
+
+// Project includes
+#include "elements/embedded_nodal_variable_calculation_element_simplex.h"
+
+
+namespace Kratos
+{
+
+template <class TVarType>
+void EmbeddedNodalVariableCalculationElementSimplex<TVarType>::CalculateLocalSystem(
+    MatrixType &rLeftHandSideMatrix,
+    VectorType &rRightHandSideVector,
+    ProcessInfo &rCurrentProcessInfo)
+{
+    this->CalculateLeftHandSide(rLeftHandSideMatrix, rCurrentProcessInfo);
+    this->CalculateRightHandSide(rRightHandSideVector, rCurrentProcessInfo);
+}
+
+template <>
+void EmbeddedNodalVariableCalculationElementSimplex<double>::CalculateLeftHandSide(
+    MatrixType &rLeftHandSideMatrix,
+    ProcessInfo &rCurrentProcessInfo)
+{
+    // Initialize Left Hand Side matrix
+    noalias(rLeftHandSideMatrix) = ZeroMatrix(2,2);
+
+    // Get the element shape function values from the normalized distance to node 0
+    const auto N = this->GetDistanceBasedShapeFunctionValues();
+
+    // Compute the Gramm matrix
+    for (unsigned int i = 0; i < 2; ++i) {
+        for (unsigned int j = 0; j < 2; ++j) {
+            rLeftHandSideMatrix(i, j) = N[i] * N[j];
+        }
+    }
+}
+
+template <>
+void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double,3>>::CalculateLeftHandSide(
+    MatrixType &rLeftHandSideMatrix,
+    ProcessInfo &rCurrentProcessInfo)
+{
+    // Initialize Left Hand Side matrix
+    noalias(rLeftHandSideMatrix) = ZeroMatrix(6,6);
+
+    // Get the element shape function values from the normalized distance to node 0
+    const auto N = this->GetDistanceBasedShapeFunctionValues();
+
+    // Compute the Gramm matrix
+    for (unsigned int i = 0; i < 2; ++i) {
+        for (unsigned int j = 0; j < 2; ++j) {
+            for (unsigned int k = 0; k < 3; ++k) {
+                rLeftHandSideMatrix(i * 3 + k, j * 3 + k) = N[i] * N[j];
+            }
+        }
+    }
+}
+template <>
+void EmbeddedNodalVariableCalculationElementSimplex<double>::CalculateRightHandSide(
+    VectorType &rRigthHandSideVector,
+    ProcessInfo &rCurrentProcessInfo)
+{
+    // Initialize Left Hand Side matrix
+    noalias(rRigthHandSideVector) = ZeroVector(2);
+
+    // Get the element shape function values from the normalized distance to node 0
+    const auto N = this->GetDistanceBasedShapeFunctionValues();
+
+    // Compute the Gramm matrix
+    for (unsigned int i = 0; i < 2; ++i) {
+        rRigthHandSideVector(i) = N[i];
+    }
+}
+
+template <>
+void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double, 3>>::CalculateRightHandSide(
+    VectorType &rRigthHandSideVector,
+    ProcessInfo &rCurrentProcessInfo)
+{
+    // Initialize Left Hand Side matrix
+    noalias(rRigthHandSideVector) = ZeroVector(6);
+
+    // Get the element shape function values from the normalized distance to node 0
+    const auto N = this->GetDistanceBasedShapeFunctionValues();
+
+    // Compute the Gramm matrix
+    for (unsigned int i = 0; i < 2; ++i) {
+        for (unsigned int k = 0; k < 3; ++k) {
+            rRigthHandSideVector(i * 3 + k) = N[i];
+        }
+    }
+}
+
+template <>
+void EmbeddedNodalVariableCalculationElementSimplex<double>::EquationIdVector(
+    EquationIdVectorType &rResult,
+    ProcessInfo &rCurrentProcessInfo)
+{
+    if (rResult.size() != 2) {
+        rResult.resize(2);
+    }
+
+    for (unsigned int i = 0; i < 2; i++) {
+        rResult[i] = GetGeometry()[i].GetDof(NODAL_MAUX).EquationId();
+    }
+}
+
+template <>
+void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double, 3>>::EquationIdVector(
+    EquationIdVectorType &rResult,
+    ProcessInfo &rCurrentProcessInfo)
+{
+    if (rResult.size() != 6) {
+        rResult.resize(6);
+    }
+
+    for (unsigned int i = 0; i < 2; i++) {
+        rResult[i * 3] = GetGeometry()[i].GetDof(NODAL_VAUX_X).EquationId();
+        rResult[i * 3 + 1] = GetGeometry()[i].GetDof(NODAL_VAUX_Y).EquationId();
+        rResult[i * 3 + 2] = GetGeometry()[i].GetDof(NODAL_VAUX_Z).EquationId();
+    }
+}
+
+template <>
+void EmbeddedNodalVariableCalculationElementSimplex<double>::GetDofList(
+    DofsVectorType &rElementalDofList,
+    ProcessInfo &rCurrentProcessInfo)
+{
+    if (rElementalDofList.size() != 2) {
+        rElementalDofList.resize(2);
+    }
+
+    for (unsigned int i = 0; i < 2; i++) {
+        rElementalDofList[i] = GetGeometry()[i].pGetDof(NODAL_MAUX);
+    }
+}
+
+template <>
+void EmbeddedNodalVariableCalculationElementSimplex<array_1d<double, 3>>::GetDofList(
+    DofsVectorType &rElementalDofList,
+    ProcessInfo &rCurrentProcessInfo)
+{
+    if (rElementalDofList.size() != 6) {
+        rElementalDofList.resize(6);
+    }
+
+    for (unsigned int i = 0; i < 2; i++) {
+        rElementalDofList[i * 3] = GetGeometry()[i].pGetDof(NODAL_VAUX_X);
+        rElementalDofList[i * 3 + 1] = GetGeometry()[i].pGetDof(NODAL_VAUX_Y);
+        rElementalDofList[i * 3 + 2] = GetGeometry()[i].pGetDof(NODAL_VAUX_Z);
+    }
+}
+
+template <class TVarType>
+const array_1d<double, 2> EmbeddedNodalVariableCalculationElementSimplex<TVarType>::GetDistanceBasedShapeFunctionValues()
+{
+    const auto d = this->GetValue(DISTANCE);
+    array_1d<double, 2> N;
+    N[0] = 1.0 - d;
+    N[1] = d;
+    return N;
+}
+
+template class EmbeddedNodalVariableCalculationElementSimplex<double>;
+template class EmbeddedNodalVariableCalculationElementSimplex<array_1d<double,3>>;
+
+} // namespace Kratos.

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla
 //

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
@@ -358,7 +358,7 @@ private:
     ///@{
 
     /// Assignment operator.
-    EmbeddedNodalVariableCalculationElementSimplex & operator=(EmbeddedNodalVariableCalculationElementSimplex const& rOther);
+    EmbeddedNodalVariableCalculationElementSimplex & operator=(EmbeddedNodalVariableCalculationElementSimplex const& rOther) = delete;
 
     /// Copy constructor.
     EmbeddedNodalVariableCalculationElementSimplex(EmbeddedNodalVariableCalculationElementSimplex const& rOther) = delete;

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
@@ -23,7 +23,6 @@
 // Project includes
 #include "includes/define.h"
 #include "includes/element.h"
-#include "geometries/geometry.h"
 
 // Application includes
 

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
@@ -1,0 +1,474 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+//
+
+#if !defined(KRATOS_EMBEDDED_NODAL_VARIABLE_CALCULATION_ELEMENT_H_INCLUDED )
+#define  KRATOS_EMBEDDED_NODAL_VARIABLE_CALCULATION_ELEMENT_H_INCLUDED
+
+// System includes
+#include <string>
+#include <iostream>
+
+
+// External includes
+
+
+// Project includes
+#include "containers/array_1d.h"
+#include "includes/define.h"
+#include "includes/element.h"
+#include "includes/serializer.h"
+#include "includes/variables.h"
+#include "geometries/geometry.h"
+#include "utilities/math_utils.h"
+#include "utilities/geometry_utilities.h"
+
+// Application includes
+
+
+namespace Kratos
+{
+
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/// An element to compute the a nodal variable from an embedded skin
+/**
+ */
+template< unsigned int TDim >
+class EmbeddedNodalVariableCalculationElementSimplex : public Element
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of EmbeddedNodalVariableCalculationElementSimplex
+    KRATOS_CLASS_POINTER_DEFINITION(EmbeddedNodalVariableCalculationElementSimplex);
+
+    /// Node type (default is: Node<3>)
+    typedef Node <3> NodeType;
+
+    /// Geometry type (using with given NodeType)
+    typedef Geometry<NodeType> GeometryType;
+
+    /// Definition of nodes container type, redefined from GeometryType
+    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
+
+    /// Vector type for local contributions to the linear system
+    typedef Vector VectorType;
+
+    /// Matrix type for local contributions to the linear system
+    typedef Matrix MatrixType;
+
+    typedef std::size_t IndexType;
+
+    typedef std::size_t SizeType;
+
+    typedef std::vector<std::size_t> EquationIdVectorType;
+
+    typedef std::vector< Dof<double>::Pointer > DofsVectorType;
+
+    typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
+
+    /// Type for shape function values container
+    typedef Kratos::Vector ShapeFunctionsType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    //Constructors.
+
+    /// Default constuctor.
+    /**
+     * @param NewId Index number of the new element (optional)
+     */
+    EmbeddedNodalVariableCalculationElementSimplex(IndexType NewId = 0)
+        : Element(NewId)
+    {}
+
+    /// Constructor using an array of nodes.
+    /**
+     * @param NewId Index of the new element
+     * @param ThisNodes An array containing the nodes of the new element
+     */
+    EmbeddedNodalVariableCalculationElementSimplex(
+        IndexType NewId,
+        const NodesArrayType& ThisNodes)
+        : Element(NewId, ThisNodes)
+    {}
+
+    /// Constructor using a geometry object.
+    /**
+     * @param NewId Index of the new element
+     * @param pGeometry Pointer to a geometry object
+     */
+    EmbeddedNodalVariableCalculationElementSimplex(
+        IndexType NewId,
+        GeometryType::Pointer pGeometry)
+        : Element(NewId, pGeometry)
+    {}
+
+    /// Constuctor using geometry and properties.
+    /**
+     * @param NewId Index of the new element
+     * @param pGeometry Pointer to a geometry object
+     * @param pProperties Pointer to the element's properties
+     */
+    EmbeddedNodalVariableCalculationElementSimplex(
+        IndexType NewId,
+        GeometryType::Pointer pGeometry,
+        PropertiesType::Pointer pProperties)
+        : Element(NewId, pGeometry, pProperties)
+    {}
+
+    /// Destructor.
+    ~EmbeddedNodalVariableCalculationElementSimplex() override
+    {}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /// Create a new element of this type
+    /**
+     * Returns a pointer to a new EmbeddedNodalVariableCalculationElementSimplex element, created using given input
+     * @param NewId the ID of the new element
+     * @param ThisNodes the nodes of the new element
+     * @param pProperties the properties assigned to the new element
+     * @return a Pointer to the new element
+     */
+    Element::Pointer Create(
+        IndexType NewId,
+        NodesArrayType const& ThisNodes,
+        PropertiesType::Pointer pProperties) const override
+    {
+        return Kratos::make_shared<EmbeddedNodalVariableCalculationElementSimplex>(NewId, GetGeometry().Create(ThisNodes), pProperties);
+    }
+
+    void Initialize() override
+    {
+    }
+
+    /// Calculate the element's local contribution to the system for the current step.
+    void CalculateLocalSystem(
+        MatrixType& rLeftHandSideMatrix,
+        VectorType& rRightHandSideVector,
+        ProcessInfo& rCurrentProcessInfo) override
+    {
+    }
+
+    void CalculateLeftHandSide(
+        MatrixType &rLeftHandSideVector,
+        ProcessInfo &rCurrentProcessInfo) override
+    {
+        const auto &r_geom = this->GetGeometry();
+
+        // Get the edge intersection points
+
+        // Compute the Gramm matrix
+        // for (unsigned int i = 0; i < TDim + 1; ++i) {
+        //     for (unsigned int j = 0; j < TDim + 1; ++j) {
+        //         for (unsigned int p = 0; p < n_samples; ++p) {
+        //             // Compute shape function values in the intersection points
+        //         }
+        //     }
+        // }
+    }
+
+    void CalculateRightHandSide(
+        VectorType &rRightHandSideVector,
+        ProcessInfo &rCurrentProcessInfo) override
+    {
+        const auto &r_geom = this->GetGeometry();
+
+        // Get the edge intersection points
+
+        // Compute the samples RHS
+    }
+
+    /// Checks the input and that all required Kratos variables have been registered.
+    /**
+     * This function provides the place to perform checks on the completeness of the input.
+     * It is designed to be called only once (or anyway, not often) typically at the beginning
+     * of the calculations, so to verify that nothing is missing from the input
+     * or that no common error is found.
+     * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
+     * @return 0 if no errors were found.
+     */
+    int Check(const ProcessInfo &rCurrentProcessInfo) override
+    {
+        KRATOS_TRY
+
+        // // Perform basic element checks
+        // int ErrorCode = Kratos::Element::Check(rCurrentProcessInfo);
+        // if(ErrorCode != 0) return ErrorCode;
+
+        // if(this->GetGeometry().size() != TDim+1)
+        //     KRATOS_THROW_ERROR(std::invalid_argument,"wrong number of nodes for element",this->Id());
+
+        // // Check that all required variables have been registered
+        // if(DISTANCE.Key() == 0)
+        //     KRATOS_THROW_ERROR(std::invalid_argument,"DISTANCE Key is 0. Check if the application was correctly registered.","");
+
+        // // Checks on nodes
+
+        // // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom
+        // for(unsigned int i=0; i<this->GetGeometry().size(); ++i)
+        // {
+        //     if(this->GetGeometry()[i].SolutionStepsDataHas(DISTANCE) == false)
+        //         KRATOS_THROW_ERROR(std::invalid_argument,"missing DISTANCE variable on solution step data for node ",this->GetGeometry()[i].Id());
+        // }
+
+        return 0;
+
+        KRATOS_CATCH("");
+    }
+
+    /// Provides the global indices for each one of this element's local rows
+    /**
+     * this determines the elemental equation ID vector for all elemental
+     * DOFs
+     * @param rResult A vector containing the global Id of each row
+     * @param rCurrentProcessInfo the current process info object (unused)
+     */
+    void EquationIdVector(
+        EquationIdVectorType& rResult,
+        ProcessInfo& rCurrentProcessInfo) override
+    {
+        // unsigned int number_of_nodes = TDim+1;
+        // if (rResult.size() != number_of_nodes)
+        //     rResult.resize(number_of_nodes, false);
+
+        // for (unsigned int i = 0; i < number_of_nodes; i++)
+        //     rResult[i] = GetGeometry()[i].GetDof(DISTANCE).EquationId();
+    }
+
+    /// Returns a list of the element's Dofs
+    /**
+     * @param ElementalDofList the list of DOFs
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void GetDofList(
+        DofsVectorType& rElementalDofList,
+        ProcessInfo& rCurrentProcessInfo) override
+    {
+        // unsigned int number_of_nodes = TDim+1;
+
+        // if (rElementalDofList.size() != number_of_nodes)
+        //     rElementalDofList.resize(number_of_nodes);
+
+        // for (unsigned int i = 0; i < number_of_nodes; i++)
+        //     rElementalDofList[i] = GetGeometry()[i].pGetDof(DISTANCE);
+    }
+
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    ///@}
+    ///@name Elemental Data
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        std::stringstream buffer;
+        buffer << "EmbeddedNodalVariableCalculationElementSimplex #" << Id();
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << "EmbeddedNodalVariableCalculationElementSimplex" << TDim << "D";
+    }
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const
+    {}
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Serialization
+    ///@{
+
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override
+    {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element );
+    }
+
+    void load(Serializer& rSerializer) override
+    {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
+    }
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    EmbeddedNodalVariableCalculationElementSimplex & operator=(EmbeddedNodalVariableCalculationElementSimplex const& rOther);
+
+    /// Copy constructor.
+    EmbeddedNodalVariableCalculationElementSimplex(EmbeddedNodalVariableCalculationElementSimplex const& rOther);
+
+    ///@}
+
+}; // Class EmbeddedNodalVariableCalculationElementSimplex
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+template< unsigned int TDim >
+inline std::istream& operator >>(
+    std::istream& rIStream,
+    EmbeddedNodalVariableCalculationElementSimplex<TDim>& rThis)
+{
+    return rIStream;
+}
+
+/// output stream function
+template< unsigned int TDim >
+inline std::ostream& operator <<(
+    std::ostream& rOStream,
+    const EmbeddedNodalVariableCalculationElementSimplex<TDim>& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+///@} // KratosCore group
+
+} // namespace Kratos.
+
+#endif // KRATOS_EMBEDDED_NODAL_VARIABLE_CALCULATION_ELEMENT_H_INCLUDED  defined

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
@@ -361,7 +361,7 @@ private:
     EmbeddedNodalVariableCalculationElementSimplex & operator=(EmbeddedNodalVariableCalculationElementSimplex const& rOther);
 
     /// Copy constructor.
-    EmbeddedNodalVariableCalculationElementSimplex(EmbeddedNodalVariableCalculationElementSimplex const& rOther);
+    EmbeddedNodalVariableCalculationElementSimplex(EmbeddedNodalVariableCalculationElementSimplex const& rOther) = delete;
 
     ///@}
 

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
@@ -15,22 +15,15 @@
 #define  KRATOS_EMBEDDED_NODAL_VARIABLE_CALCULATION_ELEMENT_H_INCLUDED
 
 // System includes
-#include <string>
-#include <iostream>
 
 
 // External includes
 
 
 // Project includes
-#include "containers/array_1d.h"
 #include "includes/define.h"
 #include "includes/element.h"
-#include "includes/serializer.h"
-#include "includes/variables.h"
 #include "geometries/geometry.h"
-#include "utilities/math_utils.h"
-#include "utilities/geometry_utilities.h"
 
 // Application includes
 
@@ -88,15 +81,11 @@ public:
     /// Matrix type for local contributions to the linear system
     typedef Matrix MatrixType;
 
-    typedef std::size_t IndexType;
-
-    typedef std::size_t SizeType;
-
-    typedef std::vector<std::size_t> EquationIdVectorType;
-
-    typedef std::vector< Dof<double>::Pointer > DofsVectorType;
-
-    typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
+    /// Element types definition
+    typedef Element::IndexType IndexType;
+    typedef Element::DofsArrayType DofsArrayType;
+    typedef Element::DofsVectorType DofsVectorType;
+    typedef Element::EquationIdVectorType EquationIdVectorType;
 
     ///@}
     ///@name Life Cycle
@@ -148,8 +137,7 @@ public:
     {}
 
     /// Destructor.
-    ~EmbeddedNodalVariableCalculationElementSimplex() override
-    {}
+    ~EmbeddedNodalVariableCalculationElementSimplex() override = default;
 
     ///@}
     ///@name Operators
@@ -176,64 +164,51 @@ public:
         return Kratos::make_shared<EmbeddedNodalVariableCalculationElementSimplex<TVarType>>(NewId, GetGeometry().Create(ThisNodes), pProperties);
     }
 
-    void Initialize() override
-    {
-    }
-
-    /// Calculate the element's local contribution to the system for the current step.
+    /**
+     * @brief Calculate the element's local contributions to the system for the current step.
+     *
+     * @param rLeftHandSideMatrix Reference to the local Left Hand Side (LHS) matrix
+     * @param rRightHandSideVector Reference to the local Right Hand Side (RHS) vector
+     * @param rCurrentProcessInfo Reference to the model part of interest ProcessInfo container
+     */
     void CalculateLocalSystem(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
         ProcessInfo& rCurrentProcessInfo) override;
 
+    /**
+     * @brief Calculate the element's local Left Hand Side (LHS) contribution to the system for the current step.
+     *
+     * @param rLeftHandSideMatrix Reference to the local Left Hand Side (LHS) matrix
+     * @param rCurrentProcessInfo Reference to the model part of interest ProcessInfo container
+     */
     void CalculateLeftHandSide(
         MatrixType &rLeftHandSideMatrix,
         ProcessInfo &rCurrentProcessInfo) override;
 
+    /**
+     * @brief Calculate the element's local Reft Hand Side (RHS) contribution to the system for the current step.
+     *
+     * @param rRightHandSideVector Reference to the local Right Hand Side (RHS) vector
+     * @param rCurrentProcessInfo Reference to the model part of interest ProcessInfo container
+     */
     void CalculateRightHandSide(
         VectorType &rRightHandSideVector,
         ProcessInfo &rCurrentProcessInfo) override;
 
-    /// Checks the input and that all required Kratos variables have been registered.
     /**
+     * @brief Checks the input and that all required Kratos variables have been registered.
      * This function provides the place to perform checks on the completeness of the input.
      * It is designed to be called only once (or anyway, not often) typically at the beginning
      * of the calculations, so to verify that nothing is missing from the input
      * or that no common error is found.
-     * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
+     * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      */
-    int Check(const ProcessInfo &rCurrentProcessInfo) override
-    {
-        KRATOS_TRY
+    int Check(const ProcessInfo &rCurrentProcessInfo) override;
 
-        // // Perform basic element checks
-        // int ErrorCode = Kratos::Element::Check(rCurrentProcessInfo);
-        // if(ErrorCode != 0) return ErrorCode;
-
-        // if(this->GetGeometry().size() != TDim+1)
-        //     KRATOS_THROW_ERROR(std::invalid_argument,"wrong number of nodes for element",this->Id());
-
-        // // Check that all required variables have been registered
-        // if(DISTANCE.Key() == 0)
-        //     KRATOS_THROW_ERROR(std::invalid_argument,"DISTANCE Key is 0. Check if the application was correctly registered.","");
-
-        // // Checks on nodes
-
-        // // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom
-        // for(unsigned int i=0; i<this->GetGeometry().size(); ++i)
-        // {
-        //     if(this->GetGeometry()[i].SolutionStepsDataHas(DISTANCE) == false)
-        //         KRATOS_THROW_ERROR(std::invalid_argument,"missing DISTANCE variable on solution step data for node ",this->GetGeometry()[i].Id());
-        // }
-
-        return 0;
-
-        KRATOS_CATCH("");
-    }
-
-    /// Provides the global indices for each one of this element's local rows
     /**
+     * @brief Provides the global indices for each one of this element's local rows
      * This determines the elemental equation ID vector for all elemental DOFs
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo the current process info object (unused)
@@ -242,8 +217,9 @@ public:
         EquationIdVectorType& rResult,
         ProcessInfo& rCurrentProcessInfo) override;
 
-    /// Returns a list of the element's Dofs
     /**
+     * @brief Get the Dof List object
+     * Returns a list of the element's Dofs
      * @param ElementalDofList the list of DOFs
      * @param rCurrentProcessInfo the current process info instance
      */

--- a/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
+++ b/kratos/elements/embedded_nodal_variable_calculation_element_simplex.h
@@ -63,7 +63,7 @@ namespace Kratos
 /// An element to compute the a nodal variable from an embedded skin
 /**
  */
-template< unsigned int TDim >
+template< class TVarType >
 class EmbeddedNodalVariableCalculationElementSimplex : public Element
 {
 public:
@@ -97,9 +97,6 @@ public:
     typedef std::vector< Dof<double>::Pointer > DofsVectorType;
 
     typedef PointerVectorSet<Dof<double>, IndexedObject> DofsArrayType;
-
-    /// Type for shape function values container
-    typedef Kratos::Vector ShapeFunctionsType;
 
     ///@}
     ///@name Life Cycle
@@ -176,7 +173,7 @@ public:
         NodesArrayType const& ThisNodes,
         PropertiesType::Pointer pProperties) const override
     {
-        return Kratos::make_shared<EmbeddedNodalVariableCalculationElementSimplex>(NewId, GetGeometry().Create(ThisNodes), pProperties);
+        return Kratos::make_shared<EmbeddedNodalVariableCalculationElementSimplex<TVarType>>(NewId, GetGeometry().Create(ThisNodes), pProperties);
     }
 
     void Initialize() override
@@ -187,38 +184,15 @@ public:
     void CalculateLocalSystem(
         MatrixType& rLeftHandSideMatrix,
         VectorType& rRightHandSideVector,
-        ProcessInfo& rCurrentProcessInfo) override
-    {
-    }
+        ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLeftHandSide(
-        MatrixType &rLeftHandSideVector,
-        ProcessInfo &rCurrentProcessInfo) override
-    {
-        const auto &r_geom = this->GetGeometry();
-
-        // Get the edge intersection points
-
-        // Compute the Gramm matrix
-        // for (unsigned int i = 0; i < TDim + 1; ++i) {
-        //     for (unsigned int j = 0; j < TDim + 1; ++j) {
-        //         for (unsigned int p = 0; p < n_samples; ++p) {
-        //             // Compute shape function values in the intersection points
-        //         }
-        //     }
-        // }
-    }
+        MatrixType &rLeftHandSideMatrix,
+        ProcessInfo &rCurrentProcessInfo) override;
 
     void CalculateRightHandSide(
         VectorType &rRightHandSideVector,
-        ProcessInfo &rCurrentProcessInfo) override
-    {
-        const auto &r_geom = this->GetGeometry();
-
-        // Get the edge intersection points
-
-        // Compute the samples RHS
-    }
+        ProcessInfo &rCurrentProcessInfo) override;
 
     /// Checks the input and that all required Kratos variables have been registered.
     /**
@@ -260,22 +234,13 @@ public:
 
     /// Provides the global indices for each one of this element's local rows
     /**
-     * this determines the elemental equation ID vector for all elemental
-     * DOFs
+     * This determines the elemental equation ID vector for all elemental DOFs
      * @param rResult A vector containing the global Id of each row
      * @param rCurrentProcessInfo the current process info object (unused)
      */
     void EquationIdVector(
         EquationIdVectorType& rResult,
-        ProcessInfo& rCurrentProcessInfo) override
-    {
-        // unsigned int number_of_nodes = TDim+1;
-        // if (rResult.size() != number_of_nodes)
-        //     rResult.resize(number_of_nodes, false);
-
-        // for (unsigned int i = 0; i < number_of_nodes; i++)
-        //     rResult[i] = GetGeometry()[i].GetDof(DISTANCE).EquationId();
-    }
+        ProcessInfo& rCurrentProcessInfo) override;
 
     /// Returns a list of the element's Dofs
     /**
@@ -284,17 +249,7 @@ public:
      */
     void GetDofList(
         DofsVectorType& rElementalDofList,
-        ProcessInfo& rCurrentProcessInfo) override
-    {
-        // unsigned int number_of_nodes = TDim+1;
-
-        // if (rElementalDofList.size() != number_of_nodes)
-        //     rElementalDofList.resize(number_of_nodes);
-
-        // for (unsigned int i = 0; i < number_of_nodes; i++)
-        //     rElementalDofList[i] = GetGeometry()[i].pGetDof(DISTANCE);
-    }
-
+        ProcessInfo& rCurrentProcessInfo) override;
 
     ///@}
     ///@name Access
@@ -325,11 +280,11 @@ public:
     /// Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "EmbeddedNodalVariableCalculationElementSimplex" << TDim << "D";
+        rOStream << "EmbeddedNodalVariableCalculationElementSimplex";
     }
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const
+    virtual void PrintData(std::ostream& rOStream) const override
     {}
 
     ///@}
@@ -409,6 +364,9 @@ private:
     ///@name Private Operations
     ///@{
 
+    const array_1d<double, 2> GetDistanceBasedShapeFunctionValues();
+
+    Variable<TVarType> GetUnknownVariable();
 
     ///@}
     ///@name Private  Access
@@ -445,19 +403,19 @@ private:
 ///@{
 
 /// input stream function
-template< unsigned int TDim >
-inline std::istream& operator >>(
-    std::istream& rIStream,
-    EmbeddedNodalVariableCalculationElementSimplex<TDim>& rThis)
+template <class TVarType>
+inline std::istream &operator>>(
+    std::istream &rIStream,
+    EmbeddedNodalVariableCalculationElementSimplex<TVarType> &rThis)
 {
     return rIStream;
 }
 
 /// output stream function
-template< unsigned int TDim >
-inline std::ostream& operator <<(
-    std::ostream& rOStream,
-    const EmbeddedNodalVariableCalculationElementSimplex<TDim>& rThis)
+template <class TVarType>
+inline std::ostream &operator<<(
+    std::ostream &rOStream,
+    const EmbeddedNodalVariableCalculationElementSimplex<TVarType> &rThis)
 {
     rThis.PrintInfo(rOStream);
     rOStream << std::endl;

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla
 //

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -702,7 +702,7 @@ private:
     CalculateEmbeddedNodalVariableFromSkinProcess& operator=(CalculateEmbeddedNodalVariableFromSkinProcess const& rOther);
 
     /// Copy constructor.
-    //CalculateEmbeddedNodalVariableFromSkinProcess(CalculateEmbeddedNodalVariableFromSkinProcess const& rOther);
+    CalculateEmbeddedNodalVariableFromSkinProcess(CalculateEmbeddedNodalVariableFromSkinProcess const& rOther) = delete;
 
     ///@}
 }; // Class CalculateEmbeddedNodalVariableFromSkinProcess

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -340,8 +340,8 @@ protected:
     ModelPart& mrBaseModelPart;
     ModelPart& mrSkinModelPart;
 
-    const Variable<TVarType> mrSkinVariable;
-    const Variable<TVarType> mrEmbeddedNodalVariable;
+    const Variable<TVarType> &mrSkinVariable;
+    const Variable<TVarType> &mrEmbeddedNodalVariable;
 
     SolvingStrategyPointerType mpSolvingStrategy;
 
@@ -391,7 +391,7 @@ protected:
         KRATOS_CATCH("")
     }
 
-    void SetObtainedEmbeddedNodalValues()
+    void SetObtainedEmbeddedNodalValues() const
     {
         const auto &rUnknownVariable = EmbeddedNodalVariableFromSkinTypeHelperClass<TVarType>::GetUnknownVariable();
         const auto &r_int_elems_model_part = (mrBaseModelPart.GetModel()).GetModelPart(mAuxModelPartName);
@@ -403,17 +403,17 @@ protected:
         }
     }
 
-    inline void AddIntersectedElementsVariables(ModelPart &rModelPart)
+    inline void AddIntersectedElementsVariables(ModelPart &rModelPart) const
     {
         EmbeddedNodalVariableFromSkinTypeHelperClass<TVarType>::AddUnknownVariable(rModelPart);
     }
 
-    void AddIntersectedElementsModelPartDOFs(ModelPart &rModelPart)
+    void AddIntersectedElementsModelPartDOFs(ModelPart &rModelPart) const
     {
         EmbeddedNodalVariableFromSkinTypeHelperClass<TVarType>::AddUnknownVariableDofs(rModelPart);
     }
 
-    void AddIntersectedElementsModelPartElements(ModelPart &rModelPart)
+    void AddIntersectedElementsModelPartElements(ModelPart &rModelPart) const
     {
         // Initialize the VISITED flag in the origin model part
         // It will be used to mark the nodes already added to the intersected elements model part
@@ -593,7 +593,7 @@ private:
         mpFindIntersectedGeometricalObjectsProcess->Clear();
     }
 
-    const Vector SetDistancesVector(ModelPart::ElementIterator ItElem)
+    const Vector SetDistancesVector(ModelPart::ElementIterator ItElem) const
     {
         auto &r_geom = ItElem->GetGeometry();
         Vector nodal_distances(r_geom.PointsNumber());
@@ -613,7 +613,7 @@ private:
         return nodal_distances;
     }
 
-    inline bool IsSplit(const Vector &rDistances)
+    inline bool IsSplit(const Vector &rDistances) const
     {
         unsigned int n_pos = 0, n_neg = 0;
 
@@ -636,7 +636,7 @@ private:
 		const Element::GeometryType& rIntObjGeometry,
 		const Element::NodeType& rEdgePoint1,
 		const Element::NodeType& rEdgePoint2,
-		Point& rIntersectionPoint)
+		Point& rIntersectionPoint) const
 	{
 		int intersection_flag = 0;
 		const auto work_dim = rIntObjGeometry.WorkingSpaceDimension();
@@ -655,7 +655,7 @@ private:
 
     void AddEdgeNodes(
         const Geometry<Node<3>> &rEdgeGeometry,
-        ModelPart &rModelPart)
+        ModelPart &rModelPart) const
     {
         // Loop the edge nodes
         for (std::size_t i = 0; i < 2; ++i) {
@@ -663,8 +663,7 @@ private:
             // Check if the node has been already added
             if (!p_i_node->Is(VISITED)) {
                 p_i_node->Set(VISITED, true);
-                const auto new_id = p_i_node->Id();
-                Node<3>::Pointer p_new_node = rModelPart.CreateNewNode(new_id, *p_i_node);
+                rModelPart.CreateNewNode(p_i_node->Id(), *p_i_node);
             }
         }
     }
@@ -672,7 +671,7 @@ private:
     Element::GeometryType::Pointer pSetEdgeElementGeometry(
         ModelPart &rModelPart,
         const Element::GeometryType &rCurrentEdgeGeometry,
-        const std::pair<std::size_t, std::size_t> NewEdgeIds)
+        const std::pair<std::size_t, std::size_t> NewEdgeIds) const
     {
         Element::GeometryType::PointsArrayType points_array;
         points_array.push_back(rModelPart.pGetNode(std::get<0>(NewEdgeIds)));
@@ -680,7 +679,7 @@ private:
         return rCurrentEdgeGeometry.Create(points_array);
     }
 
-    inline std::pair<std::size_t, std::size_t> SetEdgePair(const Geometry<Node<3>> &rEdgeGeom)
+    inline std::pair<std::size_t, std::size_t> SetEdgePair(const Geometry<Node<3>> &rEdgeGeom) const
     {
         std::pair<std::size_t, std::size_t> edge_pair(
             (rEdgeGeom[0].Id() < rEdgeGeom[1].Id()) ? rEdgeGeom[0].Id() : rEdgeGeom[1].Id(),

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -139,8 +139,8 @@ inline void EmbeddedNodalVariableFromSkinTypeHelperClass<array_1d<double, 3>>::A
     VariableUtils().AddDof(NODAL_VAUX_Z, rModelPart);
 }
 
-template< class TVarType, class TSparseSpace, class TDenseSpace, class TLinearSolver >
-class CalculateEmbeddedNodalVariableFromSkinProcess : public Process
+template <class TVarType, class TSparseSpace, class TDenseSpace, class TLinearSolver>
+class KRATOS_API(KRATOS_CORE) CalculateEmbeddedNodalVariableFromSkinProcess : public Process
 {
 public:
 
@@ -379,9 +379,10 @@ protected:
         const auto &rUnknownVariable = EmbeddedNodalVariableFromSkinTypeHelperClass<TVarType>::GetUnknownVariable();
         const auto &r_int_elems_model_part = (mrBaseModelPart.GetModel()).GetModelPart(mAuxModelPartName);
         #pragma omp parallel for
-        for (auto &r_node : r_int_elems_model_part.Nodes()) {
-            auto &r_emb_nod_val = (mrBaseModelPart.GetNode(r_node.Id())).FastGetSolutionStepValue(mrEmbeddedNodalVariable);
-            r_emb_nod_val = r_node.FastGetSolutionStepValue(rUnknownVariable);
+        for (int i_node = 0; i_node < r_int_elems_model_part.NumberOfNodes(); ++i_node) {
+            const auto it_node = r_int_elems_model_part.NodesBegin() + i_node;
+            auto &r_emb_nod_val = (mrBaseModelPart.GetNode(it_node->Id())).FastGetSolutionStepValue(mrEmbeddedNodalVariable);
+            r_emb_nod_val = it_node->FastGetSolutionStepValue(rUnknownVariable);
         }
     }
 

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -686,7 +686,7 @@ private:
     ///@{
 
     /// Assignment operator.
-    CalculateEmbeddedNodalVariableFromSkinProcess& operator=(CalculateEmbeddedNodalVariableFromSkinProcess const& rOther);
+    CalculateEmbeddedNodalVariableFromSkinProcess& operator=(CalculateEmbeddedNodalVariableFromSkinProcess const& rOther) = delete;
 
     /// Copy constructor.
     CalculateEmbeddedNodalVariableFromSkinProcess(CalculateEmbeddedNodalVariableFromSkinProcess const& rOther) = delete;

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -1,0 +1,613 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+//
+
+#if !defined(KRATOS_CALCULATE_EMBEDDED_VARIABLE_FROM_SKIN_PROCESS_INCLUDED )
+#define  KRATOS_CALCULATE_EMBEDDED_VARIABLE_FROM_SKIN_PROCESS_INCLUDED
+
+// System includes
+#include <string>
+#include <iostream>
+#include <algorithm>
+
+// External includes
+
+// Project includes
+#include "containers/model.h"
+#include "includes/define.h"
+#include "includes/kratos_flags.h"
+#include "elements/embedded_nodal_variable_calculation_element_simplex.h"
+#include "linear_solvers/cg_solver.h"
+#include "solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h"
+#include "solving_strategies/schemes/residualbased_incrementalupdate_static_scheme.h"
+#include "solving_strategies/strategies/residualbased_linear_strategy.h"
+#include "processes/process.h"
+#include "processes/find_intersected_geometrical_objects_process.h"
+#include "utilities/intersection_utilities.h"
+#include "utilities/variable_utils.h"
+
+namespace Kratos
+{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/// Short class definition.
+/**takes a model part full of SIMPLICIAL ELEMENTS (triangles and tetras) and recomputes a signed distance function
+mantaining as much as possible the position of the zero of the function prior to the call.
+
+This is achieved by minimizing the function  ( 1 - norm( gradient( distance ) )**2
+with the restriction that "distance" is a finite elment function
+*/
+template< unsigned int TDim, class TVarType, class TSparseSpace, class TDenseSpace, class TLinearSolver >
+class CalculateEmbeddedNodalVariableFromSkinProcess : public Process
+{
+public:
+
+    // KRATOS_DEFINE_LOCAL_FLAG(PERFORM_STEP1);
+    // KRATOS_DEFINE_LOCAL_FLAG(DO_EXPENSIVE_CHECKS);
+    // KRATOS_DEFINE_LOCAL_FLAG(CALCULATE_EXACT_DISTANCES_TO_PLANE);
+
+    ///@name Type Definitions
+    ///@{
+
+    typedef typename Scheme<TSparseSpace,TDenseSpace>::Pointer SchemePointerType;
+    typedef typename BuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>::Pointer BuilderSolverPointerType;
+    typedef typename SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>::UniquePointer SolvingStrategyPointerType;
+    // typedef typename FindIntersectedGeometricalObjectsProcess::Pointer FindIntersectedGeometricalObjectsProcessPointerType;
+
+    ///@}
+    ///@name Pointer Definitions
+
+    /// Pointer definition of CalculateEmbeddedNodalVariableFromSkinProcess
+    KRATOS_CLASS_POINTER_DEFINITION(CalculateEmbeddedNodalVariableFromSkinProcess);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**This process recomputed the distance function mantaining the zero of the existing distance distribution
+     * for this reason the DISTANCE should be initialized to values distinct from zero in at least some portions of the domain
+     * alternatively, the DISTANCE shall be fixed to zero at least on some nodes, and the process will compute a positive distance
+     * respecting that zero
+     * @param base_model_parr - is the model part on the top of which the calculation will be performed
+     * @param plinear_solver  - linear solver to be used internally
+     * @max_iterations        - maximum number of iteration to be employed in the nonlinear optimization process.
+     *                        - can also be set to 0 if a (very) rough approximation is enough
+     *
+     * EXAMPLE OF USAGE FROM PYTHON:
+     *
+     class distance_linear_solver_settings:
+         solver_type = "AMGCL"
+         tolerance = 1E-3
+         max_iteration = 200
+         scaling = False
+         krylov_type = "CG"
+         smoother_type = "SPAI0"
+         verbosity = 0
+
+     import linear_solver_factory
+     distance_linear_solver = linear_solver_factory.ConstructSolver(distance_linear_solver_settings)
+
+     max_iterations=1
+     distance_calculator = CalculateEmbeddedNodalVariableFromSkinProcess2D(fluid_model_part, distance_linear_solver, max_iterations)
+     distance_calculator.Execute()
+     */
+
+    CalculateEmbeddedNodalVariableFromSkinProcess(
+        ModelPart &rBaseModelPart,
+        ModelPart &rSkinModelPart,
+        const Variable<TVarType> &rSkinVariable,
+        const Variable<TVarType> &rEmbeddedNodalVariable,
+        const std::string LevelSetType = "continuous",
+        const std::string AuxPartName = "IntersectedElementsModelPart")
+        : mLevelSetType(LevelSetType),
+          mAuxModelPartName(AuxPartName),
+          mrSkinVariable(rSkinVariable),
+          mrEmbeddedNodalVariable(rEmbeddedNodalVariable),
+          mrBaseModelPart(rBaseModelPart),
+          mrSkinModelPart(rSkinModelPart)
+    {
+        KRATOS_TRY
+
+        // This will be set to true upon completing ReGenerateIntersectedElementsModelPart
+        mIntersectedElementsPartIsInitialized = false;
+
+        // Check that there is at least one element and node in the model
+        KRATOS_ERROR_IF(mrBaseModelPart.NumberOfNodes() == 0) << "The model part has no nodes." << std::endl;
+        KRATOS_ERROR_IF(mrBaseModelPart.NumberOfElements() == 0) << "The model Part has no elements." << std::endl;
+
+        // Check that the base model part is conformed by simplex elements
+        if(TDim == 2){
+            KRATOS_ERROR_IF(mrBaseModelPart.ElementsBegin()->GetGeometry().GetGeometryFamily() != GeometryData::Kratos_Triangle) <<
+                "In 2D the element type is expected to be a triangle." << std::endl;
+        } else if(TDim == 3) {
+            KRATOS_ERROR_IF(mrBaseModelPart.ElementsBegin()->GetGeometry().GetGeometryFamily() != GeometryData::Kratos_Tetrahedra) <<
+                "In 3D the element type is expected to be a tetrahedron" << std::endl;
+        }
+
+        // Check if nodes have DISTANCE variable
+        // VariableUtils().CheckVariableExists<Variable<double > >(DISTANCE, base_model_part.Nodes());
+        // VariableUtils().CheckVariableExists<Variable<double > >(FLAG_VARIABLE, base_model_part.Nodes());
+
+        // Generate an auxilary model part and populate it by elements of type DistanceCalculationElementSimplex
+        this->ReGenerateIntersectedElementsModelPart();
+
+        // Create a linear solver
+        auto p_linear_solver = Kratos::make_shared<CGSolver<TSparseSpace, TDenseSpace>>();
+
+        // Create the linear strategy
+        SchemePointerType p_scheme = Kratos::make_shared<ResidualBasedIncrementalUpdateStaticScheme<TSparseSpace, TDenseSpace>>();
+
+        bool calculate_norm_dx = false;
+        bool calculate_reactions = false;
+        bool reform_dof_at_each_iteration = false;
+        BuilderSolverPointerType p_builder_and_solver= Kratos::make_shared<ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver> >(p_linear_solver);
+
+        Model& current_model = mrBaseModelPart.GetModel();
+        ModelPart& r_aux_model_part = current_model.GetModelPart(mAuxModelPartName);
+
+        mpSolvingStrategy = Kratos::make_unique<ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>>(
+            r_aux_model_part,
+            p_scheme,
+            p_linear_solver,
+            p_builder_and_solver,
+            calculate_reactions,
+            reform_dof_at_each_iteration,
+            calculate_norm_dx);
+
+        mpSolvingStrategy->Check();
+
+        KRATOS_CATCH("")
+    }
+
+    /// Destructor.
+    ~CalculateEmbeddedNodalVariableFromSkinProcess() override
+    {
+        Model& current_model = mrBaseModelPart.GetModel();
+        if(current_model.HasModelPart(mAuxModelPartName)) {
+            current_model.DeleteModelPart(mAuxModelPartName);
+        }
+    };
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    void operator()()
+    {
+        Execute();
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    void Execute() override
+    {
+        KRATOS_TRY;
+
+        if(mIntersectedElementsPartIsInitialized == false) {
+            this->ReGenerateIntersectedElementsModelPart();
+        }
+
+        KRATOS_CATCH("")
+    }
+
+    virtual void Clear()
+    {
+        Model& current_model = mrBaseModelPart.GetModel();
+        ModelPart& r_distance_model_part = current_model.GetModelPart( mAuxModelPartName );
+        r_distance_model_part.Nodes().clear();
+        r_distance_model_part.Elements().clear();
+        r_distance_model_part.Conditions().clear();
+        // r_distance_model_part.GetProcessInfo().clear();
+        mIntersectedElementsPartIsInitialized = false;
+
+        mpSolvingStrategy->Clear();
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "CalculateEmbeddedNodalVariableFromSkinProcess";
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << "CalculateEmbeddedNodalVariableFromSkinProcess";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override
+    {
+    }
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+    ///@}
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+    // /// Minimal constructor for derived classes
+    // CalculateEmbeddedNodalVariableFromSkinProcess(
+    //     ModelPart &base_model_part,
+    //     unsigned int max_iterations,
+    //     Flags Options = NOT_CALCULATE_EXACT_DISTANCES_TO_PLANE,
+    //     std::string AuxPartName = "RedistanceCalculationPart")
+    //     : mrBaseModelPart(base_model_part), mOptions(Options), mAuxModelPartName(AuxPartName)
+    // {
+    //     mIntersectedElementsPartIsInitialized = false;
+    //     mmax_iterations = max_iterations;
+    // }
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+    const std::string mLevelSetType;
+    const std::string mAuxModelPartName;
+
+    const Variable<TVarType> mrSkinVariable;
+    const Variable<TVarType> mrEmbeddedNodalVariable;
+
+    bool mIntersectedElementsPartIsInitialized;
+
+    ModelPart& mrBaseModelPart;
+    ModelPart& mrSkinModelPart;
+
+    SolvingStrategyPointerType mpSolvingStrategy;
+    // FindIntersectedGeometricalObjectsProcessPointerType mpFindIntersectedGeometricalObjectsProcess;
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    virtual void ReGenerateIntersectedElementsModelPart()
+    {
+        KRATOS_TRY
+
+        Model& current_model = mrBaseModelPart.GetModel();
+        if(current_model.HasModelPart(mAuxModelPartName)) {
+            current_model.DeleteModelPart(mAuxModelPartName);
+        }
+
+        // Generate the auxiliary model part
+        ModelPart& r_int_elems_model_part = current_model.CreateModelPart(mAuxModelPartName);
+
+        r_int_elems_model_part.Nodes().clear();
+        r_int_elems_model_part.Elements().clear();
+        r_int_elems_model_part.Conditions().clear();
+
+        r_int_elems_model_part.SetBufferSize(1);
+        r_int_elems_model_part.SetProperties(mrBaseModelPart.pProperties());
+        r_int_elems_model_part.SetProcessInfo(mrBaseModelPart.pGetProcessInfo());
+
+        // Add intersected element nodes
+        this->AddIntersectedElementsModelPartNodes(r_int_elems_model_part);
+
+        // Add DOFs to intersected elements model part
+        this->AddIntersectedElementsModelPartDOFs(r_int_elems_model_part);
+
+        // Add intersected elements
+        this->AddIntersectedElementsModelPartElements(r_int_elems_model_part);
+
+        KRATOS_WATCH(r_int_elems_model_part)
+
+        mIntersectedElementsPartIsInitialized = true;
+
+        KRATOS_CATCH("")
+    }
+
+    void AddIntersectedElementsModelPartNodes(ModelPart &rIntersectedElementsModelPart)
+    {
+        // Initialize the VISITED flag in the origin model part
+        VariableUtils().SetFlag(VISITED, false, mrBaseModelPart.Nodes());
+
+        // Add the nodes belonging to intersected elements
+        for (unsigned int i_elem = 0; i_elem < mrBaseModelPart.NumberOfElements(); ++i_elem) {
+            auto it_elem = mrBaseModelPart.ElementsBegin() + i_elem;
+            auto elem_dist = this->SetDistancesVector(it_elem);
+            // Check if the current element is split
+            if (IsSplit(elem_dist)) {
+                auto &r_geom = it_elem->GetGeometry();
+                for (unsigned int i_node = 0; i_node < r_geom.PointsNumber(); ++i_node) {
+                    r_geom[i_node].Set(VISITED, true);
+                }
+            }
+        }
+
+        for (unsigned int i_node = 0; i_node < mrBaseModelPart.NumberOfNodes(); ++i_node) {
+            auto it_node = mrBaseModelPart.NodesBegin() + i_node;
+            if (it_node->Is(VISITED)) {
+                rIntersectedElementsModelPart.AddNode(mrBaseModelPart.pGetNode(it_node->Id()));
+            }
+        }
+    }
+
+    void AddIntersectedElementsModelPartDOFs(ModelPart &rIntersectedElementsModelPart)
+    {
+        KRATOS_WATCH("DOFs addition is not implemented yet!!!")
+        // TODO: ADD DOFs ACCORDING TO NEW ELEMENT CALCULATION
+        // VariableUtils().AddDof<Variable<double>>(DISTANCE, r_int_elems_model_part);
+    }
+
+    void AddIntersectedElementsModelPartElements(ModelPart &rIntersectedElementsModelPart)
+    {
+        // Get the base model part intersections
+        auto &r_int_obj_vect = this->ComputeIntersectedEdgesValues();
+
+        // Loop the base model part elements
+        for (unsigned int i_elem = 0; i_elem < mrBaseModelPart.NumberOfElements(); ++i_elem) {
+            auto it_elem = mrBaseModelPart.ElementsBegin() + i_elem;
+            auto elem_dist = this->SetDistancesVector(it_elem);
+            // Check if the current element is split
+            if (IsSplit(elem_dist)) {
+                if (r_int_obj_vect[i_elem].size() != 0) {
+                    // Initialize the element values
+                    auto &r_geom = it_elem->GetGeometry();
+                    const auto edges = r_geom.Edges();
+
+                    // Loop the edges
+                    for (unsigned int i_edge = 0; i_edge < r_geom.EdgesNumber(); ++i_edge) {
+                        // Initialize edge values
+                        double i_edge_d = 0.0; // Average normalized distance from lower id. node
+                        unsigned int n_int_obj = 0; // Number edge of intersecting entities
+                        TVarType i_edge_val = mrEmbeddedNodalVariable.Zero(); // Average edge variable value
+
+                        // Get the lower id. node id
+                        auto &r_edge_geom = edges[i_edge];
+                        const unsigned int i_edge_min_id = (r_edge_geom[0].Id() < r_edge_geom[1].Id()) ? r_edge_geom[0].Id() : r_edge_geom[1].Id();
+
+                        // Check the edge intersection against all the candidates
+                        for (auto &r_int_obj : r_int_obj_vect[i_elem]) {
+                            Point intersection_point;
+                            const int is_intersected = this->ComputeEdgeIntersection(
+                                r_int_obj.GetGeometry(),
+                                r_edge_geom[0],
+                                r_edge_geom[1],
+                                intersection_point);
+
+                            // Compute the variable value in the intersection point
+                            if (is_intersected == 1) {
+                                n_int_obj++;
+                                Vector int_obj_N;
+                                array_1d<double,3> local_coords;
+                                r_int_obj.GetGeometry().PointLocalCoordinates(local_coords, intersection_point);
+                                r_int_obj.GetGeometry().ShapeFunctionsValues(int_obj_N, local_coords);
+                                for (unsigned int i_node = 0; i_node < r_int_obj.GetGeometry().PointsNumber(); ++i_node) {
+                                    i_edge_val += r_int_obj.GetGeometry()[i_node].FastGetSolutionStepValue(mrSkinVariable) * int_obj_N[i_node];
+                                }
+                                i_edge_d = norm_2(intersection_point - r_edge_geom[0]) / r_edge_geom.Length();
+                            }
+                        }
+
+                        // Check if the edge is intersected
+                        if (n_int_obj != 0) {
+                            // Add the average edge value (there might exist cases in where
+                            // more than one geometry intersects the edge of interest).
+                            i_edge_d /= n_int_obj;
+                            i_edge_val /= n_int_obj;
+                        }
+                    }
+                }
+
+                // // Add elements
+                // auto p_element = Kratos::make_shared<EmbeddedNodalVariableCalculationElementSimplex<TDim>>(
+                //     it_elem->Id(),
+                //     it_elem->pGetGeometry(),
+                //     it_elem->pGetProperties());
+
+                // // Assign EXACTLY THE SAME GEOMETRY, so that memory is saved!!
+                // p_element->pGetGeometry() = it_elem->pGetGeometry();
+
+                // // Add the new element to the intersected elements model part
+                // rIntersectedElementsModelPart.Elements().push_back(p_element);
+            }
+        }
+    }
+
+    std::vector<PointerVector<GeometricalObject>>& ComputeIntersectedEdgesValues()
+    {
+        FindIntersectedGeometricalObjectsProcess find_int_objs_proc(mrBaseModelPart, mrSkinModelPart);
+        find_int_objs_proc.Initialize();
+        find_int_objs_proc.FindIntersections();
+        return find_int_objs_proc.GetIntersections();
+    }
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    const Vector SetDistancesVector(ModelPart::ElementIterator ItElem)
+    {
+        auto &r_geom = ItElem->GetGeometry();
+        Vector nodal_distances(r_geom.PointsNumber());
+
+        if (mLevelSetType == "continuous"){
+            // Continuous nodal distance function case
+            for (unsigned int i_node = 0; i_node < r_geom.PointsNumber(); ++i_node) {
+                nodal_distances[i_node] = r_geom[i_node].FastGetSolutionStepValue(DISTANCE);
+            }
+        } else if (mLevelSetType == "discontinuous") {
+            // Discontinuous elemental distance function case
+            nodal_distances = ItElem->GetValue(ELEMENTAL_DISTANCES);
+        } else {
+            KRATOS_ERROR << "Level set type must be either 'continuous' or 'discontinuous'. Got " << mLevelSetType;
+        }
+
+        return nodal_distances;
+    }
+
+    inline bool IsSplit(const array_1d<double, TDim + 1> &rDistances)
+    {
+        unsigned int n_pos = 0, n_neg = 0;
+
+        for (double dist : rDistances) {
+            if(dist >= 0) {
+                ++n_pos;
+            } else {
+                ++n_neg;
+            }
+        }
+
+        if (n_pos > 0 && n_neg > 0) {
+            return true;
+        }
+
+        return false;
+    }
+
+	int ComputeEdgeIntersection(
+		const Element::GeometryType& rIntObjGeometry,
+		const Element::NodeType& rEdgePoint1,
+		const Element::NodeType& rEdgePoint2,
+		Point& rIntersectionPoint)
+	{
+		int intersection_flag = 0;
+		const auto work_dim = rIntObjGeometry.WorkingSpaceDimension();
+		if (work_dim == 2){
+			intersection_flag = IntersectionUtilities::ComputeLineLineIntersection<Element::GeometryType>(
+				rIntObjGeometry, rEdgePoint1.Coordinates(), rEdgePoint2.Coordinates(), rIntersectionPoint.Coordinates());
+		} else if (work_dim == 3){
+			intersection_flag = IntersectionUtilities::ComputeTriangleLineIntersection<Element::GeometryType>(
+				rIntObjGeometry, rEdgePoint1.Coordinates(), rEdgePoint2.Coordinates(), rIntersectionPoint.Coordinates());
+		} else {
+			KRATOS_ERROR << "Working space dimension value equal to " << work_dim << ". Check your skin geometry implementation." << std::endl;
+		}
+
+		return intersection_flag;
+	}
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    CalculateEmbeddedNodalVariableFromSkinProcess& operator=(CalculateEmbeddedNodalVariableFromSkinProcess const& rOther);
+
+    /// Copy constructor.
+    //CalculateEmbeddedNodalVariableFromSkinProcess(CalculateEmbeddedNodalVariableFromSkinProcess const& rOther);
+
+    ///@}
+}; // Class CalculateEmbeddedNodalVariableFromSkinProcess
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+template< unsigned int TDim, class TVarType, class TSparseSpace, class TDenseSpace, class TLinearSolver>
+inline std::istream& operator >> (
+    std::istream& rIStream,
+    CalculateEmbeddedNodalVariableFromSkinProcess<TDim, TVarType, TSparseSpace, TDenseSpace, TLinearSolver>& rThis);
+
+/// output stream function
+template< unsigned int TDim, class TVarType, class TSparseSpace, class TDenseSpace, class TLinearSolver>
+inline std::ostream& operator << (
+    std::ostream& rOStream,
+    const CalculateEmbeddedNodalVariableFromSkinProcess<TDim, TVarType, TSparseSpace, TDenseSpace, TLinearSolver>& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+    return rOStream;
+}
+
+///@}
+
+}  // namespace Kratos.
+
+#endif // KRATOS_CALCULATE_EMBEDDED_VARIABLE_FROM_SKIN_PROCESS_INCLUDED  defined

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -381,6 +381,9 @@ protected:
         }
     }
 
+    template <class TVariableType>
+    inline void AddSpecializedVariable(ModelPart &rIntersectedElementsModelPart, const TVariableType&);
+
     //TODO: NOW ONLY THE INTERSECTED EDGES NODES ARE REQUIRED. WE ARE ADDING UNUSED EXTRA NODES
     void AddIntersectedElementsModelPartNodes(ModelPart &rIntersectedElementsModelPart)
     {
@@ -649,6 +652,13 @@ private:
 
     ///@}
 }; // Class CalculateEmbeddedNodalVariableFromSkinProcess
+
+template <>
+inline void CalculateEmbeddedNodalVariableFromSkinProcess::AddSpecializedVariable(
+    ModelPart &rIntersectedElementsModelPart, const Variable<double>&)
+    {
+
+    }
 
 ///@}
 

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -15,16 +15,14 @@
 #define  KRATOS_CALCULATE_EMBEDDED_VARIABLE_FROM_SKIN_PROCESS_INCLUDED
 
 // System includes
-#include <string>
-#include <iostream>
-#include <algorithm>
+
 
 // External includes
+
 
 // Project includes
 #include "containers/model.h"
 #include "includes/define.h"
-#include "includes/model_part.h"
 #include "includes/kratos_flags.h"
 #include "elements/embedded_nodal_variable_calculation_element_simplex.h"
 #include "linear_solvers/cg_solver.h"
@@ -42,17 +40,21 @@ namespace Kratos
 ///@name Kratos Globals
 ///@{
 
+
 ///@}
 ///@name Type Definitions
 ///@{
+
 
 ///@}
 ///@name  Enum's
 ///@{
 
+
 ///@}
 ///@name  Functions
 ///@{
+
 
 ///@}
 ///@name Kratos Classes
@@ -77,11 +79,6 @@ public:
     ///@name Life Cycle
     ///@{
 
-    /// Default constructor
-    EmbeddedNodalVariableFromSkinTypeHelperClass() {};
-
-    /// Destructor.
-    ~EmbeddedNodalVariableFromSkinTypeHelperClass() {};
 
     ///@}
     ///@name Operators
@@ -92,10 +89,28 @@ public:
     ///@name Operations
     ///@{
 
+    /**
+     * @brief Get the Unknown Variable object
+     * This method returns a reference to the unknown variable. For double embedded nodal
+     * variables this is a reference to NODAL_MAUX. In case of array type embedded nodal
+     * variables, it returns a reference to NODAL_VAUX. These are the variables used when
+     * solving the embedded nodal values least squares minimization problem.
+     * @return const Variable<TVarType>& Reference to the unknown variable
+     */
     static inline const Variable<TVarType> &GetUnknownVariable();
 
+    /**
+     * @brief Add the unknown variable to a model part
+     * This method adds the unknown variable to the model part of interest.
+     * @param rModelPart Reference to the model part to which the variable is added
+     */
     static inline void AddUnknownVariable(ModelPart &rModelPart);
 
+    /**
+     * @brief Add the unknown variable DOFs to a model part
+     * This method adds the unknown variable DOFs to the model part of interest
+     * @param rModelPart Reference to the model part to which the variable DOFs are added
+     */
     static inline void AddUnknownVariableDofs(ModelPart &rModelPart);
 
     ///@}
@@ -200,8 +215,10 @@ public:
         KRATOS_TRY
 
         // Check that there is at least one element and node in the model
-        KRATOS_ERROR_IF(mrBaseModelPart.NumberOfNodes() == 0) << "The model part has no nodes." << std::endl;
-        KRATOS_ERROR_IF(mrBaseModelPart.NumberOfElements() == 0) << "The model Part has no elements." << std::endl;
+        int n_loc_mesh_nodes = mrBaseModelPart.GetCommunicator().pLocalMesh()->NumberOfNodes();
+        int n_loc_mesh_elements = mrBaseModelPart.GetCommunicator().pLocalMesh()->NumberOfElements();
+        KRATOS_ERROR_IF(mrBaseModelPart.GetCommunicator().SumAll(n_loc_mesh_nodes) == 0) << "The base model part has no nodes." << std::endl;
+        KRATOS_ERROR_IF(mrBaseModelPart.GetCommunicator().SumAll(n_loc_mesh_elements) == 0) << "The base model Part has no elements." << std::endl;
 
         // Check that the base model part is conformed by simplex elements
         const auto &r_aux_geom = (mrBaseModelPart.ElementsBegin())->GetGeometry();

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -379,7 +379,7 @@ protected:
         const auto &rUnknownVariable = EmbeddedNodalVariableFromSkinTypeHelperClass<TVarType>::GetUnknownVariable();
         const auto &r_int_elems_model_part = (mrBaseModelPart.GetModel()).GetModelPart(mAuxModelPartName);
         #pragma omp parallel for
-        for (int i_node = 0; i_node < r_int_elems_model_part.NumberOfNodes(); ++i_node) {
+        for (int i_node = 0; i_node < static_cast<int>(r_int_elems_model_part.NumberOfNodes()); ++i_node) {
             const auto it_node = r_int_elems_model_part.NodesBegin() + i_node;
             auto &r_emb_nod_val = (mrBaseModelPart.GetNode(it_node->Id())).FastGetSolutionStepValue(mrEmbeddedNodalVariable);
             r_emb_nod_val = it_node->FastGetSolutionStepValue(rUnknownVariable);

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -222,7 +222,7 @@ public:
 
         // Check that the base model part is conformed by simplex elements
         const auto &r_aux_geom = (mrBaseModelPart.ElementsBegin())->GetGeometry();
-        const auto dim = r_aux_geom.Dimension();
+        const unsigned int dim = r_aux_geom.Dimension();
         if(dim == 2){
             KRATOS_ERROR_IF(r_aux_geom.GetGeometryFamily() != GeometryData::Kratos_Triangle) <<
                 "In 2D the element type is expected to be a triangle." << std::endl;
@@ -432,7 +432,7 @@ protected:
         std::size_t new_elem_id = 1;
         for (unsigned int i_elem = 0; i_elem < mrBaseModelPart.NumberOfElements(); ++i_elem) {
             auto it_elem = mrBaseModelPart.ElementsBegin() + i_elem;
-            auto elem_dist = this->SetDistancesVector(it_elem);
+            const auto elem_dist = this->SetDistancesVector(it_elem);
             // Check if the current element is split
             if (IsSplit(elem_dist)) {
                 if (r_int_obj_vect[i_elem].size() != 0) {
@@ -595,7 +595,7 @@ private:
 
     const Vector SetDistancesVector(ModelPart::ElementIterator ItElem) const
     {
-        auto &r_geom = ItElem->GetGeometry();
+        const auto &r_geom = ItElem->GetGeometry();
         Vector nodal_distances(r_geom.PointsNumber());
 
         if (mLevelSetType == "continuous"){
@@ -639,7 +639,7 @@ private:
 		Point& rIntersectionPoint) const
 	{
 		int intersection_flag = 0;
-		const auto work_dim = rIntObjGeometry.WorkingSpaceDimension();
+		const unsigned int work_dim = rIntObjGeometry.WorkingSpaceDimension();
 		if (work_dim == 2){
 			intersection_flag = IntersectionUtilities::ComputeLineLineIntersection<Element::GeometryType>(
 				rIntObjGeometry, rEdgePoint1.Coordinates(), rEdgePoint2.Coordinates(), rIntersectionPoint.Coordinates());

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -338,11 +338,11 @@ void  AddProcessesToPython(pybind11::module& m)
     // Calculate embedded variable from skin processes
     py::class_<CalculateEmbeddedNodalVariableFromSkinProcess<double, SparseSpaceType, LocalSpaceType, LinearSolverType>, CalculateEmbeddedNodalVariableFromSkinProcess<double, SparseSpaceType, LocalSpaceType, LinearSolverType>::Pointer, Process>(
         m, "CalculateEmbeddedNodalVariableFromSkinProcessDouble")
-        .def(py::init<ModelPart&, ModelPart&, const Variable<double>, const Variable<double>, const std::string, const std::string>());
+        .def(py::init<ModelPart&, ModelPart&, const Variable<double>&, const Variable<double>&, const std::string, const std::string>());
 
     py::class_<CalculateEmbeddedNodalVariableFromSkinProcess<array_1d<double, 3>, SparseSpaceType, LocalSpaceType, LinearSolverType>, CalculateEmbeddedNodalVariableFromSkinProcess<array_1d<double,3>, SparseSpaceType, LocalSpaceType, LinearSolverType>::Pointer, Process>(
         m, "CalculateEmbeddedNodalVariableFromSkinProcessArray")
-        .def(py::init<ModelPart&, ModelPart&, const Variable<array_1d<double, 3>>, const Variable<array_1d<double, 3>>, const std::string, const std::string>());
+        .def(py::init<ModelPart&, ModelPart&, const Variable<array_1d<double, 3>>&, const Variable<array_1d<double, 3>>&, const std::string, const std::string>());
 
     py::class_<ReorderAndOptimizeModelPartProcess, ReorderAndOptimizeModelPartProcess::Pointer, Process>(m,"ReorderAndOptimizeModelPartProcess")
             .def(py::init<ModelPart&, Parameters>())

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -21,6 +21,7 @@
 
 #include "processes/process.h"
 #include "python/add_processes_to_python.h"
+#include "processes/calculate_embedded_nodal_variable_from_skin_process.h"
 #include "processes/fast_transfer_between_model_parts_process.h"
 #include "processes/find_nodal_h_process.h"
 #include "processes/find_nodal_neighbours_process.h"
@@ -333,6 +334,10 @@ void  AddProcessesToPython(pybind11::module& m)
         .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinArray<2>)
         .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinDouble<2>)
     ;
+
+    // Calculate embedded variable from skin processes
+    py::class_<CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType>, CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType>::Pointer, Process>(m, "CalculateEmbeddedNodalVariableFromSkinProcessDouble2D")
+        .def(py::init<ModelPart&, ModelPart&, const Variable<double>, const Variable<double>, const std::string, const std::string>());
 
     py::class_<ReorderAndOptimizeModelPartProcess, ReorderAndOptimizeModelPartProcess::Pointer, Process>(m,"ReorderAndOptimizeModelPartProcess")
             .def(py::init<ModelPart&, Parameters>())

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -336,8 +336,13 @@ void  AddProcessesToPython(pybind11::module& m)
     ;
 
     // Calculate embedded variable from skin processes
-    py::class_<CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType>, CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType>::Pointer, Process>(m, "CalculateEmbeddedNodalVariableFromSkinProcessDouble2D")
+    py::class_<CalculateEmbeddedNodalVariableFromSkinProcess<double, SparseSpaceType, LocalSpaceType, LinearSolverType>, CalculateEmbeddedNodalVariableFromSkinProcess<double, SparseSpaceType, LocalSpaceType, LinearSolverType>::Pointer, Process>(
+        m, "CalculateEmbeddedNodalVariableFromSkinProcessDouble")
         .def(py::init<ModelPart&, ModelPart&, const Variable<double>, const Variable<double>, const std::string, const std::string>());
+
+    py::class_<CalculateEmbeddedNodalVariableFromSkinProcess<array_1d<double, 3>, SparseSpaceType, LocalSpaceType, LinearSolverType>, CalculateEmbeddedNodalVariableFromSkinProcess<array_1d<double,3>, SparseSpaceType, LocalSpaceType, LinearSolverType>::Pointer, Process>(
+        m, "CalculateEmbeddedNodalVariableFromSkinProcessArray")
+        .def(py::init<ModelPart&, ModelPart&, const Variable<array_1d<double, 3>>, const Variable<array_1d<double, 3>>, const std::string, const std::string>());
 
     py::class_<ReorderAndOptimizeModelPartProcess, ReorderAndOptimizeModelPartProcess::Pointer, Process>(m,"ReorderAndOptimizeModelPartProcess")
             .def(py::init<ModelPart&, Parameters>())

--- a/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
@@ -32,85 +32,7 @@ namespace Testing {
     typedef CalculateEmbeddedNodalVariableFromSkinProcess<double, SparseSpaceType, LocalSpaceType, LinearSolverType> EmbeddedNodalVariableProcessDouble;
     typedef CalculateEmbeddedNodalVariableFromSkinProcess<array_1d<double, 3>, SparseSpaceType, LocalSpaceType, LinearSolverType> EmbeddedNodalVariableProcessArray;
 
-    KRATOS_TEST_CASE_IN_SUITE(CalculateEmbeddedNodalVariableFromSkinProcessHorizontalPlane2D, KratosCoreFastSuite)
-    {
-        Model current_model;
-
-        // Generate the element
-        ModelPart &surface_part = current_model.CreateModelPart("Surface");
-        surface_part.AddNodalSolutionStepVariable(DISTANCE);
-        surface_part.AddNodalSolutionStepVariable(VELOCITY);
-        surface_part.AddNodalSolutionStepVariable(TEMPERATURE);
-        surface_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-        surface_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-        surface_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-        surface_part.CreateNewNode(4, 1.0, 1.0, 0.0);
-        Properties::Pointer p_properties_0(new Properties(0));
-        surface_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties_0);
-        surface_part.CreateNewElement("Element2D3N", 2, {2, 4, 3}, p_properties_0);
-
-        // Generate the skin
-        const double plane_height = 0.5;
-        ModelPart &skin_part = current_model.CreateModelPart("Skin");
-        skin_part.AddNodalSolutionStepVariable(VELOCITY);
-        skin_part.AddNodalSolutionStepVariable(TEMPERATURE);
-        skin_part.CreateNewNode(1, -1.0, plane_height, 0.0);
-        skin_part.CreateNewNode(2,  0.6, plane_height, 0.0);
-        Properties::Pointer p_properties_1(new Properties(1));
-        skin_part.CreateNewElement("Element2D2N", 1, {{1, 2}}, p_properties_1);
-        array_1d<double, 3> aux_v = ZeroVector(3);
-        for (std::size_t i_node = 0; i_node < skin_part.NumberOfNodes(); ++i_node) {
-            aux_v[0] = i_node + 1.0;
-            aux_v[1] = 2.0 * (i_node + 1.0);
-            auto it_node = skin_part.NodesBegin() + i_node;
-            it_node->FastGetSolutionStepValue(VELOCITY) = aux_v;
-            it_node->FastGetSolutionStepValue(TEMPERATURE) = it_node->Id();
-        }
-
-        // Compute the discontinuous distance function
-        CalculateDiscontinuousDistanceToSkinProcess<2> disc_dist_proc(surface_part, skin_part);
-        disc_dist_proc.Execute();
-
-        // Compute the embedded nodal variable values
-        // Double variable type case
-        EmbeddedNodalVariableProcessDouble emb_nod_var_from_skin_proc_double(
-            surface_part,
-            skin_part,
-            TEMPERATURE,
-            TEMPERATURE,
-            "discontinuous");
-
-        emb_nod_var_from_skin_proc_double.Execute();
-        emb_nod_var_from_skin_proc_double.Clear();
-
-        // Check values
-        std::vector<double> expected_values = {0.875, 1.5, 2.375, 0.0};
-        for (std::size_t i_node = 0; i_node < surface_part.NumberOfNodes(); ++i_node) {
-            const auto it_node = surface_part.NodesBegin() + i_node;
-            KRATOS_CHECK_NEAR(it_node->FastGetSolutionStepValue(TEMPERATURE), expected_values[i_node], 1e-12);
-        }
-
-        // Array variable type case
-        EmbeddedNodalVariableProcessArray emb_nod_var_from_skin_proc_array(
-            surface_part,
-            skin_part,
-            VELOCITY,
-            VELOCITY,
-            "discontinuous");
-
-        emb_nod_var_from_skin_proc_array.Execute();
-
-        // Check values
-        std::vector<double> expected_values_x = {0.875, 1.5, 2.375, 0.0};
-        std::vector<double> expected_values_y = {1.75,  3.0, 4.75,  0.0};
-        for (std::size_t i_node = 0; i_node < surface_part.NumberOfNodes(); ++i_node) {
-            const auto it_node = surface_part.NodesBegin() + i_node;
-            KRATOS_CHECK_NEAR(it_node->FastGetSolutionStepValue(VELOCITY_X), expected_values_x[i_node], 1e-10);
-            KRATOS_CHECK_NEAR(it_node->FastGetSolutionStepValue(VELOCITY_Y), expected_values_y[i_node], 1e-10);
-        }
-    }
-
-    KRATOS_TEST_CASE_IN_SUITE(CalculateEmbeddedNodalVariableFromSkinProcess2D, KratosCoreFastSuite)
+    KRATOS_TEST_CASE_IN_SUITE(CalculateEmbeddedNodalVariableFromSkinProcessDouble, KratosCoreFastSuite)
     {
         // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
         Node<3>::Pointer p_point_1 = Kratos::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
@@ -167,6 +89,68 @@ namespace Testing {
         for (std::size_t i_node = 0; i_node < check_nodes_ids.size(); ++i_node) {
             const auto p_node = surface_part.pGetNode(check_nodes_ids[i_node]);
             KRATOS_CHECK_NEAR(p_node->FastGetSolutionStepValue(TEMPERATURE), expected_values[i_node], 1e-5);
+        }
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(CalculateEmbeddedNodalVariableFromSkinProcessArray, KratosCoreFastSuite)
+    {
+        // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
+        Node<3>::Pointer p_point_1 = Kratos::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
+        Node<3>::Pointer p_point_2 = Kratos::make_shared<Node<3>>(2, 0.00, 1.00, 0.00);
+        Node<3>::Pointer p_point_3 = Kratos::make_shared<Node<3>>(3, 1.00, 1.00, 0.00);
+        Node<3>::Pointer p_point_4 = Kratos::make_shared<Node<3>>(4, 1.00, 0.00, 0.00);
+
+        Quadrilateral2D4<Node<3>> geometry(p_point_1, p_point_2, p_point_3, p_point_4);
+
+        Parameters mesher_parameters(R"({
+			"number_of_divisions": 7,
+			"element_name": "Element2D3N"
+		})");
+
+        Model current_model;
+        ModelPart &surface_part = current_model.CreateModelPart("Volume");
+        surface_part.AddNodalSolutionStepVariable(DISTANCE);
+        surface_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+        StructuredMeshGeneratorProcess(geometry, surface_part, mesher_parameters).Execute();
+
+        // Generate the skin
+        ModelPart &skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+        skin_part.CreateNewNode(901, 0.24, 0.34, 0.0);
+        skin_part.CreateNewNode(902, 0.76, 0.34, 0.0);
+        skin_part.CreateNewNode(903, 0.76, 0.66, 0.0);
+        skin_part.CreateNewNode(904, 0.24, 0.66, 0.0);
+        Properties::Pointer p_properties(new Properties(0));
+        skin_part.CreateNewElement("Element2D2N", 901, {{901, 902}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N", 902, {{902, 903}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N", 903, {{903, 904}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N", 904, {{904, 901}}, p_properties);
+        skin_part.GetNode(901).FastGetSolutionStepValue(DISPLACEMENT_X) = 1.0;
+        skin_part.GetNode(902).FastGetSolutionStepValue(DISPLACEMENT_Y) = 2.0;
+        skin_part.GetNode(903).FastGetSolutionStepValue(DISPLACEMENT_X) = 3.0;
+        skin_part.GetNode(904).FastGetSolutionStepValue(DISPLACEMENT_Y) = 2.0;
+
+        // Compute distance
+        CalculateDiscontinuousDistanceToSkinProcess<2>(surface_part, skin_part).Execute();
+
+        // Compute the embedded nodal variable values
+        EmbeddedNodalVariableProcessArray emb_nod_var_from_skin_proc(
+            surface_part,
+            skin_part,
+            DISPLACEMENT,
+            DISPLACEMENT,
+            "discontinuous");
+
+        emb_nod_var_from_skin_proc.Execute();
+
+        // Check values
+        const std::vector<std::size_t> check_nodes_ids = {19, 20, 28, 45, 46, 54};
+        const std::vector<double> expected_values_x = {0.344868, 1.83755, 1.56283, 2.99609, 2.57702, 1.75274};
+        const std::vector<double> expected_values_y = {0.539057, -0.416819, 0.132631, -0.416819, 0.539057, 1.72279};
+        for (std::size_t i_node = 0; i_node < check_nodes_ids.size(); ++i_node) {
+            const auto p_node = surface_part.pGetNode(check_nodes_ids[i_node]);
+            KRATOS_CHECK_NEAR(p_node->FastGetSolutionStepValue(DISPLACEMENT_X), expected_values_x[i_node], 1e-5);
+            KRATOS_CHECK_NEAR(p_node->FastGetSolutionStepValue(DISPLACEMENT_Y), expected_values_y[i_node], 1e-5);
         }
     }
 

--- a/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
@@ -1,0 +1,71 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "includes/checks.h"
+#include "geometries/hexahedra_3d_8.h"
+#include "geometries/quadrilateral_2d_4.h"
+#include "processes/structured_mesh_generator_process.h"
+#include "processes/calculate_discontinuous_distance_to_skin_process.h"
+#include "processes/calculate_embedded_nodal_variable_from_skin_process.h"
+
+namespace Kratos {
+namespace Testing {
+
+    KRATOS_TEST_CASE_IN_SUITE(CalculateEmbeddedNodalVariableFromSkinProcessHorizontalPlane2D, KratosCoreFastSuite)
+    {
+        Model current_model;
+
+        // Generate the element
+        ModelPart &fluid_part = current_model.CreateModelPart("Surface");
+        fluid_part.AddNodalSolutionStepVariable(DISTANCE);
+        fluid_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+        fluid_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+        fluid_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+        Properties::Pointer p_properties_0(new Properties(0));
+        fluid_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties_0);
+
+        // Generate the skin
+        const double plane_height = 0.5;
+        ModelPart &skin_part = current_model.CreateModelPart("Skin");
+        skin_part.CreateNewNode(1, -1.0, plane_height, 0.0);
+        skin_part.CreateNewNode(2,  1.0, plane_height, 0.0);
+        Properties::Pointer p_properties_1(new Properties(1));
+        skin_part.CreateNewElement("Element2D2N", 1, {{1, 2}}, p_properties_1);
+
+        // Compute the discontinuous distance function
+        CalculateDiscontinuousDistanceToSkinProcess<2> disc_dist_proc(fluid_part, skin_part);
+        disc_dist_proc.Execute();
+
+        // Check values
+        const auto &r_elem_dist = (fluid_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
+        KRATOS_CHECK_NEAR(r_elem_dist[0], -0.5, 1e-12);
+        KRATOS_CHECK_NEAR(r_elem_dist[1], -0.5, 1e-12);
+        KRATOS_CHECK_NEAR(r_elem_dist[2],  0.5, 1e-12);
+
+        // Compute the embedded nodal variable values
+        typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
+        typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
+        typedef LinearSolver<SparseSpaceType, LocalSpaceType> LinearSolverType;
+        CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType> emb_nod_var_from_skin_proc(
+            fluid_part,
+            skin_part,
+            DISTANCE,
+            DISTANCE,
+            "discontinuous");
+    }
+
+}  // namespace Testing.
+}  // namespace Kratos.

--- a/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
@@ -15,10 +15,12 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
+#include "includes/gid_io.h"
 #include "linear_solvers/linear_solver.h"
 #include "geometries/hexahedra_3d_8.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "processes/structured_mesh_generator_process.h"
+#include "processes/calculate_distance_to_skin_process.h"
 #include "processes/calculate_discontinuous_distance_to_skin_process.h"
 #include "processes/calculate_embedded_nodal_variable_from_skin_process.h"
 #include "spaces/ublas_space.h"
@@ -51,17 +53,11 @@ namespace Testing {
         Properties::Pointer p_properties_1(new Properties(1));
         skin_part.CreateNewElement("Element2D2N", 1, {{1, 2}}, p_properties_1);
         skin_part.GetNode(1).FastGetSolutionStepValue(TEMPERATURE) = 1.0;
-        skin_part.GetNode(1).FastGetSolutionStepValue(TEMPERATURE) = 2.0;
+        skin_part.GetNode(2).FastGetSolutionStepValue(TEMPERATURE) = 2.0;
 
         // Compute the discontinuous distance function
         CalculateDiscontinuousDistanceToSkinProcess<2> disc_dist_proc(fluid_part, skin_part);
         disc_dist_proc.Execute();
-
-        // Check values
-        const auto &r_elem_dist = (fluid_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
-        KRATOS_CHECK_NEAR(r_elem_dist[0], -0.5, 1e-12);
-        KRATOS_CHECK_NEAR(r_elem_dist[1], -0.5, 1e-12);
-        KRATOS_CHECK_NEAR(r_elem_dist[2],  0.5, 1e-12);
 
         // Compute the embedded nodal variable values
         typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
@@ -76,15 +72,103 @@ namespace Testing {
             "discontinuous");
 
         emb_nod_var_from_skin_proc.Execute();
+        emb_nod_var_from_skin_proc.Clear();
 
-        KRATOS_WATCH(fluid_part.GetNode(1).FastGetSolutionStepValue(DISTANCE))
-        KRATOS_WATCH(fluid_part.GetNode(2).FastGetSolutionStepValue(DISTANCE))
-        KRATOS_WATCH(fluid_part.GetNode(3).FastGetSolutionStepValue(DISTANCE))
-        KRATOS_WATCH(fluid_part.GetNode(4).FastGetSolutionStepValue(DISTANCE))
+        // Check values
         KRATOS_WATCH(fluid_part.GetNode(1).FastGetSolutionStepValue(TEMPERATURE))
         KRATOS_WATCH(fluid_part.GetNode(2).FastGetSolutionStepValue(TEMPERATURE))
         KRATOS_WATCH(fluid_part.GetNode(3).FastGetSolutionStepValue(TEMPERATURE))
         KRATOS_WATCH(fluid_part.GetNode(4).FastGetSolutionStepValue(TEMPERATURE))
+        std::vector<double> expected_values = {0.0, 0.0, 0.0, 0.0};
+        for (std::size_t i_node = 0; i_node < fluid_part.NumberOfNodes(); ++i_node) {
+            const auto it_node = fluid_part.NodesBegin() + i_node;
+            KRATOS_CHECK_NEAR(it_node->FastGetSolutionStepValue(TEMPERATURE), expected_values[i_node], 1e-12);
+        }
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(CalculateEmbeddedNodalVariableFromSkinProcess2D, KratosCoreFastSuite)
+    {
+        // Generate a volume mesh (done with the StructuredMeshGeneratorProcess)
+        Node<3>::Pointer p_point_1 = Kratos::make_shared<Node<3>>(1, 0.00, 0.00, 0.00);
+        Node<3>::Pointer p_point_2 = Kratos::make_shared<Node<3>>(2, 0.00, 1.00, 0.00);
+        Node<3>::Pointer p_point_3 = Kratos::make_shared<Node<3>>(3, 1.00, 1.00, 0.00);
+        Node<3>::Pointer p_point_4 = Kratos::make_shared<Node<3>>(4, 1.00, 0.00, 0.00);
+
+        Quadrilateral2D4<Node<3>> geometry(p_point_1, p_point_2, p_point_3, p_point_4);
+
+        Parameters mesher_parameters(R"({
+			"number_of_divisions": 7,
+			"element_name": "Element2D3N"
+		})");
+
+        Model current_model;
+        ModelPart &surface_part = current_model.CreateModelPart("Volume");
+        surface_part.AddNodalSolutionStepVariable(DISTANCE);
+        surface_part.AddNodalSolutionStepVariable(TEMPERATURE);
+        StructuredMeshGeneratorProcess(geometry, surface_part, mesher_parameters).Execute();
+
+        // Generate the skin
+        ModelPart &skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(TEMPERATURE);
+        skin_part.CreateNewNode(901, 0.24, 0.34, 0.0);
+        skin_part.CreateNewNode(902, 0.76, 0.34, 0.0);
+        skin_part.CreateNewNode(903, 0.76, 0.66, 0.0);
+        skin_part.CreateNewNode(904, 0.24, 0.66, 0.0);
+        Properties::Pointer p_properties(new Properties(0));
+        skin_part.CreateNewElement("Element2D2N", 901, {{901, 902}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N", 902, {{902, 903}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N", 903, {{903, 904}}, p_properties);
+        skin_part.CreateNewElement("Element2D2N", 904, {{904, 901}}, p_properties);
+        skin_part.GetNode(901).FastGetSolutionStepValue(TEMPERATURE) = 4.0;
+        skin_part.GetNode(902).FastGetSolutionStepValue(TEMPERATURE) = 4.0;
+        skin_part.GetNode(903).FastGetSolutionStepValue(TEMPERATURE) = 4.0;
+        skin_part.GetNode(904).FastGetSolutionStepValue(TEMPERATURE) = 4.0;
+
+        // Compute distance
+        CalculateDistanceToSkinProcess<2>(surface_part, skin_part).Execute();
+
+        // Compute the embedded nodal variable values
+        typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
+        typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
+        typedef LinearSolver<SparseSpaceType, LocalSpaceType> LinearSolverType;
+        typedef CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType> EmbeddedNodalVariableProcess;
+        EmbeddedNodalVariableProcess emb_nod_var_from_skin_proc(
+            surface_part,
+            skin_part,
+            TEMPERATURE,
+            TEMPERATURE,
+            "continuous");
+
+        emb_nod_var_from_skin_proc.Execute();
+        emb_nod_var_from_skin_proc.Clear();
+
+        GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/surface_mesh", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
+        gid_io_fluid.InitializeMesh(0.00);
+        gid_io_fluid.WriteMesh(surface_part.GetMesh());
+        gid_io_fluid.FinalizeMesh();
+        gid_io_fluid.InitializeResults(0, surface_part.GetMesh());
+        gid_io_fluid.WriteNodalResults(DISTANCE, surface_part.Nodes(), 0, 0);
+        gid_io_fluid.WriteNodalResults(TEMPERATURE, surface_part.Nodes(), 0, 0);
+        gid_io_fluid.FinalizeResults();
+
+        GidIO<> gid_io_skin("/home/rzorrilla/Desktop/skin_mesh", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
+        gid_io_skin.InitializeMesh(0.00);
+        gid_io_skin.WriteMesh(skin_part.GetMesh());
+        gid_io_skin.FinalizeMesh();
+        gid_io_skin.InitializeResults(0, skin_part.GetMesh());
+        gid_io_skin.WriteNodalResults(TEMPERATURE, skin_part.Nodes(), 0, 0);
+        gid_io_skin.FinalizeResults();
+
+        // Check values
+        KRATOS_WATCH(surface_part.GetNode(1).FastGetSolutionStepValue(TEMPERATURE))
+        KRATOS_WATCH(surface_part.GetNode(2).FastGetSolutionStepValue(TEMPERATURE))
+        KRATOS_WATCH(surface_part.GetNode(3).FastGetSolutionStepValue(TEMPERATURE))
+        KRATOS_WATCH(surface_part.GetNode(4).FastGetSolutionStepValue(TEMPERATURE))
+        std::vector<double> expected_values = {0.0, 0.0, 0.0, 0.0};
+        for (std::size_t i_node = 0; i_node < surface_part.NumberOfNodes(); ++i_node) {
+            const auto it_node = surface_part.NodesBegin() + i_node;
+            KRATOS_CHECK_NEAR(it_node->FastGetSolutionStepValue(TEMPERATURE), expected_values[i_node], 1e-12);
+        }
     }
 
 }  // namespace Testing.

--- a/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
@@ -33,6 +33,7 @@ namespace Testing {
         // Generate the element
         ModelPart &fluid_part = current_model.CreateModelPart("Surface");
         fluid_part.AddNodalSolutionStepVariable(DISTANCE);
+        fluid_part.AddNodalSolutionStepVariable(TEMPERATURE);
         fluid_part.CreateNewNode(1, 0.0, 0.0, 0.0);
         fluid_part.CreateNewNode(2, 1.0, 0.0, 0.0);
         fluid_part.CreateNewNode(3, 0.0, 1.0, 0.0);
@@ -49,6 +50,8 @@ namespace Testing {
         skin_part.CreateNewNode(2,  0.6, plane_height, 0.0);
         Properties::Pointer p_properties_1(new Properties(1));
         skin_part.CreateNewElement("Element2D2N", 1, {{1, 2}}, p_properties_1);
+        skin_part.GetNode(1).FastGetSolutionStepValue(TEMPERATURE) = 1.0;
+        skin_part.GetNode(1).FastGetSolutionStepValue(TEMPERATURE) = 2.0;
 
         // Compute the discontinuous distance function
         CalculateDiscontinuousDistanceToSkinProcess<2> disc_dist_proc(fluid_part, skin_part);
@@ -69,8 +72,19 @@ namespace Testing {
             fluid_part,
             skin_part,
             TEMPERATURE,
-            DISTANCE,
+            TEMPERATURE,
             "discontinuous");
+
+        emb_nod_var_from_skin_proc.Execute();
+
+        KRATOS_WATCH(fluid_part.GetNode(1).FastGetSolutionStepValue(DISTANCE))
+        KRATOS_WATCH(fluid_part.GetNode(2).FastGetSolutionStepValue(DISTANCE))
+        KRATOS_WATCH(fluid_part.GetNode(3).FastGetSolutionStepValue(DISTANCE))
+        KRATOS_WATCH(fluid_part.GetNode(4).FastGetSolutionStepValue(DISTANCE))
+        KRATOS_WATCH(fluid_part.GetNode(1).FastGetSolutionStepValue(TEMPERATURE))
+        KRATOS_WATCH(fluid_part.GetNode(2).FastGetSolutionStepValue(TEMPERATURE))
+        KRATOS_WATCH(fluid_part.GetNode(3).FastGetSolutionStepValue(TEMPERATURE))
+        KRATOS_WATCH(fluid_part.GetNode(4).FastGetSolutionStepValue(TEMPERATURE))
     }
 
 }  // namespace Testing.

--- a/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
@@ -40,6 +40,7 @@ namespace Testing {
         // Generate the skin
         const double plane_height = 0.5;
         ModelPart &skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(TEMPERATURE);
         skin_part.CreateNewNode(1, -1.0, plane_height, 0.0);
         skin_part.CreateNewNode(2,  1.0, plane_height, 0.0);
         Properties::Pointer p_properties_1(new Properties(1));
@@ -62,7 +63,7 @@ namespace Testing {
         CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType> emb_nod_var_from_skin_proc(
             fluid_part,
             skin_part,
-            DISTANCE,
+            TEMPERATURE,
             DISTANCE,
             "discontinuous");
     }

--- a/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
@@ -15,11 +15,13 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
+#include "linear_solvers/linear_solver.h"
 #include "geometries/hexahedra_3d_8.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "processes/structured_mesh_generator_process.h"
 #include "processes/calculate_discontinuous_distance_to_skin_process.h"
 #include "processes/calculate_embedded_nodal_variable_from_skin_process.h"
+#include "spaces/ublas_space.h"
 
 namespace Kratos {
 namespace Testing {
@@ -60,7 +62,8 @@ namespace Testing {
         typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
         typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
         typedef LinearSolver<SparseSpaceType, LocalSpaceType> LinearSolverType;
-        CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType> emb_nod_var_from_skin_proc(
+        typedef CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType> EmbeddedNodalVariableProcess;
+        EmbeddedNodalVariableProcess emb_nod_var_from_skin_proc(
             fluid_part,
             skin_part,
             TEMPERATURE,

--- a/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
@@ -12,77 +12,101 @@
 //
 
 // Project includes
-#include "testing/testing.h"
 #include "containers/model.h"
-#include "includes/checks.h"
-#include "includes/gid_io.h"
-#include "linear_solvers/linear_solver.h"
-#include "geometries/hexahedra_3d_8.h"
 #include "geometries/quadrilateral_2d_4.h"
+#include "includes/checks.h"
+#include "linear_solvers/linear_solver.h"
 #include "processes/structured_mesh_generator_process.h"
 #include "processes/calculate_distance_to_skin_process.h"
 #include "processes/calculate_discontinuous_distance_to_skin_process.h"
 #include "processes/calculate_embedded_nodal_variable_from_skin_process.h"
 #include "spaces/ublas_space.h"
+#include "testing/testing.h"
 
 namespace Kratos {
 namespace Testing {
+
+    typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
+    typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
+    typedef LinearSolver<SparseSpaceType, LocalSpaceType> LinearSolverType;
+    typedef CalculateEmbeddedNodalVariableFromSkinProcess<double, SparseSpaceType, LocalSpaceType, LinearSolverType> EmbeddedNodalVariableProcessDouble;
+    typedef CalculateEmbeddedNodalVariableFromSkinProcess<array_1d<double, 3>, SparseSpaceType, LocalSpaceType, LinearSolverType> EmbeddedNodalVariableProcessArray;
 
     KRATOS_TEST_CASE_IN_SUITE(CalculateEmbeddedNodalVariableFromSkinProcessHorizontalPlane2D, KratosCoreFastSuite)
     {
         Model current_model;
 
         // Generate the element
-        ModelPart &fluid_part = current_model.CreateModelPart("Surface");
-        fluid_part.AddNodalSolutionStepVariable(DISTANCE);
-        fluid_part.AddNodalSolutionStepVariable(TEMPERATURE);
-        fluid_part.CreateNewNode(1, 0.0, 0.0, 0.0);
-        fluid_part.CreateNewNode(2, 1.0, 0.0, 0.0);
-        fluid_part.CreateNewNode(3, 0.0, 1.0, 0.0);
-        fluid_part.CreateNewNode(4, 1.0, 1.0, 0.0);
+        ModelPart &surface_part = current_model.CreateModelPart("Surface");
+        surface_part.AddNodalSolutionStepVariable(DISTANCE);
+        surface_part.AddNodalSolutionStepVariable(VELOCITY);
+        surface_part.AddNodalSolutionStepVariable(TEMPERATURE);
+        surface_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+        surface_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+        surface_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+        surface_part.CreateNewNode(4, 1.0, 1.0, 0.0);
         Properties::Pointer p_properties_0(new Properties(0));
-        fluid_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties_0);
-        fluid_part.CreateNewElement("Element2D3N", 2, {2, 4, 3}, p_properties_0);
+        surface_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties_0);
+        surface_part.CreateNewElement("Element2D3N", 2, {2, 4, 3}, p_properties_0);
 
         // Generate the skin
         const double plane_height = 0.5;
         ModelPart &skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(VELOCITY);
         skin_part.AddNodalSolutionStepVariable(TEMPERATURE);
         skin_part.CreateNewNode(1, -1.0, plane_height, 0.0);
         skin_part.CreateNewNode(2,  0.6, plane_height, 0.0);
         Properties::Pointer p_properties_1(new Properties(1));
         skin_part.CreateNewElement("Element2D2N", 1, {{1, 2}}, p_properties_1);
-        skin_part.GetNode(1).FastGetSolutionStepValue(TEMPERATURE) = 1.0;
-        skin_part.GetNode(2).FastGetSolutionStepValue(TEMPERATURE) = 2.0;
+        array_1d<double, 3> aux_v = ZeroVector(3);
+        for (std::size_t i_node = 0; i_node < skin_part.NumberOfNodes(); ++i_node) {
+            aux_v[0] = i_node + 1.0;
+            aux_v[1] = 2.0 * (i_node + 1.0);
+            auto it_node = skin_part.NodesBegin() + i_node;
+            it_node->FastGetSolutionStepValue(VELOCITY) = aux_v;
+            it_node->FastGetSolutionStepValue(TEMPERATURE) = it_node->Id();
+        }
 
         // Compute the discontinuous distance function
-        CalculateDiscontinuousDistanceToSkinProcess<2> disc_dist_proc(fluid_part, skin_part);
+        CalculateDiscontinuousDistanceToSkinProcess<2> disc_dist_proc(surface_part, skin_part);
         disc_dist_proc.Execute();
 
         // Compute the embedded nodal variable values
-        typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
-        typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
-        typedef LinearSolver<SparseSpaceType, LocalSpaceType> LinearSolverType;
-        typedef CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType> EmbeddedNodalVariableProcess;
-        EmbeddedNodalVariableProcess emb_nod_var_from_skin_proc(
-            fluid_part,
+        // Double variable type case
+        EmbeddedNodalVariableProcessDouble emb_nod_var_from_skin_proc_double(
+            surface_part,
             skin_part,
             TEMPERATURE,
             TEMPERATURE,
             "discontinuous");
 
-        emb_nod_var_from_skin_proc.Execute();
-        emb_nod_var_from_skin_proc.Clear();
+        emb_nod_var_from_skin_proc_double.Execute();
+        emb_nod_var_from_skin_proc_double.Clear();
 
         // Check values
-        KRATOS_WATCH(fluid_part.GetNode(1).FastGetSolutionStepValue(TEMPERATURE))
-        KRATOS_WATCH(fluid_part.GetNode(2).FastGetSolutionStepValue(TEMPERATURE))
-        KRATOS_WATCH(fluid_part.GetNode(3).FastGetSolutionStepValue(TEMPERATURE))
-        KRATOS_WATCH(fluid_part.GetNode(4).FastGetSolutionStepValue(TEMPERATURE))
-        std::vector<double> expected_values = {0.0, 0.0, 0.0, 0.0};
-        for (std::size_t i_node = 0; i_node < fluid_part.NumberOfNodes(); ++i_node) {
-            const auto it_node = fluid_part.NodesBegin() + i_node;
+        std::vector<double> expected_values = {0.875, 1.5, 2.375, 0.0};
+        for (std::size_t i_node = 0; i_node < surface_part.NumberOfNodes(); ++i_node) {
+            const auto it_node = surface_part.NodesBegin() + i_node;
             KRATOS_CHECK_NEAR(it_node->FastGetSolutionStepValue(TEMPERATURE), expected_values[i_node], 1e-12);
+        }
+
+        // Array variable type case
+        EmbeddedNodalVariableProcessArray emb_nod_var_from_skin_proc_array(
+            surface_part,
+            skin_part,
+            VELOCITY,
+            VELOCITY,
+            "discontinuous");
+
+        emb_nod_var_from_skin_proc_array.Execute();
+
+        // Check values
+        std::vector<double> expected_values_x = {0.875, 1.5, 2.375, 0.0};
+        std::vector<double> expected_values_y = {1.75,  3.0, 4.75,  0.0};
+        for (std::size_t i_node = 0; i_node < surface_part.NumberOfNodes(); ++i_node) {
+            const auto it_node = surface_part.NodesBegin() + i_node;
+            KRATOS_CHECK_NEAR(it_node->FastGetSolutionStepValue(VELOCITY_X), expected_values_x[i_node], 1e-10);
+            KRATOS_CHECK_NEAR(it_node->FastGetSolutionStepValue(VELOCITY_Y), expected_values_y[i_node], 1e-10);
         }
     }
 
@@ -119,20 +143,16 @@ namespace Testing {
         skin_part.CreateNewElement("Element2D2N", 902, {{902, 903}}, p_properties);
         skin_part.CreateNewElement("Element2D2N", 903, {{903, 904}}, p_properties);
         skin_part.CreateNewElement("Element2D2N", 904, {{904, 901}}, p_properties);
-        skin_part.GetNode(901).FastGetSolutionStepValue(TEMPERATURE) = 4.0;
-        skin_part.GetNode(902).FastGetSolutionStepValue(TEMPERATURE) = 4.0;
-        skin_part.GetNode(903).FastGetSolutionStepValue(TEMPERATURE) = 4.0;
-        skin_part.GetNode(904).FastGetSolutionStepValue(TEMPERATURE) = 4.0;
+        skin_part.GetNode(901).FastGetSolutionStepValue(TEMPERATURE) = 1.0;
+        skin_part.GetNode(902).FastGetSolutionStepValue(TEMPERATURE) = 2.0;
+        skin_part.GetNode(903).FastGetSolutionStepValue(TEMPERATURE) = 3.0;
+        skin_part.GetNode(904).FastGetSolutionStepValue(TEMPERATURE) = 2.0;
 
         // Compute distance
         CalculateDistanceToSkinProcess<2>(surface_part, skin_part).Execute();
 
         // Compute the embedded nodal variable values
-        typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
-        typedef UblasSpace<double, CompressedMatrix, Vector> SparseSpaceType;
-        typedef LinearSolver<SparseSpaceType, LocalSpaceType> LinearSolverType;
-        typedef CalculateEmbeddedNodalVariableFromSkinProcess<2, double, SparseSpaceType, LocalSpaceType, LinearSolverType> EmbeddedNodalVariableProcess;
-        EmbeddedNodalVariableProcess emb_nod_var_from_skin_proc(
+        EmbeddedNodalVariableProcessDouble emb_nod_var_from_skin_proc(
             surface_part,
             skin_part,
             TEMPERATURE,
@@ -140,34 +160,13 @@ namespace Testing {
             "continuous");
 
         emb_nod_var_from_skin_proc.Execute();
-        emb_nod_var_from_skin_proc.Clear();
-
-        GidIO<> gid_io_fluid("/home/rzorrilla/Desktop/surface_mesh", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
-        gid_io_fluid.InitializeMesh(0.00);
-        gid_io_fluid.WriteMesh(surface_part.GetMesh());
-        gid_io_fluid.FinalizeMesh();
-        gid_io_fluid.InitializeResults(0, surface_part.GetMesh());
-        gid_io_fluid.WriteNodalResults(DISTANCE, surface_part.Nodes(), 0, 0);
-        gid_io_fluid.WriteNodalResults(TEMPERATURE, surface_part.Nodes(), 0, 0);
-        gid_io_fluid.FinalizeResults();
-
-        GidIO<> gid_io_skin("/home/rzorrilla/Desktop/skin_mesh", GiD_PostAscii, SingleFile, WriteDeformed, WriteConditions);
-        gid_io_skin.InitializeMesh(0.00);
-        gid_io_skin.WriteMesh(skin_part.GetMesh());
-        gid_io_skin.FinalizeMesh();
-        gid_io_skin.InitializeResults(0, skin_part.GetMesh());
-        gid_io_skin.WriteNodalResults(TEMPERATURE, skin_part.Nodes(), 0, 0);
-        gid_io_skin.FinalizeResults();
 
         // Check values
-        KRATOS_WATCH(surface_part.GetNode(1).FastGetSolutionStepValue(TEMPERATURE))
-        KRATOS_WATCH(surface_part.GetNode(2).FastGetSolutionStepValue(TEMPERATURE))
-        KRATOS_WATCH(surface_part.GetNode(3).FastGetSolutionStepValue(TEMPERATURE))
-        KRATOS_WATCH(surface_part.GetNode(4).FastGetSolutionStepValue(TEMPERATURE))
-        std::vector<double> expected_values = {0.0, 0.0, 0.0, 0.0};
-        for (std::size_t i_node = 0; i_node < surface_part.NumberOfNodes(); ++i_node) {
-            const auto it_node = surface_part.NodesBegin() + i_node;
-            KRATOS_CHECK_NEAR(it_node->FastGetSolutionStepValue(TEMPERATURE), expected_values[i_node], 1e-12);
+        std::vector<std::size_t> check_nodes_ids = {19, 20, 28, 45, 46, 54};
+        std::vector<double> expected_values = {0.883925, 1.42073, 1.69546, 2.57927, 3.11607, 3.47553};
+        for (std::size_t i_node = 0; i_node < check_nodes_ids.size(); ++i_node) {
+            const auto p_node = surface_part.pGetNode(check_nodes_ids[i_node]);
+            KRATOS_CHECK_NEAR(p_node->FastGetSolutionStepValue(TEMPERATURE), expected_values[i_node], 1e-5);
         }
     }
 

--- a/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_embedded_nodal_variable_from_skin_process.cpp
@@ -36,15 +36,17 @@ namespace Testing {
         fluid_part.CreateNewNode(1, 0.0, 0.0, 0.0);
         fluid_part.CreateNewNode(2, 1.0, 0.0, 0.0);
         fluid_part.CreateNewNode(3, 0.0, 1.0, 0.0);
+        fluid_part.CreateNewNode(4, 1.0, 1.0, 0.0);
         Properties::Pointer p_properties_0(new Properties(0));
         fluid_part.CreateNewElement("Element2D3N", 1, {1, 2, 3}, p_properties_0);
+        fluid_part.CreateNewElement("Element2D3N", 2, {2, 4, 3}, p_properties_0);
 
         // Generate the skin
         const double plane_height = 0.5;
         ModelPart &skin_part = current_model.CreateModelPart("Skin");
         skin_part.AddNodalSolutionStepVariable(TEMPERATURE);
         skin_part.CreateNewNode(1, -1.0, plane_height, 0.0);
-        skin_part.CreateNewNode(2,  1.0, plane_height, 0.0);
+        skin_part.CreateNewNode(2,  0.6, plane_height, 0.0);
         Properties::Pointer p_properties_1(new Properties(1));
         skin_part.CreateNewElement("Element2D2N", 1, {{1, 2}}, p_properties_1);
 


### PR DESCRIPTION
This PR enhances the embedded variables computation. Long story short, it minimizes the error in a least square sense to "map" the skin variable values to the background mesh.

This will allow to improve the `MESH_DISPLACEMENT`calculation in the FM-ALE algorithm and, in the future, the BC imposition over the skin.