### PR TITLE
feat(HDF5): added method for deleting attributes

### DIFF
--- a/applications/HDF5Application/custom_io/hdf5_file.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_file.cpp
@@ -243,8 +243,16 @@ bool File::HasAttribute(const std::string& rObjectPath, const std::string& rName
     KRATOS_TRY;
     htri_t status =
         H5Aexists_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(), H5P_DEFAULT);
-    KRATOS_ERROR_IF(status < 0) << "H5Aexists_by_name failed" << std::endl;
+    KRATOS_ERROR_IF(status < 0) << "H5Aexists_by_name failed." << std::endl;
     return (status > 0);
+    KRATOS_CATCH("");
+}
+
+void File::DeleteAttribute(const std::string& rObjectPath, const std::string& rName)
+{
+    KRATOS_TRY;
+    KRATOS_ERROR_IF(H5Adelete_by_name(m_file_id, rObjectPath.c_str(), rName.c_str(), H5P_DEFAULT) < 0)
+        << "H5Adelete_by_name failed.";
     KRATOS_CATCH("");
 }
 
@@ -357,7 +365,10 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_TRY;
     BuiltinTimer timer;
     hid_t type_id, space_id, attr_id;
-
+    if (HasAttribute(rObjectPath, rName))
+    {
+        DeleteAttribute(rObjectPath, rName);
+    }
     type_id = Internals::GetScalarDataType(Value);
     space_id = H5Screate(H5S_SCALAR);
     KRATOS_ERROR_IF(space_id < 0) << "H5Screate failed." << std::endl;
@@ -379,7 +390,10 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_TRY;
     BuiltinTimer timer;
     hid_t type_id, space_id, attr_id;
-
+    if (HasAttribute(rObjectPath, rName))
+    {
+        DeleteAttribute(rObjectPath, rName);
+    }
     type_id = Internals::GetScalarDataType(rValue);
     const hsize_t dim = rValue.size();
     space_id = H5Screate_simple(1, &dim, nullptr);
@@ -402,7 +416,10 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_TRY;
     BuiltinTimer timer;
     hid_t type_id, space_id, attr_id;
-
+    if (HasAttribute(rObjectPath, rName))
+    {
+        DeleteAttribute(rObjectPath, rName);
+    }
     type_id = Internals::GetScalarDataType(rValue);
     const std::array<hsize_t, 2> dims = {rValue.size1(), rValue.size2()};
     space_id = H5Screate_simple(dims.size(), dims.data(), nullptr);
@@ -424,7 +441,10 @@ void File::WriteAttribute(const std::string& rObjectPath, const std::string& rNa
     KRATOS_TRY;
     BuiltinTimer timer;
     hid_t type_id, space_id, attr_id;
-
+    if (HasAttribute(rObjectPath, rName))
+    {
+        DeleteAttribute(rObjectPath, rName);
+    }
     type_id = H5T_NATIVE_CHAR;
     const std::array<hsize_t, 1> dims = {rValue.size()};
     space_id = H5Screate_simple(dims.size(), dims.data(), nullptr);

--- a/applications/HDF5Application/custom_io/hdf5_file.h
+++ b/applications/HDF5Application/custom_io/hdf5_file.h
@@ -97,6 +97,8 @@ public:
 
     bool HasAttribute(const std::string& rObjectPath, const std::string& rName) const;
 
+    void DeleteAttribute(const std::string& rObjectPath, const std::string& rName);
+
     std::vector<std::string> GetAttributeNames(const std::string& rObjectPath) const;
 
     void CreateGroup(const std::string& rPath);

--- a/applications/HDF5Application/tests/test_hdf5_file.cpp
+++ b/applications/HDF5Application/tests/test_hdf5_file.cpp
@@ -530,7 +530,7 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_File_WriteAttribute2, KratosHDF5TestSuite)
         const int attr = 1;
         KRATOS_CHECK_EXCEPTION_IS_THROWN(
             test_file.WriteAttribute("/foo", "ATTRIBUTE", attr);
-            , "H5Acreate_by_name failed.");
+            , "H5Aexists_by_name failed.");
         KRATOS_CHECK(test_file.GetOpenObjectsCount() == 1); // Check for leaks.
     }
     H5close(); // Clean HDF5 for next unit test.
@@ -543,12 +543,30 @@ KRATOS_TEST_CASE_IN_SUITE(HDF5_File_WriteAttribute3, KratosHDF5TestSuite)
     {
         H5_stderr_muter muter;
         auto test_file = GetTestFile();
+        const double double_attr = 1.0;
+        test_file.CreateGroup("/foo");
+        test_file.WriteAttribute("/foo", "ATTRIBUTE", double_attr);
+        const HDF5::Matrix<int> mat_int_attr = TestMatrix<int>();
+        test_file.WriteAttribute("/foo", "ATTRIBUTE", mat_int_attr);
+        KRATOS_CHECK(test_file.GetOpenObjectsCount() == 1); // Check for leaks.
+    }
+    H5close(); // Clean HDF5 for next unit test.
+    KRATOS_CATCH_WITH_BLOCK("", H5close(););
+}
+
+KRATOS_TEST_CASE_IN_SUITE(HDF5_File_DeleteAttribute1, KratosHDF5TestSuite)
+{
+    KRATOS_TRY;
+    {
+        H5_stderr_muter muter;
+        auto test_file = GetTestFile();
         const double attr = 1.0;
         test_file.CreateGroup("/foo");
         test_file.WriteAttribute("/foo", "ATTRIBUTE", attr);
+        test_file.DeleteAttribute("/foo", "ATTRIBUTE");
         KRATOS_CHECK_EXCEPTION_IS_THROWN(
-            test_file.WriteAttribute("/foo", "ATTRIBUTE", attr);
-            , "H5Acreate_by_name failed.");
+            test_file.DeleteAttribute("/foo", "ATTRIBUTE");
+            , "H5Adelete_by_name failed.");
         KRATOS_CHECK(test_file.GetOpenObjectsCount() == 1); // Check for leaks.
     }
     H5close(); // Clean HDF5 for next unit test.


### PR DESCRIPTION
The new method allow to delete an existing attribute in an hdf5 file. The
methods for writing attributes are also modified to use the new delete method,
which allows existing attributes to be overwritten.