### PR TITLE
[Core] Adding register for the local flags

### DIFF
--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -525,7 +525,18 @@ catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreI
   const Kratos::Flags class_name::name(Kratos::Flags::Create(position));		\
   const Kratos::Flags class_name::NOT_##name(Kratos::Flags::Create(position, false))
 
+#ifdef KRATOS_ADD_LOCAL_FLAG_TO_KRATOS_COMPONENTS
+#undef KRATOS_ADD_LOCAL_FLAG_TO_KRATOS_COMPONENTS
+#endif
+#define KRATOS_ADD_LOCAL_FLAG_TO_KRATOS_COMPONENTS(class_name, name)    \
+    Kratos::KratosComponents<Kratos::Flags>::Add(#name, class_name::name)
 
+#ifdef KRATOS_REGISTER_LOCAL_FLAG
+#undef KRATOS_REGISTER_LOCAL_FLAG
+#endif
+#define KRATOS_REGISTER_LOCAL_FLAG(class_name, name)              \
+    KRATOS_ADD_LOCAL_FLAG_TO_KRATOS_COMPONENTS(class_name, name); \
+    KRATOS_ADD_LOCAL_FLAG_TO_KRATOS_COMPONENTS(class_name, NOT_##name);
 
 //-----------------------------------------------------------------
 //

--- a/kratos/includes/define_python.h
+++ b/kratos/includes/define_python.h
@@ -100,6 +100,19 @@ PYBIND11_DECLARE_HOLDER_TYPE(T, std::intrusive_ptr<T>);
     KRATOS_REGISTER_IN_PYTHON_FLAG_IMPLEMENTATION(module,flag);   \
     KRATOS_REGISTER_IN_PYTHON_FLAG_IMPLEMENTATION(module,NOT_##flag)
 
+#ifdef KRATOS_REGISTER_IN_PYTHON_LOCAL_FLAG_IMPLEMENTATION
+#undef KRATOS_REGISTER_IN_PYTHON_LOCAL_FLAG_IMPLEMENTATION
+#endif
+#define KRATOS_REGISTER_IN_PYTHON_LOCAL_FLAG_IMPLEMENTATION(module,class_name,flag) \
+    module.attr(#flag) = &class_name::flag;
+
+#ifdef KRATOS_REGISTER_IN_PYTHON_LOCAL_FLAG
+#undef KRATOS_REGISTER_IN_PYTHON_LOCAL_FLAG
+#endif
+#define KRATOS_REGISTER_IN_PYTHON_LOCAL_FLAG(module,class_name,flag) \
+    KRATOS_REGISTER_IN_PYTHON_LOCAL_FLAG_IMPLEMENTATION(module,class_name,flag) \
+    KRATOS_REGISTER_IN_PYTHON_LOCAL_FLAG_IMPLEMENTATION(module,class_name,NOT_##flag)
+
 // This function is used to print the ofstream-operator
 // i.e. printing an object will give the same result in Python as in C++
 // To be defined as the "__str__" function


### PR DESCRIPTION
At the moment, it is possible to create and define local flags in applications.
Could be interesting to register that local flags in Kratos and Python.
What do you think @KratosMultiphysics/technical-committee?