### PR TITLE
Core/feature connectivity preserve variants

### DIFF
--- a/kratos/modeler/connectivity_preserve_modeler.h
+++ b/kratos/modeler/connectivity_preserve_modeler.h
@@ -87,6 +87,25 @@ public:
         const Condition& rReferenceBoundaryCondition
     ) override;
 
+    /// Generate a copy of rOriginModelPart in rDestinationModelPart, using the given element type.
+    /** This function fills rDestinationModelPart using data obtained from
+     *  rOriginModelPart. The elements of rDestinationModelPart part use the
+     *  same connectivity (and id) as in rOriginModelPart but their type is
+     *  determined by rReferenceElement. In this variant, conditions are not
+     *  copied.
+     *  Note that both ModelParts will share the same nodes, as well as
+     *  ProcessInfo and tables. SubModelParts and, in MPI, communicator data
+     *  will be replicated in DestinationModelPart.
+     *  @param rOriginModelPart The source ModelPart.
+     *  @param rDestinationModelPart The ModelPart to be filled by this function.
+     *  @param rReferenceElement The Element type for rDestinationModelPart.
+     */
+    virtual void GenerateModelPart(
+        ModelPart& OriginModelPart,
+        ModelPart& DestinationModelPart,
+        const Element& rReferenceElement
+    );
+
     ///@}
 
 private:

--- a/kratos/modeler/connectivity_preserve_modeler.h
+++ b/kratos/modeler/connectivity_preserve_modeler.h
@@ -106,6 +106,25 @@ public:
         const Element& rReferenceElement
     );
 
+    /// Generate a copy of rOriginModelPart in rDestinationModelPart, using the given condition type.
+    /** This function fills rDestinationModelPart using data obtained from
+     *  rOriginModelPart. The conditions of rDestinationModelPart part use the
+     *  same connectivity (and id) as in rOriginModelPart but their type is
+     *  determined by rReferenceCondition. In this variant, elements are not
+     *  copied.
+     *  Note that both ModelParts will share the same nodes, as well as
+     *  ProcessInfo and tables. SubModelParts and, in MPI, communicator data
+     *  will be replicated in DestinationModelPart.
+     *  @param rOriginModelPart The source ModelPart.
+     *  @param rDestinationModelPart The ModelPart to be filled by this function.
+     *  @param rReferenceCondition The Condition type for rDestinationModelPart.
+     */
+    virtual void GenerateModelPart(
+        ModelPart& OriginModelPart,
+        ModelPart& DestinationModelPart,
+        const Condition& rReferenceCondition
+    );
+
     ///@}
 
 private:

--- a/kratos/python/add_modeler_to_python.cpp
+++ b/kratos/python/add_modeler_to_python.cpp
@@ -34,7 +34,7 @@ namespace Python
 
 namespace py = pybind11;
 
-void GenerateModelPart(Modeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const char* ElementName, const char* ConditionName)
+void GenerateModelPart(Modeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const std::string ElementName, const std::string ConditionName)
 {
     GM.GenerateModelPart(origin_model_part, destination_model_part,
                          KratosComponents<Element>::Get(ElementName),
@@ -42,7 +42,7 @@ void GenerateModelPart(Modeler& GM, ModelPart& origin_model_part, ModelPart& des
 
 }
 
-void GenerateMesh(Modeler& GM, ModelPart& model_part, const char* ElementName, const char* ConditionName)
+void GenerateMesh(Modeler& GM, ModelPart& model_part, const std::string ElementName, const std::string ConditionName)
 {
     GM.GenerateMesh(model_part,
                     KratosComponents<Element>::Get(ElementName),
@@ -50,7 +50,7 @@ void GenerateMesh(Modeler& GM, ModelPart& model_part, const char* ElementName, c
 
 }
 
-void GeneratePartialModelPart(ConnectivityPreserveModeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const char* Name)
+void GeneratePartialModelPart(ConnectivityPreserveModeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const std::string Name)
 {
     if (KratosComponents<Element>::Has(Name)) {
         GM.GenerateModelPart(origin_model_part, destination_model_part,

--- a/kratos/python/add_modeler_to_python.cpp
+++ b/kratos/python/add_modeler_to_python.cpp
@@ -77,6 +77,7 @@ void  AddModelerToPython(pybind11::module& m)
 
     py::class_<ConnectivityPreserveModeler,ConnectivityPreserveModeler::Pointer,Modeler>(m,"ConnectivityPreserveModeler")
     .def(py::init< >())
+    .def("GenerateModelPart",&GenerateModelPart)
     .def("GenerateModelPart",&GeneratePartialModelPart)
     ;
 

--- a/kratos/python/add_modeler_to_python.cpp
+++ b/kratos/python/add_modeler_to_python.cpp
@@ -50,10 +50,19 @@ void GenerateMesh(Modeler& GM, ModelPart& model_part, const char* ElementName, c
 
 }
 
-void GenerateModelPartElementsOnly(ConnectivityPreserveModeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const char* ElementName)
+void GeneratePartialModelPart(ConnectivityPreserveModeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const char* Name)
 {
-    GM.GenerateModelPart(origin_model_part, destination_model_part,
-                         KratosComponents<Element>::Get(ElementName));
+    if (KratosComponents<Element>::Has(Name)) {
+        GM.GenerateModelPart(origin_model_part, destination_model_part,
+                             KratosComponents<Element>::Get(Name));
+    }
+    else if (KratosComponents<Condition>::Has(Name)) {
+        GM.GenerateModelPart(origin_model_part, destination_model_part,
+                             KratosComponents<Condition>::Get(Name));
+    }
+    else {
+        KRATOS_ERROR << "Unknown Element/Condition name " << Name << "." << std::endl;
+    }
 }
 
 void  AddModelerToPython(pybind11::module& m)
@@ -68,7 +77,7 @@ void  AddModelerToPython(pybind11::module& m)
 
     py::class_<ConnectivityPreserveModeler,ConnectivityPreserveModeler::Pointer,Modeler>(m,"ConnectivityPreserveModeler")
     .def(py::init< >())
-    .def("GenerateModelPart",&GenerateModelPartElementsOnly)
+    .def("GenerateModelPart",&GeneratePartialModelPart)
     ;
 
     py::class_< EdgeSwapping2DModeler, EdgeSwapping2DModeler::Pointer, Modeler >(m,"EdgeSwapping2DModeler")

--- a/kratos/python/add_modeler_to_python.cpp
+++ b/kratos/python/add_modeler_to_python.cpp
@@ -50,6 +50,11 @@ void GenerateMesh(Modeler& GM, ModelPart& model_part, const char* ElementName, c
 
 }
 
+void GenerateModelPartElementsOnly(ConnectivityPreserveModeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const char* ElementName)
+{
+    GM.GenerateModelPart(origin_model_part, destination_model_part,
+                         KratosComponents<Element>::Get(ElementName));
+}
 
 void  AddModelerToPython(pybind11::module& m)
 {
@@ -63,8 +68,8 @@ void  AddModelerToPython(pybind11::module& m)
 
     py::class_<ConnectivityPreserveModeler,ConnectivityPreserveModeler::Pointer,Modeler>(m,"ConnectivityPreserveModeler")
     .def(py::init< >())
-            ;
-
+    .def("GenerateModelPart",&GenerateModelPartElementsOnly)
+    ;
 
     py::class_< EdgeSwapping2DModeler, EdgeSwapping2DModeler::Pointer, Modeler >(m,"EdgeSwapping2DModeler")
             .def(py::init< >())

--- a/kratos/python/add_modeler_to_python.cpp
+++ b/kratos/python/add_modeler_to_python.cpp
@@ -34,34 +34,34 @@ namespace Python
 
 namespace py = pybind11;
 
-void GenerateModelPart(Modeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const std::string ElementName, const std::string ConditionName)
+void GenerateModelPart(Modeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const std::string& rElementName, const std::string& rConditionName)
 {
     GM.GenerateModelPart(origin_model_part, destination_model_part,
-                         KratosComponents<Element>::Get(ElementName),
-                         KratosComponents<Condition>::Get(ConditionName));
+                         KratosComponents<Element>::Get(rElementName),
+                         KratosComponents<Condition>::Get(rConditionName));
 
 }
 
-void GenerateMesh(Modeler& GM, ModelPart& model_part, const std::string ElementName, const std::string ConditionName)
+void GenerateMesh(Modeler& GM, ModelPart& model_part, const std::string& rElementName, const std::string& rConditionName)
 {
     GM.GenerateMesh(model_part,
-                    KratosComponents<Element>::Get(ElementName),
-                    KratosComponents<Condition>::Get(ConditionName));
+                    KratosComponents<Element>::Get(rElementName),
+                    KratosComponents<Condition>::Get(rConditionName));
 
 }
 
-void GeneratePartialModelPart(ConnectivityPreserveModeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const std::string Name)
+void GeneratePartialModelPart(ConnectivityPreserveModeler& GM, ModelPart& origin_model_part, ModelPart& destination_model_part, const std::string& rName)
 {
-    if (KratosComponents<Element>::Has(Name)) {
+    if (KratosComponents<Element>::Has(rName)) {
         GM.GenerateModelPart(origin_model_part, destination_model_part,
-                             KratosComponents<Element>::Get(Name));
+                             KratosComponents<Element>::Get(rName));
     }
-    else if (KratosComponents<Condition>::Has(Name)) {
+    else if (KratosComponents<Condition>::Has(rName)) {
         GM.GenerateModelPart(origin_model_part, destination_model_part,
-                             KratosComponents<Condition>::Get(Name));
+                             KratosComponents<Condition>::Get(rName));
     }
     else {
-        KRATOS_ERROR << "Unknown Element/Condition name " << Name << "." << std::endl;
+        KRATOS_ERROR << "Unknown Element/Condition name " << rName << "." << std::endl;
     }
 }
 

--- a/kratos/sources/connectivity_preserve_modeler.cpp
+++ b/kratos/sources/connectivity_preserve_modeler.cpp
@@ -66,6 +66,28 @@ void ConnectivityPreserveModeler::GenerateModelPart(
     KRATOS_CATCH("");
 }
 
+void ConnectivityPreserveModeler::GenerateModelPart(
+    ModelPart& rOriginModelPart,
+    ModelPart& rDestinationModelPart,
+    Condition const& rReferenceCondition)
+{
+    KRATOS_TRY;
+
+    this->CheckVariableLists(rOriginModelPart, rDestinationModelPart);
+
+    this->ResetModelPart(rDestinationModelPart);
+
+    this->CopyCommonData(rOriginModelPart, rDestinationModelPart);
+
+    this->DuplicateConditions(rOriginModelPart, rDestinationModelPart, rReferenceCondition);
+
+    this->DuplicateCommunicatorData(rOriginModelPart,rDestinationModelPart);
+
+    this->DuplicateSubModelParts(rOriginModelPart, rDestinationModelPart);
+
+    KRATOS_CATCH("");
+}
+
 // Private methods /////////////////////////////////////////////////////////////
 void ConnectivityPreserveModeler::CheckVariableLists(ModelPart& rOriginModelPart, ModelPart& rDestinationModelPart) const
 {
@@ -228,12 +250,17 @@ ModelPart& rDestinationModelPart) const
         std::vector<ModelPart::IndexType> ids;
         ids.reserve(i_part->Elements().size());
 
-        //adding by index
-        for(auto it=i_part->ElementsBegin(); it!=i_part->ElementsEnd(); ++it)
-            ids.push_back(it->Id());
-        destination_part.AddElements(ids, 0); //adding by index
+        // Execute only if we created elements in the destination
+        if (rDestinationModelPart.NumberOfElements() > 0)
+        {
+            //adding by index
+            for(auto it=i_part->ElementsBegin(); it!=i_part->ElementsEnd(); ++it)
+                ids.push_back(it->Id());
+            destination_part.AddElements(ids, 0); //adding by index
+        }
 
-        if (rDestinationModelPart.NumberOfConditions() > 0) // Note that we may have copied elements only
+        // Execute only if we created conditions in the destination
+        if (rDestinationModelPart.NumberOfConditions() > 0)
         {
             ids.clear();
             for(auto it=i_part->ConditionsBegin(); it!=i_part->ConditionsEnd(); ++it)

--- a/kratos/sources/connectivity_preserve_modeler.cpp
+++ b/kratos/sources/connectivity_preserve_modeler.cpp
@@ -187,7 +187,7 @@ void ConnectivityPreserveModeler::DuplicateCommunicatorData(
 
     // This is a dirty hack to detect if the communicator is a Communicator or an MPICommunicator
     // Note that downcasting would not work here because MPICommunicator is not compiled in non-MPI builds
-    const bool is_mpi = ( rOriginModelPart.pElements() == rReferenceComm.LocalMesh().pElements() );
+    const bool is_mpi = ( rOriginModelPart.pElements() != rReferenceComm.LocalMesh().pElements() );
     if (is_mpi) {
         // All elements are passed as local elements to the new communicator
         ModelPart::ElementsContainerType& rDestinationLocalElements = pDestinationComm->LocalMesh().Elements();

--- a/kratos/sources/connectivity_preserve_modeler.cpp
+++ b/kratos/sources/connectivity_preserve_modeler.cpp
@@ -44,6 +44,28 @@ void ConnectivityPreserveModeler::GenerateModelPart(
     KRATOS_CATCH("");
 }
 
+void ConnectivityPreserveModeler::GenerateModelPart(
+    ModelPart& rOriginModelPart,
+    ModelPart& rDestinationModelPart,
+    Element const& rReferenceElement)
+{
+    KRATOS_TRY;
+
+    this->CheckVariableLists(rOriginModelPart, rDestinationModelPart);
+
+    this->ResetModelPart(rDestinationModelPart);
+
+    this->CopyCommonData(rOriginModelPart, rDestinationModelPart);
+
+    this->DuplicateElements(rOriginModelPart, rDestinationModelPart, rReferenceElement);
+
+    this->DuplicateCommunicatorData(rOriginModelPart,rDestinationModelPart);
+
+    this->DuplicateSubModelParts(rOriginModelPart, rDestinationModelPart);
+
+    KRATOS_CATCH("");
+}
+
 // Private methods /////////////////////////////////////////////////////////////
 void ConnectivityPreserveModeler::CheckVariableLists(ModelPart& rOriginModelPart, ModelPart& rDestinationModelPart) const
 {
@@ -211,10 +233,13 @@ ModelPart& rDestinationModelPart) const
             ids.push_back(it->Id());
         destination_part.AddElements(ids, 0); //adding by index
 
-        ids.clear();
-        for(auto it=i_part->ConditionsBegin(); it!=i_part->ConditionsEnd(); ++it)
-            ids.push_back(it->Id());
-        destination_part.AddConditions(ids, 0);
+        if (rDestinationModelPart.NumberOfConditions() > 0) // Note that we may have copied elements only
+        {
+            ids.clear();
+            for(auto it=i_part->ConditionsBegin(); it!=i_part->ConditionsEnd(); ++it)
+                ids.push_back(it->Id());
+            destination_part.AddConditions(ids, 0);
+        }
 
         // Duplicate the Communicator for this SubModelPart
         this->DuplicateCommunicatorData(*i_part, destination_part);

--- a/kratos/sources/connectivity_preserve_modeler.cpp
+++ b/kratos/sources/connectivity_preserve_modeler.cpp
@@ -198,19 +198,19 @@ void ConnectivityPreserveModeler::DuplicateCommunicatorData(
     Communicator::Pointer pDestinationComm = rReferenceComm.Create();
     pDestinationComm->SetNumberOfColors( rReferenceComm.GetNumberOfColors() );
     pDestinationComm->NeighbourIndices() = rReferenceComm.NeighbourIndices();
-    pDestinationComm->LocalMesh().SetNodes( rReferenceComm.LocalMesh().pNodes() );
-    pDestinationComm->InterfaceMesh().SetNodes( rReferenceComm.InterfaceMesh().pNodes() );
-    pDestinationComm->GhostMesh().SetNodes( rReferenceComm.GhostMesh().pNodes() );
-    for (unsigned int i = 0; i < rReferenceComm.GetNumberOfColors(); i++) {
-        pDestinationComm->pLocalMesh(i)->SetNodes( rReferenceComm.pLocalMesh(i)->pNodes() );
-        pDestinationComm->pInterfaceMesh(i)->SetNodes( rReferenceComm.pInterfaceMesh(i)->pNodes() );
-        pDestinationComm->pGhostMesh(i)->SetNodes( rReferenceComm.pGhostMesh(i)->pNodes() );
-    }
 
     // This is a dirty hack to detect if the communicator is a Communicator or an MPICommunicator
     // Note that downcasting would not work here because MPICommunicator is not compiled in non-MPI builds
     const bool is_mpi = ( rOriginModelPart.pElements() != rReferenceComm.LocalMesh().pElements() );
     if (is_mpi) {
+        pDestinationComm->LocalMesh().SetNodes( rReferenceComm.LocalMesh().pNodes() );
+        pDestinationComm->InterfaceMesh().SetNodes( rReferenceComm.InterfaceMesh().pNodes() );
+        pDestinationComm->GhostMesh().SetNodes( rReferenceComm.GhostMesh().pNodes() );
+        for (unsigned int i = 0; i < rReferenceComm.GetNumberOfColors(); i++) {
+            pDestinationComm->pLocalMesh(i)->SetNodes( rReferenceComm.pLocalMesh(i)->pNodes() );
+            pDestinationComm->pInterfaceMesh(i)->SetNodes( rReferenceComm.pInterfaceMesh(i)->pNodes() );
+            pDestinationComm->pGhostMesh(i)->SetNodes( rReferenceComm.pGhostMesh(i)->pNodes() );
+        }
         // All elements are passed as local elements to the new communicator
         ModelPart::ElementsContainerType& rDestinationLocalElements = pDestinationComm->LocalMesh().Elements();
         rDestinationLocalElements.clear();
@@ -227,8 +227,7 @@ void ConnectivityPreserveModeler::DuplicateCommunicatorData(
             rDestinationLocalConditions.push_back(*i_cond);
         }
     } else {
-        pDestinationComm->LocalMesh().pElements() = rDestinationModelPart.pElements();
-        pDestinationComm->LocalMesh().pConditions() = rDestinationModelPart.pConditions();
+        pDestinationComm->SetLocalMesh(rDestinationModelPart.pGetMesh());
     }
 
     rDestinationModelPart.SetCommunicator( pDestinationComm );

--- a/kratos/tests/test_connectivity_preserve_modeler.py
+++ b/kratos/tests/test_connectivity_preserve_modeler.py
@@ -88,11 +88,11 @@ class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
         model_part1.CreateNewCondition("Condition2D2N", 2, [2,4], model_part1.GetProperties()[1])
         model_part1.CreateNewCondition("Condition2D2N", 1, [1,2], model_part1.GetProperties()[1])
         sub1.AddConditions([2])
-        
+
         current_model = KratosMultiphysics.Model()
         new_model_part = current_model.CreateModelPart("New1")
         new_model_part2 = current_model.CreateModelPart("New2")
-        
+
         modeler = KratosMultiphysics.ConnectivityPreserveModeler()
         modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "Condition2D2N")
         self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
@@ -150,9 +150,53 @@ class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
         self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
         self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
 
+    def test_element_only_copy(self):
+        current_model = KratosMultiphysics.Model()
+        model_part1 = current_model.CreateModelPart("Main")
+        model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
 
+        model_part1.CreateNewNode(1,0.0,0.1,0.2)
+        model_part1.CreateNewNode(2,2.0,0.1,0.2)
+        model_part1.CreateNewNode(3,1.0,1.1,0.2)
+        model_part1.CreateNewNode(4,2.0,3.1,10.2)
 
+        sub1 = model_part1.CreateSubModelPart("sub1")
 
+        model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
+        model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
+
+        model_part1.CreateNewCondition("Condition2D2N", 2, [2,4], model_part1.GetProperties()[1])
+        sub1.AddConditions([2])
+
+        element_model_part = current_model.CreateModelPart("ElementCopy")
+
+        modeler = KratosMultiphysics.ConnectivityPreserveModeler()
+
+        modeler.GenerateModelPart(model_part1, element_model_part, "Element2D3N")
+
+        self.assertEqual(len(element_model_part.Nodes) , len(model_part1.Nodes))
+        self.assertEqual(len(element_model_part.Elements) , len(model_part1.Elements))
+        self.assertEqual(len(element_model_part.Conditions) , 0)
+
+        element_sub1_copy = element_model_part.GetSubModelPart("sub1")
+
+        self.assertEqual(len(element_sub1_copy.Nodes) , len(sub1.Nodes))
+        self.assertEqual(len(element_sub1_copy.Elements) , len(sub1.Elements))
+        self.assertEqual(len(element_sub1_copy.Conditions) , 0)
+
+        condition_model_part = current_model.CreateModelPart("ConditionCopy")
+
+        modeler.GenerateModelPart(model_part1, condition_model_part, "Condition2D2N")
+
+        self.assertEqual(len(condition_model_part.Nodes) , len(model_part1.Nodes))
+        self.assertEqual(len(condition_model_part.Elements) , 0)
+        self.assertEqual(len(condition_model_part.Conditions) , len(model_part1.Conditions))
+
+        condition_sub1_copy = condition_model_part.GetSubModelPart("sub1")
+
+        self.assertEqual(len(condition_sub1_copy.Nodes) , len(sub1.Nodes))
+        self.assertEqual(len(condition_sub1_copy.Elements) , 0)
+        self.assertEqual(len(condition_sub1_copy.Conditions) , len(sub1.Conditions))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Adding variants to ConnectivityPreserveModeler that work only on elements or conditions.

Relatively straightforward, but it required some minor tweaking of the class when copying submodelpart data.