### PR TITLE
[Core][ContactStructuralMechanicsApplication] Removing warnings and fixing minor error after #4362 

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.cpp
@@ -344,11 +344,6 @@ void MortarContactCondition<TDim, TNumNodes, TFrictional, TNormalVariation, TNum
 
         const bool dual_LM =  DerivativesUtilitiesType::CalculateAeAndDeltaAe(slave_geometry, normal_slave, master_geometry, rDerivativeData, rVariables, consider_normal_variation, conditions_points_slave, this_integration_method, GetAxisymmetricCoefficient(rVariables));
 
-    #ifdef KRATOS_DEBUG
-        if (dual_LM == false)
-            KRATOS_WARNING("No dual LM") << "NOT USING DUAL LM. Integration area: " << integration_area << "\tOriginal area: " << geometry_area << "\tRatio: " << integration_area/geometry_area << std::endl;
-    #endif
-
         for (IndexType i_geom = 0; i_geom < conditions_points_slave.size(); ++i_geom) {
             PointerVector< PointType > points_array(TDim); // The points are stored as local coordinates, we calculate the global coordinates of this points
             array_1d<BelongType, TDim> belong_array;

--- a/kratos/utilities/exact_mortar_segmentation_utility.cpp
+++ b/kratos/utilities/exact_mortar_segmentation_utility.cpp
@@ -25,9 +25,9 @@
 namespace Kratos {
 template <>
 bool ExactMortarIntegrationUtility<2, 2, false>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     ConditionArrayListType& rConditionsPointsSlave
     )
@@ -36,17 +36,17 @@ bool ExactMortarIntegrationUtility<2, 2, false>::GetExactIntegration(
     const double tolerance = 1.0e3 * ZeroTolerance;
 
     double total_weight = 0.0;
-    array_1d<double, 2> auxiliar_coordinates(2 , 0.0);
+    array_1d<double, 2> auxiliar_coordinates = ZeroVector(2);
 
     // Declaring auxiliar values
     PointType projected_gp_global;
-    GeometryNodeType::CoordinatesArrayType projected_gp_local;
+    GeometryType::CoordinatesArrayType projected_gp_local;
 
     // First look if the edges of the slave are inside of the master, if not check if the opposite is true, if not then the element is not in contact
     for (IndexType i_slave = 0; i_slave < 2; ++i_slave) {
-        const array_1d<double, 3>& normal = rOriginalSlaveGeometry[i_slave].FastGetSolutionStepValue(NORMAL);
+        const array_1d<double, 3>& r_normal = rOriginalSlaveGeometry[i_slave].FastGetSolutionStepValue(NORMAL);
 
-        const double distance = GeometricalProjectionUtilities::FastProjectDirection(rOriginalMasterGeometry, rOriginalSlaveGeometry[i_slave], projected_gp_global, rMasterNormal, -normal ); // The opposite direction
+        const double distance = GeometricalProjectionUtilities::FastProjectDirection(rOriginalMasterGeometry, rOriginalSlaveGeometry[i_slave], projected_gp_global, rMasterNormal, -r_normal ); // The opposite direction
 
         if (distance > mDistanceThreshold) {
             rConditionsPointsSlave.clear();
@@ -134,9 +134,9 @@ bool ExactMortarIntegrationUtility<2, 2, false>::GetExactIntegration(
 
 template <>
 bool ExactMortarIntegrationUtility<3, 3, false>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     ConditionArrayListType& rConditionsPointsSlave
     )
@@ -208,7 +208,7 @@ bool ExactMortarIntegrationUtility<3, 3, false>::GetExactIntegration(
         // We add the internal nodes
         PushBackPoints(point_list, all_inside, slave_geometry);
 
-        return TriangleIntersections<GeometryNodeType>(rConditionsPointsSlave, point_list, rOriginalSlaveGeometry, slave_geometry, master_geometry, slave_tangent_xi, slave_tangent_eta, slave_center);
+        return TriangleIntersections<GeometryType>(rConditionsPointsSlave, point_list, rOriginalSlaveGeometry, slave_geometry, master_geometry, slave_tangent_xi, slave_tangent_eta, slave_center);
     }
 
     return false;
@@ -219,9 +219,9 @@ bool ExactMortarIntegrationUtility<3, 3, false>::GetExactIntegration(
 
 template <>
 bool ExactMortarIntegrationUtility<3, 4, false>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     ConditionArrayListType& rConditionsPointsSlave
     )
@@ -301,9 +301,9 @@ bool ExactMortarIntegrationUtility<3, 4, false>::GetExactIntegration(
 
 template <>
 bool ExactMortarIntegrationUtility<3, 3, false, 4>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     ConditionArrayListType& rConditionsPointsSlave
     )
@@ -384,7 +384,7 @@ bool ExactMortarIntegrationUtility<3, 3, false, 4>::GetExactIntegration(
         // We add the internal nodes
         PushBackPoints(point_list, all_inside_slave, slave_geometry);
 
-        return TriangleIntersections<GeometryNodeType>(rConditionsPointsSlave, point_list, rOriginalSlaveGeometry, slave_geometry, master_geometry, slave_tangent_xi, slave_tangent_eta, slave_center);
+        return TriangleIntersections<GeometryType>(rConditionsPointsSlave, point_list, rOriginalSlaveGeometry, slave_geometry, master_geometry, slave_tangent_xi, slave_tangent_eta, slave_center);
     }
 
     return false;
@@ -395,9 +395,9 @@ bool ExactMortarIntegrationUtility<3, 3, false, 4>::GetExactIntegration(
 
 template <>
 bool ExactMortarIntegrationUtility<3, 4, false, 3>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     ConditionArrayListType& rConditionsPointsSlave
     )
@@ -494,9 +494,9 @@ bool ExactMortarIntegrationUtility<3, 4, false, 3>::GetExactIntegration(
 
 template <>
 bool ExactMortarIntegrationUtility<2, 2, true>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     ConditionArrayListType& rConditionsPointsSlave
     )
@@ -505,18 +505,18 @@ bool ExactMortarIntegrationUtility<2, 2, true>::GetExactIntegration(
     const double tolerance = 1.0e3 * ZeroTolerance;
 
     double total_weight = 0.0;
-    array_1d<double, 2> auxiliar_coordinates(2, 0.0);
+    array_1d<double, 2> auxiliar_coordinates = ZeroVector(2);
     array_1d<PointBelongsLine2D2N, 2> auxiliar_belong;
 
     // Declaring auxiliar values
     PointType projected_gp_global;
-    GeometryNodeType::CoordinatesArrayType projected_gp_local;
+    GeometryType::CoordinatesArrayType projected_gp_local;
 
     // First look if the edges of the slave are inside of the master, if not check if the opposite is true, if not then the element is not in contact
     for (unsigned int i_slave = 0; i_slave < 2; ++i_slave) {
-        const array_1d<double, 3>& normal = rOriginalSlaveGeometry[i_slave].FastGetSolutionStepValue(NORMAL);
+        const array_1d<double, 3>& r_normal = rOriginalSlaveGeometry[i_slave].FastGetSolutionStepValue(NORMAL);
 
-        const double distance = GeometricalProjectionUtilities::FastProjectDirection(rOriginalMasterGeometry, rOriginalSlaveGeometry[i_slave], projected_gp_global, rMasterNormal, -normal ); // The opposite direction
+        const double distance = GeometricalProjectionUtilities::FastProjectDirection(rOriginalMasterGeometry, rOriginalSlaveGeometry[i_slave], projected_gp_global, rMasterNormal, -r_normal ); // The opposite direction
 
         if (distance > mDistanceThreshold) {
             rConditionsPointsSlave.clear();
@@ -619,9 +619,9 @@ bool ExactMortarIntegrationUtility<2, 2, true>::GetExactIntegration(
 
 template <>
 bool ExactMortarIntegrationUtility<3, 3, true>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     ConditionArrayListType& rConditionsPointsSlave
     )
@@ -688,7 +688,7 @@ bool ExactMortarIntegrationUtility<3, 3, true>::GetExactIntegration(
         // We add the internal nodes
         PushBackPoints(point_list, all_inside, slave_geometry, PointBelongs::Slave);
 
-        return TriangleIntersections<GeometryNodeType>(rConditionsPointsSlave, point_list, rOriginalSlaveGeometry, slave_geometry, master_geometry, slave_tangent_xi, slave_tangent_eta, slave_center);
+        return TriangleIntersections<GeometryType>(rConditionsPointsSlave, point_list, rOriginalSlaveGeometry, slave_geometry, master_geometry, slave_tangent_xi, slave_tangent_eta, slave_center);
     }
 
     return false;
@@ -699,9 +699,9 @@ bool ExactMortarIntegrationUtility<3, 3, true>::GetExactIntegration(
 
 template <>
 bool ExactMortarIntegrationUtility<3, 4, true>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     ConditionArrayListType& rConditionsPointsSlave
     )
@@ -781,9 +781,9 @@ bool ExactMortarIntegrationUtility<3, 4, true>::GetExactIntegration(
 
 template <>
 bool ExactMortarIntegrationUtility<3, 3, true, 4>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     ConditionArrayListType& rConditionsPointsSlave
     )
@@ -864,7 +864,7 @@ bool ExactMortarIntegrationUtility<3, 3, true, 4>::GetExactIntegration(
         // We add the internal nodes
         PushBackPoints(point_list, all_inside_slave, slave_geometry, PointBelongs::Slave);
 
-        return TriangleIntersections<GeometryNodeType>(rConditionsPointsSlave, point_list, rOriginalSlaveGeometry, slave_geometry, master_geometry, slave_tangent_xi, slave_tangent_eta, slave_center);
+        return TriangleIntersections<GeometryType>(rConditionsPointsSlave, point_list, rOriginalSlaveGeometry, slave_geometry, master_geometry, slave_tangent_xi, slave_tangent_eta, slave_center);
     }
 
     return false;
@@ -875,9 +875,9 @@ bool ExactMortarIntegrationUtility<3, 3, true, 4>::GetExactIntegration(
 
 template <>
 bool ExactMortarIntegrationUtility<3, 4, true, 3>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     ConditionArrayListType& rConditionsPointsSlave
     )
@@ -972,9 +972,9 @@ bool ExactMortarIntegrationUtility<3, 4, true, 3>::GetExactIntegration(
 
 template<SizeType TDim, SizeType TNumNodes, bool TBelong, SizeType TNumNodesMaster>
 bool ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong, TNumNodesMaster>::GetExactIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     IntegrationPointsType& rIntegrationPointsSlave
     )
@@ -1019,9 +1019,9 @@ bool ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong, TNumNodesMaster>::G
 
 template<SizeType TDim, SizeType TNumNodes, bool TBelong, SizeType TNumNodesMaster>
 bool ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong, TNumNodesMaster>::GetExactAreaIntegration(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     const array_1d<double, 3>& rSlaveNormal,
-    GeometryNodeType& rOriginalMasterGeometry,
+    const GeometryType& rOriginalMasterGeometry,
     const array_1d<double, 3>& rMasterNormal,
     double& rArea
     )
@@ -1044,7 +1044,7 @@ bool ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong, TNumNodesMaster>::G
 
 template<SizeType TDim, SizeType TNumNodes, bool TBelong, SizeType TNumNodesMaster>
 void ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong, TNumNodesMaster>::GetTotalArea(
-    GeometryNodeType& rOriginalSlaveGeometry,
+    const GeometryType& rOriginalSlaveGeometry,
     ConditionArrayListType& rConditionsPointsSlave,
     double& rArea
     )
@@ -1237,7 +1237,7 @@ void ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong, TNumNodesMaster>::G
 /***********************************************************************************/
 
 template<SizeType TDim, SizeType TNumNodes, bool TBelong, SizeType TNumNodesMaster>
-GeometryNodeType::IntegrationPointsArrayType ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong, TNumNodesMaster>::GetIntegrationTriangle()
+GeometryType::IntegrationPointsArrayType ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong, TNumNodesMaster>::GetIntegrationTriangle()
 {
     // Setting the auxiliar integration points
     switch (mIntegrationOrder) {
@@ -1296,8 +1296,8 @@ inline std::vector<IndexType> ExactMortarIntegrationUtility<TDim, TNumNodes, TBe
 template<SizeType TDim, SizeType TNumNodes, bool TBelong, SizeType TNumNodesMaster>
 inline void ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong, TNumNodesMaster>::ComputeClippingIntersections(
     PointListType& rPointList,
-    GeometryPointType& rSlaveGeometry,
-    GeometryPointType& rMasterGeometry,
+    const GeometryPointType& rSlaveGeometry,
+    const GeometryPointType& rMasterGeometry,
     const PointType& rRefCenter
     )
 {
@@ -1346,9 +1346,9 @@ template <class TGeometryType>
 inline bool ExactMortarIntegrationUtility<TDim, TNumNodes, TBelong, TNumNodesMaster>::TriangleIntersections(
     ConditionArrayListType& rConditionsPointsSlave,
     PointListType& rPointList,
-    TGeometryType& rOriginalSlaveGeometry,
-    GeometryPointType& rSlaveGeometry,
-    GeometryPointType& rMasterGeometry,
+    const TGeometryType& rOriginalSlaveGeometry,
+    const GeometryPointType& rSlaveGeometry,
+    const GeometryPointType& rMasterGeometry,
     const array_1d<double, 3>& rSlaveTangentXi,
     const array_1d<double, 3>& rSlaveTangentEta,
     const PointType& rRefCenter,

--- a/kratos/utilities/exact_mortar_segmentation_utility.cpp
+++ b/kratos/utilities/exact_mortar_segmentation_utility.cpp
@@ -74,8 +74,11 @@ bool ExactMortarIntegrationUtility<2, 2, false>::GetExactIntegration(
             double delta_xi = (i_master == 0) ? 0.5 : -0.5;
             const bool is_inside = GeometricalProjectionUtilities::ProjectIterativeLine2D(rOriginalSlaveGeometry, rOriginalMasterGeometry[i_master].Coordinates(), projected_gp_local, rSlaveNormal, tolerance, delta_xi);
 
-            if (is_inside)
+            if (is_inside) {
                 auxiliar_xi.push_back(projected_gp_local[0]);
+                if (projected_gp_local[0] > (1.0 - tolerance)) auxiliar_coordinates[1] = 1.0;
+                else if (projected_gp_local[0] < (-1.0 + tolerance)) auxiliar_coordinates[0] = -1.0;
+            }
         }
 
         // In this case one edge of the slave belongs to the master and additionally one node of the master belongs to the slave
@@ -101,9 +104,8 @@ bool ExactMortarIntegrationUtility<2, 2, false>::GetExactIntegration(
                     auxiliar_coordinates[0] = auxiliar_xi[1];
                 }
             }
-        } else { // THIS IS NOT SUPPOSED TO HAPPEN
-            KRATOS_DEBUG_ERROR << "THIS IS NOT SUPPOSED TO HAPPEN!!!!\n" << rOriginalSlaveGeometry << "\n" << rOriginalMasterGeometry << std::endl;
-            return false;  // NOTE: Giving problems
+        } else { // Projection not possible
+            return false;
         }
 
         total_weight = auxiliar_coordinates[1] - auxiliar_coordinates[0];
@@ -549,6 +551,8 @@ bool ExactMortarIntegrationUtility<2, 2, true>::GetExactIntegration(
 
             if (is_inside) {
                 auxiliar_xi.push_back(projected_gp_local[0]);
+                if (projected_gp_local[0] > (1.0 - tolerance)) auxiliar_coordinates[1] = 1.0;
+                else if (projected_gp_local[0] < (-1.0 + tolerance)) auxiliar_coordinates[0] = -1.0;
                 auxiliar_master_belong.push_back( static_cast<PointBelongsLine2D2N>(2 + i_master));
             }
         }
@@ -584,9 +588,8 @@ bool ExactMortarIntegrationUtility<2, 2, true>::GetExactIntegration(
                     auxiliar_belong[0] = auxiliar_master_belong[1];
                 }
             }
-        } else { // THIS IS NOT SUPPOSED TO HAPPEN
-            KRATOS_DEBUG_ERROR << "THIS IS NOT SUPPOSED TO HAPPEN!!!!\n" << rOriginalSlaveGeometry << "\n" << rOriginalMasterGeometry << std::endl;
-            return false;  // NOTE: Giving problems
+        } else { // Projection not possible
+            return false;
         }
 
         total_weight = auxiliar_coordinates[1] - auxiliar_coordinates[0];

--- a/kratos/utilities/exact_mortar_segmentation_utility.h
+++ b/kratos/utilities/exact_mortar_segmentation_utility.h
@@ -50,13 +50,13 @@ namespace Kratos {
     /// Geometric definitions
     typedef Point PointType;
     typedef Node<3> NodeType;
-    typedef Geometry<NodeType> GeometryNodeType;
+    typedef Geometry<NodeType> GeometryType;
     typedef Geometry<PointType> GeometryPointType;
 
     ///Type definition for integration methods
     typedef GeometryData::IntegrationMethod IntegrationMethod;
     typedef IntegrationPoint<2> IntegrationPointType;
-    typedef GeometryNodeType::IntegrationPointsArrayType IntegrationPointsType;
+    typedef GeometryType::IntegrationPointsArrayType IntegrationPointsType;
 
     /// The definition of the size type
     typedef std::size_t SizeType;
@@ -183,9 +183,9 @@ public:
      * @return True if there is a common area (the geometries intersect), false otherwise
      */
     bool GetExactIntegration(
-        GeometryNodeType& rOriginalSlaveGeometry,
+        const GeometryType& rOriginalSlaveGeometry,
         const array_1d<double, 3>& rSlaveNormal,
-        GeometryNodeType& rOriginalMasterGeometry,
+        const GeometryType& rOriginalMasterGeometry,
         const array_1d<double, 3>& rMasterNormal,
         ConditionArrayListType& rConditionsPointsSlave
         );
@@ -200,9 +200,9 @@ public:
      * @return True if there is a common area (the geometries intersect), false otherwise
      */
     bool GetExactIntegration(
-        GeometryNodeType& rOriginalSlaveGeometry,
+        const GeometryType& rOriginalSlaveGeometry,
         const array_1d<double, 3>& rSlaveNormal,
-        GeometryNodeType& rOriginalMasterGeometry,
+        const GeometryType& rOriginalMasterGeometry,
         const array_1d<double, 3>& rMasterNormal,
         IntegrationPointsType& rIntegrationPointsSlave
         );
@@ -217,9 +217,9 @@ public:
      * @return True if there is a common area (the geometries intersect), false otherwise
      */
     bool GetExactAreaIntegration(
-        GeometryNodeType& rOriginalSlaveGeometry,
+        const GeometryType& rOriginalSlaveGeometry,
         const array_1d<double, 3>& rSlaveNormal,
-        GeometryNodeType& rOriginalMasterGeometry,
+        const GeometryType& rOriginalMasterGeometry,
         const array_1d<double, 3>& rMasterNormal,
         double& rArea
         );
@@ -231,7 +231,7 @@ public:
      * @param rArea The total area integrated
      */
     void GetTotalArea(
-        GeometryNodeType& rOriginalSlaveGeometry,
+        const GeometryType& rOriginalSlaveGeometry,
         ConditionArrayListType& rConditionsPointsSlave,
         double& rArea
         );
@@ -276,9 +276,9 @@ public:
     */
     static inline void MathematicaDebug(
         const IndexType IndexSlave,
-        GeometryType& rSlaveGeometry,
+        const GeometryType& rSlaveGeometry,
         const IndexType IndexMaster,
-        GeometryType& rMasterGeometry,
+        const GeometryType& rMasterGeometry,
         ConditionArrayListType& rConditionsPointSlave
         )
     {
@@ -358,7 +358,7 @@ protected:
     /**
      * @brief Get the integration method to consider
      */
-    GeometryNodeType::IntegrationPointsArrayType GetIntegrationTriangle();
+    GeometryType::IntegrationPointsArrayType GetIntegrationTriangle();
 
     /**
      * @brief This method checks if the whole array is true
@@ -585,7 +585,7 @@ protected:
         )
     {
         for (IndexType i_node = 0; i_node < TSizeCheck; ++i_node) {
-            GeometryNodeType::CoordinatesArrayType projected_gp_local;
+            GeometryType::CoordinatesArrayType projected_gp_local;
             rAllInside[i_node] = rGeometry1.IsInside( rGeometry2[i_node].Coordinates( ), projected_gp_local, Tolerance) ;
         }
     }
@@ -609,8 +609,8 @@ protected:
      */
     inline void ComputeClippingIntersections(
         PointListType& rPointList,
-        GeometryPointType& rSlaveGeometry,
-        GeometryPointType& rMasterGeometry,
+        const GeometryPointType& rSlaveGeometry,
+        const GeometryPointType& rMasterGeometry,
         const PointType& rRefCenter
         );
 
@@ -626,13 +626,13 @@ protected:
      * @param IsAllInside To simplify and consider the point_list directly
      * @return If there is intersection or not (true/false)
      */
-    template <class TGeometryType = GeometryNodeType>
+    template <class TGeometryType = GeometryType>
     inline bool TriangleIntersections(
         ConditionArrayListType& rConditionsPointsSlave,
         PointListType& rPointList,
-        TGeometryType& rrOriginalSlaveGeometry,
-        GeometryPointType& rSlaveGeometry,
-        GeometryPointType& rMasterGeometry,
+        const TGeometryType& rOriginalSlaveGeometry,
+        const GeometryPointType& rSlaveGeometry,
+        const GeometryPointType& rMasterGeometry,
         const array_1d<double, 3>& rSlaveTangentXi,
         const array_1d<double, 3>& rSlaveTangentEta,
         const PointType& rRefCenter,

--- a/kratos/utilities/mortar_utilities.cpp
+++ b/kratos/utilities/mortar_utilities.cpp
@@ -474,9 +474,6 @@ void AddAreaWeightedNodalValue<Variable<double>, Historical>(
 {
     double area_coeff = pThisNode->GetValue(NODAL_AREA);
     const bool null_area = (std::abs(area_coeff) < RefArea * Tolerance);
-#ifdef KRATOS_DEBUG
-    KRATOS_WARNING_IF("WARNING:: NODE OF NULL AREA.", null_area && pThisNode->Is(SLAVE)) << " ID: " << pThisNode->Id() << std::endl;
-#endif
     area_coeff = null_area ? 0.0 : 1.0/area_coeff;
     double& r_aux_value = pThisNode->FastGetSolutionStepValue(rThisVariable);
     #pragma omp atomic
@@ -496,9 +493,6 @@ void AddAreaWeightedNodalValue<Variable<array_1d<double, 3>>, Historical>(
 {
     double area_coeff = pThisNode->GetValue(NODAL_AREA);
     const bool null_area = (std::abs(area_coeff) < RefArea * Tolerance);
-#ifdef KRATOS_DEBUG
-    KRATOS_WARNING_IF("WARNING:: NODE OF NULL AREA.", null_area && pThisNode->Is(SLAVE)) << " ID: " << pThisNode->Id() << std::endl;
-#endif
     area_coeff = null_area ? 0.0 : 1.0/area_coeff;
     auto& aux_vector = pThisNode->FastGetSolutionStepValue(rThisVariable);
     const auto& nodal_vaux = pThisNode->GetValue(NODAL_VAUX);
@@ -522,9 +516,6 @@ void AddAreaWeightedNodalValue<Variable<double>, NonHistorical>(
 {
     double area_coeff = pThisNode->GetValue(NODAL_AREA);
     const bool null_area = (std::abs(area_coeff) < RefArea * Tolerance);
-#ifdef KRATOS_DEBUG
-    KRATOS_WARNING_IF("WARNING:: NODE OF NULL AREA.", null_area && pThisNode->Is(SLAVE)) << " ID: " << pThisNode->Id() << std::endl;
-#endif
     area_coeff = null_area ? 0.0 : 1.0/area_coeff;
     double& r_aux_value = pThisNode->GetValue(rThisVariable);
     #pragma omp atomic
@@ -544,9 +535,6 @@ void AddAreaWeightedNodalValue<Variable<array_1d<double, 3>>, NonHistorical>(
 {
     double area_coeff = pThisNode->GetValue(NODAL_AREA);
     const bool null_area = (std::abs(area_coeff) < RefArea * Tolerance);
-#ifdef KRATOS_DEBUG
-    KRATOS_WARNING_IF("WARNING:: NODE OF NULL AREA.", null_area && pThisNode->Is(SLAVE)) << " ID: " << pThisNode->Id() << std::endl;
-#endif
     area_coeff = null_area ? 0.0 : 1.0/area_coeff;
     auto& aux_vector = pThisNode->GetValue(rThisVariable);
     const auto& nodal_vaux = pThisNode->GetValue(NODAL_VAUX);


### PR DESCRIPTION
This fixes some tests that stopped working after #4362. additionally I removed some warnings that appeared on debug, but didn't give any special information. I make constant the geometries on ExactIntegrationUtility