### PR TITLE
Cps/ Hotfix missing includes and normal calculation

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -10,6 +10,7 @@
 //  Main authors:    Inigo Lopez
 
 #include "custom_utilities/potential_flow_utilities.h"
+#include "compressible_potential_flow_application_variables.h"
 
 namespace Kratos {
 namespace PotentialFlowUtilities {

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
@@ -44,7 +44,7 @@ class ComputeLiftProcess(KratosMultiphysics.Process):
         self.moment_coefficient = KratosMultiphysics.Vector(3)
 
         for cond in self.body_model_part.Conditions:
-            surface_normal = cond.GetValue(KratosMultiphysics.NORMAL)
+            surface_normal = cond.GetGeometry().Normal()
             pressure_coefficient = cond.GetValue(KratosMultiphysics.PRESSURE_COEFFICIENT)
 
             # Computing forces

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_incompressible_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_incompressible_potential_element.cpp
@@ -13,6 +13,7 @@
 
 // Project includes
 #include "testing/testing.h"
+#include "containers/model.h"
 #include "includes/model_part.h"
 #include "compressible_potential_flow_application_variables.h"
 #include "custom_elements/incompressible_potential_flow_element.h"


### PR DESCRIPTION
Hi!, 

After #4668 I get two compilation errors due to missing includes. 

Also, the normal of the updated compute_lift_process was not using GetGeometry(). 