### PR TITLE
[Fluid] Distance modification threadsafe initialization

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla
 //
@@ -36,28 +36,51 @@ DistanceModificationProcess::DistanceModificationProcess(
     const bool CheckAtEachStep,
     const bool NegElemDeactivation,
     const bool RecoverOriginalDistance)
-    : Process(), mrModelPart(rModelPart) {
-
+    : Process(),
+      mrModelPart(rModelPart)
+{
+    // Member variables initialization
     mDistanceThreshold = DistanceThreshold;
     mCheckAtEachStep = CheckAtEachStep;
     mNegElemDeactivation = NegElemDeactivation;
     mRecoverOriginalDistance = RecoverOriginalDistance;
+
+    // Initialize the EMBEDDED_IS_ACTIVE variable flag to 0
+    this->InitializeEmbeddedIsActive();
 }
 
 DistanceModificationProcess::DistanceModificationProcess(
     ModelPart& rModelPart,
     Parameters& rParameters)
-    : Process(), mrModelPart(rModelPart)
+    : Process(),
+      mrModelPart(rModelPart)
 {
+    // Check default settings
     this->CheckDefaultsAndProcessSettings(rParameters);
+
+    // Initialize the EMBEDDED_IS_ACTIVE variable flag to 0
+    this->InitializeEmbeddedIsActive();
 }
 
 DistanceModificationProcess::DistanceModificationProcess(
     Model &rModel,
     Parameters &rParameters)
-    : Process(), mrModelPart(rModel.GetModelPart(rParameters["model_part_name"].GetString()))
+    : Process(),
+      mrModelPart(rModel.GetModelPart(rParameters["model_part_name"].GetString()))
 {
+    // Check default settings
     this->CheckDefaultsAndProcessSettings(rParameters);
+
+    // Initialize the EMBEDDED_IS_ACTIVE variable flag to 0
+    this->InitializeEmbeddedIsActive();
+}
+
+void DistanceModificationProcess::InitializeEmbeddedIsActive()
+{
+    for (int i_node = 0; i_node < static_cast<int>(mrModelPart.NumberOfNodes()); ++i_node) {
+        auto it_node = mrModelPart.NodesBegin() + i_node;
+        it_node->SetValue(EMBEDDED_IS_ACTIVE, 0);
+    }
 }
 
 void DistanceModificationProcess::CheckDefaultsAndProcessSettings(Parameters &rParameters)

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla
 //
@@ -169,6 +169,14 @@ private:
     ///@{
 
     void CheckDefaultsAndProcessSettings(Parameters &rParameters);
+
+    /**
+     * @brief Initialize the EMBEDDED_IS_ACTIVE variable
+     * This method initializes the non historical variable EMBEDDED_IS_ACTIVE.
+     * It needs to be called in the constructor to do a threadsafe initialization
+     * of such nodal variable before any other operation is done.
+     */
+    void InitializeEmbeddedIsActive();
 
     void ModifyDistance();
 


### PR DESCRIPTION
While doing other stuff I realized that the initialization of the `EMBEDDED_IS_ACTIVE` variable in the `DistanceModificationProcess` was not threadsafe (I'm still wondering how we didn't note this before). 

This should be a temporary solution since I guess that the `EMBEDDED_IS_ACTIVE` variable can be substituted by a flag, which can be communicated now. I will try this in a different branch.