### PR TITLE
cps/ Using nonhistorical VariableToZero process

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_forces_on_nodes_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_forces_on_nodes_process.py
@@ -29,7 +29,7 @@ class ComputeForcesOnNodesProcess(KratosMultiphysics.Process):
     def Execute(self):
         KratosMultiphysics.Logger.PrintInfo('ComputeForcesOnNodesProcess', 'Computing reactions on nodes')
 
-        KratosMultiphysics.VariableUtils().SetHistoricalVariableToZero(KratosMultiphysics.REACTION, self.body_model_part.Nodes)
+        KratosMultiphysics.VariableUtils().SetNonHistoricalVariableToZero(KratosMultiphysics.REACTION, self.body_model_part.Nodes)
 
         free_stream_velocity = self.body_model_part.ProcessInfo.GetValue(CPFApp.VELOCITY_INFINITY)
         #TODO: Read density from ProcessInfo once available


### PR DESCRIPTION
Small modification after #4723 since tests were not passing. The historical VariableToZero process was  used but REACTION is not defined in the variable list of the potential solver. Now the SetNonHistoricalVariableToZero is called instead. 