### PR TITLE
fix(HDF5): allow reading and writing a model part with empty properties

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_properties_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_properties_io.cpp
@@ -17,8 +17,10 @@ void ReadProperties(File& rFile, std::string const& rPrefix, PropertiesContainer
     KRATOS_TRY;
 
     Vector<int> prop_ids;
-    rFile.ReadAttribute(rPrefix + "/Properties", "Ids", prop_ids);
-
+    if (rFile.HasAttribute(rPrefix + "/Properties", "Ids"))
+    {
+        rFile.ReadAttribute(rPrefix + "/Properties", "Ids", prop_ids);
+    }
     for (auto pid : prop_ids)
     {
         std::stringstream pstream;
@@ -59,7 +61,10 @@ void WriteProperties(File& rFile, std::string const& rPrefix, PropertiesContaine
         WriteProperties(rFile, rPrefix, r_properties);
     }
     rFile.AddPath(rPrefix + "/Properties");
-    rFile.WriteAttribute(rPrefix + "/Properties", "Ids", prop_ids);
+    if (rProperties.size() > 0) // H5Awrite fails for empty container (sub model parts)
+    {
+        rFile.WriteAttribute(rPrefix + "/Properties", "Ids", prop_ids);
+    }
 
     KRATOS_CATCH("");
 }

--- a/applications/HDF5Application/tests/test_hdf5_model_part_io.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_model_part_io.cpp
@@ -129,7 +129,7 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_ModelPartIO_ReadConditions3, KratosHDF5TestSuite)
     model_part_io.ReadConditions(r_read_model_part.Nodes(), r_read_model_part.rProperties(), r_read_model_part.Conditions());
 }
 
-KRATOS_TEST_CASE_IN_SUITE(HDF5_ModelPartIO_Properties, KratosHDF5TestSuite)
+KRATOS_TEST_CASE_IN_SUITE(HDF5_ModelPartIO_Properties1, KratosHDF5TestSuite)
 {
     Model this_model;
     ModelPart& r_write_model_part = this_model.CreateModelPart("test_write");
@@ -152,6 +152,22 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_ModelPartIO_Properties, KratosHDF5TestSuite)
                                r_write_properties[3].Data());
     CompareDataValueContainers(r_read_properties[4].Data(),
                                r_write_properties[4].Data());
+}
+
+KRATOS_TEST_CASE_IN_SUITE(HDF5_ModelPartIO_Properties2, KratosHDF5TestSuite)
+{
+    KRATOS_TRY;
+    Model this_model;
+    ModelPart& r_write_model_part = this_model.CreateModelPart("test_write");
+    HDF5::PropertiesContainerType& r_write_properties = r_write_model_part.rProperties();
+    HDF5::ModelPartIO model_part_io(pGetTestSerialFile(), "/Step");
+    model_part_io.WriteProperties(r_write_properties); // write empty properties container
+    ModelPart& r_read_model_part = this_model.CreateModelPart("test_read");
+    HDF5::PropertiesContainerType& r_read_properties = r_read_model_part.rProperties();
+    model_part_io.ReadProperties(r_read_properties); // read empty properties container
+    KRATOS_CHECK(r_write_model_part.NumberOfProperties() == 0);
+    KRATOS_CHECK(r_read_model_part.NumberOfProperties() == 0);
+    KRATOS_CATCH_WITH_BLOCK("", H5close();); // prevent failure from propagating to subsequent tests
 }
 
 KRATOS_TEST_CASE_IN_SUITE(HDF5_ModelPartIO_ReadModelPart1, KratosHDF5TestSuite)


### PR DESCRIPTION
HDF5Awrite() fails to write properties ids when the container is empty. This
happens for sub model parts. This issue is resolved by only writing the
properties ids when the container is non-empty and only reading if the attribute
exists.