### PR TITLE
[MPI] unittest.main can now work in MPI

### DIFF
--- a/applications/MappingApplication/tests/test_nearest_element_mapper.py
+++ b/applications/MappingApplication/tests/test_nearest_element_mapper.py
@@ -81,10 +81,6 @@ class NearestElementBladeMapping(blade_mapping_test.BladeMappingTests):
         cls.print_output = False
 
 if __name__ == '__main__':
-    import sys
-    if "--using-mpi" in sys.argv:
-        from KratosMultiphysics import mpi # initialize MPI
-        sys.argv.remove("--using-mpi") # has to be removed bcs Unittest cannot parse it
     KM.Logger.GetDefaultOutput().SetSeverity(KM.Logger.Severity.WARNING)
     import KratosMultiphysics.KratosUnittest as KratosUnittest
     KratosUnittest.main()

--- a/applications/MappingApplication/tests/test_nearest_neighbor_mapper.py
+++ b/applications/MappingApplication/tests/test_nearest_neighbor_mapper.py
@@ -77,10 +77,6 @@ class NearestNeighborBladeMapping(blade_mapping_test.BladeMappingTests):
         cls.print_output = False
 
 if __name__ == '__main__':
-    import sys
-    if "--using-mpi" in sys.argv:
-        from KratosMultiphysics import mpi # initialize MPI
-        sys.argv.remove("--using-mpi") # has to be removed bcs Unittest cannot parse it
     KM.Logger.GetDefaultOutput().SetSeverity(KM.Logger.Severity.WARNING)
     import KratosMultiphysics.KratosUnittest as KratosUnittest
     KratosUnittest.main()

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import, division
 from KratosMultiphysics import Logger
 
 from unittest import *
+import unittest
 from contextlib import contextmanager
 
 import getopt
@@ -90,6 +91,10 @@ def Usage():
     for l in lines:
         Logger.PrintInfo(l) # using the logger to only print once in MPI
 
+def main():
+    if "--using-mpi" in sys.argv:
+        sys.argv.remove("--using-mpi") # has to be removed bcs unittest cannot parse it
+    unittest.main()
 
 def runTests(tests):
     verbose_values = [0, 1, 2]

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, absolute_import, division
 from KratosMultiphysics import Logger
 
-import unittest
 from unittest import * # needed to make all functions available to the tests using this file
 from contextlib import contextmanager
 
@@ -10,7 +9,7 @@ import sys
 import os
 
 
-class TestLoader(unittest.TestLoader):
+class TestLoader(TestLoader):
     def loadTestsFromTestCases(self, testCaseClasses):
         ''' Return a list of suites with all tests cases contained in every
         testCaseClass in testCaseClasses '''
@@ -24,7 +23,7 @@ class TestLoader(unittest.TestLoader):
         return allTests
 
 
-class TestCase(unittest.TestCase):
+class TestCase(TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -96,6 +95,7 @@ def main():
     # because it cannot parse extra command line arguments
     if "--using-mpi" in sys.argv:
         sys.argv.remove("--using-mpi") # has to be removed bcs unittest cannot parse it
+    import unittest
     unittest.main()
 
 def runTests(tests):
@@ -157,14 +157,14 @@ def runTests(tests):
 
 
 KratosSuites = {
-    'small':          unittest.TestSuite(),
-    'nightly':        unittest.TestSuite(),
-    'all':            unittest.TestSuite(),
-    'validation':     unittest.TestSuite(),
-    'mpi_small':      unittest.TestSuite(),
-    'mpi_nightly':    unittest.TestSuite(),
-    'mpi_all':        unittest.TestSuite(),
-    'mpi_validation': unittest.TestSuite(),
+    'small':          TestSuite(),
+    'nightly':        TestSuite(),
+    'all':            TestSuite(),
+    'validation':     TestSuite(),
+    'mpi_small':      TestSuite(),
+    'mpi_nightly':    TestSuite(),
+    'mpi_all':        TestSuite(),
+    'mpi_validation': TestSuite(),
 }
 
 

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -1,8 +1,8 @@
 from __future__ import print_function, absolute_import, division
 from KratosMultiphysics import Logger
 
-from unittest import *
 import unittest
+from unittest import * # needed to make all functions available to the tests using this file
 from contextlib import contextmanager
 
 import getopt
@@ -10,7 +10,7 @@ import sys
 import os
 
 
-class TestLoader(TestLoader):
+class TestLoader(unittest.TestLoader):
     def loadTestsFromTestCases(self, testCaseClasses):
         ''' Return a list of suites with all tests cases contained in every
         testCaseClass in testCaseClasses '''
@@ -24,7 +24,7 @@ class TestLoader(TestLoader):
         return allTests
 
 
-class TestCase(TestCase):
+class TestCase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
@@ -92,6 +92,8 @@ def Usage():
         Logger.PrintInfo(l) # using the logger to only print once in MPI
 
 def main():
+    # this deliberately overiddes the function "unittest.main",
+    # because it cannot parse extra command line arguments
     if "--using-mpi" in sys.argv:
         sys.argv.remove("--using-mpi") # has to be removed bcs unittest cannot parse it
     unittest.main()
@@ -155,14 +157,14 @@ def runTests(tests):
 
 
 KratosSuites = {
-    'small': TestSuite(),
-    'nightly': TestSuite(),
-    'all': TestSuite(),
-    'validation': TestSuite(),
-    'mpi_small': TestSuite(),
-    'mpi_nightly': TestSuite(),
-    'mpi_all': TestSuite(),
-    'mpi_validation': TestSuite(),
+    'small':          unittest.TestSuite(),
+    'nightly':        unittest.TestSuite(),
+    'all':            unittest.TestSuite(),
+    'validation':     unittest.TestSuite(),
+    'mpi_small':      unittest.TestSuite(),
+    'mpi_nightly':    unittest.TestSuite(),
+    'mpi_all':        unittest.TestSuite(),
+    'mpi_validation': unittest.TestSuite(),
 }
 
 


### PR DESCRIPTION
`unittest.main` cannot parse the `--using-mpi` argument, hence I remove it and pass the call