### PR TITLE
feat(HDF5): enable data set overwrite and mesh move operation

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -4,7 +4,7 @@
 #include <sstream>
 #include <regex>
 #include <utility>
-#include <type_traits>
+#include <array>
 #include "includes/kratos_parameters.h"
 #include "utilities/builtin_timer.h"
 #include "input_output/logger.h"
@@ -37,23 +37,75 @@ std::vector<std::string> Split(const std::string& rPath, char Delimiter)
     return splitted;
 }
 
-template <class TScalar>
-hid_t GetScalarDataType()
+hid_t GetScalarDataType(const Vector<int>&)
 {
-    hid_t type_id;
-    constexpr bool is_int_type = std::is_same<int, TScalar>::value;
-    constexpr bool is_double_type = std::is_same<double, TScalar>::value;
-    if (is_int_type)
-        type_id = H5T_NATIVE_INT;
-    else if (is_double_type)
-        type_id = H5T_NATIVE_DOUBLE;
-    else
-        static_assert(is_int_type || is_double_type,
-                      "Unsupported scalar data type.");
-
-    return type_id;
+    return H5T_NATIVE_INT;
 }
 
+hid_t GetScalarDataType(const Vector<double>&)
+{
+    return H5T_NATIVE_DOUBLE;
+}
+
+hid_t GetScalarDataType(const Vector<array_1d<double, 3>>&)
+{
+    return H5T_NATIVE_DOUBLE;
+}
+
+hid_t GetScalarDataType(const Matrix<int>&)
+{
+    return H5T_NATIVE_INT;
+}
+
+hid_t GetScalarDataType(const Matrix<double>&)
+{
+    return H5T_NATIVE_DOUBLE;
+}
+
+hid_t GetScalarDataType(int)
+{
+    return H5T_NATIVE_INT;
+}
+
+hid_t GetScalarDataType(double)
+{
+    return H5T_NATIVE_DOUBLE;
+}
+
+std::vector<hsize_t> GetDataDimensions(const Vector<int>& rData)
+{
+    return std::vector<hsize_t>{rData.size()};
+}
+
+std::vector<hsize_t> GetDataDimensions(const Vector<double>& rData)
+{
+    return std::vector<hsize_t>{rData.size()};
+}
+
+std::vector<hsize_t> GetDataDimensions(const Vector<array_1d<double, 3>>& rData)
+{
+    return std::vector<hsize_t>{rData.size(), 3};
+}
+
+std::vector<hsize_t> GetDataDimensions(const Matrix<int>& rData)
+{
+    return std::vector<hsize_t>{rData.size1(), rData.size2()};
+}
+
+std::vector<hsize_t> GetDataDimensions(const Matrix<double>& rData)
+{
+    return std::vector<hsize_t>{rData.size1(), rData.size2()};
+}
+
+std::vector<hsize_t> GetDataDimensions(const File& rFile, const std::string& rPath)
+{
+    const std::vector<unsigned> dims = rFile.GetDataDimensions(rPath);
+    std::vector<hsize_t> h5_dims;
+    h5_dims.reserve(dims.size());
+    std::for_each(dims.begin(), dims.end(),
+                  [&h5_dims](unsigned d) { h5_dims.push_back(d); });
+    return h5_dims;
+}
 } // namespace Internals.
 
 File::File(Parameters Settings)
@@ -306,7 +358,7 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     BuiltinTimer timer;
     hid_t type_id, space_id, attr_id;
 
-    type_id = Internals::GetScalarDataType<TScalar>();
+    type_id = Internals::GetScalarDataType(Value);
     space_id = H5Screate(H5S_SCALAR);
     KRATOS_ERROR_IF(space_id < 0) << "H5Screate failed." << std::endl;
     attr_id = H5Acreate_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(), type_id,
@@ -328,7 +380,7 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     BuiltinTimer timer;
     hid_t type_id, space_id, attr_id;
 
-    type_id = Internals::GetScalarDataType<TScalar>();
+    type_id = Internals::GetScalarDataType(rValue);
     const hsize_t dim = rValue.size();
     space_id = H5Screate_simple(1, &dim, nullptr);
     KRATOS_ERROR_IF(space_id < 0) << "H5Screate failed." << std::endl;
@@ -351,12 +403,9 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     BuiltinTimer timer;
     hid_t type_id, space_id, attr_id;
 
-    type_id = Internals::GetScalarDataType<TScalar>();
-    const unsigned ndims = 2;
-    hsize_t dims[ndims];
-    dims[0] = rValue.size1();
-    dims[1] = rValue.size2();
-    space_id = H5Screate_simple(ndims, dims, nullptr);
+    type_id = Internals::GetScalarDataType(rValue);
+    const std::array<hsize_t, 2> dims = {rValue.size1(), rValue.size2()};
+    space_id = H5Screate_simple(dims.size(), dims.data(), nullptr);
     KRATOS_ERROR_IF(space_id < 0) << "H5Screate failed." << std::endl;
     attr_id = H5Acreate_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(), type_id,
                                 space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -377,10 +426,8 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     hid_t type_id, space_id, attr_id;
 
     type_id = H5T_NATIVE_CHAR;
-    const unsigned ndims = 1;
-    hsize_t dims[ndims];
-    dims[0] = rValue.size();
-    space_id = H5Screate_simple(ndims, dims, nullptr);
+    const std::array<hsize_t, 1> dims = {rValue.size()};
+    space_id = H5Screate_simple(dims.size(), dims.data(), nullptr);
     KRATOS_ERROR_IF(space_id < 0) << "H5Screate failed." << std::endl;
     attr_id = H5Acreate_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(), type_id,
                                 space_id, H5P_DEFAULT, H5P_DEFAULT, H5P_DEFAULT);
@@ -578,7 +625,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     hid_t mem_type_id, attr_type_id, space_id, attr_id;
     int ndims;
 
-    mem_type_id = Internals::GetScalarDataType<TScalar>();
+    mem_type_id = Internals::GetScalarDataType(rValue);
     attr_id = H5Aopen_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(),
                                     H5P_DEFAULT, H5P_DEFAULT);
     KRATOS_ERROR_IF(attr_id < 0) << "H5Aopen_by_name failed." << std::endl;
@@ -617,7 +664,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     int ndims;
     hsize_t dims[1];
 
-    mem_type_id = Internals::GetScalarDataType<TScalar>();
+    mem_type_id = Internals::GetScalarDataType(rValue);
     attr_id = H5Aopen_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(),
                                     H5P_DEFAULT, H5P_DEFAULT);
     KRATOS_ERROR_IF(attr_id < 0) << "H5Aopen_by_name failed." << std::endl;
@@ -658,7 +705,7 @@ void File::ReadAttribute(const std::string& rObjectPath, const std::string& rNam
     int ndims;
     hsize_t dims[2];
 
-    mem_type_id = Internals::GetScalarDataType<TScalar>();
+    mem_type_id = Internals::GetScalarDataType(rValue);
     attr_id = H5Aopen_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(),
                                     H5P_DEFAULT, H5P_DEFAULT);
     KRATOS_ERROR_IF(attr_id < 0) << "H5Aopen_by_name failed." << std::endl;
@@ -882,9 +929,6 @@ template void File::ReadAttribute(const std::string& rObjectPath, const std::str
 template void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, Vector<double>& rValue);
 template void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, Matrix<int>& rValue);
 template void File::ReadAttribute(const std::string& rObjectPath, const std::string& rName, Matrix<double>& rValue);
-
-template hid_t Internals::GetScalarDataType<int>();
-template hid_t Internals::GetScalarDataType<double>();
 
 } // namespace HDF5.
 } // namespace Kratos.

--- a/applications/HDF5Application/custom_io/hdf5_file.h
+++ b/applications/HDF5Application/custom_io/hdf5_file.h
@@ -300,12 +300,20 @@ bool IsPath(const std::string& rPath);
 /// Return vector of non-empty substrings separated by a delimiter.
 std::vector<std::string> Split(const std::string& rPath, char Delimiter);
 
-template <class TScalar>
-hid_t GetScalarDataType();
+hid_t GetScalarDataType(const Vector<int>&);
+hid_t GetScalarDataType(const Vector<double>&);
+hid_t GetScalarDataType(const Vector<array_1d<double, 3>>&);
+hid_t GetScalarDataType(const Matrix<int>&);
+hid_t GetScalarDataType(const Matrix<double>&);
+hid_t GetScalarDataType(int);
+hid_t GetScalarDataType(double);
 
-extern template hid_t GetScalarDataType<int>();
-extern template hid_t GetScalarDataType<double>();
-
+std::vector<hsize_t> GetDataDimensions(const Vector<int>& rData);
+std::vector<hsize_t> GetDataDimensions(const Vector<double>& rData);
+std::vector<hsize_t> GetDataDimensions(const Vector<array_1d<double, 3>>& rData);
+std::vector<hsize_t> GetDataDimensions(const Matrix<int>& rData);
+std::vector<hsize_t> GetDataDimensions(const Matrix<double>& rData);
+std::vector<hsize_t> GetDataDimensions(const File& rFile, const std::string& rPath);
 } // namespace Internals.
 
 ///@} addtogroup

--- a/applications/HDF5Application/custom_io/hdf5_file_parallel.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file_parallel.cpp
@@ -345,7 +345,7 @@ void FileParallel::WriteDataSetMatrixImpl(const std::string& rPath,
         local_start[0] = 0;
 
     // Set the data type.
-    hid_t dtype_id = Internals::GetScalarDataType<T>();
+    hid_t dtype_id = Internals::GetScalarDataType(rData);
 
     // Create and write the data set.
     hid_t file_id = GetFileId();
@@ -528,7 +528,7 @@ void FileParallel::ReadDataSetMatrixImpl(const std::string& rPath,
     local_start[0] = StartIndex;
 
     // Set the data type.
-    hid_t dtype_id = Internals::GetScalarDataType<T>();
+    hid_t dtype_id = Internals::GetScalarDataType(rData);
     if (dtype_id == H5T_NATIVE_INT)
     {
         KRATOS_ERROR_IF_NOT(HasIntDataType(rPath))

--- a/applications/HDF5Application/custom_io/hdf5_points_data.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_points_data.cpp
@@ -60,7 +60,7 @@ void PointsData::SetData(NodesContainerType const& rNodes)
         {
             const auto& r_node = *it;
             mIds[i] = r_node.Id();
-            mCoords[i] = r_node.Coordinates();
+            mCoords[i] = r_node.GetInitialPosition().Coordinates();
             ++it;
         }
     }

--- a/applications/HDF5Application/python_scripts/core/operations/model_part.py
+++ b/applications/HDF5Application/python_scripts/core/operations/model_part.py
@@ -192,6 +192,17 @@ class PrimalBossakInput(VariableIO):
             model_part.Nodes, model_part.GetCommunicator())
 
 
+class MoveMesh(object):
+    '''Perform a mesh move operation on a model part.
+
+    The primary use case is to set the mesh to the current configuration after
+    reading the model part.
+    '''
+
+    def __call__(self, model_part, *args):
+        KratosMultiphysics.SolvingStrategy(model_part, True).MoveMesh()
+
+
 def Create(settings):
     '''Return the operation specified by the setting 'operation_type'.
 
@@ -223,6 +234,8 @@ def Create(settings):
         return PrimalBossakOutput(settings)
     elif operation_type == 'primal_bossak_input':
         return PrimalBossakInput(settings)
+    elif operation_type == 'move_mesh':
+        return MoveMesh()
     else:
         if settings.Has('module_name'):
             module_name = settings['module_name'].GetString()

--- a/applications/HDF5Application/python_scripts/user_defined_io_process.py
+++ b/applications/HDF5Application/python_scripts/user_defined_io_process.py
@@ -1,0 +1,15 @@
+'''Construct a user-defined input/output process.
+
+This factory is for advanced use cases. It allows users to define a custom 
+input/output process via json settings which are passed directly to
+HDF5Application.core.
+
+license: HDF5Application/license.txt
+'''
+import KratosMultiphysics
+import KratosMultiphysics.HDF5Application.core as _core
+
+def Factory(process_settings, Model):
+    """Construct a user-defined input/output process for HDF5."""
+
+    return _core.Factory(process_settings["Parameters"], Model)

--- a/applications/HDF5Application/tests/test_hdf5_file_serial.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_file_serial.cpp
@@ -53,6 +53,7 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_FileSerial_ReadDataSet2, KratosHDF5TestSuite)
         HDF5::File::Vector<double> data_out = TestVector<double>(3);
         HDF5::WriteInfo info;
         test_file.WriteDataSet("/data", data_out, info);
+        test_file.WriteDataSet("/data", data_out, info); // Test write on existing.
         HDF5::File::Vector<double> data_in;
         test_file.ReadDataSet("/data", data_in, 0, data_out.size());
         KRATOS_CHECK(data_in.size() == data_out.size());
@@ -165,7 +166,7 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_FileSerial_ReadDataSet8, KratosHDF5TestSuite)
         HDF5::File::Vector<int> data_in;
         KRATOS_CHECK_EXCEPTION_IS_THROWN(
             test_file.ReadDataSet("/data", data_in, 0, data_out.size());
-            , "Data type is not int: /data");
+            , "Wrong scalar data type: /data");
         KRATOS_CHECK(test_file.GetOpenObjectsCount() == 1); // Check for leaks.
     }
     H5close(); // Clean HDF5 for next unit test.
@@ -249,7 +250,7 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_FileSerial_ReadDataSet13, KratosHDF5TestSuite)
         HDF5::File::Matrix<int> data_in;
         KRATOS_CHECK_EXCEPTION_IS_THROWN(
             test_file.ReadDataSet("/data", data_in, 0, data_out.size1());
-            , "Data type is not int: /data");
+            , "Wrong scalar data type: /data");
         KRATOS_CHECK(test_file.GetOpenObjectsCount() == 1); // Check for leaks.
     }
     H5close(); // Clean HDF5 for next unit test.
@@ -269,6 +270,54 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_FileSerial_ReadDataSet14, KratosHDF5TestSuite)
             test_file.ReadDataSet("/data", data_in, 10, 3);
             , "StartIndex (10) + BlockSize (3) > size of data set (3).");
         KRATOS_CHECK(test_file.GetOpenObjectsCount() == 1); // Check for leaks.
+    }
+    H5close(); // Clean HDF5 for next unit test.
+    KRATOS_CATCH_WITH_BLOCK("", H5close(););
+}
+
+KRATOS_TEST_CASE_IN_SUITE(HDF5_FileSerial_ReadDataSet15, KratosHDF5TestSuite)
+{
+    KRATOS_TRY;
+    {
+        auto test_file = GetTestSerialFile();
+        HDF5::File::Vector<double> data_out1 = TestVector<double>(3);
+        HDF5::File::Vector<double> data_out2 = TestVector<double>(4);
+        HDF5::WriteInfo info;
+        test_file.WriteDataSet("/data", data_out1, info);
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(test_file.WriteDataSet("/data", data_out2, info);
+                                         , "Wrong dimensions: /data");
+    }
+    H5close(); // Clean HDF5 for next unit test.
+    KRATOS_CATCH_WITH_BLOCK("", H5close(););
+}
+
+KRATOS_TEST_CASE_IN_SUITE(HDF5_FileSerial_ReadDataSet16, KratosHDF5TestSuite)
+{
+    KRATOS_TRY;
+    {
+        auto test_file = GetTestSerialFile();
+        HDF5::File::Vector<double> data_out1 = TestVector<double>(3);
+        HDF5::File::Vector<int> data_out2 = TestVector<int>(3);
+        HDF5::WriteInfo info;
+        test_file.WriteDataSet("/data", data_out1, info);
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(test_file.WriteDataSet("/data", data_out2, info);
+                                         , "Wrong scalar data type: /data");
+    }
+    H5close(); // Clean HDF5 for next unit test.
+    KRATOS_CATCH_WITH_BLOCK("", H5close(););
+}
+
+KRATOS_TEST_CASE_IN_SUITE(HDF5_FileSerial_ReadDataSet17, KratosHDF5TestSuite)
+{
+    KRATOS_TRY;
+    {
+        auto test_file = GetTestSerialFile();
+        HDF5::File::Vector<double> data_out1 = TestVector<double>(3);
+        HDF5::File::Vector<array_1d<double, 3>> data_out2 = TestVector<array_1d<double, 3>>(3);
+        HDF5::WriteInfo info;
+        test_file.WriteDataSet("/data", data_out1, info);
+        KRATOS_CHECK_EXCEPTION_IS_THROWN(test_file.WriteDataSet("/data", data_out2, info);
+                                         , "Wrong dimensions: /data");
     }
     H5close(); // Clean HDF5 for next unit test.
     KRATOS_CATCH_WITH_BLOCK("", H5close(););

--- a/applications/HDF5Application/tests/test_utils.cpp
+++ b/applications/HDF5Application/tests/test_utils.cpp
@@ -206,6 +206,10 @@ std::size_t TestModelPartFactory::AddElements(std::string const& rElement, std::
     const auto& r_elem = KratosComponents<Element>::Get(rElement);
     std::vector<ModelPart::IndexType> node_ids(r_elem.GetGeometry().size());
     std::size_t start_index = (mrTestModelPart.NumberOfElements() > 0) ? mrTestModelPart.Elements().back().Id() : 0;
+    if (!mrTestModelPart.HasProperties(1))
+    {
+        mrTestModelPart.CreateNewProperties(1);
+    }
     for (std::size_t i = 0; i < NumElems; ++i)
     {
         for (std::size_t j = 0; j < r_elem.GetGeometry().size(); ++j)
@@ -220,6 +224,10 @@ std::size_t TestModelPartFactory::AddConditions(std::string const& rCondition, s
     const auto& r_cond = KratosComponents<Condition>::Get(rCondition);
     std::vector<ModelPart::IndexType> node_ids(r_cond.GetGeometry().size());
     std::size_t start_index = (mrTestModelPart.NumberOfConditions() > 0) ? mrTestModelPart.Conditions().back().Id() : 0;
+    if (!mrTestModelPart.HasProperties(1))
+    {
+        mrTestModelPart.CreateNewProperties(1);
+    }
     for (std::size_t i = 0; i < NumConds; ++i)
     {
         for (std::size_t j = 0; j < r_cond.GetGeometry().size(); ++j)


### PR DESCRIPTION
This PR includes:
- the ability to overwrite an existing data set in hdf5 in serial (previously an error was thrown)
- the initial coordinates are now written to hdf5 instead of the current
- a mesh move operation is added to the core process factory so that the current configuration can be immediately updated after reading the initial coordinates and displacements
- a user-defined process is added to provide a more powerful and flexible way to construct hdf5 input/output processes (it simply passes the json to the hdf5 core module)
- refactoring to simplify some implementation details