### PR TITLE
feat(core): added truediv for python vector

### DIFF
--- a/kratos/python/add_vector_to_python.cpp
+++ b/kratos/python/add_vector_to_python.cpp
@@ -55,6 +55,7 @@ namespace Python
 //         binder.def("__sub__", [](TVectorType vec1, const double scalar){for(unsigned int i=0; i<vec1.size(); ++i) vec1[i]-=scalar; return vec1;}, py::is_operator());
          binder.def("__mul__", [](TVectorType vec1, const double scalar){for(unsigned int i=0; i<vec1.size(); ++i) vec1[i]*=scalar; return vec1;}, py::is_operator());
          binder.def("__div__", [](TVectorType vec1, const double scalar){for(unsigned int i=0; i<vec1.size(); ++i) vec1[i]/=scalar; return vec1;}, py::is_operator());
+         binder.def("__truediv__", [](TVectorType vec1, const double scalar){for(unsigned int i=0; i<vec1.size(); ++i) vec1[i]/=scalar; return vec1;}, py::is_operator());
 //         binder.def("__radd__", [](TVectorType vec1, const double scalar){for(unsigned int i=0; i<vec1.size(); ++i) vec1[i]+=scalar; return vec1;}, py::is_operator());
 //         binder.def("__rsub__", [](TVectorType vec1, const double scalar){for(unsigned int i=0; i<vec1.size(); ++i) vec1[i]-=scalar; return vec1;}, py::is_operator());
          binder.def("__rmul__", [](TVectorType vec1, const double scalar){for(unsigned int i=0; i<vec1.size(); ++i) vec1[i]*=scalar; return vec1;}, py::is_operator());

--- a/kratos/tests/test_vector_interface.py
+++ b/kratos/tests/test_vector_interface.py
@@ -153,6 +153,18 @@ class TestVectorInterface(KratosUnittest.TestCase):
         self.assertEqual(6.0,a.norm_1())
         self.assertEqual(math.sqrt(14.0),a.norm_2())
 
+    def test_truediv(self):
+        a = Vector(3)
+        a[0] = 1.0
+        a[1] = 2.0
+        a[2] = 3.0
+        b = a / 3.
+        self.assertEqual(a[0], 1.0)
+        self.assertEqual(a[1], 2.0)
+        self.assertEqual(a[2], 3.0)
+        self.assertAlmostEqual(b[0], 1.0 / 3.0)
+        self.assertAlmostEqual(b[1], 2.0 / 3.0)
+        self.assertAlmostEqual(b[2], 3.0 / 3.0)
 
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
This PR adds __truediv__ to Vector in python. It allows the following:
```
v = KratosMultiphysics.Vector(3)
...
w = v / 2 # divides each element by 2.
```
This functionality was needed in #4668.
