### PR TITLE
[ContactStructuralMechanicsApplication] Refactor  of conv. criteria and active set utilities

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/CMakeLists.txt
+++ b/applications/ContactStructuralMechanicsApplication/CMakeLists.txt
@@ -19,6 +19,7 @@ set( KRATOS_CONTACT_STRUCTURAL_MECHANICS_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/derivatives_utilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/mortar_explicit_contribution_utilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/interface_preprocess.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/active_set_utilities.cpp
 
     ## PROCESSES
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/aalm_adapt_penalty_value_process.cpp

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/advanced_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/advanced_contact_search_process.cpp
@@ -431,7 +431,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CorrectALMF
     )
 {
     if (norm_2(ItNode->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) < ZeroTolerance) {
-        if (ItNode->GetValue(FRICTION_COEFFICIENT) < ZeroTolerance) {
+        if (ItNode->GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || BaseType::mOptions.Is(BaseType::PURE_SLIP)) {
             ItNode->Set(SLIP, true);
         } else {
             ItNode->Set(SLIP, false);
@@ -548,7 +548,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::PredictALMF
     )
 {
     if (norm_2(ItNode->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) < ZeroTolerance) {
-        if (ItNode->GetValue(FRICTION_COEFFICIENT) < ZeroTolerance) {
+        if (ItNode->GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || BaseType::mOptions.Is(BaseType::PURE_SLIP)) {
             ItNode->Set(SLIP, true);
         } else {
             ItNode->Set(SLIP, false);

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/advanced_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/advanced_contact_search_process.cpp
@@ -40,7 +40,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CheckPairin
 {
     // Getting the corresponding submodelparts
     ModelPart& r_contact_model_part = BaseType::mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !BaseType::mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = BaseType::mOptions.IsNot(BaseType::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
     ModelPart& r_master_model_part = r_sub_contact_model_part.GetSubModelPart("MasterSubModelPart" + BaseType::mThisParameters["id_name"].GetString());
     ModelPart& r_slave_model_part = r_sub_contact_model_part.GetSubModelPart("SlaveSubModelPart" + BaseType::mThisParameters["id_name"].GetString());
 
@@ -86,7 +86,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ComputeActi
 
     // Iterate over the nodes
     ModelPart& r_contact_model_part = BaseType::mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !BaseType::mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = BaseType::mOptions.IsNot(BaseType::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
     NodesArrayType& r_nodes_array = r_sub_contact_model_part.Nodes();
 
     // If we do an static check
@@ -99,7 +99,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ComputeActi
     #pragma omp parallel for firstprivate(auxiliar_length, auxiliar_check, has_weighted_gap)
     for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
         auto it_node = r_nodes_array.begin() + i;
-        if (it_node->Is(SLAVE) == !BaseType::mInvertedSearch) {
+        if (it_node->Is(SLAVE) == BaseType::mOptions.IsNot(BaseType::INVERTED_SEARCH)) {
             auxiliar_check = false;
             auxiliar_length = reference_auxiliar_length;
             has_weighted_gap = it_node->SolutionStepsDataHas(WEIGHTED_GAP);
@@ -177,7 +177,7 @@ void AdvancedContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ComputeLine
 
     // Iterate over the nodes
     ModelPart& r_contact_model_part = BaseType::mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !BaseType::mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = BaseType::mOptions.IsNot(BaseType::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + BaseType::mThisParameters["id_name"].GetString());
     NodesArrayType& r_nodes_array = r_sub_contact_model_part.Nodes();
 
     // We compute now the normal gap and set the nodes under certain threshold as active

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
@@ -1583,6 +1583,7 @@ Parameters BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::GetDefaul
         "id_name"                              : "",
         "consider_gap_threshold"               : false,
         "predict_correct_lagrange_multiplier"  : false,
+        "pure_slip"                            : false,
         "debug_mode"                           : false,
         "octree_search_parameters" : {
             "bounding_box_factor"    : 0.1,

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
@@ -27,6 +27,31 @@
 
 namespace Kratos
 {
+/// Local Flags
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+const Kratos::Flags BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::INVERTED_SEARCH(Kratos::Flags::Create(0));
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+const Kratos::Flags BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::NOT_INVERTED_SEARCH(Kratos::Flags::Create(0, false));
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+const Kratos::Flags BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CREATE_AUXILIAR_CONDITIONS(Kratos::Flags::Create(1));
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+const Kratos::Flags BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::NOT_CREATE_AUXILIAR_CONDITIONS(Kratos::Flags::Create(1, false));
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+const Kratos::Flags BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::MULTIPLE_SEARCHS(Kratos::Flags::Create(2));
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+const Kratos::Flags BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::NOT_MULTIPLE_SEARCHS(Kratos::Flags::Create(2, false));
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+const Kratos::Flags BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::PREDEFINE_MASTER_SLAVE(Kratos::Flags::Create(3));
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+const Kratos::Flags BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::NOT_PREDEFINE_MASTER_SLAVE(Kratos::Flags::Create(3, false));
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+const Kratos::Flags BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::PURE_SLIP(Kratos::Flags::Create(4));
+template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
+const Kratos::Flags BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::NOT_PURE_SLIP(Kratos::Flags::Create(4, false));
+
+/***********************************************************************************/
+/***********************************************************************************/
+
 template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
 BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::BaseContactSearchProcess(
     ModelPart & rMainModelPart,
@@ -41,17 +66,19 @@ BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::BaseContactSearchPro
     mThisParameters.ValidateAndAssignDefaults(default_parameters);
 
     mCheckGap = this->ConvertCheckGap(mThisParameters["check_gap"].GetString());
-    mInvertedSearch = mThisParameters["inverted_search"].GetBool();
-    mPredefinedMasterSlave = mThisParameters["predefined_master_slave"].GetBool();
+    mOptions.Set(BaseContactSearchProcess::INVERTED_SEARCH, mThisParameters["inverted_search"].GetBool());
+    mOptions.Set(BaseContactSearchProcess::PREDEFINE_MASTER_SLAVE, mThisParameters["predefined_master_slave"].GetBool());
+    mOptions.Set(BaseContactSearchProcess::PURE_SLIP, mThisParameters["pure_slip"].GetBool());
 
     // The search tree considered
     const SearchTreeType type_search = ConvertSearchTree(mThisParameters["type_search"].GetString());
-    if (!mPredefinedMasterSlave && type_search == SearchTreeType::OctreeWithOBB)
+    if (mOptions.IsNot(BaseContactSearchProcess::PREDEFINE_MASTER_SLAVE) && type_search == SearchTreeType::OctreeWithOBB)
         mThisParameters["type_search"].SetString("KdtreeInRadius");
 
     // If we are going to consider multple searchs
     const std::string& id_name = mThisParameters["id_name"].GetString();
-    mMultipleSearchs = id_name == "" ? false : true;
+    const bool multiple_searchs = id_name == "" ? false : true;
+    mOptions.Set(BaseContactSearchProcess::MULTIPLE_SEARCHS, multiple_searchs);
 
     // Check if the computing contact submodelpart
     const std::string sub_computing_model_part_name = "ComputingContactSub" + id_name;
@@ -60,20 +87,20 @@ BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::BaseContactSearchPro
         p_computing_model_part->CreateSubModelPart(sub_computing_model_part_name);
     } else {
         ModelPart& r_computing_contact_model_part = mrMainModelPart.GetSubModelPart("ComputingContact");
-        if (!(r_computing_contact_model_part.HasSubModelPart(sub_computing_model_part_name)) && mMultipleSearchs) {
+        if (!(r_computing_contact_model_part.HasSubModelPart(sub_computing_model_part_name)) && mOptions.Is(BaseContactSearchProcess::MULTIPLE_SEARCHS)) {
             r_computing_contact_model_part.CreateSubModelPart(sub_computing_model_part_name);
         } else { // We clean the existing modelpart
-            ModelPart& r_sub_computing_contact_model_part = !mMultipleSearchs ? r_computing_contact_model_part : r_computing_contact_model_part.GetSubModelPart(sub_computing_model_part_name);
+            ModelPart& r_sub_computing_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_computing_contact_model_part : r_computing_contact_model_part.GetSubModelPart(sub_computing_model_part_name);
             CleanModelPart(r_sub_computing_contact_model_part);
         }
     }
 
     // Updating the base condition
     mConditionName = mThisParameters["condition_name"].GetString();
-    if (mConditionName == "")
-        mCreateAuxiliarConditions = false;
-    else {
-        mCreateAuxiliarConditions = true;
+    if (mConditionName == "") {
+        mOptions.Set(BaseContactSearchProcess::CREATE_AUXILIAR_CONDITIONS, false);
+    } else {
+        mOptions.Set(BaseContactSearchProcess::CREATE_AUXILIAR_CONDITIONS, true);
         std::ostringstream condition_name;
         condition_name << mConditionName << "Condition" << TDim << "D" << TNumNodes << "N" << mThisParameters["final_string"].GetString();
         mConditionName = condition_name.str();
@@ -83,7 +110,7 @@ BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::BaseContactSearchPro
 
     // We get the contact model part
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + id_name);
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + id_name);
 
     // We set to zero the NORMAL_GAP
     if (mCheckGap == CheckGap::MappingCheck)
@@ -166,7 +193,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::InitializeMorta
 {
     // Iterate in the conditions
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
     ConditionsArrayType& r_conditions_array = r_sub_contact_model_part.Conditions();
     const auto it_cond_begin = r_conditions_array.begin();
     const int num_conditions = static_cast<int>(r_conditions_array.size());
@@ -224,10 +251,10 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::SetOriginDestin
         for(int i=0; i<static_cast<int>(rModelPart.Nodes().size()); ++i) {
             auto it_node = it_node_begin + i;
 
-            if (it_node->Is(SLAVE) == !mInvertedSearch) {
+            if (it_node->Is(SLAVE) == !mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH)) {
                 slave_nodes_ids_buffer.push_back(it_node->Id());
             }
-            if (it_node->Is(MASTER) == !mInvertedSearch) {
+            if (it_node->Is(MASTER) == !mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH)) {
                 master_nodes_ids_buffer.push_back(it_node->Id());
             }
         }
@@ -236,10 +263,10 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::SetOriginDestin
         for(int i=0; i<static_cast<int>(rModelPart.Conditions().size()); ++i) {
             auto it_cond = it_cond_begin + i;
 
-            if (it_cond->Is(SLAVE) == !mInvertedSearch) {
+            if (it_cond->Is(SLAVE) == !mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH)) {
                 slave_conditions_ids_buffer.push_back(it_cond->Id());
             }
-            if (it_cond->Is(MASTER) == !mInvertedSearch) {
+            if (it_cond->Is(MASTER) == !mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH)) {
                 master_conditions_ids_buffer.push_back(it_cond->Id());
             }
         }
@@ -273,7 +300,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ClearMortarCond
     ResetContactOperators();
 
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
     NodesArrayType& r_nodes_array = r_sub_contact_model_part.Nodes();
 
     switch(mTypeSolution) {
@@ -301,7 +328,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CheckContactMod
 {
     // Iterate in the conditions
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
     ConditionsArrayType& r_conditions_array = r_sub_contact_model_part.Conditions();
 
     const SizeType total_number_conditions = mrMainModelPart.GetRootModelPart().NumberOfConditions();
@@ -359,13 +386,13 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CreatePointList
 
         // Iterate in the conditions
         ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-        ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+        ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
         ConditionsArrayType& r_conditions_array = r_sub_contact_model_part.Conditions();
         const auto it_cond_begin = r_conditions_array.begin();
 
         for(IndexType i = 0; i < r_conditions_array.size(); ++i) {
             auto it_cond = it_cond_begin + i;
-            if (it_cond->Is(MASTER) == !mInvertedSearch || !mPredefinedMasterSlave) {
+            if (it_cond->Is(MASTER) == !mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH) || mOptions.IsNot(BaseContactSearchProcess::PREDEFINE_MASTER_SLAVE)) {
                 mPointListDestination.push_back(Kratos::make_shared<PointType>((*it_cond.base())));
             }
         }
@@ -395,7 +422,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::UpdatePointList
 
         // The contact model parts
         ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-        ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+        ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
 
         // We compute the delta displacement
         if (dynamic) {
@@ -430,7 +457,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::UpdateMortarCon
 
     // The contact model parts
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
 
     // Calculate the mean of the normal in all the nodes
     MortarUtilities::ComputeNodesMeanNormalModelPart(r_sub_contact_model_part);
@@ -439,14 +466,14 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::UpdateMortarCon
     IndexType condition_id = GetMaximumConditionsIds();
     const std::string sub_computing_model_part_name = "ComputingContactSub" + mThisParameters["id_name"].GetString();
     ModelPart& r_computing_contact_model_part = mrMainModelPart.GetSubModelPart("ComputingContact");
-    ModelPart& r_sub_computing_contact_model_part = !mMultipleSearchs ? r_computing_contact_model_part : r_computing_contact_model_part.GetSubModelPart(sub_computing_model_part_name);
+    ModelPart& r_sub_computing_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_computing_contact_model_part : r_computing_contact_model_part.GetSubModelPart(sub_computing_model_part_name);
 
     // We reset the computing contact model part in case of already initialized
     if (r_sub_computing_contact_model_part.Conditions().size() > 0)
         ClearMortarConditions();
 
     // In case of not predefined master/slave we reset the flags
-    if (!mPredefinedMasterSlave) {
+    if (mOptions.IsNot(BaseContactSearchProcess::PREDEFINE_MASTER_SLAVE)) {
         NodesArrayType& r_nodes_array = r_sub_contact_model_part.Nodes();
         ConditionsArrayType& r_conditions_array = r_sub_contact_model_part.Conditions();
         VariableUtils().SetFlag(SLAVE, false, r_nodes_array);
@@ -470,7 +497,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::UpdateMortarCon
     }
 
     // In case of not predefined master/slave we assign the master/slave nodes and conditions
-    if (!mPredefinedMasterSlave)
+    if (mOptions.IsNot(BaseContactSearchProcess::PREDEFINE_MASTER_SLAVE))
         NotPredefinedMasterSlave(r_sub_contact_model_part);
 
     // We create the submodelparts for master and slave
@@ -541,7 +568,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::SearchUsingKDTr
     for(int i = 0; i < num_conditions; ++i) {
         auto it_cond = it_cond_begin + i;
 
-        if (!mPredefinedMasterSlave || it_cond->Is(SLAVE) == !mInvertedSearch) {
+        if (mOptions.IsNot(BaseContactSearchProcess::PREDEFINE_MASTER_SLAVE) || it_cond->Is(SLAVE) == !mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH)) {
             // Initialize values
             PointVector points_found(allocation_size);
 
@@ -610,7 +637,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::SearchUsingKDTr
                             }
                         }
 
-                        const CheckResult condition_checked_right = CheckCondition(p_indexes_pairs, (*it_cond.base()), p_cond_master, mInvertedSearch);
+                        const CheckResult condition_checked_right = CheckCondition(p_indexes_pairs, (*it_cond.base()), p_cond_master, mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH));
 
                         if (condition_checked_right == CheckResult::OK)
                             p_indexes_pairs->AddId(p_cond_master->Id());
@@ -653,12 +680,12 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::SearchUsingOcTr
     ModelPart& rSubComputingContactModelPart
     )
 {
-    KRATOS_ERROR_IF(mInvertedSearch) << "Octree only works with not inverted master/slave model parts (for now)" << std::endl;
-    KRATOS_ERROR_IF_NOT(mPredefinedMasterSlave) << "Octree only works with predefined master/slave model part (for now)" << std::endl;
+    KRATOS_ERROR_IF(mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH)) << "Octree only works with not inverted master/slave model parts (for now)" << std::endl;
+    KRATOS_ERROR_IF_NOT(mOptions.Is(BaseContactSearchProcess::PREDEFINE_MASTER_SLAVE)) << "Octree only works with predefined master/slave model part (for now)" << std::endl;
 
     // Getting model
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
     const std::string master_model_part_name = "MasterSubModelPart" + mThisParameters["id_name"].GetString();
     ModelPart& r_master_model_part = r_sub_contact_model_part.GetSubModelPart(master_model_part_name);
     const std::string slave_model_part_name = "SlaveSubModelPart" + mThisParameters["id_name"].GetString();
@@ -705,7 +732,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::SearchUsingOcTr
                 for (auto p_leaf : leaves) {
                     for (auto p_cond_master : *(p_leaf->pGetObjects())) {
                         if (p_cond_master->Is(SELECTED)) {
-                            const CheckResult condition_checked_right = CheckGeometricalObject(p_indexes_pairs, (*it_cond.base()), p_cond_master, mInvertedSearch);
+                            const CheckResult condition_checked_right = CheckGeometricalObject(p_indexes_pairs, (*it_cond.base()), p_cond_master, mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH));
 
                             if (condition_checked_right == CheckResult::OK)
                                 p_indexes_pairs->AddId(p_cond_master->Id());
@@ -751,7 +778,7 @@ bool BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::AddPairing(
 {
     pIndexesPairs->AddId(pCondMaster->Id());
 
-    if (mCreateAuxiliarConditions) { // We add the ID and we create a new auxiliar condition
+    if (mOptions.Is(BaseContactSearchProcess::CREATE_AUXILIAR_CONDITIONS)) { // We add the ID and we create a new auxiliar condition
         ++rConditionId;
         Condition::Pointer p_auxiliar_condition = rComputingModelPart.CreateNewCondition(mConditionName, rConditionId, pCondSlave->GetGeometry(), pProperties);
         // We set the geometrical values
@@ -776,7 +803,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CheckMortarCond
 {
     // Iterate in the conditions
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
     ConditionsArrayType& r_conditions_array = r_sub_contact_model_part.Conditions();
 
     for(int i = 0; i < static_cast<int>(r_conditions_array.size()); ++i) {
@@ -808,7 +835,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CheckMortarCond
 template<SizeType TDim, SizeType TNumNodes, SizeType TNumNodesMaster>
 void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::InvertSearch()
 {
-    mInvertedSearch = !mInvertedSearch;
+    mOptions.Flip(BaseContactSearchProcess::INVERTED_SEARCH);
 }
 
 /***********************************************************************************/
@@ -878,7 +905,7 @@ inline typename BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::Chec
         return CheckResult::Fail;
 
     // Otherwise will not be necessary to check
-    if (!mPredefinedMasterSlave || pCond2->Is(SLAVE) == !InvertedSearch) {
+    if (mOptions.IsNot(BaseContactSearchProcess::PREDEFINE_MASTER_SLAVE) || pCond2->Is(SLAVE) == !InvertedSearch) {
         auto p_indexes_pairs_2 = pCond2->GetValue(INDEX_MAP);
         if (p_indexes_pairs_2->find(pCond1->Id()) != p_indexes_pairs_2->end())
             return CheckResult::Fail;
@@ -1124,13 +1151,13 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CheckPairing(
 {
     // Getting the corresponding submodelparts
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub" + mThisParameters["id_name"].GetString());
 
     // We set the gap to an enormous value in order to initialize it
     VariableUtils().SetNonHistoricalVariable(NORMAL_GAP, 1.0e12, r_sub_contact_model_part.Nodes());
 
     // We compute the gap in the slave
-    ComputeMappedGap(!mInvertedSearch);
+    ComputeMappedGap(!mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH));
 
     // We revert the nodes to the original position
     NodesArrayType& r_nodes_array = r_sub_contact_model_part.Nodes();
@@ -1169,7 +1196,7 @@ inline void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ComputeM
 
     // Iterate over the nodes
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
     ModelPart& r_master_model_part = r_sub_contact_model_part.GetSubModelPart("MasterSubModelPart"+mThisParameters["id_name"].GetString());
     NodesArrayType& r_nodes_array_master = r_master_model_part.Nodes();
     const auto it_node_begin_master = r_nodes_array_master.begin();
@@ -1256,14 +1283,14 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ComputeActiveIn
 
     // Iterate over the nodes
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
     NodesArrayType& r_nodes_array = r_sub_contact_model_part.Nodes();
 
     // We compute now the normal gap and set the nodes under certain threshold as active
     #pragma omp parallel for
     for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
         auto it_node = r_nodes_array.begin() + i;
-        if (it_node->Is(SLAVE) == !mInvertedSearch) {
+        if (it_node->Is(SLAVE) == !mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH)) {
 //             if (it_node->GetValue(NORMAL_GAP) < ZeroTolerance) {
             if (it_node->GetValue(NORMAL_GAP) < GapThreshold * it_node->FastGetSolutionStepValue(NODAL_H)) {
                 SetActiveNode(it_node, common_epsilon, scale_factor);
@@ -1347,7 +1374,7 @@ inline void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ComputeW
 
     // Auxiliar gap
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
     NodesArrayType& r_nodes_array = r_sub_contact_model_part.Nodes();
     switch(mTypeSolution) {
         case TypeSolution::VectorLagrangeMultiplier :
@@ -1377,7 +1404,7 @@ inline void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ComputeW
     // Compute explicit contibution of the conditions
     const std::string sub_computing_model_part_name = "ComputingContactSub" + mThisParameters["id_name"].GetString();
     ModelPart& r_computing_contact_model_part = mrMainModelPart.GetSubModelPart("ComputingContact");
-    ModelPart& r_sub_computing_contact_model_part = !mMultipleSearchs ? r_computing_contact_model_part : r_computing_contact_model_part.GetSubModelPart(sub_computing_model_part_name);
+    ModelPart& r_sub_computing_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_computing_contact_model_part : r_computing_contact_model_part.GetSubModelPart(sub_computing_model_part_name);
     ContactUtilities::ComputeExplicitContributionConditions(r_sub_computing_contact_model_part);
 }
 
@@ -1413,7 +1440,7 @@ inline void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::CreateAu
     // Actually creating the new conditions
     for(IndexType i = 0; i < r_conditions_array.size(); ++i) {
         auto it_cond = r_conditions_array.begin() + i;
-        if (it_cond->Is(SLAVE) == !mInvertedSearch) {
+        if (it_cond->Is(SLAVE) == !mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH)) {
             IndexMap::Pointer p_indexes_pairs = it_cond->GetValue(INDEX_MAP);
             for (auto it_pair = p_indexes_pairs->begin(); it_pair != p_indexes_pairs->end(); ++it_pair ) {
                 if (it_pair->second == 0) { // If different than 0 it is an existing condition
@@ -1468,7 +1495,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ResetContactOpe
 {
     // We iterate over the conditions
     ModelPart& r_contact_model_part = mrMainModelPart.GetSubModelPart("Contact");
-    ModelPart& r_sub_contact_model_part = !mMultipleSearchs ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
+    ModelPart& r_sub_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_contact_model_part : r_contact_model_part.GetSubModelPart("ContactSub"+mThisParameters["id_name"].GetString());
     ConditionsArrayType& r_conditions_array = r_sub_contact_model_part.Conditions();
     const auto it_cond_begin = r_conditions_array.begin();
 
@@ -1477,7 +1504,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ResetContactOpe
         #pragma omp parallel for
         for(int i = 0; i < static_cast<int>(r_conditions_array.size()); ++i) {
             auto it_cond = it_cond_begin + i;
-            if (it_cond->Is(SLAVE) == !mInvertedSearch) {
+            if (it_cond->Is(SLAVE) == !mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH)) {
                 IndexMap::Pointer p_indexes_pairs = it_cond->GetValue(INDEX_MAP);
 
                 if (p_indexes_pairs != nullptr) {
@@ -1490,14 +1517,14 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::ResetContactOpe
         // We remove all the computing conditions conditions
         const std::string sub_computing_model_part_name = "ComputingContactSub" + mThisParameters["id_name"].GetString();
         ModelPart& r_computing_contact_model_part = mrMainModelPart.GetSubModelPart("ComputingContact");
-        ModelPart& r_sub_computing_contact_model_part = !mMultipleSearchs ? r_computing_contact_model_part : r_computing_contact_model_part.GetSubModelPart(sub_computing_model_part_name);
+        ModelPart& r_sub_computing_contact_model_part = mOptions.IsNot(BaseContactSearchProcess::MULTIPLE_SEARCHS) ? r_computing_contact_model_part : r_computing_contact_model_part.GetSubModelPart(sub_computing_model_part_name);
         ConditionsArrayType& r_computing_conditions_array = r_sub_computing_contact_model_part.Conditions();
         VariableUtils().SetFlag(TO_ERASE, true, r_computing_conditions_array);
     } else {
         // We iterate, but not in OMP
         for(IndexType i = 0; i < r_conditions_array.size(); ++i) {
             auto it_cond = r_conditions_array.begin() + i;
-            if (it_cond->Is(SLAVE) == !mInvertedSearch) {
+            if (it_cond->Is(SLAVE) == !mOptions.Is(BaseContactSearchProcess::INVERTED_SEARCH)) {
                 IndexMap::Pointer p_indexes_pairs = it_cond->GetValue(INDEX_MAP);
                 if (p_indexes_pairs != nullptr) {
                     // The vector with the ids to remove

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
@@ -1059,7 +1059,7 @@ inline void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::AddPoten
                     if (mTypeSolution == TypeSolution::VectorLagrangeMultiplier && FrictionalProblem) {
                         NodeType& r_node = r_slave_geometry[i_node];
                         if (norm_2(r_node.FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) < ZeroTolerance) {
-                            if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance) {
+                            if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || mOptions.Is(BaseContactSearchProcess::PURE_SLIP)) {
                                 r_node.Set(SLIP, true);
                             } else {
                                 r_node.Set(SLIP, false);
@@ -1067,7 +1067,7 @@ inline void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::AddPoten
                         }
                     }  else if (mTypeSolution == TypeSolution::FrictionlessPenaltyMethod) {
                         NodeType& r_node = r_slave_geometry[i_node];
-                        if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance) {
+                        if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || mOptions.Is(BaseContactSearchProcess::PURE_SLIP)) {
                             r_node.Set(SLIP, true);
                         } else {
                             r_node.Set(SLIP, false);
@@ -1082,7 +1082,7 @@ inline void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::AddPoten
                     if (mTypeSolution == TypeSolution::VectorLagrangeMultiplier && FrictionalProblem) {
                         NodeType& r_node = r_slave_geometry[i_node];
                         if (norm_2(r_node.FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) < ZeroTolerance) {
-                            if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance) {
+                            if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || mOptions.Is(BaseContactSearchProcess::PURE_SLIP)) {
                                 r_node.Set(SLIP, true);
                             } else {
                                 r_node.Set(SLIP, false);
@@ -1090,7 +1090,7 @@ inline void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::AddPoten
                         }
                     } else if (mTypeSolution == TypeSolution::FrictionlessPenaltyMethod) {
                         NodeType& r_node = r_slave_geometry[i_node];
-                        if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance) {
+                        if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || mOptions.Is(BaseContactSearchProcess::PURE_SLIP)) {
                             r_node.Set(SLIP, true);
                         } else {
                             r_node.Set(SLIP, false);
@@ -1107,7 +1107,7 @@ inline void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::AddPoten
             if (mTypeSolution == TypeSolution::VectorLagrangeMultiplier && FrictionalProblem) {
                 NodeType& r_node = r_slave_geometry[i_node];
                 if (norm_2(r_node.FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) < ZeroTolerance) {
-                    if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance) {
+                    if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || mOptions.Is(BaseContactSearchProcess::PURE_SLIP)) {
                         r_node.Set(SLIP, true);
                     } else {
                         r_node.Set(SLIP, false);
@@ -1115,7 +1115,7 @@ inline void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::AddPoten
                 }
             } else if (mTypeSolution == TypeSolution::FrictionlessPenaltyMethod) {
                 NodeType& r_node = r_slave_geometry[i_node];
-                if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance) {
+                if (r_node.GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || mOptions.Is(BaseContactSearchProcess::PURE_SLIP)) {
                     r_node.Set(SLIP, true);
                 } else {
                     r_node.Set(SLIP, false);
@@ -1320,7 +1320,7 @@ void BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::SetActiveNode(
 
     // Set SLIP flag
     if (mrMainModelPart.Is(SLIP)) {
-        if (ItNode->GetValue(FRICTION_COEFFICIENT) < ZeroTolerance) {
+        if (ItNode->GetValue(FRICTION_COEFFICIENT) < ZeroTolerance || mOptions.Is(BaseContactSearchProcess::PURE_SLIP)) {
             ItNode->Set(SLIP, true);
         } else {
             ItNode->Set(SLIP, false);

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
@@ -105,6 +105,13 @@ public:
     /// Pointer definition of BaseContactSearchProcess
     KRATOS_CLASS_POINTER_DEFINITION( BaseContactSearchProcess );
 
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( INVERTED_SEARCH );
+    KRATOS_DEFINE_LOCAL_FLAG( CREATE_AUXILIAR_CONDITIONS );
+    KRATOS_DEFINE_LOCAL_FLAG( MULTIPLE_SEARCHS );
+    KRATOS_DEFINE_LOCAL_FLAG( PREDEFINE_MASTER_SLAVE );
+    KRATOS_DEFINE_LOCAL_FLAG( PURE_SLIP );
+
     ///@}
     ///@name  Enum's
     ///@{
@@ -272,10 +279,7 @@ protected:
     std::string mConditionName;        /// The name of the condition to be created
     PointVector mPointListDestination; /// A list that contents the all the points (from nodes) from the modelpart
 
-    bool mInvertedSearch;              /// The search will be done inverting the way master and slave/master is assigned
-    bool mCreateAuxiliarConditions;    /// If the auxiliar conditions are created or not
-    bool mMultipleSearchs;             /// If we consider multiple serach or not
-    bool mPredefinedMasterSlave;       /// If the master/slave sides are predefined
+    Flags mOptions;                    /// Local flags
 
     ///@}
     ///@name Protected Operators

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.h
@@ -269,10 +269,11 @@ protected:
     Parameters mThisParameters;        /// The configuration parameters
     CheckGap mCheckGap;                /// If the gap is checked during the search
     TypeSolution mTypeSolution;        /// The solution type
-    bool mInvertedSearch;              /// The search will be done inverting the way master and slave/master is assigned
     std::string mConditionName;        /// The name of the condition to be created
-    bool mCreateAuxiliarConditions;    /// If the auxiliar conditions are created or not
     PointVector mPointListDestination; /// A list that contents the all the points (from nodes) from the modelpart
+
+    bool mInvertedSearch;              /// The search will be done inverting the way master and slave/master is assigned
+    bool mCreateAuxiliarConditions;    /// If the auxiliar conditions are created or not
     bool mMultipleSearchs;             /// If we consider multiple serach or not
     bool mPredefinedMasterSlave;       /// If the master/slave sides are predefined
 

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_search_wrapper_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_search_wrapper_process.cpp
@@ -115,6 +115,7 @@ Parameters ContactSearchWrapperProcess::GetDefaultParameters()
         "id_name"                              : "",
         "consider_gap_threshold"               : false,
         "predict_correct_lagrange_multiplier"  : false,
+        "pure_slip"                            : false,
         "debug_mode"                           : false,
         "octree_search_parameters" : {
             "bounding_box_factor"             : 0.1,

--- a/applications/ContactStructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -208,6 +208,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
         .def(py::init<bool>())
         .def(py::init<bool, bool>())
         .def(py::init<bool, bool, bool>())
+        .def(py::init<bool, bool, bool, bool>())
         ;
 
     // Dual set strategy for SSNM Convergence Criterion (frictional penalty case)
@@ -218,6 +219,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
         .def(py::init<bool>())
         .def(py::init<bool, bool>())
         .def(py::init<bool, bool, bool>())
+        .def(py::init<bool, bool, bool, bool>())
         ;
 
     // Displacement and lagrange multiplier Convergence Criterion

--- a/applications/ContactStructuralMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -67,11 +67,8 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
     ;
 
     // Active set utilities
-    py::class_<ActiveSetUtilities, typename ActiveSetUtilities::Pointer>(m, "ActiveSetUtilities")
-    .def(py::init<>())
-    .def("ComputePenaltyFrictionlessActiveSet",&ActiveSetUtilities::ComputePenaltyFrictionlessActiveSet)
-    .def("ComputePenaltyFrictionalActiveSet",&ActiveSetUtilities::ComputePenaltyFrictionalActiveSet)
-    ;
+    m.def("ComputePenaltyFrictionlessActiveSet",&ActiveSetUtilities::ComputePenaltyFrictionlessActiveSet);
+    m.def("ComputePenaltyFrictionalActiveSet",&ActiveSetUtilities::ComputePenaltyFrictionalActiveSet);
 
     // Interface preprocess
     py::class_<InterfacePreprocessCondition, typename InterfacePreprocessCondition::Pointer>(m, "InterfacePreprocessCondition")

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictional_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictional_mortar_criteria.h
@@ -66,6 +66,7 @@ public:
     /// Local Flags
     KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
     KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
+    KRATOS_DEFINE_LOCAL_FLAG( PURE_SLIP );
 
     /// The base convergence criteria class definition
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > ConvergenceCriteriaBaseType;
@@ -165,7 +166,7 @@ public:
         BaseType::PostCriteria(rModelPart, rDofSet, rA, rDx, rb);
 
         // Compute the active set
-        const array_1d<std::size_t, 2> is_converged = ActiveSetUtilities::ComputeALMFrictionalActiveSet(rModelPart);
+        const array_1d<std::size_t, 2> is_converged = ActiveSetUtilities::ComputeALMFrictionalActiveSet(rModelPart, BaseType::mOptions.Is(ALMFrictionalMortarConvergenceCriteria::PURE_SLIP));
 
         // We save to the process info if the active set has converged
         const bool active_set_converged = (is_converged[0] + is_converged[1]) == 0 ? true : false;
@@ -353,6 +354,10 @@ template<class TSparseSpace, class TDenseSpace>
 const Kratos::Flags ALMFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(3));
 template<class TSparseSpace, class TDenseSpace>
 const Kratos::Flags ALMFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(3, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags ALMFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::PURE_SLIP(Kratos::Flags::Create(4));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags ALMFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_PURE_SLIP(Kratos::Flags::Create(4, false));
 
 }  // namespace Kratos
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictional_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictional_mortar_criteria.h
@@ -100,14 +100,16 @@ public:
 
     /// Default constructors
     explicit ALMFrictionalMortarConvergenceCriteria(
+        const bool PureSlip = false,
         const bool PrintingOutput = false,
         const bool ComputeDynamicFactor = false,
-        const bool GiDIODebug = false
-        ) : BaseType(ComputeDynamicFactor, GiDIODebug)
+        const bool IODebug = false
+        ) : BaseType(ComputeDynamicFactor, IODebug)
     {
         // Set local flags
         BaseType::mOptions.Set(ALMFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT, PrintingOutput);
         BaseType::mOptions.Set(ALMFrictionalMortarConvergenceCriteria::TABLE_IS_INITIALIZED, false);
+        BaseType::mOptions.Set(ALMFrictionalMortarConvergenceCriteria::PURE_SLIP, PureSlip);
     }
 
     ///Copy constructor

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictional_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictional_mortar_criteria.h
@@ -54,7 +54,7 @@ namespace Kratos
  */
 template<class TSparseSpace, class TDenseSpace>
 class ALMFrictionalMortarConvergenceCriteria
-    : public  BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >
+    : public BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions
@@ -62,6 +62,10 @@ public:
 
     /// Pointer definition of ALMFrictionalMortarConvergenceCriteria
     KRATOS_CLASS_POINTER_DEFINITION( ALMFrictionalMortarConvergenceCriteria );
+
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
+    KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
 
     /// The base convergence criteria class definition
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > ConvergenceCriteriaBaseType;
@@ -80,7 +84,7 @@ public:
     typedef ModelPart::NodesContainerType                                 NodesArrayType;
     typedef ModelPart::ConditionsContainerType                       ConditionsArrayType;
 
-    /// The table stream definition TODO: Replace by logger
+    /// The r_table stream definition TODO: Replace by logger
     typedef TableStreamUtility::Pointer                          TablePrinterPointerType;
 
     /// The index type definition
@@ -98,17 +102,16 @@ public:
         const bool PrintingOutput = false,
         const bool ComputeDynamicFactor = false,
         const bool GiDIODebug = false
-        ) : BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >(ComputeDynamicFactor, GiDIODebug),
-        mPrintingOutput(PrintingOutput),
-        mTableIsInitialized(false)
+        ) : BaseType(ComputeDynamicFactor, GiDIODebug)
     {
+        // Set local flags
+        BaseType::mOptions.Set(ALMFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT, PrintingOutput);
+        BaseType::mOptions.Set(ALMFrictionalMortarConvergenceCriteria::TABLE_IS_INITIALIZED, false);
     }
 
     ///Copy constructor
     ALMFrictionalMortarConvergenceCriteria( ALMFrictionalMortarConvergenceCriteria const& rOther )
       :BaseType(rOther)
-      ,mPrintingOutput(rOther.mPrintingOutput)
-      ,mTableIsInitialized(rOther.mTableIsInitialized)
     {
     }
 
@@ -172,49 +175,49 @@ public:
         if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
             if (r_process_info.Has(TABLE_UTILITY)) {
                 TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                auto& table = p_table->GetTable();
+                auto& r_table = p_table->GetTable();
                 if (is_converged[0] == 0) {
-                    if (!mPrintingOutput)
-                        table << BOLDFONT(FGRN("       Achieved"));
+                    if (BaseType::mOptions.IsNot(ALMFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FGRN("       Achieved"));
                     else
-                        table << "Achieved";
+                        r_table << "Achieved";
                 } else {
-                    if (!mPrintingOutput)
-                        table << BOLDFONT(FRED("   Not achieved"));
+                    if (BaseType::mOptions.IsNot(ALMFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FRED("   Not achieved"));
                     else
-                        table << "Not achieved";
+                        r_table << "Not achieved";
                 }
                 if (is_converged[1] == 0) {
-                    if (!mPrintingOutput)
-                        table << BOLDFONT(FGRN("       Achieved"));
+                    if (BaseType::mOptions.IsNot(ALMFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FGRN("       Achieved"));
                     else
-                        table << "Achieved";
+                        r_table << "Achieved";
                 } else {
-                    if (!mPrintingOutput)
-                        table << BOLDFONT(FRED("   Not achieved"));
+                    if (BaseType::mOptions.IsNot(ALMFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FRED("   Not achieved"));
                     else
-                        table << "Not achieved";
+                        r_table << "Not achieved";
                 }
             } else {
                 if (is_converged[0] == 0) {
-                    if (!mPrintingOutput)
+                    if (BaseType::mOptions.IsNot(ALMFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("ALMFrictionalMortarConvergenceCriteria") << BOLDFONT("\tActive set") << " convergence is " << BOLDFONT(FGRN("achieved")) << std::endl;
                     else
                         KRATOS_INFO("ALMFrictionalMortarConvergenceCriteria") << "\tActive set convergence is achieved" << std::endl;
                 } else {
-                    if (!mPrintingOutput)
+                    if (BaseType::mOptions.IsNot(ALMFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("ALMFrictionalMortarConvergenceCriteria") << BOLDFONT("\tActive set") << " convergence is " << BOLDFONT(FRED("not achieved")) << std::endl;
                     else
                         KRATOS_INFO("ALMFrictionalMortarConvergenceCriteria") << "\tActive set convergence is not achieved" << std::endl;
                 }
 
                 if (is_converged[1] == 0) {
-                    if (!mPrintingOutput)
+                    if (BaseType::mOptions.IsNot(ALMFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("ALMFrictionalMortarConvergenceCriteria") << BOLDFONT("\tSlip/stick set") << " convergence is " << BOLDFONT(FGRN("achieved")) << std::endl;
                     else
                         KRATOS_INFO("ALMFrictionalMortarConvergenceCriteria") << "\tSlip/stick set convergence is achieved" << std::endl;
                 } else {
-                    if (!mPrintingOutput)
+                    if (BaseType::mOptions.IsNot(ALMFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("ALMFrictionalMortarConvergenceCriteria") << BOLDFONT("\tSlip/stick set") << " convergence is " << BOLDFONT(FRED("not achieved")) << std::endl;
                     else
                         KRATOS_INFO("ALMFrictionalMortarConvergenceCriteria") << "\tSlip/stick set  convergence is not achieved" << std::endl;
@@ -234,12 +237,12 @@ public:
         ConvergenceCriteriaBaseType::mConvergenceCriteriaIsInitialized = true;
 
         ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-        if (r_process_info.Has(TABLE_UTILITY) && mTableIsInitialized == false) {
+        if (r_process_info.Has(TABLE_UTILITY) && BaseType::mOptions.IsNot(ALMFrictionalMortarConvergenceCriteria::TABLE_IS_INITIALIZED)) {
             TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-            auto& table = p_table->GetTable();
-            table.AddColumn("ACTIVE SET CONV", 15);
-            table.AddColumn("SLIP/STICK CONV", 15);
-            mTableIsInitialized = true;
+            auto& r_table = p_table->GetTable();
+            r_table.AddColumn("ACTIVE SET CONV", 15);
+            r_table.AddColumn("SLIP/STICK CONV", 15);
+            BaseType::mOptions.Set(ALMFrictionalMortarConvergenceCriteria::TABLE_IS_INITIALIZED, true);
         }
     }
 
@@ -283,7 +286,7 @@ protected:
     void ResetWeightedGap(ModelPart& rModelPart) override
     {
         // Auxiliar zero array
-        const array_1d<double, 3> zero_array(3, 0.0);
+        const array_1d<double, 3> zero_array = ZeroVector(3);
 
         // We reset the weighted values
         NodesArrayType& nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
@@ -312,9 +315,6 @@ private:
     ///@name Member Variables
     ///@{
 
-    bool mPrintingOutput;     /// If the colors and bold are printed
-    bool mTableIsInitialized; /// If the table is already initialized
-
     ///@}
     ///@name Private Operators
     ///@{
@@ -341,8 +341,18 @@ private:
 
 }; // Class ALMFrictionalMortarConvergenceCriteria
 
-///@name Explicit Specializations
+///@name Local flags creation
 ///@{
+
+/// Local Flags
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags ALMFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::PRINTING_OUTPUT(Kratos::Flags::Create(2));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags ALMFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_PRINTING_OUTPUT(Kratos::Flags::Create(2, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags ALMFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(3));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags ALMFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(3, false));
 
 }  // namespace Kratos
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictionless_components_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/alm_frictionless_components_mortar_criteria.h
@@ -63,6 +63,10 @@ public:
     /// Pointer definition of ALMFrictionlessComponentsMortarConvergenceCriteria
     KRATOS_CLASS_POINTER_DEFINITION( ALMFrictionlessComponentsMortarConvergenceCriteria );
 
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
+    KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
+
     /// The base convergence criteria class definition
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > ConvergenceCriteriaBaseType;
 
@@ -80,7 +84,7 @@ public:
     typedef ModelPart::NodesContainerType                                 NodesArrayType;
     typedef ModelPart::ConditionsContainerType                       ConditionsArrayType;
 
-    /// The table stream definition TODO: Replace by logger
+    /// The r_table stream definition TODO: Replace by logger
     typedef TableStreamUtility::Pointer                          TablePrinterPointerType;
 
     /// The index type definition
@@ -95,17 +99,16 @@ public:
         const bool PrintingOutput = false,
         const bool ComputeDynamicFactor = false,
         const bool GiDIODebug = false
-        ) : BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >(ComputeDynamicFactor, GiDIODebug),
-        mPrintingOutput(PrintingOutput),
-        mTableIsInitialized(false)
+        ) : BaseType(ComputeDynamicFactor, GiDIODebug)
     {
+        // Set local flags
+        BaseType::mOptions.Set(ALMFrictionlessComponentsMortarConvergenceCriteria::PRINTING_OUTPUT, PrintingOutput);
+        BaseType::mOptions.Set(ALMFrictionlessComponentsMortarConvergenceCriteria::TABLE_IS_INITIALIZED, false);
     }
 
     ///Copy constructor
     ALMFrictionlessComponentsMortarConvergenceCriteria( ALMFrictionlessComponentsMortarConvergenceCriteria const& rOther )
       :BaseType(rOther)
-      ,mPrintingOutput(rOther.mPrintingOutput)
-      ,mTableIsInitialized(rOther.mTableIsInitialized)
     {
     }
 
@@ -169,26 +172,26 @@ public:
         if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
             if (r_process_info.Has(TABLE_UTILITY)) {
                 TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                auto& table = p_table->GetTable();
+                auto& r_table = p_table->GetTable();
                 if (active_set_converged) {
-                    if (mPrintingOutput == false)
-                        table << BOLDFONT(FGRN("       Achieved"));
+                    if (BaseType::mOptions.IsNot(ALMFrictionlessComponentsMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FGRN("       Achieved"));
                     else
-                        table << "Achieved";
+                        r_table << "Achieved";
                 } else {
-                    if (mPrintingOutput == false)
-                        table << BOLDFONT(FRED("   Not achieved"));
+                    if (BaseType::mOptions.IsNot(ALMFrictionlessComponentsMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FRED("   Not achieved"));
                     else
-                        table << "Not achieved";
+                        r_table << "Not achieved";
                 }
             } else {
                 if (active_set_converged) {
-                    if (mPrintingOutput == false)
+                    if (BaseType::mOptions.IsNot(ALMFrictionlessComponentsMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("ALMFrictionlessComponentsMortarConvergenceCriteria") << BOLDFONT("\tActive set") << " convergence is " << BOLDFONT(FGRN("achieved")) << std::endl;
                     else
                         KRATOS_INFO("ALMFrictionlessComponentsMortarConvergenceCriteria") << "\tActive set convergence is achieved" << std::endl;
                 } else {
-                    if (mPrintingOutput == false)
+                    if (BaseType::mOptions.IsNot(ALMFrictionlessComponentsMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("ALMFrictionlessComponentsMortarConvergenceCriteria") << BOLDFONT("\tActive set") << " convergence is " << BOLDFONT(FRED("not achieved")) << std::endl;
                     else
                         KRATOS_INFO("ALMFrictionlessComponentsMortarConvergenceCriteria") << "\tActive set convergence is not achieved" << std::endl;
@@ -208,11 +211,11 @@ public:
         ConvergenceCriteriaBaseType::mConvergenceCriteriaIsInitialized = true;
 
         ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-        if (r_process_info.Has(TABLE_UTILITY) && mTableIsInitialized == false) {
+        if (r_process_info.Has(TABLE_UTILITY) && BaseType::mOptions.IsNot(ALMFrictionlessComponentsMortarConvergenceCriteria::TABLE_IS_INITIALIZED)) {
             TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-            auto& table = p_table->GetTable();
-            table.AddColumn("ACTIVE SET CONV", 15);
-            mTableIsInitialized = true;
+            auto& r_table = p_table->GetTable();
+            r_table.AddColumn("ACTIVE SET CONV", 15);
+            BaseType::mOptions.Set(ALMFrictionlessComponentsMortarConvergenceCriteria::TABLE_IS_INITIALIZED, true);
         }
     }
 
@@ -270,9 +273,6 @@ private:
     ///@name Member Variables
     ///@{
 
-    bool mPrintingOutput;     /// If the colors and bold are printed
-    bool mTableIsInitialized; /// If the table is already initialized
-
     ///@}
     ///@name Private Operators
     ///@{
@@ -299,8 +299,18 @@ private:
 
 }; // Class ALMFrictionlessComponentsMortarConvergenceCriteria
 
-///@name Explicit Specializations
+///@name Local flags creation
 ///@{
+
+/// Local Flags
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags ALMFrictionlessComponentsMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::PRINTING_OUTPUT(Kratos::Flags::Create(2));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags ALMFrictionlessComponentsMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_PRINTING_OUTPUT(Kratos::Flags::Create(2, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags ALMFrictionlessComponentsMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(3));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags ALMFrictionlessComponentsMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(3, false));
 
 }  // namespace Kratos
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/base_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/base_mortar_criteria.h
@@ -99,14 +99,14 @@ public:
         const bool IODebug = false
         )
         : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-          mpGidIO(nullptr)
+          mpIO(nullptr)
     {
         // Set local flags
         mOptions.Set(BaseMortarConvergenceCriteria::COMPUTE_DYNAMIC_FACTOR, ComputeDynamicFactor);
         mOptions.Set(BaseMortarConvergenceCriteria::IO_DEBUG, IODebug);
 
         if (mOptions.Is(BaseMortarConvergenceCriteria::IO_DEBUG)) {
-            mpGidIO = Kratos::make_shared<GidIOBaseType>("POST_LINEAR_ITER", GiD_PostBinary, SingleFile, WriteUndeformed,  WriteElementsOnly);
+            mpIO = Kratos::make_shared<GidIOBaseType>("POST_LINEAR_ITER", GiD_PostBinary, SingleFile, WriteUndeformed,  WriteElementsOnly);
         }
     }
 
@@ -114,7 +114,7 @@ public:
     BaseMortarConvergenceCriteria( BaseMortarConvergenceCriteria const& rOther )
       :BaseType(rOther),
        mOptions(rOther.mOptions),
-       mpGidIO(rOther.mpGidIO)
+       mpIO(rOther.mpIO)
     {
     }
 
@@ -220,33 +220,33 @@ public:
             const double label = static_cast<double>(nl_iter);
 
             if (nl_iter == 1) {
-                mpGidIO->InitializeMesh(label);
-                mpGidIO->WriteMesh(rModelPart.GetMesh());
-                mpGidIO->FinalizeMesh();
-                mpGidIO->InitializeResults(label, rModelPart.GetMesh());
+                mpIO->InitializeMesh(label);
+                mpIO->WriteMesh(rModelPart.GetMesh());
+                mpIO->FinalizeMesh();
+                mpIO->InitializeResults(label, rModelPart.GetMesh());
             }
 
-            mpGidIO->WriteNodalFlags(INTERFACE, "INTERFACE", rModelPart.Nodes(), label);
-            mpGidIO->WriteNodalFlags(ACTIVE, "ACTIVE", rModelPart.Nodes(), label);
-            mpGidIO->WriteNodalFlags(SLAVE, "SLAVE", rModelPart.Nodes(), label);
-            mpGidIO->WriteNodalFlags(ISOLATED, "ISOLATED", rModelPart.Nodes(), label);
-            mpGidIO->WriteNodalResults(NORMAL, rModelPart.Nodes(), label, 0);
-            mpGidIO->WriteNodalResultsNonHistorical(DYNAMIC_FACTOR, rModelPart.Nodes(), label);
-            mpGidIO->WriteNodalResultsNonHistorical(AUGMENTED_NORMAL_CONTACT_PRESSURE, rModelPart.Nodes(), label);
-            mpGidIO->WriteNodalResults(DISPLACEMENT, rModelPart.Nodes(), label, 0);
+            mpIO->WriteNodalFlags(INTERFACE, "INTERFACE", rModelPart.Nodes(), label);
+            mpIO->WriteNodalFlags(ACTIVE, "ACTIVE", rModelPart.Nodes(), label);
+            mpIO->WriteNodalFlags(SLAVE, "SLAVE", rModelPart.Nodes(), label);
+            mpIO->WriteNodalFlags(ISOLATED, "ISOLATED", rModelPart.Nodes(), label);
+            mpIO->WriteNodalResults(NORMAL, rModelPart.Nodes(), label, 0);
+            mpIO->WriteNodalResultsNonHistorical(DYNAMIC_FACTOR, rModelPart.Nodes(), label);
+            mpIO->WriteNodalResultsNonHistorical(AUGMENTED_NORMAL_CONTACT_PRESSURE, rModelPart.Nodes(), label);
+            mpIO->WriteNodalResults(DISPLACEMENT, rModelPart.Nodes(), label, 0);
             if (rModelPart.Nodes().begin()->SolutionStepsDataHas(VELOCITY_X)) {
-                mpGidIO->WriteNodalResults(VELOCITY, rModelPart.Nodes(), label, 0);
-                mpGidIO->WriteNodalResults(ACCELERATION, rModelPart.Nodes(), label, 0);
+                mpIO->WriteNodalResults(VELOCITY, rModelPart.Nodes(), label, 0);
+                mpIO->WriteNodalResults(ACCELERATION, rModelPart.Nodes(), label, 0);
             }
             if (r_nodes_array.begin()->SolutionStepsDataHas(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE))
-                mpGidIO->WriteNodalResults(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE, rModelPart.Nodes(), label, 0);
+                mpIO->WriteNodalResults(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE, rModelPart.Nodes(), label, 0);
             else if (r_nodes_array.begin()->SolutionStepsDataHas(VECTOR_LAGRANGE_MULTIPLIER_X))
-                mpGidIO->WriteNodalResults(VECTOR_LAGRANGE_MULTIPLIER, rModelPart.Nodes(), label, 0);
-            mpGidIO->WriteNodalResults(WEIGHTED_GAP, rModelPart.Nodes(), label, 0);
+                mpIO->WriteNodalResults(VECTOR_LAGRANGE_MULTIPLIER, rModelPart.Nodes(), label, 0);
+            mpIO->WriteNodalResults(WEIGHTED_GAP, rModelPart.Nodes(), label, 0);
             if (frictional_problem) {
-                mpGidIO->WriteNodalFlags(SLIP, "SLIP", rModelPart.Nodes(), label);
-                mpGidIO->WriteNodalResults(WEIGHTED_SLIP, rModelPart.Nodes(), label, 0);
-                mpGidIO->WriteNodalResultsNonHistorical(AUGMENTED_TANGENT_CONTACT_PRESSURE, rModelPart.Nodes(), label);
+                mpIO->WriteNodalFlags(SLIP, "SLIP", rModelPart.Nodes(), label);
+                mpIO->WriteNodalResults(WEIGHTED_SLIP, rModelPart.Nodes(), label, 0);
+                mpIO->WriteNodalResultsNonHistorical(AUGMENTED_TANGENT_CONTACT_PRESSURE, rModelPart.Nodes(), label);
             }
         }
 
@@ -281,12 +281,12 @@ public:
         // Update normal of the conditions
         MortarUtilities::ComputeNodesMeanNormalModelPart(rModelPart.GetSubModelPart("Contact"));
 
-        // GiD IO for debugging
+        // IO for debugging
         if (mOptions.Is(BaseMortarConvergenceCriteria::IO_DEBUG)) {
-            mpGidIO->CloseResultFile();
+            mpIO->CloseResultFile();
             std::ostringstream new_name ;
             new_name << "POST_LINEAR_ITER_STEP=""POST_LINEAR_ITER_STEP=" << rModelPart.GetProcessInfo()[STEP];
-            mpGidIO->ChangeOutputName(new_name.str());
+            mpIO->ChangeOutputName(new_name.str());
         }
     }
 
@@ -306,9 +306,9 @@ public:
         const TSystemVectorType& rb
         ) override
     {
-        // GiD IO for debugging
+        // IO for debugging
         if (mOptions.Is(BaseMortarConvergenceCriteria::IO_DEBUG)) {
-            mpGidIO->FinalizeResults();
+            mpIO->FinalizeResults();
         }
     }
 
@@ -378,7 +378,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    GidIOBaseType::Pointer mpGidIO; /// The pointer to the debugging GidIO
+    GidIOBaseType::Pointer mpIO; /// The pointer to the debugging IO
 
     ///@}
     ///@name Private Operators

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_contact_criteria.h
@@ -66,6 +66,11 @@ public:
     /// Pointer definition of DisplacementLagrangeMultiplierContactCriteria
     KRATOS_CLASS_POINTER_DEFINITION( DisplacementLagrangeMultiplierContactCriteria );
 
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( ENSURE_CONTACT );
+    KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
+    KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
+
     /// The base class definition (and it subclasses)
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > BaseType;
     typedef typename BaseType::TDataType                    TDataType;
@@ -76,7 +81,7 @@ public:
     /// The sparse space used
     typedef TSparseSpace                              SparseSpaceType;
 
-    /// The table stream definition TODO: Replace by logger
+    /// The r_table stream definition TODO: Replace by logger
     typedef TableStreamUtility::Pointer       TablePrinterPointerType;
 
     /// The index type definition
@@ -96,7 +101,7 @@ public:
      * @param LMRatioTolerance Relative tolerance for lagrange multiplier error
      * @param LMAbsTolerance Absolute tolerance for lagrange multiplier error
      * @param EnsureContact To check if the contact is lost
-     * @param pTable The pointer to the output table
+     * @param pTable The pointer to the output r_table
      * @param PrintingOutput If the output is going to be printed in a txt file
      */
     explicit DisplacementLagrangeMultiplierContactCriteria(
@@ -107,11 +112,13 @@ public:
         const bool EnsureContact = false,
         const bool PrintingOutput = false
         )
-        : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-        mEnsureContact(EnsureContact),
-        mPrintingOutput(PrintingOutput),
-        mTableIsInitialized(false)
+        : BaseType()
     {
+        // Set local flags
+        mOptions.Set(DisplacementLagrangeMultiplierContactCriteria::ENSURE_CONTACT, EnsureContact);
+        mOptions.Set(DisplacementLagrangeMultiplierContactCriteria::PRINTING_OUTPUT, PrintingOutput);
+        mOptions.Set(DisplacementLagrangeMultiplierContactCriteria::TABLE_IS_INITIALIZED, false);
+
         // The displacement solution
         mDispRatioTolerance = DispRatioTolerance;
         mDispAbsTolerance = DispAbsTolerance;
@@ -126,8 +133,7 @@ public:
      * @param ThisParameters The configuration parameters
      */
     explicit DisplacementLagrangeMultiplierContactCriteria( Parameters ThisParameters = Parameters(R"({})"))
-        : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-          mTableIsInitialized(false)
+        : BaseType()
     {
         // The default parameters
         Parameters default_parameters = Parameters(R"(
@@ -150,21 +156,20 @@ public:
         mLMRatioTolerance =  ThisParameters["contact_displacement_relative_tolerance"].GetDouble();
         mLMAbsTolerance =  ThisParameters["contact_displacement_absolute_tolerance"].GetDouble();
 
-        // Additional flags -> NOTE: Replace for a real flag?
-        mEnsureContact = ThisParameters["ensure_contact"].GetBool();
-        mPrintingOutput = ThisParameters["print_convergence_criterion"].GetBool();
+        // Set local flags
+        mOptions.Set(DisplacementLagrangeMultiplierContactCriteria::ENSURE_CONTACT, ThisParameters["ensure_contact"].GetBool());
+        mOptions.Set(DisplacementLagrangeMultiplierContactCriteria::PRINTING_OUTPUT, ThisParameters["print_convergence_criterion"].GetBool());
+        mOptions.Set(DisplacementLagrangeMultiplierContactCriteria::TABLE_IS_INITIALIZED, false);
     }
 
     // Copy constructor.
     DisplacementLagrangeMultiplierContactCriteria( DisplacementLagrangeMultiplierContactCriteria const& rOther )
       :BaseType(rOther)
+      ,mOptions(rOther.mOptions)
       ,mDispRatioTolerance(rOther.mDispRatioTolerance)
       ,mDispAbsTolerance(rOther.mDispAbsTolerance)
       ,mLMRatioTolerance(rOther.mLMRatioTolerance)
       ,mLMAbsTolerance(rOther.mLMAbsTolerance)
-      ,mEnsureContact(rOther.mEnsureContact)
-      ,mPrintingOutput(rOther.mPrintingOutput)
-      ,mTableIsInitialized(rOther.mTableIsInitialized)
     {
     }
 
@@ -197,13 +202,17 @@ public:
             TDataType disp_solution_norm = 0.0, lm_solution_norm = 0.0, disp_increase_norm = 0.0, lm_increase_norm = 0.0;
             IndexType disp_dof_num(0),lm_dof_num(0);
 
-            // Loop over Dofs
-            #pragma omp parallel for reduction(+:disp_solution_norm,lm_solution_norm,disp_increase_norm,lm_increase_norm,disp_dof_num,lm_dof_num)
-            for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
-                auto it_dof = rDofSet.begin() + i;
+            // First iterator
+            const auto it_dof_begin = rDofSet.begin();
 
-                std::size_t dof_id;
-                TDataType dof_value, dof_incr;
+            // Auxiliar values
+            std::size_t dof_id = 0;
+            TDataType dof_value = 0.0, dof_incr = 0.0;
+
+            // Loop over Dofs
+            #pragma omp parallel for reduction(+:disp_solution_norm,lm_solution_norm,disp_increase_norm,lm_increase_norm,disp_dof_num,lm_dof_num,dof_id,dof_value,dof_incr)
+            for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
+                auto it_dof = it_dof_begin + i;
 
                 if (it_dof->IsFree()) {
                     dof_id = it_dof->EquationId();
@@ -227,7 +236,7 @@ public:
             if(lm_increase_norm == 0.0) lm_increase_norm = 1.0;
             if(disp_solution_norm == 0.0) disp_solution_norm = 1.0;
 
-            KRATOS_ERROR_IF(mEnsureContact && lm_solution_norm == 0.0) << "WARNING::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
+            KRATOS_ERROR_IF(mOptions.Is(DisplacementLagrangeMultiplierContactCriteria::ENSURE_CONTACT) && lm_solution_norm == 0.0) << "WARNING::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
 
             const TDataType disp_ratio = std::sqrt(disp_increase_norm/disp_solution_norm);
             const TDataType lm_ratio = std::sqrt(lm_increase_norm/lm_solution_norm);
@@ -243,11 +252,11 @@ public:
                 if (r_process_info.Has(TABLE_UTILITY)) {
                     std::cout.precision(4);
                     TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                    auto& Table = p_table->GetTable();
-                    Table  << disp_ratio  << mDispRatioTolerance  << disp_abs  << mDispAbsTolerance  << lm_ratio  << mLMRatioTolerance  << lm_abs  << mLMAbsTolerance;
+                    auto& r_table = p_table->GetTable();
+                    r_table  << disp_ratio  << mDispRatioTolerance  << disp_abs  << mDispAbsTolerance  << lm_ratio  << mLMRatioTolerance  << lm_abs  << mLMAbsTolerance;
                 } else {
                     std::cout.precision(4);
-                    if (mPrintingOutput == false) {
+                    if (mOptions.IsNot(DisplacementLagrangeMultiplierContactCriteria::PRINTING_OUTPUT)) {
                         KRATOS_INFO("DisplacementLagrangeMultiplierContactCriteria") << BOLDFONT("DoF ONVERGENCE CHECK") << "\tSTEP: " << r_process_info[STEP] << "\tNL ITERATION: " << r_process_info[NL_ITERATION_NUMBER] << std::endl;
                         KRATOS_INFO("DisplacementLagrangeMultiplierContactCriteria") << BOLDFONT("\tDISPLACEMENT: RATIO = ") << disp_ratio << BOLDFONT(" EXP.RATIO = ") << mDispRatioTolerance << BOLDFONT(" ABS = ") << disp_abs << BOLDFONT(" EXP.ABS = ") << mDispAbsTolerance << std::endl;
                         KRATOS_INFO("DisplacementLagrangeMultiplierContactCriteria") << BOLDFONT(" LAGRANGE MUL:\tRATIO = ") << lm_ratio << BOLDFONT(" EXP.RATIO = ") << mLMRatioTolerance << BOLDFONT(" ABS = ") << lm_abs << BOLDFONT(" EXP.ABS = ") << mLMAbsTolerance << std::endl;
@@ -261,19 +270,19 @@ public:
 
             // We check if converged
             const bool disp_converged = (disp_ratio <= mDispRatioTolerance || disp_abs <= mDispAbsTolerance);
-            const bool lm_converged = (!mEnsureContact && lm_solution_norm == 0.0) ? true : (lm_ratio <= mLMRatioTolerance || lm_abs <= mLMAbsTolerance);
+            const bool lm_converged = (mOptions.IsNot(DisplacementLagrangeMultiplierContactCriteria::ENSURE_CONTACT) && lm_solution_norm == 0.0) ? true : (lm_ratio <= mLMRatioTolerance || lm_abs <= mLMAbsTolerance);
 
             if (disp_converged && lm_converged) {
                 if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
                     if (r_process_info.Has(TABLE_UTILITY)) {
                         TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                        auto& table = p_table->GetTable();
-                        if (mPrintingOutput == false)
-                            table << BOLDFONT(FGRN("       Achieved"));
+                        auto& r_table = p_table->GetTable();
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierContactCriteria::PRINTING_OUTPUT))
+                            r_table << BOLDFONT(FGRN("       Achieved"));
                         else
-                            table << "Achieved";
+                            r_table << "Achieved";
                     } else {
-                        if (mPrintingOutput == false)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierContactCriteria::PRINTING_OUTPUT))
                             KRATOS_INFO("DisplacementLagrangeMultiplierContactCriteria") << BOLDFONT("\tDoF") << " convergence is " << BOLDFONT(FGRN("achieved")) << std::endl;
                         else
                             KRATOS_INFO("DisplacementLagrangeMultiplierContactCriteria") << "\tDoF convergence is achieved" << std::endl;
@@ -284,13 +293,13 @@ public:
                 if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
                     if (r_process_info.Has(TABLE_UTILITY)) {
                         TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                        auto& table = p_table->GetTable();
-                        if (mPrintingOutput == false)
-                            table << BOLDFONT(FRED("   Not achieved"));
+                        auto& r_table = p_table->GetTable();
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierContactCriteria::PRINTING_OUTPUT))
+                            r_table << BOLDFONT(FRED("   Not achieved"));
                         else
-                            table << "Not achieved";
+                            r_table << "Not achieved";
                     } else {
-                        if (mPrintingOutput == false)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierContactCriteria::PRINTING_OUTPUT))
                             KRATOS_INFO("DisplacementLagrangeMultiplierContactCriteria") << BOLDFONT("\tDoF") << " convergence is " << BOLDFONT(FRED(" not achieved")) << std::endl;
                         else
                             KRATOS_INFO("DisplacementLagrangeMultiplierContactCriteria") << "\tDoF convergence is not achieved" << std::endl;
@@ -312,19 +321,19 @@ public:
         BaseType::mConvergenceCriteriaIsInitialized = true;
 
         ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-        if (r_process_info.Has(TABLE_UTILITY) && mTableIsInitialized == false) {
+        if (r_process_info.Has(TABLE_UTILITY) && mOptions.IsNot(DisplacementLagrangeMultiplierContactCriteria::TABLE_IS_INITIALIZED)) {
             TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-            auto& table = p_table->GetTable();
-            table.AddColumn("DP RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("LM RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("CONVERGENCE", 15);
-            mTableIsInitialized = true;
+            auto& r_table = p_table->GetTable();
+            r_table.AddColumn("DP RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("LM RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("CONVERGENCE", 15);
+            mOptions.Set(DisplacementLagrangeMultiplierContactCriteria::TABLE_IS_INITIALIZED, true);
         }
     }
 
@@ -382,10 +391,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    bool mEnsureContact; /// This "flag" is used to check that the norm of the LM is always greater than 0 (no contact)
-
-    bool mPrintingOutput;          /// If the colors and bold are printed
-    bool mTableIsInitialized;      /// If the table is already initialized
+    Flags mOptions; /// Local flags
 
     TDataType mDispRatioTolerance; /// The ratio threshold for the norm of the displacement
     TDataType mDispAbsTolerance;   /// The absolute value threshold for the norm of the displacement
@@ -417,11 +423,24 @@ private:
     ///@name Unaccessible methods
     ///@{
     ///@}
-};
+};  // Kratos DisplacementLagrangeMultiplierContactCriteria
 
-///@} // Kratos classes
+///@name Local flags creation
+///@{
 
-///@} // Application group
+/// Local Flags
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierContactCriteria<TSparseSpace, TDenseSpace>::ENSURE_CONTACT(Kratos::Flags::Create(0));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierContactCriteria<TSparseSpace, TDenseSpace>::NOT_ENSURE_CONTACT(Kratos::Flags::Create(0, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierContactCriteria<TSparseSpace, TDenseSpace>::PRINTING_OUTPUT(Kratos::Flags::Create(1));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierContactCriteria<TSparseSpace, TDenseSpace>::NOT_PRINTING_OUTPUT(Kratos::Flags::Create(1, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierContactCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(2));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierContactCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(2, false));
 }
 
 #endif	/* KRATOS_DISPLACEMENT_LAGRANGE_MULTIPLIER_CONTACT_CRITERIA_H */

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_contact_criteria.h
@@ -66,6 +66,12 @@ public:
     /// Pointer definition of DisplacementLagrangeMultiplierMixedContactCriteria
     KRATOS_CLASS_POINTER_DEFINITION( DisplacementLagrangeMultiplierMixedContactCriteria );
 
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( ENSURE_CONTACT );
+    KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
+    KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
+    KRATOS_DEFINE_LOCAL_FLAG( INITIAL_RESIDUAL_IS_SET );
+
     /// The base class definition (and it subclasses)
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > BaseType;
     typedef typename BaseType::TDataType                    TDataType;
@@ -76,7 +82,7 @@ public:
     /// The sparse space used
     typedef TSparseSpace                              SparseSpaceType;
 
-    /// The table stream definition TODO: Replace by logger
+    /// The r_table stream definition TODO: Replace by logger
     typedef TableStreamUtility::Pointer       TablePrinterPointerType;
 
     /// The index type definition
@@ -96,7 +102,7 @@ public:
      * @param LMRatioTolerance Relative tolerance for lagrange multiplier residual  error
      * @param LMAbsTolerance Absolute tolerance for lagrange multiplier residual error
      * @param EnsureContact To check if the contact is lost
-     * @param pTable The pointer to the output table
+     * @param pTable The pointer to the output r_table
      * @param PrintingOutput If the output is going to be printed in a txt file
      */
     explicit DisplacementLagrangeMultiplierMixedContactCriteria(
@@ -107,18 +113,19 @@ public:
         const bool EnsureContact = false,
         const bool PrintingOutput = false
         )
-        : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-          mEnsureContact(EnsureContact),
-          mPrintingOutput(PrintingOutput),
-          mTableIsInitialized(false)
+        : BaseType()
     {
+        // Set local flags
+        mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::ENSURE_CONTACT, EnsureContact);
+        mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::PRINTING_OUTPUT, PrintingOutput);
+        mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::TABLE_IS_INITIALIZED, false);
+        mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
+
         mDispRatioTolerance = DispRatioTolerance;
         mDispAbsTolerance = DispAbsTolerance;
 
         mLMRatioTolerance = LMRatioTolerance;
         mLMAbsTolerance = LMAbsTolerance;
-
-        mInitialResidualIsSet = false;
     }
 
     /**
@@ -126,8 +133,7 @@ public:
      * @param ThisParameters The configuration parameters
      */
     explicit DisplacementLagrangeMultiplierMixedContactCriteria( Parameters ThisParameters = Parameters(R"({})"))
-        : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-          mTableIsInitialized(false)
+        : BaseType()
     {
         // The default parameters
         Parameters default_parameters = Parameters(R"(
@@ -150,26 +156,23 @@ public:
         mLMRatioTolerance =  ThisParameters["contact_displacement_relative_tolerance"].GetDouble();
         mLMAbsTolerance =  ThisParameters["contact_displacement_absolute_tolerance"].GetDouble();
 
-        // Additional flags -> NOTE: Replace for a ral flag?¿
-        mEnsureContact = ThisParameters["ensure_contact"].GetBool();
-        mPrintingOutput = ThisParameters["print_convergence_criterion"].GetBool();
-
-        // We "initialize" the flag-> NOTE: Replace for a ral flag?¿
-        mInitialResidualIsSet = false;
+        // Set local flags
+        mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::ENSURE_CONTACT, ThisParameters["ensure_contact"].GetBool());
+        mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::PRINTING_OUTPUT, ThisParameters["print_convergence_criterion"].GetBool());
+        mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::TABLE_IS_INITIALIZED, false);
+        mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
     }
 
     //* Copy constructor.
     DisplacementLagrangeMultiplierMixedContactCriteria( DisplacementLagrangeMultiplierMixedContactCriteria const& rOther )
       :BaseType(rOther)
-      ,mInitialResidualIsSet(rOther.mInitialResidualIsSet)
+      ,mOptions(rOther.mOptions)
       ,mDispRatioTolerance(rOther.mDispRatioTolerance)
       ,mDispAbsTolerance(rOther.mDispAbsTolerance)
       ,mDispInitialResidualNorm(rOther.mDispInitialResidualNorm)
       ,mDispCurrentResidualNorm(rOther.mDispCurrentResidualNorm)
       ,mLMRatioTolerance(rOther.mLMRatioTolerance)
       ,mLMAbsTolerance(rOther.mLMAbsTolerance)
-      ,mPrintingOutput(rOther.mPrintingOutput)
-      ,mTableIsInitialized(rOther.mTableIsInitialized)
     {
     }
 
@@ -202,13 +205,17 @@ public:
             TDataType disp_residual_solution_norm = 0.0, lm_solution_norm = 0.0, lm_increase_norm = 0.0;
             IndexType disp_dof_num(0),lm_dof_num(0);
 
-            // Loop over Dofs
-            #pragma omp parallel for reduction(+:disp_residual_solution_norm,lm_solution_norm,lm_increase_norm,disp_dof_num,lm_dof_num)
-            for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
-                auto it_dof = rDofSet.begin() + i;
+            // First iterator
+            const auto it_dof_begin = rDofSet.begin();
 
-                std::size_t dof_id;
-                TDataType residual_dof_value, dof_value, dof_incr;
+            // Auxiliar values
+            std::size_t dof_id = 0;
+            TDataType residual_dof_value = 0.0, dof_value = 0.0, dof_incr = 0.0;
+
+            // Loop over Dofs
+            #pragma omp parallel for reduction(+:disp_residual_solution_norm,lm_solution_norm,lm_increase_norm,disp_dof_num,lm_dof_num,dof_id,residual_dof_value,dof_value,dof_incr)
+            for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
+                auto it_dof = it_dof_begin + i;
 
                 if (it_dof->IsFree()) {
                     dof_id = it_dof->EquationId();
@@ -229,7 +236,7 @@ public:
             }
 
             if(lm_increase_norm == 0.0) lm_increase_norm = 1.0;
-            KRATOS_ERROR_IF(mEnsureContact && lm_solution_norm == 0.0) << "ERROR::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
+            KRATOS_ERROR_IF(mOptions.Is(DisplacementLagrangeMultiplierMixedContactCriteria::ENSURE_CONTACT) && lm_solution_norm == 0.0) << "ERROR::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
 
             mDispCurrentResidualNorm = disp_residual_solution_norm;
             const TDataType lm_ratio = std::sqrt(lm_increase_norm/lm_solution_norm);
@@ -238,10 +245,10 @@ public:
             TDataType residual_disp_ratio;
 
             // We initialize the solution
-            if (mInitialResidualIsSet == false) {
+            if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedContactCriteria::INITIAL_RESIDUAL_IS_SET)) {
                 mDispInitialResidualNorm = (disp_residual_solution_norm == 0.0) ? 1.0 : disp_residual_solution_norm;
                 residual_disp_ratio = 1.0;
-                mInitialResidualIsSet = true;
+                mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::INITIAL_RESIDUAL_IS_SET, true);
             }
 
             // We calculate the ratio of the displacements
@@ -258,11 +265,11 @@ public:
                 if (r_process_info.Has(TABLE_UTILITY)) {
                     std::cout.precision(4);
                     TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                    auto& Table = p_table->GetTable();
-                    Table << residual_disp_ratio << mDispRatioTolerance << residual_disp_abs << mDispAbsTolerance << lm_ratio << mLMRatioTolerance << lm_abs << mLMAbsTolerance;
+                    auto& r_table = p_table->GetTable();
+                    r_table << residual_disp_ratio << mDispRatioTolerance << residual_disp_abs << mDispAbsTolerance << lm_ratio << mLMRatioTolerance << lm_abs << mLMAbsTolerance;
                 } else {
                     std::cout.precision(4);
-                    if (mPrintingOutput == false) {
+                    if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedContactCriteria::PRINTING_OUTPUT)) {
                         KRATOS_INFO("DisplacementLagrangeMultiplierMixedContactCriteria") << BOLDFONT("MIXED CONVERGENCE CHECK") << "\tSTEP: " << r_process_info[STEP] << "\tNL ITERATION: " << r_process_info[NL_ITERATION_NUMBER] << std::endl << std::scientific;
                         KRATOS_INFO("DisplacementLagrangeMultiplierMixedContactCriteria") << BOLDFONT("\tDISPLACEMENT: RATIO = ") << residual_disp_ratio << BOLDFONT(" EXP.RATIO = ") << mDispRatioTolerance << BOLDFONT(" ABS = ") << residual_disp_abs << BOLDFONT(" EXP.ABS = ") << mDispAbsTolerance << std::endl;
                         KRATOS_INFO("DisplacementLagrangeMultiplierMixedContactCriteria") << BOLDFONT("\tLAGRANGE MUL: RATIO = ") << lm_ratio << BOLDFONT(" EXP.RATIO = ") << mLMRatioTolerance << BOLDFONT(" ABS = ") << lm_abs << BOLDFONT(" EXP.ABS = ") << mLMAbsTolerance << std::endl;
@@ -279,19 +286,19 @@ public:
 
             // We check if converged
             const bool disp_converged = (residual_disp_ratio <= mDispRatioTolerance || residual_disp_abs <= mDispAbsTolerance);
-            const bool lm_converged = (!mEnsureContact && lm_solution_norm == 0.0) ? true : (lm_ratio <= mLMRatioTolerance || lm_abs <= mLMAbsTolerance);
+            const bool lm_converged = (mOptions.IsNot(DisplacementLagrangeMultiplierMixedContactCriteria::ENSURE_CONTACT) && lm_solution_norm == 0.0) ? true : (lm_ratio <= mLMRatioTolerance || lm_abs <= mLMAbsTolerance);
 
             if ( disp_converged && lm_converged ) {
                 if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
                     if (r_process_info.Has(TABLE_UTILITY)) {
                         TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                        auto& table = p_table->GetTable();
-                        if (mPrintingOutput == false)
-                            table << BOLDFONT(FGRN("       Achieved"));
+                        auto& r_table = p_table->GetTable();
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedContactCriteria::PRINTING_OUTPUT))
+                            r_table << BOLDFONT(FGRN("       Achieved"));
                         else
-                            table << "Achieved";
+                            r_table << "Achieved";
                     } else {
-                        if (mPrintingOutput == false)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedContactCriteria::PRINTING_OUTPUT))
                             KRATOS_INFO("DisplacementLagrangeMultiplierMixedContactCriteria") << BOLDFONT("\tConvergence") << " is " << BOLDFONT(FGRN("achieved")) << std::endl;
                         else
                             KRATOS_INFO("DisplacementLagrangeMultiplierMixedContactCriteria") << "\tConvergence is achieved" << std::endl;
@@ -302,13 +309,13 @@ public:
                 if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
                     if (r_process_info.Has(TABLE_UTILITY)) {
                         TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                        auto& table = p_table->GetTable();
-                        if (mPrintingOutput == false)
-                            table << BOLDFONT(FRED("   Not achieved"));
+                        auto& r_table = p_table->GetTable();
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedContactCriteria::PRINTING_OUTPUT))
+                            r_table << BOLDFONT(FRED("   Not achieved"));
                         else
-                            table << "Not achieved";
+                            r_table << "Not achieved";
                     } else {
-                        if (mPrintingOutput == false)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedContactCriteria::PRINTING_OUTPUT))
                             KRATOS_INFO("DisplacementLagrangeMultiplierMixedContactCriteria") << BOLDFONT("\tConvergence") << " is " << BOLDFONT(FRED(" not achieved")) << std::endl;
                         else
                             KRATOS_INFO("DisplacementLagrangeMultiplierMixedContactCriteria") << "\tConvergence is not achieved" << std::endl;
@@ -329,19 +336,19 @@ public:
         BaseType::mConvergenceCriteriaIsInitialized = true;
 
         ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-        if (r_process_info.Has(TABLE_UTILITY) && mTableIsInitialized == false) {
+        if (r_process_info.Has(TABLE_UTILITY) && mOptions.IsNot(DisplacementLagrangeMultiplierMixedContactCriteria::TABLE_IS_INITIALIZED)) {
             TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-            auto& table = p_table->GetTable();
-            table.AddColumn("DP RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("LM RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("CONVERGENCE", 15);
-            mTableIsInitialized = true;
+            auto& r_table = p_table->GetTable();
+            r_table.AddColumn("DP RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("LM RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("CONVERGENCE", 15);
+            mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::TABLE_IS_INITIALIZED, true);
         }
     }
 
@@ -361,7 +368,7 @@ public:
         const TSystemVectorType& rb
         ) override
     {
-        mInitialResidualIsSet = false;
+        mOptions.Set(DisplacementLagrangeMultiplierMixedContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
     }
 
     ///@}
@@ -418,12 +425,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    bool mInitialResidualIsSet; /// This "flag" is set in order to set that the initial residual is already computed
-
-    bool mEnsureContact; /// This "flag" is used to check that the norm of the LM is always greater than 0 (no contact)
-
-    bool mPrintingOutput;      /// If the colors and bold are printed
-    bool mTableIsInitialized;  /// If the table is already initialized
+    Flags mOptions; /// Local flags
 
     TDataType mDispRatioTolerance;      /// The ratio threshold for the norm of the displacement residual
     TDataType mDispAbsTolerance;        /// The absolute value threshold for the norm of the displacement residual
@@ -457,11 +459,28 @@ private:
     ///@name Unaccessible methods
     ///@{
     ///@}
-};
+};  // Kratos DisplacementLagrangeMultiplierMixedContactCriteria
 
-///@} // Kratos classes
+///@name Local flags creation
+///@{
 
-///@} // Application group
+/// Local Flags
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedContactCriteria<TSparseSpace, TDenseSpace>::ENSURE_CONTACT(Kratos::Flags::Create(0));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedContactCriteria<TSparseSpace, TDenseSpace>::NOT_ENSURE_CONTACT(Kratos::Flags::Create(0, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedContactCriteria<TSparseSpace, TDenseSpace>::PRINTING_OUTPUT(Kratos::Flags::Create(1));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedContactCriteria<TSparseSpace, TDenseSpace>::NOT_PRINTING_OUTPUT(Kratos::Flags::Create(1, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedContactCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(2));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedContactCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(2, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedContactCriteria<TSparseSpace, TDenseSpace>::INITIAL_RESIDUAL_IS_SET(Kratos::Flags::Create(3));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedContactCriteria<TSparseSpace, TDenseSpace>::NOT_INITIAL_RESIDUAL_IS_SET(Kratos::Flags::Create(3, false));
 }
 
 #endif	/* KRATOS_DISPLACEMENT_LAGRANGE_MULTIPLIER_MIXED_CONTACT_CRITERIA_H */

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_frictional_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_mixed_frictional_contact_criteria.h
@@ -66,6 +66,12 @@ public:
     /// Pointer definition of DisplacementLagrangeMultiplierMixedFrictionalContactCriteria
     KRATOS_CLASS_POINTER_DEFINITION( DisplacementLagrangeMultiplierMixedFrictionalContactCriteria );
 
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( ENSURE_CONTACT );
+    KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
+    KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
+    KRATOS_DEFINE_LOCAL_FLAG( INITIAL_RESIDUAL_IS_SET );
+
     /// The base class definition (and it subclasses)
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > BaseType;
     typedef typename BaseType::TDataType                    TDataType;
@@ -76,7 +82,7 @@ public:
     /// The sparse space used
     typedef TSparseSpace                              SparseSpaceType;
 
-    /// The table stream definition TODO: Replace by logger
+    /// The r_table stream definition TODO: Replace by logger
     typedef TableStreamUtility::Pointer       TablePrinterPointerType;
 
     /// The index type definition
@@ -96,7 +102,7 @@ public:
      * @param LMRatioTolerance Relative tolerance for lagrange multiplier residual  error
      * @param LMAbsTolerance Absolute tolerance for lagrange multiplier residual error
      * @param EnsureContact To check if the contact is lost
-     * @param pTable The pointer to the output table
+     * @param pTable The pointer to the output r_table
      * @param PrintingOutput If the output is going to be printed in a txt file
      */
     explicit DisplacementLagrangeMultiplierMixedFrictionalContactCriteria(
@@ -109,11 +115,14 @@ public:
         const bool EnsureContact = false,
         const bool PrintingOutput = false
         )
-        : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-          mEnsureContact(EnsureContact),
-          mPrintingOutput(PrintingOutput),
-          mTableIsInitialized(false)
+        : BaseType()
     {
+        // Set local flags
+        mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::ENSURE_CONTACT, EnsureContact);
+        mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::PRINTING_OUTPUT, PrintingOutput);
+        mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::TABLE_IS_INITIALIZED, false);
+        mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
+
         // The displacement residual
         mDispRatioTolerance = DispRatioTolerance;
         mDispAbsTolerance = DispAbsTolerance;
@@ -125,9 +134,6 @@ public:
         // The tangent contact residual
         mLMTangentRatioTolerance = LMTangentRatioTolerance;
         mLMTangentAbsTolerance = LMTangentAbsTolerance;
-
-        // We "initialize" the flag-> NOTE: Replace for a ral flag?¿
-        mInitialResidualIsSet = false;
     }
 
     /**
@@ -135,8 +141,7 @@ public:
      * @param ThisParameters The configuration parameters
      */
     explicit DisplacementLagrangeMultiplierMixedFrictionalContactCriteria( Parameters ThisParameters = Parameters(R"({})"))
-        : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-          mTableIsInitialized(false)
+        : BaseType()
     {
         // The default parameters
         Parameters default_parameters = Parameters(R"(
@@ -165,18 +170,17 @@ public:
         mLMTangentRatioTolerance =  ThisParameters["frictional_contact_displacement_relative_tolerance"].GetDouble();
         mLMTangentAbsTolerance =  ThisParameters["frictional_contact_displacement_absolute_tolerance"].GetDouble();
 
-        // Additional flags -> NOTE: Replace for a ral flag?¿
-        mEnsureContact = ThisParameters["ensure_contact"].GetBool();
-        mPrintingOutput = ThisParameters["print_convergence_criterion"].GetBool();
-
-        // We "initialize" the flag-> NOTE: Replace for a ral flag?¿
-        mInitialResidualIsSet = false;
+        // Set local flags
+        mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::ENSURE_CONTACT, ThisParameters["ensure_contact"].GetBool());
+        mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::PRINTING_OUTPUT, ThisParameters["print_convergence_criterion"].GetBool());
+        mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::TABLE_IS_INITIALIZED, false);
+        mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
     }
 
     //* Copy constructor.
     DisplacementLagrangeMultiplierMixedFrictionalContactCriteria( DisplacementLagrangeMultiplierMixedFrictionalContactCriteria const& rOther )
       :BaseType(rOther)
-      ,mInitialResidualIsSet(rOther.mInitialResidualIsSet)
+      ,mOptions(rOther.mOptions)
       ,mDispRatioTolerance(rOther.mDispRatioTolerance)
       ,mDispAbsTolerance(rOther.mDispAbsTolerance)
       ,mDispInitialResidualNorm(rOther.mDispInitialResidualNorm)
@@ -185,8 +189,6 @@ public:
       ,mLMNormalAbsTolerance(rOther.mLMNormalAbsTolerance)
       ,mLMTangentRatioTolerance(rOther.mLMNormalRatioTolerance)
       ,mLMTangentAbsTolerance(rOther.mLMNormalAbsTolerance)
-      ,mPrintingOutput(rOther.mPrintingOutput)
-      ,mTableIsInitialized(rOther.mTableIsInitialized)
     {
     }
 
@@ -220,15 +222,19 @@ public:
             IndexType disp_dof_num(0),lm_dof_num(0);
 
             // The nodes array
-            auto& nodes_array = rModelPart.Nodes();
+            auto& r_nodes_array = rModelPart.Nodes();
+
+            // First iterator
+            const auto it_dof_begin = rDofSet.begin();
+
+            // Auxiliar values
+            std::size_t dof_id = 0;
+            TDataType residual_dof_value = 0.0, dof_value = 0.0, dof_incr = 0.0;
 
             // Loop over Dofs
-            #pragma omp parallel for reduction(+:disp_residual_solution_norm,normal_lm_solution_norm,normal_lm_increase_norm,disp_dof_num,lm_dof_num)
+            #pragma omp parallel for reduction(+:disp_residual_solution_norm,normal_lm_solution_norm,normal_lm_increase_norm,disp_dof_num,lm_dof_num,dof_id,residual_dof_value,dof_value,dof_incr)
             for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
-                auto it_dof = rDofSet.begin() + i;
-
-                std::size_t dof_id;
-                TDataType residual_dof_value, dof_value, dof_incr;
+                auto it_dof = it_dof_begin + i;
 
                 if (it_dof->IsFree()) {
                     dof_id = it_dof->EquationId();
@@ -236,13 +242,13 @@ public:
                     const auto curr_var = it_dof->GetVariable();
                     if (curr_var == VECTOR_LAGRANGE_MULTIPLIER_X) {
                         // The normal of the node (TODO: how to solve this without accesing all the time to the database?)
-                        const auto& it_node = nodes_array.find(it_dof->Id());
-                        const array_1d<double, 3>& normal = it_node->FastGetSolutionStepValue(NORMAL);
+                        const auto& it_node = r_nodes_array.find(it_dof->Id());
+                        const double normal_x = it_node->FastGetSolutionStepValue(NORMAL_X);
 
                         dof_value = it_dof->GetSolutionStepValue(0);
                         dof_incr = rDx[dof_id];
-                        const TDataType normal_dof_value = dof_value * normal[0];
-                        const TDataType normal_dof_incr = dof_incr * normal[0];
+                        const TDataType normal_dof_value = dof_value * normal_x;
+                        const TDataType normal_dof_incr = dof_incr * normal_x;
 
                         normal_lm_solution_norm += std::pow(normal_dof_value, 2);
                         normal_lm_increase_norm += std::pow(normal_dof_incr, 2);
@@ -250,14 +256,14 @@ public:
                         tangent_lm_increase_norm += std::pow(dof_incr - normal_dof_incr, 2);
                         lm_dof_num++;
                     } else if (curr_var == VECTOR_LAGRANGE_MULTIPLIER_Y) {
-                         // The normal of the node (TODO: how to solve this without accesing all the time to the database?)
-                        const auto& it_node = nodes_array.find(it_dof->Id());
-                        const array_1d<double, 3>& normal = it_node->FastGetSolutionStepValue(NORMAL);
+                        // The normal of the node (TODO: how to solve this without accesing all the time to the database?)
+                        const auto& it_node = r_nodes_array.find(it_dof->Id());
+                        const double normal_y = it_node->FastGetSolutionStepValue(NORMAL_Y);
 
                         dof_value = it_dof->GetSolutionStepValue(0);
                         dof_incr = rDx[dof_id];
-                        const TDataType normal_dof_value = dof_value * normal[1];
-                        const TDataType normal_dof_incr = dof_incr * normal[1];
+                        const TDataType normal_dof_value = dof_value * normal_y;
+                        const TDataType normal_dof_incr = dof_incr * normal_y;
 
                         normal_lm_solution_norm += std::pow(normal_dof_value, 2);
                         normal_lm_increase_norm += std::pow(normal_dof_incr, 2);
@@ -266,13 +272,13 @@ public:
                         lm_dof_num++;
                     } else if (curr_var == VECTOR_LAGRANGE_MULTIPLIER_Z) {
                         // The normal of the node (TODO: how to solve this without accesing all the time to the database?)
-                        const auto& it_node = nodes_array.find(it_dof->Id());
-                        const array_1d<double, 3>& normal = it_node->FastGetSolutionStepValue(NORMAL);
+                        const auto& it_node = r_nodes_array.find(it_dof->Id());
+                        const double normal_z = it_node->FastGetSolutionStepValue(NORMAL_Z);
 
                         dof_value = it_dof->GetSolutionStepValue(0);
                         dof_incr = rDx[dof_id];
-                        const TDataType normal_dof_value = dof_value * normal[2];
-                        const TDataType normal_dof_incr = dof_incr * normal[2];
+                        const TDataType normal_dof_value = dof_value * normal_z;
+                        const TDataType normal_dof_incr = dof_incr * normal_z;
 
                         normal_lm_solution_norm += std::pow(normal_dof_value, 2);
                         normal_lm_increase_norm += std::pow(normal_dof_incr, 2);
@@ -288,7 +294,7 @@ public:
             }
 
             if(normal_lm_increase_norm == 0.0) normal_lm_increase_norm = 1.0;
-            KRATOS_ERROR_IF(mEnsureContact && normal_lm_solution_norm == 0.0) << "ERROR::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
+            KRATOS_ERROR_IF(mOptions.Is(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::ENSURE_CONTACT) && normal_lm_solution_norm == 0.0) << "ERROR::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
 
             mDispCurrentResidualNorm = disp_residual_solution_norm;
             const TDataType normal_lm_ratio = std::sqrt(normal_lm_increase_norm/normal_lm_solution_norm);
@@ -299,10 +305,10 @@ public:
             TDataType residual_disp_ratio;
 
             // We initialize the solution
-            if (mInitialResidualIsSet == false) {
+            if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::INITIAL_RESIDUAL_IS_SET)) {
                 mDispInitialResidualNorm = (disp_residual_solution_norm == 0.0) ? 1.0 : disp_residual_solution_norm;
                 residual_disp_ratio = 1.0;
-                mInitialResidualIsSet = true;
+                mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::INITIAL_RESIDUAL_IS_SET, true);
             }
 
             // We calculate the ratio of the displacements
@@ -319,11 +325,11 @@ public:
                 if (r_process_info.Has(TABLE_UTILITY)) {
                     std::cout.precision(4);
                     TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                    auto& Table = p_table->GetTable();
-                    Table << residual_disp_ratio << mDispRatioTolerance << residual_disp_abs << mDispAbsTolerance << normal_lm_ratio << mLMNormalRatioTolerance << normal_lm_abs << mLMNormalAbsTolerance << tangent_lm_ratio << mLMTangentRatioTolerance << tangent_lm_abs << mLMTangentAbsTolerance;
+                    auto& r_table = p_table->GetTable();
+                    r_table << residual_disp_ratio << mDispRatioTolerance << residual_disp_abs << mDispAbsTolerance << normal_lm_ratio << mLMNormalRatioTolerance << normal_lm_abs << mLMNormalAbsTolerance << tangent_lm_ratio << mLMTangentRatioTolerance << tangent_lm_abs << mLMTangentAbsTolerance;
                 } else {
                     std::cout.precision(4);
-                    if (mPrintingOutput == false) {
+                    if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::PRINTING_OUTPUT)) {
                         KRATOS_INFO("DisplacementLagrangeMultiplierMixedFrictionalContactCriteria") << BOLDFONT("MIXED CONVERGENCE CHECK") << "\tSTEP: " << r_process_info[STEP] << "\tNL ITERATION: " << r_process_info[NL_ITERATION_NUMBER] << std::endl << std::scientific;
                         KRATOS_INFO("DisplacementLagrangeMultiplierMixedFrictionalContactCriteria") << BOLDFONT("\tDISPLACEMENT: RATIO = ") << residual_disp_ratio << BOLDFONT(" EXP.RATIO = ") << mDispRatioTolerance << BOLDFONT(" ABS = ") << residual_disp_abs << BOLDFONT(" EXP.ABS = ") << mDispAbsTolerance << std::endl;
                         KRATOS_INFO("DisplacementLagrangeMultiplierMixedFrictionalContactCriteria") << BOLDFONT("\tNORMAL LAGRANGE MUL: RATIO = ") << normal_lm_ratio << BOLDFONT(" EXP.RATIO = ") << mLMNormalRatioTolerance << BOLDFONT(" ABS = ") << normal_lm_abs << BOLDFONT(" EXP.ABS = ") << mLMNormalAbsTolerance << std::endl;
@@ -343,19 +349,19 @@ public:
 
             // We check if converged
             const bool disp_converged = (residual_disp_ratio <= mDispRatioTolerance || residual_disp_abs <= mDispAbsTolerance);
-            const bool lm_converged = (!mEnsureContact && normal_lm_solution_norm == 0.0) ? true : (normal_lm_ratio <= mLMNormalRatioTolerance || normal_lm_abs <= mLMNormalAbsTolerance) && (tangent_lm_ratio <= mLMTangentRatioTolerance || tangent_lm_abs <= mLMTangentAbsTolerance);
+            const bool lm_converged = (mOptions.IsNot(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::ENSURE_CONTACT) && normal_lm_solution_norm == 0.0) ? true : (normal_lm_ratio <= mLMNormalRatioTolerance || normal_lm_abs <= mLMNormalAbsTolerance) && (tangent_lm_ratio <= mLMTangentRatioTolerance || tangent_lm_abs <= mLMTangentAbsTolerance);
 
             if ( disp_converged && lm_converged ) {
                 if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
                     if (r_process_info.Has(TABLE_UTILITY)) {
                         TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                        auto& table = p_table->GetTable();
-                        if (mPrintingOutput == false)
-                            table << BOLDFONT(FGRN("       Achieved"));
+                        auto& r_table = p_table->GetTable();
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::PRINTING_OUTPUT))
+                            r_table << BOLDFONT(FGRN("       Achieved"));
                         else
-                            table << "Achieved";
+                            r_table << "Achieved";
                     } else {
-                        if (mPrintingOutput == false)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::PRINTING_OUTPUT))
                             KRATOS_INFO("DisplacementLagrangeMultiplierMixedFrictionalContactCriteria") << BOLDFONT("\tConvergence") << " is " << BOLDFONT(FGRN("achieved")) << std::endl;
                         else
                             KRATOS_INFO("DisplacementLagrangeMultiplierMixedFrictionalContactCriteria") << "\tConvergence is achieved" << std::endl;
@@ -366,13 +372,13 @@ public:
                 if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
                     if (r_process_info.Has(TABLE_UTILITY)) {
                         TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                        auto& table = p_table->GetTable();
-                        if (mPrintingOutput == false)
-                            table << BOLDFONT(FRED("   Not achieved"));
+                        auto& r_table = p_table->GetTable();
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::PRINTING_OUTPUT))
+                            r_table << BOLDFONT(FRED("   Not achieved"));
                         else
-                            table << "Not achieved";
+                            r_table << "Not achieved";
                     } else {
-                        if (mPrintingOutput == false)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::PRINTING_OUTPUT))
                             KRATOS_INFO("DisplacementLagrangeMultiplierMixedFrictionalContactCriteria") << BOLDFONT("\tConvergence") << " is " << BOLDFONT(FRED(" not achieved")) << std::endl;
                         else
                             KRATOS_INFO("DisplacementLagrangeMultiplierMixedFrictionalContactCriteria") << "\tConvergence is not achieved" << std::endl;
@@ -393,23 +399,23 @@ public:
         BaseType::mConvergenceCriteriaIsInitialized = true;
 
         ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-        if (r_process_info.Has(TABLE_UTILITY) && mTableIsInitialized == false) {
+        if (r_process_info.Has(TABLE_UTILITY) && mOptions.IsNot(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::TABLE_IS_INITIALIZED)) {
             TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-            auto& table = p_table->GetTable();
-            table.AddColumn("DP RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("N.LM RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("T.LM RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("CONVERGENCE", 15);
-            mTableIsInitialized = true;
+            auto& r_table = p_table->GetTable();
+            r_table.AddColumn("DP RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("N.LM RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("T.LM RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("CONVERGENCE", 15);
+            mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::TABLE_IS_INITIALIZED, true);
         }
     }
 
@@ -429,7 +435,7 @@ public:
         const TSystemVectorType& rb
         ) override
     {
-        mInitialResidualIsSet = false;
+        mOptions.Set(DisplacementLagrangeMultiplierMixedFrictionalContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
     }
 
     ///@}
@@ -486,12 +492,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    bool mInitialResidualIsSet; /// This "flag" is set in order to set that the initial residual is already computed
-
-    bool mEnsureContact; /// This "flag" is used to check that the norm of the LM is always greater than 0 (no contact)
-
-    bool mPrintingOutput;      /// If the colors and bold are printed
-    bool mTableIsInitialized;  /// If the table is already initialized
+    Flags mOptions; /// Local flags
 
     TDataType mDispRatioTolerance;      /// The ratio threshold for the norm of the displacement residual
     TDataType mDispAbsTolerance;        /// The absolute value threshold for the norm of the displacement residual
@@ -528,11 +529,28 @@ private:
     ///@name Unaccessible methods
     ///@{
     ///@}
-};
+};  // Kratos DisplacementLagrangeMultiplierMixedFrictionalContactCriteria
 
-///@} // Kratos classes
+///@name Local flags creation
+///@{
 
-///@} // Application group
+/// Local Flags
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedFrictionalContactCriteria<TSparseSpace, TDenseSpace>::ENSURE_CONTACT(Kratos::Flags::Create(0));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedFrictionalContactCriteria<TSparseSpace, TDenseSpace>::NOT_ENSURE_CONTACT(Kratos::Flags::Create(0, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedFrictionalContactCriteria<TSparseSpace, TDenseSpace>::PRINTING_OUTPUT(Kratos::Flags::Create(1));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedFrictionalContactCriteria<TSparseSpace, TDenseSpace>::NOT_PRINTING_OUTPUT(Kratos::Flags::Create(1, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedFrictionalContactCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(2));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedFrictionalContactCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(2, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedFrictionalContactCriteria<TSparseSpace, TDenseSpace>::INITIAL_RESIDUAL_IS_SET(Kratos::Flags::Create(3));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierMixedFrictionalContactCriteria<TSparseSpace, TDenseSpace>::NOT_INITIAL_RESIDUAL_IS_SET(Kratos::Flags::Create(3, false));
 }
 
 #endif	/* KRATOS_DISPLACEMENT_LAGRANGE_MULTIPLIER_MIXED_FRICTIONAL_CONTACT_CRITERIA_H */

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_contact_criteria.h
@@ -66,6 +66,12 @@ public:
     /// Pointer definition of DisplacementLagrangeMultiplierResidualContactCriteria
     KRATOS_CLASS_POINTER_DEFINITION( DisplacementLagrangeMultiplierResidualContactCriteria );
 
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( ENSURE_CONTACT );
+    KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
+    KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
+    KRATOS_DEFINE_LOCAL_FLAG( INITIAL_RESIDUAL_IS_SET );
+
     /// The base class definition (and it subclasses)
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > BaseType;
     typedef typename BaseType::TDataType                    TDataType;
@@ -76,7 +82,7 @@ public:
     /// The sparse space used
     typedef TSparseSpace                              SparseSpaceType;
 
-    /// The table stream definition TODO: Replace by logger
+    /// The r_table stream definition TODO: Replace by logger
     typedef TableStreamUtility::Pointer       TablePrinterPointerType;
 
     /// The index type definition
@@ -96,7 +102,7 @@ public:
      * @param LMRatioTolerance Relative tolerance for lagrange multiplier residual  error
      * @param LMAbsTolerance Absolute tolerance for lagrange multiplier residual error
      * @param EnsureContact To check if the contact is lost
-     * @param pTable The pointer to the output table
+     * @param pTable The pointer to the output r_table
      * @param PrintingOutput If the output is going to be printed in a txt file
      */
     explicit DisplacementLagrangeMultiplierResidualContactCriteria(
@@ -107,18 +113,19 @@ public:
         const bool EnsureContact = false,
         const bool PrintingOutput = false
         )
-        : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-          mEnsureContact(EnsureContact),
-          mPrintingOutput(PrintingOutput),
-          mTableIsInitialized(false)
+        : BaseType()
     {
+        // Set local flags
+        mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::ENSURE_CONTACT, EnsureContact);
+        mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::PRINTING_OUTPUT, PrintingOutput);
+        mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::TABLE_IS_INITIALIZED, false);
+        mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
+
         mDispRatioTolerance = DispRatioTolerance;
         mDispAbsTolerance = DispAbsTolerance;
 
         mLMRatioTolerance = LMRatioTolerance;
         mLMAbsTolerance = LMAbsTolerance;
-
-        mInitialResidualIsSet = false;
     }
 
     /**
@@ -126,8 +133,7 @@ public:
      * @param ThisParameters The configuration parameters
      */
     explicit DisplacementLagrangeMultiplierResidualContactCriteria( Parameters ThisParameters = Parameters(R"({})"))
-        : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-          mTableIsInitialized(false)
+        : BaseType()
     {
         // The default parameters
         Parameters default_parameters = Parameters(R"(
@@ -150,18 +156,17 @@ public:
         mLMRatioTolerance =  ThisParameters["contact_displacement_absolute_tolerance"].GetDouble();
         mLMAbsTolerance =  ThisParameters["contact_residual_absolute_tolerance"].GetDouble();
 
-        // Additional flags -> NOTE: Replace for a ral flag?¿
-        mEnsureContact = ThisParameters["ensure_contact"].GetBool();
-        mPrintingOutput = ThisParameters["print_convergence_criterion"].GetBool();
-
-        // We "initialize" the flag-> NOTE: Replace for a ral flag?¿
-        mInitialResidualIsSet = false;
+        // Set local flags
+        mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::ENSURE_CONTACT, ThisParameters["ensure_contact"].GetBool());
+        mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::PRINTING_OUTPUT, ThisParameters["print_convergence_criterion"].GetBool());
+        mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::TABLE_IS_INITIALIZED, false);
+        mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
     }
 
     //* Copy constructor.
     DisplacementLagrangeMultiplierResidualContactCriteria( DisplacementLagrangeMultiplierResidualContactCriteria const& rOther )
       :BaseType(rOther)
-      ,mInitialResidualIsSet(rOther.mInitialResidualIsSet)
+      ,mOptions(rOther.mOptions)
       ,mDispRatioTolerance(rOther.mDispRatioTolerance)
       ,mDispAbsTolerance(rOther.mDispAbsTolerance)
       ,mDispInitialResidualNorm(rOther.mDispInitialResidualNorm)
@@ -170,8 +175,6 @@ public:
       ,mLMAbsTolerance(rOther.mLMAbsTolerance)
       ,mLMInitialResidualNorm(rOther.mLMInitialResidualNorm)
       ,mLMCurrentResidualNorm(rOther.mLMCurrentResidualNorm)
-      ,mPrintingOutput(rOther.mPrintingOutput)
-      ,mTableIsInitialized(rOther.mTableIsInitialized)
     {
     }
 
@@ -204,13 +207,17 @@ public:
             TDataType disp_residual_solution_norm = 0.0, lm_residual_solution_norm = 0.0;
             IndexType disp_dof_num(0),lm_dof_num(0);
 
-            // Loop over Dofs
-            #pragma omp parallel for reduction(+:disp_residual_solution_norm,lm_residual_solution_norm,disp_dof_num,lm_dof_num)
-            for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
-                auto it_dof = rDofSet.begin() + i;
+            // First iterator
+            const auto it_dof_begin = rDofSet.begin();
 
-                std::size_t dof_id;
-                TDataType residual_dof_value;
+            // Auxiliar values
+            std::size_t dof_id = 0;
+            TDataType residual_dof_value = 0.0;
+
+            // Loop over Dofs
+            #pragma omp parallel for reduction(+:disp_residual_solution_norm,lm_residual_solution_norm,disp_dof_num,lm_dof_num,dof_id,residual_dof_value)
+            for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
+                auto it_dof = it_dof_begin + i;
 
                 if (it_dof->IsFree()) {
                     dof_id = it_dof->EquationId();
@@ -234,12 +241,12 @@ public:
             TDataType residual_lm_ratio = 1.0;
 
             // We initialize the solution
-            if (mInitialResidualIsSet == false) {
+            if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualContactCriteria::INITIAL_RESIDUAL_IS_SET)) {
                 mDispInitialResidualNorm = (disp_residual_solution_norm == 0.0) ? 1.0 : disp_residual_solution_norm;
                 mLMInitialResidualNorm = (lm_residual_solution_norm == 0.0) ? 1.0 : lm_residual_solution_norm;
                 residual_disp_ratio = 1.0;
                 residual_lm_ratio = 1.0;
-                mInitialResidualIsSet = true;
+                mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::INITIAL_RESIDUAL_IS_SET, true);
             }
 
             // We calculate the ratio of the displacements
@@ -248,7 +255,7 @@ public:
             // We calculate the ratio of the LM
             residual_lm_ratio = mLMCurrentResidualNorm/mLMInitialResidualNorm;
 
-            KRATOS_ERROR_IF(mEnsureContact && residual_lm_ratio == 0.0) << "ERROR::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
+            KRATOS_ERROR_IF(mOptions.Is(DisplacementLagrangeMultiplierResidualContactCriteria::ENSURE_CONTACT) && residual_lm_ratio == 0.0) << "ERROR::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
 
             // We calculate the absolute norms
             const TDataType residual_disp_abs = mDispCurrentResidualNorm/disp_dof_num;
@@ -266,7 +273,7 @@ public:
                     Table << residual_disp_ratio << mDispRatioTolerance << residual_disp_abs << mDispAbsTolerance << residual_lm_ratio << mLMRatioTolerance << residual_lm_abs << mLMAbsTolerance;
                 } else {
                     std::cout.precision(4);
-                    if (mPrintingOutput == false) {
+                    if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualContactCriteria::PRINTING_OUTPUT)) {
                         KRATOS_INFO("DisplacementLagrangeMultiplierResidualContactCriteria") << BOLDFONT("RESIDUAL CONVERGENCE CHECK") << "\tSTEP: " << r_process_info[STEP] << "\tNL ITERATION: " << r_process_info[NL_ITERATION_NUMBER] << std::endl << std::scientific;
                         KRATOS_INFO("DisplacementLagrangeMultiplierResidualContactCriteria") << BOLDFONT("\tDISPLACEMENT: RATIO = ") << residual_disp_ratio << BOLDFONT(" EXP.RATIO = ") << mDispRatioTolerance << BOLDFONT(" ABS = ") << residual_disp_abs << BOLDFONT(" EXP.ABS = ") << mDispAbsTolerance << std::endl;
                         KRATOS_INFO("DisplacementLagrangeMultiplierResidualContactCriteria") << BOLDFONT("\tLAGRANGE MUL: RATIO = ") << residual_lm_ratio << BOLDFONT(" EXP.RATIO = ") << mLMRatioTolerance << BOLDFONT(" ABS = ") << residual_lm_abs << BOLDFONT(" EXP.ABS = ") << mLMAbsTolerance << std::endl;
@@ -283,19 +290,19 @@ public:
 
             // We check if converged
             const bool disp_converged = (residual_disp_ratio <= mDispRatioTolerance || residual_disp_abs <= mDispAbsTolerance);
-            const bool lm_converged = (!mEnsureContact && residual_lm_ratio == 0.0) ? true : (residual_lm_ratio <= mLMRatioTolerance || residual_lm_abs <= mLMAbsTolerance);
+            const bool lm_converged = (mOptions.IsNot(DisplacementLagrangeMultiplierResidualContactCriteria::ENSURE_CONTACT) && residual_lm_ratio == 0.0) ? true : (residual_lm_ratio <= mLMRatioTolerance || residual_lm_abs <= mLMAbsTolerance);
 
             if (disp_converged && lm_converged ) {
                 if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
                     if (r_process_info.Has(TABLE_UTILITY)) {
                         TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
                         auto& Table = p_table->GetTable();
-                        if (mPrintingOutput == false)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualContactCriteria::PRINTING_OUTPUT))
                             Table << BOLDFONT(FGRN("       Achieved"));
                         else
                             Table << "Achieved";
                     } else {
-                        if (mPrintingOutput == false)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualContactCriteria::PRINTING_OUTPUT))
                             KRATOS_INFO("DisplacementLagrangeMultiplierResidualContactCriteria") << BOLDFONT("\tResidual") << " convergence is " << BOLDFONT(FGRN("achieved")) << std::endl;
                         else
                             KRATOS_INFO("DisplacementLagrangeMultiplierResidualContactCriteria") << "\tResidual convergence is achieved" << std::endl;
@@ -306,13 +313,13 @@ public:
                 if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
                     if (r_process_info.Has(TABLE_UTILITY)) {
                         TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                        auto& table = p_table->GetTable();
-                        if (mPrintingOutput == false)
-                            table << BOLDFONT(FRED("   Not achieved"));
+                        auto& r_table = p_table->GetTable();
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualContactCriteria::PRINTING_OUTPUT))
+                            r_table << BOLDFONT(FRED("   Not achieved"));
                         else
-                            table << "Not achieved";
+                            r_table << "Not achieved";
                     } else {
-                        if (mPrintingOutput == false)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualContactCriteria::PRINTING_OUTPUT))
                             KRATOS_INFO("DisplacementLagrangeMultiplierResidualContactCriteria") << BOLDFONT("\tResidual") << " convergence is " << BOLDFONT(FRED(" not achieved")) << std::endl;
                         else
                             KRATOS_INFO("DisplacementLagrangeMultiplierResidualContactCriteria") << "\tResidual convergence is not achieved" << std::endl;
@@ -333,19 +340,19 @@ public:
         BaseType::mConvergenceCriteriaIsInitialized = true;
 
         ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-        if (r_process_info.Has(TABLE_UTILITY) && mTableIsInitialized == false) {
+        if (r_process_info.Has(TABLE_UTILITY) && mOptions.IsNot(DisplacementLagrangeMultiplierResidualContactCriteria::TABLE_IS_INITIALIZED)) {
             TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-            auto& table = p_table->GetTable();
-            table.AddColumn("DP RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("LM RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("CONVERGENCE", 15);
-            mTableIsInitialized = true;
+            auto& r_table = p_table->GetTable();
+            r_table.AddColumn("DP RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("LM RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("CONVERGENCE", 15);
+            mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::TABLE_IS_INITIALIZED, true);
         }
     }
 
@@ -365,7 +372,7 @@ public:
         const TSystemVectorType& rb
         ) override
     {
-        mInitialResidualIsSet = false;
+        mOptions.Set(DisplacementLagrangeMultiplierResidualContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
     }
 
     ///@}
@@ -422,12 +429,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    bool mInitialResidualIsSet; /// This "flag" is set in order to set that the initial residual is already computed
-
-    bool mEnsureContact; /// This "flag" is used to check that the norm of the LM is always greater than 0 (no contact)
-
-    bool mPrintingOutput;      /// If the colors and bold are printed
-    bool mTableIsInitialized;  /// If the table is already initialized
+    Flags mOptions; /// Local flags
 
     TDataType mDispRatioTolerance;      /// The ratio threshold for the norm of the displacement residual
     TDataType mDispAbsTolerance;        /// The absolute value threshold for the norm of the displacement residual
@@ -463,11 +465,28 @@ private:
     ///@name Unaccessible methods
     ///@{
     ///@}
-};
+};  // Kratos DisplacementLagrangeMultiplierResidualContactCriteria
 
-///@} // Kratos classes
+///@name Local flags creation
+///@{
 
-///@} // Application group
+/// Local Flags
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualContactCriteria<TSparseSpace, TDenseSpace>::ENSURE_CONTACT(Kratos::Flags::Create(0));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualContactCriteria<TSparseSpace, TDenseSpace>::NOT_ENSURE_CONTACT(Kratos::Flags::Create(0, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualContactCriteria<TSparseSpace, TDenseSpace>::PRINTING_OUTPUT(Kratos::Flags::Create(1));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualContactCriteria<TSparseSpace, TDenseSpace>::NOT_PRINTING_OUTPUT(Kratos::Flags::Create(1, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualContactCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(2));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualContactCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(2, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualContactCriteria<TSparseSpace, TDenseSpace>::INITIAL_RESIDUAL_IS_SET(Kratos::Flags::Create(3));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualContactCriteria<TSparseSpace, TDenseSpace>::NOT_INITIAL_RESIDUAL_IS_SET(Kratos::Flags::Create(3, false));
 }
 
 #endif /* KRATOS_DISPLACEMENT_LAGRANGE_MULTIPLIER_RESIDUAL_CONTACT_CRITERIA_H */

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_frictional_contact_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_lagrangemultiplier_residual_frictional_contact_criteria.h
@@ -66,6 +66,12 @@ public:
     /// Pointer definition of DisplacementLagrangeMultiplierResidualFrictionalContactCriteria
     KRATOS_CLASS_POINTER_DEFINITION( DisplacementLagrangeMultiplierResidualFrictionalContactCriteria );
 
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( ENSURE_CONTACT );
+    KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
+    KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
+    KRATOS_DEFINE_LOCAL_FLAG( INITIAL_RESIDUAL_IS_SET );
+
     /// The base class definition (and it subclasses)
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > BaseType;
     typedef typename BaseType::TDataType                    TDataType;
@@ -76,7 +82,7 @@ public:
     /// The sparse space used
     typedef TSparseSpace                              SparseSpaceType;
 
-    /// The table stream definition TODO: Replace by logger
+    /// The r_table stream definition TODO: Replace by logger
     typedef TableStreamUtility::Pointer       TablePrinterPointerType;
 
     /// The index type definition
@@ -96,7 +102,7 @@ public:
      * @param LMRatioTolerance Relative tolerance for lagrange multiplier residual  error
      * @param LMAbsTolerance Absolute tolerance for lagrange multiplier residual error
      * @param EnsureContact To check if the contact is lost
-     * @param pTable The pointer to the output table
+     * @param pTable The pointer to the output r_table
      * @param PrintingOutput If the output is going to be printed in a txt file
      */
     explicit DisplacementLagrangeMultiplierResidualFrictionalContactCriteria(
@@ -108,11 +114,14 @@ public:
         const TDataType LMTangentAbsTolerance,
         const bool EnsureContact = false,
         const bool PrintingOutput = false
-        ) : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-          mEnsureContact(EnsureContact),
-          mPrintingOutput(PrintingOutput),
-          mTableIsInitialized(false)
+        ) : BaseType()
     {
+        // Set local flags
+        mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::ENSURE_CONTACT, EnsureContact);
+        mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::PRINTING_OUTPUT, PrintingOutput);
+        mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::TABLE_IS_INITIALIZED, false);
+        mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
+
         // The displacement residual
         mDispRatioTolerance = DispRatioTolerance;
         mDispAbsTolerance = DispAbsTolerance;
@@ -124,9 +133,6 @@ public:
         // The tangent contact residual
         mLMTangentRatioTolerance = LMTangentRatioTolerance;
         mLMTangentAbsTolerance = LMTangentAbsTolerance;
-
-        // We "initialize" the flag-> NOTE: Replace for a ral flag?¿
-        mInitialResidualIsSet = false;
     }
 
     /**
@@ -134,8 +140,7 @@ public:
      * @param ThisParameters The configuration parameters
      */
     explicit DisplacementLagrangeMultiplierResidualFrictionalContactCriteria( Parameters ThisParameters = Parameters(R"({})"))
-        : ConvergenceCriteria< TSparseSpace, TDenseSpace >(),
-          mTableIsInitialized(false)
+        : BaseType()
     {
         // The default parameters
         Parameters default_parameters = Parameters(R"(
@@ -164,18 +169,17 @@ public:
         mLMTangentRatioTolerance =  ThisParameters["frictional_contact_residual_relative_tolerance"].GetDouble();
         mLMTangentAbsTolerance =  ThisParameters["frictional_contact_residual_absolute_tolerance"].GetDouble();
 
-        // Additional flags -> NOTE: Replace for a ral flag?¿
-        mEnsureContact = ThisParameters["ensure_contact"].GetBool();
-        mPrintingOutput = ThisParameters["print_convergence_criterion"].GetBool();
-
-        // We "initialize" the flag-> NOTE: Replace for a ral flag?¿
-        mInitialResidualIsSet = false;
+        // Set local flags
+        mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::ENSURE_CONTACT, ThisParameters["ensure_contact"].GetBool());
+        mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::PRINTING_OUTPUT, ThisParameters["print_convergence_criterion"].GetBool());
+        mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::TABLE_IS_INITIALIZED, false);
+        mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
     }
 
     //* Copy constructor.
     DisplacementLagrangeMultiplierResidualFrictionalContactCriteria( DisplacementLagrangeMultiplierResidualFrictionalContactCriteria const& rOther )
       :BaseType(rOther)
-      ,mInitialResidualIsSet(rOther.mInitialResidualIsSet)
+      ,mOptions(rOther.mOptions)
       ,mDispRatioTolerance(rOther.mDispRatioTolerance)
       ,mDispAbsTolerance(rOther.mDispAbsTolerance)
       ,mDispInitialResidualNorm(rOther.mDispInitialResidualNorm)
@@ -188,9 +192,6 @@ public:
       ,mLMTangentAbsTolerance(rOther.mLMTangentAbsTolerance)
       ,mLMTangentInitialResidualNorm(rOther.mLMTangentInitialResidualNorm)
       ,mLMTangentCurrentResidualNorm(rOther.mLMTangentCurrentResidualNorm)
-      ,mEnsureContact(rOther.mEnsureContact)
-      ,mPrintingOutput(rOther.mPrintingOutput)
-      ,mTableIsInitialized(rOther.mTableIsInitialized)
     {
     }
 
@@ -224,15 +225,19 @@ public:
             IndexType disp_dof_num(0),lm_dof_num(0);
 
             // The nodes array
-            auto& nodes_array = rModelPart.Nodes();
+            auto& r_nodes_array = rModelPart.Nodes();
+
+            // First iterator
+            const auto it_dof_begin = rDofSet.begin();
+
+            // Auxiliar values
+            std::size_t dof_id = 0;
+            TDataType residual_dof_value = 0.0;
 
             // Loop over Dofs
-            #pragma omp parallel for reduction(+:disp_residual_solution_norm,normal_lm_residual_solution_norm, tangent_lm_residual_solution_norm,disp_dof_num,lm_dof_num)
+            #pragma omp parallel for reduction(+:disp_residual_solution_norm,normal_lm_residual_solution_norm, tangent_lm_residual_solution_norm,disp_dof_num,lm_dof_num,dof_id,residual_dof_value)
             for (int i = 0; i < static_cast<int>(rDofSet.size()); i++) {
-                auto it_dof = rDofSet.begin() + i;
-
-                std::size_t dof_id;
-                TDataType residual_dof_value;
+                auto it_dof = it_dof_begin + i;
 
                 if (it_dof->IsFree()) {
                     // The component of the residual
@@ -242,28 +247,28 @@ public:
                     const auto curr_var = it_dof->GetVariable();
                     if (curr_var == VECTOR_LAGRANGE_MULTIPLIER_X) {
                         // The normal of the node (TODO: how to solve this without accesing all the time to the database?)
-                        const auto& it_node = nodes_array.find(it_dof->Id());
-                        const array_1d<double, 3>& normal = it_node->FastGetSolutionStepValue(NORMAL);
+                        const auto& it_node = r_nodes_array.find(it_dof->Id());
+                        const double normal_x = it_node->FastGetSolutionStepValue(NORMAL_X);
 
-                        const TDataType normal_comp_residual = residual_dof_value * normal[0];
+                        const TDataType normal_comp_residual = residual_dof_value * normal_x;
                         normal_lm_residual_solution_norm += std::pow(normal_comp_residual, 2);
                         tangent_lm_residual_solution_norm += std::pow(residual_dof_value - normal_comp_residual, 2);
                         lm_dof_num++;
                     } else if (curr_var == VECTOR_LAGRANGE_MULTIPLIER_Y) {
                         // The normal of the node (TODO: how to solve this without accesing all the time to the database?)
-                        const auto& it_node = nodes_array.find(it_dof->Id());
-                        const array_1d<double, 3>& normal = it_node->FastGetSolutionStepValue(NORMAL);
+                        const auto& it_node = r_nodes_array.find(it_dof->Id());
+                        const double normal_y = it_node->FastGetSolutionStepValue(NORMAL_Y);
 
-                        const TDataType normal_comp_residual = residual_dof_value * normal[1];
+                        const TDataType normal_comp_residual = residual_dof_value * normal_y;
                         normal_lm_residual_solution_norm += std::pow(normal_comp_residual, 2);
                         tangent_lm_residual_solution_norm += std::pow(residual_dof_value - normal_comp_residual, 2);
                         lm_dof_num++;
                     } else if (curr_var == VECTOR_LAGRANGE_MULTIPLIER_Z) {
                         // The normal of the node (TODO: how to solve this without accesing all the time to the database?)
-                        const auto& it_node = nodes_array.find(it_dof->Id());
-                        const array_1d<double, 3>& normal = it_node->FastGetSolutionStepValue(NORMAL);
+                        const auto& it_node = r_nodes_array.find(it_dof->Id());
+                        const double normal_z = it_node->FastGetSolutionStepValue(NORMAL_Z);
 
-                        const TDataType normal_comp_residual = residual_dof_value * normal[2];
+                        const TDataType normal_comp_residual = residual_dof_value * normal_z;
                         normal_lm_residual_solution_norm += std::pow(normal_comp_residual, 2);
                         tangent_lm_residual_solution_norm += std::pow(residual_dof_value - normal_comp_residual, 2);
                         lm_dof_num++;
@@ -283,14 +288,14 @@ public:
             TDataType residual_tangent_lm_ratio = 1.0;
 
             // We initialize the solution
-            if (mInitialResidualIsSet == false) {
+            if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::INITIAL_RESIDUAL_IS_SET)) {
                 mDispInitialResidualNorm = (disp_residual_solution_norm == 0.0) ? 1.0 : disp_residual_solution_norm;
                 mLMNormalInitialResidualNorm = (normal_lm_residual_solution_norm == 0.0) ? 1.0 : normal_lm_residual_solution_norm;
                 mLMTangentInitialResidualNorm = (tangent_lm_residual_solution_norm == 0.0) ? 1.0 : tangent_lm_residual_solution_norm;
                 residual_disp_ratio = 1.0;
                 residual_normal_lm_ratio = 1.0;
                 residual_tangent_lm_ratio = 1.0;
-                mInitialResidualIsSet = true;
+                mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::INITIAL_RESIDUAL_IS_SET, true);
             }
 
             // We calculate the ratio of the displacements
@@ -300,7 +305,7 @@ public:
             residual_normal_lm_ratio = mLMNormalCurrentResidualNorm/mLMNormalInitialResidualNorm;
             residual_tangent_lm_ratio = mLMTangentCurrentResidualNorm/mLMTangentInitialResidualNorm;
 
-            KRATOS_ERROR_IF(mEnsureContact && residual_normal_lm_ratio == 0.0) << "ERROR::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
+            KRATOS_ERROR_IF(mOptions.Is(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::ENSURE_CONTACT) && residual_normal_lm_ratio == 0.0) << "ERROR::CONTACT LOST::ARE YOU SURE YOU ARE SUPPOSED TO HAVE CONTACT?" << std::endl;
 
             // We calculate the absolute norms
             const TDataType residual_disp_abs = mDispCurrentResidualNorm/disp_dof_num;
@@ -315,11 +320,11 @@ public:
                 if (r_process_info.Has(TABLE_UTILITY)) {
                     std::cout.precision(4);
                     TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                    auto& Table = p_table->GetTable();
-                    Table << residual_disp_ratio << mDispRatioTolerance << residual_disp_abs << mDispAbsTolerance << residual_normal_lm_ratio << mLMNormalRatioTolerance << residual_normal_lm_abs << mLMNormalAbsTolerance << residual_tangent_lm_ratio << mLMTangentRatioTolerance << residual_tangent_lm_abs << mLMTangentAbsTolerance;
+                    auto& r_table = p_table->GetTable();
+                    r_table << residual_disp_ratio << mDispRatioTolerance << residual_disp_abs << mDispAbsTolerance << residual_normal_lm_ratio << mLMNormalRatioTolerance << residual_normal_lm_abs << mLMNormalAbsTolerance << residual_tangent_lm_ratio << mLMTangentRatioTolerance << residual_tangent_lm_abs << mLMTangentAbsTolerance;
                 } else {
                     std::cout.precision(4);
-                    if (!mPrintingOutput) {
+                    if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::PRINTING_OUTPUT)) {
                         KRATOS_INFO("DisplacementLagrangeMultiplierResidualFrictionalContactCriteria") << BOLDFONT("RESIDUAL CONVERGENCE CHECK") << "\tSTEP: " << r_process_info[STEP] << "\tNL ITERATION: " << r_process_info[NL_ITERATION_NUMBER] << std::endl << std::scientific;
                         KRATOS_INFO("DisplacementLagrangeMultiplierResidualFrictionalContactCriteria") << BOLDFONT("\tDISPLACEMENT: RATIO = ") << residual_disp_ratio << BOLDFONT(" EXP.RATIO = ") << mDispRatioTolerance << BOLDFONT(" ABS = ") << residual_disp_abs << BOLDFONT(" EXP.ABS = ") << mDispAbsTolerance << std::endl;
                         KRATOS_INFO("DisplacementLagrangeMultiplierResidualFrictionalContactCriteria") << BOLDFONT("\tNORMAL LAGRANGE MUL: RATIO = ") << residual_normal_lm_ratio << BOLDFONT(" EXP.RATIO = ") << mLMNormalRatioTolerance << BOLDFONT(" ABS = ") << residual_normal_lm_abs << BOLDFONT(" EXP.ABS = ") << mLMNormalAbsTolerance << std::endl;
@@ -339,19 +344,19 @@ public:
 
             // We check if converged
             const bool disp_converged = (residual_disp_ratio <= mDispRatioTolerance || residual_disp_abs <= mDispAbsTolerance);
-            const bool lm_converged = (!mEnsureContact && residual_normal_lm_ratio == 0.0) ? true : (residual_normal_lm_ratio <= mLMNormalRatioTolerance || residual_normal_lm_abs <= mLMNormalAbsTolerance) && (residual_tangent_lm_ratio <= mLMTangentRatioTolerance || residual_tangent_lm_abs <= mLMTangentAbsTolerance);
+            const bool lm_converged = (mOptions.IsNot(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::ENSURE_CONTACT) && residual_normal_lm_ratio == 0.0) ? true : (residual_normal_lm_ratio <= mLMNormalRatioTolerance || residual_normal_lm_abs <= mLMNormalAbsTolerance) && (residual_tangent_lm_ratio <= mLMTangentRatioTolerance || residual_tangent_lm_abs <= mLMTangentAbsTolerance);
 
             if (disp_converged && lm_converged ) {
                 if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
                     if (r_process_info.Has(TABLE_UTILITY)) {
                         TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                        auto& Table = p_table->GetTable();
-                        if (!mPrintingOutput)
-                            Table << BOLDFONT(FGRN("       Achieved"));
+                        auto& r_table = p_table->GetTable();
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::PRINTING_OUTPUT))
+                            r_table << BOLDFONT(FGRN("       Achieved"));
                         else
-                            Table << "Achieved";
+                            r_table << "Achieved";
                     } else {
-                        if (!mPrintingOutput)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::PRINTING_OUTPUT))
                             KRATOS_INFO("DisplacementLagrangeMultiplierResidualFrictionalContactCriteria") << BOLDFONT("\tResidual") << " convergence is " << BOLDFONT(FGRN("achieved")) << std::endl;
                         else
                             KRATOS_INFO("DisplacementLagrangeMultiplierResidualFrictionalContactCriteria") << "\tResidual convergence is achieved" << std::endl;
@@ -362,13 +367,13 @@ public:
                 if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
                     if (r_process_info.Has(TABLE_UTILITY)) {
                         TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                        auto& table = p_table->GetTable();
-                        if (!mPrintingOutput)
-                            table << BOLDFONT(FRED("   Not achieved"));
+                        auto& r_table = p_table->GetTable();
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::PRINTING_OUTPUT))
+                            r_table << BOLDFONT(FRED("   Not achieved"));
                         else
-                            table << "Not achieved";
+                            r_table << "Not achieved";
                     } else {
-                        if (!mPrintingOutput)
+                        if (mOptions.IsNot(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::PRINTING_OUTPUT))
                             KRATOS_INFO("DisplacementLagrangeMultiplierResidualFrictionalContactCriteria") << BOLDFONT("\tResidual") << " convergence is " << BOLDFONT(FRED(" not achieved")) << std::endl;
                         else
                             KRATOS_INFO("DisplacementLagrangeMultiplierResidualFrictionalContactCriteria") << "\tResidual convergence is not achieved" << std::endl;
@@ -389,23 +394,23 @@ public:
         BaseType::mConvergenceCriteriaIsInitialized = true;
 
         ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-        if (r_process_info.Has(TABLE_UTILITY) && mTableIsInitialized == false) {
+        if (r_process_info.Has(TABLE_UTILITY) && mOptions.IsNot(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::TABLE_IS_INITIALIZED)) {
             TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-            auto& table = p_table->GetTable();
-            table.AddColumn("DP RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("N.LM RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("T.LM RATIO", 10);
-            table.AddColumn("EXP. RAT", 10);
-            table.AddColumn("ABS", 10);
-            table.AddColumn("EXP. ABS", 10);
-            table.AddColumn("CONVERGENCE", 15);
-            mTableIsInitialized = true;
+            auto& r_table = p_table->GetTable();
+            r_table.AddColumn("DP RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("N.LM RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("T.LM RATIO", 10);
+            r_table.AddColumn("EXP. RAT", 10);
+            r_table.AddColumn("ABS", 10);
+            r_table.AddColumn("EXP. ABS", 10);
+            r_table.AddColumn("CONVERGENCE", 15);
+            mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::TABLE_IS_INITIALIZED, true);
         }
     }
 
@@ -425,7 +430,7 @@ public:
         const TSystemVectorType& rb
         ) override
     {
-        mInitialResidualIsSet = false;
+        mOptions.Set(DisplacementLagrangeMultiplierResidualFrictionalContactCriteria::INITIAL_RESIDUAL_IS_SET, false);
     }
 
     ///@}
@@ -482,12 +487,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    bool mInitialResidualIsSet; /// This "flag" is set in order to set that the initial residual is already computed
-
-    bool mEnsureContact; /// This "flag" is used to check that the norm of the LM is always greater than 0 (no contact)
-
-    bool mPrintingOutput;      /// If the colors and bold are printed
-    bool mTableIsInitialized;  /// If the table is already initialized
+    Flags mOptions; /// Local flags
 
     TDataType mDispRatioTolerance;      /// The ratio threshold for the norm of the displacement residual
     TDataType mDispAbsTolerance;        /// The absolute value threshold for the norm of the displacement residual
@@ -528,11 +528,28 @@ private:
     ///@name Unaccessible methods
     ///@{
     ///@}
-};
+};  // Kratos DisplacementLagrangeMultiplierResidualFrictionalContactCriteria
 
-///@} // Kratos classes
+///@name Local flags creation
+///@{
 
-///@} // Kratos namespace
+/// Local Flags
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualFrictionalContactCriteria<TSparseSpace, TDenseSpace>::ENSURE_CONTACT(Kratos::Flags::Create(0));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualFrictionalContactCriteria<TSparseSpace, TDenseSpace>::NOT_ENSURE_CONTACT(Kratos::Flags::Create(0, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualFrictionalContactCriteria<TSparseSpace, TDenseSpace>::PRINTING_OUTPUT(Kratos::Flags::Create(1));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualFrictionalContactCriteria<TSparseSpace, TDenseSpace>::NOT_PRINTING_OUTPUT(Kratos::Flags::Create(1, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualFrictionalContactCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(2));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualFrictionalContactCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(2, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualFrictionalContactCriteria<TSparseSpace, TDenseSpace>::INITIAL_RESIDUAL_IS_SET(Kratos::Flags::Create(3));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags DisplacementLagrangeMultiplierResidualFrictionalContactCriteria<TSparseSpace, TDenseSpace>::NOT_INITIAL_RESIDUAL_IS_SET(Kratos::Flags::Create(3, false));
 }
 
 #endif /* KRATOS_DISPLACEMENT_LAGRANGE_MULTIPLIER_RESIDUAL_FRICTIONAL_CONTACT_CRITERIA_H */

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/mesh_tying_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/mesh_tying_mortar_criteria.h
@@ -45,7 +45,11 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
-/** @brief Custom convergence criteria for the mortar condition
+/**
+ * @class ALMFrictionlessComponentsMortarConvergenceCriteria
+ * @ingroup ContactStructuralMechanicsApplication
+ * @brief Custom convergence criteria for the mortar mesh tying condition
+ * @author Vicente Mataix Ferrandiz
  */
 template<class TSparseSpace, class TDenseSpace>
 class MeshTyingMortarConvergenceCriteria
@@ -84,7 +88,7 @@ public:
 
     /// Default constructors
     explicit MeshTyingMortarConvergenceCriteria()
-        : BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >()
+        : BaseType()
     {
     }
 
@@ -102,7 +106,7 @@ public:
     ///@{
 
     /**
-     * Compute relative and absolute error.
+     * @brief Compute relative and absolute error.
      * @param rModelPart Reference to the ModelPart containing the contact problem.
      * @param rDofSet Reference to the container of the problem's degrees of freedom (stored by the BuilderAndSolver)
      * @param rA System matrix (unused)
@@ -128,7 +132,7 @@ public:
     }
 
     /**
-     * This function initialize the convergence criteria
+     * @brief This function initialize the convergence criteria
      * @param rModelPart The model part of interest
      */
     void Initialize(ModelPart& rModelPart) override

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/mortar_and_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/mortar_and_criteria.h
@@ -63,6 +63,10 @@ public:
     /// Pointer definition of MortarAndConvergenceCriteria
     KRATOS_CLASS_POINTER_DEFINITION( MortarAndConvergenceCriteria );
 
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
+    KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
+
     /// The base convergence criteria class definition
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > ConvergenceCriteriaBaseType;
 
@@ -97,29 +101,27 @@ public:
      * Constructor.
      */
     explicit MortarAndConvergenceCriteria(
-        typename ConvergenceCriteria < TSparseSpace, TDenseSpace >::Pointer pFirstCriterion,
-        typename ConvergenceCriteria < TSparseSpace, TDenseSpace >::Pointer pSecondCriterion,
+        typename ConvergenceCriteriaBaseType::Pointer pFirstCriterion,
+        typename ConvergenceCriteriaBaseType::Pointer pSecondCriterion,
         const bool PrintingOutput = false,
         ConditionNumberUtilityPointerType pConditionNumberUtility = nullptr
         )
-        :And_Criteria< TSparseSpace, TDenseSpace >(pFirstCriterion, pSecondCriterion),
-        mPrintingOutput(PrintingOutput),
-        mpConditionNumberUtility(pConditionNumberUtility),
-        mTableIsInitialized(false)
+        :BaseType(pFirstCriterion, pSecondCriterion),
+        mpConditionNumberUtility(pConditionNumberUtility)
     {
+        // Set local flags
+        mOptions.Set(MortarAndConvergenceCriteria::PRINTING_OUTPUT, PrintingOutput);
+        mOptions.Set(MortarAndConvergenceCriteria::TABLE_IS_INITIALIZED, false);
     }
 
     /**
      * Copy constructor.
      */
     MortarAndConvergenceCriteria(MortarAndConvergenceCriteria const& rOther)
-      :BaseType(rOther)
-      ,mPrintingOutput(rOther.mPrintingOutput)
-      ,mTableIsInitialized(rOther.mTableIsInitialized)
-      ,mpConditionNumberUtility(rOther.mpConditionNumberUtility)
+        :BaseType(rOther)
+        ,mOptions(rOther.mOptions)
+        ,mpConditionNumberUtility(rOther.mpConditionNumberUtility)
      {
-         BaseType::mpFirstCriterion  = rOther.mpFirstCriterion;
-         BaseType::mpSecondCriterion = rOther.mpSecondCriterion;
      }
 
     /** Destructor.
@@ -166,10 +168,10 @@ public:
             if (r_process_info.Has(TABLE_UTILITY)) {
                 std::cout.precision(4);
                 TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                auto& Table = p_table->GetTable();
-                Table  << condition_number;
+                auto& r_table = p_table->GetTable();
+                r_table  << condition_number;
             } else {
-                if (mPrintingOutput == false)
+                if (mOptions.IsNot(MortarAndConvergenceCriteria::PRINTING_OUTPUT))
                     KRATOS_INFO("MortarAndConvergenceCriteria") << "\n" << BOLDFONT("CONDITION NUMBER:") << "\t " << std::scientific << condition_number << std::endl;
                 else
                     KRATOS_INFO("MortarAndConvergenceCriteria") << "\n" << "CONDITION NUMBER:" << "\t" << std::scientific << condition_number << std::endl;
@@ -194,13 +196,13 @@ public:
         // The process info
         ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
 
-        if (r_process_info.Has(TABLE_UTILITY) && mTableIsInitialized == false) {
+        if (r_process_info.Has(TABLE_UTILITY) && mOptions.IsNot(MortarAndConvergenceCriteria::TABLE_IS_INITIALIZED)) {
             TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-            (p_table->GetTable()).SetBold(!mPrintingOutput);
+            (p_table->GetTable()).SetBold(mOptions.IsNot(MortarAndConvergenceCriteria::PRINTING_OUTPUT));
             (p_table->GetTable()).AddColumn("ITER", 4);
         }
 
-        mTableIsInitialized = true;
+        mOptions.Set(MortarAndConvergenceCriteria::TABLE_IS_INITIALIZED, true);
         BaseType::Initialize(rModelPart);
 
         if (r_process_info.Has(TABLE_UTILITY) && mpConditionNumberUtility != nullptr) {
@@ -230,7 +232,7 @@ public:
 
         if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
             std::cout.precision(4);
-            if (mPrintingOutput == false)
+            if (mOptions.IsNot(MortarAndConvergenceCriteria::PRINTING_OUTPUT))
                 std::cout << "\n\n" << BOLDFONT("CONVERGENCE CHECK") << "\tSTEP: " << rModelPart.GetProcessInfo()[STEP] << "\tTIME: " << std::scientific << rModelPart.GetProcessInfo()[TIME] << "\tDELTA TIME: " << std::scientific << rModelPart.GetProcessInfo()[DELTA_TIME] << std::endl;
             else
                 std::cout << "\n\n" << "CONVERGENCE CHECK" << "\tSTEP: " << rModelPart.GetProcessInfo()[STEP] << "\tTIME: " << std::scientific << rModelPart.GetProcessInfo()[TIME] << "\tDELTA TIME: " << std::scientific << rModelPart.GetProcessInfo()[DELTA_TIME] << std::endl;
@@ -320,9 +322,9 @@ private:
     ///@name Member Variables
     ///@{
 
-    bool mPrintingOutput;                                       /// If the colors and bold are printed
+    Flags mOptions; /// Local flags
+
     ConditionNumberUtilityPointerType mpConditionNumberUtility; /// The utility to compute the condition number
-    bool mTableIsInitialized;                                   /// If the table is already initialized
 
     ///@}
     ///@name Private Operators
@@ -346,14 +348,20 @@ private:
 
     ///@}
 
-}; /* Class MortarAndConvergenceCriteria */
+};  // Kratos MortarAndConvergenceCriteria
 
-///@}
-
-///@name Type Definitions */
+///@name Local flags creation
 ///@{
 
-///@}
+/// Local Flags
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags MortarAndConvergenceCriteria<TSparseSpace, TDenseSpace>::PRINTING_OUTPUT(Kratos::Flags::Create(1));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags MortarAndConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_PRINTING_OUTPUT(Kratos::Flags::Create(1, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags MortarAndConvergenceCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(2));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags MortarAndConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(2, false));
 
 }  /* namespace Kratos.*/
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictional_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictional_mortar_criteria.h
@@ -100,14 +100,16 @@ public:
 
     /// Default constructors
     explicit PenaltyFrictionalMortarConvergenceCriteria(
+        const bool PureSlip = false,
         const bool PrintingOutput = false,
         const bool ComputeDynamicFactor = true,
-        const bool GiDIODebug = false
-        ) : BaseType(ComputeDynamicFactor, GiDIODebug)
+        const bool IODebug = false
+        ) : BaseType(ComputeDynamicFactor, IODebug)
     {
         // Set local flags
         BaseType::mOptions.Set(PenaltyFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT, PrintingOutput);
         BaseType::mOptions.Set(PenaltyFrictionalMortarConvergenceCriteria::TABLE_IS_INITIALIZED, false);
+        BaseType::mOptions.Set(PenaltyFrictionalMortarConvergenceCriteria::PURE_SLIP, PureSlip);
     }
 
     ///Copy constructor

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictional_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictional_mortar_criteria.h
@@ -66,6 +66,10 @@ public:
     /// The base convergence criteria class definition
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > ConvergenceCriteriaBaseType;
 
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
+    KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
+
     /// The base class definition (and it subclasses)
     typedef BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >          BaseType;
     typedef typename BaseType::TDataType                                       TDataType;
@@ -80,7 +84,7 @@ public:
     typedef ModelPart::NodesContainerType                                 NodesArrayType;
     typedef ModelPart::ConditionsContainerType                       ConditionsArrayType;
 
-    /// The table stream definition TODO: Replace by logger
+    /// The r_table stream definition TODO: Replace by logger
     typedef TableStreamUtility::Pointer                          TablePrinterPointerType;
 
     /// The index type definition
@@ -98,17 +102,16 @@ public:
         const bool PrintingOutput = false,
         const bool ComputeDynamicFactor = true,
         const bool GiDIODebug = false
-        ) : BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >(ComputeDynamicFactor, GiDIODebug),
-        mPrintingOutput(PrintingOutput),
-        mTableIsInitialized(false)
+        ) : BaseType(ComputeDynamicFactor, GiDIODebug)
     {
+        // Set local flags
+        BaseType::mOptions.Set(PenaltyFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT, PrintingOutput);
+        BaseType::mOptions.Set(PenaltyFrictionalMortarConvergenceCriteria::TABLE_IS_INITIALIZED, false);
     }
 
     ///Copy constructor
     PenaltyFrictionalMortarConvergenceCriteria( PenaltyFrictionalMortarConvergenceCriteria const& rOther )
       :BaseType(rOther)
-      ,mPrintingOutput(rOther.mPrintingOutput)
-      ,mTableIsInitialized(rOther.mTableIsInitialized)
     {
     }
 
@@ -174,49 +177,49 @@ public:
         if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
             if (r_process_info.Has(TABLE_UTILITY)) {
                 TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                auto& table = p_table->GetTable();
+                auto& r_table = p_table->GetTable();
                 if (is_converged[0] == 0) {
-                    if (mPrintingOutput == false)
-                        table << BOLDFONT(FGRN("       Achieved"));
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FGRN("       Achieved"));
                     else
-                        table << "Achieved";
+                        r_table << "Achieved";
                 } else {
-                    if (mPrintingOutput == false)
-                        table << BOLDFONT(FRED("   Not achieved"));
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FRED("   Not achieved"));
                     else
-                        table << "Not achieved";
+                        r_table << "Not achieved";
                 }
                 if (is_converged[1] == 0) {
-                    if (mPrintingOutput == false)
-                        table << BOLDFONT(FGRN("       Achieved"));
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FGRN("       Achieved"));
                     else
-                        table << "Achieved";
+                        r_table << "Achieved";
                 } else {
-                    if (mPrintingOutput == false)
-                        table << BOLDFONT(FRED("   Not achieved"));
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FRED("   Not achieved"));
                     else
-                        table << "Not achieved";
+                        r_table << "Not achieved";
                 }
             } else {
                 if (is_converged[0] == 0) {
-                    if (mPrintingOutput == false)
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("PenaltyFrictionalMortarConvergenceCriteria") << BOLDFONT("\tActive set") << " convergence is " << BOLDFONT(FGRN("achieved")) << std::endl;
                     else
                         KRATOS_INFO("PenaltyFrictionalMortarConvergenceCriteria") << "\tActive set convergence is achieved" << std::endl;
                 } else {
-                    if (mPrintingOutput == false)
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("PenaltyFrictionalMortarConvergenceCriteria") << BOLDFONT("\tActive set") << " convergence is " << BOLDFONT(FRED("not achieved")) << std::endl;
                     else
                         KRATOS_INFO("PenaltyFrictionalMortarConvergenceCriteria") << "\tActive set convergence is not achieved" << std::endl;
                 }
 
                 if (is_converged[1] == 0) {
-                    if (mPrintingOutput == false)
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("PenaltyFrictionalMortarConvergenceCriteria") << BOLDFONT("\tSlip/stick set") << " convergence is " << BOLDFONT(FGRN("achieved")) << std::endl;
                     else
                         KRATOS_INFO("PenaltyFrictionalMortarConvergenceCriteria") << "\tSlip/stick set convergence is achieved" << std::endl;
                 } else {
-                    if (mPrintingOutput == false)
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionalMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("PenaltyFrictionalMortarConvergenceCriteria") << BOLDFONT("\tSlip/stick set") << " convergence is " << BOLDFONT(FRED("not achieved")) << std::endl;
                     else
                         KRATOS_INFO("PenaltyFrictionalMortarConvergenceCriteria") << "\tSlip/stick set  convergence is not achieved" << std::endl;
@@ -236,12 +239,12 @@ public:
         ConvergenceCriteriaBaseType::mConvergenceCriteriaIsInitialized = true;
 
         ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-        if (r_process_info.Has(TABLE_UTILITY) && mTableIsInitialized == false) {
+        if (r_process_info.Has(TABLE_UTILITY) && BaseType::mOptions.IsNot(PenaltyFrictionalMortarConvergenceCriteria::TABLE_IS_INITIALIZED)) {
             TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-            auto& table = p_table->GetTable();
-            table.AddColumn("ACTIVE SET CONV", 15);
-            table.AddColumn("SLIP/STICK CONV", 15);
-            mTableIsInitialized = true;
+            auto& r_table = p_table->GetTable();
+            r_table.AddColumn("ACTIVE SET CONV", 15);
+            r_table.AddColumn("SLIP/STICK CONV", 15);
+            BaseType::mOptions.Set(PenaltyFrictionalMortarConvergenceCriteria::TABLE_IS_INITIALIZED, true);
         }
     }
 
@@ -285,7 +288,7 @@ protected:
     void ResetWeightedGap(ModelPart& rModelPart) override
     {
         // Auxiliar zero array
-        const array_1d<double, 3> zero_array(3, 0.0);
+        const array_1d<double, 3> zero_array = ZeroVector(3);
 
         // We reset the weighted values
         NodesArrayType& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
@@ -314,9 +317,6 @@ private:
     ///@name Member Variables
     ///@{
 
-    bool mPrintingOutput;     /// If the colors and bold are printed
-    bool mTableIsInitialized; /// If the table is already initialized
-
     ///@}
     ///@name Private Operators
     ///@{
@@ -343,8 +343,18 @@ private:
 
 }; // Class PenaltyFrictionalMortarConvergenceCriteria
 
-///@name Explicit Specializations
+///@name Local flags creation
 ///@{
+
+/// Local Flags
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags PenaltyFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::PRINTING_OUTPUT(Kratos::Flags::Create(2));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags PenaltyFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_PRINTING_OUTPUT(Kratos::Flags::Create(2, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags PenaltyFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(3));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags PenaltyFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(3, false));
 
 }  // namespace Kratos
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictional_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictional_mortar_criteria.h
@@ -69,6 +69,7 @@ public:
     /// Local Flags
     KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
     KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
+    KRATOS_DEFINE_LOCAL_FLAG( PURE_SLIP );
 
     /// The base class definition (and it subclasses)
     typedef BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >          BaseType;
@@ -165,7 +166,7 @@ public:
         BaseType::PostCriteria(rModelPart, rDofSet, rA, rDx, rb);
 
         // Compute the active set
-        const array_1d<std::size_t, 2> is_converged = ActiveSetUtilities::ComputePenaltyFrictionalActiveSet(rModelPart);
+        const array_1d<std::size_t, 2> is_converged = ActiveSetUtilities::ComputePenaltyFrictionalActiveSet(rModelPart, BaseType::mOptions.Is(PenaltyFrictionalMortarConvergenceCriteria::PURE_SLIP));
 
         // We save to the process info if the active set has converged
         const bool active_set_converged = (is_converged[0] + is_converged[1]) == 0 ? true : false;
@@ -355,6 +356,10 @@ template<class TSparseSpace, class TDenseSpace>
 const Kratos::Flags PenaltyFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(3));
 template<class TSparseSpace, class TDenseSpace>
 const Kratos::Flags PenaltyFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(3, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags PenaltyFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::PURE_SLIP(Kratos::Flags::Create(4));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags PenaltyFrictionalMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_PURE_SLIP(Kratos::Flags::Create(4, false));
 
 }  // namespace Kratos
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictionless_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/penalty_frictionless_mortar_criteria.h
@@ -54,7 +54,7 @@ namespace Kratos
  */
 template<class TSparseSpace, class TDenseSpace>
 class PenaltyFrictionlessMortarConvergenceCriteria
-    : public  BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >
+    : public BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >
 {
 public:
     ///@name Type Definitions
@@ -62,6 +62,10 @@ public:
 
     /// Pointer definition of PenaltyFrictionlessMortarConvergenceCriteria
     KRATOS_CLASS_POINTER_DEFINITION( PenaltyFrictionlessMortarConvergenceCriteria );
+
+    /// Local Flags
+    KRATOS_DEFINE_LOCAL_FLAG( PRINTING_OUTPUT );
+    KRATOS_DEFINE_LOCAL_FLAG( TABLE_IS_INITIALIZED );
 
     /// The base convergence criteria class definition
     typedef ConvergenceCriteria< TSparseSpace, TDenseSpace > ConvergenceCriteriaBaseType;
@@ -80,7 +84,7 @@ public:
     typedef ModelPart::NodesContainerType                                 NodesArrayType;
     typedef ModelPart::ConditionsContainerType                       ConditionsArrayType;
 
-    /// The table stream definition TODO: Replace by logger
+    /// The r_table stream definition TODO: Replace by logger
     typedef TableStreamUtility::Pointer                          TablePrinterPointerType;
 
     /// The index type definition
@@ -95,17 +99,16 @@ public:
         const bool PrintingOutput = false,
         const bool ComputeDynamicFactor = true,
         const bool GiDIODebug = false
-        ) : BaseMortarConvergenceCriteria< TSparseSpace, TDenseSpace >(ComputeDynamicFactor, GiDIODebug),
-        mPrintingOutput(PrintingOutput),
-        mTableIsInitialized(false)
+        ) : BaseType(ComputeDynamicFactor, GiDIODebug)
     {
+        // Set local flags
+        BaseType::mOptions.Set(PenaltyFrictionlessMortarConvergenceCriteria::PRINTING_OUTPUT, PrintingOutput);
+        BaseType::mOptions.Set(PenaltyFrictionlessMortarConvergenceCriteria::TABLE_IS_INITIALIZED, false);
     }
 
     ///Copy constructor
     PenaltyFrictionlessMortarConvergenceCriteria( PenaltyFrictionlessMortarConvergenceCriteria const& rOther )
       :BaseType(rOther)
-      ,mPrintingOutput(rOther.mPrintingOutput)
-      ,mTableIsInitialized(rOther.mTableIsInitialized)
     {
     }
 
@@ -171,24 +174,24 @@ public:
         if (rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) {
             if (r_process_info.Has(TABLE_UTILITY)) {
                 TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-                auto& table = p_table->GetTable();
+                auto& r_table = p_table->GetTable();
                 if (active_set_converged) {
-                    if (mPrintingOutput == false)
-                        table << BOLDFONT(FGRN("       Achieved"));
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionlessMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FGRN("       Achieved"));
                     else
-                        table << "Achieved";
+                        r_table << "Achieved";
                 } else {
-                    if (mPrintingOutput == false)
-                        table << BOLDFONT(FRED("   Not achieved"));
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionlessMortarConvergenceCriteria::PRINTING_OUTPUT))
+                        r_table << BOLDFONT(FRED("   Not achieved"));
                     else
-                        table << "Not achieved";
+                        r_table << "Not achieved";
                 }
             } else {
                 if (active_set_converged) {
-                    if (mPrintingOutput == false)
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionlessMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("PenaltyFrictionlessMortarConvergenceCriteria")  << BOLDFONT("\tActive set") << " convergence is " << BOLDFONT(FGRN("achieved")) << std::endl;
                 } else {
-                    if (mPrintingOutput == false)
+                    if (BaseType::mOptions.IsNot(PenaltyFrictionlessMortarConvergenceCriteria::PRINTING_OUTPUT))
                         KRATOS_INFO("PenaltyFrictionlessMortarConvergenceCriteria")  << BOLDFONT("\tActive set") << " convergence is " << BOLDFONT(FRED("not achieved")) << std::endl;
                     else
                         KRATOS_INFO("PenaltyFrictionlessMortarConvergenceCriteria")  << "\tActive set convergence is not achieved" << std::endl;
@@ -208,11 +211,11 @@ public:
         ConvergenceCriteriaBaseType::mConvergenceCriteriaIsInitialized = true;
 
         ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-        if (r_process_info.Has(TABLE_UTILITY) && mTableIsInitialized == false) {
+        if (r_process_info.Has(TABLE_UTILITY) && BaseType::mOptions.IsNot(PenaltyFrictionlessMortarConvergenceCriteria::TABLE_IS_INITIALIZED)) {
             TablePrinterPointerType p_table = r_process_info[TABLE_UTILITY];
-            auto& table = p_table->GetTable();
-            table.AddColumn("ACTIVE SET CONV", 15);
-            mTableIsInitialized = true;
+            auto& r_table = p_table->GetTable();
+            r_table.AddColumn("ACTIVE SET CONV", 15);
+            BaseType::mOptions.Set(PenaltyFrictionlessMortarConvergenceCriteria::TABLE_IS_INITIALIZED, true);
         }
     }
 
@@ -270,10 +273,6 @@ private:
     ///@name Member Variables
     ///@{
 
-    TablePrinterPointerType p_table; /// Pointer to the fancy table
-    bool mPrintingOutput;            /// If the colors and bold are printed
-    bool mTableIsInitialized;        /// If the table is already initialized
-
     ///@}
     ///@name Private Operators
     ///@{
@@ -300,8 +299,18 @@ private:
 
 }; // Class PenaltyFrictionlessMortarConvergenceCriteria
 
-///@name Explicit Specializations
+///@name Local flags creation
 ///@{
+
+/// Local Flags
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags PenaltyFrictionlessMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::PRINTING_OUTPUT(Kratos::Flags::Create(2));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags PenaltyFrictionlessMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_PRINTING_OUTPUT(Kratos::Flags::Create(2, false));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags PenaltyFrictionlessMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::TABLE_IS_INITIALIZED(Kratos::Flags::Create(3));
+template<class TSparseSpace, class TDenseSpace>
+const Kratos::Flags PenaltyFrictionlessMortarConvergenceCriteria<TSparseSpace, TDenseSpace>::NOT_TABLE_IS_INITIALIZED(Kratos::Flags::Create(3, false));
 
 }  // namespace Kratos
 

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/active_set_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/active_set_utilities.cpp
@@ -158,6 +158,7 @@ array_1d<std::size_t, 2> ComputePenaltyFrictionalActiveSet(
                     if (it_node->Is(ACTIVE)) {
                         it_node->Set(ACTIVE, false);
                         it_node->Set(SLIP, PureSlip);
+                        #pragma omp atomic
                         is_converged_0 += 1;
                     }
                 }

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/active_set_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/active_set_utilities.cpp
@@ -1,0 +1,370 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:             BSD License
+//                                       license: StructuralMechanicsApplication/license.txt
+//
+//  Main authors:    Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "custom_utilities/active_set_utilities.h"
+#include "utilities/openmp_utils.h"
+#include "contact_structural_mechanics_application_variables.h"
+
+namespace Kratos
+{
+namespace ActiveSetUtilities
+{
+std::size_t ComputePenaltyFrictionlessActiveSet(ModelPart& rModelPart)
+{
+    // Defining the convergence
+    IndexType is_converged = 0;
+
+    // We get the process info
+    ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
+
+    // We check the active/inactive set during the first non-linear iteration or for the general semi-smooth case
+    if (rModelPart.Is(INTERACTION) || r_process_info[NL_ITERATION_NUMBER] == 1) {
+        const double common_epsilon = r_process_info[INITIAL_PENALTY];
+
+        auto& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
+        const auto it_node_begin = r_nodes_array.begin();
+
+        #pragma omp parallel for reduction(+:is_converged)
+        for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
+            auto it_node = it_node_begin + i;
+            if (it_node->Is(SLAVE)) {
+                const double epsilon = it_node->Has(INITIAL_PENALTY) ? it_node->GetValue(INITIAL_PENALTY) : common_epsilon;
+                const double augmented_normal_pressure = epsilon * it_node->FastGetSolutionStepValue(WEIGHTED_GAP);
+
+                it_node->SetValue(AUGMENTED_NORMAL_CONTACT_PRESSURE, augmented_normal_pressure); // NOTE: This value is purely for debugging interest (to see the "effective" pressure)
+
+                if (augmented_normal_pressure < 0.0) { // NOTE: This could be conflictive (< or <=)
+                    if (it_node->IsNot(ACTIVE)) {
+                        it_node->Set(ACTIVE, true);
+                        is_converged += 1;
+                    }
+                } else {
+                    if (it_node->Is(ACTIVE)) {
+                        it_node->Set(ACTIVE, false);
+                        is_converged += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    return is_converged;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+array_1d<std::size_t, 2> ComputePenaltyFrictionalActiveSet(
+    ModelPart& rModelPart,
+    const bool PureSlip
+    )
+{
+    // Auxiliar zero array
+    const array_1d<double, 3> zero_array = ZeroVector(3);
+
+    // Defining the convergence
+    array_1d<std::size_t, 2> is_converged;
+    is_converged[0] = 0;
+    is_converged[1] = 0;
+
+    std::size_t& is_converged_0 = is_converged[0];
+    std::size_t& is_converged_1 = is_converged[1];
+
+    // We get the process info
+    ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
+
+    // We check the active/inactive set during the first non-linear iteration or for the general semi-smooth case
+    if (rModelPart.Is(INTERACTION) || r_process_info[NL_ITERATION_NUMBER] == 1) {
+        const double common_epsilon = r_process_info[INITIAL_PENALTY];
+        const double tangent_factor = r_process_info[TANGENT_FACTOR];
+
+        auto& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
+        const auto it_node_begin = r_nodes_array.begin();
+
+        #pragma omp parallel for
+        for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
+            auto it_node = it_node_begin + i;
+            if (it_node->Is(SLAVE)) {
+                const double epsilon = it_node->Has(INITIAL_PENALTY) ? it_node->GetValue(INITIAL_PENALTY) : common_epsilon;
+
+                const double augmented_normal_pressure = epsilon * it_node->FastGetSolutionStepValue(WEIGHTED_GAP);
+
+//                 // BEGIN Adding debugging value of NORMAL_GAP
+//                 it_node->SetValue(NORMAL_GAP, it_node->FastGetSolutionStepValue(WEIGHTED_GAP)/it_node->GetValue(NODAL_AREA));
+//                 // END Adding debugging value of NORMAL_GAP
+
+                it_node->SetValue(AUGMENTED_NORMAL_CONTACT_PRESSURE, augmented_normal_pressure);
+
+                if (augmented_normal_pressure < 0.0) { // NOTE: This could be conflictive (< or <=)
+                    // The friction coefficient
+                    const double mu = it_node->GetValue(FRICTION_COEFFICIENT);
+
+                    // The weighted slip
+                    const array_1d<double, 3>& r_gt = it_node->FastGetSolutionStepValue(WEIGHTED_SLIP);
+
+//                     // BEGIN Adding debugging value of TANGENT_SLIP
+//                     it_node->SetValue(TANGENT_SLIP, r_gt/it_node->GetValue(NODAL_AREA));
+//                     // END Adding debugging value of TANGENT_SLIP
+
+                    // Computing the augmented tangent pressure
+                    const array_1d<double,3> augmented_tangent_pressure_components = tangent_factor * epsilon * r_gt;
+
+                    // Finally we assign and compute the norm
+                    it_node->SetValue(AUGMENTED_TANGENT_CONTACT_PRESSURE, augmented_tangent_pressure_components);
+                    const double augmented_tangent_pressure = norm_2(augmented_tangent_pressure_components);
+
+                    // We activate the deactivated nodes and add the contribution
+                    if (it_node->IsNot(ACTIVE)) {
+                        it_node->Set(ACTIVE, true);
+                        #pragma omp atomic
+                        is_converged_0 += 1;
+                    }
+
+                    // Check for the slip/stick state
+                    if (augmented_tangent_pressure < mu * std::abs(augmented_normal_pressure)) { // STICK CASE
+//                         KRATOS_WARNING_IF("PenaltyFrictionalMortarConvergenceCriteria", norm_2(r_gt) > Tolerance) << "In case of stick should be zero, if not this means that is not properly working. Node ID: " << it_node->Id() << std::endl;
+//                         noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array; // NOTE: In case of stick should be zero, if not this means that is not properly working
+                        if (it_node->Is(SLIP)) {
+                            it_node->Set(SLIP, false);
+                            #pragma omp atomic
+                            is_converged_1 += 1;
+                        }
+                    } else { // SLIP CASE
+                        const double norm_slip = norm_2(r_gt);
+                        const array_1d<double,3> tangent_direction = r_gt/norm_slip;
+                        it_node->SetValue(AUGMENTED_TANGENT_CONTACT_PRESSURE, mu * augmented_normal_pressure * tangent_direction);
+                        if (it_node->IsNot(SLIP)) {
+                            it_node->Set(SLIP, true);
+                            #pragma omp atomic
+                            is_converged_1 += 1;
+                        }
+                    }
+                } else {
+                    noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array;
+                    if (it_node->Is(ACTIVE)) {
+                        it_node->Set(ACTIVE, false);
+                        it_node->Set(SLIP, false);
+                        is_converged_0 += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    return is_converged;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t ComputeALMFrictionlessActiveSet(ModelPart& rModelPart)
+{
+    // Defining the convergence
+    IndexType is_converged = 0;
+
+    // We get the process info
+    ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
+
+    // We check the active/inactive set during the first non-linear iteration or for the general semi-smooth case
+    if (rModelPart.Is(INTERACTION) || r_process_info[NL_ITERATION_NUMBER] == 1) {
+        const double common_epsilon = r_process_info[INITIAL_PENALTY];
+        const double scale_factor = r_process_info[SCALE_FACTOR];
+
+        auto& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
+        const auto it_node_begin = r_nodes_array.begin();
+
+        #pragma omp parallel for reduction(+:is_converged)
+        for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
+            auto it_node = it_node_begin + i;
+            if (it_node->Is(SLAVE)) {
+                const double epsilon = it_node->Has(INITIAL_PENALTY) ? it_node->GetValue(INITIAL_PENALTY) : common_epsilon;
+                const double augmented_normal_pressure = scale_factor * it_node->FastGetSolutionStepValue(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE) + epsilon * it_node->FastGetSolutionStepValue(WEIGHTED_GAP);
+
+                it_node->SetValue(AUGMENTED_NORMAL_CONTACT_PRESSURE, augmented_normal_pressure); // NOTE: This value is purely for debugging interest (to see the "effective" pressure)
+
+                if (augmented_normal_pressure < 0.0) { // NOTE: This could be conflictive (< or <=)
+                    if (it_node->IsNot(ACTIVE)) {
+                        it_node->FastGetSolutionStepValue(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE) = augmented_normal_pressure/scale_factor;
+                        it_node->Set(ACTIVE, true);
+                        is_converged += 1;
+                    }
+                } else {
+                    if (it_node->Is(ACTIVE)) {
+                        it_node->Set(ACTIVE, false);
+                        is_converged += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    return is_converged;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t ComputeALMFrictionlessComponentsActiveSet(ModelPart& rModelPart)
+{
+    // Defining the convergence
+    IndexType is_converged = 0;
+
+    // We get the process info
+    ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
+
+    // We check the active/inactive set during the first non-linear iteration or for the general semi-smooth case
+    if (rModelPart.Is(INTERACTION) || r_process_info[NL_ITERATION_NUMBER] == 1) {
+        const double common_epsilon = r_process_info[INITIAL_PENALTY];
+        const double scale_factor = r_process_info[SCALE_FACTOR];
+
+        auto& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
+        const auto it_node_begin = r_nodes_array.begin();
+
+        #pragma omp parallel for reduction(+:is_converged)
+        for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
+            auto it_node = it_node_begin + i;
+            if (it_node->Is(SLAVE)) {
+                const double epsilon = it_node->Has(INITIAL_PENALTY) ? it_node->GetValue(INITIAL_PENALTY) : common_epsilon;
+
+                const array_1d<double,3>& r_lagrange_multiplier = it_node->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER);
+                const array_1d<double,3>& r_nodal_normal = it_node->FastGetSolutionStepValue(NORMAL);
+                const double normal_r_lagrange_multiplier = inner_prod(r_nodal_normal, r_lagrange_multiplier);
+
+                const double augmented_normal_pressure = scale_factor * normal_r_lagrange_multiplier + epsilon * it_node->FastGetSolutionStepValue(WEIGHTED_GAP);
+
+                it_node->SetValue(AUGMENTED_NORMAL_CONTACT_PRESSURE, augmented_normal_pressure); // NOTE: This value is purely for debugging interest (to see the "effective" pressure)
+
+                if (augmented_normal_pressure < 0.0) { // NOTE: This could be conflictive (< or <=)
+                    if (it_node->IsNot(ACTIVE)) {
+                        noalias(it_node->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) = r_nodal_normal * augmented_normal_pressure/scale_factor;
+                        it_node->Set(ACTIVE, true);
+                        is_converged += 1;
+                    }
+                } else {
+                    if (it_node->Is(ACTIVE)) {
+                        it_node->Set(ACTIVE, false);
+                        is_converged += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    return is_converged;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+array_1d<std::size_t, 2> ComputeALMFrictionalActiveSet(
+    ModelPart& rModelPart,
+    const bool PureSlip
+    )
+{
+    // Auxiliar zero array
+    const array_1d<double, 3> zero_array = ZeroVector(3);
+
+    // Defining the convergence
+    array_1d<std::size_t, 2> is_converged;
+    is_converged[0] = 0;
+    is_converged[1] = 0;
+
+    std::size_t& is_converged_0 = is_converged[0];
+    std::size_t& is_converged_1 = is_converged[1];
+
+    // We get the process info
+    ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
+
+    // We check the active/inactive set during the first non-linear iteration or for the general semi-smooth case
+    if (rModelPart.Is(INTERACTION) || r_process_info[NL_ITERATION_NUMBER] == 1) {
+        const double common_epsilon = r_process_info[INITIAL_PENALTY];
+        const double scale_factor = r_process_info[SCALE_FACTOR];
+        const double tangent_factor = r_process_info[TANGENT_FACTOR];
+
+        auto& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
+        const auto it_node_begin = r_nodes_array.begin();
+
+        #pragma omp parallel for
+        for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
+            auto it_node = it_node_begin + i;
+            if (it_node->Is(SLAVE)) {
+                const double epsilon = it_node->Has(INITIAL_PENALTY) ? it_node->GetValue(INITIAL_PENALTY) : common_epsilon;
+
+                const array_1d<double,3>& r_lagrange_multiplier = it_node->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER);
+                const array_1d<double,3>& r_nodal_normal = it_node->FastGetSolutionStepValue(NORMAL);
+                const double normal_lagrange_multiplier = inner_prod(r_nodal_normal, r_lagrange_multiplier);
+
+                const double augmented_normal_pressure = scale_factor * normal_lagrange_multiplier + epsilon * it_node->FastGetSolutionStepValue(WEIGHTED_GAP);
+
+                it_node->SetValue(AUGMENTED_NORMAL_CONTACT_PRESSURE, augmented_normal_pressure);
+
+                if (augmented_normal_pressure < 0.0) { // NOTE: This could be conflictive (< or <=)
+                    // The friction coefficient
+                    const double mu = it_node->GetValue(FRICTION_COEFFICIENT);
+
+                    // The weighted slip
+                    const array_1d<double, 3>& r_gt = it_node->FastGetSolutionStepValue(WEIGHTED_SLIP);
+
+                    // Computing the augmented tangent pressure
+                    const array_1d<double,3> tangent_lagrange_multiplier = r_lagrange_multiplier - normal_lagrange_multiplier * r_nodal_normal;
+                    const array_1d<double,3> augmented_tangent_pressure_components = scale_factor * tangent_lagrange_multiplier + tangent_factor * epsilon * r_gt;
+
+                    // Finally we assign and compute the norm
+                    it_node->SetValue(AUGMENTED_TANGENT_CONTACT_PRESSURE, augmented_tangent_pressure_components);
+                    const double augmented_tangent_pressure = norm_2(augmented_tangent_pressure_components);
+
+                    // We activate the deactivated nodes and add the contribution
+                    if (it_node->IsNot(ACTIVE)) {
+                        noalias(it_node->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) = r_nodal_normal * augmented_normal_pressure/scale_factor + augmented_tangent_pressure_components/scale_factor;
+                        it_node->Set(ACTIVE, true);
+                        #pragma omp atomic
+                        is_converged_0 += 1;
+                    }
+
+                    // Check for the slip/stick state
+                    if (augmented_tangent_pressure <= - mu * augmented_normal_pressure) { // STICK CASE // FIXME: Check the <=
+//                             KRATOS_WARNING_IF("PenaltyFrictionalMortarConvergenceCriteria", norm_2(r_gt) > Tolerance) << "In case of stick should be zero, if not this means that is not properly working. Node ID: " << it_node->Id() << std::endl;
+//                             noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array; // NOTE: In case of stick should be zero, if not this means that is not properly working
+                        if (it_node->Is(SLIP)) {
+                            it_node->Set(SLIP, false);
+                            #pragma omp atomic
+                            is_converged_1 += 1;
+                        }
+                    } else { // SLIP CASE
+                        if (it_node->IsNot(SLIP)) {
+                            it_node->Set(SLIP, true);
+                            #pragma omp atomic
+                            is_converged_1 += 1;
+                        }
+                    }
+                } else {
+                    noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array;
+                    if (it_node->Is(ACTIVE)) {
+                        it_node->Set(ACTIVE, false);
+                        it_node->Set(SLIP, false);
+                        #pragma omp atomic
+                        is_converged_0 += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    return is_converged;
+}
+
+} // namespace ActiveSetUtilities
+} // namespace Kratos

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/active_set_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/active_set_utilities.cpp
@@ -137,7 +137,7 @@ array_1d<std::size_t, 2> ComputePenaltyFrictionalActiveSet(
                     if (augmented_tangent_pressure < mu * std::abs(augmented_normal_pressure)) { // STICK CASE
 //                         KRATOS_WARNING_IF("ComputePenaltyFrictionalActiveSet", norm_2(r_gt) > Tolerance) << "In case of stick should be zero, if not this means that is not properly working. Node ID: " << it_node->Id() << std::endl;
 //                         noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array; // NOTE: In case of stick should be zero, if not this means that is not properly working
-                        KRATOS_WARNING_IF("ComputePenaltyFrictionalActiveSet", PureSlip) << "This node is supposed to be on STICK state. Currently working on pure slip. Node ID: " << it_node->Id() << "\tTangent pressure: " << augmented_tangent_pressure << "\tNormal x friction coeff." << mu * std::abs(augmented_normal_pressure)  << std::endl;
+                        KRATOS_WARNING_IF("ComputePenaltyFrictionalActiveSet", PureSlip) << "This node is supposed to be on STICK state. Currently working on pure slip. Node ID: " << it_node->Id() << "\tTangent pressure: " << augmented_tangent_pressure << "\tNormal x friction coeff.: " << mu * std::abs(augmented_normal_pressure)  << std::endl;
                         if (it_node->Is(SLIP) && !PureSlip) {
                             it_node->Set(SLIP, false);
                             #pragma omp atomic
@@ -157,7 +157,7 @@ array_1d<std::size_t, 2> ComputePenaltyFrictionalActiveSet(
                     noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array;
                     if (it_node->Is(ACTIVE)) {
                         it_node->Set(ACTIVE, false);
-                        it_node->Set(SLIP, false);
+                        it_node->Set(SLIP, PureSlip);
                         is_converged_0 += 1;
                     }
                 }
@@ -339,7 +339,7 @@ array_1d<std::size_t, 2> ComputeALMFrictionalActiveSet(
                     if (augmented_tangent_pressure <= - mu * augmented_normal_pressure) { // STICK CASE // FIXME: Check the <=
 //                             KRATOS_WARNING_IF("ComputeALMFrictionalActiveSet", norm_2(r_gt) > Tolerance) << "In case of stick should be zero, if not this means that is not properly working. Node ID: " << it_node->Id() << std::endl;
 //                             noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array; // NOTE: In case of stick should be zero, if not this means that is not properly working
-                        KRATOS_WARNING_IF("ComputeALMFrictionalActiveSet", PureSlip) << "This node is supposed to be on STICK state. Currently working on pure slip. Node ID: " << it_node->Id() << "\tTangent pressure: " << augmented_tangent_pressure << "\tNormal x friction coeff." << mu * std::abs(augmented_normal_pressure)  << std::endl;
+                        KRATOS_WARNING_IF("ComputeALMFrictionalActiveSet", PureSlip) << "This node is supposed to be on STICK state. Currently working on pure slip. Node ID: " << it_node->Id() << "\tTangent pressure: " << augmented_tangent_pressure << "\tNormal x friction coeff.: " << mu * std::abs(augmented_normal_pressure)  << std::endl;
                         if (it_node->Is(SLIP) && !PureSlip) {
                             it_node->Set(SLIP, false);
                             #pragma omp atomic
@@ -356,7 +356,7 @@ array_1d<std::size_t, 2> ComputeALMFrictionalActiveSet(
                     noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array;
                     if (it_node->Is(ACTIVE)) {
                         it_node->Set(ACTIVE, false);
-                        it_node->Set(SLIP, false);
+                        it_node->Set(SLIP, PureSlip);
                         #pragma omp atomic
                         is_converged_0 += 1;
                     }

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/active_set_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/active_set_utilities.cpp
@@ -135,9 +135,10 @@ array_1d<std::size_t, 2> ComputePenaltyFrictionalActiveSet(
 
                     // Check for the slip/stick state
                     if (augmented_tangent_pressure < mu * std::abs(augmented_normal_pressure)) { // STICK CASE
-//                         KRATOS_WARNING_IF("PenaltyFrictionalMortarConvergenceCriteria", norm_2(r_gt) > Tolerance) << "In case of stick should be zero, if not this means that is not properly working. Node ID: " << it_node->Id() << std::endl;
+//                         KRATOS_WARNING_IF("ComputePenaltyFrictionalActiveSet", norm_2(r_gt) > Tolerance) << "In case of stick should be zero, if not this means that is not properly working. Node ID: " << it_node->Id() << std::endl;
 //                         noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array; // NOTE: In case of stick should be zero, if not this means that is not properly working
-                        if (it_node->Is(SLIP)) {
+                        KRATOS_WARNING_IF("ComputePenaltyFrictionalActiveSet", PureSlip) << "This node is supposed to be on STICK state. Currently working on pure slip. Node ID: " << it_node->Id() << "\tTangent pressure: " << augmented_tangent_pressure << "\tNormal x friction coeff." << mu * std::abs(augmented_normal_pressure)  << std::endl;
+                        if (it_node->Is(SLIP) && !PureSlip) {
                             it_node->Set(SLIP, false);
                             #pragma omp atomic
                             is_converged_1 += 1;
@@ -336,9 +337,10 @@ array_1d<std::size_t, 2> ComputeALMFrictionalActiveSet(
 
                     // Check for the slip/stick state
                     if (augmented_tangent_pressure <= - mu * augmented_normal_pressure) { // STICK CASE // FIXME: Check the <=
-//                             KRATOS_WARNING_IF("PenaltyFrictionalMortarConvergenceCriteria", norm_2(r_gt) > Tolerance) << "In case of stick should be zero, if not this means that is not properly working. Node ID: " << it_node->Id() << std::endl;
+//                             KRATOS_WARNING_IF("ComputeALMFrictionalActiveSet", norm_2(r_gt) > Tolerance) << "In case of stick should be zero, if not this means that is not properly working. Node ID: " << it_node->Id() << std::endl;
 //                             noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array; // NOTE: In case of stick should be zero, if not this means that is not properly working
-                        if (it_node->Is(SLIP)) {
+                        KRATOS_WARNING_IF("ComputeALMFrictionalActiveSet", PureSlip) << "This node is supposed to be on STICK state. Currently working on pure slip. Node ID: " << it_node->Id() << "\tTangent pressure: " << augmented_tangent_pressure << "\tNormal x friction coeff." << mu * std::abs(augmented_normal_pressure)  << std::endl;
+                        if (it_node->Is(SLIP) && !PureSlip) {
                             it_node->Set(SLIP, false);
                             #pragma omp atomic
                             is_converged_1 += 1;

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/active_set_utilities.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/active_set_utilities.h
@@ -17,8 +17,6 @@
 // External includes
 
 // Project includes
-#include "utilities/openmp_utils.h"
-#include "contact_structural_mechanics_application_variables.h"
 #include "includes/model_part.h"
 
 namespace Kratos
@@ -39,19 +37,15 @@ namespace Kratos
 ///@{
 
 /**
- * @class ActiveSetUtilities
+ * @namespace ActiveSetUtilities
  * @ingroup ContactStructuralMechanicsApplication
- * @brief This class includes some utilities used for contact active set computations
+ * @brief This namespace includes some utilities used for contact active set computations
  * @author Vicente Mataix Ferrandiz
  */
-class ActiveSetUtilities
+namespace ActiveSetUtilities
 {
-public:
     ///@name Type Definitions
     ///@{
-
-    /// Pointer definition of MortarUtilities
-    KRATOS_CLASS_POINTER_DEFINITION( ActiveSetUtilities );
 
     // Some geometrical definitions
     typedef Node<3>                                              NodeType;
@@ -60,10 +54,6 @@ public:
     /// Definition of geometries
     typedef Geometry<NodeType>                               GeometryType;
 
-    /// The containers of the components of the model parts
-    typedef ModelPart::NodesContainerType                  NodesArrayType;
-    typedef ModelPart::ConditionsContainerType        ConditionsArrayType;
-
     /// Index type definition
     typedef std::size_t                                         IndexType;
 
@@ -71,376 +61,48 @@ public:
     typedef std::size_t                                          SizeType;
 
     ///@}
-    ///@name Life Cycle
-    ///@{
-
-    ///@}
-    ///@name Access
-    ///@{
-
-    ///@}
-    ///@name Inquiry
-    ///@{
-
-    ///@}
-    ///@name Input and output
-    ///@{
-
-    ///@}
-    ///@name Friends
-    ///@{
-
-    ///@}
-    ///@name Operations
+    ///@name  Functions
     ///@{
 
     /**
      * @brief This function computes the active set for penalty frictionless cases
      * @param rThisModelPart The modelpart to compute
      */
-    static inline std::size_t ComputePenaltyFrictionlessActiveSet(ModelPart& rModelPart)
-    {
-        // Defining the convergence
-        IndexType is_converged = 0;
-
-        // We get the process info
-        ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-
-        // We check the active/inactive set during the first non-linear iteration or for the general semi-smooth case
-        if (rModelPart.Is(INTERACTION) || r_process_info[NL_ITERATION_NUMBER] == 1) {
-            const double common_epsilon = r_process_info[INITIAL_PENALTY];
-
-            NodesArrayType& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
-            const auto it_node_begin = r_nodes_array.begin();
-
-            #pragma omp parallel for reduction(+:is_converged)
-            for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
-                auto it_node = it_node_begin + i;
-                if (it_node->Is(SLAVE)) {
-                    const double epsilon = it_node->Has(INITIAL_PENALTY) ? it_node->GetValue(INITIAL_PENALTY) : common_epsilon;
-                    const double augmented_normal_pressure = epsilon * it_node->FastGetSolutionStepValue(WEIGHTED_GAP);
-
-                    it_node->SetValue(AUGMENTED_NORMAL_CONTACT_PRESSURE, augmented_normal_pressure); // NOTE: This value is purely for debugging interest (to see the "effective" pressure)
-
-                    if (augmented_normal_pressure < 0.0) { // NOTE: This could be conflictive (< or <=)
-                        if (it_node->IsNot(ACTIVE)) {
-                            it_node->Set(ACTIVE, true);
-                            is_converged += 1;
-                        }
-                    } else {
-                        if (it_node->Is(ACTIVE)) {
-                            it_node->Set(ACTIVE, false);
-                            is_converged += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        return is_converged;
-    }
+    std::size_t KRATOS_API(CONTACT_STRUCTURAL_MECHANICS_APPLICATION) ComputePenaltyFrictionlessActiveSet(ModelPart& rModelPart);
 
     /**
      * @brief This function computes the active set for penalty frictional cases
      * @param rThisModelPart The modelpart to compute
+     * @param PureSlip If we are considering pure slip case
      */
-    static inline array_1d<std::size_t, 2> ComputePenaltyFrictionalActiveSet(ModelPart& rModelPart)
-    {
-        // Auxiliar zero array
-        const array_1d<double, 3> zero_array = ZeroVector(3);
-
-        // Defining the convergence
-        array_1d<std::size_t, 2> is_converged;
-        is_converged[0] = 0;
-        is_converged[1] = 0;
-
-        std::size_t& is_converged_0 = is_converged[0];
-        std::size_t& is_converged_1 = is_converged[1];
-
-        // We get the process info
-        ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-
-        // We check the active/inactive set during the first non-linear iteration or for the general semi-smooth case
-        if (rModelPart.Is(INTERACTION) || r_process_info[NL_ITERATION_NUMBER] == 1) {
-            const double common_epsilon = r_process_info[INITIAL_PENALTY];
-            const double tangent_factor = r_process_info[TANGENT_FACTOR];
-
-            NodesArrayType& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
-            const auto it_node_begin = r_nodes_array.begin();
-
-            #pragma omp parallel for
-            for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
-                auto it_node = it_node_begin + i;
-                if (it_node->Is(SLAVE)) {
-                    const double epsilon = it_node->Has(INITIAL_PENALTY) ? it_node->GetValue(INITIAL_PENALTY) : common_epsilon;
-
-                    const double augmented_normal_pressure = epsilon * it_node->FastGetSolutionStepValue(WEIGHTED_GAP);
-
-//                     // BEGIN Adding debugging value of NORMAL_GAP
-//                     it_node->SetValue(NORMAL_GAP, it_node->FastGetSolutionStepValue(WEIGHTED_GAP)/it_node->GetValue(NODAL_AREA));
-//                     // END Adding debugging value of NORMAL_GAP
-
-                    it_node->SetValue(AUGMENTED_NORMAL_CONTACT_PRESSURE, augmented_normal_pressure);
-
-                    if (augmented_normal_pressure < 0.0) { // NOTE: This could be conflictive (< or <=)
-                        // The friction coefficient
-                        const double mu = it_node->GetValue(FRICTION_COEFFICIENT);
-
-                        // The weighted slip
-                        const array_1d<double, 3>& r_gt = it_node->FastGetSolutionStepValue(WEIGHTED_SLIP);
-
-//                         // BEGIN Adding debugging value of TANGENT_SLIP
-//                         it_node->SetValue(TANGENT_SLIP, r_gt/it_node->GetValue(NODAL_AREA));
-//                         // END Adding debugging value of TANGENT_SLIP
-
-                        // Computing the augmented tangent pressure
-                        const array_1d<double,3> augmented_tangent_pressure_components = tangent_factor * epsilon * r_gt;
-
-                        // Finally we assign and compute the norm
-                        it_node->SetValue(AUGMENTED_TANGENT_CONTACT_PRESSURE, augmented_tangent_pressure_components);
-                        const double augmented_tangent_pressure = norm_2(augmented_tangent_pressure_components);
-
-                        // We activate the deactivated nodes and add the contribution
-                        if (it_node->IsNot(ACTIVE)) {
-                            it_node->Set(ACTIVE, true);
-                            #pragma omp atomic
-                            is_converged_0 += 1;
-                        }
-
-                        // Check for the slip/stick state
-                        if (augmented_tangent_pressure < mu * std::abs(augmented_normal_pressure)) { // STICK CASE
-//                             KRATOS_WARNING_IF("PenaltyFrictionalMortarConvergenceCriteria", norm_2(r_gt) > Tolerance) << "In case of stick should be zero, if not this means that is not properly working. Node ID: " << it_node->Id() << std::endl;
-//                             noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array; // NOTE: In case of stick should be zero, if not this means that is not properly working
-                            if (it_node->Is(SLIP)) {
-                                it_node->Set(SLIP, false);
-                                #pragma omp atomic
-                                is_converged_1 += 1;
-                            }
-                        } else { // SLIP CASE
-                            const double norm_slip = norm_2(r_gt);
-                            const array_1d<double,3> tangent_direction = r_gt/norm_slip;
-                            it_node->SetValue(AUGMENTED_TANGENT_CONTACT_PRESSURE, mu * augmented_normal_pressure * tangent_direction);
-                            if (it_node->IsNot(SLIP)) {
-                                it_node->Set(SLIP, true);
-                                #pragma omp atomic
-                                is_converged_1 += 1;
-                            }
-                        }
-                    } else {
-                        noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array;
-                        if (it_node->Is(ACTIVE)) {
-                            it_node->Set(ACTIVE, false);
-                            it_node->Set(SLIP, false);
-                            is_converged_0 += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        return is_converged;
-    }
+    array_1d<std::size_t, 2> KRATOS_API(CONTACT_STRUCTURAL_MECHANICS_APPLICATION) ComputePenaltyFrictionalActiveSet(
+        ModelPart& rModelPart,
+        const bool PureSlip = false
+        );
 
     /**
      * @brief This function computes the active set for penalty frictionless cases
      * @param rThisModelPart The modelpart to compute
      */
-    static inline std::size_t ComputeALMFrictionlessActiveSet(ModelPart& rModelPart)
-    {
-        // Defining the convergence
-        IndexType is_converged = 0;
-
-        // We get the process info
-        ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-
-        // We check the active/inactive set during the first non-linear iteration or for the general semi-smooth case
-        if (rModelPart.Is(INTERACTION) || r_process_info[NL_ITERATION_NUMBER] == 1) {
-            const double common_epsilon = r_process_info[INITIAL_PENALTY];
-            const double scale_factor = r_process_info[SCALE_FACTOR];
-
-            NodesArrayType& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
-            const auto it_node_begin = r_nodes_array.begin();
-
-            #pragma omp parallel for reduction(+:is_converged)
-            for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
-                auto it_node = it_node_begin + i;
-                if (it_node->Is(SLAVE)) {
-                    const double epsilon = it_node->Has(INITIAL_PENALTY) ? it_node->GetValue(INITIAL_PENALTY) : common_epsilon;
-                    const double augmented_normal_pressure = scale_factor * it_node->FastGetSolutionStepValue(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE) + epsilon * it_node->FastGetSolutionStepValue(WEIGHTED_GAP);
-
-                    it_node->SetValue(AUGMENTED_NORMAL_CONTACT_PRESSURE, augmented_normal_pressure); // NOTE: This value is purely for debugging interest (to see the "effective" pressure)
-
-                    if (augmented_normal_pressure < 0.0) { // NOTE: This could be conflictive (< or <=)
-                        if (it_node->IsNot(ACTIVE)) {
-                            it_node->FastGetSolutionStepValue(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE) = augmented_normal_pressure/scale_factor;
-                            it_node->Set(ACTIVE, true);
-                            is_converged += 1;
-                        }
-                    } else {
-                        if (it_node->Is(ACTIVE)) {
-                            it_node->Set(ACTIVE, false);
-                            is_converged += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        return is_converged;
-    }
+    std::size_t KRATOS_API(CONTACT_STRUCTURAL_MECHANICS_APPLICATION) ComputeALMFrictionlessActiveSet(ModelPart& rModelPart);
 
     /**
      * @brief This function computes the active set for penalty frictionless cases
      * @param rThisModelPart The modelpart to compute
      */
-    static inline std::size_t ComputeALMFrictionlessComponentsActiveSet(ModelPart& rModelPart)
-    {
-        // Defining the convergence
-        IndexType is_converged = 0;
-
-        // We get the process info
-        ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-
-        // We check the active/inactive set during the first non-linear iteration or for the general semi-smooth case
-        if (rModelPart.Is(INTERACTION) || r_process_info[NL_ITERATION_NUMBER] == 1) {
-            const double common_epsilon = r_process_info[INITIAL_PENALTY];
-            const double scale_factor = r_process_info[SCALE_FACTOR];
-
-            NodesArrayType& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
-            const auto it_node_begin = r_nodes_array.begin();
-
-            #pragma omp parallel for reduction(+:is_converged)
-            for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
-                auto it_node = it_node_begin + i;
-                if (it_node->Is(SLAVE)) {
-                    const double epsilon = it_node->Has(INITIAL_PENALTY) ? it_node->GetValue(INITIAL_PENALTY) : common_epsilon;
-
-                    const array_1d<double,3>& r_lagrange_multiplier = it_node->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER);
-                    const array_1d<double,3>& r_nodal_normal = it_node->FastGetSolutionStepValue(NORMAL);
-                    const double normal_r_lagrange_multiplier = inner_prod(r_nodal_normal, r_lagrange_multiplier);
-
-                    const double augmented_normal_pressure = scale_factor * normal_r_lagrange_multiplier + epsilon * it_node->FastGetSolutionStepValue(WEIGHTED_GAP);
-
-                    it_node->SetValue(AUGMENTED_NORMAL_CONTACT_PRESSURE, augmented_normal_pressure); // NOTE: This value is purely for debugging interest (to see the "effective" pressure)
-
-                    if (augmented_normal_pressure < 0.0) { // NOTE: This could be conflictive (< or <=)
-                        if (it_node->IsNot(ACTIVE)) {
-                            noalias(it_node->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) = r_nodal_normal * augmented_normal_pressure/scale_factor;
-                            it_node->Set(ACTIVE, true);
-                            is_converged += 1;
-                        }
-                    } else {
-                        if (it_node->Is(ACTIVE)) {
-                            it_node->Set(ACTIVE, false);
-                            is_converged += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        return is_converged;
-    }
+    std::size_t KRATOS_API(CONTACT_STRUCTURAL_MECHANICS_APPLICATION) ComputeALMFrictionlessComponentsActiveSet(ModelPart& rModelPart);
 
     /**
      * @brief This function computes the active set for penalty frictional cases
      * @param rThisModelPart The modelpart to compute
+     * @param PureSlip If we are considering pure slip case
      */
-    static inline array_1d<std::size_t, 2> ComputeALMFrictionalActiveSet(ModelPart& rModelPart)
-    {
-        // Auxiliar zero array
-        const array_1d<double, 3> zero_array = ZeroVector(3);
+    array_1d<std::size_t, 2> KRATOS_API(CONTACT_STRUCTURAL_MECHANICS_APPLICATION) ComputeALMFrictionalActiveSet(
+        ModelPart& rModelPart,
+        const bool PureSlip = false
+        );
 
-        // Defining the convergence
-        array_1d<std::size_t, 2> is_converged;
-        is_converged[0] = 0;
-        is_converged[1] = 0;
+};// namespace ActiveSetUtilities
 
-        std::size_t& is_converged_0 = is_converged[0];
-        std::size_t& is_converged_1 = is_converged[1];
-
-        // We get the process info
-        ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
-
-        // We check the active/inactive set during the first non-linear iteration or for the general semi-smooth case
-        if (rModelPart.Is(INTERACTION) || r_process_info[NL_ITERATION_NUMBER] == 1) {
-            const double common_epsilon = r_process_info[INITIAL_PENALTY];
-            const double scale_factor = r_process_info[SCALE_FACTOR];
-            const double tangent_factor = r_process_info[TANGENT_FACTOR];
-
-            NodesArrayType& r_nodes_array = rModelPart.GetSubModelPart("Contact").Nodes();
-            const auto it_node_begin = r_nodes_array.begin();
-
-            #pragma omp parallel for
-            for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
-                auto it_node = it_node_begin + i;
-                if (it_node->Is(SLAVE)) {
-                    const double epsilon = it_node->Has(INITIAL_PENALTY) ? it_node->GetValue(INITIAL_PENALTY) : common_epsilon;
-
-                    const array_1d<double,3>& r_lagrange_multiplier = it_node->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER);
-                    const array_1d<double,3>& r_nodal_normal = it_node->FastGetSolutionStepValue(NORMAL);
-                    const double normal_lagrange_multiplier = inner_prod(r_nodal_normal, r_lagrange_multiplier);
-
-                    const double augmented_normal_pressure = scale_factor * normal_lagrange_multiplier + epsilon * it_node->FastGetSolutionStepValue(WEIGHTED_GAP);
-
-                    it_node->SetValue(AUGMENTED_NORMAL_CONTACT_PRESSURE, augmented_normal_pressure);
-
-                    if (augmented_normal_pressure < 0.0) { // NOTE: This could be conflictive (< or <=)
-                        // The friction coefficient
-                        const double mu = it_node->GetValue(FRICTION_COEFFICIENT);
-
-                        // The weighted slip
-                        const array_1d<double, 3>& r_gt = it_node->FastGetSolutionStepValue(WEIGHTED_SLIP);
-
-                        // Computing the augmented tangent pressure
-                        const array_1d<double,3> tangent_lagrange_multiplier = r_lagrange_multiplier - normal_lagrange_multiplier * r_nodal_normal;
-                        const array_1d<double,3> augmented_tangent_pressure_components = scale_factor * tangent_lagrange_multiplier + tangent_factor * epsilon * r_gt;
-
-                        // Finally we assign and compute the norm
-                        it_node->SetValue(AUGMENTED_TANGENT_CONTACT_PRESSURE, augmented_tangent_pressure_components);
-                        const double augmented_tangent_pressure = norm_2(augmented_tangent_pressure_components);
-
-                        // We activate the deactivated nodes and add the contribution
-                        if (it_node->IsNot(ACTIVE)) {
-                            noalias(it_node->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER)) = r_nodal_normal * augmented_normal_pressure/scale_factor + augmented_tangent_pressure_components/scale_factor;
-                            it_node->Set(ACTIVE, true);
-                            #pragma omp atomic
-                            is_converged_0 += 1;
-                        }
-
-                        // Check for the slip/stick state
-                        if (augmented_tangent_pressure <= - mu * augmented_normal_pressure) { // STICK CASE // FIXME: Check the <=
-//                             KRATOS_WARNING_IF("PenaltyFrictionalMortarConvergenceCriteria", norm_2(r_gt) > Tolerance) << "In case of stick should be zero, if not this means that is not properly working. Node ID: " << it_node->Id() << std::endl;
-//                             noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array; // NOTE: In case of stick should be zero, if not this means that is not properly working
-                            if (it_node->Is(SLIP)) {
-                                it_node->Set(SLIP, false);
-                                #pragma omp atomic
-                                is_converged_1 += 1;
-                            }
-                        } else { // SLIP CASE
-                            if (it_node->IsNot(SLIP)) {
-                                it_node->Set(SLIP, true);
-                                #pragma omp atomic
-                                is_converged_1 += 1;
-                            }
-                        }
-                    } else {
-                        noalias(it_node->FastGetSolutionStepValue(WEIGHTED_SLIP)) = zero_array;
-                        if (it_node->Is(ACTIVE)) {
-                            it_node->Set(ACTIVE, false);
-                            it_node->Set(SLIP, false);
-                            #pragma omp atomic
-                            is_converged_0 += 1;
-                        }
-                    }
-                }
-            }
-        }
-
-        return is_converged;
-    }
-
-};// class ActiveSetUtilities
-
-}
+} // namespace Kratos
 #endif /* KRATOS_ACTIVE_SET_UTILITIES defined */

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
@@ -262,6 +262,16 @@ class ALMContactProcess(search_base_process.SearchBaseProcess):
         # We call to the base process
         super(ALMContactProcess, self).ExecuteFinalize()
 
+    def _set_additional_parameters(self, param):
+        """ This sets additional parameters for the search
+
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        param -- The parameters where to set additional values
+        """
+        param.AddEmptyValue("pure_slip")
+        param["pure_slip"].SetBool(self.pure_slip)
+
     def _get_condition_name(self):
         """ This method returns the condition name
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
@@ -143,12 +143,18 @@ class ALMContactProcess(search_base_process.SearchBaseProcess):
         self.frictional_law = self.contact_settings["frictional_law"].GetString()
 
         # If we compute a frictional contact simulation
-        if self.contact_settings["contact_type"].GetString() == "Frictional":
+        contact_type = self.contact_settings["contact_type"].GetString()
+        if contact_type == "Frictional" or contact_type == "FrictionalPureSlip":
             self.is_frictional = True
+            if contact_type == "FrictionalPureSlip":
+                self.pure_slip = True
+            else:
+                self.pure_slip = False
             if self.normal_variation == CSMA.NormalDerivativesComputation.NO_DERIVATIVES_COMPUTATION:
                 self.normal_variation = CSMA.NormalDerivativesComputation.NO_DERIVATIVES_COMPUTATION_WITH_NORMAL_UPDATE
         else:
             self.is_frictional = False
+            self.pure_slip = False
 
     def ExecuteInitialize(self):
         """ This method is executed at the begining to initialize the process

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_convergence_criteria_factory.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_convergence_criteria_factory.py
@@ -36,7 +36,7 @@ class convergence_criterion:
                 KM.Logger.PrintInfo("::[Mechanical Solver]:: ", "CONVERGENCE CRITERION : " + self.convergence_criterion_name)
 
             if self.convergence_criterion_name == "contact_displacement_criterion":
-                if (self.mortar_type == "ALMContactFrictional" and self.frictional_decomposed):
+                if self.mortar_type == "ALMContactFrictional" and self.frictional_decomposed:
                     self.mechanical_convergence_criterion = CSMA.DisplacementLagrangeMultiplierFrictionalContactCriteria(D_RT, D_AT, CD_RT, CD_AT, FCD_RT, FCD_AT, ensure_contact, self.print_convergence_criterion)
                 elif "Penalty" in self.mortar_type:
                     self.mechanical_convergence_criterion = CSMA.DisplacementContactCriteria(D_RT, D_AT, self.print_convergence_criterion)
@@ -46,7 +46,7 @@ class convergence_criterion:
                 self.mechanical_convergence_criterion.SetEchoLevel(self.echo_level)
 
             elif self.convergence_criterion_name == "contact_residual_criterion":
-                if (self.mortar_type == "ALMContactFrictional" and self.frictional_decomposed):
+                if self.mortar_type == "ALMContactFrictional" and self.frictional_decomposed:
                     self.mechanical_convergence_criterion = CSMA.DisplacementLagrangeMultiplierResidualFrictionalContactCriteria(R_RT, R_AT, CR_RT, CR_AT, FCR_RT, FCR_AT, ensure_contact, self.print_convergence_criterion)
                 elif "Penalty" in self.mortar_type:
                     self.mechanical_convergence_criterion = CSMA.DisplacementResidualContactCriteria(R_RT, R_AT, self.print_convergence_criterion)
@@ -55,7 +55,7 @@ class convergence_criterion:
                 self.mechanical_convergence_criterion.SetEchoLevel(self.echo_level)
 
             elif self.convergence_criterion_name == "contact_mixed_criterion":
-                if (self.mortar_type == "ALMContactFrictional" and self.frictional_decomposed):
+                if self.mortar_type == "ALMContactFrictional" and self.frictional_decomposed:
                     self.mechanical_convergence_criterion = CSMA.DisplacementLagrangeMultiplierMixedFrictionalontactCriteria(R_RT, R_AT, CR_RT, CR_AT, FCR_RT, FCR_AT, ensure_contact, self.print_convergence_criterion)
                 elif "Penalty" in self.mortar_type:
                     self.mechanical_convergence_criterion = CSMA.DisplacementResidualContactCriteria(R_RT, R_AT, self.print_convergence_criterion)
@@ -164,21 +164,29 @@ class convergence_criterion:
                 Mortar = CSMA.ALMFrictionlessComponentsMortarConvergenceCriteria(self.print_convergence_criterion, self.compute_dynamic_factor, self.gidio_debug)
             else:
                 Mortar = CSMA.ALMFrictionlessComponentsMortarConvergenceCriteria()
-        elif self.mortar_type == "ALMContactFrictional":
-            if include_table:
-                Mortar = CSMA.ALMFrictionalMortarConvergenceCriteria(self.print_convergence_criterion, self.compute_dynamic_factor, self.gidio_debug)
+        elif self.mortar_type == "ALMContactFrictional" or self.mortar_type == "ALMContactFrictionalPureSlip":
+            if self.mortar_type == "ALMContactFrictionalPureSlip":
+                pure_slip = True
             else:
-                Mortar = CSMA.ALMFrictionalMortarConvergenceCriteria()
+                pure_slip = False
+            if include_table:
+                Mortar = CSMA.ALMFrictionalMortarConvergenceCriteria(pure_slip, self.print_convergence_criterion, self.compute_dynamic_factor, self.gidio_debug)
+            else:
+                Mortar = CSMA.ALMFrictionalMortarConvergenceCriteria(pure_slip)
         elif self.mortar_type == "PenaltyContactFrictionless":
             if include_table:
                 Mortar = CSMA.PenaltyFrictionlessMortarConvergenceCriteria(self.print_convergence_criterion, self.compute_dynamic_factor, self.gidio_debug)
             else:
                 Mortar = CSMA.PenaltyFrictionlessMortarConvergenceCriteria()
-        elif self.mortar_type == "PenaltyContactFrictional":
-            if include_table:
-                Mortar = CSMA.PenaltyFrictionalMortarConvergenceCriteria(self.print_convergence_criterion, self.compute_dynamic_factor, self.gidio_debug)
+        elif self.mortar_type == "PenaltyContactFrictional" or self.mortar_type == "PenaltyContactFrictionalPureSlip":
+            if self.mortar_type == "PenaltyContactFrictionalPureSlip":
+                pure_slip = True
             else:
-                Mortar = CSMA.PenaltyFrictionalMortarConvergenceCriteria()
+                pure_slip = False
+            if include_table:
+                Mortar = CSMA.PenaltyFrictionalMortarConvergenceCriteria(pure_slip, self.print_convergence_criterion, self.compute_dynamic_factor, self.gidio_debug)
+            else:
+                Mortar = CSMA.PenaltyFrictionalMortarConvergenceCriteria(pure_slip)
         elif "MeshTying" in self.mortar_type:
             Mortar = CSMA.MeshTyingMortarConvergenceCriteria()
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/explicit_penalty_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/explicit_penalty_contact_process.py
@@ -168,9 +168,9 @@ class ExplicitPenaltyContactProcess(penalty_contact_process.PenaltyContactProces
 
             # Calling for the active set utilities (to activate deactivate nodes)
             if self.contact_settings["contact_type"].GetString() == "Frictionless":
-                CSMA.ActiveSetUtilities.ComputePenaltyFrictionlessActiveSet(self.computing_model_part)
+                CSMA.ComputePenaltyFrictionlessActiveSet(self.computing_model_part)
             else:
-                CSMA.ActiveSetUtilities.ComputePenaltyFrictionalActiveSet(self.computing_model_part)
+                CSMA.ComputePenaltyFrictionalActiveSet(self.computing_model_part)
 
             # Activate/deactivate conditions
             CSMA.ContactUtilities.ActivateConditionWithActiveNodes(self.computing_model_part)

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/penalty_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/penalty_contact_process.py
@@ -185,23 +185,23 @@ class PenaltyContactProcess(alm_contact_process.ALMContactProcess):
         # We define the condition name to be used
         if self.contact_settings["contact_type"].GetString() == "Frictionless":
             if self.normal_variation == CSMA.NormalDerivativesComputation.NODAL_ELEMENTAL_DERIVATIVES:
-                if self.contact_settings["alternative_formulations"]["axisymmetric"].GetBool() is True:
+                if self.contact_settings["alternative_formulations"]["axisymmetric"].GetBool():
                     condition_name = "PenaltyNVFrictionlessAxisymMortarContact"
                 else:
                     condition_name = "PenaltyNVFrictionlessMortarContact"
             else:
-                if self.contact_settings["alternative_formulations"]["axisymmetric"].GetBool() is True:
+                if self.contact_settings["alternative_formulations"]["axisymmetric"].GetBool():
                     condition_name = "PenaltyFrictionlessAxisymMortarContact"
                 else:
                     condition_name = "PenaltyFrictionlessMortarContact"
-        elif self.is_frictional is True:
+        elif self.is_frictional:
             if self.normal_variation == CSMA.NormalDerivativesComputation.NODAL_ELEMENTAL_DERIVATIVES:
-                if self.contact_settings["alternative_formulations"]["axisymmetric"].GetBool() is True:
+                if self.contact_settings["alternative_formulations"]["axisymmetric"].GetBool():
                     condition_name = "PenaltyNVFrictionalAxisymMortarContact"
                 else:
                     condition_name = "PenaltyNVFrictionalMortarContact"
             else:
-                if self.contact_settings["alternative_formulations"]["axisymmetric"].GetBool() is True:
+                if self.contact_settings["alternative_formulations"]["axisymmetric"].GetBool():
                     condition_name = "PenaltyFrictionalAxisymMortarContact"
                 else:
                     condition_name = "PenaltyFrictionalMortarContact"

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/search_base_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/search_base_process.py
@@ -421,9 +421,20 @@ class SearchBaseProcess(KM.Process):
         search_parameters["predefined_master_slave"].SetBool(self.predefined_master_slave)
         search_parameters["id_name"].SetString(key)
 
+        # Setting additional parameters
+        self._set_additional_parameters(search_parameters)
+
         # We create the search process
         self.search_utility_list[key] = CSMA.ContactSearchProcess(self.computing_model_part, search_parameters)
 
+    def _set_additional_parameters(self, param):
+        """ This sets additional parameters for the search
+
+        Keyword arguments:
+        self -- It signifies an instance of a class.
+        param -- The parameters where to set additional values
+        """
+        pass
 
     def _get_enum_flag(self, param, label, dictionary):
         """ Parse enums settings using an auxiliary dictionary of acceptable values.

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_active_set_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_active_set_utilities.cpp
@@ -1,0 +1,336 @@
+// KRATOS  ___|  |                   |                   |
+//       \___ \  __|  __| |   |  __| __| |   |  __| _` | |
+//             | |   |    |   | (    |   |   | |   (   | |
+//       _____/ \__|_|   \__,_|\___|\__|\__,_|_|  \__,_|_| MECHANICS
+//
+//  License:	   BSD License
+//				   license: StructuralMechanicsApplication/license.txt
+//
+//  Main authors:  Vicente Mataix Ferrandiz
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "contact_structural_mechanics_application_variables.h"
+#include "custom_utilities/active_set_utilities.h"
+
+namespace Kratos
+{
+    namespace Testing
+    {
+        /**
+        * Checks the correct work of the acttive set utilities
+        * Test ComputePenaltyFrictionlessActiveSet
+        */
+        KRATOS_TEST_CASE_IN_SUITE(ComputePenaltyFrictionlessActiveSet, KratosContactStructuralMechanicsFastSuite)
+        {
+            Model this_model;
+            ModelPart& r_model_part = this_model.CreateModelPart("Main", 3);
+            ModelPart& r_contact_model_part = r_model_part.CreateSubModelPart("Contact");
+
+            r_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+            r_model_part.AddNodalSolutionStepVariable(WEIGHTED_GAP);
+
+            auto& r_process_info = r_model_part.GetProcessInfo();
+            r_process_info[STEP] = 1;
+            r_process_info[NL_ITERATION_NUMBER] = 1;
+            r_process_info[DELTA_TIME] = 1.0;
+            r_process_info[INITIAL_PENALTY] = 1.0e3;
+
+            // First we create the nodes
+            auto p_node1 = r_contact_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
+            auto p_node2 = r_contact_model_part.CreateNewNode(2, 1.0 , 0.0 , 0.0);
+            auto p_node3 = r_contact_model_part.CreateNewNode(3, 2.0 , 0.0 , 0.0);
+
+            // Set flags
+            for (auto& r_node : r_model_part.Nodes()) {
+                r_node.Set(SLAVE);
+                r_node.Set(ACTIVE);
+            }
+
+            // Set values
+            p_node1->FastGetSolutionStepValue(WEIGHTED_GAP) = -1.0e-3;
+            p_node2->FastGetSolutionStepValue(WEIGHTED_GAP) = 0.0;
+            p_node3->FastGetSolutionStepValue(WEIGHTED_GAP) = 1.0e-3;
+
+            // Call utilities
+            const auto is_converged = ActiveSetUtilities::ComputePenaltyFrictionlessActiveSet(r_model_part);
+
+            // Check flags
+            KRATOS_CHECK_EQUAL(is_converged, 2);
+            KRATOS_CHECK(p_node1->Is(ACTIVE));
+            KRATOS_CHECK(p_node2->IsNot(ACTIVE));
+            KRATOS_CHECK(p_node3->IsNot(ACTIVE));
+        }
+
+        /**
+        * Checks the correct work of the acttive set utilities
+        * Test ComputePenaltyFrictionalActiveSet
+        */
+        KRATOS_TEST_CASE_IN_SUITE(ComputePenaltyFrictionalActiveSet, KratosContactStructuralMechanicsFastSuite)
+        {
+            Model this_model;
+            ModelPart& r_model_part = this_model.CreateModelPart("Main", 3);
+            ModelPart& r_contact_model_part = r_model_part.CreateSubModelPart("Contact");
+
+            r_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+            r_model_part.AddNodalSolutionStepVariable(WEIGHTED_GAP);
+            r_model_part.AddNodalSolutionStepVariable(WEIGHTED_SLIP);
+
+            auto& r_process_info = r_model_part.GetProcessInfo();
+            r_process_info[STEP] = 1;
+            r_process_info[NL_ITERATION_NUMBER] = 1;
+            r_process_info[DELTA_TIME] = 1.0;
+            r_process_info[INITIAL_PENALTY] = 1.0e3;
+            r_process_info[TANGENT_FACTOR] = 1.0;
+
+            // First we create the nodes
+            auto p_node1 = r_contact_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
+            auto p_node2 = r_contact_model_part.CreateNewNode(2, 1.0 , 0.0 , 0.0);
+            auto p_node3 = r_contact_model_part.CreateNewNode(3, 2.0 , 0.0 , 0.0);
+
+            // Set flags
+            for (auto& r_node : r_model_part.Nodes()) {
+                r_node.Set(SLAVE);
+                r_node.Set(ACTIVE);
+                r_node.Set(SLIP);
+                r_node.SetValue(FRICTION_COEFFICIENT, 1.0);
+            }
+
+            // Set values
+            p_node1->FastGetSolutionStepValue(WEIGHTED_GAP) = -1.0e-3;
+            p_node1->FastGetSolutionStepValue(WEIGHTED_SLIP_X) = -1.0e-3;
+            p_node2->FastGetSolutionStepValue(WEIGHTED_GAP) = 0.0;
+            p_node2->FastGetSolutionStepValue(WEIGHTED_SLIP_X) = 0.0;
+            p_node3->FastGetSolutionStepValue(WEIGHTED_GAP) = 1.0e-3;
+            p_node3->FastGetSolutionStepValue(WEIGHTED_SLIP_X) = 1.0e-3;
+
+            // Call utilities
+            auto is_converged = ActiveSetUtilities::ComputePenaltyFrictionalActiveSet(r_model_part);
+
+            // Check flags
+            KRATOS_CHECK_EQUAL(is_converged[0], 2);
+            KRATOS_CHECK_EQUAL(is_converged[1], 0);
+            KRATOS_CHECK(p_node1->Is(ACTIVE));
+            KRATOS_CHECK(p_node1->Is(SLIP));
+            KRATOS_CHECK(p_node2->IsNot(ACTIVE));
+            KRATOS_CHECK(p_node2->IsNot(SLIP));
+            KRATOS_CHECK(p_node3->IsNot(ACTIVE));
+            KRATOS_CHECK(p_node3->IsNot(SLIP));
+
+            // Set flags
+            for (auto& r_node : r_model_part.Nodes()) {
+                r_node.Set(ACTIVE);
+                r_node.Set(SLIP);
+            }
+
+            // Call utilities (pure slip)
+            is_converged = ActiveSetUtilities::ComputePenaltyFrictionalActiveSet(r_model_part, true);
+
+            // Check flags
+            KRATOS_CHECK_EQUAL(is_converged[0], 2);
+            KRATOS_CHECK_EQUAL(is_converged[1], 0);
+            KRATOS_CHECK(p_node1->Is(ACTIVE));
+            KRATOS_CHECK(p_node1->Is(SLIP));
+            KRATOS_CHECK(p_node2->IsNot(ACTIVE));
+            KRATOS_CHECK(p_node2->Is(SLIP));
+            KRATOS_CHECK(p_node3->IsNot(ACTIVE));
+            KRATOS_CHECK(p_node3->Is(SLIP));
+        }
+
+        /**
+        * Checks the correct work of the acttive set utilities
+        * Test ComputeALMFrictionlessActiveSet
+        */
+        KRATOS_TEST_CASE_IN_SUITE(ComputeALMFrictionlessActiveSet, KratosContactStructuralMechanicsFastSuite)
+        {
+            Model this_model;
+            ModelPart& r_model_part = this_model.CreateModelPart("Main", 3);
+            ModelPart& r_contact_model_part = r_model_part.CreateSubModelPart("Contact");
+
+            r_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+            r_model_part.AddNodalSolutionStepVariable(WEIGHTED_GAP);
+            r_model_part.AddNodalSolutionStepVariable(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE);
+
+            auto& r_process_info = r_model_part.GetProcessInfo();
+            r_process_info[STEP] = 1;
+            r_process_info[NL_ITERATION_NUMBER] = 1;
+            r_process_info[DELTA_TIME] = 1.0;
+            r_process_info[INITIAL_PENALTY] = 1.0e3;
+            r_process_info[SCALE_FACTOR] = 1.0;
+
+            // First we create the nodes
+            auto p_node1 = r_contact_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
+            auto p_node2 = r_contact_model_part.CreateNewNode(2, 1.0 , 0.0 , 0.0);
+            auto p_node3 = r_contact_model_part.CreateNewNode(3, 2.0 , 0.0 , 0.0);
+
+            // Set flags
+            for (auto& r_node : r_model_part.Nodes()) {
+                r_node.Set(SLAVE);
+                r_node.Set(ACTIVE);
+            }
+
+            // Set values
+            p_node1->FastGetSolutionStepValue(WEIGHTED_GAP) = -1.0e-3;
+            p_node1->FastGetSolutionStepValue(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE) = -1.0e3;
+            p_node2->FastGetSolutionStepValue(WEIGHTED_GAP) = 0.0;
+            p_node2->FastGetSolutionStepValue(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE) = 0.0;
+            p_node3->FastGetSolutionStepValue(WEIGHTED_GAP) = 1.0e-3;
+            p_node3->FastGetSolutionStepValue(LAGRANGE_MULTIPLIER_CONTACT_PRESSURE) = -1.0e3;
+
+            // Call utilities
+            const auto is_converged = ActiveSetUtilities::ComputeALMFrictionlessActiveSet(r_model_part);
+
+            // Check flags
+            KRATOS_CHECK_EQUAL(is_converged, 1);
+            KRATOS_CHECK(p_node1->Is(ACTIVE));
+            KRATOS_CHECK(p_node2->IsNot(ACTIVE));
+            KRATOS_CHECK(p_node3->Is(ACTIVE));
+        }
+
+        /**
+        * Checks the correct work of the acttive set utilities
+        * Test ComputeALMFrictionlessComponentsActiveSet
+        */
+        KRATOS_TEST_CASE_IN_SUITE(ComputeALMFrictionlessComponentsActiveSet, KratosContactStructuralMechanicsFastSuite)
+        {
+            Model this_model;
+            ModelPart& r_model_part = this_model.CreateModelPart("Main", 3);
+            ModelPart& r_contact_model_part = r_model_part.CreateSubModelPart("Contact");
+
+            r_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+            r_model_part.AddNodalSolutionStepVariable(WEIGHTED_GAP);
+            r_model_part.AddNodalSolutionStepVariable(VECTOR_LAGRANGE_MULTIPLIER);
+            r_model_part.AddNodalSolutionStepVariable(NORMAL);
+
+            auto& r_process_info = r_model_part.GetProcessInfo();
+            r_process_info[STEP] = 1;
+            r_process_info[NL_ITERATION_NUMBER] = 1;
+            r_process_info[DELTA_TIME] = 1.0;
+            r_process_info[INITIAL_PENALTY] = 1.0e3;
+            r_process_info[SCALE_FACTOR] = 1.0;
+
+            // First we create the nodes
+            auto p_node1 = r_contact_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
+            auto p_node2 = r_contact_model_part.CreateNewNode(2, 1.0 , 0.0 , 0.0);
+            auto p_node3 = r_contact_model_part.CreateNewNode(3, 2.0 , 0.0 , 0.0);
+
+            // Set flags
+            for (auto& r_node : r_model_part.Nodes()) {
+                r_node.Set(SLAVE);
+                r_node.Set(ACTIVE);
+            }
+
+            // Set values
+            p_node1->FastGetSolutionStepValue(WEIGHTED_GAP) = -1.0e-3;
+            p_node1->FastGetSolutionStepValue(NORMAL_Y) = 1.0;
+            p_node1->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER_Y) = -1.0e3;
+            p_node2->FastGetSolutionStepValue(WEIGHTED_GAP) = 0.0;
+            p_node2->FastGetSolutionStepValue(NORMAL_Y) = 1.0;
+            p_node2->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER_Y) = 0.0;
+            p_node3->FastGetSolutionStepValue(WEIGHTED_GAP) = 1.0e-3;
+            p_node3->FastGetSolutionStepValue(NORMAL_Y) = 1.0;
+            p_node3->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER_Y) = -1.0e3;
+
+            // Call utilities
+            const auto is_converged = ActiveSetUtilities::ComputeALMFrictionlessComponentsActiveSet(r_model_part);
+
+            // Check flags
+            KRATOS_CHECK_EQUAL(is_converged, 1);
+            KRATOS_CHECK(p_node1->Is(ACTIVE));
+            KRATOS_CHECK(p_node2->IsNot(ACTIVE));
+            KRATOS_CHECK(p_node3->Is(ACTIVE));
+        }
+
+        /**
+        * Checks the correct work of the acttive set utilities
+        * Test ComputeALMFrictionalActiveSet
+        */
+        KRATOS_TEST_CASE_IN_SUITE(ComputeALMFrictionalActiveSet, KratosContactStructuralMechanicsFastSuite)
+        {
+            Model this_model;
+            ModelPart& r_model_part = this_model.CreateModelPart("Main", 3);
+            ModelPart& r_contact_model_part = r_model_part.CreateSubModelPart("Contact");
+
+            r_model_part.AddNodalSolutionStepVariable(DISPLACEMENT);
+            r_model_part.AddNodalSolutionStepVariable(WEIGHTED_GAP);
+            r_model_part.AddNodalSolutionStepVariable(WEIGHTED_SLIP);
+            r_model_part.AddNodalSolutionStepVariable(VECTOR_LAGRANGE_MULTIPLIER);
+            r_model_part.AddNodalSolutionStepVariable(NORMAL);
+
+            auto& r_process_info = r_model_part.GetProcessInfo();
+            r_process_info[STEP] = 1;
+            r_process_info[NL_ITERATION_NUMBER] = 1;
+            r_process_info[DELTA_TIME] = 1.0;
+            r_process_info[INITIAL_PENALTY] = 1.0e3;
+            r_process_info[SCALE_FACTOR] = 1.0;
+            r_process_info[TANGENT_FACTOR] = 1.0;
+
+            // First we create the nodes
+            auto p_node1 = r_contact_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
+            auto p_node2 = r_contact_model_part.CreateNewNode(2, 1.0 , 0.0 , 0.0);
+            auto p_node3 = r_contact_model_part.CreateNewNode(3, 2.0 , 0.0 , 0.0);
+
+            // Set flags
+            for (auto& r_node : r_model_part.Nodes()) {
+                r_node.Set(SLAVE);
+                r_node.Set(ACTIVE);
+                r_node.Set(SLIP);
+                r_node.SetValue(FRICTION_COEFFICIENT, 1.0);
+            }
+
+            // Set values
+            p_node1->FastGetSolutionStepValue(WEIGHTED_GAP) = -1.0e-3;
+
+            p_node1->FastGetSolutionStepValue(WEIGHTED_SLIP_X) = -1.0e-3;
+            p_node1->FastGetSolutionStepValue(NORMAL_Y) = 1.0;
+            p_node1->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER_Y) = -1.0e3;
+            p_node2->FastGetSolutionStepValue(WEIGHTED_GAP) = 0.0;
+            p_node2->FastGetSolutionStepValue(WEIGHTED_SLIP_X) = 0.0;
+            p_node2->FastGetSolutionStepValue(NORMAL_Y) = 1.0;
+            p_node2->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER_Y) = 0.0;
+            p_node3->FastGetSolutionStepValue(WEIGHTED_GAP) = 1.0e-3;
+            p_node3->FastGetSolutionStepValue(WEIGHTED_SLIP_X) = 1.0e-3;
+            p_node3->FastGetSolutionStepValue(NORMAL_Y) = 1.0;
+            p_node3->FastGetSolutionStepValue(VECTOR_LAGRANGE_MULTIPLIER_Y) = -1.0e3;
+
+            // Call utilities
+            auto is_converged = ActiveSetUtilities::ComputeALMFrictionalActiveSet(r_model_part);
+
+            // Check flags
+            KRATOS_CHECK_EQUAL(is_converged[0], 1);
+            KRATOS_CHECK_EQUAL(is_converged[1], 2);
+            KRATOS_CHECK(p_node1->Is(ACTIVE));
+            KRATOS_CHECK(p_node1->IsNot(SLIP));
+            KRATOS_CHECK(p_node2->IsNot(ACTIVE));
+            KRATOS_CHECK(p_node2->IsNot(SLIP));
+            KRATOS_CHECK(p_node3->Is(ACTIVE));
+            KRATOS_CHECK(p_node3->IsNot(SLIP));
+
+            // Set flags
+            for (auto& r_node : r_model_part.Nodes()) {
+                r_node.Set(ACTIVE);
+                r_node.Set(SLIP);
+            }
+
+            // Call utilities (pure slip)
+            is_converged = ActiveSetUtilities::ComputeALMFrictionalActiveSet(r_model_part, true);
+
+            // Check flags
+            KRATOS_CHECK_EQUAL(is_converged[0], 1);
+            KRATOS_CHECK_EQUAL(is_converged[1], 0);
+            KRATOS_CHECK(p_node1->Is(ACTIVE));
+            KRATOS_CHECK(p_node1->Is(SLIP));
+            KRATOS_CHECK(p_node2->IsNot(ACTIVE));
+            KRATOS_CHECK(p_node2->Is(SLIP));
+            KRATOS_CHECK(p_node3->Is(ACTIVE));
+            KRATOS_CHECK(p_node3->Is(SLIP));
+        }
+
+    } // namespace Testing
+}  // namespace Kratos.


### PR DESCRIPTION
This PR refactors the conv. criteria using local flags, as well as the search processes, as well as the active set utilities. Also adds the possibility of compute pure frictional slip contact (not flipping if the state is stick)