### PR TITLE
[Mapping] Projection Utilities

### DIFF
--- a/applications/MappingApplication/CMakeLists.txt
+++ b/applications/MappingApplication/CMakeLists.txt
@@ -23,6 +23,7 @@ set( KRATOS_MAPPING_APPLICATION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/mapper_factory.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/mapper_flags.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/mapper_utilities.cpp
+	${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/projection_utilities.cpp
 )
 
 set(KRATOS_MAPPING_APPLICATION_SOURCES_MPI "")

--- a/applications/MappingApplication/custom_utilities/projection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/projection_utilities.cpp
@@ -1,0 +1,273 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher, Jordi Cotela
+//
+// See Master-Thesis P.Bucher
+// "Development and Implementation of a Parallel
+//  Framework for Non-Matching Grid Mapping"
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "projection_utilities.h"
+#include "mapping_application_variables.h"
+
+namespace Kratos
+{
+namespace ProjectionUtilities
+{
+
+typedef std::size_t SizeType;
+typedef std::size_t IndexType;
+
+typedef Geometry<Node<3>> GeometryType;
+
+namespace {
+
+void FillEquationIdVector(const GeometryType& rGeometry,
+                          std::vector<int>& rEquationIds)
+{
+    const SizeType num_points = rGeometry.PointsNumber();
+
+    if (rEquationIds.size() != num_points) {
+        rEquationIds.resize(num_points);
+    }
+
+    IndexType point_index = 0;
+    for (const auto& r_node : rGeometry.Points()) {
+        KRATOS_DEBUG_ERROR_IF_NOT(r_node.Has(INTERFACE_EQUATION_ID)) << r_node << " does not have an \"INTERFACE_EQUATION_ID\"" << std::endl;
+        rEquationIds[point_index++] = r_node.GetValue(INTERFACE_EQUATION_ID);
+    }
+}
+
+}
+
+PairingIndex ProjectOnLine(const GeometryType& rGeometry,
+                           const Point& rPointToProject,
+                           const double LocalCoordTol,
+                           Vector& rShapeFunctionValues,
+                           std::vector<int>& rEquationIds,
+                           double& rProjectionDistance,
+                           const bool ComputeApproximation)
+{
+    Point projected_point;
+
+    rProjectionDistance = std::abs(GeometricalProjectionUtilities::FastProjectOnLine(rGeometry, rPointToProject, projected_point));
+
+    array_1d<double, 3> local_coords;
+    PairingIndex pairing_index;
+
+    const bool is_inside = rGeometry.IsInside(projected_point, local_coords, 1e-14);
+
+    if (is_inside) {
+        pairing_index = PairingIndex::Line_Inside;
+        rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
+        FillEquationIdVector(rGeometry, rEquationIds);
+
+    } else if (!ComputeApproximation) {
+        return PairingIndex::Unspecified;
+
+    } else if (!is_inside && rGeometry.IsInside(projected_point, local_coords, LocalCoordTol)) {
+        pairing_index = PairingIndex::Line_Outside;
+        rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
+        FillEquationIdVector(rGeometry, rEquationIds);
+
+    } else {
+        // projection is ouside the line, searching the closest point
+        pairing_index = PairingIndex::Closest_Point;
+        const double dist_1 = MapperUtilities::ComputeDistance(rPointToProject, rGeometry[0]);
+        const double dist_2 = MapperUtilities::ComputeDistance(rPointToProject, rGeometry[1]);
+
+        rEquationIds.resize(1);
+        if (dist_1 < dist_2) {
+            KRATOS_DEBUG_ERROR_IF_NOT(rGeometry[0].Has(INTERFACE_EQUATION_ID)) << rGeometry[0] << " does not have an \"INTERFACE_EQUATION_ID\"" << std::endl;
+            rEquationIds[0] = rGeometry[0].GetValue(INTERFACE_EQUATION_ID);
+            rProjectionDistance = dist_1;
+        } else {
+            KRATOS_DEBUG_ERROR_IF_NOT(rGeometry[1].Has(INTERFACE_EQUATION_ID)) << rGeometry[1] << " does not have an \"INTERFACE_EQUATION_ID\"" << std::endl;
+            rEquationIds[0] = rGeometry[1].GetValue(INTERFACE_EQUATION_ID);
+            rProjectionDistance = dist_2;
+        }
+
+        rShapeFunctionValues.resize(1);
+        rShapeFunctionValues[0] = 1.0;
+    }
+
+    return pairing_index;
+}
+
+PairingIndex ProjectOnSurface(const GeometryType& rGeometry,
+                     const Point& rPointToProject,
+                     const double LocalCoordTol,
+                     Vector& rShapeFunctionValues,
+                     std::vector<int>& rEquationIds,
+                     double& rProjectionDistance,
+                     const bool ComputeApproximation)
+{
+    Point projected_point;
+
+    rProjectionDistance = std::abs(GeometricalProjectionUtilities::FastProjectOnGeometry(rGeometry, rPointToProject, projected_point));
+
+    array_1d<double, 3> local_coords;
+    PairingIndex pairing_index;
+
+    const bool is_inside = rGeometry.IsInside(projected_point, local_coords, 1e-14);
+
+    if (is_inside) {
+        pairing_index = PairingIndex::Surface_Inside;
+        rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
+        FillEquationIdVector(rGeometry, rEquationIds);
+
+    } else if (!ComputeApproximation) {
+        return PairingIndex::Unspecified;
+
+    } else if (!is_inside && rGeometry.IsInside(projected_point, local_coords, LocalCoordTol)) {
+        pairing_index = PairingIndex::Surface_Outside;
+        rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
+        FillEquationIdVector(rGeometry, rEquationIds);
+
+    } else { // inter-/extrapolation failed, trying to project on "subgeometries"
+        pairing_index = PairingIndex::Unspecified;
+        std::vector<int> edge_eq_ids;
+        Vector edge_sf_values;
+        double edge_distance;
+
+        for (const auto& r_edge : const_cast<GeometryType&>(rGeometry).Edges()) { // TODO update this after #4767
+
+            const PairingIndex edge_index = ProjectOnLine(r_edge, rPointToProject, LocalCoordTol, edge_sf_values, edge_eq_ids, edge_distance);
+
+            // check if the current edge gives a better result
+            if (edge_index > pairing_index || (edge_index == pairing_index && edge_distance < rProjectionDistance)) {
+                pairing_index = edge_index;
+                rShapeFunctionValues = edge_sf_values;
+                rProjectionDistance = edge_distance;
+                rEquationIds = edge_eq_ids;
+            }
+        }
+    }
+
+    return pairing_index;
+}
+
+PairingIndex ProjectIntoVolume(const GeometryType& rGeometry,
+                               const Point& rPointToProject,
+                               const double LocalCoordTol,
+                               Vector& rShapeFunctionValues,
+                               std::vector<int>& rEquationIds,
+                               double& rProjectionDistance,
+                               const bool ComputeApproximation)
+{
+    array_1d<double, 3> local_coords;
+    PairingIndex pairing_index;
+    bool is_inside = rGeometry.IsInside(rPointToProject, local_coords);
+
+    if (is_inside) {
+        pairing_index = PairingIndex::Volume_Inside;
+        rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
+        FillEquationIdVector(rGeometry, rEquationIds);
+
+        rProjectionDistance = MapperUtilities::ComputeDistance(rPointToProject, rGeometry.Center());
+        rProjectionDistance /= rGeometry.Volume(); // Normalize Distance by Volume
+
+    } else if (!ComputeApproximation) {
+        return PairingIndex::Unspecified;
+
+    } else if (!is_inside && rGeometry.IsInside(rPointToProject, local_coords, LocalCoordTol)) {
+        pairing_index = PairingIndex::Volume_Outside;
+        rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
+        FillEquationIdVector(rGeometry, rEquationIds);
+
+        rProjectionDistance = MapperUtilities::ComputeDistance(rPointToProject, rGeometry.Center());
+        rProjectionDistance /= rGeometry.Volume(); // Normalize Distance by Volume
+
+    } else { // inter-/extrapolation failed, trying to project on "subgeometries"
+        pairing_index = PairingIndex::Unspecified;
+        std::vector<int> face_eq_ids;
+        Vector face_sf_values;
+        double face_distance;
+
+        for (const auto& r_face : const_cast<GeometryType&>(rGeometry).Faces()) { // TODO update this after #4767
+
+            const PairingIndex face_index = ProjectOnSurface(r_face, rPointToProject, LocalCoordTol, face_sf_values, face_eq_ids, face_distance);
+
+            // check if the current edge gives a better result
+            if (face_index > pairing_index || (face_index == pairing_index && face_distance < rProjectionDistance)) {
+                pairing_index = face_index;
+                rShapeFunctionValues = face_sf_values;
+                rProjectionDistance = face_distance;
+                rEquationIds = face_eq_ids;
+            }
+        }
+    }
+
+    return pairing_index;
+}
+
+bool ComputeProjection(const GeometryType& rGeometry,
+                       const Point& rPointToProject,
+                       const double LocalCoordTol,
+                       Vector& rShapeFunctionValues,
+                       std::vector<int>& rEquationIds,
+                       double& rProjectionDistance,
+                       PairingIndex& rPairingIndex,
+                       const bool ComputeApproximation)
+{
+    const SizeType num_points = rGeometry.PointsNumber();
+    const auto geom_family = rGeometry.GetGeometryFamily();
+    bool is_full_projection = false;
+
+    if (geom_family == GeometryData::Kratos_Linear && num_points == 2) { // linear line
+        rPairingIndex = ProjectOnLine(rGeometry, rPointToProject, LocalCoordTol, rShapeFunctionValues, rEquationIds, rProjectionDistance, ComputeApproximation);
+        is_full_projection = (rPairingIndex == PairingIndex::Line_Inside);
+
+    } else if ((geom_family == GeometryData::Kratos_Triangle      && num_points == 3) || // linear triangle
+               (geom_family == GeometryData::Kratos_Quadrilateral && num_points == 4)) { // linear quad
+        rPairingIndex = ProjectOnSurface(rGeometry, rPointToProject, LocalCoordTol, rShapeFunctionValues, rEquationIds, rProjectionDistance, ComputeApproximation);
+        is_full_projection = (rPairingIndex == PairingIndex::Surface_Inside);
+
+    } else if (geom_family == GeometryData::Kratos_Tetrahedra ||
+               geom_family == GeometryData::Kratos_Prism ||
+               geom_family == GeometryData::Kratos_Hexahedra) { // Volume projection
+        rPairingIndex = ProjectIntoVolume(rGeometry, rPointToProject, LocalCoordTol, rShapeFunctionValues, rEquationIds, rProjectionDistance, ComputeApproximation);
+        is_full_projection = (rPairingIndex == PairingIndex::Volume_Inside);
+
+    } else if (ComputeApproximation) {
+        KRATOS_WARNING_ONCE("Mapper") << "Unsupported type of geometry for projection, trying to use an approximation (Nearest Neighbor)" << std::endl;
+
+        if (rShapeFunctionValues.size() != 1) {
+            rShapeFunctionValues.resize(1);
+        }
+        rShapeFunctionValues[0] = 1.0;
+
+        if (rEquationIds.size() != 1) {
+            rEquationIds.resize(1);
+        }
+
+        rProjectionDistance = std::numeric_limits<double>::max();
+        rPairingIndex = PairingIndex::Closest_Point;
+        for (const auto& r_node : rGeometry.Points()) {
+            const double dist = MapperUtilities::ComputeDistance(rPointToProject, r_node);
+            if (dist < rProjectionDistance) {
+                rProjectionDistance = dist;
+                KRATOS_DEBUG_ERROR_IF_NOT(r_node.Has(INTERFACE_EQUATION_ID)) << r_node << " does not have an \"INTERFACE_EQUATION_ID\"" << std::endl;
+                rEquationIds[0] = r_node.GetValue(INTERFACE_EQUATION_ID);
+            }
+        }
+    }
+
+    KRATOS_DEBUG_ERROR_IF(rPairingIndex != PairingIndex::Unspecified && rShapeFunctionValues.size() != rEquationIds.size()) << "Number of equation-ids is not the same as the number of ShapeFunction values, something went wrong!" << std::endl;
+
+    return is_full_projection;
+}
+
+} // namespace ProjectionUtilities
+} // namespace Kratos.

--- a/applications/MappingApplication/custom_utilities/projection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/projection_utilities.cpp
@@ -66,9 +66,7 @@ PairingIndex ProjectOnLine(const GeometryType& rGeometry,
     array_1d<double, 3> local_coords;
     PairingIndex pairing_index;
 
-    const bool is_inside = rGeometry.IsInside(projected_point, local_coords, 1e-14);
-
-    if (is_inside) {
+    if (rGeometry.IsInside(projected_point, local_coords, 1e-14)) {
         pairing_index = PairingIndex::Line_Inside;
         rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
         FillEquationIdVector(rGeometry, rEquationIds);
@@ -76,7 +74,7 @@ PairingIndex ProjectOnLine(const GeometryType& rGeometry,
     } else if (!ComputeApproximation) {
         return PairingIndex::Unspecified;
 
-    } else if (!is_inside && rGeometry.IsInside(projected_point, local_coords, LocalCoordTol)) {
+    } else if (rGeometry.IsInside(projected_point, local_coords, LocalCoordTol)) {
         pairing_index = PairingIndex::Line_Outside;
         rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
         FillEquationIdVector(rGeometry, rEquationIds);
@@ -120,9 +118,7 @@ PairingIndex ProjectOnSurface(const GeometryType& rGeometry,
     array_1d<double, 3> local_coords;
     PairingIndex pairing_index;
 
-    const bool is_inside = rGeometry.IsInside(projected_point, local_coords, 1e-14);
-
-    if (is_inside) {
+    if (rGeometry.IsInside(projected_point, local_coords, 1e-14)) {
         pairing_index = PairingIndex::Surface_Inside;
         rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
         FillEquationIdVector(rGeometry, rEquationIds);
@@ -130,7 +126,7 @@ PairingIndex ProjectOnSurface(const GeometryType& rGeometry,
     } else if (!ComputeApproximation) {
         return PairingIndex::Unspecified;
 
-    } else if (!is_inside && rGeometry.IsInside(projected_point, local_coords, LocalCoordTol)) {
+    } else if (rGeometry.IsInside(projected_point, local_coords, LocalCoordTol)) {
         pairing_index = PairingIndex::Surface_Outside;
         rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
         FillEquationIdVector(rGeometry, rEquationIds);
@@ -168,9 +164,8 @@ PairingIndex ProjectIntoVolume(const GeometryType& rGeometry,
 {
     array_1d<double, 3> local_coords;
     PairingIndex pairing_index;
-    bool is_inside = rGeometry.IsInside(rPointToProject, local_coords);
 
-    if (is_inside) {
+    if (rGeometry.IsInside(rPointToProject, local_coords)) {
         pairing_index = PairingIndex::Volume_Inside;
         rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
         FillEquationIdVector(rGeometry, rEquationIds);
@@ -181,7 +176,7 @@ PairingIndex ProjectIntoVolume(const GeometryType& rGeometry,
     } else if (!ComputeApproximation) {
         return PairingIndex::Unspecified;
 
-    } else if (!is_inside && rGeometry.IsInside(rPointToProject, local_coords, LocalCoordTol)) {
+    } else if (rGeometry.IsInside(rPointToProject, local_coords, LocalCoordTol)) {
         pairing_index = PairingIndex::Volume_Outside;
         rGeometry.ShapeFunctionsValues(rShapeFunctionValues, local_coords);
         FillEquationIdVector(rGeometry, rEquationIds);

--- a/applications/MappingApplication/custom_utilities/projection_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/projection_utilities.cpp
@@ -49,6 +49,17 @@ void FillEquationIdVector(const GeometryType& rGeometry,
     }
 }
 
+bool IsBetterProjection(const PairingIndex CurrentPairingIndex,
+                        const PairingIndex PairingIndexToCheck,
+                        const double CurrentMinDistance,
+                        const double DistanceToCheck)
+{
+    // the projection is better if either:
+    // - the new pairing-index is better (i.e. larger) than the current pairing-index
+    // - the new pairing-index the same as the current pairing-index but the projection distance is smaller
+    return (PairingIndexToCheck > CurrentPairingIndex || (PairingIndexToCheck == CurrentPairingIndex && DistanceToCheck < CurrentMinDistance));
+}
+
 }
 
 PairingIndex ProjectOnLine(const GeometryType& rGeometry,
@@ -142,7 +153,7 @@ PairingIndex ProjectOnSurface(const GeometryType& rGeometry,
             const PairingIndex edge_index = ProjectOnLine(r_edge, rPointToProject, LocalCoordTol, edge_sf_values, edge_eq_ids, edge_distance);
 
             // check if the current edge gives a better result
-            if (edge_index > pairing_index || (edge_index == pairing_index && edge_distance < rProjectionDistance)) {
+            if (IsBetterProjection(pairing_index, edge_index, rProjectionDistance, edge_distance)) {
                 pairing_index = edge_index;
                 rShapeFunctionValues = edge_sf_values;
                 rProjectionDistance = edge_distance;
@@ -195,7 +206,7 @@ PairingIndex ProjectIntoVolume(const GeometryType& rGeometry,
             const PairingIndex face_index = ProjectOnSurface(r_face, rPointToProject, LocalCoordTol, face_sf_values, face_eq_ids, face_distance);
 
             // check if the current edge gives a better result
-            if (face_index > pairing_index || (face_index == pairing_index && face_distance < rProjectionDistance)) {
+            if (IsBetterProjection(pairing_index, face_index, rProjectionDistance, face_distance)) {
                 pairing_index = face_index;
                 rShapeFunctionValues = face_sf_values;
                 rProjectionDistance = face_distance;

--- a/applications/MappingApplication/custom_utilities/projection_utilities.h
+++ b/applications/MappingApplication/custom_utilities/projection_utilities.h
@@ -1,0 +1,86 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher, Jordi Cotela
+//
+// See Master-Thesis P.Bucher
+// "Development and Implementation of a Parallel
+//  Framework for Non-Matching Grid Mapping"
+
+#if !defined(KRATOS_PROJECTION_UTILITIES_H_INCLUDED)
+#define  KRATOS_PROJECTION_UTILITIES_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "custom_utilities/mapper_utilities.h"
+#include "utilities/geometrical_projection_utilities.h"
+
+namespace Kratos
+{
+namespace ProjectionUtilities
+{
+
+enum class PairingIndex
+{
+    Volume_Inside   = -1,
+    Volume_Outside  = -2,
+    Surface_Inside  = -3,
+    Surface_Outside = -4,
+    Line_Inside     = -5,
+    Line_Outside    = -6,
+    Closest_Point   = -7,
+    Unspecified     = -8
+};
+
+typedef std::size_t SizeType;
+typedef std::size_t IndexType;
+
+typedef Geometry<Node<3>> GeometryType;
+
+PairingIndex ProjectOnLine(const GeometryType& rGeometry,
+                           const Point& rPointToProject,
+                           const double LocalCoordTol,
+                           Vector& rShapeFunctionValues,
+                           std::vector<int>& rEquationIds,
+                           double& rProjectionDistance,
+                           const bool ComputeApproximation=true);
+
+PairingIndex ProjectOnSurface(const GeometryType& rGeometry,
+                     const Point& rPointToProject,
+                     const double LocalCoordTol,
+                     Vector& rShapeFunctionValues,
+                     std::vector<int>& rEquationIds,
+                     double& rProjectionDistance,
+                     const bool ComputeApproximation=true);
+
+PairingIndex ProjectIntoVolume(const GeometryType& rGeometry,
+                               const Point& rPointToProject,
+                               const double LocalCoordTol,
+                               Vector& rShapeFunctionValues,
+                               std::vector<int>& rEquationIds,
+                               double& rProjectionDistance,
+                               const bool ComputeApproximation=true);
+
+bool ComputeProjection(const GeometryType& rGeometry,
+                       const Point& rPointToProject,
+                       const double LocalCoordTol,
+                       Vector& rShapeFunctionValues,
+                       std::vector<int>& rEquationIds,
+                       double& rProjectionDistance,
+                       PairingIndex& rPairingIndex,
+                       const bool ComputeApproximation=true);
+
+}  // namespace ProjectionUtilities.
+
+}  // namespace Kratos.
+
+#endif // KRATOS_PROJECTION_UTILITIES_H_INCLUDED  defined

--- a/applications/MappingApplication/tests/cpp_tests/test_projection_utilities.cpp
+++ b/applications/MappingApplication/tests/cpp_tests/test_projection_utilities.cpp
@@ -1,0 +1,394 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher
+//
+
+// Project includes
+#include "geometries/line_2d_2.h"
+#include "geometries/triangle_3d_3.h"
+#include "geometries/quadrilateral_3d_4.h"
+#include "geometries/tetrahedra_3d_4.h"
+#include "geometries/hexahedra_3d_8.h"
+#include "testing/testing.h"
+#include "custom_utilities/projection_utilities.h"
+#include "mapping_application_variables.h"
+
+namespace Kratos {
+namespace Testing {
+
+typedef Node<3> NodeType;
+typedef Geometry<NodeType> GeometryType;
+
+namespace {
+
+template<std::size_t TSize>
+void SetEqIdsOnNodes(GeometryType& rGeometry,
+                     const std::array<int, TSize>& rExpEquationIds)
+{
+    KRATOS_CHECK_EQUAL(TSize, rGeometry.PointsNumber());
+
+    std::size_t node_idx = 0;
+    for (auto& r_node : rGeometry.Points()) {
+        r_node.SetValue(INTERFACE_EQUATION_ID, rExpEquationIds[node_idx++]);
+    }
+}
+
+template<std::size_t TSize>
+void TestComputeProjection(const GeometryType& rGeometry,
+                           const Point& rPointToProject,
+                           const double LocalCoordTol,
+                           const std::array<double, TSize>& rExpSFValues,
+                           const std::array<int, TSize>& rExpEquationIds,
+                           const double ExpProjectionDistance,
+                           const ProjectionUtilities::PairingIndex ExpPairingIndex,
+                           const bool ComputeApproximation,
+                           const bool FullProjection)
+{
+    Vector sf_values;
+    std::vector<int> eq_ids;
+    double proj_dist;
+    ProjectionUtilities::PairingIndex pairing_index;
+
+    const bool is_full_projection = ProjectionUtilities::ComputeProjection(rGeometry, rPointToProject, LocalCoordTol, sf_values, eq_ids, proj_dist, pairing_index, ComputeApproximation);
+
+    KRATOS_CHECK_EQUAL(FullProjection, is_full_projection);
+    KRATOS_CHECK_EQUAL(ExpPairingIndex, pairing_index);
+
+    if (pairing_index != ProjectionUtilities::PairingIndex::Unspecified) {
+        KRATOS_CHECK_DOUBLE_EQUAL(ExpProjectionDistance, proj_dist);
+
+        KRATOS_CHECK_EQUAL(rExpSFValues.size(), sf_values.size());
+        KRATOS_CHECK_EQUAL(rExpEquationIds.size(), rExpEquationIds.size());
+
+        for (std::size_t i=0; i<TSize; ++i) {
+            KRATOS_CHECK_NEAR(rExpSFValues[i], sf_values[i], 1E-13);
+            KRATOS_CHECK_EQUAL(rExpEquationIds[i], eq_ids[i]);
+        }
+    }
+}
+
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Line_Inside, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Line2D2<NodeType>>(node_1, node_2));
+
+    double proj_dist = 0.2;
+    const Point point_to_project(0.25, proj_dist, 0.0);
+    const double local_coord_tol = 0.2;
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Line_Inside;
+    const bool compute_approximation = false;
+    const bool full_projection = true;
+
+    const std::array<double, 2> exp_sf_values {0.75, 0.25};
+    const std::array<int, 2> exp_eq_ids {35, 18};
+
+    SetEqIdsOnNodes(*p_geom, exp_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Line_Outside, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Line2D2<NodeType>>(node_1, node_2));
+
+    double proj_dist = 0.2;
+    const Point point_to_project(-0.1, proj_dist, 0.0);
+    const double local_coord_tol = 0.2;
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Line_Outside;
+    const bool compute_approximation = true;
+    const bool full_projection = false;
+
+    const std::array<double, 2> exp_sf_values {1.1, -0.1};
+    const std::array<int, 2> exp_eq_ids {35, 18};
+
+    SetEqIdsOnNodes(*p_geom, exp_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Line_Closest_Point, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Line2D2<NodeType>>(node_1, node_2));
+
+    const Point point_to_project(-0.35, 0.2, 0.0);
+    const double local_coord_tol = 0.0;
+    double proj_dist = std::sqrt(std::pow(point_to_project[0],2) + std::pow(point_to_project[1],2) + std::pow(point_to_project[2],2)); // closest point is (0,0,0)
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Closest_Point;
+    const bool compute_approximation = true;
+    const bool full_projection = false;
+
+    const std::array<double, 1> exp_sf_values {1.0};
+    const std::array<int, 1> exp_eq_ids {35};
+    const std::array<int, 2> all_eq_ids {35, 18};
+
+    SetEqIdsOnNodes(*p_geom, all_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Line_Unspecified, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Line2D2<NodeType>>(node_1, node_2));
+
+    double proj_dist = 0.2;
+    const Point point_to_project(-0.25, proj_dist, 0.0);
+    const double local_coord_tol = 0.2;
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Unspecified;
+    const bool compute_approximation = false;
+    const bool full_projection = false;
+
+    const std::array<double, 2> exp_sf_values {};
+    const std::array<int, 2> exp_eq_ids {};
+
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Triangle_Inside, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 1.0, 1.0, 0.0));
+
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Triangle3D3<NodeType>>(node_1, node_2, node_3));
+
+    double proj_dist = 0.35;
+    const Point point_to_project(0.5, 0.3, proj_dist);
+    const double local_coord_tol = 0.2;
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Surface_Inside;
+    const bool compute_approximation = false;
+    const bool full_projection = true;
+
+    const std::array<double, 3> exp_sf_values {0.5, 0.2, 0.3};
+    const std::array<int, 3> exp_eq_ids {35, 18, 108};
+
+    SetEqIdsOnNodes(*p_geom, exp_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Triangle_Outside, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 1.0, 1.0, 0.0));
+
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Triangle3D3<NodeType>>(node_1, node_2, node_3));
+
+    double proj_dist = 0.35;
+    const Point point_to_project(1.1, 0.1, proj_dist);
+    const double local_coord_tol = 0.2;
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Surface_Outside;
+    const bool compute_approximation = true;
+    const bool full_projection = false;
+
+    const std::array<double, 3> exp_sf_values {-0.1, 1.0, 0.1};
+    const std::array<int, 3> exp_eq_ids {35, 18, 108};
+
+    SetEqIdsOnNodes(*p_geom, exp_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Triangle_Line, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 1.0, 1.0, 0.0));
+
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Triangle3D3<NodeType>>(node_1, node_2, node_3));
+
+    const Point point_to_project(1.1, 0.1, 0.35);
+    const double local_coord_tol = 0.0;
+    double proj_dist = std::sqrt(std::pow(0.1, 2) + std::pow(0.35,2));
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Line_Inside;
+    const bool compute_approximation = true;
+    const bool full_projection = false;
+
+    const std::array<double, 2> exp_sf_values {0.9, 0.1};
+    const std::array<int, 2> exp_eq_ids {18, 108};
+    const std::array<int, 3> all_eq_ids {35, 18, 108};
+
+    SetEqIdsOnNodes(*p_geom, all_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Triangle_Closest_Point, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 1.0, 1.0, 0.0));
+
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Triangle3D3<NodeType>>(node_1, node_2, node_3));
+
+    const Point point_to_project(1.1, -1.2, 0.0);
+    const double local_coord_tol = 0.0;
+    double proj_dist = std::sqrt(std::pow(0.1, 2) + std::pow(point_to_project[1], 2));
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Closest_Point;
+    const bool compute_approximation = true;
+    const bool full_projection = false;
+
+    const std::array<double, 1> exp_sf_values {1.0};
+    const std::array<int, 1> exp_eq_ids {18};
+    const std::array<int, 3> all_eq_ids {35, 18, 108};
+
+    SetEqIdsOnNodes(*p_geom, all_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Triangle_Unspecified, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 1.0, 1.0, 0.0));
+
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Triangle3D3<NodeType>>(node_1, node_2, node_3));
+
+    const Point point_to_project(1.1, -0.1, 0.0);
+    const double local_coord_tol = 0.0;
+    double proj_dist = std::sqrt(std::pow(0.1, 2) + std::pow(point_to_project[1], 2));
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Unspecified;
+    const bool compute_approximation = false;
+    const bool full_projection = false;
+
+    const std::array<double, 1> exp_sf_values {};
+    const std::array<int, 1> exp_eq_ids {};
+
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Quadrilateral_Inside, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 1.0, 1.0, 0.0));
+    auto node_4(Kratos::make_intrusive<NodeType>(4, 0.0, 1.0, 0.0));
+
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Quadrilateral3D4<NodeType>>(node_1, node_2, node_3, node_4));
+
+    double proj_dist = 0.35;
+    const Point point_to_project(0.5, 0.3, proj_dist);
+    const double local_coord_tol = 0.2;
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Surface_Inside;
+    const bool compute_approximation = false;
+    const bool full_projection = true;
+
+    const std::array<double, 4> exp_sf_values {0.35, 0.35, 0.15, 0.15};
+    const std::array<int, 4> exp_eq_ids {35, 18, 108, 95};
+
+    SetEqIdsOnNodes(*p_geom, exp_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Quadrilateral_Outside, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 1.0, 1.0, 0.0));
+    auto node_4(Kratos::make_intrusive<NodeType>(4, 0.0, 1.0, 0.0));
+
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Quadrilateral3D4<NodeType>>(node_1, node_2, node_3, node_4));
+
+    double proj_dist = 0.35;
+    const Point point_to_project(-0.1, -0.1, proj_dist);
+    const double local_coord_tol = 0.2;
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Surface_Outside;
+    const bool compute_approximation = true;
+    const bool full_projection = false;
+
+    const std::array<double, 4> exp_sf_values {1.21, -0.11, 0.01, -0.11};
+    const std::array<int, 4> exp_eq_ids {35, 18, 108, 95};
+
+    SetEqIdsOnNodes(*p_geom, exp_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Tetrahedra_Inside, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 1.0, 1.0, 0.0));
+    auto node_4(Kratos::make_intrusive<NodeType>(4, 0.5, 1.0, 1.0));
+
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Tetrahedra3D4<NodeType>>(node_1, node_2, node_3, node_4));
+
+    const Point point_to_project(0.5, 0.3, 0.2);
+    const double local_coord_tol = 0.2;
+    double proj_dist = 1.4465476141489435058;
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Volume_Inside;
+    const bool compute_approximation = false;
+    const bool full_projection = true;
+
+    const std::array<double, 4> exp_sf_values {0.4, 0.3, 0.1, 0.2};
+    const std::array<int, 4> exp_eq_ids {35, 18, 108, 95};
+
+    SetEqIdsOnNodes(*p_geom, exp_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Hexahedra_Inside, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 1.0, 1.0, 0.0));
+    auto node_4(Kratos::make_intrusive<NodeType>(4, 0.0, 1.0, 0.0));
+    auto node_5(Kratos::make_intrusive<NodeType>(5, 0.0, 0.0, 1.0));
+    auto node_6(Kratos::make_intrusive<NodeType>(6, 1.0, 0.0, 1.0));
+    auto node_7(Kratos::make_intrusive<NodeType>(7, 1.0, 1.0, 1.0));
+    auto node_8(Kratos::make_intrusive<NodeType>(8, 0.0, 1.0, 1.0));
+
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Hexahedra3D8<NodeType>>(node_1, node_2, node_3, node_4, node_5, node_6, node_7, node_8));
+
+    const Point point_to_project(0.5, 0.3, 0.2);
+    const double local_coord_tol = 0.2;
+    double proj_dist = 0.36055512754639901241;
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Volume_Inside;
+    const bool compute_approximation = false;
+    const bool full_projection = true;
+
+    const std::array<double, 8> exp_sf_values {0.28, 0.28, 0.12, 0.12, 0.07, 0.07, 0.03, 0.03};
+    const std::array<int, 8> exp_eq_ids {35, 18, 108, 95, 12, 14, 19, 22};
+
+    SetEqIdsOnNodes(*p_geom, exp_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(ProjectionUtils_Hexahedra_Outside, KratosMappingApplicationSerialTestSuite)
+{
+    auto node_1(Kratos::make_intrusive<NodeType>(1, 0.0, 0.0, 0.0));
+    auto node_2(Kratos::make_intrusive<NodeType>(2, 1.0, 0.0, 0.0));
+    auto node_3(Kratos::make_intrusive<NodeType>(3, 1.0, 1.0, 0.0));
+    auto node_4(Kratos::make_intrusive<NodeType>(4, 0.0, 1.0, 0.0));
+    auto node_5(Kratos::make_intrusive<NodeType>(5, 0.0, 0.0, 1.0));
+    auto node_6(Kratos::make_intrusive<NodeType>(6, 1.0, 0.0, 1.0));
+    auto node_7(Kratos::make_intrusive<NodeType>(7, 1.0, 1.0, 1.0));
+    auto node_8(Kratos::make_intrusive<NodeType>(8, 0.0, 1.0, 1.0));
+
+    const GeometryType::Pointer p_geom(Kratos::make_shared<Hexahedra3D8<NodeType>>(node_1, node_2, node_3, node_4, node_5, node_6, node_7, node_8));
+
+    const Point point_to_project(0.5, 0.5, -0.1);
+    const double local_coord_tol = 0.2;
+    double proj_dist = 0.6;
+    ProjectionUtilities::PairingIndex pairing_index = ProjectionUtilities::PairingIndex::Volume_Outside;
+    const bool compute_approximation = true;
+    const bool full_projection = false;
+
+    const std::array<double, 8> exp_sf_values {0.275, 0.275, 0.275, 0.275, -0.025, -0.025, -0.025, -0.025};
+    const std::array<int, 8> exp_eq_ids {35, 18, 108, 95, 12, 14, 19, 22};
+
+    SetEqIdsOnNodes(*p_geom, exp_eq_ids);
+    TestComputeProjection(*p_geom, point_to_project, local_coord_tol, exp_sf_values, exp_eq_ids, proj_dist, pairing_index, compute_approximation, full_projection);
+}
+
+}  // namespace Testing
+}  // namespace Kratos


### PR DESCRIPTION
This PR adds the projection utilities for hierarchically projecting on sub-geometries in case a projection fails.
E.g. if a projection on a triangle fails, I will try to project on the lines of the triangle instead of using the closest point. Only if also the projection on the lines fails then I will take the closest point

I am adding this separately to not blow up the upcoming PR
Tests are added