### PR TITLE
Extending WorkFolderScope context manager

### DIFF
--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -161,14 +161,33 @@ def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
 
 
 class WorkFolderScope:
-    """Helper-class to execute test in a specific path"""
-    def __init__(self, rel_path_work_folder, file_path):
-        """file_path is the __file__ argument"""
+    """ Helper-class to execute test in a specific target path
+    
+        Input
+        -----
+        - rel_path_work_folder: String
+            Relative path of the target dir from the calling script
+
+        - file_path: String
+            Absolute path of the calling script
+
+        -add_to_path: Bool
+            "False" (default) if no need to add the target dir to the path, "True" otherwise.
+    """
+
+    def __init__(self, rel_path_work_folder, file_path, add_to_path=False):
         self.currentPath = os.getcwd()
+        self.add_to_path = add_to_path
+        if self.add_to_path:
+            self.currentPythonpath = sys.path
         self.scope = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(file_path)), rel_path_work_folder))
 
     def __enter__(self):
         os.chdir(self.scope)
+        if self.add_to_path:
+            sys.path.append(self.scope)
 
     def __exit__(self, exc_type, exc_value, traceback):
         os.chdir(self.currentPath)
+        if self.add_to_path:
+            sys.path = self.currentPythonpath

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -162,7 +162,7 @@ def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
 
 class WorkFolderScope:
     """ Helper-class to execute test in a specific target path
-    
+
         Input
         -----
         - rel_path_work_folder: String
@@ -171,7 +171,7 @@ class WorkFolderScope:
         - file_path: String
             Absolute path of the calling script
 
-        -add_to_path: Bool
+        - add_to_path: Bool
             "False" (default) if no need to add the target dir to the path, "True" otherwise.
     """
 


### PR DESCRIPTION
This ports the extension of the WorkFolderScope made in #4332 so it can add the folder to the path (A cherry pick will be needed nevertheless...)

It is necessary in case someone wants to directly import secondary scripts that exists outside Kratos Path.

