### PR TITLE
[Core] Adding Table Reading Capability for BC and Loads

### DIFF
--- a/kratos/processes/apply_component_table_process.hpp
+++ b/kratos/processes/apply_component_table_process.hpp
@@ -1,0 +1,196 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ignasi de Pouplana
+//  Collaborator:    Alejandro Cornejo
+//
+
+#if !defined(KRATOS_APPLY_COMPONENT_TABLE_PROCESS)
+#define  KRATOS_APPLY_COMPONENT_TABLE_PROCESS
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/table.h"
+#include "includes/kratos_flags.h"
+#include "includes/kratos_parameters.h"
+#include "processes/process.h"
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+/// The base class for all processes in Kratos.
+/** This function applies a table value to a component
+*/
+class ApplyComponentTableProcess : public Process
+{
+    
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of ApplyConstantScalarValueProcess
+    KRATOS_CLASS_POINTER_DEFINITION(ApplyComponentTableProcess);
+    
+    /// Defining a table with double argument and result type as table type.
+    typedef Table<double,double> TableType;
+    
+    /// Constructor
+    ApplyComponentTableProcess(ModelPart& model_part,
+                                Parameters rParameters
+                                ) : Process(Flags()) , mr_model_part(model_part)
+    {
+        KRATOS_TRY
+
+        //only include validation with c++11 since raw_literals do not exist in c++03
+        Parameters default_parameters( R"(
+            {
+                "model_part_name":"PLEASE_CHOOSE_MODEL_PART_NAME",
+                "variable_name": "PLEASE_PRESCRIBE_VARIABLE_NAME",
+                "is_fixed": false,
+                "value" : 1.0,
+                "table" : 1
+            }  )" );
+        
+        // Some values need to be mandatorily prescribed since no meaningful default value exist. For this reason try accessing to them
+        // So that an error is thrown if they don't exist
+        rParameters["table"];
+        rParameters["variable_name"];
+        rParameters["model_part_name"];
+
+        // Now validate agains defaults -- this also ensures no type mismatch
+        rParameters.ValidateAndAssignDefaults(default_parameters);
+
+        mvariable_name = rParameters["variable_name"].GetString();
+        mis_fixed = rParameters["is_fixed"].GetBool();
+        minitial_value = rParameters["value"].GetDouble();
+        
+        unsigned int TableId = rParameters["table"].GetInt();
+        mpTable = model_part.pGetTable(TableId);
+        KRATOS_CATCH("");
+    }
+   
+    /// Destructor
+    ~ApplyComponentTableProcess() override {}
+
+    /// Execute method is used to execute the ApplyComponentTableProcess algorithms.
+    void Execute() override
+    {
+    }
+    
+    /// this function is designed for being called at the beginning of the computations
+    /// right after reading the model and the groups
+    void ExecuteInitialize() override
+    {
+        KRATOS_TRY;
+        
+        typedef VariableComponent< VectorComponentAdaptor<array_1d<double, 3> > > component_type;
+        component_type var_component = KratosComponents< component_type >::Get(mvariable_name);
+        
+        const int nnodes = static_cast<int>(mr_model_part.Nodes().size());
+
+        if (nnodes != 0) {
+            ModelPart::NodesContainerType::iterator it_begin = mr_model_part.NodesBegin();
+
+            #pragma omp parallel for
+            for(int i = 0; i<nnodes; i++) {
+                ModelPart::NodesContainerType::iterator it = it_begin + i;
+
+                if(mis_fixed) {
+                    it->Fix(var_component);
+                }
+
+                it->FastGetSolutionStepValue(var_component) = minitial_value;
+            }
+        }
+        KRATOS_CATCH("");
+    }
+
+    /// this function will be executed at every time step BEFORE performing the solve phase
+    void ExecuteInitializeSolutionStep() override
+    {
+        KRATOS_TRY;
+        
+        typedef VariableComponent< VectorComponentAdaptor<array_1d<double, 3> > > component_type;
+        component_type var_component = KratosComponents< component_type >::Get(mvariable_name);
+        
+        const double time = mr_model_part.GetProcessInfo()[TIME];
+        double value = mpTable->GetValue(time);
+        
+        const int nnodes = static_cast<int>(mr_model_part.Nodes().size());
+
+        if (nnodes != 0) {
+            ModelPart::NodesContainerType::iterator it_begin = mr_model_part.NodesBegin();
+
+            #pragma omp parallel for
+            for(int i = 0; i < nnodes; i++) {
+                ModelPart::NodesContainerType::iterator it = it_begin + i;
+                it->FastGetSolutionStepValue(var_component) = value;
+            }
+        }
+        KRATOS_CATCH("");
+    }
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "ApplyComponentTableProcess";
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << "ApplyComponentTableProcess";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override
+    {
+    }
+
+
+protected:
+
+    /// Member Variables
+    ModelPart& mr_model_part;
+    std::string mvariable_name;
+    bool mis_fixed;
+    double minitial_value;
+    TableType::Pointer mpTable;
+    
+private:
+
+    /// Assignment operator.
+    ApplyComponentTableProcess& operator=(ApplyComponentTableProcess const& rOther);
+    
+}; // Class ApplyComponentTableProcess
+
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream,
+                                  ApplyComponentTableProcess& rThis);
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                                  const ApplyComponentTableProcess& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+} // namespace Kratos.
+
+#endif /* KRATOS_APPLY_COMPONENT_TABLE_PROCESS defined */

--- a/kratos/processes/apply_double_table_process.hpp
+++ b/kratos/processes/apply_double_table_process.hpp
@@ -1,0 +1,152 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ignasi de Pouplana
+//  Collaborator:    Alejandro Cornejo
+//
+
+#if !defined(KRATOS_APPLY_DOUBLE_TABLE_PROCESS)
+#define  KRATOS_APPLY_DOUBLE_TABLE_PROCESS
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "custom_processes/apply_component_table_process.hpp"
+// #include "fem_to_dem_application_variables.h"
+
+namespace Kratos
+{
+
+/// The base class for all processes in Kratos.
+/** This function applies a value according to a table defined in the mdpa
+*/
+class ApplyDoubleTableProcess : public ApplyComponentTableProcess
+{
+    
+public:
+
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of ApplyConstantScalarValueProcess
+    KRATOS_CLASS_POINTER_DEFINITION(ApplyDoubleTableProcess);
+
+    /// Constructor
+    ApplyDoubleTableProcess(ModelPart& model_part, Parameters rParameters) 
+        :ApplyComponentTableProcess(model_part, rParameters) {}
+
+    
+    /// Destructor
+    ~ApplyDoubleTableProcess() override {}
+
+    /// Execute method is used to execute the ApplyDoubleTableProcess algorithms.
+    void Execute() override
+    {
+    }
+    
+    /// this function is designed for being called at the beginning of the computations
+    /// right after reading the model and the groups
+    void ExecuteInitialize() override
+    {
+        KRATOS_TRY;
+        
+        Variable<double> var = KratosComponents< Variable<double> >::Get(mvariable_name);
+        
+        const int nnodes = static_cast<int>(mr_model_part.Nodes().size());
+
+        if (nnodes != 0) {
+            ModelPart::NodesContainerType::iterator it_begin = mr_model_part.NodesBegin();
+
+            #pragma omp parallel for
+            for(int i = 0; i < nnodes; i++) {
+                ModelPart::NodesContainerType::iterator it = it_begin + i;
+                if(mis_fixed) {
+                    it->Fix(var);
+                }
+                it->FastGetSolutionStepValue(var) = minitial_value;
+            }
+        }
+        KRATOS_CATCH("");
+    }
+
+    /// this function will be executed at every time step BEFORE performing the solve phase
+    void ExecuteInitializeSolutionStep() override
+    {
+        KRATOS_TRY;
+        
+        Variable<double> var = KratosComponents< Variable<double> >::Get(mvariable_name);
+        
+        double time;
+        if (mTimeUnitConverter != 0) {
+            time = mr_model_part.GetProcessInfo()[TIME] / mTimeUnitConverter;
+        } else {
+            time = mr_model_part.GetProcessInfo()[TIME];
+        }
+        double value = mpTable->GetValue(time);
+        
+        const int nnodes = static_cast<int>(mr_model_part.Nodes().size());
+
+        if(nnodes != 0) {
+            ModelPart::NodesContainerType::iterator it_begin = mr_model_part.NodesBegin();
+
+            #pragma omp parallel for
+            for(int i = 0; i < nnodes; i++) {
+                ModelPart::NodesContainerType::iterator it = it_begin + i;
+                it->FastGetSolutionStepValue(var) = value;
+            }
+        }
+        KRATOS_CATCH("");
+    }
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "ApplyDoubleTableProcess";
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << "ApplyDoubleTableProcess";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override
+    {
+    }
+
+protected:
+
+private:
+
+    /// Assignment operator.
+    ApplyDoubleTableProcess& operator=(ApplyDoubleTableProcess const& rOther);
+  
+}; // Class ApplyDoubleTableProcess
+
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream,
+                                  ApplyDoubleTableProcess& rThis);
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                                  const ApplyDoubleTableProcess& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+} // namespace Kratos.
+
+#endif /* KRATOS_APPLY_DOUBLE_TABLE_PROCESS defined */

--- a/kratos/processes/apply_double_table_process.hpp
+++ b/kratos/processes/apply_double_table_process.hpp
@@ -19,7 +19,7 @@
 // External includes
 
 // Project includes
-#include "custom_processes/apply_component_table_process.hpp"
+#include "apply_component_table_process.hpp"
 // #include "fem_to_dem_application_variables.h"
 
 namespace Kratos
@@ -66,9 +66,9 @@ public:
             ModelPart::NodesContainerType::iterator it_begin = mr_model_part.NodesBegin();
 
             #pragma omp parallel for
-            for(int i = 0; i < nnodes; i++) {
+            for (int i = 0; i < nnodes; i++) {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
-                if(mis_fixed) {
+                if (mis_fixed) {
                     it->Fix(var);
                 }
                 it->FastGetSolutionStepValue(var) = minitial_value;
@@ -84,21 +84,16 @@ public:
         
         Variable<double> var = KratosComponents< Variable<double> >::Get(mvariable_name);
         
-        double time;
-        if (mTimeUnitConverter != 0) {
-            time = mr_model_part.GetProcessInfo()[TIME] / mTimeUnitConverter;
-        } else {
-            time = mr_model_part.GetProcessInfo()[TIME];
-        }
+        const double time = mr_model_part.GetProcessInfo()[TIME];
         double value = mpTable->GetValue(time);
         
         const int nnodes = static_cast<int>(mr_model_part.Nodes().size());
 
-        if(nnodes != 0) {
+        if (nnodes != 0) {
             ModelPart::NodesContainerType::iterator it_begin = mr_model_part.NodesBegin();
 
             #pragma omp parallel for
-            for(int i = 0; i < nnodes; i++) {
+            for (int i = 0; i < nnodes; i++) {
                 ModelPart::NodesContainerType::iterator it = it_begin + i;
                 it->FastGetSolutionStepValue(var) = value;
             }

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -58,7 +58,7 @@
 #include "processes/apply_periodic_boundary_condition_process.h"
 #include "processes/integration_values_extrapolation_to_nodes_process.h"
 #include "processes/apply_component_table_process.hpp"
-#include "processes/apply_constant_scalarvalue_process.h"
+#include "processes/apply_double_table_process.hpp"
 #include "includes/node.h"
 
 #include "spaces/ublas_space.h"

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -57,6 +57,8 @@
 #include "processes/skin_detection_process.h"
 #include "processes/apply_periodic_boundary_condition_process.h"
 #include "processes/integration_values_extrapolation_to_nodes_process.h"
+#include "processes/apply_component_table_process.hpp"
+#include "processes/apply_constant_scalarvalue_process.h"
 #include "includes/node.h"
 
 #include "spaces/ublas_space.h"
@@ -544,9 +546,17 @@ void  AddProcessesToPython(pybind11::module& m)
 
     // The process to recover internal variables
     py::class_<IntegrationValuesExtrapolationToNodesProcess, IntegrationValuesExtrapolationToNodesProcess::Pointer, Process>(m, "IntegrationValuesExtrapolationToNodesProcess")
-    .def(py::init<ModelPart&>())
-    .def(py::init<ModelPart&, Parameters>())
-    ;
+        .def(py::init<ModelPart&>())
+        .def(py::init<ModelPart&, Parameters>())
+        ;
+
+    py::class_<ApplyComponentTableProcess, ApplyComponentTableProcess::Pointer, Process> (m, "ApplyComponentTableProcess")
+        .def( py::init< ModelPart&, Parameters>())
+        ;
+
+    py::class_<ApplyDoubleTableProcess, ApplyDoubleTableProcess::Pointer, Process> (m, "ApplyDoubleTableProcess")
+        .def( py::init< ModelPart&, Parameters>())
+        ;
 }
 
 }  // namespace Python.

--- a/kratos/python_scripts/apply_normal_load_table_process.py
+++ b/kratos/python_scripts/apply_normal_load_table_process.py
@@ -1,0 +1,46 @@
+import KratosMultiphysics
+
+def Factory(settings, Model):
+    if(type(settings) != KratosMultiphysics.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    return ApplyNormalLoadTableProcess(Model, settings["Parameters"])
+
+## All the processes python should be derived from "Process"
+class ApplyNormalLoadTableProcess(KratosMultiphysics.Process):
+    def __init__(self, Model, settings ):
+        KratosMultiphysics.Process.__init__(self)
+
+        model_part = Model[settings["model_part_name"].GetString()]
+        
+        self.components_process_list = []
+        
+        if settings["active"][0].GetBool() == True:
+            normal_params = KratosMultiphysics.Parameters("{}")
+            normal_params.AddValue("model_part_name",settings["model_part_name"])
+            normal_params.AddValue("variable_name",settings["variable_name"])
+
+            normal_params.AddValue("value",settings["value"][0])
+            if settings["table"][0].GetInt() == 0:
+                self.components_process_list.append(KratosMultiphysics.ApplyConstantScalarValueProcess(model_part, normal_params))
+            else:
+                normal_params.AddValue("table",settings["table"][0])
+                self.components_process_list.append(KratosMultiphysics.ApplyDoubleTableProcess(model_part, normal_params))
+
+        if settings["active"][1].GetBool() == True:
+            tangential_params = KratosMultiphysics.Parameters("{}")
+            tangential_params.AddValue("model_part_name",settings["model_part_name"])
+            tangential_params.AddEmptyValue("variable_name").SetString("TANGENTIAL_CONTACT_STRESS") # Note: this is not general
+            tangential_params.AddValue("value",settings["value"][1])
+            if settings["table"][1].GetInt() == 0:
+                self.components_process_list.append(KratosMultiphysics.ApplyConstantScalarValueProcess(model_part, tangential_params))
+            else:
+                tangential_params.AddValue("table",settings["table"][1])
+                self.components_process_list.append(KratosMultiphysics.ApplyDoubleTableProcess(model_part, tangential_params))
+                
+    def ExecuteInitialize(self):
+        for component in self.components_process_list:
+            component.ExecuteInitialize()
+
+    def ExecuteInitializeSolutionStep(self):
+        for component in self.components_process_list:
+            component.ExecuteInitializeSolutionStep()

--- a/kratos/python_scripts/apply_scalar_constraint_table_process.py
+++ b/kratos/python_scripts/apply_scalar_constraint_table_process.py
@@ -1,0 +1,32 @@
+import KratosMultiphysics
+
+def Factory(settings, Model):
+    if(type(settings) != KratosMultiphysics.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    return ApplyScalarConstraintTableProcess(Model, settings["Parameters"])
+
+## All the processes python should be derived from "Process"
+class ApplyScalarConstraintTableProcess(KratosMultiphysics.Process):
+    def __init__(self, Model, settings ):
+        KratosMultiphysics.Process.__init__(self)
+
+        model_part = Model[settings["model_part_name"].GetString()]
+
+        params = KratosMultiphysics.Parameters("{}")
+        params.AddValue("model_part_name",settings["model_part_name"])
+        params.AddValue("variable_name",settings["variable_name"])
+        if settings.Has("is_fixed"):
+            params.AddValue("is_fixed",settings["is_fixed"])
+        
+        params.AddValue("value",settings["value"])
+        if settings["table"].GetInt() == 0:
+            self.process = KratosMultiphysics.ApplyConstantScalarValueProcess(model_part, params)
+        else:
+            params.AddValue("table",settings["table"])
+            self.process = KratosMultiphysics.ApplyDoubleTableProcess(model_part, params)
+
+    def ExecuteInitialize(self):
+        self.process.ExecuteInitialize()
+
+    def ExecuteInitializeSolutionStep(self):
+        self.process.ExecuteInitializeSolutionStep()

--- a/kratos/python_scripts/apply_vector_constraint_table_process.py
+++ b/kratos/python_scripts/apply_vector_constraint_table_process.py
@@ -1,0 +1,63 @@
+import KratosMultiphysics
+
+def Factory(settings, Model):
+    if(type(settings) != KratosMultiphysics.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    return ApplyVectorConstraintTableProcess(Model, settings["Parameters"])
+
+## All the processes python should be derived from "Process"
+class ApplyVectorConstraintTableProcess(KratosMultiphysics.Process):
+    def __init__(self, Model, settings ):
+        KratosMultiphysics.Process.__init__(self)
+
+        model_part = Model[settings["model_part_name"].GetString()]
+        variable_name = settings["variable_name"].GetString()
+
+        self.components_process_list = []
+
+        if settings["active"][0].GetBool() == True:
+            x_params = KratosMultiphysics.Parameters("{}")
+            x_params.AddValue("model_part_name",settings["model_part_name"])
+            if settings.Has("is_fixed"):
+                x_params.AddValue("is_fixed",settings["is_fixed"][0])
+            x_params.AddValue("value",settings["value"][0])
+            x_params.AddEmptyValue("variable_name").SetString(variable_name+"_X")
+            if settings["table"][0].GetInt() == 0:
+                self.components_process_list.append(KratosMultiphysics.ApplyConstantScalarValueProcess(model_part, x_params))
+            else:
+                x_params.AddValue("table",settings["table"][0])
+                self.components_process_list.append(KratosMultiphysics.ApplyComponentTableProcess(model_part, x_params))
+
+        if settings["active"][1].GetBool() == True:
+            y_params = KratosMultiphysics.Parameters("{}")
+            y_params.AddValue("model_part_name",settings["model_part_name"])
+            if settings.Has("is_fixed"):
+                y_params.AddValue("is_fixed",settings["is_fixed"][1])
+            y_params.AddValue("value",settings["value"][1])
+            y_params.AddEmptyValue("variable_name").SetString(variable_name+"_Y")
+            if settings["table"][1].GetInt() == 0:
+                self.components_process_list.append(KratosMultiphysics.ApplyConstantScalarValueProcess(model_part, y_params))
+            else:
+                y_params.AddValue("table",settings["table"][1])
+                self.components_process_list.append(KratosMultiphysics.ApplyComponentTableProcess(model_part, y_params))
+
+        if settings["active"][2].GetBool() == True:
+            z_params = KratosMultiphysics.Parameters("{}")
+            z_params.AddValue("model_part_name",settings["model_part_name"])
+            if settings.Has("is_fixed"):
+                z_params.AddValue("is_fixed",settings["is_fixed"][2])
+            z_params.AddValue("value",settings["value"][2])
+            z_params.AddEmptyValue("variable_name").SetString(variable_name+"_Z")
+            if settings["table"][2].GetInt() == 0:
+                self.components_process_list.append(KratosMultiphysics.ApplyConstantScalarValueProcess(model_part, z_params))
+            else:
+                z_params.AddValue("table",settings["table"][2])
+                self.components_process_list.append(KratosMultiphysics.ApplyComponentTableProcess(model_part, z_params))
+
+    def ExecuteInitialize(self):
+        for component in self.components_process_list:
+            component.ExecuteInitialize()
+
+    def ExecuteInitializeSolutionStep(self):
+        for component in self.components_process_list:
+            component.ExecuteInitializeSolutionStep()


### PR DESCRIPTION
In this PR I'm adding to the core an implemenation carried out initially by @ipouplana regarding the application of Boundary Conditions and loads whose value is defined according to a Table.
The json format is:
```
{
    "python_module": "apply_vector_constraint_table_process",
            "kratos_module": "KratosMultiphysics",

            "Parameters":    {
                "model_part_name": "Structure.DISPLACEMENT_Displacement_Auto2",
                "variable_name":   "DISPLACEMENT",
                "active":          [true,true,true],
                "is_fixed":        [true,true,true],
                "value":           [0.0,0.0,0.0],
                "table":           [1,0,0]
            }
        }
```
Where the key "table" defines the table that is goberning that direction.

Inside the mdpa ons must include the table as:
```
Begin Table 1 TIME DISPLACEMENT_X
  0.0 0.1
  1.0 0.2
  10 0.2
End Table
```

and including the defined table inside the SubModelPart:

```
Begin SubModelPart DISPLACEMENT_Displacement_Auto2
    Begin SubModelPartTables
	1
	End SubModelPartTables
	Begin SubModelPartNodes
            1
            2
            6
           11
           17
           25
           35
           47
           61
    End SubModelPartNodes
    Begin SubModelPartElements
    End SubModelPartElements
    Begin SubModelPartConditions
    End SubModelPartConditions
End SubModelPart
```