### PR TITLE
[Shallow] Printing the topography

### DIFF
--- a/applications/ShallowWaterApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/ShallowWaterApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -21,11 +21,7 @@
 #include "custom_utilities/move_shallow_water_particle_utility.h"
 #include "custom_utilities/shallow_water_variables_utility.h"
 #include "custom_utilities/estimate_dt_utility.h"
-<<<<<<< HEAD
-=======
-#include "custom_utilities/replicate_model_part_utility.h"
 #include "custom_utilities/post_process_utilities.h"
->>>>>>> a73c3a1... printing the topography
 
 
 namespace Kratos

--- a/applications/ShallowWaterApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/ShallowWaterApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -21,6 +21,11 @@
 #include "custom_utilities/move_shallow_water_particle_utility.h"
 #include "custom_utilities/shallow_water_variables_utility.h"
 #include "custom_utilities/estimate_dt_utility.h"
+<<<<<<< HEAD
+=======
+#include "custom_utilities/replicate_model_part_utility.h"
+#include "custom_utilities/post_process_utilities.h"
+>>>>>>> a73c3a1... printing the topography
 
 
 namespace Kratos
@@ -73,6 +78,25 @@ namespace Python
     py::class_< EstimateDtShallow > (m, "EstimateDtShallow")
         .def(py::init<ModelPart&, Parameters>())
         .def("EstimateDt", &EstimateDtShallow::EstimateDt)
+        ;
+
+    py::class_< PostProcessUtilities > (m, "PostProcessUtilities")
+        .def(py::init<ModelPart&>())
+        .def("ApplyIdOffsetOnNodes", &PostProcessUtilities::ApplyIdOffsetOnNodes)
+        .def("ApplyIdOffsetOnElements", &PostProcessUtilities::ApplyIdOffsetOnElements)
+        .def("ApplyIdOffsetOnConditions", &PostProcessUtilities::ApplyIdOffsetOnConditions)
+        .def("UndoIdOffsetOnNodes", &PostProcessUtilities::UndoIdOffsetOnNodes)
+        .def("UndoIdOffsetOnElements", &PostProcessUtilities::UndoIdOffsetOnElements)
+        .def("UndoIdOffsetOnConditions", &PostProcessUtilities::UndoIdOffsetOnConditions)
+        .def("DefineAuxiliaryProperties", &PostProcessUtilities::DefineAuxiliaryProperties)
+        .def("AssignSolidFluidProperties", &PostProcessUtilities::AssignSolidFluidProperties)
+        .def("RestoreSolidFluidProperties", &PostProcessUtilities::RestoreSolidFluidProperties)
+        .def("AssignDryWetProperties", &PostProcessUtilities::AssignDryWetProperties)
+        .def("RestoreDryWetProperties", &PostProcessUtilities::RestoreDryWetProperties)
+        .def("SetBathymetryMeshPosition", &PostProcessUtilities::SetBathymetryMeshPosition)
+        .def("SetFreeSurfaceMeshPosition", &PostProcessUtilities::SetFreeSurfaceMeshPosition)
+        .def("SetToZeroMeshPosition", &PostProcessUtilities::SetToZeroMeshPosition)
+        .def("ResetMeshPosition", &PostProcessUtilities::ResetMeshPosition)
         ;
 
   }

--- a/applications/ShallowWaterApplication/custom_utilities/post_process_utilities.h
+++ b/applications/ShallowWaterApplication/custom_utilities/post_process_utilities.h
@@ -1,0 +1,450 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Miguel Maso Sotomayor
+//
+
+#ifndef KRATOS_POST_PROCESS_UTILITIES_H_INCLUDED
+#define KRATOS_POST_PROCESS_UTILITIES_H_INCLUDED
+
+
+// System includes
+
+
+// External includes
+
+
+// Project includes
+#include "includes/define.h"
+#include "shallow_water_application_variables.h"
+
+
+namespace Kratos
+{
+///@addtogroup ShallowWaterApplication
+///@{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/// Auxiliary utilities for post process purpose.
+/** Gid is able to representate different entities when they have different Id and diffrent properties.
+*/
+class PostProcessUtilities
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    typedef std::size_t IndexType;
+
+    /// Pointer definition of PostProcessUtilities
+    KRATOS_CLASS_POINTER_DEFINITION(PostProcessUtilities);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    PostProcessUtilities(ModelPart& rThisModelPart) : mrModelPart(rThisModelPart) {}
+
+    /// Destructor.
+    ~PostProcessUtilities() = default;
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    void ApplyIdOffsetOnNodes()
+    {
+        ApplyIdOffset(mrModelPart.Nodes());
+    }
+
+    void UndoIdOffsetOnNodes()
+    {
+        UndoIdOffset(mrModelPart.Nodes());
+    }
+
+    void ApplyIdOffsetOnElements()
+    {
+        ApplyIdOffset(mrModelPart.Elements());
+    }
+
+    void UndoIdOffsetOnElements()
+    {
+        UndoIdOffset(mrModelPart.Elements());
+    }
+
+    void ApplyIdOffsetOnConditions()
+    {
+        ApplyIdOffset(mrModelPart.Conditions());
+    }
+
+    void UndoIdOffsetOnConditions()
+    {
+        UndoIdOffset(mrModelPart.Conditions());
+    }
+
+    void DefineAuxiliaryProperties()
+    {
+        mFluidToSolidPropertiesMap.clear();
+        mSolidToFluidPropertiesMap.clear();
+        mWetToDryPropertiesMap.clear();
+        mDryToWetPropertiesMap.clear();
+
+        // Create a two copies for each property
+        const int nprop = static_cast<int>(mrModelPart.NumberOfProperties());
+        ModelPart::PropertiesContainerType::iterator prop_begin = mrModelPart.PropertiesBegin();
+
+        IndexType last_id = 0;
+        IndexVectorType prop_ids;
+
+        // Loop the original ids
+        for (int i = 0; i < nprop; ++i)
+        {
+            auto prop = prop_begin + i;
+
+            if (prop->Id() > last_id) {
+                last_id = prop->Id();
+            }
+            prop_ids.push_back(prop->Id());
+        }
+
+        // Creating the auxiliary ids for the solid domain
+        for (auto id : prop_ids)
+        {
+            // Get pointers to the properties and create the dry property
+            Properties::Pointer fluid_prop = mrModelPart.pGetProperties(id);
+            Properties::Pointer solid_prop(new Properties(*fluid_prop));
+            solid_prop->SetId(++last_id);
+
+            // Add the new property and add them to the maps
+            mrModelPart.AddProperties(solid_prop);
+            mFluidToSolidPropertiesMap[fluid_prop->Id()] = last_id;
+            mSolidToFluidPropertiesMap[solid_prop->Id()] = id;
+        }
+
+        // Creating the auxiliary ids for the dry domain
+        for (auto id : prop_ids)
+        {
+            // Get pointers to the properties and create the dry property
+            Properties::Pointer wet_prop = mrModelPart.pGetProperties(id);
+            Properties::Pointer dry_prop(new Properties(*wet_prop));
+            dry_prop->SetId(++last_id);
+
+            // Add the new property and add them to the maps
+            mrModelPart.AddProperties(dry_prop);
+            mWetToDryPropertiesMap[wet_prop->Id()] = last_id;
+            mDryToWetPropertiesMap[dry_prop->Id()] = id;
+        }
+
+    }
+
+    void AssignSolidFluidProperties()
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < static_cast<int>(mrModelPart.NumberOfElements()); ++i)
+        {
+            auto it_elem = mrModelPart.ElementsBegin() + i;
+            IndexType solid_prop_id = mFluidToSolidPropertiesMap[it_elem->GetProperties().Id()];
+            it_elem->SetProperties(mrModelPart.pGetProperties(solid_prop_id));
+        }
+    }
+
+    void RestoreSolidFluidProperties()
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < static_cast<int>(mrModelPart.NumberOfElements()); ++i)
+        {
+            auto it_elem = mrModelPart.ElementsBegin() + i;
+            IndexType fluid_prop_id = mSolidToFluidPropertiesMap[it_elem->GetProperties().Id()];
+            it_elem->SetProperties(mrModelPart.pGetProperties(fluid_prop_id));
+        }
+    }
+
+    void AssignDryWetProperties(Flags& rFlag)
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < static_cast<int>(mrModelPart.NumberOfElements()); ++i)
+        {
+            auto elem = mrModelPart.ElementsBegin() + i;
+
+            if (elem->Is(rFlag))
+            {
+                auto search = mDryToWetPropertiesMap.find(elem->GetProperties().Id());
+                if (search != mDryToWetPropertiesMap.end()) // The element was dry
+                {
+                    IndexType wet_prop_id = search->second;
+                    elem->SetProperties(mrModelPart.pGetProperties(wet_prop_id));
+                }
+            }
+            else
+            {
+                auto search = mWetToDryPropertiesMap.find(elem->GetProperties().Id());
+                if (search != mWetToDryPropertiesMap.end()) // The element was wet
+                {
+                    IndexType dry_prop_id = search->second;
+                    elem->SetProperties(mrModelPart.pGetProperties(dry_prop_id));
+                }
+            }
+        }
+    }
+
+    void RestoreDryWetProperties()
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < static_cast<int>(mrModelPart.NumberOfElements()); ++i)
+        {
+            auto elem = mrModelPart.ElementsBegin() + i;
+
+            auto search = mDryToWetPropertiesMap.find(elem->GetProperties().Id());
+            if (search != mDryToWetPropertiesMap.end()) // The element was dry
+            {
+                IndexType wet_prop_id = search->second;
+                elem->SetProperties(mrModelPart.pGetProperties(wet_prop_id));
+            }
+        }
+    }
+
+    void SetBathymetryMeshPosition()
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < static_cast<int>(mrModelPart.NumberOfNodes()); ++i)
+        {
+            auto it_node = mrModelPart.NodesBegin() + i;
+            it_node->Z() = it_node->FastGetSolutionStepValue(BATHYMETRY);
+        }
+    }
+
+    void SetFreeSurfaceMeshPosition()
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < static_cast<int>(mrModelPart.NumberOfNodes()); ++i)
+        {
+            auto it_node = mrModelPart.NodesBegin() + i;
+            it_node->Z() = it_node->FastGetSolutionStepValue(FREE_SURFACE_ELEVATION);
+        }
+    }
+
+    void SetToZeroMeshPosition()
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < static_cast<int>(mrModelPart.NumberOfNodes()); ++i)
+        {
+            auto it_node = mrModelPart.NodesBegin() + i;
+            it_node->Z() = 0.0;
+        }
+    }
+
+    void ResetMeshPosition()
+    {
+        #pragma omp parallel for
+        for (int i = 0; i < static_cast<int>(mrModelPart.NumberOfNodes()); ++i)
+        {
+            auto it_node = mrModelPart.NodesBegin() + i;
+            it_node->Z() = it_node->Z0();
+        }
+    }
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const;
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const;
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const;
+
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    ModelPart& mrModelPart;
+
+    std::map<IndexType, IndexType> mFluidToSolidPropertiesMap;
+    std::map<IndexType, IndexType> mSolidToFluidPropertiesMap;
+
+    std::map<IndexType, IndexType> mWetToDryPropertiesMap;
+    std::map<IndexType, IndexType> mDryToWetPropertiesMap;
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    template<class TContainerType>
+    void ApplyIdOffset(TContainerType& rContainer)
+    {
+        IndexType offset = rContainer.size();
+        #pragma omp parallel for
+        for (int i = 0; i < static_cast<int> (rContainer.size()); ++i)
+        {
+            auto it_cont = rContainer.begin() + i;
+            it_cont->SetId(it_cont->Id() + offset);
+        }
+    }
+
+    template<class TContainerType>
+    void UndoIdOffset(TContainerType& rContainer)
+    {
+        int offset = static_cast<int> (rContainer.size());
+        #pragma omp parallel for
+        for (int i = 0; i < offset; ++i)
+        {
+            auto it_cont = rContainer.begin() + i;
+            it_cont->SetId(it_cont->Id() - offset);
+        }
+    }
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    PostProcessUtilities& operator=(PostProcessUtilities const& rOther);
+
+    /// Copy constructor.
+    PostProcessUtilities(PostProcessUtilities const& rOther);
+
+
+    ///@}
+
+}; // Class PostProcessUtilities
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream,
+                PostProcessUtilities& rThis);
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                const PostProcessUtilities& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_POST_PROCESS_UTILITIES_H_INCLUDED  defined

--- a/applications/ShallowWaterApplication/python_scripts/shallow_water_gid_output_process.py
+++ b/applications/ShallowWaterApplication/python_scripts/shallow_water_gid_output_process.py
@@ -1,0 +1,110 @@
+import KratosMultiphysics as KM
+import KratosMultiphysics.ShallowWaterApplication as SW
+
+def Factory(settings, model):
+    if not isinstance(settings, KM.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    return ShallowWaterGidOutputProcess(model, settings["Parameters"])
+
+from KratosMultiphysics.gid_output_process import GiDOutputProcess
+
+## This process sets the value of a scalar variable using the AssignScalarVariableProcess.
+class ShallowWaterGidOutputProcess(GiDOutputProcess):
+    def __init__(self, model, settings):
+        first_level_defaults = KM.Parameters("""
+        {
+            "output_name"               : "file"
+            "model_part_name"           : "unknown",
+            "result_file_configuration" : {},
+            "point_data_configuration"  : []
+        }
+        """)
+        settings.ValidateAndAssignDefaults(first_level_defaults)
+        self.param = settings
+
+        self.base_file_name = self.param["output_name"].GetString()
+        self.model_part = model[self.param["model_part_name"].GetString()]
+        self.body_io = None
+        self.volume_list_files = []
+
+        # This output does not support cuts. Initializing empty instances
+        self.cut_model_part = None
+        self.cut_io = None
+        self.output_surface_index = 0
+        self.cut_list_files = []
+
+        # I am not interested on point output, but initialize that stuff
+        point_data_configuration = self.param["point_data_configuration"]
+        if point_data_configuration.size() > 0:
+            import point_output_process
+            self.point_output_process = point_output_process.PointOutputProcess(self.model_part,point_data_configuration)
+        else:
+            self.point_output_process = None
+
+        self.step_count = 0
+        self.printed_step_count = 0
+        self.next_output = 0.0
+
+    def ExecuteInitialize(self):
+        super(ShallowWaterGiDOutputProcess, self).ExecuteInitialize()
+
+    def ExecuteBeforeSolutionLoop(self):
+        super(ShallowWaterGiDOutputProcess, self).ExecuteBeforeSolutionLoop()
+
+    def ExecuteInitializeSolutionStep(self):
+        super(ShallowWaterGiDOutputProcess, self).ExecuteInitializeSolutionStep()
+
+    def ExecuteFinalizeSolutionStep(self):
+        super(ShallowWaterGiDOutputProcess, self).ExecuteFinalizeSolutionStep()
+
+    def ExecuteBeforeOutputStep(self):
+        super(ShallowWaterGiDOutputProcess, self).ExecuteBeforeOutputStep()
+
+    def IsOutputStep(self):
+        return super(ShallowWaterGiDOutputProcess, self).IsOutputStep()
+
+    def PrintOutput(self):
+        super(ShallowWaterGiDOutputProcess, self).PrintOutput()
+
+    def ExecuteAfterOutputStep(self):
+        super(ShallowWaterGiDOutputProcess, self).ExecuteAfterOutputStep()
+
+    def ExecuteFinalize(self):
+        super(ShallowWaterGiDOutputProcess, self).ExecuteFinalize()
+
+    def Check(self):
+        super(ShallowWaterGiDOutputProcess, self).Check()
+
+    def __write_mesh(self, label):
+        if self.body_io is not None:
+            self.body_io.InitializeMesh(label)
+            if self.body_output:
+                self.body_io.WriteMesh(self.model_part.GetMesh())
+            if self.node_output:
+                self.body_io.WriteNodeMesh(self.model_part.GetMesh())
+            self.body_io.FinalizeMesh()
+
+        if self.cut_io is not None:
+            self.cut_io.InitializeMesh(label)
+            self.cut_io.WriteMesh(self.cut_model_part.GetMesh())
+            self.cut_io.FinalizeMesh()
+
+    def __write_nodal_results(self, label):
+        if self.body_io is not None:
+            for variable in self.nodal_variables:
+                self.body_io.WriteNodalResults(variable, self.model_part.GetCommunicator().LocalMesh().Nodes, label, 0)
+
+        if self.cut_io is not None:
+            self.cut_manager.UpdateCutData(self.cut_model_part, self.model_part)
+            for variable in self.nodal_variables:
+                self.cut_io.WriteNodalResults(variable, self.cut_model_part.GetCommunicator().LocalMesh().Nodes, label, 0)
+
+    def __write_nonhistorical_nodal_results(self, label):
+        if self.body_io is not None:
+            for variable in self.nodal_nonhistorical_variables:
+                self.body_io.WriteNodalResultsNonHistorical(variable, self.model_part.Nodes, label)
+
+        if self.cut_io is not None:
+            self.cut_manager.UpdateCutData(self.cut_model_part, self.model_part)
+            for variable in self.nodal_nonhistorical_variables:
+                self.cut_io.WriteNodalResultsNonHistorical(variable, self.cut_model_part.Nodes, label)


### PR DESCRIPTION
Shallow water equations are a 2D reduced model, however, the user would like to see the how the "volume" looks like.

In this PR there is a derived output process which prints the mesh two times:
- The first time prints the computational mesh with the results
- The second time prints the same mesh with an offset which represents the topography

In the picture is shown a simple test: a linear wave on a parabolic bowl. This custom output is printing two meshes in order to see at the same time the bathymetry and the free surface.

![Captura de pantalla de 2019-04-24 17-37-41](https://user-images.githubusercontent.com/25640870/56674971-53103780-66bb-11e9-9a24-645c763df643.png)

I have found a trouble when deriving a private method of **GiDOutputProcess**. This is the easiest workaround I have found:

https://github.com/KratosMultiphysics/Kratos/blob/880bbf796ad1d06e5eedae4e934be313557c549e/applications/ShallowWaterApplication/python_scripts/shallow_water_gid_output_process.py#L82
