### PR TITLE
Mpi/deprecating communicator methods

### DIFF
--- a/applications/DEMApplication/custom_strategies/strategies/explicit_solver_continuum.cpp
+++ b/applications/DEMApplication/custom_strategies/strategies/explicit_solver_continuum.cpp
@@ -249,7 +249,7 @@ namespace Kratos {
 
         }
         //Synch this var.
-        r_model_part.GetCommunicator().MaxAll(r_process_info[SEARCH_CONTROL]);
+        r_process_info[SEARCH_CONTROL] = r_model_part.GetCommunicator().GetDataCommunicator().MaxAll(r_process_info[SEARCH_CONTROL]);
     }
 
     void ContinuumExplicitSolverStrategy::MarkNewSkinParticles() {
@@ -466,7 +466,7 @@ namespace Kratos {
         ModelPart& r_model_part = GetModelPart();
         ElementsArrayType& pElements = r_model_part.GetCommunicator().LocalMesh().Elements();
 
-        unsigned int total_contacts = 0;
+        int total_contacts = 0;
         const int number_of_particles = (int) mListOfSphericParticles.size();
         std::vector<int> neighbour_counter;
         std::vector<int> sum;
@@ -491,10 +491,8 @@ namespace Kratos {
             total_sum += sum[i];
         }
 
-        int global_total_contacts = total_contacts;
-        r_model_part.GetCommunicator().SumAll(global_total_contacts);
-        int global_number_of_elements = (int) pElements.size();
-        r_model_part.GetCommunicator().SumAll(global_number_of_elements);
+        int global_total_contacts = r_model_part.GetCommunicator().GetDataCommunicator().SumAll(total_contacts);
+        int global_number_of_elements = r_model_part.GetCommunicator().GetDataCommunicator().SumAll((int) pElements.size());
 
         double coord_number = double(global_total_contacts) / double(global_number_of_elements);
 
@@ -597,8 +595,7 @@ namespace Kratos {
         DestroyMarkedParticlesRebuildLists();
 
         //KRATOS_WARNING("DEM") << "Mesh repair complete. In MPI node " <<GetModelPart().GetCommunicator().MyPID()<<". "<< particle_counter << " particles were removed. " << "\n" << std::endl;
-        double total_spheres_removed = particle_counter;
-        GetModelPart().GetCommunicator().SumAll(total_spheres_removed);
+        int total_spheres_removed = GetModelPart().GetCommunicator().GetDataCommunicator().SumAll(particle_counter);
 
         if(GetModelPart().GetCommunicator().MyPID() == 0) {
             KRATOS_WARNING("DEM") << "A total of "<<total_spheres_removed<<" spheres were removed due to excessive overlapping." << std::endl;

--- a/applications/DEMApplication/custom_utilities/create_and_destroy.cpp
+++ b/applications/DEMApplication/custom_utilities/create_and_destroy.cpp
@@ -57,8 +57,7 @@ namespace Kratos {
             if(thread_maximums[i] > max_Id) max_Id = thread_maximums[i];
         }
 
-        r_modelpart.GetCommunicator().MaxAll(max_Id);
-        return max_Id;
+        return r_modelpart.GetCommunicator().GetDataCommunicator().MaxAll(max_Id);
         KRATOS_CATCH("")
     }
 
@@ -79,8 +78,7 @@ namespace Kratos {
             if ((int) (element_it->Id()) > max_Id) max_Id = element_it->Id();
         }
 
-        r_modelpart.GetCommunicator().MaxAll(max_Id);
-        return max_Id;
+        return r_modelpart.GetCommunicator().GetDataCommunicator().MaxAll(max_Id);
         KRATOS_CATCH("")
     }
 
@@ -95,17 +93,14 @@ namespace Kratos {
             if ((int) (condition_it->Id()) > max_Id) max_Id = condition_it->Id();
         }
 
-        r_modelpart.GetCommunicator().MaxAll(max_Id);
-        return max_Id;
+        return r_modelpart.GetCommunicator().GetDataCommunicator().MaxAll(max_Id);
         KRATOS_CATCH("")
     }
 
     void ParticleCreatorDestructor::RenumberElementIdsFromGivenValue(ModelPart& r_modelpart, const int initial_id) {
         KRATOS_TRY
         const int number_of_elements = r_modelpart.GetCommunicator().LocalMesh().NumberOfElements();
-        int total_accumulated_elements = 0;
-
-        r_modelpart.GetCommunicator().ScanSum(number_of_elements, total_accumulated_elements);
+        int total_accumulated_elements = r_modelpart.GetCommunicator().GetDataCommunicator().ScanSum(number_of_elements);
 
         int id = total_accumulated_elements - number_of_elements + initial_id;
         auto& local_mesh = r_modelpart.GetCommunicator().LocalMesh();
@@ -1044,13 +1039,14 @@ SphericParticle* ParticleCreatorDestructor::SphereCreatorForBreakableClusters(Mo
                 }
             }
 
-            r_balls_model_part.GetCommunicator().MinAll(mStrictLowPoint[0]);
-            r_balls_model_part.GetCommunicator().MinAll(mStrictLowPoint[1]);
-            r_balls_model_part.GetCommunicator().MinAll(mStrictLowPoint[2]);
-            r_balls_model_part.GetCommunicator().MaxAll(mStrictHighPoint[0]);
-            r_balls_model_part.GetCommunicator().MaxAll(mStrictHighPoint[1]);
-            r_balls_model_part.GetCommunicator().MaxAll(mStrictHighPoint[2]);
-            r_balls_model_part.GetCommunicator().MaxAll(ref_radius);
+            const auto& r_comm = r_balls_model_part.GetCommunicator().GetDataCommunicator();
+            mStrictLowPoint[0] = r_comm.MinAll(mStrictLowPoint[0]);
+            mStrictLowPoint[1] = r_comm.MinAll(mStrictLowPoint[1]);
+            mStrictLowPoint[2] = r_comm.MinAll(mStrictLowPoint[2]);
+            mStrictHighPoint[0] = r_comm.MaxAll(mStrictHighPoint[0]);
+            mStrictHighPoint[1] = r_comm.MaxAll(mStrictHighPoint[1]);
+            mStrictHighPoint[2] = r_comm.MaxAll(mStrictHighPoint[2]);
+            ref_radius = r_comm.MaxAll(ref_radius);
 
 
             array_1d<double, 3 > midpoint;

--- a/applications/DEMApplication/custom_utilities/inlet.cpp
+++ b/applications/DEMApplication/custom_utilities/inlet.cpp
@@ -483,8 +483,7 @@ namespace Kratos {
                 continue;
             }
 
-            int total_mesh_size_accross_mpi_processes = mesh_size_elements; //temporary value until reduction is done
-            r_modelpart.GetCommunicator().SumAll(total_mesh_size_accross_mpi_processes);
+            int total_mesh_size_accross_mpi_processes = r_modelpart.GetCommunicator().GetDataCommunicator().SumAll(mesh_size_elements);
             const double this_mpi_process_portion_of_inlet_mesh = (double) mesh_size_elements / (double) total_mesh_size_accross_mpi_processes;
             double num_part_surface_time = GetInputNumberOfParticles(mp);
             num_part_surface_time *= this_mpi_process_portion_of_inlet_mesh;

--- a/applications/FSIapplication/custom_utilities/partitioned_fsi_utilities.hpp
+++ b/applications/FSIapplication/custom_utilities/partitioned_fsi_utilities.hpp
@@ -407,8 +407,8 @@ public:
             uz_mesh_norm += std::pow(it_node->FastGetSolutionStepValue(MESH_DISPLACEMENT_Z), 2);
         }
 
-        std::vector<double> local_data = {p_norm, vx_norm, vy_norm, vz_norm, rx_norm, ry_norm, rz_norm, ux_mesh_norm, uy_mesh_norm, uz_mesh_norm};
-        std::vector<double> global_sum = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+        std::vector<double> local_data{p_norm, vx_norm, vy_norm, vz_norm, rx_norm, ry_norm, rz_norm, ux_mesh_norm, uy_mesh_norm, uz_mesh_norm};
+        std::vector<double> global_sum{0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
         rInterfaceModelPart.GetCommunicator().GetDataCommunicator().SumAll(local_data, global_sum);
 
         p_norm       = global_sum[0];
@@ -462,8 +462,8 @@ public:
             uz_norm += std::pow(disp[2], 2);
         }
 
-        std::vector<double> local_data = {ux_norm, uy_norm, uz_norm};
-        std::vector<double> global_sum = {0, 0, 0};
+        std::vector<double> local_data{ux_norm, uy_norm, uz_norm};
+        std::vector<double> global_sum{0, 0, 0};
         rInterfaceModelPart.GetCommunicator().GetDataCommunicator().SumAll(local_data, global_sum);
 
         ux_norm = global_sum[0];

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
@@ -465,21 +465,28 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries(){
 
     // Once all the entities have been created, renumber the ids.
     // Created entities local number partial reduction
+    const DataCommunicator& r_comm = mrModelPart.GetCommunicator().GetDataCommunicator();
     int n_nodes_local = new_nodes_vect.size();
-    int n_conds_local = new_conds_vect.size();
     int n_elems_local = mNewElementsPointers.size();
-    int n_nodes_local_scansum, n_elems_local_scansum, n_conds_local_scansum;
-    mrModelPart.GetCommunicator().ScanSum(n_nodes_local, n_nodes_local_scansum);
-    mrModelPart.GetCommunicator().ScanSum(n_elems_local, n_elems_local_scansum);
-    mrModelPart.GetCommunicator().ScanSum(n_conds_local, n_conds_local_scansum);
+    int n_conds_local = new_conds_vect.size();
+
+    std::vector<int> local_data{n_nodes_local, n_elems_local, n_conds_local};
+    std::vector<int> reduced_data{0, 0, 0};
+    r_comm.ScanSum(local_data, reduced_data);
+
+    int n_nodes_local_scansum = reduced_data[0];
+    int n_elems_local_scansum = reduced_data[1];
+    int n_conds_local_scansum = reduced_data[2];
 
     // Origin model part number of entities
     int n_nodes_orig = mrModelPart.NumberOfNodes();
     int n_elems_orig = mrModelPart.NumberOfElements();
     int n_conds_orig = mrModelPart.NumberOfConditions();
-    mrModelPart.GetCommunicator().SumAll(n_nodes_orig);
-    mrModelPart.GetCommunicator().SumAll(n_elems_orig);
-    mrModelPart.GetCommunicator().SumAll(n_conds_orig);
+    local_data = {n_nodes_orig, n_elems_orig, n_conds_orig};
+    r_comm.SumAll(local_data, reduced_data);
+    n_nodes_orig = reduced_data[0];
+    n_elems_orig = reduced_data[1];
+    n_conds_orig = reduced_data[2];
 
     // Initialize the new ids. values
     std::size_t new_node_id(n_nodes_orig + n_nodes_local_scansum - n_nodes_local + 1);
@@ -513,7 +520,7 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries(){
     mrVisualizationModelPart.AddConditions(new_conds_vect.begin(), new_conds_vect.end());
 
     // Wait for all nodes to renumber its nodes
-    mrModelPart.GetCommunicator().Barrier();
+    r_comm.Barrier();
 }
 
 bool EmbeddedSkinVisualizationProcess::ElementIsPositive(

--- a/applications/FluidDynamicsApplication/custom_processes/mass_conservation_check_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/mass_conservation_check_process.cpp
@@ -75,19 +75,14 @@ std::string MassConservationCheckProcess::Initialize(){
     double pos_vol = 0.0;
     double neg_vol = 0.0;
     double inter_area = 0.0;
-    const auto& comm = mrModelPart.GetCommunicator();
+    const auto& r_comm = mrModelPart.GetCommunicator().GetDataCommunicator();
 
     ComputeVolumesAndInterface( pos_vol, neg_vol, inter_area );
 
-    comm.Barrier();
-    if ( comm.SumAll(pos_vol) && comm.SumAll(neg_vol) && comm.SumAll(inter_area)  ){
-        // if communication was successful
-        this->mInitialPositiveVolume = pos_vol;
-        this->mInitialNegativeVolume = neg_vol;
-        this->mTheoreticalNegativeVolume = neg_vol;
-    } else {
-        KRATOS_DEBUG_ERROR << "Communication failed in MassConservationCheckProcess::Initialize()";
-    }
+    this->mInitialPositiveVolume = r_comm.SumAll(pos_vol);
+    this->mInitialNegativeVolume = r_comm.SumAll(neg_vol);
+    this->mTheoreticalNegativeVolume = neg_vol;
+    inter_area = r_comm.SumAll(inter_area);
 
     std::string output_line =   "------ Initial values ----------------- \n";
     output_line +=              "  positive volume (air)   = " + std::to_string(this->mInitialPositiveVolume) + "\n";
@@ -112,11 +107,16 @@ std::string MassConservationCheckProcess::ExecuteInTimeStep(){
     double net_inflow_outlet = ComputeFlowOverBoundary(OUTLET);
 
     // computing global quantities via MPI communication
-    const auto& comm = mrModelPart.GetCommunicator();
+    const auto& r_comm = mrModelPart.GetCommunicator().GetDataCommunicator();
+    std::vector<double> local_data{pos_vol, neg_vol, inter_area, net_inflow_inlet, net_inflow_outlet};
+    std::vector<double> remote_sum{0, 0, 0, 0, 0};
+    r_comm.SumAll(local_data, remote_sum);
 
-    comm.Barrier();
-    KRATOS_ERROR_IF_NOT( comm.SumAll(pos_vol) && comm.SumAll(neg_vol) && comm.SumAll(inter_area) && comm.SumAll(net_inflow_inlet) && comm.SumAll(net_inflow_outlet) )
-    << "Communication failed in MassConservationCheckProcess::ExecuteInTimeStep()";
+    pos_vol = remote_sum[0];
+    neg_vol = remote_sum[1];
+    inter_area = remote_sum[2];
+    net_inflow_inlet = remote_sum[3];
+    net_inflow_outlet = remote_sum[4];
 
     // making a "time step forwards" and updating the
     const double current_time = mrModelPart.GetProcessInfo()[TIME];

--- a/applications/FluidDynamicsApplication/custom_processes/two_fluids_inlet_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/two_fluids_inlet_process.cpp
@@ -171,7 +171,7 @@ TwoFluidsInletProcess::TwoFluidsInletProcess(
     r_fluid_1_inlet.AddConditions( index_cond_fluid1 );
     r_fluid_2_inlet.AddConditions( index_cond_fluid2 );
 
-    r_root_model_part.GetCommunicator().Barrier();
+    r_root_model_part.GetCommunicator().GetDataCommunicator().Barrier();
 }
 
 

--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
@@ -635,8 +635,7 @@ protected:
             }
         }
 
-        BaseType::GetModelPart().GetCommunicator().SumAll(NormV);
-
+        NormV = BaseType::GetModelPart().GetCommunicator().GetDataCommunicator().SumAll(NormV);
         NormV = sqrt(NormV);
 
         if (NormV == 0.0) NormV = 1.00;
@@ -673,8 +672,7 @@ protected:
             }
         }
 
-        BaseType::GetModelPart().GetCommunicator().SumAll(NormP);
-
+        NormP = BaseType::GetModelPart().GetCommunicator().GetDataCommunicator().SumAll(NormP);
         NormP = sqrt(NormP);
 
         if (NormP == 0.0) NormP = 1.00;
@@ -869,10 +867,11 @@ protected:
      */
      void PeriodicConditionProjectionCorrection(ModelPart& rModelPart)
      {
+         Communicator& r_comm = rModelPart.GetCommunicator();
          if (mrPeriodicIdVar.Key() != Kratos::Variable<int>::StaticObject().Key())
          {
-             int GlobalNodesNum = rModelPart.GetCommunicator().LocalMesh().Nodes().size();
-             rModelPart.GetCommunicator().SumAll(GlobalNodesNum);
+             int GlobalNodesNum = r_comm.LocalMesh().Nodes().size();
+             GlobalNodesNum = r_comm.GetDataCommunicator().SumAll(GlobalNodesNum);
 
              for (typename ModelPart::ConditionIterator itCond = rModelPart.ConditionsBegin(); itCond != rModelPart.ConditionsEnd(); itCond++ )
              {
@@ -954,10 +953,11 @@ protected:
 
      void PeriodicConditionVelocityCorrection(ModelPart& rModelPart)
      {
+         Communicator& r_comm = rModelPart.GetCommunicator();
          if (mrPeriodicIdVar.Key() != Kratos::Variable<int>::StaticObject().Key())
          {
-             int GlobalNodesNum = rModelPart.GetCommunicator().LocalMesh().Nodes().size();
-             rModelPart.GetCommunicator().SumAll(GlobalNodesNum);
+             int GlobalNodesNum = r_comm.LocalMesh().Nodes().size();
+             GlobalNodesNum = r_comm.GetDataCommunicator().SumAll(GlobalNodesNum);
 
              for (typename ModelPart::ConditionIterator itCond = rModelPart.ConditionsBegin(); itCond != rModelPart.ConditionsEnd(); itCond++ )
              {

--- a/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/drag_utilities.cpp
@@ -39,7 +39,7 @@ namespace Kratos
     }
 
     array_1d<double, 3> DragUtilities::CalculateEmbeddedDrag(ModelPart& rModelPart) {
-        
+
         // Initialize total drag force
         array_1d<double, 3> drag_force = ZeroVector(3);
         double& drag_x = drag_force[0];
@@ -62,13 +62,13 @@ namespace Kratos
             drag_y_red += elem_drag[1];
             drag_z_red += elem_drag[2];
         }
-        
+
         drag_x += drag_x_red;
         drag_y += drag_y_red;
         drag_z += drag_z_red;
 
         // Perform MPI synchronization
-        rModelPart.GetCommunicator().SumAll(drag_force);
+        drag_force = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(drag_force);
 
         return drag_force;
     }

--- a/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/estimate_dt_utilities.h
@@ -192,7 +192,7 @@ public:
         }
 
         // Perform MPI sync if needed
-        mrModelPart.GetCommunicator().MinAll(NewDt);
+        NewDt = mrModelPart.GetCommunicator().GetDataCommunicator().MinAll(NewDt);
 
         return NewDt;
 

--- a/applications/HDF5Application/custom_io/hdf5_model_part_io.cpp
+++ b/applications/HDF5Application/custom_io/hdf5_model_part_io.cpp
@@ -35,22 +35,19 @@ void WriteContainerIds(File& rFile, std::string const& rPath, TContainer const& 
 int GlobalNumberOfNodes(ModelPart const& rModelPart)
 {
     int number_of_nodes = rModelPart.NumberOfNodes();
-    rModelPart.GetCommunicator().SumAll(number_of_nodes);
-    return number_of_nodes;
+    return rModelPart.GetCommunicator().GetDataCommunicator().SumAll(number_of_nodes);
 }
 
 int GlobalNumberOfElements(ModelPart const& rModelPart)
 {
     int number_of_elems = rModelPart.NumberOfElements();
-    rModelPart.GetCommunicator().SumAll(number_of_elems);
-    return number_of_elems;
+    return rModelPart.GetCommunicator().GetDataCommunicator().SumAll(number_of_elems);
 }
 
 int GlobalNumberOfConditions(ModelPart const& rModelPart)
 {
     int number_of_conds = rModelPart.NumberOfConditions();
-    rModelPart.GetCommunicator().SumAll(number_of_conds);
-    return number_of_conds;
+    return rModelPart.GetCommunicator().GetDataCommunicator().SumAll(number_of_conds);
 }
 }
 

--- a/applications/MappingApplication/custom_utilities/mapper_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapper_utilities.cpp
@@ -34,9 +34,7 @@ void AssignInterfaceEquationIds(Communicator& rModelPartCommunicator)
 {
     const int num_nodes_local = rModelPartCommunicator.LocalMesh().NumberOfNodes();
 
-    int num_nodes_accumulated;
-
-    rModelPartCommunicator.ScanSum(num_nodes_local, num_nodes_accumulated);
+    int num_nodes_accumulated = rModelPartCommunicator.GetDataCommunicator().ScanSum(num_nodes_local);
 
     const int start_equation_id = num_nodes_accumulated - num_nodes_local;
 
@@ -74,7 +72,7 @@ double ComputeSearchRadius(ModelPart& rModelPart, const int EchoLevel)
         max_element_size = ComputeMaxEdgeLengthLocal(rModelPart.GetCommunicator().LocalMesh().Nodes());
     }
 
-    rModelPart.GetCommunicator().MaxAll(max_element_size); // Compute the maximum among the partitions
+    max_element_size = rModelPart.GetCommunicator().GetDataCommunicator().MaxAll(max_element_size); // Compute the maximum among the partitions
     return max_element_size * search_safety_factor;
 }
 

--- a/applications/MappingApplication/custom_utilities/mapper_utilities.h
+++ b/applications/MappingApplication/custom_utilities/mapper_utilities.h
@@ -187,8 +187,7 @@ void CreateMapperLocalSystemsFromNodes(const Communicator& rModelPartCommunicato
         rLocalSystems[i] = Kratos::make_unique<TMapperLocalSystem>((*it_node).get());
     }
 
-    int num_local_systems = rLocalSystems.size(); // int bcs of MPI
-    rModelPartCommunicator.SumAll(num_local_systems);
+    int num_local_systems = rModelPartCommunicator.GetDataCommunicator().SumAll((int)(rLocalSystems.size())); // int bcs of MPI
 
     KRATOS_ERROR_IF_NOT(num_local_systems > 0)
         << "No mapper local systems were created" << std::endl;
@@ -197,22 +196,19 @@ void CreateMapperLocalSystemsFromNodes(const Communicator& rModelPartCommunicato
 inline int ComputeNumberOfNodes(ModelPart& rModelPart)
 {
     int num_nodes = rModelPart.GetCommunicator().LocalMesh().NumberOfNodes();
-    rModelPart.GetCommunicator().SumAll(num_nodes); // Compute the sum among the partitions
-    return num_nodes;
+    return rModelPart.GetCommunicator().GetDataCommunicator().SumAll(num_nodes); // Compute the sum among the partitions
 }
 
 inline int ComputeNumberOfConditions(ModelPart& rModelPart)
 {
     int num_conditions = rModelPart.GetCommunicator().LocalMesh().NumberOfConditions();
-    rModelPart.GetCommunicator().SumAll(num_conditions); // Compute the sum among the partitions
-    return num_conditions;
+    return rModelPart.GetCommunicator().GetDataCommunicator().SumAll(num_conditions); // Compute the sum among the partitions
 }
 
 inline int ComputeNumberOfElements(ModelPart& rModelPart)
 {
     int num_elements = rModelPart.GetCommunicator().LocalMesh().NumberOfElements();
-    rModelPart.GetCommunicator().SumAll(num_elements); // Compute the sum among the partitions
-    return num_elements;
+    return rModelPart.GetCommunicator().GetDataCommunicator().SumAll(num_elements); // Compute the sum among the partitions
 }
 
 template <class T1, class T2>

--- a/applications/StructuralMechanicsApplication/custom_processes/compute_center_of_gravity_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/compute_center_of_gravity_process.cpp
@@ -42,8 +42,8 @@ void ComputeCenterOfGravityProcess::Execute()
     }
 
     // sum up across partitions
-    mrThisModelPart.GetCommunicator().SumAll(total_mass);
-    mrThisModelPart.GetCommunicator().SumAll(center_of_gravity);
+    total_mass = mrThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(total_mass);
+    center_of_gravity = mrThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(center_of_gravity);
 
     center_of_gravity /= total_mass;
 

--- a/applications/StructuralMechanicsApplication/custom_processes/compute_mass_moment_of_inertia_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/compute_mass_moment_of_inertia_process.cpp
@@ -47,7 +47,7 @@ void ComputeMassMomentOfInertiaProcess::Execute()
     }
 
     // sum up across partitions
-    mrThisModelPart.GetCommunicator().SumAll(moment_of_inertia);
+    moment_of_inertia = mrThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(moment_of_inertia);
 
     std::stringstream info_stream;
     info_stream << "Moment of Inertia of ModelPart \"" << mrThisModelPart.Name() << "\"";

--- a/applications/StructuralMechanicsApplication/custom_processes/total_structural_mass_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/total_structural_mass_process.cpp
@@ -100,7 +100,7 @@ void TotalStructuralMassProcess::Execute()
     }
 
     // sum up across partitions
-    mrThisModelPart.GetCommunicator().SumAll(total_mass);
+   total_mass = mrThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(total_mass);
 
     std::stringstream info_stream;
     info_stream << "Total Mass of ModelPart \"" << mrThisModelPart.Name() << "\"";

--- a/applications/ThermoMechanicalApplication/custom_utilities/biphasic_filling_utilities.h
+++ b/applications/ThermoMechanicalApplication/custom_utilities/biphasic_filling_utilities.h
@@ -74,7 +74,7 @@ public:
             }
         }
         //syncronoze
-        ThisModelPart.GetCommunicator().MaxAll(is_exit);
+        is_exit = ThisModelPart.GetCommunicator().GetDataCommunicator().MaxAll(is_exit);
         if(is_exit == 1.0)
             return 1.0;
 
@@ -101,7 +101,7 @@ public:
             }
         }
         //syncronoze
-        ThisModelPart.GetCommunicator().MaxAll(is_dry_node);
+        is_dry_node = ThisModelPart.GetCommunicator().GetDataCommunicator().MaxAll(is_dry_node);
 
         //assign smagorinsky at air element
         AirSmagorinskey(ThisModelPart, C_Smagorinsky);
@@ -194,8 +194,8 @@ public:
 
         }
         //syncronoze
-        ThisModelPart.GetCommunicator().SumAll(wet_nodes);
-        ThisModelPart.GetCommunicator().SumAll(node_size);
+        wet_nodes = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(wet_nodes);
+        node_size = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(node_size);
         double filling_percent = 0.0;
 
         if(wet_nodes != 0) filling_percent = 100.0*double(wet_nodes)/double(node_size);
@@ -238,8 +238,8 @@ public:
         }
 
         //syncronoze
-        ThisModelPart.GetCommunicator().SumAll(wet_nodes);
-        ThisModelPart.GetCommunicator().SumAll(node_size);
+        wet_nodes = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(wet_nodes);
+        node_size = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(node_size);
         double filling_percent = 0.0;
 
         if(wet_nodes != 0) filling_percent = 100.0*double(wet_nodes)/double(node_size);
@@ -575,7 +575,7 @@ public:
                 net_input -= Velocity[0]*AreaNormal[0] + Velocity[1]*AreaNormal[1] + Velocity[2]*AreaNormal[2];
             }
         }
-        ThisModelPart.GetCommunicator().SumAll(net_input);
+        net_input = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(net_input);
 
         ProcessInfo& CurrentProcessInfo = ThisModelPart.GetProcessInfo();
         const double delta_t = CurrentProcessInfo[DELTA_TIME];
@@ -704,7 +704,7 @@ public:
 	  }
 
         //syncronoze
-        ThisModelPart.GetCommunicator().MinAll(is_wet);
+        is_wet = ThisModelPart.GetCommunicator().GetDataCommunicator().MinAll(is_wet);
 
 		//If there is a dry node then do extrapolation for velocity
 		if(is_wet == 0.0)
@@ -957,9 +957,7 @@ public:
 
         }
         //syncronoze
-        ThisModelPart.GetCommunicator().MaxAll(is_dry_node);
-
-        return is_dry_node;
+        return ThisModelPart.GetCommunicator().GetDataCommunicator().MaxAll(is_dry_node);
 
         KRATOS_CATCH("")
     }
@@ -1068,9 +1066,7 @@ public:
 
 		}
 
-		ThisModelPart.GetCommunicator().MaxAll(h_max);
-
-		return h_max;
+		return ThisModelPart.GetCommunicator().GetDataCommunicator().MaxAll(h_max);
 
 		KRATOS_CATCH("");
 	}
@@ -1110,8 +1106,8 @@ public:
 		}
 		double n = static_cast<double>(n_edges);
 
-		ThisModelPart.GetCommunicator().SumAll(h_avg);
-		ThisModelPart.GetCommunicator().SumAll(n);
+		h_avg = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(h_avg);
+		n = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(n);
 		h_avg /= n;
 		return h_avg;
 
@@ -1323,11 +1319,8 @@ private:
             }
         }
         //syncronoze
-        ThisModelPart.GetCommunicator().SumAll(wetvol);
-        ThisModelPart.GetCommunicator().SumAll(cutare);
-
-        wet_volume = wetvol;
-        cutted_area = cutare;
+        wet_volume = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(wetvol);
+        cutted_area = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(cutare);
 
         KRATOS_CATCH("")
     }
@@ -1397,11 +1390,8 @@ private:
             }
         }
         //syncronoze
-        ThisModelPart.GetCommunicator().SumAll(wetvol);
-        ThisModelPart.GetCommunicator().SumAll(cutare);
-
-        wet_volume = wetvol;
-        cutted_area = cutare;
+        wet_volume = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(wetvol);
+        cutted_area = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(cutare);
 
         KRATOS_CATCH("")
     }
@@ -1468,11 +1458,8 @@ private:
             }
         }
         //syncronoze
-        ThisModelPart.GetCommunicator().SumAll(wetvol);
-        ThisModelPart.GetCommunicator().SumAll(cutare);
-
-        pos_volume = wetvol;
-        cutted_area = cutare;
+        pos_volume = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(wetvol);
+        cutted_area = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(cutare);
 
         KRATOS_CATCH("")
     }

--- a/applications/ThermoMechanicalApplication/custom_utilities/estimate_time_step.h
+++ b/applications/ThermoMechanicalApplication/custom_utilities/estimate_time_step.h
@@ -149,8 +149,7 @@ namespace Kratos
 
 	      //perform mpi sync if needed
 	      double global_dt = dt;
-	      ThisModelPart.GetCommunicator().MinAll(global_dt);
-	      dt = global_dt;
+	      dt = ThisModelPart.GetCommunicator().GetDataCommunicator().MinAll(global_dt);
 
 	      return dt;
 
@@ -220,7 +219,7 @@ namespace Kratos
 				  {
 					  max_delta_temp = std::max(max_delta_temp, mdelta[i]);
 				  }
-				  ThisModelPart.GetCommunicator().MaxAll(max_delta_temp);
+				  max_delta_temp = ThisModelPart.GetCommunicator().GetDataCommunicator().MaxAll(max_delta_temp);
 				  // Now we can keep on
 				  if( max_delta_temp > 0.0 )
 				  {
@@ -295,12 +294,12 @@ namespace Kratos
 					  max_nodal_volume = std::max(max_nodal_volume, mdelta[i]);
 				  }
 
-				  ThisModelPart.GetCommunicator().SumAll(current_solidified_volume);
-				  ThisModelPart.GetCommunicator().SumAll(old_solidified_volume);
-				  ThisModelPart.GetCommunicator().SumAll(tot_vol);
-				  ThisModelPart.GetCommunicator().SumAll(current_over_mushy_zone);
-				  ThisModelPart.GetCommunicator().SumAll(old_over_mushy_zone);
-				  ThisModelPart.GetCommunicator().MaxAll(max_nodal_volume);
+				  current_solidified_volume = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(current_solidified_volume);
+				  old_solidified_volume = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(old_solidified_volume);
+				  tot_vol = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(tot_vol);
+				  current_over_mushy_zone = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(current_over_mushy_zone);
+				  old_over_mushy_zone = ThisModelPart.GetCommunicator().GetDataCommunicator().SumAll(old_over_mushy_zone);
+				  max_nodal_volume = ThisModelPart.GetCommunicator().GetDataCommunicator().MaxAll(max_nodal_volume);
 
 				  if(tot_vol == 0.0)   KRATOS_THROW_ERROR(std::logic_error, "inside ComputeSolidificationCoolingDt: total volume is zero!", "")
 
@@ -373,7 +372,7 @@ namespace Kratos
 				  max_delta_temp=std::max(-current_temp+old_temp,max_delta_temp);
 			  }
 
-			  ThisModelPart.GetCommunicator().MaxAll(max_delta_temp);
+			  max_delta_temp = ThisModelPart.GetCommunicator().GetDataCommunicator().MaxAll(max_delta_temp);
 
 			  if( max_delta_temp > 0.0 ){
 				  double new_delta_time = max_cooling_delta_temp / max_delta_temp;
@@ -618,7 +617,7 @@ namespace Kratos
 		      }
 		    }
 
-		ThisModelPart.GetCommunicator().MaxAll(is_in_range_point);
+		is_in_range_point = ThisModelPart.GetCommunicator().GetDataCommunicator().MaxAll(is_in_range_point);
 
 		return (is_in_range_point==1)? 1 : 0;
 	 }
@@ -749,8 +748,7 @@ namespace Kratos
 			double current_temp = it->FastGetSolutionStepValue(TEMPERATURE);
 			if( current_temp < last_temp){last_temp = current_temp;   }
 		}
-		ThisModelPart.GetCommunicator().MinAll(last_temp);
-		return last_temp;
+		return ThisModelPart.GetCommunicator().GetDataCommunicator().MinAll(last_temp);
 	 }
 	 //private:
 	//	 /////////////////////////////////////////////////////////////////////////////
@@ -781,7 +779,7 @@ namespace Kratos
 		 }
 
 
-		 ThisModelPart.GetCommunicator().MinAll(is_hot_point);
+		 is_hot_point = ThisModelPart.GetCommunicator().GetDataCommunicator().MinAll(is_hot_point);
 
 		 return (is_hot_point == 1.0) ? 1 : 0;
 	 }

--- a/applications/TrilinosApplication/custom_processes/trilinos_levelset_convection_process.h
+++ b/applications/TrilinosApplication/custom_processes/trilinos_levelset_convection_process.h
@@ -112,8 +112,8 @@ public:
                 "In 3D the element type is expected to be a tetrahedra" << std::endl;
         }
 
-        rBaseModelPart.GetCommunicator().SumAll(n_nodes);
-        rBaseModelPart.GetCommunicator().SumAll(n_elems);
+        n_nodes = rBaseModelPart.GetCommunicator().GetDataCommunicator().SumAll(n_nodes);
+        n_elems = rBaseModelPart.GetCommunicator().GetDataCommunicator().SumAll(n_elems);
 
         KRATOS_ERROR_IF(n_nodes == 0) << "The model has no nodes." << std::endl;
         KRATOS_ERROR_IF(n_elems == 0) << "The model has no elements." << std::endl;

--- a/applications/TrilinosApplication/custom_strategies/convergencecriterias/trilinos_displacement_criteria.h
+++ b/applications/TrilinosApplication/custom_strategies/convergencecriterias/trilinos_displacement_criteria.h
@@ -291,7 +291,7 @@ private:
 
         //perform the sum between all of the nodes
         TDataType ReferenceDispNorm = local_ReferenceDispNorm;
-        rModelPart.GetCommunicator().SumAll(ReferenceDispNorm);
+        ReferenceDispNorm = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(ReferenceDispNorm);
 
 
         ReferenceDispNorm = std::sqrt(ReferenceDispNorm);

--- a/applications/TrilinosApplication/custom_utilities/mpi_normal_calculation_utilities.cpp
+++ b/applications/TrilinosApplication/custom_utilities/mpi_normal_calculation_utilities.cpp
@@ -259,7 +259,7 @@ void MPINormalCalculationUtils::IdentifyFaces(ModelPart& rModelPart,
     }
 
     // Get the maximum from all processes
-    rModelPart.GetCommunicator().MaxAll(MaxNeigh);
+    MaxNeigh = rModelPart.GetCommunicator().GetDataCommunicator().MaxAll(MaxNeigh);
 }
 
 

--- a/applications/TrilinosApplication/custom_utilities/trilinos_mvqn_recursive_convergence_accelerator.hpp
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_mvqn_recursive_convergence_accelerator.hpp
@@ -206,8 +206,7 @@ public:
 
             // Construct the interface map
             int NumLocalInterfaceDofs = mrInterfaceModelPart.GetCommunicator().LocalMesh().NumberOfNodes() * n_dim;
-            int NumGlobalInterfaceDofs = NumLocalInterfaceDofs;
-            mrInterfaceModelPart.GetCommunicator().SumAll(NumGlobalInterfaceDofs);
+            int NumGlobalInterfaceDofs = mrInterfaceModelPart.GetCommunicator().GetDataCommunicator().SumAll(NumLocalInterfaceDofs);
             int IndexBase = 0; // 0 for C-style vectors, 1 for Fortran numbering
             Epetra_Map InterfaceMap(NumGlobalInterfaceDofs, NumLocalInterfaceDofs, IndexBase, mrEpetraCommunicator);
 

--- a/applications/TrilinosApplication/custom_utilities/trilinos_partitioned_fsi_utilities.h
+++ b/applications/TrilinosApplication/custom_utilities/trilinos_partitioned_fsi_utilities.h
@@ -99,8 +99,7 @@ namespace Kratos
       {
           // Initialize Epetra_Map for the vector
           int NumLocalInterfaceDofs = rInterfaceModelPart.GetCommunicator().LocalMesh().NumberOfNodes() * TDim;
-          int NumGlobalInterfaceDofs = NumLocalInterfaceDofs;
-          rInterfaceModelPart.GetCommunicator().SumAll(NumGlobalInterfaceDofs);
+          int NumGlobalInterfaceDofs = rInterfaceModelPart.GetCommunicator().GetDataCommunicator().SumAll(NumLocalInterfaceDofs);
           int IndexBase = 0; // 0 for C-style vectors, 1 for Fortran numbering
           Epetra_Map InterfaceMap(NumGlobalInterfaceDofs,NumLocalInterfaceDofs,IndexBase,mrEpetraComm);
 

--- a/applications/TrilinosApplication/external_includes/ml_solver.h
+++ b/applications/TrilinosApplication/external_includes/ml_solver.h
@@ -301,7 +301,7 @@ public:
             }
         }
 
-        r_model_part.GetCommunicator().MinAll(old_ndof);
+        old_ndof = r_model_part.GetCommunicator().GetDataCommunicator().MinAll(old_ndof);
 
         if (old_ndof == -1) {
             mNumDof = 1;

--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -477,60 +477,70 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Barrier() const
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
+    void Barrier() const
     {
         mrDataCommunicator.Barrier();
     }
 
-    virtual bool SumAll(int& rValue) const
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
+    bool SumAll(int& rValue) const
     {
         rValue = mrDataCommunicator.SumAll(rValue);
         return true;
     }
 
-    virtual bool SumAll(double& rValue) const
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
+    bool SumAll(double& rValue) const
     {
         rValue = mrDataCommunicator.SumAll(rValue);
         return true;
     }
 
-    virtual bool SumAll(array_1d<double, 3>& rValue) const
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
+    bool SumAll(array_1d<double, 3>& rValue) const
     {
         rValue = mrDataCommunicator.SumAll(rValue);
         return true;
     }
 
-    virtual bool MinAll(int& rValue) const
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
+    bool MinAll(int& rValue) const
     {
         rValue = mrDataCommunicator.MinAll(rValue);
         return true;
     }
 
-    virtual bool MinAll(double& rValue) const
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
+    bool MinAll(double& rValue) const
     {
         rValue = mrDataCommunicator.MinAll(rValue);
         return true;
     }
 
-    virtual bool MaxAll(int& rValue) const
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
+    bool MaxAll(int& rValue) const
     {
         rValue = mrDataCommunicator.MaxAll(rValue);
         return true;
     }
 
-    virtual bool MaxAll(double& rValue) const
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
+    bool MaxAll(double& rValue) const
     {
         rValue = mrDataCommunicator.MaxAll(rValue);
         return true;
     }
 
-    virtual bool ScanSum(const double& send_partial, double& receive_accumulated) const
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
+    bool ScanSum(const double& send_partial, double& receive_accumulated) const
     {
         receive_accumulated = mrDataCommunicator.ScanSum(send_partial);
         return true;
     }
 
-    virtual bool ScanSum(const int& send_partial, int& receive_accumulated) const
+    KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
+    bool ScanSum(const int& send_partial, int& receive_accumulated) const
     {
         receive_accumulated = mrDataCommunicator.ScanSum(send_partial);
         return true;

--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -248,11 +248,8 @@ void VtkOutput::WriteConditionsAndElementsToFile(const ModelPart& rModelPart, st
 {
     const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
 
-    int num_elements = static_cast<int>(r_local_mesh.NumberOfElements());
-    rModelPart.GetCommunicator().SumAll(num_elements);
-
-    int num_conditions = static_cast<int>(r_local_mesh.NumberOfConditions());
-    rModelPart.GetCommunicator().SumAll(num_conditions);
+    int num_elements = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(static_cast<int>(r_local_mesh.NumberOfElements()));
+    int num_conditions = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(static_cast<int>(r_local_mesh.NumberOfConditions()));
 
     if (num_elements > 0) {
         if (num_conditions > 0 && rModelPart.GetCommunicator().MyPID() == 0) {
@@ -410,8 +407,7 @@ void VtkOutput::WriteElementResultsToFile(const ModelPart& rModelPart, std::ofst
     const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
     Parameters element_results = mOutputSettings["element_data_value_variables"];
 
-    int num_elements = static_cast<int>(r_local_mesh.NumberOfElements());
-    rModelPart.GetCommunicator().SumAll(num_elements);
+    int num_elements = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(static_cast<int>(r_local_mesh.NumberOfElements()));
 
     if (num_elements > 0) {
         // write cells header
@@ -432,11 +428,8 @@ void VtkOutput::WriteConditionResultsToFile(const ModelPart& rModelPart, std::of
     const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
     Parameters condition_results = mOutputSettings["condition_data_value_variables"];
 
-    int num_elements = static_cast<int>(r_local_mesh.NumberOfElements());
-    rModelPart.GetCommunicator().SumAll(num_elements);
-
-    int num_conditions = static_cast<int>(r_local_mesh.NumberOfConditions());
-    rModelPart.GetCommunicator().SumAll(num_conditions);
+    int num_elements = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(static_cast<int>(r_local_mesh.NumberOfElements()));
+    int num_conditions = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(static_cast<int>(static_cast<int>(r_local_mesh.NumberOfConditions())));
 
     if (num_elements == 0 && num_conditions > 0) {
         // write cells header

--- a/kratos/mpi/includes/mpi_communicator.h
+++ b/kratos/mpi/includes/mpi_communicator.h
@@ -1787,6 +1787,7 @@ private:
         }
 
         KRATOS_WARNING_IF_ALL_RANKS("MPICommunicator", position > rBuffer.size())
+        << GetDataCommunicator()
         << "Error in estimating receive buffer size." << std::endl;
     }
 

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -296,8 +296,8 @@ public:
         // Check that there is at least one element and node in the model
         int n_loc_mesh_nodes = mrBaseModelPart.GetCommunicator().pLocalMesh()->NumberOfNodes();
         int n_loc_mesh_elements = mrBaseModelPart.GetCommunicator().pLocalMesh()->NumberOfElements();
-        KRATOS_ERROR_IF(mrBaseModelPart.GetCommunicator().SumAll(n_loc_mesh_nodes) == 0) << "The base model part has no nodes." << std::endl;
-        KRATOS_ERROR_IF(mrBaseModelPart.GetCommunicator().SumAll(n_loc_mesh_elements) == 0) << "The base model Part has no elements." << std::endl;
+        KRATOS_ERROR_IF(mrBaseModelPart.GetCommunicator().GetDataCommunicator().SumAll(n_loc_mesh_nodes) == 0) << "The base model part has no nodes." << std::endl;
+        KRATOS_ERROR_IF(mrBaseModelPart.GetCommunicator().GetDataCommunicator().SumAll(n_loc_mesh_elements) == 0) << "The base model Part has no elements." << std::endl;
 
         // Check that the base model part is conformed by simplex elements
         const auto &r_aux_geom = (mrBaseModelPart.ElementsBegin())->GetGeometry();

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -1,10 +1,10 @@
-//    |  /           | 
-//    ' /   __| _` | __|  _ \   __| 
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ \.
-//   _|\_\_|  \__,_|\__|\___/ ____/ 
-//                   Multi-Physics  
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
@@ -62,10 +62,10 @@ class LevelSetConvectionProcess
     : public Process
 {
 public:
-    
+
     KRATOS_DEFINE_LOCAL_FLAG(PERFORM_STEP1);
     KRATOS_DEFINE_LOCAL_FLAG(DO_EXPENSIVE_CHECKS);
-    
+
     ///@name Type Definitions
     ///@{
 
@@ -98,7 +98,7 @@ public:
           mMaxSubsteps(max_substeps)
     {
         KRATOS_TRY
-        
+
         // Check that there is at least one element and node in the model
         const auto n_nodes = rBaseModelPart.NumberOfNodes();
         const auto n_elems = rBaseModelPart.NumberOfElements();
@@ -110,13 +110,13 @@ public:
         VariableUtils().CheckVariableExists< Variable< array_1d < double, 3 > > >(VELOCITY, rBaseModelPart.Nodes());
 
         if(TDim == 2){
-            KRATOS_ERROR_IF(rBaseModelPart.ElementsBegin()->GetGeometry().GetGeometryFamily() != GeometryData::Kratos_Triangle) << 
+            KRATOS_ERROR_IF(rBaseModelPart.ElementsBegin()->GetGeometry().GetGeometryFamily() != GeometryData::Kratos_Triangle) <<
                 "In 2D the element type is expected to be a triangle" << std::endl;
         } else if(TDim == 3) {
-            KRATOS_ERROR_IF(rBaseModelPart.ElementsBegin()->GetGeometry().GetGeometryFamily() != GeometryData::Kratos_Tetrahedra) << 
+            KRATOS_ERROR_IF(rBaseModelPart.ElementsBegin()->GetGeometry().GetGeometryFamily() != GeometryData::Kratos_Tetrahedra) <<
                 "In 3D the element type is expected to be a tetrahedra" << std::endl;
         }
-        
+
         // Allocate if needed the variable DYNAMIC_TAU of the process info, and if it does not exist, set it to zero
         if( rBaseModelPart.GetProcessInfo().Has(DYNAMIC_TAU) == false){
             rBaseModelPart.GetProcessInfo().SetValue(DYNAMIC_TAU,0.0);
@@ -153,9 +153,9 @@ public:
             CalculateNormDxFlag);
 
         mpSolvingStrategy->SetEchoLevel(0);
-        
+
         rBaseModelPart.GetProcessInfo().SetValue(CROSS_WIND_STABILIZATION_FACTOR, cross_wind_stabilization_factor);
-        
+
         //TODO: check flag DO_EXPENSIVE_CHECKS
         mpSolvingStrategy->Check();
 
@@ -163,7 +163,7 @@ public:
     }
 
     /// Destructor.
-    ~LevelSetConvectionProcess() override 
+    ~LevelSetConvectionProcess() override
     {
         mrBaseModelPart.GetModel().DeleteModelPart("DistanceConvectionPart");
     }
@@ -213,16 +213,16 @@ public:
 
         for(unsigned int step = 1; step <= n_substep; ++step){
 
-            KRATOS_INFO_IF("LevelSetConvectionProcess", mpSolvingStrategy->GetEchoLevel() > 0 && rank == 0) << 
+            KRATOS_INFO_IF("LevelSetConvectionProcess", mpSolvingStrategy->GetEchoLevel() > 0 && rank == 0) <<
                 "Doing step "<< step << " of " << n_substep << std::endl;
 
             // Compute shape functions of old and new step
             const double Nold = 1.0 - static_cast<double>(step) / static_cast<double>(n_substep);
             const double Nnew = 1.0 - Nold;
-            
+
             const double Nold_before = 1.0 - static_cast<double>(step-1) / static_cast<double>(n_substep);
-            const double Nnew_before = 1.0 - Nold_before;            
-            
+            const double Nnew_before = 1.0 - Nold_before;
+
             // Emulate clone time step by copying the new distance onto the old one
             #pragma omp parallel for
             for (int i_node = 0; i_node < static_cast<int>(mpDistanceModelPart->NumberOfNodes()); ++i_node){
@@ -235,14 +235,14 @@ public:
                 it_node->FastGetSolutionStepValue(VELOCITY, 1) = Nold_before * v_old + Nnew_before * v;
                 it_node->FastGetSolutionStepValue(mrLevelSetVar, 1) = it_node->FastGetSolutionStepValue(mrLevelSetVar);
             }
-            
+
             mpSolvingStrategy->Solve();
         }
 
-        // Reset the processinfo to the original settings 
+        // Reset the processinfo to the original settings
         rCurrentProcessInfo.SetValue(DELTA_TIME, previous_delta_time);
         rCurrentProcessInfo.GetValue(CONVECTION_DIFFUSION_SETTINGS)->SetUnknownVariable(r_previous_var);
-        
+
         // Reset the velocities and levelset values to the one saved before the solution process
         #pragma omp parallel for
         for (int i_node = 0; i_node < static_cast<int>(mpDistanceModelPart->NumberOfNodes()); ++i_node){
@@ -251,7 +251,7 @@ public:
             it_node->FastGetSolutionStepValue(VELOCITY,1) = mVelocityOld[i_node];
             it_node->FastGetSolutionStepValue(mrLevelSetVar,1) = mOldDistance[i_node];
         }
-        
+
         KRATOS_CATCH("")
     }
 
@@ -263,7 +263,7 @@ public:
         mDistancePartIsInitialized = false;
 
         mpSolvingStrategy->Clear();
-        
+
         mVelocity.clear();
         mVelocityOld.clear();
         mOldDistance.clear();
@@ -315,7 +315,7 @@ protected:
     Variable<double>& mrLevelSetVar;
 
     const double mMaxAllowedCFL;
-    
+
     bool mDistancePartIsInitialized;
 
 	const unsigned int mMaxSubsteps;
@@ -355,13 +355,13 @@ protected:
 
         if(current_model.HasModelPart("DistanceConvectionPart"))
             current_model.DeleteModelPart("DistanceConvectionPart");
-        
+
         mpDistanceModelPart= &(current_model.CreateModelPart("DistanceConvectionPart"));
 
 
         // Check buffer size
         const auto base_buffer_size = rBaseModelPart.GetBufferSize();
-        KRATOS_ERROR_IF(base_buffer_size < 2) << 
+        KRATOS_ERROR_IF(base_buffer_size < 2) <<
             "Base model part buffer size is " << base_buffer_size << ". Set it to a minimum value of 2." << std::endl;
 
         // Generate
@@ -390,14 +390,14 @@ protected:
 
             // Assign EXACTLY THE SAME GEOMETRY, so that memory is saved!!
             p_element->pGetGeometry() = it_elem->pGetGeometry();
-            
+
             mpDistanceModelPart->Elements().push_back(p_element);
         }
 
         // Next is for mpi (but mpi would also imply calling an mpi strategy)
         Communicator::Pointer pComm = rBaseModelPart.GetCommunicator().Create();
         mpDistanceModelPart->SetCommunicator(pComm);
-        
+
         // Resize the arrays
         const auto n_nodes = mpDistanceModelPart->NumberOfNodes();
         mVelocity.resize(n_nodes);
@@ -411,10 +411,10 @@ protected:
 
 
     unsigned int EvaluateNumberOfSubsteps(){
-        // First of all compute the cfl number 
+        // First of all compute the cfl number
         const auto n_elem = mpDistanceModelPart->NumberOfElements();
         const double dt = mpDistanceModelPart->GetProcessInfo()[DELTA_TIME];
-        
+
 		// Vector where each thread will store its maximum (VS does not support OpenMP reduce max)
 		int NumThreads = OpenMPUtils::GetNumThreads();
 		std::vector<double> list_of_max_local_cfl(NumThreads, 0.0);
@@ -466,9 +466,9 @@ protected:
         max_cfl_found *= dt;
 
         // Synchronize maximum CFL between processes
-        mpDistanceModelPart->GetCommunicator().MaxAll(max_cfl_found);
-        
-        unsigned int n_steps = static_cast<unsigned int>(max_cfl_found / mMaxAllowedCFL); 
+        max_cfl_found = mpDistanceModelPart->GetCommunicator().GetDataCommunicator().MaxAll(max_cfl_found);
+
+        unsigned int n_steps = static_cast<unsigned int>(max_cfl_found / mMaxAllowedCFL);
         if(n_steps < 1){
             n_steps = 1;
         }
@@ -477,7 +477,7 @@ protected:
 		if (mMaxSubsteps > 0 && mMaxSubsteps < n_steps){
             n_steps = mMaxSubsteps;
         }
-        
+
         return n_steps;
     }
 
@@ -565,6 +565,6 @@ inline std::ostream& operator << (
 
 }  // namespace Kratos.
 
-#endif // KRATOS_LEVELSET_CONVECTION_PROCESS_INCLUDED  defined 
+#endif // KRATOS_LEVELSET_CONVECTION_PROCESS_INCLUDED  defined
 
 

--- a/kratos/processes/variational_distance_calculation_process.h
+++ b/kratos/processes/variational_distance_calculation_process.h
@@ -318,9 +318,9 @@ public:
         }
 
         // Synchronize the maximum and minimum distance values
-        auto &r_communicator = r_distance_model_part.GetCommunicator();
-        r_communicator.MaxAll(max_dist);
-        r_communicator.MinAll(min_dist);
+        const auto &r_communicator = r_distance_model_part.GetCommunicator().GetDataCommunicator();
+        max_dist = r_communicator.MaxAll(max_dist);
+        min_dist = r_communicator.MinAll(min_dist);
 
         // Assign the max dist to all of the non-fixed positive nodes
         // and the minimum one to the non-fixed negatives
@@ -431,7 +431,7 @@ protected:
 
     void ValidateInput()
     {
-        const Communicator& r_comm = mr_base_model_part.GetCommunicator();
+        const DataCommunicator& r_comm = mr_base_model_part.GetCommunicator().GetDataCommunicator();
         int num_elements = mr_base_model_part.NumberOfElements();
         int num_nodes = mr_base_model_part.NumberOfNodes();
 
@@ -444,11 +444,8 @@ protected:
             << "In 3D the element type is expected to be a tetrahedron" << std::endl;
         }
 
-        r_comm.SumAll(num_nodes);
-        KRATOS_ERROR_IF(num_nodes == 0) << "The model part has no nodes." << std::endl;
-
-        r_comm.SumAll(num_elements);
-        KRATOS_ERROR_IF(num_elements == 0) << "The model Part has no elements." << std::endl;
+        KRATOS_ERROR_IF(r_comm.SumAll(num_nodes) == 0) << "The model part has no nodes." << std::endl;
+        KRATOS_ERROR_IF(r_comm.SumAll(num_elements) == 0) << "The model Part has no elements." << std::endl;
 
         // Check that required nodal variables are present
         VariableUtils().CheckVariableExists<Variable<double > >(DISTANCE, mr_base_model_part.Nodes());

--- a/kratos/python/add_model_part_to_python.cpp
+++ b/kratos/python/add_model_part_to_python.cpp
@@ -685,38 +685,51 @@ bool CommunicatorAssembleNonHistoricalData(Communicator& rCommunicator, Variable
 template<class TDataType>
 TDataType CommunicatorSumAll(Communicator& rCommunicator, const TDataType& rValue)
 {
-    TDataType Value = rValue;
-    rCommunicator.SumAll(Value);
-    return Value;
+    KRATOS_WARNING("Communicator")
+    << "Using deprecated method Communicator::SumAll " << std::endl
+    << "Please retrieve the data communicator with Communicator::GetDataCommunicator "
+    << "and use DataCommunicator::SumAll instead." << std::endl;
+    return rCommunicator.GetDataCommunicator().SumAll(rValue);
 }
 
 template<class TDataType>
 TDataType CommunicatorMinAll(Communicator& rCommunicator, const TDataType& rValue)
 {
-    TDataType Value = rValue;
-    rCommunicator.MinAll(Value);
-    return Value;
+    KRATOS_WARNING("Communicator")
+    << "Using deprecated method Communicator::MinAll " << std::endl
+    << "Please retrieve the data communicator with Communicator::GetDataCommunicator "
+    << "and use DataCommunicator::MinAll instead." << std::endl;
+    return rCommunicator.GetDataCommunicator().MinAll(rValue);
 }
 
 template<class TDataType>
 TDataType CommunicatorMaxAll(Communicator& rCommunicator, const TDataType& rValue)
 {
-    TDataType Value = rValue;
-    rCommunicator.MaxAll(Value);
-    return Value;
+    KRATOS_WARNING("Communicator")
+    << "Using deprecated method Communicator::MaxAll " << std::endl
+    << "Please retrieve the data communicator with Communicator::GetDataCommunicator "
+    << "and use DataCommunicator::MaxAll instead." << std::endl;
+    return rCommunicator.GetDataCommunicator().MaxAll(rValue);
 }
 
 template<class TDataType>
 TDataType CommunicatorScanSum(Communicator& rCommunicator, const TDataType rSendPartial, TDataType rReceiveAccumulated)
 {
-    TDataType SendPartial = rSendPartial;
-    TDataType ReceiveAccumulated = rReceiveAccumulated;
-    rCommunicator.ScanSum(SendPartial, ReceiveAccumulated);
-    return ReceiveAccumulated;
+    KRATOS_WARNING("Communicator")
+    << "Using deprecated method Communicator::ScanSum " << std::endl
+    << "Please retrieve the data communicator with Communicator::GetDataCommunicator "
+    << "and use DataCommunicator::ScanSum instead." << std::endl;
+    return rCommunicator.GetDataCommunicator().ScanSum(rSendPartial);
 }
 
-
-
+void CommunicatorBarrier(Communicator& rCommunicator)
+{
+    KRATOS_WARNING("Communicator")
+    << "Using deprecated method Communicator::Barrier " << std::endl
+    << "Please retrieve the data communicator with Communicator::GetDataCommunicator "
+    << "and use DataCommunicator::Barrier instead." << std::endl;
+    return rCommunicator.GetDataCommunicator().Barrier();
+}
 
 void AddModelPartToPython(pybind11::module& m)
 {
@@ -734,7 +747,7 @@ void AddModelPartToPython(pybind11::module& m)
     py::class_<Communicator > (m,"Communicator")
         .def(py::init<>())
         .def("MyPID", &Communicator::MyPID)
-        .def("Barrier", &Communicator::Barrier)
+        .def("Barrier", CommunicatorBarrier)
         .def("TotalProcesses", &Communicator::TotalProcesses)
         .def("GetNumberOfColors", &Communicator::GetNumberOfColors)
         .def("NeighbourIndices", NeighbourIndicesConst, py::return_value_policy::reference_internal)
@@ -746,6 +759,7 @@ void AddModelPartToPython(pybind11::module& m)
         .def("GhostMesh", CommunicatorGetGhostMeshWithIndex, py::return_value_policy::reference_internal )
         .def("InterfaceMesh", CommunicatorGetInterfaceMesh, py::return_value_policy::reference_internal )
         .def("InterfaceMesh", CommunicatorGetInterfaceMeshWithIndex, py::return_value_policy::reference_internal )
+        .def("GetDataCommunicator", &Communicator::GetDataCommunicator, py::return_value_policy::reference_internal )
         .def("SumAll", CommunicatorSumAll<int> )
         .def("SumAll", CommunicatorSumAll<double> )
         .def("SumAll", CommunicatorSumAll<array_1d<double,3> > )

--- a/kratos/utilities/brute_force_point_locator.cpp
+++ b/kratos/utilities/brute_force_point_locator.cpp
@@ -92,8 +92,7 @@ void BruteForcePointLocator::CheckResults(const std::string& rObjectName,
                                           const Point& rThePoint,
                                           const int LocalObjectFound) const
 {
-    int global_objects_found = LocalObjectFound;
-    mrModelPart.GetCommunicator().SumAll(global_objects_found);
+    int global_objects_found = mrModelPart.GetCommunicator().GetDataCommunicator().SumAll(LocalObjectFound);
 
     if (global_objects_found > 1) {
         KRATOS_WARNING_IF_ALL_RANKS("BruteForcePointLocator", LocalObjectFound == 1) << "More than one " << rObjectName << " found for Point:" << rThePoint << std::endl; // TODO pass data-comm from the modelpart to the logger once available

--- a/kratos/utilities/embedded_skin_utility.cpp
+++ b/kratos/utilities/embedded_skin_utility.cpp
@@ -153,14 +153,15 @@ namespace Kratos
         int n_nodes_local = rNewNodesVect.size();
         int n_conds_local = rNewCondsVect.size();
         int n_nodes_local_scansum, n_conds_local_scansum;
-        mrModelPart.GetCommunicator().ScanSum(n_nodes_local, n_nodes_local_scansum);
-        mrModelPart.GetCommunicator().ScanSum(n_conds_local, n_conds_local_scansum);
+        const auto& r_comm = mrModelPart.GetCommunicator().GetDataCommunicator();
+        n_nodes_local_scansum = r_comm.ScanSum(n_nodes_local);
+        n_conds_local_scansum = r_comm.ScanSum(n_conds_local);
 
         // Origin model part number of entities
         int n_nodes_orig = mrModelPart.NumberOfNodes();
         int n_conds_orig = mrModelPart.NumberOfConditions();
-        mrModelPart.GetCommunicator().SumAll(n_nodes_orig);
-        mrModelPart.GetCommunicator().SumAll(n_conds_orig);
+        n_nodes_orig = r_comm.SumAll(n_nodes_orig);
+        n_conds_orig = r_comm.SumAll(n_nodes_orig);
 
         // Initialize the new ids. values
         std::size_t new_node_id(n_nodes_orig + n_nodes_local_scansum - n_nodes_local + 1);
@@ -186,7 +187,7 @@ namespace Kratos
         mrSkinModelPart.AddConditions(rNewCondsVect.begin(), rNewCondsVect.end());
 
         // Wait for all nodes to renumber its nodes
-        mrModelPart.GetCommunicator().Barrier();
+        r_comm.Barrier();
     }
 
     template<std::size_t TDim>

--- a/kratos/utilities/embedded_skin_utility.cpp
+++ b/kratos/utilities/embedded_skin_utility.cpp
@@ -161,7 +161,7 @@ namespace Kratos
         int n_nodes_orig = mrModelPart.NumberOfNodes();
         int n_conds_orig = mrModelPart.NumberOfConditions();
         n_nodes_orig = r_comm.SumAll(n_nodes_orig);
-        n_conds_orig = r_comm.SumAll(n_nodes_orig);
+        n_conds_orig = r_comm.SumAll(n_conds_orig);
 
         // Initialize the new ids. values
         std::size_t new_node_id(n_nodes_orig + n_nodes_local_scansum - n_nodes_local + 1);

--- a/kratos/utilities/parallel_levelset_distance_calculator.h
+++ b/kratos/utilities/parallel_levelset_distance_calculator.h
@@ -2,13 +2,13 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
-//                    
+//
 //
 
 #if !defined(KRATOS_PARALLEL_DISTANCE_CALCULATOR_H_INCLUDED )
@@ -94,7 +94,7 @@ public:
         KRATOS_TRY
 
 		Check(rModelPart, rDistanceVar, rAreaVar);
-                         
+
 		ResetVariables(rModelPart,rDistanceVar, max_distance);
 
 		CalculateExactDistancesOnDividedElements(rModelPart, rDistanceVar, rAreaVar, max_distance, Options);
@@ -126,7 +126,7 @@ public:
         KRATOS_TRY
 
 		Check(rModelPart, rDistanceVar, rAreaVar);
-                         
+
 		ResetVariables(rModelPart,rDistanceVar, max_distance);
 
 		AbsDistancesOnDividedElements(rModelPart, rDistanceVar, rAreaVar, max_distance);
@@ -202,7 +202,7 @@ public:
         for(unsigned int level=0; level<max_levels; level++)
         {
             //loop on active elements and advance the distance computation
-            #pragma omp parallel for private(DN_DX,visited) 
+            #pragma omp parallel for private(DN_DX,visited)
             for(int i = 0; i<elem_size; i++)
             {
                 PointerVector< Element>::iterator it=rModelPart.ElementsBegin()+i;
@@ -223,7 +223,7 @@ public:
             //mpi sync variables
             if(is_distributed == true)
             {
-                #pragma omp parallel for private(DN_DX) 
+                #pragma omp parallel for private(DN_DX)
                 for(int i = 0; i<node_size; i++)
                 {
                     ModelPart::NodesContainerType::iterator it=rModelPart.NodesBegin()+i;
@@ -240,19 +240,19 @@ public:
                 rModelPart.GetCommunicator().AssembleCurrentData(rAreaVar);
                 rModelPart.GetCommunicator().AssembleCurrentData(rDistanceVar);
 
-                #pragma omp parallel for private(DN_DX) 
+                #pragma omp parallel for private(DN_DX)
                 for(int i = 0; i<node_size; i++)
                 {
                     ModelPart::NodesContainerType::iterator it=rModelPart.NodesBegin()+i;
                     it->FastGetSolutionStepValue(rDistanceVar) += it->GetValue(rDistanceVar);
                 }
 
-                rModelPart.GetCommunicator().Barrier();
+                rModelPart.GetCommunicator().GetDataCommunicator().Barrier();
             }
 
 
             //finalize the computation of the distance
-            #pragma omp parallel for private(DN_DX) 
+            #pragma omp parallel for private(DN_DX)
             for(int i = 0; i<node_size; i++)
             {
                 ModelPart::NodesContainerType::iterator it=rModelPart.NodesBegin()+i;
@@ -272,7 +272,7 @@ public:
         //*****************************************************************+
         //*****************************************************************+
         //assign the sign to the distance function according to the original distribution. Set to max for nodes that were not calculated
-        #pragma omp parallel for 
+        #pragma omp parallel for
         for(int i = 0; i<node_size; i++)
         {
             ModelPart::NodesContainerType::iterator it=rModelPart.NodesBegin()+i;
@@ -334,7 +334,7 @@ public:
 
         }
 
-        r_model_part.GetCommunicator().MaxAll(h_max);
+        h_max = r_model_part.GetCommunicator().GetDataCommunicator().MaxAll(h_max);
 
         return h_max;
 
@@ -721,7 +721,7 @@ private:
         //check that variables needed are in the model part
         if(!(rModelPart.NodesBegin()->SolutionStepsDataHas(rDistanceVar)) )
             KRATOS_THROW_ERROR(std::logic_error,"distance Variable is not in the model part","");
-        
+
         if(!(rModelPart.NodesBegin()->SolutionStepsDataHas(rAreaVar)) )
             KRATOS_THROW_ERROR(std::logic_error,"Area Variable is not in the model part","");
 
@@ -731,7 +731,7 @@ private:
 
 		KRATOS_CATCH("")
 	}
-                         
+
     void ResetVariables(ModelPart& rModelPart,
                             const Variable<double>& rDistanceVar,
 							const double MaxDistance)
@@ -740,7 +740,7 @@ private:
 
         //reset the variables needed
         const int node_size = rModelPart.Nodes().size();
-        
+
         #pragma omp parallel for
         for(int i = 0; i<node_size; i++)
         {
@@ -940,7 +940,7 @@ private:
         const int elem_size = rModelPart.Elements().size();
 		const int node_size = rModelPart.Nodes().size();
 
-        
+
         //*****************************************************************+
         //*****************************************************************+
         //*****************************************************************+
@@ -948,7 +948,7 @@ private:
         for(unsigned int level=0; level<max_levels; level++)
         {
             //loop on active elements and advance the distance computation
-            #pragma omp parallel for private(DN_DX,visited) 
+            #pragma omp parallel for private(DN_DX,visited)
             for(int i = 0; i<elem_size; i++)
             {
                 PointerVector< Element>::iterator it=rModelPart.ElementsBegin()+i;
@@ -964,7 +964,7 @@ private:
 
                     AddDistanceToNodes(rDistanceVar,rAreaVar,geom,DN_DX,Volume);
                 }
-            } 
+            }
 
 			bool is_distributed = false;
 			if(rModelPart.GetCommunicator().TotalProcesses() > 1)
@@ -973,7 +973,7 @@ private:
 		    //mpi sync variables
             if(is_distributed == true)
             {
-                #pragma omp parallel for private(DN_DX) 
+                #pragma omp parallel for private(DN_DX)
                 for(int i = 0; i<node_size; i++)
                 {
                     ModelPart::NodesContainerType::iterator it=rModelPart.NodesBegin()+i;
@@ -990,19 +990,19 @@ private:
                 rModelPart.GetCommunicator().AssembleCurrentData(rAreaVar);
                 rModelPart.GetCommunicator().AssembleCurrentData(rDistanceVar);
 
-                #pragma omp parallel for private(DN_DX) 
+                #pragma omp parallel for private(DN_DX)
                 for(int i = 0; i<node_size; i++)
                 {
                     ModelPart::NodesContainerType::iterator it=rModelPart.NodesBegin()+i;
                     it->FastGetSolutionStepValue(rDistanceVar) += it->GetValue(rDistanceVar);
                 }
 
-                rModelPart.GetCommunicator().Barrier();
+                rModelPart.GetCommunicator().GetDataCommunicator().Barrier();
             }
 
 
             //finalize the computation of the distance
-            #pragma omp parallel for private(DN_DX) 
+            #pragma omp parallel for private(DN_DX)
             for(int i = 0; i<node_size; i++)
             {
                 ModelPart::NodesContainerType::iterator it=rModelPart.NodesBegin()+i;
@@ -1021,7 +1021,7 @@ private:
 		KRATOS_CATCH("")
 	}
 
- 
+
      void AssignDistanceSign(ModelPart& rModelPart,
                             const Variable<double>& rDistanceVar,
                             const Variable<double>& rAreaVar,
@@ -1034,7 +1034,7 @@ private:
         //*****************************************************************+
         //assign the sign to the distance function according to the original distribution. Set to max for nodes that were not calculated
         const int node_size = rModelPart.Nodes().size();
-        #pragma omp parallel for 
+        #pragma omp parallel for
         for(int i = 0; i<node_size; i++)
         {
             ModelPart::NodesContainerType::iterator it=rModelPart.NodesBegin()+i;
@@ -1123,6 +1123,6 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_PARALLEL_DISTANCE_CALCULATOR_H_INCLUDED  defined 
+#endif // KRATOS_PARALLEL_DISTANCE_CALCULATOR_H_INCLUDED  defined
 
 

--- a/kratos/utilities/variable_redistribution_utility.cpp
+++ b/kratos/utilities/variable_redistribution_utility.cpp
@@ -60,9 +60,8 @@ void VariableRedistributionUtility::CallSpecializedConvertDistributedValuesToPoi
     const Variable<TValueType>& rPointVariable)
 {
     // Check if there is any condition in the current partition
-    const unsigned int n_loc_conds = rModelPart.GetCommunicator().LocalMesh().NumberOfConditions();
-    int n_tot_conds = n_loc_conds;
-    rModelPart.GetCommunicator().SumAll(n_tot_conds);
+    const int n_loc_conds = rModelPart.GetCommunicator().LocalMesh().NumberOfConditions();
+    int n_tot_conds = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(n_loc_conds);
 
     // If there is conditions, this function dispatches the call to the correct specialization
     if (n_tot_conds != 0){
@@ -102,9 +101,8 @@ void VariableRedistributionUtility::CallSpecializedDistributePointValues(
     unsigned int MaximumIterations)
 {
     // Check if there is any condition in the current partition
-    const unsigned int n_loc_conds = rModelPart.GetCommunicator().LocalMesh().NumberOfConditions();
-    int n_tot_conds = n_loc_conds;
-    rModelPart.GetCommunicator().SumAll(n_tot_conds);
+    const int n_loc_conds = rModelPart.GetCommunicator().LocalMesh().NumberOfConditions();
+    int n_tot_conds = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(n_loc_conds);
 
     // If there is conditions, this function dispatches the call to the correct specialization
     if (n_tot_conds != 0){
@@ -240,7 +238,7 @@ void VariableRedistributionUtility::SpecializedDistributePointValues(
         UpdateDistributionRHS<TPointNumber,TValueType>(rModelPart,rPointVariable, rDistributedVariable, mass_matrix);
 
         error_l2_norm = SolveDistributionIteration(rModelPart,rDistributedVariable);
-        rModelPart.GetCommunicator().SumAll(error_l2_norm);
+        error_l2_norm = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(error_l2_norm);
 
         // Check convergence
         iteration++;
@@ -270,7 +268,7 @@ void VariableRedistributionUtility::DummySpecializedDistributePointValues(
         DummyUpdateDistributionRHS<TValueType>(rModelPart, rDistributedVariable);
 
         error_l2_norm = DummySolveDistributionIteration(rModelPart,rDistributedVariable);;
-        rModelPart.GetCommunicator().SumAll(error_l2_norm);
+        error_l2_norm = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(error_l2_norm);
 
         // Check convergence
         iteration++;

--- a/kratos/utilities/variable_utils.cpp
+++ b/kratos/utilities/variable_utils.cpp
@@ -258,14 +258,15 @@ array_1d<double, 3> VariableUtils::SumNonHistoricalNodeVectorVariable(
     KRATOS_TRY
 
     array_1d<double, 3> sum_value = ZeroVector(3);
+    auto& r_comm = rModelPart.GetCommunicator();
 
     #pragma omp parallel
     {
         array_1d<double, 3> private_sum_value = ZeroVector(3);
 
         #pragma omp for
-        for (int k = 0; k < static_cast<int>(rModelPart.GetCommunicator().LocalMesh().NumberOfNodes()); ++k) {
-            const auto it_node = rModelPart.GetCommunicator().LocalMesh().NodesBegin() + k;
+        for (int k = 0; k < static_cast<int>(r_comm.LocalMesh().NumberOfNodes()); ++k) {
+            const auto it_node = r_comm.LocalMesh().NodesBegin() + k;
             private_sum_value += it_node->GetValue(rVar);
         }
 
@@ -275,9 +276,7 @@ array_1d<double, 3> VariableUtils::SumNonHistoricalNodeVectorVariable(
         }
     }
 
-    rModelPart.GetCommunicator().SumAll(sum_value);
-
-    return sum_value;
+    return r_comm.GetDataCommunicator().SumAll(sum_value);
 
     KRATOS_CATCH("")
 }
@@ -294,14 +293,15 @@ array_1d<double, 3> VariableUtils::SumHistoricalNodeVectorVariable(
     KRATOS_TRY
 
     array_1d<double, 3> sum_value = ZeroVector(3);
+    auto& r_comm = rModelPart.GetCommunicator();
 
     #pragma omp parallel
     {
         array_1d<double, 3> private_sum_value = ZeroVector(3);
 
         #pragma omp for
-        for (int k = 0; k < static_cast<int>(rModelPart.GetCommunicator().LocalMesh().NumberOfNodes()); ++k) {
-            const auto it_node = rModelPart.GetCommunicator().LocalMesh().NodesBegin() + k;
+        for (int k = 0; k < static_cast<int>(r_comm.LocalMesh().NumberOfNodes()); ++k) {
+            const auto it_node = r_comm.LocalMesh().NodesBegin() + k;
             private_sum_value += it_node->GetSolutionStepValue(rVar, rBuffStep);
         }
 
@@ -311,9 +311,7 @@ array_1d<double, 3> VariableUtils::SumHistoricalNodeVectorVariable(
         }
     }
 
-    rModelPart.GetCommunicator().SumAll(sum_value);
-
-    return sum_value;
+    return r_comm.GetDataCommunicator().SumAll(sum_value);
 
     KRATOS_CATCH("")
 }
@@ -329,14 +327,15 @@ array_1d<double, 3> VariableUtils::SumConditionVectorVariable(
     KRATOS_TRY
 
     array_1d<double, 3> sum_value = ZeroVector(3);
+    const auto& r_comm = rModelPart.GetCommunicator();
 
     #pragma omp parallel
     {
         array_1d<double, 3> private_sum_value = ZeroVector(3);
 
         #pragma omp for
-        for (int k = 0; k < static_cast<int>(rModelPart.GetCommunicator().LocalMesh().NumberOfConditions()); ++k) {
-            const auto it_cond = rModelPart.GetCommunicator().LocalMesh().ConditionsBegin() + k;
+        for (int k = 0; k < static_cast<int>(r_comm.LocalMesh().NumberOfConditions()); ++k) {
+            const auto it_cond = r_comm.LocalMesh().ConditionsBegin() + k;
             private_sum_value += it_cond->GetValue(rVar);
         }
 
@@ -346,9 +345,7 @@ array_1d<double, 3> VariableUtils::SumConditionVectorVariable(
         }
     }
 
-    rModelPart.GetCommunicator().SumAll(sum_value);
-
-    return sum_value;
+    return r_comm.GetDataCommunicator().SumAll(sum_value);
 
     KRATOS_CATCH("")
 }
@@ -364,14 +361,15 @@ array_1d<double, 3> VariableUtils::SumElementVectorVariable(
     KRATOS_TRY
 
     array_1d<double, 3> sum_value = ZeroVector(3);
+    auto& r_comm = rModelPart.GetCommunicator();
 
     #pragma omp parallel
     {
         array_1d<double, 3> private_sum_value = ZeroVector(3);
 
         #pragma omp for
-        for (int k = 0; k < static_cast<int>(rModelPart.GetCommunicator().LocalMesh().NumberOfElements()); ++k) {
-            const auto it_elem = rModelPart.GetCommunicator().LocalMesh().ElementsBegin() + k;
+        for (int k = 0; k < static_cast<int>(r_comm.LocalMesh().NumberOfElements()); ++k) {
+            const auto it_elem = r_comm.LocalMesh().ElementsBegin() + k;
             private_sum_value += it_elem->GetValue(rVar);
         }
 
@@ -381,9 +379,7 @@ array_1d<double, 3> VariableUtils::SumElementVectorVariable(
         }
     }
 
-    rModelPart.GetCommunicator().SumAll(sum_value);
-
-    return sum_value;
+    return r_comm.GetDataCommunicator().SumAll(sum_value);
 
     KRATOS_CATCH("")
 }

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -710,9 +710,7 @@ public:
             sum_value += it_node->GetValue(rVar);
         }
 
-        r_communicator.SumAll(sum_value);
-
-        return sum_value;
+        return r_communicator.GetDataCommunicator().SumAll(sum_value);
 
         KRATOS_CATCH("")
     }
@@ -758,9 +756,7 @@ public:
             sum_value += it_node->GetSolutionStepValue(rVar, rBuffStep);
         }
 
-        r_communicator.SumAll(sum_value);
-
-        return sum_value;
+        return r_communicator.GetDataCommunicator().SumAll(sum_value);
 
         KRATOS_CATCH("")
     }
@@ -804,9 +800,7 @@ public:
             sum_value += it_cond->GetValue(rVar);
         }
 
-        r_communicator.SumAll(sum_value);
-
-        return sum_value;
+        return r_communicator.GetDataCommunicator().SumAll(sum_value);
 
         KRATOS_CATCH("")
     }
@@ -850,9 +844,7 @@ public:
             sum_value += it_elem->GetValue(rVar);
         }
 
-        r_communicator.SumAll(sum_value);
-
-        return sum_value;
+        return r_communicator.GetDataCommunicator().SumAll(sum_value);
 
         KRATOS_CATCH("")
     }


### PR DESCRIPTION
As discussed in #4745, some Communicator methods can be deprecated by new methods in DataCommunicator. Here I am adding the deprecation warnings and replacing any old calls I could find in the applications that I am compiling.