### PR TITLE
Initialize node reordering in nodal graph creation.

### DIFF
--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -669,6 +669,12 @@ private:
 
     inline void CreatePartition(unsigned int NumberOfThreads,const int NumberOfRows, DenseVector<unsigned int>& partitions);
 
+    /// Iterate over a Node block, calling ReorderedNodeId on each node.
+    /** This method allows derived implementations to initalize reordering
+     *  without storing the nodes.
+     */
+    void ScanNodeBlock();
+
     ///@}
     ///@name Private  Access
     ///@{
@@ -677,7 +683,6 @@ private:
     ///@}
     ///@name Private Inquiry
     ///@{
-
 
     ///@}
     ///@name Un accessible methods


### PR DESCRIPTION
Do some minimal processing of nodal blocks (instead of just skipping them) when creating the nodal graph for metis partitioners. This gives a chance to reorder the nodes (if the ModelPartIO supports it) before creating the graph from Element and Condition blocks.

I do not love this solution, since `ReadNodalGraph` will always check for consistent numbering after the read, which is unnecessary if the derived class implements reordering. However, the only ways I could think of avoiding this involve either exposing the internals of ModelPartIO to derived classes (things like manipulating the file stream) or iterating over the file twice, once to process the nodes and check for consistency, once to actually read the nodal graph from element/condition blocks.

This closes #4324.