### PR TITLE
[Core] enhance geometrical projection utilities

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
@@ -27,6 +27,9 @@ using NodeType = Node<3>;
 using GeometryNodeType = Geometry<NodeType>;
 using GeometryPointType = Geometry<Point>;
 
+namespace
+{
+
 GeometryNodeType::Pointer CreateTriangle2D3NForTestNode()
 {
     GeometryNodeType::PointsArrayType points;
@@ -47,11 +50,10 @@ GeometryPointType::Pointer CreateTriangle2D3NForTestPoint()
     return GeometryPointType::Pointer(new Triangle3D3<Point>(points));
 }
 
-KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionNode, KratosCoreFastSuite)
+template<class TGeometryType>
+void TestFastProjectDirection(const TGeometryType& rGeom)
 {
-    GeometryNodeType::Pointer p_geom = CreateTriangle2D3NForTestNode();
-
-    double expected_proj_dist = 1.258;
+    const double expected_proj_dist = 1.258;
 
     const double x_coord = 0.325;
     const double y_coord = 0.147;
@@ -72,7 +74,7 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionNode
     Point projected_point;
 
     double proj_distance = GeometricalProjectionUtilities::FastProjectDirection(
-        *p_geom,
+        rGeom,
         point_to_proj,
         projected_point,
         normal_vector,
@@ -84,41 +86,20 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionNode
     KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Z(), 0.0);
 }
 
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionNode, KratosCoreFastSuite)
+{
+    GeometryNodeType::Pointer p_geom = CreateTriangle2D3NForTestNode();
+
+    TestFastProjectDirection(*p_geom);
+}
+
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionPoint, KratosCoreFastSuite)
 {
     GeometryPointType::Pointer p_geom = CreateTriangle2D3NForTestPoint();
 
-    double expected_proj_dist = 1.258;
-
-    const double x_coord = 0.325;
-    const double y_coord = 0.147;
-
-    const Point point_to_proj(x_coord, y_coord, expected_proj_dist);
-
-    array_1d<double,3> dir_vector;
-    array_1d<double,3> normal_vector;
-
-    dir_vector[0] = 0.0;
-    dir_vector[1] = 0.0;
-    dir_vector[2] = -1.0;
-
-    normal_vector[0] = 0.0;
-    normal_vector[1] = 0.0;
-    normal_vector[2] = 1.0;
-
-    Point projected_point;
-
-    double proj_distance = GeometricalProjectionUtilities::FastProjectDirection(
-        *p_geom,
-        point_to_proj,
-        projected_point,
-        normal_vector,
-        dir_vector);
-
-    KRATOS_CHECK_DOUBLE_EQUAL(expected_proj_dist, proj_distance);
-    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.X(), x_coord);
-    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Y(), y_coord);
-    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Z(), 0.0);
+    TestFastProjectDirection(*p_geom);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProject, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
@@ -23,8 +23,8 @@ namespace Kratos
 namespace Testing
 {
 
-using NodeType = typename GeometricalProjectionUtilities::NodeType;
-using GeometryType = typename GeometricalProjectionUtilities::GeometryType;
+using NodeType = Node<3>;
+using GeometryType = Geometry<NodeType>;
 
 GeometryType::Pointer CreateTriangle2D3NForTest()
 {

--- a/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
@@ -24,21 +24,69 @@ namespace Testing
 {
 
 using NodeType = Node<3>;
-using GeometryType = Geometry<NodeType>;
+using GeometryNodeType = Geometry<NodeType>;
+using GeometryPointType = Geometry<Point>;
 
-GeometryType::Pointer CreateTriangle2D3NForTest()
+GeometryNodeType::Pointer CreateTriangle2D3NForTestNode()
 {
-    GeometryType::PointsArrayType points;
+    GeometryNodeType::PointsArrayType points;
     points.push_back(Kratos::make_shared<NodeType>(1,0.04, 0.02, 0.0));
     points.push_back(Kratos::make_shared<NodeType>(2,1.1, 0.03, 0.0));
     points.push_back(Kratos::make_shared<NodeType>(3,1.08, 1.0, 0.0));
 
-    return GeometryType::Pointer(new Triangle3D3<NodeType>(points));
+    return GeometryNodeType::Pointer(new Triangle3D3<NodeType>(points));
 }
 
-KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirection, KratosCoreFastSuite)
+GeometryPointType::Pointer CreateTriangle2D3NForTestPoint()
 {
-    GeometryType::Pointer p_geom = CreateTriangle2D3NForTest();
+    GeometryPointType::PointsArrayType points;
+    points.push_back(Kratos::make_shared<Point>(0.04, 0.02, 0.0));
+    points.push_back(Kratos::make_shared<Point>(1.1, 0.03, 0.0));
+    points.push_back(Kratos::make_shared<Point>(1.08, 1.0, 0.0));
+
+    return GeometryPointType::Pointer(new Triangle3D3<Point>(points));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionNode, KratosCoreFastSuite)
+{
+    GeometryNodeType::Pointer p_geom = CreateTriangle2D3NForTestNode();
+
+    double expected_proj_dist = 1.258;
+
+    const double x_coord = 0.325;
+    const double y_coord = 0.147;
+
+    const Point point_to_proj(x_coord, y_coord, expected_proj_dist);
+
+    array_1d<double,3> dir_vector;
+    array_1d<double,3> normal_vector;
+
+    dir_vector[0] = 0.0;
+    dir_vector[1] = 0.0;
+    dir_vector[2] = -1.0;
+
+    normal_vector[0] = 0.0;
+    normal_vector[1] = 0.0;
+    normal_vector[2] = 1.0;
+
+    Point projected_point;
+
+    double proj_distance = GeometricalProjectionUtilities::FastProjectDirection(
+        *p_geom,
+        point_to_proj,
+        projected_point,
+        normal_vector,
+        dir_vector);
+
+    KRATOS_CHECK_DOUBLE_EQUAL(expected_proj_dist, proj_distance);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.X(), x_coord);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Y(), y_coord);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Z(), 0.0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionPoint, KratosCoreFastSuite)
+{
+    GeometryPointType::Pointer p_geom = CreateTriangle2D3NForTestPoint();
 
     double expected_proj_dist = 1.258;
 

--- a/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
@@ -86,6 +86,33 @@ void TestFastProjectDirection(const TGeometryType& rGeom)
     KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Z(), 0.0);
 }
 
+template<class TGeometryType>
+void TestProjectOnGeometry(TGeometryType& rGeom)
+{
+    const double expected_proj_dist = 1.258;
+
+    const double x_coord = 0.325;
+    const double y_coord = 0.147;
+
+    const Point point_to_proj(x_coord, y_coord, expected_proj_dist);
+
+    array_1d<double,3> projection_local_coords;
+
+    double proj_distance;
+
+    const bool is_inside = GeometricalProjectionUtilities::ProjectOnGeometry(
+        rGeom,
+        point_to_proj,
+        projection_local_coords,
+        proj_distance);
+
+    KRATOS_CHECK(is_inside);
+    KRATOS_CHECK_DOUBLE_EQUAL(expected_proj_dist, proj_distance);
+    KRATOS_CHECK_DOUBLE_EQUAL(projection_local_coords[0], 0.14315441462465977596);
+    KRATOS_CHECK_DOUBLE_EQUAL(projection_local_coords[1], 0.12813107740178911187);
+    KRATOS_CHECK_DOUBLE_EQUAL(projection_local_coords[2], 0.0);
+}
+
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionNode, KratosCoreFastSuite)
@@ -100,6 +127,20 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionPoin
     GeometryPointType::Pointer p_geom = CreateTriangle2D3NForTestPoint();
 
     TestFastProjectDirection(*p_geom);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesProjectOnGeometryNode, KratosCoreFastSuite)
+{
+    GeometryNodeType::Pointer p_geom = CreateTriangle2D3NForTestNode();
+
+    TestProjectOnGeometry(*p_geom);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesProjectOnGeometryPoint, KratosCoreFastSuite)
+{
+    GeometryPointType::Pointer p_geom = CreateTriangle2D3NForTestPoint();
+
+    TestProjectOnGeometry(*p_geom);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProject, KratosCoreFastSuite)

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -102,6 +102,7 @@ public:
 
     /**
      * @brief Project a point over a line/plane following an arbitrary direction
+     * @tparam TGeometryType The type of the geometry
      * @param rGeom The geometry where to be projected
      * @param rPointDestiny The point to be projected
      * @param rPointProjected The point pojected over the plane
@@ -110,8 +111,9 @@ public:
      * @param EchoLevel If we want debugging info we should consider greater than 0
      * @return Distance The distance between surfaces
      */
+    template<class TGeometryType>
     static inline double FastProjectDirection(
-        const GeometryType& rGeom,
+        const TGeometryType& rGeom,
         const PointType& rPointDestiny,
         PointType& rPointProjected,
         const array_1d<double,3>& rNormal,
@@ -173,13 +175,15 @@ public:
 
     /**
      * @brief Projects iteratively to get the coordinate
+     * @tparam TGeometryType The type of the geometry
      * @param rGeomOrigin The origin geometry
      * @param rPointDestiny The destination point
      * @param rResultingPoint The distance between the point and the plane
      * @return Inside True is inside, false not
      */
+    template<class TGeometryType>
     static inline bool ProjectIterativeLine2D(
-        GeometryType& rGeomOrigin,
+        TGeometryType& rGeomOrigin,
         const GeometryType::CoordinatesArrayType& rPointDestiny,
         GeometryType::CoordinatesArrayType& rResultingPoint,
         const array_1d<double, 3>& rNormal,

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -8,6 +8,7 @@
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
+//                   Philipp Bucher
 //
 
 #if !defined(KRATOS_GEOMETRICAL_PROJECTION_UTILITIES)
@@ -99,7 +100,7 @@ public:
      * @brief Project a point over a line/plane following an arbitrary direction
      * @tparam TGeometryType The type of the geometry
      * @param rGeom The geometry where to be projected
-     * @param rPointDestiny The point to be projected
+     * @param rPointToProject The point to be projected
      * @param rPointProjected The point pojected over the plane
      * @param rNormal The normal of the geometry
      * @param rVector The direction to project
@@ -109,7 +110,7 @@ public:
     template<class TGeometryType>
     static inline double FastProjectDirection(
         const TGeometryType& rGeom,
-        const PointType& rPointDestiny,
+        const PointType& rPointToProject,
         PointType& rPointProjected,
         const array_1d<double,3>& rNormal,
         const array_1d<double,3>& rVector,
@@ -122,17 +123,17 @@ public:
         // We define the distance
         double distance = 0.0;
 
-        const array_1d<double,3> vector_points = rGeom[0].Coordinates() - rPointDestiny.Coordinates();
+        const array_1d<double,3> vector_points = rGeom[0].Coordinates() - rPointToProject.Coordinates();
 
         if( norm_2( rVector ) < zero_tolerance && norm_2( rNormal ) > zero_tolerance ) {
             distance = inner_prod(vector_points, rNormal)/norm_2(rNormal);
-            noalias(rPointProjected.Coordinates()) = rPointDestiny.Coordinates() + rVector * distance;
+            noalias(rPointProjected.Coordinates()) = rPointToProject.Coordinates() + rVector * distance;
             KRATOS_WARNING_IF("GeometricalProjectionUtilities", EchoLevel > 0) << "WARNING:: Zero projection vector. Projection using the condition vector instead." << std::endl;
         } else if (std::abs(inner_prod(rVector, rNormal) ) > zero_tolerance) {
             distance = inner_prod(vector_points, rNormal)/inner_prod(rVector, rNormal);
-            noalias(rPointProjected.Coordinates()) = rPointDestiny.Coordinates() + rVector * distance;
+            noalias(rPointProjected.Coordinates()) = rPointToProject.Coordinates() + rVector * distance;
         } else {
-            noalias(rPointProjected.Coordinates()) = rPointDestiny.Coordinates();
+            noalias(rPointProjected.Coordinates()) = rPointToProject.Coordinates();
             KRATOS_WARNING_IF("GeometricalProjectionUtilities", EchoLevel > 0) << "WARNING:: The line and the plane are coplanar. Something wrong happened " << std::endl;
         }
 
@@ -142,27 +143,27 @@ public:
     /**
      * @brief Project a point over a plane (avoiding some steps)
      * @param rPointOrigin A point in the plane
-     * @param rPointDestiny The point to be projected
+     * @param rPointToProject The point to be projected
      * @param rNormal The normal of the plane
      * @param rDistance The distance to the projection
      * @return PointProjected The point pojected over the plane
      */
     static inline PointType FastProject(
         const PointType& rPointOrigin,
-        const PointType& rPointDestiny,
+        const PointType& rPointToProject,
         const array_1d<double,3>& rNormal,
         double& rDistance
         )
     {
-        const array_1d<double,3> vector_points = rPointDestiny.Coordinates() - rPointOrigin.Coordinates();
+        const array_1d<double,3> vector_points = rPointToProject.Coordinates() - rPointOrigin.Coordinates();
 
         rDistance = inner_prod(vector_points, rNormal);
 
         PointType point_projected;
     #ifdef KRATOS_USE_AMATRIX   // This macro definition is for the migration period and to be removed afterward please do not use it
-        point_projected.Coordinates() = rPointDestiny.Coordinates() - rNormal * rDistance;
+        point_projected.Coordinates() = rPointToProject.Coordinates() - rNormal * rDistance;
     #else
-        noalias(point_projected.Coordinates()) = rPointDestiny.Coordinates() - rNormal * rDistance;
+        noalias(point_projected.Coordinates()) = rPointToProject.Coordinates() - rNormal * rDistance;
     #endif // ifdef KRATOS_USE_AMATRIX
 
         return point_projected;
@@ -172,13 +173,13 @@ public:
      * @brief Project a point over a line/plane (simplified since using the normal in the center)
      * @tparam TGeometryType The type of the geometry
      * @param rGeom The geometry where to be projected
-     * @param rPointDestiny The point to be projected
+     * @param rPointToProject The point to be projected
      * @param rLocalCoords The local coordinates of the projection
      * @return Inside True is inside, false not
      */
     template<class TGeometryType>
     bool ProjectOnGeometry(TGeometryType& rGeom,
-                           const Point& rPointDestiny,
+                           const Point& rPointToProject,
                            array_1d<double,3>& rLocalCoords,
                            double& rDistance)
     {
@@ -192,7 +193,7 @@ public:
         // trying to project to the geometry
         rDistance = std::abs(FastProjectDirection(
             rGeom,
-            rPointDestiny,
+            rPointToProject,
             projected_point,
             rGeom.UnitNormal(local_coords_init),
             rGeom.UnitNormal(local_coords_init)));

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -64,11 +64,6 @@ public:
     // Some geometrical definitions
     typedef Node<3>                                              NodeType;
     typedef Point                                               PointType;
-    typedef PointType::CoordinatesArrayType          CoordinatesArrayType;
-
-    /// Definition of geometries
-    typedef Geometry<NodeType>                               GeometryType;
-    typedef Geometry<PointType>                         GeometryPointType;
 
     /// Index type definition
     typedef std::size_t                                         IndexType;
@@ -184,8 +179,8 @@ public:
     template<class TGeometryType>
     static inline bool ProjectIterativeLine2D(
         TGeometryType& rGeomOrigin,
-        const GeometryType::CoordinatesArrayType& rPointDestiny,
-        GeometryType::CoordinatesArrayType& rResultingPoint,
+        const array_1d<double,3>& rPointDestiny,
+        array_1d<double,3>& rResultingPoint,
         const array_1d<double, 3>& rNormal,
         const double Tolerance = 1.0e-8,
         double DeltaXi = 0.5

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -76,6 +76,8 @@ public:
     ///@name Life Cycle
     ///@{
 
+    GeometricalProjectionUtilities() = delete;
+
     ///@}
     ///@name Access
     ///@{

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -183,20 +183,20 @@ public:
                            array_1d<double,3>& rLocalCoords,
                            double& rDistance)
     {
-        array_1d<double,3> local_coords_init;
-
         Point projected_point;
 
-        // using the center as trial for the projection
-        rGeom.PointLocalCoordinates(local_coords_init, rGeom.Center());
+        // using the normal in the center as trial for the projection
+        array_1d<double,3> local_coords_center;
+        rGeom.PointLocalCoordinates(local_coords_center, rGeom.Center());
+        const array_1d<double,3> normal = rGeom.UnitNormal(local_coords_center);
 
         // trying to project to the geometry
         rDistance = std::abs(FastProjectDirection(
             rGeom,
             rPointToProject,
             projected_point,
-            rGeom.UnitNormal(local_coords_init),
-            rGeom.UnitNormal(local_coords_init)));
+            normal,
+            normal));
 
         bool is_inside = rGeom.IsInside(projected_point, rLocalCoords, 1E-14);
 

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -178,7 +178,7 @@ public:
      * @return Inside True is inside, false not
      */
     template<class TGeometryType>
-    bool ProjectOnGeometry(TGeometryType& rGeom,
+    static inline bool ProjectOnGeometry(TGeometryType& rGeom,
                            const Point& rPointToProject,
                            array_1d<double,3>& rLocalCoords,
                            double& rDistance)

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -26,22 +26,6 @@
 
 namespace Kratos
 {
-///@name Kratos Globals
-///@{
-
-///@}
-///@name Type Definitions
-///@{
-
-///@}
-///@name  Enum's
-///@{
-
-///@}
-///@name  Functions
-///@{
-
-///@}
 ///@name Kratos Classes
 ///@{
 
@@ -77,22 +61,6 @@ public:
     ///@{
 
     GeometricalProjectionUtilities() = delete;
-
-    ///@}
-    ///@name Access
-    ///@{
-
-    ///@}
-    ///@name Inquiry
-    ///@{
-
-    ///@}
-    ///@name Input and output
-    ///@{
-
-    ///@}
-    ///@name Friends
-    ///@{
 
     ///@}
     ///@name Operations
@@ -300,6 +268,8 @@ public:
 
 private:
 };// class GeometricalProjectionUtilities
+
+///@}
 
 }
 #endif /* KRATOS_GEOMETRICAL_PROJECTION_UTILITIES defined */

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -169,6 +169,40 @@ public:
     }
 
     /**
+     * @brief Project a point over a line/plane (simplified since using the normal in the center)
+     * @tparam TGeometryType The type of the geometry
+     * @param rGeom The geometry where to be projected
+     * @param rPointDestiny The point to be projected
+     * @param rLocalCoords The local coordinates of the projection
+     * @return Inside True is inside, false not
+     */
+    template<class TGeometryType>
+    bool ProjectOnGeometry(TGeometryType& rGeom,
+                           const Point& rPointDestiny,
+                           array_1d<double,3>& rLocalCoords,
+                           double& rDistance)
+    {
+        array_1d<double,3> local_coords_init;
+
+        Point projected_point;
+
+        // using the center as trial for the projection
+        rGeom.PointLocalCoordinates(local_coords_init, rGeom.Center());
+
+        // trying to project to the geometry
+        rDistance = std::abs(FastProjectDirection(
+            rGeom,
+            rPointDestiny,
+            projected_point,
+            rGeom.UnitNormal(local_coords_init),
+            rGeom.UnitNormal(local_coords_init)));
+
+        bool is_inside = rGeom.IsInside(projected_point, rLocalCoords, 1E-14);
+
+        return is_inside;
+    }
+
+    /**
      * @brief Projects iteratively to get the coordinate
      * @tparam TGeometryType The type of the geometry
      * @param rGeomOrigin The origin geometry

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -168,9 +168,7 @@ public:
             normal,
             normal));
 
-        bool is_inside = rGeom.IsInside(projected_point, rLocalCoords, 1E-14);
-
-        return is_inside;
+        return rGeom.IsInside(projected_point, rLocalCoords, 1E-14);
     }
 
     /**


### PR DESCRIPTION
this PR enhance and adds a new function to the `GeometricalProjectionUtilities`:
- All the things that were done are separated into different commits to make review easier
- The GeometryType is now templated => with this we can use geometries with `Node` or `Point` as template argument (in my case I want to use the Point-based geometry to minimize the memory-consumption)
- minor cleanup was done
- A new function was added for projecting, it is simplified because it uses the Normal in the center of the geometry and hence providing a simpler interface