### PR TITLE
const VariablesListDataValueContainer.Data() variant.

### DIFF
--- a/kratos/containers/variables_list_data_value_container.h
+++ b/kratos/containers/variables_list_data_value_container.h
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
 //                   Riccardo Rossi
-//                    
+//
 //
 
 #if !defined(KRATOS_VARIABLES_LIST_DATA_VALUE_CONTAINER_H_INCLUDED )
@@ -52,11 +52,11 @@ namespace Kratos
 ///@}
 ///@name Kratos Classes
 ///@{
-    
-/** 
+
+/**
 * @class VariablesListDataValueContainer
-* @ingroup KratosCore 
-* @brief A  shared  variable  list gives the position of each variable in the containers sharing it. 
+* @ingroup KratosCore
+* @brief A  shared  variable  list gives the position of each variable in the containers sharing it.
 * @details The mechanism is very simple. There is an array which stores the local offset for each variable in the container and assigns  the  value−1  for  the  rest  of  the variables
 * For more details see P. Dadvand, R. Rossi, E. Oñate: An Object-oriented Environment for Developing Finite Element Codes for Multi-disciplinary Applications. Computational Methods in Engineering. 2010
 * @author Pooyan Dadvand
@@ -345,7 +345,7 @@ public:
     template<class TDataType>
     const TDataType& GetValue(const Variable<TDataType>& rThisVariable, SizeType QueueIndex) const
     {
-        KRATOS_ERROR_IF_NOT(mpVariablesList->Has(rThisVariable)) << "This container only can store the variables specified in its variables list. The variables list doesn't have this variable:" << rThisVariable << std::endl;    
+        KRATOS_ERROR_IF_NOT(mpVariablesList->Has(rThisVariable)) << "This container only can store the variables specified in its variables list. The variables list doesn't have this variable:" << rThisVariable << std::endl;
         return *(const TDataType*)Position(rThisVariable, QueueIndex);
     }
 
@@ -394,8 +394,8 @@ public:
 
     template<class TDataType>
     TDataType& FastGetValue(const Variable<TDataType>& rThisVariable, SizeType QueueIndex, SizeType ThisPosition)
-    {   
-        KRATOS_DEBUG_ERROR_IF_NOT(mpVariablesList->Has(rThisVariable)) << "This container only can store the variables specified in its variables list. The variables list doesn't have this variable:" << rThisVariable << std::endl;	
+    {
+        KRATOS_DEBUG_ERROR_IF_NOT(mpVariablesList->Has(rThisVariable)) << "This container only can store the variables specified in its variables list. The variables list doesn't have this variable:" << rThisVariable << std::endl;
         KRATOS_DEBUG_ERROR_IF((QueueIndex + 1) > mQueueSize) << "Trying to access data from step " << QueueIndex << " but only " << mQueueSize << " steps are stored." << std::endl;
         return *(TDataType*)(Position(QueueIndex) + ThisPosition);
     }
@@ -694,6 +694,11 @@ public:
         return mpData;
     }
 
+    const BlockType* Data() const
+    {
+        return mpData;
+    }
+
     BlockType* Data(SizeType QueueIndex)
     {
         return Position(QueueIndex);
@@ -702,10 +707,10 @@ public:
     BlockType* Data(VariableData const & rThisVariable)
     {
         #ifdef KRATOS_DEBUG
-        if ( !mpVariablesList->Has(rThisVariable) ) {            
+        if ( !mpVariablesList->Has(rThisVariable) ) {
             KRATOS_ERROR << "Variable " << rThisVariable.Name() << " is not added to this variables list. Stopping" << std::endl;
         }
-        #endif      
+        #endif
         return Position(rThisVariable);
     }
 


### PR DESCRIPTION
This PR only adds a `const BlockType* Data() const` method to `VariablesListDataValueContainer` to complement the existing non-const variant (all other changes are whitespace, sorry...)

I need this method to refactor the MPICommunicator.