### PR TITLE
[Core] Introduce missing resize in element and condition base class

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -315,8 +315,9 @@ public:
      */
     virtual void GetValuesVector(Vector& values, int Step = 0)
     {
-        if (values.size() != 0)
+        if (values.size() != 0) {
             values.resize(0, false);
+        }
     }
 
     /**
@@ -324,8 +325,9 @@ public:
      */
     virtual void GetFirstDerivativesVector(Vector& values, int Step = 0)
     {
-        if (values.size() != 0)
+        if (values.size() != 0) {
             values.resize(0, false);
+        }
     }
 
     /**
@@ -333,8 +335,9 @@ public:
      */
     virtual void GetSecondDerivativesVector(Vector& values, int Step = 0)
     {
-        if (values.size() != 0)
+        if (values.size() != 0) {
             values.resize(0, false);
+        }
     }
 
     /**
@@ -473,8 +476,9 @@ public:
                     const std::vector< Variable< MatrixType > >& rLHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
     {
-        if (rLeftHandSideMatrices.size() != 0)
+        if (rLeftHandSideMatrices.size() != 0) {
             rLeftHandSideMatrices.resize(0);
+        }
     }
 
     /**
@@ -501,8 +505,9 @@ public:
                     const std::vector< Variable< VectorType > >& rRHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
     {
-        if (rRightHandSideVectors.size() != 0)
+        if (rRightHandSideVectors.size() != 0) {
             rRightHandSideVectors.resize(0);
+        }
     }
 
 

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -315,6 +315,8 @@ public:
      */
     virtual void GetValuesVector(Vector& values, int Step = 0)
     {
+        if (values.size() != 0)
+            values.resize(0, false);
     }
 
     /**
@@ -322,6 +324,8 @@ public:
      */
     virtual void GetFirstDerivativesVector(Vector& values, int Step = 0)
     {
+        if (values.size() != 0)
+            values.resize(0, false);
     }
 
     /**
@@ -329,6 +333,8 @@ public:
      */
     virtual void GetSecondDerivativesVector(Vector& values, int Step = 0)
     {
+        if (values.size() != 0)
+            values.resize(0, false);
     }
 
     /**
@@ -467,6 +473,8 @@ public:
                     const std::vector< Variable< MatrixType > >& rLHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
     {
+        if (rLeftHandSideMatrices.size() != 0)
+            rLeftHandSideMatrices.resize(0);
     }
 
     /**
@@ -493,6 +501,8 @@ public:
                     const std::vector< Variable< VectorType > >& rRHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
     {
+        if (rRightHandSideVectors.size() != 0)
+            rRightHandSideVectors.resize(0);
     }
 
 

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -309,6 +309,8 @@ public:
      */
     virtual void GetValuesVector(Vector& values, int Step = 0)
     {
+        if (values.size() != 0)
+            values.resize(0, false);
     }
 
     /**
@@ -316,6 +318,8 @@ public:
      */
     virtual void GetFirstDerivativesVector(Vector& values, int Step = 0)
     {
+        if (values.size() != 0)
+            values.resize(0, false);
     }
 
     /**
@@ -323,6 +327,8 @@ public:
      */
     virtual void GetSecondDerivativesVector(Vector& values, int Step = 0)
     {
+        if (values.size() != 0)
+            values.resize(0, false);
     }
 
     /**
@@ -440,6 +446,10 @@ public:
                                       const std::vector< Variable< VectorType > >& rRHSVariables,
                                       ProcessInfo& rCurrentProcessInfo)
     {
+        if (rLeftHandSideMatrices.size() != 0)
+	        rLeftHandSideMatrices.resize(0);
+        if (rRightHandSideVectors.size() != 0)
+	        rRightHandSideVectors.resize(0);
     }
 
     /**
@@ -466,6 +476,8 @@ public:
                     const std::vector< Variable< MatrixType > >& rLHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
     {
+        if (rLeftHandSideMatrices.size() != 0)
+	        rLeftHandSideMatrices.resize(0);
     }
 
     /**
@@ -492,6 +504,8 @@ public:
                     const std::vector< Variable< VectorType > >& rRHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
     {
+        if (rRightHandSideVectors.size() != 0)
+	        rRightHandSideVectors.resize(0);
     }
 
 

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -309,8 +309,9 @@ public:
      */
     virtual void GetValuesVector(Vector& values, int Step = 0)
     {
-        if (values.size() != 0)
+        if (values.size() != 0) {
             values.resize(0, false);
+        }
     }
 
     /**
@@ -318,8 +319,9 @@ public:
      */
     virtual void GetFirstDerivativesVector(Vector& values, int Step = 0)
     {
-        if (values.size() != 0)
+        if (values.size() != 0) {
             values.resize(0, false);
+        }
     }
 
     /**
@@ -327,8 +329,9 @@ public:
      */
     virtual void GetSecondDerivativesVector(Vector& values, int Step = 0)
     {
-        if (values.size() != 0)
+        if (values.size() != 0) {
             values.resize(0, false);
+        }
     }
 
     /**
@@ -446,10 +449,12 @@ public:
                                       const std::vector< Variable< VectorType > >& rRHSVariables,
                                       ProcessInfo& rCurrentProcessInfo)
     {
-        if (rLeftHandSideMatrices.size() != 0)
+        if (rLeftHandSideMatrices.size() != 0) {
 	        rLeftHandSideMatrices.resize(0);
-        if (rRightHandSideVectors.size() != 0)
+        }
+        if (rRightHandSideVectors.size() != 0) {
 	        rRightHandSideVectors.resize(0);
+        }
     }
 
     /**
@@ -476,8 +481,9 @@ public:
                     const std::vector< Variable< MatrixType > >& rLHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
     {
-        if (rLeftHandSideMatrices.size() != 0)
+        if (rLeftHandSideMatrices.size() != 0) {
 	        rLeftHandSideMatrices.resize(0);
+        }
     }
 
     /**
@@ -504,8 +510,9 @@ public:
                     const std::vector< Variable< VectorType > >& rRHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
     {
-        if (rRightHandSideVectors.size() != 0)
+        if (rRightHandSideVectors.size() != 0) {
 	        rRightHandSideVectors.resize(0);
+        }
     }
 
 


### PR DESCRIPTION
See title. The problem with the missing resize is as follows:

If ones loops over the elements/conditions of an mdpa and asks for the solution vector using "GetValuesVector", then one obtains the values with the correct size, since internally a resize is done. However, if among this set there is elements/conditions which do not operate on DOFS (e.g. the general SurfaceCondition3D3N), then asking for the GetValuesVector will call the base class and "return" exactly the input vector, which may look different every time. This is logically wrong. If an element or condition does not have a solution vector, and the base class is called, then also the corresponding output argument should be resized to zero. This is already done in some places, but not consistently everywhere. This PR resolves this problem.    