### PR TITLE
feat(StructuralMechanics): added total lagrangian elements to adjoint solver

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_solid_element.cpp
@@ -140,6 +140,14 @@ Element::Pointer AdjointSolidElement<TPrimalElement>::Create(IndexType NewId,
 }
 
 template <class TPrimalElement>
+Element::Pointer AdjointSolidElement<TPrimalElement>::Create(IndexType NewId,
+                                                             GeometryType::Pointer pGeom,
+                                                             PropertiesType::Pointer pProperties) const
+{
+    return Kratos::make_shared<AdjointSolidElement<TPrimalElement>>(NewId, pGeom, pProperties);
+}
+
+template <class TPrimalElement>
 void AdjointSolidElement<TPrimalElement>::Initialize()
 {
     KRATOS_TRY;
@@ -312,7 +320,7 @@ int AdjointSolidElement<TPrimalElement>::Check(const ProcessInfo& rCurrentProces
         KRATOS_CHECK_DOF_IN_NODE(ADJOINT_DISPLACEMENT_Y, r_node);
         KRATOS_CHECK_DOF_IN_NODE(ADJOINT_DISPLACEMENT_Z, r_node);
     }
-    return mPrimalElement.Check(rCurrentProcessInfo);
+    return 0;
     KRATOS_CATCH("");
 }
 

--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_solid_element.h
@@ -87,6 +87,10 @@ public:
                             NodesArrayType const& ThisNodes,
                             PropertiesType::Pointer pProperties) const override;
 
+    Element::Pointer Create(IndexType NewId,
+                            GeometryType::Pointer pGeom,
+                            PropertiesType::Pointer pProperties) const override;
+
     void Initialize() override;
 
     void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
@@ -51,7 +51,12 @@ class StructuralMechanicsAdjointStaticSolver(MechanicalSolver):
                     "ShellThinElement3D3N"           : "AdjointFiniteDifferencingShellThinElement3D3N",
                     "CrLinearBeamElement3D2N"        : "AdjointFiniteDifferenceCrBeamElementLinear3D2N",
                     "TrussLinearElement3D2N"         : "AdjointFiniteDifferenceTrussLinearElement3D2N",
-                    "TrussElement3D2N"               : "AdjointFiniteDifferenceTrussElement3D2N"
+                    "TrussElement3D2N"               : "AdjointFiniteDifferenceTrussElement3D2N",
+                    "TotalLagrangianElement2D3N"     : "TotalLagrangianAdjointElement2D3N",
+                    "TotalLagrangianElement2D4N"     : "TotalLagrangianAdjointElement2D4N",
+                    "TotalLagrangianElement2D6N"     : "TotalLagrangianAdjointElement2D6N",
+                    "TotalLagrangianElement3D4N"     : "TotalLagrangianAdjointElement3D4N",
+                    "TotalLagrangianElement3D8N"     : "TotalLagrangianAdjointElement3D8N"
                 },
                 "condition_name_table" :
                 {


### PR DESCRIPTION
The changes add total lagrangian adjoint elements to the list of available
adjoint elements in the structural_mechanics_adjoint_static_solver. The elements
are already tested in the cpp unit tests. In order to interface with the
replacement process, the second Create() method needed to be added to the adjoint
element. Also, to avoid checking for primal dofs, the Check() method was
modified.