### PR TITLE
[FSI][Mapping] One side serial mapper through mapper factory

### DIFF
--- a/applications/MappingApplication/python_scripts/python_mapper_factory.py
+++ b/applications/MappingApplication/python_scripts/python_mapper_factory.py
@@ -10,13 +10,27 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 import KratosMultiphysics
 from KratosMultiphysics.MappingApplication import MapperFactory
 
+# Import applications
+try:
+    from KratosMultiphysics.FSIApplication import NonConformant_OneSideMap
+    have_fsi = True
+except ImportError:
+    have_fsi = False
+
 def _CreateCoreMortarMapper(model_part_origin, model_part_destination, mapper_settings):
     # return core mortar mapper
     raise NotImplementedError
 
 def _CreateApproximateMortarMapper(model_part_origin, model_part_destination, mapper_settings):
-    # return mapper from FSIApp
-    raise NotImplementedError
+    if (have_fsi):
+        return NonConformant_OneSideMap.NonConformant_OneSideMap(
+            model_part_origin,
+            model_part_destination,
+            mapper_settings["search_radius_factor"].GetDouble(),
+            mapper_settings["mapper_max_iterations"].GetInt(),
+            mapper_settings["mapper_tolerance"].GetDouble())
+    else:
+        raise Exception("FSIApplication is required to construct the approximate_mortar mapper.")
 
 def _CreateVertexMorphingMapper(model_part_origin, model_part_destination, mapper_settings):
     # return mapper from ShapeOptApp


### PR DESCRIPTION
As discussed in #4648, I started to use the new mapper factory in the FSI application. As a first application case, this uses the new mapping factory only in the single faced serial case. Since the approximate mortar mapper is quite old, its API doesn't match the one in `mapper.h`, so further changes will be required in the future.

Once this is merged I'll also update the CHT solver.