### PR TITLE
Cps/Using normal from Geometry() instead of NormalCalculationUtils()

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.cpp
@@ -53,12 +53,6 @@ void PotentialWallCondition<TDim, TNumNodes>::Initialize()
 {
     KRATOS_TRY;
 
-    const array_1d<double, 3>& rNormal = this->GetValue(NORMAL);
-
-    KRATOS_ERROR_IF(norm_2(rNormal) < std::numeric_limits<double>::epsilon())
-        << "Error on condition -> " << this->Id() << "\n"
-        << "NORMAL must be calculated before using this condition." << std::endl;
-
     if (mInitializeWasPerformed)
         return;
 

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_forces_on_nodes_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_forces_on_nodes_process.py
@@ -38,7 +38,7 @@ class ComputeForcesOnNodesProcess(KratosMultiphysics.Process):
         dynamic_pressure = 0.5*free_stream_density*free_stream_velocity_norm**2
 
         for cond in self.body_model_part.Conditions:
-            condition_normal = cond.GetValue(KratosMultiphysics.NORMAL)
+            condition_normal = cond.GetGeometry().Normal()
             pressure_coefficient = cond.GetValue(KratosMultiphysics.PRESSURE)
 
             for node in cond.GetNodes():

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
@@ -35,7 +35,7 @@ class ComputeLiftProcess(KratosMultiphysics.Process):
         rz = 0.0
 
         for cond in self.body_model_part.Conditions:
-            n = cond.GetValue(KratosMultiphysics.NORMAL)
+            n = cond.GetGeometry().Normal()
             cp = cond.GetValue(KratosMultiphysics.PRESSURE)
 
             rx += n[0]*cp

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_moment_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_moment_process.py
@@ -42,7 +42,7 @@ class ComputeMomentProcess(KratosMultiphysics.Process):
         m = KratosMultiphysics.Vector(3)
 
         for cond in self.body_model_part.Conditions:
-            n =  KratosMultiphysics.Vector(cond.GetValue(KratosMultiphysics.NORMAL)) #normal direction assumed outward of domain
+            n =  cond.GetGeometry().Normal()#normal direction assumed outward of domain
             cp = cond.GetValue(KratosMultiphysics.PRESSURE)
             mid_point = cond.GetGeometry().Center()
             lever = mid_point-self.reference_point

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process.py
@@ -42,8 +42,6 @@ class DefineWakeProcess(KratosMultiphysics.Process):
         self.fluid_model_part = Model[settings["fluid_part_name"].GetString()]
 
 
-        KratosMultiphysics.NormalCalculationUtils().CalculateOnSimplex(self.fluid_model_part,self.fluid_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE])
-
         # Neigbour search tool instance
         AvgElemNum = 10
         AvgNodeNum = 10

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
@@ -51,10 +51,6 @@ class DefineWakeProcess2D(KratosMultiphysics.Process):
         self.fluid_model_part = self.body_model_part.GetRootModelPart()
         self.trailing_edge_model_part = self.fluid_model_part.CreateSubModelPart("trailing_edge_model_part")
 
-        # Call the nodal normal calculation util
-        KratosMultiphysics.NormalCalculationUtils().CalculateOnSimplex(
-            self.fluid_model_part, self.fluid_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE])
-
         # Find nodal neigbours util call
         avg_elem_num = 10
         avg_node_num = 10

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -70,7 +70,6 @@ class PotentialFlowSolver(FluidSolver):
         self.main_model_part.AddNodalSolutionStepVariable(KCPFApp.AUXILIARY_VELOCITY_POTENTIAL)
 
         # Kratos variables
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NORMAL)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
 
     def AddDofs(self):


### PR DESCRIPTION
As suggested by @philbucher in https://github.com/KratosMultiphysics/Kratos/pull/4711#issuecomment-487681743, I remove the NormalUtils calls by using the normal from Geometry(). 

Also, since normals are already available from Geometry(), we can remove the check that was present in the potential_wall_condition.cpp.