### PR TITLE
Updating build policy

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
   - build
     
+# Master branch build
 build linux_master:
     stage: build
     tags:
@@ -12,6 +13,7 @@ build linux_master:
         - cp scripts/build/gitlab/build_and_test_master.sh build.sh
         - bash build.sh
   
+# Build only PR / MR
 build linux_branch:
     stage: build
     tags:
@@ -19,6 +21,8 @@ build linux_branch:
     except: 
         refs:
             - master
+    only:
+        - merge_requests
     script:
         - cp scripts/build/gitlab/build_and_test_branch.sh build.sh
         - bash build.sh


### PR DESCRIPTION
That should prevent building sparse builds from branch commits that are not tied to a PR