### PR TITLE
[DemStructures] Adding stress failure check utility 

### DIFF
--- a/applications/DemStructuresCouplingApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/DemStructuresCouplingApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -12,6 +12,7 @@
 #include "custom_utilities/compute_dem_face_load_utility.h"
 #include "custom_utilities/interpolate_structural_solution_for_dem_utility.h"
 #include "custom_utilities/control_module_fem_dem_utilities.hpp"
+#include "custom_utilities/stress_failure_check_utilities.hpp"
 
 namespace Kratos {
 
@@ -46,6 +47,11 @@ namespace Kratos {
                 .def("ExecuteInitialize", &ControlModuleFemDemUtilities::ExecuteInitialize)
                 .def("ExecuteInitializeSolutionStep", &ControlModuleFemDemUtilities::ExecuteInitializeSolutionStep)
                 .def("ExecuteFinalizeSolutionStep", &ControlModuleFemDemUtilities::ExecuteFinalizeSolutionStep)
+            ;
+
+            class_<StressFailureCheckUtilities> (m, "StressFailureCheckUtilities")
+                .def(init<ModelPart&,ModelPart&,Parameters&>())
+                .def("ExecuteFinalizeSolutionStep", &StressFailureCheckUtilities::ExecuteFinalizeSolutionStep)
             ;
 
         }

--- a/applications/DemStructuresCouplingApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/DemStructuresCouplingApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -50,7 +50,7 @@ namespace Kratos {
             ;
 
             class_<StressFailureCheckUtilities> (m, "StressFailureCheckUtilities")
-                .def(init<ModelPart&,ModelPart&,Parameters&>())
+                .def(init<ModelPart&,Parameters&>())
                 .def("ExecuteFinalizeSolutionStep", &StressFailureCheckUtilities::ExecuteFinalizeSolutionStep)
             ;
 

--- a/applications/DemStructuresCouplingApplication/custom_utilities/stress_failure_check_utilities.hpp
+++ b/applications/DemStructuresCouplingApplication/custom_utilities/stress_failure_check_utilities.hpp
@@ -1,0 +1,290 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ignasi de Pouplana
+//
+
+
+#ifndef KRATOS_STRESS_FAILURE_CHECK_UTILITIES
+#define KRATOS_STRESS_FAILURE_CHECK_UTILITIES
+
+// System includes
+#include <fstream>
+#include <iostream>
+#include <cmath>
+
+// Project includes
+#include "geometries/geometry.h"
+#include "includes/define.h"
+#include "includes/model_part.h"
+#include "includes/kratos_parameters.h"
+#include "utilities/openmp_utils.h"
+
+// Application includes
+#include "dem_structures_coupling_application_variables.h"
+
+
+namespace Kratos
+{
+
+/// Note: For the moment this only works for cylindrical probes with its axis oriented in Z direction.
+
+class StressFailureCheckUtilities
+{
+
+public:
+
+KRATOS_CLASS_POINTER_DEFINITION(StressFailureCheckUtilities);
+
+/// Default constructor.
+
+StressFailureCheckUtilities(ModelPart& rModelPart,
+                            Parameters& rParameters
+                            ) :
+                            mrModelPart(rModelPart)
+{
+    KRATOS_TRY
+
+    Parameters default_parameters( R"(
+        {
+            "cylinder_center": [0.0,0.0],
+            "min_radius": 0.00381,
+            "max_radius": 0.00481
+        }  )" );
+
+    // Now validate agains defaults -- this also ensures no type mismatch
+    rParameters.ValidateAndAssignDefaults(default_parameters);
+
+    mCylinderCenter[0] = rParameters["cylinder_center"][0].GetDouble();
+    mCylinderCenter[1] = rParameters["cylinder_center"][1].GetDouble();
+    mMinRadius = rParameters["min_radius"].GetDouble();
+    mMaxRadius = rParameters["max_radius"].GetDouble();
+
+    KRATOS_CATCH("");
+}
+
+/// Destructor.
+
+virtual ~StressFailureCheckUtilities(){}
+
+//***************************************************************************************************************
+//***************************************************************************************************************
+
+// Before FEM and DEM solution
+void ExecuteInitialize()
+{
+    KRATOS_TRY;
+
+    KRATOS_CATCH("");
+}
+
+// Before FEM and DEM solution
+void ExecuteInitializeSolutionStep()
+{
+    KRATOS_TRY;
+
+    KRATOS_CATCH("");
+}
+
+// After FEM and DEM solution
+void ExecuteFinalizeSolutionStep()
+{
+    int NElems = static_cast<int>(mrModelPart.Elements().size());
+    ModelPart::ElementsContainerType::iterator el_begin = mrModelPart.ElementsBegin();
+
+    std::vector<double> Sigma1(OpenMPUtils::GetNumThreads(), 0.0);
+    std::vector<double> Sigma2(OpenMPUtils::GetNumThreads(), 0.0);
+    std::vector<double> Sigma3(OpenMPUtils::GetNumThreads(), 0.0);
+
+    #pragma omp parallel for
+    for(int i = 0; i < NElems; i++)
+    {
+        ModelPart::ElementsContainerType::iterator itElem = el_begin + i;
+
+        double X = itElem->GetGeometry().GetPoint(0).X();
+        double Y = itElem->GetGeometry().GetPoint(0).Y();
+
+
+    }
+
+
+/////////////////////
+
+        // std::vector<double> thread_maxima(OpenMPUtils::GetNumThreads(), 0.0);
+        // const int number_of_particles = (int) mListOfSphericContinuumParticles.size();
+
+        // #pragma omp parallel for
+        // for (int i = 0; i < number_of_particles; i++) {
+        //     double max_sphere = mListOfSphericContinuumParticles[i]->CalculateMaxSearchDistance(has_mpi, r_process_info);
+        //     if (max_sphere > thread_maxima[OpenMPUtils::ThisThread()]) thread_maxima[OpenMPUtils::ThisThread()] = max_sphere;
+        // }
+
+        // double maximum_across_threads = 0.0;
+        // for (int i = 0; i < OpenMPUtils::GetNumThreads(); i++) {
+        //     if (thread_maxima[i] > maximum_across_threads) maximum_across_threads = thread_maxima[i];
+        // }
+
+/////////////////////
+
+            // BoundedMatrix<double, 3, 3> average_stress_tensor = ZeroMatrix(3,3);
+            // for (int i = 0; i < 3; i++) {
+            //     for (int j = 0; j < 3; j++) {
+            //         average_stress_tensor(i,j) = 0.5 * ((*(element1->mSymmStressTensor))(i,j) + (*(element2->mSymmStressTensor))(i,j));
+            //     }
+            // }
+
+            // Vector principal_stresses(3);
+            // noalias(principal_stresses) = AuxiliaryFunctions::EigenValuesDirectMethod(average_stress_tensor);
+
+            // Properties& element1_props = element1->GetProperties();
+            // Properties& element2_props = element2->GetProperties();
+
+            // const double mohr_coulomb_c = 1e6 * 0.5*(element1_props[INTERNAL_COHESION] + element2_props[INTERNAL_COHESION]);
+            // const double mohr_coulomb_phi = 0.5 * (element1_props[INTERNAL_FRICTION_ANGLE] + element2_props[INTERNAL_FRICTION_ANGLE]);
+            // const double mohr_coulomb_phi_in_radians = mohr_coulomb_phi * Globals::Pi / 180.0;
+            // const double sinphi = std::sin(mohr_coulomb_phi_in_radians);
+            // const double cosphi = std::cos(mohr_coulomb_phi_in_radians);
+
+            // const double max_stress = *std::max_element(principal_stresses.begin(), principal_stresses.end());
+            // const double min_stress = *std::min_element(principal_stresses.begin(), principal_stresses.end());
+
+/////////////////////
+
+        // std::fstream PropDataFile;
+        // PropDataFile.open ("PropagationData.tcl", std::fstream::out | std::fstream::trunc);
+        // PropDataFile.precision(12);
+        // PropDataFile << "set PropagationData [list]" << std::endl;
+        // PropDataFile << "return $PropagationData" << std::endl;
+        // PropDataFile.close();
+
+}
+
+
+
+//***************************************************************************************************************
+//***************************************************************************************************************
+
+///@}
+///@name Inquiry
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+/// Turn back information as a stemplate<class T, std::size_t dim> tring.
+
+virtual std::string Info() const
+{
+    return "";
+}
+
+/// Print information about this object.
+
+virtual void PrintInfo(std::ostream& rOStream) const
+{
+}
+
+/// Print object's data.
+
+virtual void PrintData(std::ostream& rOStream) const
+{
+}
+
+
+///@}
+///@name Friends
+///@{
+
+///@}
+
+protected:
+///@name Protected static Member r_variables
+///@{
+
+    ModelPart& mrModelPart;
+    array_1d<double,2> mCylinderCenter;
+    double mMinRadius;
+    double mMaxRadius;
+
+///@}
+///@name Protected member r_variables
+///@{ template<class T, std::size_t dim>
+
+
+///@}
+///@name Protected Operators
+///@{
+
+
+///@}
+///@name Protected Operations
+///@{
+
+
+///@}
+///@name Protected  Access
+///@{
+
+///@}
+///@name Protected Inquiry
+///@{
+
+
+///@}
+///@name Protected LifeCycle
+///@{
+
+
+///@}
+
+private:
+
+///@name Static Member r_variables
+///@{
+
+
+///@}
+///@name Member r_variables
+///@{
+///@}
+///@name Private Operators
+///@{
+
+///@}
+///@name Private Operations
+///@{
+
+
+///@}
+///@name Private  Access
+///@{
+
+
+///@}
+///@name Private Inquiry
+///@{
+
+
+///@}
+///@name Un accessible methods
+///@{
+
+/// Assignment operator.
+StressFailureCheckUtilities & operator=(StressFailureCheckUtilities const& rOther);
+
+
+///@}
+
+}; // Class StressFailureCheckUtilities
+
+}  // namespace Python.
+
+#endif // KRATOS_STRESS_FAILURE_CHECK_UTILITIES

--- a/applications/DemStructuresCouplingApplication/custom_utilities/stress_failure_check_utilities.hpp
+++ b/applications/DemStructuresCouplingApplication/custom_utilities/stress_failure_check_utilities.hpp
@@ -27,6 +27,8 @@
 #include "utilities/openmp_utils.h"
 
 // Application includes
+#include "custom_utilities/AuxiliaryFunctions.h"
+
 #include "dem_structures_coupling_application_variables.h"
 
 
@@ -53,7 +55,7 @@ StressFailureCheckUtilities(ModelPart& rModelPart,
 
     Parameters default_parameters( R"(
         {
-            "cylinder_center": [0.0,0.0],
+            "cylinder_center": [0.0,0.0,0.0],
             "min_radius": 0.00381,
             "max_radius": 0.00481
         }  )" );
@@ -63,8 +65,17 @@ StressFailureCheckUtilities(ModelPart& rModelPart,
 
     mCylinderCenter[0] = rParameters["cylinder_center"][0].GetDouble();
     mCylinderCenter[1] = rParameters["cylinder_center"][1].GetDouble();
+    mCylinderCenter[2] = rParameters["cylinder_center"][2].GetDouble();
     mMinRadius = rParameters["min_radius"].GetDouble();
     mMaxRadius = rParameters["max_radius"].GetDouble();
+
+    mSigma1File.open("sigma1average_t.txt", std::fstream::out | std::fstream::trunc);
+    mSigma1File << "0.0 0.0" << std::endl;
+    mSigma1File.close();
+
+    mSigma3File.open("sigma3average_t.txt", std::fstream::out | std::fstream::trunc);
+    mSigma3File << "0.0 0.0" << std::endl;
+    mSigma3File.close();
 
     KRATOS_CATCH("");
 }
@@ -76,93 +87,67 @@ virtual ~StressFailureCheckUtilities(){}
 //***************************************************************************************************************
 //***************************************************************************************************************
 
-// Before FEM and DEM solution
-void ExecuteInitialize()
-{
-    KRATOS_TRY;
-
-    KRATOS_CATCH("");
-}
-
-// Before FEM and DEM solution
-void ExecuteInitializeSolutionStep()
-{
-    KRATOS_TRY;
-
-    KRATOS_CATCH("");
-}
-
-// After FEM and DEM solution
 void ExecuteFinalizeSolutionStep()
 {
-    int NElems = static_cast<int>(mrModelPart.Elements().size());
-    ModelPart::ElementsContainerType::iterator el_begin = mrModelPart.ElementsBegin();
+    // int NElems = static_cast<int>(mrModelPart.Elements().size());
+    // ModelPart::ElementsContainerType::iterator el_begin = mrModelPart.ElementsBegin();
+    std::vector<double> ThreadSigma1(OpenMPUtils::GetNumThreads(), 0.0);
+    // std::vector<double> ThreadSigma2(OpenMPUtils::GetNumThreads(), 0.0);
+    std::vector<double> ThreadSigma3(OpenMPUtils::GetNumThreads(), 0.0);
+    std::vector<int> ThreadNParticles(OpenMPUtils::GetNumThreads(), 0);
 
-    std::vector<double> Sigma1(OpenMPUtils::GetNumThreads(), 0.0);
-    std::vector<double> Sigma2(OpenMPUtils::GetNumThreads(), 0.0);
-    std::vector<double> Sigma3(OpenMPUtils::GetNumThreads(), 0.0);
-
-    #pragma omp parallel for
-    for(int i = 0; i < NElems; i++)
+    #pragma omp parallel
     {
-        ModelPart::ElementsContainerType::iterator itElem = el_begin + i;
+        int k = OpenMPUtils::ThisThread();
 
-        double X = itElem->GetGeometry().GetPoint(0).X();
-        double Y = itElem->GetGeometry().GetPoint(0).Y();
+        #pragma omp for
+        for(int i = 0; i < static_cast<int>(mrModelPart.Elements().size()); i++)
+        {
+            ModelPart::ElementsContainerType::iterator itElem = mrModelPart.ElementsBegin() + i;
 
+            const array_1d<double,3> DemPosition = itElem->GetGeometry().GetPoint(0).Coordinates();
+            const double XDistance2 = std::pow(DemPosition[0]-mCylinderCenter[0],2);
+            const double YDistance2 = std::pow(DemPosition[1]-mCylinderCenter[1],2);
 
+            if( XDistance2 + YDistance2 > mMinRadius && XDistance2 + YDistance2 < mMaxRadius )
+            {
+                // BoundedMatrix<double, 3, 3> stress_tensor = (*(itElem->mSymmStressTensor));
+                Vector principal_stresses(3);
+                noalias(principal_stresses) = AuxiliaryFunctions::EigenValuesDirectMethod((*(itElem->mSymmStressTensor)));
+                const double max_stress = *std::max_element(principal_stresses.begin(), principal_stresses.end());
+                const double min_stress = *std::min_element(principal_stresses.begin(), principal_stresses.end());
+                ThreadSigma1[k] += max_stress;
+                ThreadSigma3[k] += min_stress;
+                ThreadNParticles[k] += 1;
+            }
+        }
     }
 
+    double Sigma1Average = 0.0;
+    double Sigma3Average = 0.0;
+    int NParticles = 0;
+    for (int k = 0; k < OpenMPUtils::GetNumThreads(); k++)
+    {
+        Sigma1Average += ThreadSigma1[k];
+        Sigma3Average += ThreadSigma3[k];
+        NParticles += ThreadNParticles[k];
+    }
 
-/////////////////////
+    if(NParticles > 0)
+    {
+        Sigma1Average = Sigma1Average/NParticles;
+        Sigma3Average = Sigma3Average/NParticles;
+    }
 
-        // std::vector<double> thread_maxima(OpenMPUtils::GetNumThreads(), 0.0);
-        // const int number_of_particles = (int) mListOfSphericContinuumParticles.size();
+    double CurrentTime = mrModelPart.GetProcessInfo()[TIME];
 
-        // #pragma omp parallel for
-        // for (int i = 0; i < number_of_particles; i++) {
-        //     double max_sphere = mListOfSphericContinuumParticles[i]->CalculateMaxSearchDistance(has_mpi, r_process_info);
-        //     if (max_sphere > thread_maxima[OpenMPUtils::ThisThread()]) thread_maxima[OpenMPUtils::ThisThread()] = max_sphere;
-        // }
+    mSigma1File.open("sigma1average_t.txt", std::fstream::out | std::fstream::app);
+    mSigma1File << CurrentTime << " " << Sigma1Average << std::endl;
+    mSigma1File.close();
 
-        // double maximum_across_threads = 0.0;
-        // for (int i = 0; i < OpenMPUtils::GetNumThreads(); i++) {
-        //     if (thread_maxima[i] > maximum_across_threads) maximum_across_threads = thread_maxima[i];
-        // }
-
-/////////////////////
-
-            // BoundedMatrix<double, 3, 3> average_stress_tensor = ZeroMatrix(3,3);
-            // for (int i = 0; i < 3; i++) {
-            //     for (int j = 0; j < 3; j++) {
-            //         average_stress_tensor(i,j) = 0.5 * ((*(element1->mSymmStressTensor))(i,j) + (*(element2->mSymmStressTensor))(i,j));
-            //     }
-            // }
-
-            // Vector principal_stresses(3);
-            // noalias(principal_stresses) = AuxiliaryFunctions::EigenValuesDirectMethod(average_stress_tensor);
-
-            // Properties& element1_props = element1->GetProperties();
-            // Properties& element2_props = element2->GetProperties();
-
-            // const double mohr_coulomb_c = 1e6 * 0.5*(element1_props[INTERNAL_COHESION] + element2_props[INTERNAL_COHESION]);
-            // const double mohr_coulomb_phi = 0.5 * (element1_props[INTERNAL_FRICTION_ANGLE] + element2_props[INTERNAL_FRICTION_ANGLE]);
-            // const double mohr_coulomb_phi_in_radians = mohr_coulomb_phi * Globals::Pi / 180.0;
-            // const double sinphi = std::sin(mohr_coulomb_phi_in_radians);
-            // const double cosphi = std::cos(mohr_coulomb_phi_in_radians);
-
-            // const double max_stress = *std::max_element(principal_stresses.begin(), principal_stresses.end());
-            // const double min_stress = *std::min_element(principal_stresses.begin(), principal_stresses.end());
-
-/////////////////////
-
-        // std::fstream PropDataFile;
-        // PropDataFile.open ("PropagationData.tcl", std::fstream::out | std::fstream::trunc);
-        // PropDataFile.precision(12);
-        // PropDataFile << "set PropagationData [list]" << std::endl;
-        // PropDataFile << "return $PropagationData" << std::endl;
-        // PropDataFile.close();
-
+    mSigma3File.open("sigma3average_t.txt", std::fstream::out | std::fstream::app);
+    mSigma3File << CurrentTime << " " << Sigma3Average << std::endl;
+    mSigma3File.close();
 }
 
 
@@ -210,9 +195,11 @@ protected:
 ///@{
 
     ModelPart& mrModelPart;
-    array_1d<double,2> mCylinderCenter;
+    array_1d<double,3> mCylinderCenter;
     double mMinRadius;
     double mMaxRadius;
+    std::fstream mSigma1File;
+    std::fstream mSigma3File;
 
 ///@}
 ///@name Protected member r_variables

--- a/applications/DemStructuresCouplingApplication/python_scripts/dem_fem_coupling_algorithm.py
+++ b/applications/DemStructuresCouplingApplication/python_scripts/dem_fem_coupling_algorithm.py
@@ -70,6 +70,9 @@ class Algorithm(object):
         # self.control_module_fem_dem_utility = control_module_fem_dem_utility.ControlModuleFemDemUtility(self.model,self.dem_solution.spheres_model_part)
         # self.control_module_fem_dem_utility.ExecuteInitialize()
 
+        # from KratosMultiphysics.DemStructuresCouplingApplication import stress_failure_check_utility
+        # self.stress_failure_check_utility = stress_failure_check_utility.StressFailureCheckUtility(self.dem_solution.spheres_model_part)
+
         mixed_mp = self.model.CreateModelPart('MixedPart')
         filename = os.path.join(self.dem_solution.post_path, self.dem_solution.DEM_parameters["problem_name"].GetString())
         self.gid_output = dem_structures_coupling_gid_output.DemStructuresCouplingGiDOutput(
@@ -219,6 +222,8 @@ class Algorithm(object):
                     self.dem_solution.PrintResultsForGid(self.dem_solution.time)
                     self.dem_solution.demio.PrintMultifileLists(self.dem_solution.time, self.dem_solution.post_path)
                     self.dem_solution.time_old_print = self.dem_solution.time
+
+                    # self.stress_failure_check_utility.ExecuteFinalizeSolutionStep()
 
                 self.dem_solution.FinalizeTimeStep(self.dem_solution.time)
 

--- a/applications/DemStructuresCouplingApplication/python_scripts/stress_failure_check_utility.py
+++ b/applications/DemStructuresCouplingApplication/python_scripts/stress_failure_check_utility.py
@@ -2,67 +2,18 @@ import KratosMultiphysics
 import KratosMultiphysics.DemStructuresCouplingApplication as DemFem
 
 class StressFailureCheckUtility(object):
-    def __init__(self, Model, spheres_model_part):
+    def __init__(self, model_part):
 
-        self.components_utility_list = []
-
-        self.top_fem_model_part = Model["Structure.SurfacePressure3D_top_pressure"]
-        self.top_dem_model_part = spheres_model_part.GetSubModelPart("topdem")
-        top_settings = KratosMultiphysics.Parameters( """
+        self.model_part = model_part
+        self.settings = KratosMultiphysics.Parameters( """
         {
-            "variable_name": "DISPLACEMENT",
-            "reaction_variable_name": "REACTION",
-            "dem_force_variable_name": "TOTAL_FORCES",
-            "target_stress_variable_name": "TARGET_STRESS",
-            "reaction_stress_variable_name": "REACTION_STRESS",
-            "loading_velocity_variable_name": "LOADING_VELOCITY",
-            "imposed_direction" : 2,
-            "target_stress_table_id" : 1,
-            "initial_velocity" : 0.0,
-            "limit_velocity" : -0.1,
-            "velocity_factor" : 0.5,
-            "compression_length" : 0.00381,
-            "young_modulus" : 7.0e9,
-            "start_time" : 0.0,
-            "face_area": 8.0617e-3
+            "cylinder_center": [0.0,0.0,0.0],
+            "min_radius": 0.00381,
+            "max_radius": 0.00481
         }  """ )
 
-        self.components_utility_list.append(DemFem.ControlModuleFemDemUtilities(self.top_fem_model_part,self.top_dem_model_part,top_settings))
-
-        self.bot_fem_model_part = Model["Structure.SurfacePressure3D_bottom_pressure"]
-        self.bot_dem_model_part = spheres_model_part.GetSubModelPart("botdem")
-        bot_settings = KratosMultiphysics.Parameters( """
-        {
-            "variable_name": "DISPLACEMENT",
-            "reaction_variable_name": "REACTION",
-            "dem_force_variable_name": "TOTAL_FORCES",
-            "target_stress_variable_name": "TARGET_STRESS",
-            "reaction_stress_variable_name": "REACTION_STRESS",
-            "loading_velocity_variable_name": "LOADING_VELOCITY",
-            "imposed_direction" : 2,
-            "target_stress_table_id" : 2,
-            "initial_velocity" : 0.0,
-            "limit_velocity" : 0.1,
-            "velocity_factor" : 0.5,
-            "compression_length" : 0.00381,
-            "young_modulus" : 7.0e9,
-            "start_time" : 0.0,
-            "face_area": 8.0617e-3
-        }  """ )
-
-        self.components_utility_list.append(DemFem.ControlModuleFemDemUtilities(self.bot_fem_model_part,self.bot_dem_model_part,bot_settings))
-
-    def ExecuteInitialize(self):
-
-        for component in self.components_utility_list:
-            component.ExecuteInitialize()
-
-    def ExecuteInitializeSolutionStep(self):
-
-        for component in self.components_utility_list:
-            component.ExecuteInitializeSolutionStep()
+        self.utility = DemFem.StressFailureCheckUtilities(self.model_part,self.settings)
 
     def ExecuteFinalizeSolutionStep(self):
 
-        for component in self.components_utility_list:
-            component.ExecuteFinalizeSolutionStep()
+        self.utility.ExecuteFinalizeSolutionStep()

--- a/applications/DemStructuresCouplingApplication/python_scripts/stress_failure_check_utility.py
+++ b/applications/DemStructuresCouplingApplication/python_scripts/stress_failure_check_utility.py
@@ -9,7 +9,7 @@ class StressFailureCheckUtility(object):
         {
             "cylinder_center": [0.0,0.0,0.0],
             "min_radius": 0.00381,
-            "max_radius": 0.00481
+            "max_radius": 0.006
         }  """ )
 
         self.utility = DemFem.StressFailureCheckUtilities(self.model_part,self.settings)

--- a/applications/DemStructuresCouplingApplication/python_scripts/stress_failure_check_utility.py
+++ b/applications/DemStructuresCouplingApplication/python_scripts/stress_failure_check_utility.py
@@ -1,0 +1,68 @@
+import KratosMultiphysics
+import KratosMultiphysics.DemStructuresCouplingApplication as DemFem
+
+class StressFailureCheckUtility(object):
+    def __init__(self, Model, spheres_model_part):
+
+        self.components_utility_list = []
+
+        self.top_fem_model_part = Model["Structure.SurfacePressure3D_top_pressure"]
+        self.top_dem_model_part = spheres_model_part.GetSubModelPart("topdem")
+        top_settings = KratosMultiphysics.Parameters( """
+        {
+            "variable_name": "DISPLACEMENT",
+            "reaction_variable_name": "REACTION",
+            "dem_force_variable_name": "TOTAL_FORCES",
+            "target_stress_variable_name": "TARGET_STRESS",
+            "reaction_stress_variable_name": "REACTION_STRESS",
+            "loading_velocity_variable_name": "LOADING_VELOCITY",
+            "imposed_direction" : 2,
+            "target_stress_table_id" : 1,
+            "initial_velocity" : 0.0,
+            "limit_velocity" : -0.1,
+            "velocity_factor" : 0.5,
+            "compression_length" : 0.00381,
+            "young_modulus" : 7.0e9,
+            "start_time" : 0.0,
+            "face_area": 8.0617e-3
+        }  """ )
+
+        self.components_utility_list.append(DemFem.ControlModuleFemDemUtilities(self.top_fem_model_part,self.top_dem_model_part,top_settings))
+
+        self.bot_fem_model_part = Model["Structure.SurfacePressure3D_bottom_pressure"]
+        self.bot_dem_model_part = spheres_model_part.GetSubModelPart("botdem")
+        bot_settings = KratosMultiphysics.Parameters( """
+        {
+            "variable_name": "DISPLACEMENT",
+            "reaction_variable_name": "REACTION",
+            "dem_force_variable_name": "TOTAL_FORCES",
+            "target_stress_variable_name": "TARGET_STRESS",
+            "reaction_stress_variable_name": "REACTION_STRESS",
+            "loading_velocity_variable_name": "LOADING_VELOCITY",
+            "imposed_direction" : 2,
+            "target_stress_table_id" : 2,
+            "initial_velocity" : 0.0,
+            "limit_velocity" : 0.1,
+            "velocity_factor" : 0.5,
+            "compression_length" : 0.00381,
+            "young_modulus" : 7.0e9,
+            "start_time" : 0.0,
+            "face_area": 8.0617e-3
+        }  """ )
+
+        self.components_utility_list.append(DemFem.ControlModuleFemDemUtilities(self.bot_fem_model_part,self.bot_dem_model_part,bot_settings))
+
+    def ExecuteInitialize(self):
+
+        for component in self.components_utility_list:
+            component.ExecuteInitialize()
+
+    def ExecuteInitializeSolutionStep(self):
+
+        for component in self.components_utility_list:
+            component.ExecuteInitializeSolutionStep()
+
+    def ExecuteFinalizeSolutionStep(self):
+
+        for component in self.components_utility_list:
+            component.ExecuteFinalizeSolutionStep()


### PR DESCRIPTION
This adds a new utility designed to print the average maximum and minimum stresses of the DEM particles that fall inside a certain region of a cylinder. This should give us a better idea on when the probe actually fails.

I just tested it with a small example (around 1800 particles) and it seems to work properly.