### PR TITLE
[Core] Construct tensors and vector with correct size instead on resize

### DIFF
--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -1240,16 +1240,16 @@ public:
     static inline TMatrixType StressVectorToTensor(const TVector& rStressVector)
     {
         KRATOS_TRY;
-        TMatrixType stress_tensor;
+        
+        const SizeType matrix_size = rStressVector.size() == 3 ? 2 : 3;
+        TMatrixType stress_tensor(matrix_size, matrix_size);
 
         if (rStressVector.size()==3) {
-            stress_tensor.resize(2,2,false);
             stress_tensor(0,0) = rStressVector[0];
             stress_tensor(0,1) = rStressVector[2];
             stress_tensor(1,0) = rStressVector[2];
             stress_tensor(1,1) = rStressVector[1];
         } else if (rStressVector.size()==4) {
-            stress_tensor.resize(3,3,false);
             stress_tensor(0,0) = rStressVector[0];
             stress_tensor(0,1) = rStressVector[3];
             stress_tensor(0,2) = 0.0;
@@ -1260,7 +1260,6 @@ public:
             stress_tensor(2,1) = 0.0;
             stress_tensor(2,2) = rStressVector[2];
         } else if (rStressVector.size()==6) {
-            stress_tensor.resize(3,3,false);
             stress_tensor(0,0) = rStressVector[0];
             stress_tensor(0,1) = rStressVector[3];
             stress_tensor(0,2) = rStressVector[5];
@@ -1293,39 +1292,37 @@ public:
     {
         KRATOS_TRY;
 
-        TMatrixType Tensor;
+        const SizeType matrix_size = rVector.size() == 3 ? 2 : 3;
+        TMatrixType tensor(matrix_size, matrix_size);
 
         if (rVector.size() == 3) {
-            Tensor.resize(2,2,false);
-            Tensor(0,0) = rVector[0];
-            Tensor(0,1) = rVector[2];
-            Tensor(1,0) = rVector[2];
-            Tensor(1,1) = rVector[1];
+            tensor(0,0) = rVector[0];
+            tensor(0,1) = rVector[2];
+            tensor(1,0) = rVector[2];
+            tensor(1,1) = rVector[1];
         } else if (rVector.size() == 4) {
-            Tensor.resize(3,3,false);
-            Tensor(0,0) = rVector[0];
-            Tensor(0,1) = rVector[3];
-            Tensor(0,2) = 0.0;
-            Tensor(1,0) = rVector[3];
-            Tensor(1,1) = rVector[1];
-            Tensor(1,2) = 0.0;
-            Tensor(2,0) = 0.0;
-            Tensor(2,1) = 0.0;
-            Tensor(2,2) = rVector[2];
+            tensor(0,0) = rVector[0];
+            tensor(0,1) = rVector[3];
+            tensor(0,2) = 0.0;
+            tensor(1,0) = rVector[3];
+            tensor(1,1) = rVector[1];
+            tensor(1,2) = 0.0;
+            tensor(2,0) = 0.0;
+            tensor(2,1) = 0.0;
+            tensor(2,2) = rVector[2];
         } else if (rVector.size() == 6) {
-            Tensor.resize(3,3,false);
-            Tensor(0,0) = rVector[0];
-            Tensor(0,1) = rVector[3];
-            Tensor(0,2) = rVector[5];
-            Tensor(1,0) = rVector[3];
-            Tensor(1,1) = rVector[1];
-            Tensor(1,2) = rVector[4];
-            Tensor(2,0) = rVector[5];
-            Tensor(2,1) = rVector[4];
-            Tensor(2,2) = rVector[2];
+            tensor(0,0) = rVector[0];
+            tensor(0,1) = rVector[3];
+            tensor(0,2) = rVector[5];
+            tensor(1,0) = rVector[3];
+            tensor(1,1) = rVector[1];
+            tensor(1,2) = rVector[4];
+            tensor(2,0) = rVector[5];
+            tensor(2,1) = rVector[4];
+            tensor(2,2) = rVector[2];
         }
 
-        return Tensor;
+        return tensor;
 
         KRATOS_CATCH("");
     }
@@ -1360,17 +1357,15 @@ public:
     {
         KRATOS_TRY
 
-        TMatrixType strain_tensor;
+        const SizeType matrix_size = rStrainVector.size() == 3 ? 2 : 3;
+        TMatrixType strain_tensor(matrix_size, matrix_size);
 
         if (rStrainVector.size()==3) {
-            strain_tensor.resize(2,2, false);
-
             strain_tensor(0,0) = rStrainVector[0];
             strain_tensor(0,1) = 0.5*rStrainVector[2];
             strain_tensor(1,0) = 0.5*rStrainVector[2];
             strain_tensor(1,1) = rStrainVector[1];
         } else if (rStrainVector.size()==4) {
-            strain_tensor.resize(3,3, false);
             strain_tensor(0,0) = rStrainVector[0];
             strain_tensor(0,1) = 0.5*rStrainVector[3];
             strain_tensor(0,2) = 0;
@@ -1381,7 +1376,6 @@ public:
             strain_tensor(2,1) = 0;
             strain_tensor(2,2) = rStrainVector[2];
         } else if (rStrainVector.size()==6) {
-            strain_tensor.resize(3,3, false);
             strain_tensor(0,0) = rStrainVector[0];
             strain_tensor(0,1) = 0.5*rStrainVector[3];
             strain_tensor(0,2) = 0.5*rStrainVector[5];
@@ -1391,8 +1385,6 @@ public:
             strain_tensor(2,0) = 0.5*rStrainVector[5];
             strain_tensor(2,1) = 0.5*rStrainVector[4];
             strain_tensor(2,2) = rStrainVector[2];
-
-
         }
 
         return strain_tensor;
@@ -1422,8 +1414,6 @@ public:
     {
         KRATOS_TRY;
 
-        Vector StrainVector;
-
         if(rSize == 0) {
             if(rStrainTensor.size1() == 2) {
                 rSize = 3;
@@ -1431,29 +1421,28 @@ public:
                 rSize = 6;
             }
         }
+        
+        Vector strain_vector(rSize);
 
         if (rSize == 3) {
-            StrainVector.resize(3,false);
-            StrainVector[0] = rStrainTensor(0,0);
-            StrainVector[1] = rStrainTensor(1,1);
-            StrainVector[2] = 2.0*rStrainTensor(0,1);
+            strain_vector[0] = rStrainTensor(0,0);
+            strain_vector[1] = rStrainTensor(1,1);
+            strain_vector[2] = 2.0*rStrainTensor(0,1);
         } else if (rSize == 4) {
-            StrainVector.resize(4,false);
-            StrainVector[0] = rStrainTensor(0,0);
-            StrainVector[1] = rStrainTensor(1,1);
-            StrainVector[2] = rStrainTensor(2,2);
-            StrainVector[3] = 2.0*rStrainTensor(0,1);
+            strain_vector[0] = rStrainTensor(0,0);
+            strain_vector[1] = rStrainTensor(1,1);
+            strain_vector[2] = rStrainTensor(2,2);
+            strain_vector[3] = 2.0*rStrainTensor(0,1);
         } else if (rSize == 6) {
-            StrainVector.resize(6,false);
-            StrainVector[0] = rStrainTensor(0,0);
-            StrainVector[1] = rStrainTensor(1,1);
-            StrainVector[2] = rStrainTensor(2,2);
-            StrainVector[3] = 2.0*rStrainTensor(0,1);
-            StrainVector[4] = 2.0*rStrainTensor(1,2);
-            StrainVector[5] = 2.0*rStrainTensor(0,2);
+            strain_vector[0] = rStrainTensor(0,0);
+            strain_vector[1] = rStrainTensor(1,1);
+            strain_vector[2] = rStrainTensor(2,2);
+            strain_vector[3] = 2.0*rStrainTensor(0,1);
+            strain_vector[4] = 2.0*rStrainTensor(1,2);
+            strain_vector[5] = 2.0*rStrainTensor(0,2);
         }
 
-        return StrainVector;
+        return strain_vector;
 
         KRATOS_CATCH("");
      }
@@ -1480,39 +1469,35 @@ public:
     {
         KRATOS_TRY;
 
-        TVector StressVector;
-
         if(rSize == 0) {
             if(rStressTensor.size1() == 2) {
                 rSize = 3;
-            }
-            else if(rStressTensor.size1() == 3) {
+            } else if(rStressTensor.size1() == 3) {
                 rSize = 6;
             }
         }
+        
+        TVector stress_vector(rSize);
 
         if (rSize == 3) {
-            if (StressVector.size() != 3) StressVector.resize(3,false);
-            StressVector[0] = rStressTensor(0,0);
-            StressVector[1] = rStressTensor(1,1);
-            StressVector[2] = rStressTensor(0,1);
+            stress_vector[0] = rStressTensor(0,0);
+            stress_vector[1] = rStressTensor(1,1);
+            stress_vector[2] = rStressTensor(0,1);
         } else if (rSize == 4) {
-            if (StressVector.size() != 4) StressVector.resize(4,false);
-            StressVector[0] = rStressTensor(0,0);
-            StressVector[1] = rStressTensor(1,1);
-            StressVector[2] = rStressTensor(2,2);
-            StressVector[3] = rStressTensor(0,1);
+            stress_vector[0] = rStressTensor(0,0);
+            stress_vector[1] = rStressTensor(1,1);
+            stress_vector[2] = rStressTensor(2,2);
+            stress_vector[3] = rStressTensor(0,1);
         } else if (rSize == 6) {
-            if (StressVector.size() != 6) StressVector.resize(6,false);
-            StressVector[0] = rStressTensor(0,0);
-            StressVector[1] = rStressTensor(1,1);
-            StressVector[2] = rStressTensor(2,2);
-            StressVector[3] = rStressTensor(0,1);
-            StressVector[4] = rStressTensor(1,2);
-            StressVector[5] = rStressTensor(0,2);
+            stress_vector[0] = rStressTensor(0,0);
+            stress_vector[1] = rStressTensor(1,1);
+            stress_vector[2] = rStressTensor(2,2);
+            stress_vector[3] = rStressTensor(0,1);
+            stress_vector[4] = rStressTensor(1,2);
+            stress_vector[5] = rStressTensor(0,2);
         }
 
-        return StressVector;
+        return stress_vector;
 
         KRATOS_CATCH("");
      }
@@ -1536,8 +1521,6 @@ public:
     {
         KRATOS_TRY;
 
-        Vector vector;
-
         if(rSize == 0) {
             if(rTensor.size1() == 2) {
                 rSize = 3;
@@ -1545,21 +1528,20 @@ public:
                 rSize = 6;
             }
         }
+        
+        Vector vector(rSize);
 
         if (rSize == 3) {
-            vector.resize(3,false);
             vector[0]= rTensor(0,0);
             vector[1]= rTensor(1,1);
             vector[2]= rTensor(0,1);
 
         } else if (rSize==4) {
-            vector.resize(4,false);
             vector[0]= rTensor(0,0);
             vector[1]= rTensor(1,1);
             vector[2]= rTensor(2,2);
             vector[3]= rTensor(0,1);
         } else if (rSize==6) {
-            vector.resize(6);
             vector[0]= rTensor(0,0);
             vector[1]= rTensor(1,1);
             vector[2]= rTensor(2,2);


### PR DESCRIPTION
Fixes #3156

This is besides much more efficient, as it avoids the resize operation