### PR TITLE
Cps/ Hotfix for embedded element (compilation error)

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.h
@@ -95,20 +95,10 @@ public:
     ///@{
 
     /// Assignment operator.
-    EmbeddedIncompressiblePotentialFlowElement& operator=(EmbeddedIncompressiblePotentialFlowElement const& rOther)
-    {
-        BaseType::operator=(rOther);
-        Flags::operator=(rOther);
-        return *this;
-    }
+    EmbeddedIncompressiblePotentialFlowElement& operator=(EmbeddedIncompressiblePotentialFlowElement const& rOther) = delete;
 
     /// Move operator.
-    EmbeddedIncompressiblePotentialFlowElement& operator=(EmbeddedIncompressiblePotentialFlowElement&& rOther)
-    {
-        BaseType::operator=(rOther);
-        Flags::operator=(rOther);
-        return *this;
-    }
+    EmbeddedIncompressiblePotentialFlowElement& operator=(EmbeddedIncompressiblePotentialFlowElement&& rOther) = delete;
 
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,


### PR DESCRIPTION
Hi,

After #4681 I introduced a compilation error. 

It has to do with the changes done in #4679, which were not merged into the embedded branch before pushing the embedded element (not auto-detected by Github, but I should have merged master first). 

I delete the assign and move operators also in the embedded element.