### PR TITLE
[DEMStructures] Sticky spheres will not be taken into account in the average stress

### DIFF
--- a/applications/DemStructuresCouplingApplication/custom_utilities/stress_failure_check_utilities.hpp
+++ b/applications/DemStructuresCouplingApplication/custom_utilities/stress_failure_check_utilities.hpp
@@ -102,10 +102,13 @@ void ExecuteFinalizeSolutionStep()
             const double Distance2 = std::pow(DemPosition[0]-mCylinderCenter[0],2)
                                     + std::pow(DemPosition[1]-mCylinderCenter[1],2);
 
-            if( (Distance2 >= std::pow(mMinRadius,2)) && (Distance2 <= std::pow(mMaxRadius,2)) )
+            Element* p_element = ptr_itElem->get();
+            SphericContinuumParticle* pDemElem = dynamic_cast<SphericContinuumParticle*> (p_element);
+
+            if( (pDemElem->IsNot(DEMFlags::STICKY))
+                && (Distance2 >= std::pow(mMinRadius,2))
+                && (Distance2 <= std::pow(mMaxRadius,2)) )
             {
-                Element* p_element = ptr_itElem->get();
-                SphericContinuumParticle* pDemElem = dynamic_cast<SphericContinuumParticle*> (p_element);
                 BoundedMatrix<double, 3, 3> stress_tensor = (*(pDemElem->mSymmStressTensor));
                 Vector principal_stresses(3);
                 noalias(principal_stresses) = AuxiliaryFunctions::EigenValuesDirectMethod(stress_tensor);


### PR DESCRIPTION
I just run the same example twice: obtaining the average stress using all the spheres,  and computing the average stress avoiding the sticky spheres. In the latter case the average stress doesn't rise after the peak.