### PR TITLE
Cps/ Switching to raw pointers in conditions

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.cpp
@@ -298,7 +298,7 @@ void PotentialWallCondition<TDim, TNumNodes>::FindParentElement(
         if (std::includes(ElementNodeIds.begin(), ElementNodeIds.end(),
                           NodeIds.begin(), NodeIds.end()))
         {
-            mpElement = &*ElementCandidates(i);
+            mpElement = ElementCandidates(i).get();
             return;
         }
     }

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.cpp
@@ -66,7 +66,7 @@ void PotentialWallCondition<TDim, TNumNodes>::Initialize()
     GetSortedIds(NodeIds, rGeom);
     FindParentElement(NodeIds, ElementNodeIds, ElementCandidates);
 
-    KRATOS_ERROR_IF(mpElement.get() == nullptr)
+    KRATOS_ERROR_IF_NOT(mpElement)
         << "error in condition # " << this->Id() << "\n"
         << "Condition cannot find parent element" << std::endl;
     KRATOS_CATCH("");
@@ -254,9 +254,9 @@ void PotentialWallCondition<TDim, TNumNodes>::load(Serializer& rSerializer)
 // private operators
 
 template <unsigned int TDim, unsigned int TNumNodes>
-inline GlobalPointer<Element> PotentialWallCondition<TDim, TNumNodes>::pGetElement() const
+inline Element* PotentialWallCondition<TDim, TNumNodes>::pGetElement() const
 {
-    KRATOS_ERROR_IF(mpElement.get() == nullptr)
+    KRATOS_ERROR_IF_NOT(mpElement)
         << "No element found for condition #" << this->Id() << std::endl;
     return mpElement;
 }
@@ -298,7 +298,7 @@ void PotentialWallCondition<TDim, TNumNodes>::FindParentElement(
         if (std::includes(ElementNodeIds.begin(), ElementNodeIds.end(),
                           NodeIds.begin(), NodeIds.end()))
         {
-            mpElement = ElementCandidates(i);
+            mpElement = &*ElementCandidates(i);
             return;
         }
     }

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
@@ -273,7 +273,7 @@ private:
 
     bool mInitializeWasPerformed = false;
 
-    GlobalPointer<Element> mpElement;
+    Element* mpElement;
 
     void CalculateNormal2D(array_1d<double, 3>& An) const;
 
@@ -293,7 +293,7 @@ private:
     ///@name Private Operators
     ///@{
 
-    inline GlobalPointer<Element> pGetElement() const;
+    inline Element* pGetElement() const;
 
     void GetElementCandidates(GlobalPointersVector<Element>& ElementCandidates,
                               const GeometryType& rGeom) const;


### PR DESCRIPTION
Hi,

This is a follow up from #4860.

Not sure if this is the correct way to do so. mpElement and pGetElement() are now Element* pointers. However, I didn't manage to also use raw_pointers when dealing with NEIGHBOUR_ELEMENTS, since these seem to be a GlobalPointersVector. Is it possible to use raw_pointers with the NEIGHBOUR_ELEMENTS?

To put into context what's going on in the condition, we try to link which element is the one next to each condition (to later retrieve the element PRESSURE), and we store its pointer in mpElement. In order to find it, we make use of the NEIGHBOUR_ELEMENTS. 

The current implementation compiles and tests pass.
