### PR TITLE
[MetisApp][GlobalPointer] missing include

### DIFF
--- a/applications/MetisApplication/custom_processes/metis_scalar_reorder_process.h
+++ b/applications/MetisApplication/custom_processes/metis_scalar_reorder_process.h
@@ -18,6 +18,7 @@
 
 // Project includes
 #include "includes/model_part.h"
+#include "includes/global_pointer_variables.h"
 
 extern "C"
 {


### PR DESCRIPTION
currently broken, is only compiled when using METIS < 5