### PR TITLE
[Fluid] Update TO_SPLIT flag in distance modification process

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -264,6 +264,9 @@ void DistanceModificationProcess::ModifyDistance() {
 
     // Syncronize data between partitions (the modified distance has always a lower value)
     mrModelPart.GetCommunicator().SynchronizeCurrentDataToMin(DISTANCE);
+
+    // Update the TO_SPLIT flag
+    this->SetContinuousDistanceToSplitFlag();
 }
 
 void DistanceModificationProcess::ModifyDiscontinuousDistance(){
@@ -332,6 +335,9 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance(){
             }
         }
     }
+
+    // Update the TO_SPLIT flag
+    this->SetDiscontinuousDistanceToSplitFlag();
 }
 
 void DistanceModificationProcess::RecoverDeactivationPreviousState(){
@@ -371,6 +377,9 @@ void DistanceModificationProcess::RecoverOriginalDistance() {
     mModifiedDistancesValues.resize(0);
     mModifiedDistancesIDs.shrink_to_fit();
     mModifiedDistancesValues.shrink_to_fit();
+
+    // Restore the TO_SPLIT flag original status
+    this->SetContinuousDistanceToSplitFlag();
 }
 
 void DistanceModificationProcess::RecoverOriginalDiscontinuousDistance() {
@@ -386,6 +395,9 @@ void DistanceModificationProcess::RecoverOriginalDiscontinuousDistance() {
     mModifiedElementalDistancesValues.resize(0);
     mModifiedDistancesIDs.shrink_to_fit();
     mModifiedElementalDistancesValues.shrink_to_fit();
+
+    // Restore the TO_SPLIT flag original status
+    this->SetDiscontinuousDistanceToSplitFlag();
 }
 
 void DistanceModificationProcess::DeactivateFullNegativeElements() {
@@ -443,6 +455,30 @@ void DistanceModificationProcess::DeactivateFullNegativeElements() {
             it_node->FastGetSolutionStepValue(PRESSURE) = 0.0;
             it_node->FastGetSolutionStepValue(VELOCITY) = ZeroVector(3);
         }
+    }
+}
+
+void DistanceModificationProcess::SetContinuousDistanceToSplitFlag()
+{
+    #pragma omp parallel for
+    for (int i_elem = 0; i_elem < static_cast<int>(mrModelPart.NumberOfElements()); ++i_elem) {
+        auto it_elem = mrModelPart.ElementsBegin() + i_elem;
+        auto &r_geom = it_elem->GetGeometry();
+        std::vector<double> elem_dist;
+        for (unsigned int i_node = 0; i_node < r_geom.PointsNumber(); ++i_node) {
+            elem_dist.push_back(r_geom[i_node].FastGetSolutionStepValue(DISTANCE));
+        }
+        this->SetElementToSplitFlag(*it_elem, elem_dist);
+    }
+}
+
+void DistanceModificationProcess::SetDiscontinuousDistanceToSplitFlag()
+{
+    #pragma omp parallel for
+    for (int i_elem = 0; i_elem < static_cast<int>(mrModelPart.NumberOfElements()); ++i_elem) {
+        auto it_elem = mrModelPart.ElementsBegin() + i_elem;
+        const auto &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
+        this->SetElementToSplitFlag(*it_elem, r_elem_dist);
     }
 }
 

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -198,7 +198,7 @@ private:
         unsigned int n_pos = 0;
         unsigned int n_neg = 0;
         for (double i_dist : rDistancesVector) {
-            if (i_dist < 0) {
+            if (i_dist < 0.0) {
                 n_neg++;
             } else {
                 n_pos++;

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.h
@@ -190,6 +190,31 @@ private:
 
     void DeactivateFullNegativeElements();
 
+    template<class TDistancesVectorType>
+    void SetElementToSplitFlag(
+        Element &rElem,
+        const TDistancesVectorType& rDistancesVector)
+    {
+        unsigned int n_pos = 0;
+        unsigned int n_neg = 0;
+        for (double i_dist : rDistancesVector) {
+            if (i_dist < 0) {
+                n_neg++;
+            } else {
+                n_pos++;
+            }
+        }
+        if (n_neg != 0 && n_pos != 0) {
+            rElem.Set(TO_SPLIT, true);
+        } else {
+            rElem.Set(TO_SPLIT, false);
+        }
+    }
+
+    void SetContinuousDistanceToSplitFlag();
+
+    void SetDiscontinuousDistanceToSplitFlag();
+
     ///@}
     ///@name Private  Access
     ///@{

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
@@ -77,15 +77,21 @@ KRATOS_TEST_CASE_IN_SUITE(DistanceModificationTriangle, FluidDynamicsApplication
     dist_mod_process.ExecuteInitialize();
     dist_mod_process.ExecuteBeforeSolutionLoop();
     dist_mod_process.ExecuteInitializeSolutionStep();
-    KRATOS_CHECK_NEAR((model_part.GetNode(1)).FastGetSolutionStepValue(DISTANCE), -1.0e-3, 1e-9);
-    KRATOS_CHECK_NEAR((model_part.GetNode(2)).FastGetSolutionStepValue(DISTANCE), 1.0, 1e-9);
-    KRATOS_CHECK_NEAR((model_part.GetNode(3)).FastGetSolutionStepValue(DISTANCE), 1.0, 1e-9);
+    const double tolerance = 1e-9;
+    std::array<double, 3> expected_values = {-1.0e-3, 1.0, 1.0};
+    for (unsigned int i_node = 1; i_node < 4; ++i_node) {
+        KRATOS_CHECK_NEAR((model_part.GetNode(i_node)).FastGetSolutionStepValue(DISTANCE), expected_values[i_node - 1], tolerance);
+    }
+
+    // Check that the flag TO_SPLIT is correctly set
+    KRATOS_CHECK((model_part.ElementsBegin())->Is(TO_SPLIT));
 
     // Check the original distance recovering
     dist_mod_process.ExecuteFinalizeSolutionStep();
-    KRATOS_CHECK_NEAR((model_part.GetNode(1)).FastGetSolutionStepValue(DISTANCE), -1.0e-5, 1e-9);
-    KRATOS_CHECK_NEAR((model_part.GetNode(2)).FastGetSolutionStepValue(DISTANCE), 1.0, 1e-9);
-    KRATOS_CHECK_NEAR((model_part.GetNode(3)).FastGetSolutionStepValue(DISTANCE), 1.0, 1e-9);
+    std::array<double, 3> expected_orig_values = {-1.0e-5, 1.0, 1.0};
+    for (unsigned int i_node = 1; i_node < 4; ++i_node) {
+        KRATOS_CHECK_NEAR((model_part.GetNode(i_node)).FastGetSolutionStepValue(DISTANCE), expected_orig_values[i_node - 1], tolerance);
+    }
 }
 
 KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceModificationTriangle, FluidDynamicsApplicationFastSuite) {
@@ -109,16 +115,22 @@ KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceModificationTriangle, FluidDynami
     dist_mod_process.ExecuteBeforeSolutionLoop();
     dist_mod_process.ExecuteInitializeSolutionStep();
     auto elem_dist = (model_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
-    KRATOS_CHECK_NEAR(elem_dist[0], -0.000797885, 1e-9);
-    KRATOS_CHECK_NEAR(elem_dist[1], 1.0, 1e-9);
-    KRATOS_CHECK_NEAR(elem_dist[2], 1.0, 1e-9);
+    const double tolerance = 1e-9;
+    std::array<double, 3> expected_values = {-0.000797885, 1.0, 1.0};
+    for (unsigned int i = 0; i < elem_dist.size(); ++i) {
+        KRATOS_CHECK_NEAR(elem_dist[i], expected_values[i], tolerance);
+    }
+
+    // Check that the flag TO_SPLIT is correctly set
+    KRATOS_CHECK((model_part.ElementsBegin())->Is(TO_SPLIT));
 
     // Check the original distance recovering
     dist_mod_process.ExecuteFinalizeSolutionStep();
     elem_dist = (model_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
-    KRATOS_CHECK_NEAR(elem_dist[0], -1.0e-5, 1e-9);
-    KRATOS_CHECK_NEAR(elem_dist[1], 1.0, 1e-9);
-    KRATOS_CHECK_NEAR(elem_dist[2], 1.0, 1e-9);
+    std::array<double, 3> expected_orig_values = {-1.0e-5, 1.0, 1.0};
+    for (unsigned int i = 0; i < elem_dist.size(); ++i) {
+        KRATOS_CHECK_NEAR(elem_dist[i], expected_orig_values[i], tolerance);
+    }
 }
 
 }


### PR DESCRIPTION
This PR adds the update of the elemental flag TO_SPLIT after the distance correction. The flag is set by the continuous and discontinuous distance processes but the intersection status might change after the modification. Right now it is not used (at least in my embedded formulations) but might be useful in the future.