### PR TITLE
[MeshMoving] python module

### DIFF
--- a/applications/MeshMovingApplication/MeshMovingApplication.py
+++ b/applications/MeshMovingApplication/MeshMovingApplication.py
@@ -1,11 +1,8 @@
 from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
+import KratosMultiphysics as KM
 from KratosMeshMovingApplication import *
 application = KratosMeshMovingApplication()
 application_name = "KratosMeshMovingApplication"
 application_folder = "MeshMovingApplication"
 
-# The following lines are common for all applications
-from .. import application_importer
-import inspect
-caller = inspect.stack()[1]  # Information about the file that imported this, to check for unexpected imports
-application_importer.ImportApplication(application, application_name, application_folder, caller, __path__)
+KM._ImportApplicationAsModule(application, application_name, application_folder, __path__)

--- a/applications/MeshMovingApplication/python_scripts/python_solvers_wrapper_mesh_motion.py
+++ b/applications/MeshMovingApplication/python_scripts/python_solvers_wrapper_mesh_motion.py
@@ -44,8 +44,8 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
         err_msg += 'Available options are: "OpenMP", "MPI"'
         raise Exception(err_msg)
 
-    solver_module = __import__(solver_module_name)
-    solver = solver_module.CreateSolver(model, solver_settings)
+    module_full = 'KratosMultiphysics.MeshMovingApplication.' + solver_module_name
+    solver = __import__(module_full, fromlist=[solver_module_name]).CreateSolver(model, solver_settings)
 
     return solver
 


### PR DESCRIPTION
using the new python import system

I think I have updated all usages in the FSI and ShapeOptApp but please also have a look yourselves

note that after this the python-scripts have to be imported with a preceeding `KratosMultiphysics.MeshMovingApplication`

This is the new standard