### PR TITLE
[Core] generic project to line

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
@@ -148,11 +148,11 @@ void TestFastProjectOnGeometry(TGeometryType& rGeom)
 template<class TGeometryType>
 void TestFastProjectOnLine2D(TGeometryType& rGeom)
 {
-    const double expected_proj_dist = -1.258;
+    const double expected_proj_dist = 1.258;
 
     const double x_coord = 0.325;
 
-    const Point point_to_proj(x_coord, expected_proj_dist,0.0);
+    const Point point_to_proj(x_coord, expected_proj_dist, 0.0);
     Point projected_point;
 
     const double proj_distance = GeometricalProjectionUtilities::FastProjectOnLine(
@@ -178,11 +178,11 @@ void TestFastProjectOnLine3D(TGeometryType& rGeom)
         point_to_proj,
         projected_point);
 
-    const double expected_proj_dist = std::sqrt(171/14);
+    const double expected_proj_dist = std::sqrt(171.0/14.0);
 
-    const double expected_coord_x = 4/14;
-    const double expected_coord_y = 27/14;
-    const double expected_coord_z = -19/14;
+    const double expected_coord_x = 4.0/14.0;
+    const double expected_coord_y = 27.0/14.0;
+    const double expected_coord_z = -19.0/14.0;
 
     KRATOS_CHECK_DOUBLE_EQUAL(expected_proj_dist, proj_distance);
     KRATOS_CHECK_DOUBLE_EQUAL(projected_point.X(), expected_coord_x);

--- a/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
@@ -30,7 +30,7 @@ using GeometryPointType = Geometry<Point>;
 namespace
 {
 
-GeometryNodeType::Pointer CreateTriangle2D3NForTestNode()
+GeometryNodeType::Pointer CreateTriangle3D3NForTestNode()
 {
     GeometryNodeType::PointsArrayType points;
     points.push_back(Kratos::make_shared<NodeType>(1,0.04, 0.02, 0.0));
@@ -40,7 +40,7 @@ GeometryNodeType::Pointer CreateTriangle2D3NForTestNode()
     return GeometryNodeType::Pointer(new Triangle3D3<NodeType>(points));
 }
 
-GeometryPointType::Pointer CreateTriangle2D3NForTestPoint()
+GeometryPointType::Pointer CreateTriangle3D3NForTestPoint()
 {
     GeometryPointType::PointsArrayType points;
     points.push_back(Kratos::make_shared<Point>(0.04, 0.02, 0.0));
@@ -112,28 +112,28 @@ void TestFastProjectOnGeometry(TGeometryType& rGeom)
 
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionNode, KratosCoreFastSuite)
 {
-    GeometryNodeType::Pointer p_geom = CreateTriangle2D3NForTestNode();
+    GeometryNodeType::Pointer p_geom = CreateTriangle3D3NForTestNode();
 
     TestFastProjectDirection(*p_geom);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionPoint, KratosCoreFastSuite)
 {
-    GeometryPointType::Pointer p_geom = CreateTriangle2D3NForTestPoint();
+    GeometryPointType::Pointer p_geom = CreateTriangle3D3NForTestPoint();
 
     TestFastProjectDirection(*p_geom);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectOnGeometryNode, KratosCoreFastSuite)
 {
-    GeometryNodeType::Pointer p_geom = CreateTriangle2D3NForTestNode();
+    GeometryNodeType::Pointer p_geom = CreateTriangle3D3NForTestNode();
 
     TestFastProjectOnGeometry(*p_geom);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectOnGeometryPoint, KratosCoreFastSuite)
 {
-    GeometryPointType::Pointer p_geom = CreateTriangle2D3NForTestPoint();
+    GeometryPointType::Pointer p_geom = CreateTriangle3D3NForTestPoint();
 
     TestFastProjectOnGeometry(*p_geom);
 }

--- a/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometrical_projection_utilities.cpp
@@ -16,6 +16,7 @@
 #include "testing/testing.h"
 #include "utilities/geometrical_projection_utilities.h"
 
+#include "geometries/line_3d_2.h"
 #include "geometries/triangle_3d_3.h"
 
 namespace Kratos
@@ -29,6 +30,42 @@ using GeometryPointType = Geometry<Point>;
 
 namespace
 {
+
+GeometryNodeType::Pointer CreateLine3D2NForTestNode2D()
+{
+    GeometryNodeType::PointsArrayType points;
+    points.push_back(Kratos::make_shared<NodeType>(1, 0.0, 0.0, 0.0));
+    points.push_back(Kratos::make_shared<NodeType>(2, 1.0, 0.0, 0.0));
+
+    return GeometryNodeType::Pointer(new Line3D2<NodeType>(points));
+}
+
+GeometryPointType::Pointer CreateLine3D2NForTestPoint2D()
+{
+    GeometryPointType::PointsArrayType points;
+    points.push_back(Kratos::make_shared<Point>(0.0, 0.0, 0.0));
+    points.push_back(Kratos::make_shared<Point>(1.0, 0.0, 0.0));
+
+    return GeometryPointType::Pointer(new Line3D2<Point>(points));
+}
+
+GeometryNodeType::Pointer CreateLine3D2NForTestNode3D()
+{
+    GeometryNodeType::PointsArrayType points;
+    points.push_back(Kratos::make_shared<NodeType>(1, 1.0, 3.0, -1.0));
+    points.push_back(Kratos::make_shared<NodeType>(2, 3.0, 6.0, 0.0));
+
+    return GeometryNodeType::Pointer(new Line3D2<NodeType>(points));
+}
+
+GeometryPointType::Pointer CreateLine3D2NForTestPoint3D()
+{
+    GeometryPointType::PointsArrayType points;
+    points.push_back(Kratos::make_shared<Point>(1.0, 3.0, -1.0));
+    points.push_back(Kratos::make_shared<Point>(3.0, 6.0, 0.0));
+
+    return GeometryPointType::Pointer(new Line3D2<Point>(points));
+}
 
 GeometryNodeType::Pointer CreateTriangle3D3NForTestNode()
 {
@@ -108,6 +145,51 @@ void TestFastProjectOnGeometry(TGeometryType& rGeom)
     KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Z(), 0.0);
 }
 
+template<class TGeometryType>
+void TestFastProjectOnLine2D(TGeometryType& rGeom)
+{
+    const double expected_proj_dist = -1.258;
+
+    const double x_coord = 0.325;
+
+    const Point point_to_proj(x_coord, expected_proj_dist,0.0);
+    Point projected_point;
+
+    const double proj_distance = GeometricalProjectionUtilities::FastProjectOnLine(
+        rGeom,
+        point_to_proj,
+        projected_point);
+
+    KRATOS_CHECK_DOUBLE_EQUAL(expected_proj_dist, proj_distance);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.X(), x_coord);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Y(), 0.0);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Z(), 0.0);
+}
+
+template<class TGeometryType>
+void TestFastProjectOnLine3D(TGeometryType& rGeom)
+{
+    // Reference: Ref: https://www.qc.edu.hk/math/Advanced%20Level/Point_to_line.htm "Method 3 Using Dot Product"
+    const Point point_to_proj(-2.0, 4.0, -3.0);
+    Point projected_point;
+
+    const double proj_distance = GeometricalProjectionUtilities::FastProjectOnLine(
+        rGeom,
+        point_to_proj,
+        projected_point);
+
+    const double expected_proj_dist = std::sqrt(171/14);
+
+    const double expected_coord_x = 4/14;
+    const double expected_coord_y = 27/14;
+    const double expected_coord_z = -19/14;
+
+    KRATOS_CHECK_DOUBLE_EQUAL(expected_proj_dist, proj_distance);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.X(), expected_coord_x);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Y(), expected_coord_y);
+    KRATOS_CHECK_DOUBLE_EQUAL(projected_point.Z(), expected_coord_z);
+}
+
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectDirectionNode, KratosCoreFastSuite)
@@ -136,6 +218,24 @@ KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectOnGeometryPoi
     GeometryPointType::Pointer p_geom = CreateTriangle3D3NForTestPoint();
 
     TestFastProjectOnGeometry(*p_geom);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectOnLineNode, KratosCoreFastSuite)
+{
+    GeometryNodeType::Pointer p_geom = CreateLine3D2NForTestNode2D();
+    TestFastProjectOnLine2D(*p_geom);
+
+    p_geom = CreateLine3D2NForTestNode3D();
+    TestFastProjectOnLine3D(*p_geom);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProjectOnLinePoint, KratosCoreFastSuite)
+{
+    GeometryPointType::Pointer p_geom = CreateLine3D2NForTestPoint2D();
+    TestFastProjectOnLine2D(*p_geom);
+
+    p_geom = CreateLine3D2NForTestPoint3D();
+    TestFastProjectOnLine3D(*p_geom);
 }
 
 KRATOS_TEST_CASE_IN_SUITE(GeometricalProjectionUtilitiesFastProject, KratosCoreFastSuite)

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -169,6 +169,33 @@ public:
     }
 
     /**
+     * @brief Project a point over a line (2D or 3D)
+     * @tparam TGeometryType The type of the line
+     * @param rGeom The line where to be projected
+     * @param rPointToProject The point to be projected
+     * @param rPointProjected The point pojected over the line
+     * @return Distance The distance between point and line
+     * source: https://www.qc.edu.hk/math/Advanced%20Level/Point_to_line.htm "Method 3 Using Dot Product"
+     */
+    template<class TGeometryType>
+    static inline double FastProjectOnLine(const TGeometryType& rGeom,
+                                           const Point& rPointToProject,
+                                           PointType& rPointProjected)
+    {
+        const array_1d<double, 3> p_a = rGeom[0].Coordinates();
+        const array_1d<double, 3> p_b = rGeom[1].Coordinates();
+        const array_1d<double, 3> ab = p_b - p_a;
+
+        const array_1d<double, 3> p_c = rPointToProject.Coordinates();
+
+        const double factor = (inner_prod(p_b, p_c) - inner_prod(p_a, p_c) - inner_prod(p_b, p_a) + inner_prod(p_a, p_a)) / inner_prod(ab, ab);
+
+        rPointProjected.Coordinates() = p_a + factor * ab;
+
+        return norm_2(rPointProjected.Coordinates()-p_c);
+    }
+
+    /**
      * @brief Projects iteratively to get the coordinate
      * @tparam TGeometryType The type of the geometry
      * @param rGeomOrigin The origin geometry

--- a/kratos/utilities/geometrical_projection_utilities.h
+++ b/kratos/utilities/geometrical_projection_utilities.h
@@ -175,7 +175,7 @@ public:
      * @param rPointToProject The point to be projected
      * @param rPointProjected The point pojected over the line
      * @return Distance The distance between point and line
-     * source: https://www.qc.edu.hk/math/Advanced%20Level/Point_to_line.htm "Method 3 Using Dot Product"
+     * @link https://www.qc.edu.hk/math/Advanced%20Level/Point_to_line.htm "Method 3 Using Dot Product"
      */
     template<class TGeometryType>
     static inline double FastProjectOnLine(const TGeometryType& rGeom,


### PR DESCRIPTION
This PR adds a method to project a point to a line 
Note that this works in 3D, without specifying a normal!
Source: https://www.qc.edu.hk/math/Advanced%20Level/Point_to_line.htm ; method 3

I added tests to make sure it works (a simple 2D tests and a 3D test, same as the example that the website shows)

should we deprecate `ProjectIterativeLine2D`? I think this method is better and faster, but I am not sure how you use it