### PR TITLE
[Core][TO DISCUSS NOT TO MERGE] Modification of geometry to allow external pointer vectors

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -550,7 +550,7 @@ public:
         return mpPointVector->max_size();
     }
 
-    void swap(Geometry& rOther)
+    void swap(GeometryType& rOther)
     {
         mpPointVector->swap(rOther.mpPointVector);
     }
@@ -632,6 +632,11 @@ public:
         return Pointer( new Geometry( ThisPoints, mpGeometryData ) );
     }
 
+    virtual Pointer Create(GeometryType const& ThisGeometry) const
+    {
+        return Pointer(new GeometryType((*ThisGeometry.mpPointVector), mpGeometryData));
+    }
+
     /** This methods will create a duplicate of all its points and
     substitute them with its points. */
     void ClonePoints()
@@ -640,26 +645,26 @@ public:
             *i = typename PointType::Pointer( new PointType( **i ) );
     }
 
-    // virtual Kratos::shared_ptr< Geometry< Point > > Clone() const
-    // {
-    //     Geometry< Point >::PointsArrayType NewPoints;
+     //virtual Kratos::shared_ptr< Geometry< Point > > Clone() const
+     //{
+     //    Geometry< Point >::PointsArrayType NewPoints;
 
-    //     //making a copy of the nodes TO POINTS (not Nodes!!!)
+     //    //making a copy of the nodes TO POINTS (not Nodes!!!)
 
-    //     for ( IndexType i = 0 ; i < this->size() ; i++ )
-    //     {
-    //         NewPoints.push_back(Kratos::make_shared< Point >((*this)[i]));
-    //     }
+     //    for ( IndexType i = 0 ; i < this->size() ; i++ )
+     //    {
+     //        NewPoints.push_back(Kratos::make_shared< Point >((*mpPointVector)[i]));
+     //    }
 
-    //     //NewPoints[i] = typename Point::Pointer(new Point(*mPoints[i]));
+     //    //NewPoints[i] = typename Point::Pointer(new Point(*mPoints[i]));
 
-    //     //creating a geometry with the new points
-    //     Geometry< Point >::Pointer p_clone( new Geometry< Point >( NewPoints ) );
+     //    //creating a geometry with the new points
+     //    Geometry< Point >::Pointer p_clone( new Geometry< Point >( NewPoints ) );
 
-    //     p_clone->ClonePoints();
+     //    p_clone->ClonePoints();
 
-    //     return p_clone;
-    // }
+     //    return p_clone;
+     //}
 
     /**
      * @brief Lumping factors for the calculation of the lumped mass matrix

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -226,7 +226,8 @@ public:
 
     /// data type stores in this container.
     //typedef PointerVector::value_type value_type;
-    typedef std::shared_ptr<PointType> PointPointerType;
+    //typedef std::shared_ptr<PointType> PointPointerType;
+    typedef typename PointType::Pointer PointPointerType;
     typedef const PointPointerType ConstPointPointerType;
     typedef TPointType& PointReferenceType;
     typedef const TPointType& ConstPointReferenceType;
@@ -236,21 +237,12 @@ public:
     typedef typename PointerVector<TPointType>::const_iterator const_iterator;
     typedef typename PointerVector<TPointType>::reverse_iterator reverse_iterator;
     typedef typename PointerVector<TPointType>::const_reverse_iterator const_reverse_iterator;
-    //typedef boost::indirect_iterator<typename PointPointerContainerType::iterator>                iterator;
-    //typedef boost::indirect_iterator<typename PointPointerContainerType::const_iterator>          const_iterator;
-    //typedef boost::indirect_iterator<typename PointPointerContainerType::reverse_iterator>        reverse_iterator;
-    //typedef boost::indirect_iterator<typename PointPointerContainerType::const_reverse_iterator>  const_reverse_iterator;
 
     typedef typename PointerVector<TPointType>::iterator ptr_iterator;
     typedef typename PointerVector<TPointType>::const_iterator ptr_const_iterator;
     typedef typename PointerVector<TPointType>::reverse_iterator ptr_reverse_iterator;
     typedef typename PointerVector<TPointType>::const_reverse_iterator ptr_const_reverse_iterator;
     typedef typename PointerVector<TPointType>::difference_type difference_type;
-
-    //typedef typename PointerVector::ptr_iterator               ptr_iterator;
-    //typedef typename PointerVector::ptr_const_iterator         ptr_const_iterator;
-    //typedef typename PointerVector::ptr_reverse_iterator       ptr_reverse_iterator;
-    //typedef typename PointerVector::ptr_const_reverse_iterator ptr_const_reverse_iterator;
 
     ///@}
     ///@name Life Cycle
@@ -387,8 +379,8 @@ public:
     */
     Geometry& operator=( const Geometry& rOther )
     {
-        PointerVector::operator=( rOther );
         mpGeometryData = rOther.mpGeometryData;
+        mpPointVector = rOther.mpPointVector;
 
         return *this;
     }
@@ -605,13 +597,13 @@ public:
     ///** Gives a reference to underly normal container. */
     PointPointerContainerType& GetContainer()
     {
-        return mpPointVector.GetContainer();
+        return mpPointVector->GetContainer();
     }
 
     /** Gives a constant reference to underly normal container. */
     const PointPointerContainerType& GetContainer() const
     {
-        return mpPointVector.GetContainer();
+        return mpPointVector->GetContainer();
     }
 
     ///@}
@@ -2667,9 +2659,12 @@ public:
 
 
     ///@}
-    ///@name Friends
+    ///@name Members
     ///@{
 
+    GeometryData const* mpGeometryData;
+
+    std::shared_ptr<PointerVector<TPointType>> mpPointVector;
 
     ///@}
 
@@ -2916,9 +2911,6 @@ private:
     ///@name Member Variables
     ///@{
 
-    GeometryData const* mpGeometryData;
-
-    std::shared_ptr<PointerVector<TPointType>> mpPointVector;
 
     ///@}
     ///@name Serialization

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -66,7 +66,7 @@ namespace Kratos
  * @see GeometryAndFormulationElement
  */
 template<class TPointType>
-class Geometry : public PointerVector<TPointType>
+class Geometry
 {
 public:
     ///@}
@@ -114,7 +114,7 @@ public:
 
     /** Base type for geometry.
     */
-    typedef PointerVector<TPointType> BaseType;
+    //typedef PointerVector<TPointType> BaseType;
 
 
     /** The bounding box */
@@ -288,16 +288,10 @@ public:
     */
     Geometry(const PointsArrayType &ThisPoints,
              GeometryData const *pThisGeometryData = &GeometryDataInstance())
-        : BaseType(ThisPoints), mpGeometryData(pThisGeometryData)
+        : mpGeometryData(pThisGeometryData)
     {
+		mpPointerVector = std::make_unique(ThisPoints);
     }
-
-//       Geometry(const PointsArrayType& ThisPoints,
-//         GeometryData const& ThisGeometryData= msEmptyGeometryData)
-//  : BaseType(ThisPoints)
-//  , mGeometryData(ThisGeometryData)
-//  {
-//  }
 
     /** Copy constructor.
     Construct this geometry as a copy of given geometry.
@@ -308,8 +302,8 @@ public:
     source geometry's points too.
     */
     Geometry( const Geometry& rOther )
-        : BaseType( rOther )
-        , mpGeometryData( rOther.mpGeometryData )
+        : mpGeometryData( rOther.mpGeometryData ),
+		  mpPointerVector( rOther.mpPointerVector )
     {
     }
 
@@ -326,8 +320,8 @@ public:
     source geometry's points too.
     */
     template<class TOtherPointType> Geometry( Geometry<TOtherPointType> const & rOther )
-        : BaseType( rOther.begin(), rOther.end() )
-        , mpGeometryData( rOther.mpGeometryData )
+        : mpGeometryData(rOther.mpGeometryData),
+		  mpPointerVector(rOther.begin(), rOther.end())
     {
     }
 
@@ -390,6 +384,217 @@ public:
     }
 
     ///@}
+	///@name PointVector Operators
+	///@{
+
+	TPointType& operator[](const size_type& i)
+	{
+		return mpPointerVector[i];
+	}
+
+	TPointType const& operator[](const size_type& i) const
+	{
+		return mpPointerVector[i];
+	}
+
+	pointer& operator()(const size_type& i)
+	{
+		return mpPointerVector(i);
+	}
+
+	const_pointer& operator()(const size_type& i) const
+	{
+		return mpPointerVector(i);
+	}
+
+	bool operator==(const Geometry& r) const // nothrow
+	{
+		if (size() != r.size())
+			return false;
+		else
+			return std::equal(
+				mpPointerVector.begin(),
+				mpPointerVector.end(),
+				r.mpPointerVector.begin(),
+				this->EqualKeyTo());
+	}
+
+	///@}
+	///@name Operations
+	///@{
+
+	iterator                   begin()
+	{
+		return iterator(mpPointerVector.begin());
+	}
+	const_iterator             begin() const
+	{
+		return const_iterator(mpPointerVector.begin());
+	}
+	iterator                   end()
+	{
+		return iterator(mpPointerVector.end());
+	}
+	const_iterator             end() const
+	{
+		return const_iterator(mpPointerVector.end());
+	}
+	reverse_iterator           rbegin()
+	{
+		return reverse_iterator(mpPointerVector.rbegin());
+	}
+	const_reverse_iterator     rbegin() const
+	{
+		return const_reverse_iterator(mpPointerVector.rbegin());
+	}
+	reverse_iterator           rend()
+	{
+		return reverse_iterator(mpPointerVector.rend());
+	}
+	const_reverse_iterator     rend() const
+	{
+		return const_reverse_iterator(mpPointerVector.rend());
+	}
+	ptr_iterator               ptr_begin()
+	{
+		return mpPointerVector.begin();
+	}
+	ptr_const_iterator         ptr_begin() const
+	{
+		return mpPointerVector.begin();
+	}
+	ptr_iterator               ptr_end()
+	{
+		return mpPointerVector.end();
+	}
+	ptr_const_iterator         ptr_end() const
+	{
+		return mpPointerVector.end();
+	}
+	ptr_reverse_iterator       ptr_rbegin()
+	{
+		return mpPointerVector.rbegin();
+	}
+	ptr_const_reverse_iterator ptr_rbegin() const
+	{
+		return mpPointerVector.rbegin();
+	}
+	ptr_reverse_iterator       ptr_rend()
+	{
+		return mpPointerVector.rend();
+	}
+	ptr_const_reverse_iterator ptr_rend() const
+	{
+		return mpPointerVector.rend();
+	}
+
+	reference        front()       /* nothrow */
+	{
+		assert(!empty());
+		return *(mpPointerVector.front());
+	}
+	const_reference  front() const /* nothrow */
+	{
+		assert(!empty());
+		return *(mpPointerVector.front());
+	}
+	reference        back()        /* nothrow */
+	{
+		assert(!empty());
+		return *(mpPointerVector.back());
+	}
+	const_reference  back() const  /* nothrow */
+	{
+		assert(!empty());
+		return *(mpPointerVector.back());
+	}
+
+	size_type size() const
+	{
+		return mpPointerVector.size();
+	}
+
+	size_type max_size() const
+	{
+		return mpPointerVector.max_size();
+	}
+
+	void swap(PointerVector& rOther)
+	{
+		mpPointerVector.swap(rOther.mpPointerVector);
+	}
+
+	void push_back(TPointType x)
+	{
+		mpPointerVector.push_back(x);
+	}
+
+	iterator insert(iterator Position, const TPointType pData)
+	{
+		return iterator(mpPointerVector.insert(Position, pData));
+	}
+
+	template <class InputIterator>
+	void insert(InputIterator First, InputIterator Last)
+	{
+		for (; First != Last; ++First)
+			insert(*First);
+	}
+
+
+	iterator erase(iterator pos)
+	{
+		return iterator(mpPointerVector.erase(pos.base()));
+	}
+
+	iterator erase(iterator first, iterator last)
+	{
+		return iterator(mpPointerVector.erase(first.base(), last.base()));
+	}
+
+	void clear()
+	{
+		mpPointerVector.clear();
+	}
+
+	void reserve(int dim)
+	{
+		mpPointerVector.reserve(dim);
+	}
+
+	int capacity()
+	{
+		return mpPointerVector.capacity();
+	}
+
+	///@}
+	///@name Access
+	///@{
+
+	/** Gives a reference to underly normal container. */
+	TContainerType& GetContainer()
+	{
+		return mpPointerVector.GetContainer();
+	}
+
+	/** Gives a constant reference to underly normal container. */
+	const TContainerType& GetContainer() const
+	{
+		return mpPointerVector.GetContainer();
+	}
+
+
+
+	///@}
+	///@name Inquiry
+	///@{
+
+	bool empty() const
+	{
+		return mpPointerVector.empty();
+	}
+
+	///@}
     ///@name Operations
     ///@{
 
@@ -2679,6 +2884,7 @@ private:
 
     GeometryData const* mpGeometryData;
 
+	std::unique<PointerVector<TPointType>> mpPointerVector;
 
     ///@}
     ///@name Serialization

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -209,16 +209,24 @@ public:
      */
     typedef DenseVector<double> NormalType;
 
+	/// data type stores in this container.
+	typedef TDataType data_type;
+	typedef TPointerType value_type;
+	typedef TPointerType pointer;
+	typedef const TPointerType const_pointer;
+	typedef TDataType& reference;
+	typedef const TDataType& const_reference;
+	typedef TContainerType ContainerType;
 
-    typedef typename BaseType::iterator              iterator;
-    typedef typename BaseType::const_iterator          const_iterator;
-    typedef typename BaseType::reverse_iterator        reverse_iterator;
-    typedef typename BaseType::const_reverse_iterator  const_reverse_iterator;
+    typedef typename PointerVector::iterator              iterator;
+    typedef typename PointerVector::const_iterator          const_iterator;
+    typedef typename PointerVector::reverse_iterator        reverse_iterator;
+    typedef typename PointerVector::const_reverse_iterator  const_reverse_iterator;
 
-    typedef typename BaseType::ptr_iterator ptr_iterator;
-    typedef typename BaseType::ptr_const_iterator ptr_const_iterator;
-    typedef typename BaseType::ptr_reverse_iterator ptr_reverse_iterator;
-    typedef typename BaseType::ptr_const_reverse_iterator ptr_const_reverse_iterator;
+    typedef typename PointerVector::ptr_iterator ptr_iterator;
+    typedef typename PointerVector::ptr_const_iterator ptr_const_iterator;
+    typedef typename PointerVector::ptr_reverse_iterator ptr_reverse_iterator;
+    typedef typename PointerVector::ptr_const_reverse_iterator ptr_const_reverse_iterator;
     ///@}
     ///@name Life Cycle
     ///@{
@@ -354,7 +362,7 @@ public:
     */
     Geometry& operator=( const Geometry& rOther )
     {
-        BaseType::operator=( rOther );
+		PointerVector::operator=( rOther );
         mpGeometryData = rOther.mpGeometryData;
 
         return *this;
@@ -509,12 +517,12 @@ public:
 		return *(mpPointerVector.back());
 	}
 
-	size_type size() const
+	SizeType size() const
 	{
 		return mpPointerVector.size();
 	}
 
-	size_type max_size() const
+	SizeType max_size() const
 	{
 		return mpPointerVector.max_size();
 	}
@@ -2894,13 +2902,13 @@ private:
 
     void save( Serializer& rSerializer ) const override
     {
-        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
+        //KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
 //                 rSerializer.save( "Geometry Data", mpGeometryData );
     }
 
     void load( Serializer& rSerializer ) override
     {
-        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
+        //KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
         //rSerializer.load( "Geometry Data", const_cast<GeometryData*>( mpGeometryData ) );
     }
 

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -180,6 +180,11 @@ public:
         BaseType::Points().push_back( pSecondPoint );
     }
 
+    Line2D2( const Geometry& rOther )
+        : BaseType(rOther)
+    {
+    }
+
 
     explicit Line2D2( const PointsArrayType& ThisPoints )
         : BaseType( ThisPoints, &msGeometryData )
@@ -277,6 +282,11 @@ public:
     typename BaseType::Pointer Create( PointsArrayType const& ThisPoints ) const override
     {
         return typename BaseType::Pointer( new Line2D2( ThisPoints ) );
+    }
+
+    typename BaseType::Pointer Create(Geometry<TPointType> const& ThisGeometry) const override
+    {
+        return typename BaseType::Pointer(new Line2D2(ThisGeometry) );
     }
 
     // Geometry< Point<3> >::Pointer Clone() const override

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -1539,12 +1539,12 @@ private:
 
     void save( Serializer& rSerializer ) const override
     {
-        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, PointsArrayType );
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType);
     }
 
     void load( Serializer& rSerializer ) override
     {
-        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, PointsArrayType );
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType);
     }
 
     Quadrilateral3D4(): BaseType( PointsArrayType(), &msGeometryData ) {}

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -254,7 +254,27 @@ public:
     {
         KRATOS_TRY
         KRATOS_WARNING("Condition") << " Call base class condition Clone " << std::endl;
-        Condition::Pointer p_new_cond = Kratos::make_intrusive<Condition>(NewId, GetGeometry().Create(ThisNodes), pGetProperties());
+        Condition::Pointer p_new_cond = Kratos::make_intrusive<Condition>(
+            NewId, GetGeometry().Create(ThisNodes), pGetProperties());
+        p_new_cond->SetData(this->GetData());
+        p_new_cond->Set(Flags(*this));
+        return p_new_cond;
+        KRATOS_CATCH("");
+    }
+
+    /**
+    * @brief It creates a new condition pointer and clones the previous condition data
+    * @param NewId the ID of the new condition
+    * @param ThisNodes the nodes of the new condition
+    * @param pProperties the properties assigned to the new condition
+    * @return a Pointer to the new condition
+    */
+    virtual Pointer Clone(IndexType NewId, GeometryType const& ThisGeometry) const
+    {
+        KRATOS_TRY
+        KRATOS_WARNING("Condition") << " Call base class condition Clone " << std::endl;
+        Condition::Pointer p_new_cond = Kratos::make_intrusive<Condition>(
+            NewId, GetGeometry().Create(ThisGeometry), pGetProperties());
         p_new_cond->SetData(this->GetData());
         p_new_cond->Set(Flags(*this));
         return p_new_cond;

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -255,6 +255,23 @@ public:
         KRATOS_CATCH("");
     }
 
+    /**
+    * @brief It creates a new element pointer and clones the previous element data
+    * @param NewId the ID of the new element
+    * @param ThisNodes the nodes of the new element
+    * @param pProperties the properties assigned to the new element
+    * @return a Pointer to the new element
+    */
+    virtual Pointer Clone(IndexType NewId, GeometryType const& ThisGeometry) const
+    {
+        KRATOS_TRY
+            KRATOS_WARNING("Element") << " Call base class element Clone " << std::endl;
+        Element::Pointer p_new_elem = Kratos::make_intrusive<Element>(NewId, GetGeometry().Create(ThisGeometry), pGetProperties());
+        p_new_elem->SetData(this->GetData());
+        p_new_elem->Set(Flags(*this));
+        return p_new_elem;
+        KRATOS_CATCH("");
+    }
 
     /**
      * ELEMENTS inherited from this class have to implement next

--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -976,6 +976,14 @@ public:
         KRATOS_CATCH("")
     }
 
+    ModelPart::ElementType::Pointer CreateNewElement(std::string ElementName,
+        ModelPart::IndexType Id, Geometry< Node < 3 > > ThisGeometry,
+        ModelPart::PropertiesType::Pointer pProperties, ModelPart::IndexType ThisIndex);
+
+    ElementType::Pointer CreateNewElement(std::string ElementName,
+        ModelPart::IndexType Id, Geometry< Node < 3 > >::Pointer pGeometry,
+        ModelPart::PropertiesType::Pointer pProperties, ModelPart::IndexType ThisIndex);
+
     /** Inserts an element in the current mesh.
      */
     ElementType::Pointer CreateNewElement(std::string ElementName, IndexType Id, std::vector<IndexType> ElementNodeIds, PropertiesType::Pointer pProperties, IndexType ThisIndex = 0);

--- a/kratos/processes/calculate_signed_distance_to_3d_skin_process.h
+++ b/kratos/processes/calculate_signed_distance_to_3d_skin_process.h
@@ -1586,11 +1586,11 @@ public:
 
                     // ######## ADDING NEW CONDITION #########
                     //form a triangle
-                    Triangle3D3< Node<3> > triangle(pnode1, pnode2, pnode3);
+                    Triangle3D3<Node<3> >::Pointer ptr_geom = Kratos::make_shared<Triangle3D3<Node<3> >>(pnode1, pnode2, pnode3);
 
                     Condition const& rReferenceCondition = KratosComponents<Condition>::Get("Condition3D");
                     Properties::Pointer properties = mrNewSkinModelPart.rProperties()(0);
-                    Condition::Pointer p_condition = rReferenceCondition.Create(id_condition++, triangle, properties);
+                    Condition::Pointer p_condition = rReferenceCondition.Create(id_condition++, ptr_geom, properties);
 
                     mrNewSkinModelPart.Conditions().push_back(p_condition);
                 }
@@ -1656,8 +1656,8 @@ public:
 
                     // ######## ADDING NEW CONDITION #########
                     //form two triangles
-                    Triangle3D3< Node<3> > triangle1(pnode1, pnode2, pnode3);
-                    Triangle3D3< Node<3> > triangle2(pnode1, pnode3, pnode4);
+                    Triangle3D3<Node<3> >::Pointer triangle1 = Kratos::make_shared<Triangle3D3<Node<3> >>(pnode1, pnode2, pnode3);
+                    Triangle3D3<Node<3> >::Pointer triangle2 = Kratos::make_shared<Triangle3D3<Node<3> >>(pnode1, pnode3, pnode4);
 
                     Condition const& rReferenceCondition = KratosComponents<Condition>::Get("Condition3D");
                  

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -853,6 +853,64 @@ void ModelPart::AddElements(std::vector<IndexType> const& ElementIds, IndexType 
 /** Inserts an element in the mesh with ThisIndex.
 */
 ModelPart::ElementType::Pointer ModelPart::CreateNewElement(std::string ElementName,
+    ModelPart::IndexType Id, Geometry< Node < 3 > > ThisGeometry,
+    ModelPart::PropertiesType::Pointer pProperties, ModelPart::IndexType ThisIndex)
+{
+    Geometry<Node<3>>::Pointer ptr_geometry = Kratos::make_shared<Geometry<Node<3>>>(ThisGeometry);
+
+    if (IsSubModelPart())
+    {
+        ElementType::Pointer p_new_element = mpParentModelPart->CreateNewElement(ElementName, Id, ptr_geometry, pProperties, ThisIndex);
+        GetMesh(ThisIndex).AddElement(p_new_element);
+        return p_new_element;
+    }
+
+    auto existing_element_iterator = GetMesh(ThisIndex).Elements().find(Id);
+    KRATOS_ERROR_IF(existing_element_iterator != GetMesh(ThisIndex).ElementsEnd())
+        << "trying to construct an element with ID " << Id << " however an element with the same Id already exists";
+
+
+    //create the new element
+    ElementType const& r_clone_element = KratosComponents<ElementType>::Get(ElementName);
+    Element::Pointer p_element = r_clone_element.Create(Id, ptr_geometry, pProperties);
+
+    //add the new element
+    GetMesh(ThisIndex).AddElement(p_element);
+
+    return p_element;
+}
+
+/** Inserts an element in the mesh with ThisIndex.
+*/
+ModelPart::ElementType::Pointer ModelPart::CreateNewElement(std::string ElementName,
+    ModelPart::IndexType Id, Geometry< Node < 3 > >::Pointer pGeometry,
+    ModelPart::PropertiesType::Pointer pProperties, ModelPart::IndexType ThisIndex)
+{
+    if (IsSubModelPart())
+    {
+        ElementType::Pointer p_new_element = mpParentModelPart->CreateNewElement(ElementName, Id, pGeometry, pProperties, ThisIndex);
+        GetMesh(ThisIndex).AddElement(p_new_element);
+        return p_new_element;
+    }
+
+    auto existing_element_iterator = GetMesh(ThisIndex).Elements().find(Id);
+    KRATOS_ERROR_IF(existing_element_iterator != GetMesh(ThisIndex).ElementsEnd())
+        << "trying to construct an element with ID " << Id << " however an element with the same Id already exists";
+
+
+    //create the new element
+    ElementType const& r_clone_element = KratosComponents<ElementType>::Get(ElementName);
+    Element::Pointer p_element = r_clone_element.Create(Id, pGeometry, pProperties);
+
+    //add the new element
+    GetMesh(ThisIndex).AddElement(p_element);
+
+    return p_element;
+}
+
+/** Inserts an element in the mesh with ThisIndex.
+*/
+ModelPart::ElementType::Pointer ModelPart::CreateNewElement(std::string ElementName,
         ModelPart::IndexType Id, std::vector<ModelPart::IndexType> ElementNodeIds,
         ModelPart::PropertiesType::Pointer pProperties, ModelPart::IndexType ThisIndex)
 {

--- a/kratos/utilities/cutting_utility.h
+++ b/kratos/utilities/cutting_utility.h
@@ -295,12 +295,12 @@ public:
 					int position = this_model_part.Nodes().find(geom[i].Id()) - it_begin_node_old;  //the id of the node minus one is the position in the Condition_Node array (position0 = node1)
 					triangle_nodes[i]=Condition_Nodes[position]; // saving the i nodeId
 				} //nodes id saved. now we have to create the element.
-				Triangle3D3<Node<3> > geometry(
+                Triangle3D3<Node<3> >::Pointer ptr_geom = Kratos::make_shared<Triangle3D3<Node<3> >>(
 					new_model_part.Nodes()(triangle_nodes[0]),  //condition to be added
 					new_model_part.Nodes()(triangle_nodes[1]),
 					new_model_part.Nodes()(triangle_nodes[2])
 				);
-				Condition::Pointer p_condition = rReferenceCondition.Create(number_of_triangles+1, geometry, properties); //está bien? acá la verdad ni idea. sobre todo number_of_triangles (la posición). o debe ser un puntero de elemento en vez de un entero?
+				Condition::Pointer p_condition = rReferenceCondition.Create(number_of_triangles+1, ptr_geom, properties); //está bien? acá la verdad ni idea. sobre todo number_of_triangles (la posición). o debe ser un puntero de elemento en vez de un entero?
 				new_model_part.Conditions().push_back(p_condition);
 				++number_of_triangles;
 			}
@@ -767,13 +767,13 @@ public:
                 }
 
                 //generate new Elements
-                Triangle3D3<Node<3> > geom(
+                Triangle3D3<Node<3> >::Pointer ptr_geom = Kratos::make_shared<Triangle3D3<Node<3> >>(
                     new_model_part.Nodes()(TriangleNodesArray[0]),
                     new_model_part.Nodes()(TriangleNodesArray[1]),
                     new_model_part.Nodes()(TriangleNodesArray[2])
                 );
 
-                Condition::Pointer p_condition = rReferenceCondition.Create(number_of_triangles+1+first_element, geom, properties); //creating the element using the reference element. notice we are using the first element to avoid overriting nodes created by other cutting planes
+                Condition::Pointer p_condition = rReferenceCondition.Create(number_of_triangles+1+first_element, ptr_geom, properties); //creating the element using the reference element. notice we are using the first element to avoid overriting nodes created by other cutting planes
                 new_model_part.Conditions().push_back(p_condition);
                 ++number_of_triangles;
 
@@ -905,13 +905,13 @@ public:
                         nodes_for_2triang[index*3+1] =  temp_int;
                     }
 
-                    Triangle3D3<Node<3> > geom(
+                    Triangle3D3<Node<3> >::Pointer ptr_geom = Kratos::make_shared<Triangle3D3<Node<3> >>(
                         new_model_part.Nodes()(nodes_for_2triang[index*3+0]),
                         new_model_part.Nodes()(nodes_for_2triang[index*3+1]),
                         new_model_part.Nodes()(nodes_for_2triang[index*3+2])
                     );
 
-                    Condition::Pointer p_condition = rReferenceCondition.Create(number_of_triangles+1+first_element, geom, properties);
+                    Condition::Pointer p_condition = rReferenceCondition.Create(number_of_triangles+1+first_element, ptr_geom, properties);
 
                     new_model_part.Conditions().push_back(p_condition);
                     ++number_of_triangles;


### PR DESCRIPTION
Hi all,

I'd have a very small modification for the geometry. This would allow the possibility to exchange the PointerVector and link it to different ones. 

With the suggested strategy one can have the pointer vector stored at multiple objects. Or exchange it if necessary.

This would help us to link from inside the geometry to a foreign list of nodes which might be stored at special classes (in our case Nurbs classes, but any kind of shape is possible).

Do you think this would go in a possible direction?

@KratosMultiphysics/technical-committee @KratosMultiphysics/implementation-committee 