### PR TITLE
Core/flag utility constants

### DIFF
--- a/kratos/containers/flags.h
+++ b/kratos/containers/flags.h
@@ -243,6 +243,15 @@ public:
     ///@name Access
     ///@{
 
+    static const Flags AllDefined()
+    {
+        return Flags(~0,0);
+    }
+
+    static const Flags AllTrue()
+    {
+        return Flags(~0,~0);
+    }
 
     ///@}
     ///@name Inquiry
@@ -418,6 +427,13 @@ private:
     ///@name Private Inquiry
     ///@{
 
+    ///@}
+    ///@name Private LifeCycle
+    ///@{
+
+    Flags(BlockType DefinedFlags, BlockType SetFlags):
+        mIsDefined(DefinedFlags), mFlags(SetFlags)
+    {}
 
     ///@}
     ///@name Un accessible methods

--- a/kratos/includes/kratos_flags.h
+++ b/kratos/includes/kratos_flags.h
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
-//                    
+//
 //
 
 #if !defined(KRATOS_KRATOS_FLAGS_H_INCLUDED )
@@ -110,13 +110,8 @@ KRATOS_CREATE_FLAG(PERIODIC,        34);
 //          KRATOS_DEFINE_FLAG(,31);
 //          KRATOS_DEFINE_FLAG(,30);
 
-
-
-
-
-
-
-
+const Flags ALL_DEFINED(Flags::AllDefined());
+const Flags ALL_TRUE(Flags::AllTrue());
 
   ///@}
   ///@name Type Definitions

--- a/kratos/mpi/tests/sources/test_flag_synchronization.cpp
+++ b/kratos/mpi/tests/sources/test_flag_synchronization.cpp
@@ -107,6 +107,32 @@ KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorFlagsOrAllUnset, KratosMPICoreFastS
     KRATOS_CHECK_EQUAL(synchronized_flag.IsDefined(PERIODIC), false);
 }
 
+// Synchronization using ALL_DEFINED as mask //////////////////////////////////
+
+KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorFlagsReduceWithAllDefinedAsMask, KratosMPICoreFastSuite)
+{
+    MPIDataCommunicator mpi_world_communicator(MPI_COMM_WORLD);
+    const int rank = mpi_world_communicator.Rank();
+    const int size = mpi_world_communicator.Size();
+
+    Kratos::Flags test_flag;
+    test_flag.Set(STRUCTURE, rank == 0);
+    test_flag.Set(INLET, rank == 0);
+
+    // Using ALL_DEFINED as argument should synchronize all defined flags
+    Kratos::Flags synchronized_and_flag = mpi_world_communicator.AndReduceAll(test_flag, ALL_DEFINED);
+
+    KRATOS_CHECK_EQUAL(synchronized_and_flag.Is(STRUCTURE), (size == 1)); // true for single-rank runs, false for multiple ranks.
+    KRATOS_CHECK_EQUAL(synchronized_and_flag.Is(INLET), (size == 1));
+    KRATOS_CHECK_EQUAL(synchronized_and_flag.IsDefined(PERIODIC), false);
+
+    Kratos::Flags synchronized_or_flag = mpi_world_communicator.OrReduceAll(test_flag, ALL_DEFINED);
+
+    KRATOS_CHECK_EQUAL(synchronized_or_flag.Is(STRUCTURE), true);
+    KRATOS_CHECK_EQUAL(synchronized_or_flag.Is(INLET), true);
+    KRATOS_CHECK_EQUAL(synchronized_or_flag.IsDefined(PERIODIC), false);
+}
+
 // Flags And //////////////////////////////////////////////////////////////////
 
 KRATOS_TEST_CASE_IN_SUITE(MPIDataCommunicatorFlagsAndOperations, KratosMPICoreFastSuite)

--- a/kratos/python/add_containers_to_python.cpp
+++ b/kratos/python/add_containers_to_python.cpp
@@ -362,6 +362,10 @@ void  AddContainersToPython(pybind11::module& m)
     KRATOS_REGISTER_IN_PYTHON_FLAG(m,MARKER);
     KRATOS_REGISTER_IN_PYTHON_FLAG(m,PERIODIC);
 
+    // Note: using internal macro for these two because they do not have a NOT_ version
+    KRATOS_REGISTER_IN_PYTHON_FLAG_IMPLEMENTATION(m,ALL_DEFINED);
+    KRATOS_REGISTER_IN_PYTHON_FLAG_IMPLEMENTATION(m,ALL_TRUE);
+
 
 //     AddDeprecatedVariablesToPython();
 //     AddC2CVariablesToPython();

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -79,7 +79,7 @@ KratosApplication::KratosApplication(const std::string ApplicationName)
       mSurfaceCondition3D8N( 0, GeometryType::Pointer(new Quadrilateral3D8<NodeType >(GeometryType::PointsArrayType(8)))),
       mSurfaceCondition3D9N( 0, GeometryType::Pointer(new Quadrilateral3D9<NodeType >(GeometryType::PointsArrayType(9)))),
 
-      // Master-Slave Constraint 
+      // Master-Slave Constraint
       mMasterSlaveConstraint(),
       mLinearMasterSlaveConstraint(),
 
@@ -95,12 +95,12 @@ KratosApplication::KratosApplication(const std::string ApplicationName)
       mCondition3D8N( 0, GeometryType::Pointer(new Quadrilateral3D8<NodeType >(GeometryType::PointsArrayType(8)))),
       mCondition3D9N( 0, GeometryType::Pointer(new Quadrilateral3D9<NodeType >(GeometryType::PointsArrayType(9)))),
       // Deprecated conditions end
-      
+
       // Periodic conditions
       mPeriodicCondition( 0, GeometryType::Pointer(new Line2D2<NodeType >(GeometryType::PointsArrayType(2)))),
       mPeriodicConditionEdge( 0, GeometryType::Pointer(new Quadrilateral3D4<NodeType >(GeometryType::PointsArrayType(4)))),
       mPeriodicConditionCorner( 0, GeometryType::Pointer(new Hexahedra3D8<NodeType >(GeometryType::PointsArrayType(8)))),
-      
+
       // Elements
       mElement2D2N( 0, GeometryType::Pointer(new Line2D2<NodeType >(GeometryType::PointsArrayType(2)))),
       mElement2D3N( 0, GeometryType::Pointer(new Triangle2D3<NodeType >(GeometryType::PointsArrayType(3)))),
@@ -111,7 +111,7 @@ KratosApplication::KratosApplication(const std::string ApplicationName)
       mElement3D6N( 0, GeometryType::Pointer(new Prism3D6<NodeType >(GeometryType::PointsArrayType(6)))),
       mElement3D8N( 0, GeometryType::Pointer(new Hexahedra3D8<NodeType >(GeometryType::PointsArrayType(8)))),
       mElement3D10N( 0, GeometryType::Pointer(new Tetrahedra3D10<NodeType >(GeometryType::PointsArrayType(10)))),
-      
+
       // Components
       mpVariableData(KratosComponents<VariableData>::pGetComponents()),
       mpIntVariables(KratosComponents<Variable<int> >::pGetComponents()),
@@ -205,7 +205,7 @@ void KratosApplication::RegisterKratosCore() {
     KRATOS_REGISTER_ELEMENT("Element3D6N", mElement3D6N)
     KRATOS_REGISTER_ELEMENT("Element3D8N", mElement3D8N)
     KRATOS_REGISTER_ELEMENT("Element3D10N", mElement3D10N)
-    
+
     //Register general geometries:
 
     //Points:
@@ -321,6 +321,10 @@ void KratosApplication::RegisterKratosCore() {
     KRATOS_REGISTER_FLAG(BLOCKED);
     KRATOS_REGISTER_FLAG(MARKER);
     KRATOS_REGISTER_FLAG(PERIODIC);
+
+    // Note: using internal macro for these two because they do not have a NOT_ version
+    KRATOS_ADD_FLAG_TO_KRATOS_COMPONENTS(ALL_DEFINED);
+    KRATOS_ADD_FLAG_TO_KRATOS_COMPONENTS(ALL_TRUE);
 
     // Register ConstitutiveLaw BaseClass
     KRATOS_REGISTER_CONSTITUTIVE_LAW("ConstitutiveLaw", mConstitutiveLaw);


### PR DESCRIPTION
In this PR I am adding two `Flags` constants called `ALL_DEFINED` and `ALL_TRUE` for convenience. The rationale between these is to use them to synchronize all flags at the same time on MPI. Consider
```
// or the ACTIVE flag
Flags output = mpi_world_communicator.OrReduce(flags, ACTIVE , root); 
```
This synchronizes only the `ACTIVE` flag. To synchronize multiple flags, one needs to call the MPI operation once for each flag (inefficient) or use bitwise OR to "enable" multiple flags at the same time:
```
// act on both ACTIVE and STRUCTURE flags
Flags output = mpi_world_communicator.OrReduce(flags, ACTIVE | STRUCTURE , root); 
```
This quickly becomes inconvenient:
```
Flags output = mpi_world_communicator.OrReduce(flags, ACTIVE | RIGID | STRUCTURE | MPI_BOUNDARY | PERIODIC | INLET | OUTLET | ISOLATED , root);
```
Using the convenience flags defined by this PR, all defined flags can be synchronized at once with
```
Flags output = mpi_world_communicator.OrReduce(flags, ALL_DEFINED , root); 
```
This PR also adds a test for this kind of synchronization.

Note that these DO NOT eat up the limited number of flags available in Kratos.