### PR TITLE
Warning removal campaign -- recent changes in MPI Communicator

### DIFF
--- a/applications/FSIapplication/python_scripts/partitioned_fsi_base_solver.py
+++ b/applications/FSIapplication/python_scripts/partitioned_fsi_base_solver.py
@@ -443,7 +443,7 @@ class PartitionedFSIBaseSolver(PythonSolver):
         for condition in self.structure_solver.main_model_part.Conditions:
             max_cond_id = max(max_cond_id, condition.Id)
 
-        max_cond_id = self.structure_solver.main_model_part.GetCommunicator().MaxAll(max_cond_id)
+        max_cond_id = self.structure_solver.main_model_part.GetCommunicator().GetDataCommunicator().MaxAll(max_cond_id)
 
         # Set up the point load condition in the structure interface
         structure_interfaces_list = self.settings["coupling_settings"]["structure_interfaces_list"]

--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_solver.py
@@ -159,7 +159,7 @@ class AdjointFluidSolver(PythonSolver):
         else:
             element_num_nodes = 0
 
-        element_num_nodes = self.main_model_part.GetCommunicator().MaxAll(element_num_nodes)
+        element_num_nodes = self.main_model_part.GetCommunicator().GetDataCommunicator().MaxAll(element_num_nodes)
         return element_num_nodes
 
     def _GetConditionNumNodes(self):
@@ -171,7 +171,7 @@ class AdjointFluidSolver(PythonSolver):
         else:
             condition_num_nodes = 0
 
-        condition_num_nodes = self.main_model_part.GetCommunicator().MaxAll(condition_num_nodes)
+        condition_num_nodes = self.main_model_part.GetCommunicator().GetDataCommunicator().MaxAll(condition_num_nodes)
         return condition_num_nodes
 
     def _ExecuteCheckAndPrepare(self):

--- a/applications/FluidDynamicsApplication/python_scripts/apply_outlet_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_outlet_process.py
@@ -134,12 +134,13 @@ class ApplyOutletProcess(KratosMultiphysics.Process):
         for node in self.outlet_model_part.GetCommunicator().LocalMesh().Nodes:
             vnode = node.GetSolutionStepValue(KratosMultiphysics.VELOCITY)
             outlet_avg_vel_norm += math.sqrt(vnode[0]*vnode[0] + vnode[1]*vnode[1] + vnode[2]*vnode[2])
-        outlet_avg_vel_norm = self.outlet_model_part.GetCommunicator().SumAll(outlet_avg_vel_norm)
+        comm = self.outlet_model_part.GetCommunicator().GetDataCommunicator()
+        outlet_avg_vel_norm = comm.SumAll(outlet_avg_vel_norm)
 
         tot_len = len(self.outlet_model_part.GetCommunicator().LocalMesh().Nodes)   # Partition outlet model part number of nodes
-        tot_len = self.outlet_model_part.GetCommunicator().SumAll(tot_len)          # Get the total outlet model part nodes
+        tot_len = comm.SumAll(tot_len)                                              # Get the total outlet model part nodes
 
-        outlet_avg_vel_norm /= tot_len;
+        outlet_avg_vel_norm /= tot_len
 
         # Store the average velocity in the ProcessInfo to be used in the outlet inflow prevention condition
         min_outlet_avg_vel_norm = 1.0

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
@@ -178,7 +178,7 @@ class FluidSolver(PythonSolver):
         else:
             element_num_nodes = 0
 
-        element_num_nodes = self.main_model_part.GetCommunicator().MaxAll(element_num_nodes)
+        element_num_nodes = self.main_model_part.GetCommunicator().GetDataCommunicator().MaxAll(element_num_nodes)
         return element_num_nodes
 
     def _GetConditionNumNodes(self):
@@ -190,7 +190,7 @@ class FluidSolver(PythonSolver):
         else:
             condition_num_nodes = 0
 
-        condition_num_nodes = self.main_model_part.GetCommunicator().MaxAll(condition_num_nodes)
+        condition_num_nodes = self.main_model_part.GetCommunicator().GetDataCommunicator().MaxAll(condition_num_nodes)
         return condition_num_nodes
 
     def _ExecuteCheckAndPrepare(self):

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_adjoint_vmsmonolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_adjoint_vmsmonolithic_solver.py
@@ -77,7 +77,6 @@ class AdjointVMSMonolithicMPISolver(AdjointVMSMonolithicSolver):
 
         ## Add specific MPI variables
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)
-        KratosMPI.mpi.world.barrier()
 
         KratosMultiphysics.Logger.PrintInfo(self.__class__.__name__, "Variables for the AdjointVMSMonolithicMPISolver added correctly in each processor.")
 
@@ -96,7 +95,6 @@ class AdjointVMSMonolithicMPISolver(AdjointVMSMonolithicSolver):
 
     def AddDofs(self):
         super(self.__class__, self).AddDofs()
-        KratosMPI.mpi.world.barrier()
 
         KratosMultiphysics.Logger.PrintInfo(self.__class__.__name__, "DOFs for the AdjointVMSMonolithicMPISolver added correctly in all processors.")
 

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_embedded_solver.py
@@ -95,7 +95,6 @@ class NavierStokesMPIEmbeddedMonolithicSolver(navier_stokes_embedded_solver.Navi
     def AddVariables(self):
         super(NavierStokesMPIEmbeddedMonolithicSolver, self).AddVariables()
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)
-        KratosMPI.mpi.world.barrier()
 
         KratosMultiphysics.Logger.PrintInfo("NavierStokesMPIEmbeddedMonolithicSolver","Variables for the Trilinos monolithic embedded fluid solver added correctly.")
 
@@ -115,7 +114,6 @@ class NavierStokesMPIEmbeddedMonolithicSolver(navier_stokes_embedded_solver.Navi
 
     def AddDofs(self):
         super(NavierStokesMPIEmbeddedMonolithicSolver, self).AddDofs()
-        KratosMPI.mpi.world.barrier()
 
         KratosMultiphysics.Logger.PrintInfo("NavierStokesMPIEmbeddedMonolithicSolver","DOFs for the VMS Trilinos fluid solver added correctly.")
 

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_fractionalstep.py
@@ -100,7 +100,6 @@ class TrilinosNavierStokesSolverFractionalStep(navier_stokes_solver_fractionalst
         ## Add specific MPI variables
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)
         self.main_model_part.AddNodalSolutionStepVariable(KratosFluid.PATCH_INDEX)
-        KratosMPI.mpi.world.barrier()
 
         KratosMultiphysics.Logger.PrintInfo("TrilinosNavierStokesSolverFractionalStep","variables for the trilinos fractional step solver added correctly")
 
@@ -123,7 +122,6 @@ class TrilinosNavierStokesSolverFractionalStep(navier_stokes_solver_fractionalst
     def AddDofs(self):
         ## Base class DOFs addition
         super(TrilinosNavierStokesSolverFractionalStep, self).AddDofs()
-        KratosMPI.mpi.world.barrier()
 
         KratosMultiphysics.Logger.PrintInfo("TrilinosNavierStokesSolverFractionalStep","DOFs for the VMS Trilinos fluid solver added correctly in all processors.")
 

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
@@ -99,7 +99,6 @@ class TrilinosNavierStokesSolverMonolithic(navier_stokes_solver_vmsmonolithic.Na
 
         ## Add specific MPI variables
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)
-        KratosMPI.mpi.world.barrier()
 
         KratosMultiphysics.Logger.Print("Variables for the VMS fluid Trilinos solver added correctly in each processor.")
 
@@ -119,7 +118,6 @@ class TrilinosNavierStokesSolverMonolithic(navier_stokes_solver_vmsmonolithic.Na
     def AddDofs(self):
         ## Base class DOFs addition
         super(TrilinosNavierStokesSolverMonolithic, self).AddDofs()
-        KratosMPI.mpi.world.barrier()
 
         KratosMultiphysics.Logger.Print("DOFs for the VMS Trilinos fluid solver added correctly in all processors.")
 

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
@@ -93,8 +93,6 @@ class NavierStokesMPITwoFluidsSolver(navier_stokes_two_fluids_solver.NavierStoke
         super(NavierStokesMPITwoFluidsSolver, self).AddVariables()
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PARTITION_INDEX)
 
-        KratosMPI.mpi.world.barrier()
-
         KratosMultiphysics.Logger.PrintInfo("NavierStokesMPITwoFluidsSolver","Variables for the Trilinos Two Fluid solver added correctly.")
 
     def ImportModelPart(self):
@@ -113,7 +111,6 @@ class NavierStokesMPITwoFluidsSolver(navier_stokes_two_fluids_solver.NavierStoke
 
     def AddDofs(self):
         super(NavierStokesMPITwoFluidsSolver, self).AddDofs()
-        KratosMPI.mpi.world.barrier()
 
         KratosMultiphysics.Logger.PrintInfo("NavierStokesMPITwoFluidsSolver","DOFs for the Trilinos Two Fluid solver added correctly.")
 

--- a/applications/FluidDynamicsApplication/tests/adjoint_mpi_vms_sensitivity_2d.py
+++ b/applications/FluidDynamicsApplication/tests/adjoint_mpi_vms_sensitivity_2d.py
@@ -54,7 +54,7 @@ class AdjointMPIVMSSensitivity(KratosUnittest.TestCase):
                 parameter_file.close()
             primal_simulation = FluidDynamicsAnalysis(model,project_parameters)
             primal_simulation.Run()
-            KratosMPI.mpi.world.barrier()
+            Kratos.DataCommunicator.GetDefault().Barrier()
 
             # solve adjoint
             with open('AdjointVMSSensitivity2DTest/mpi_cylinder_test_adjoint_parameters.json', 'r') as parameter_file:
@@ -64,7 +64,7 @@ class AdjointMPIVMSSensitivity(KratosUnittest.TestCase):
             adjoint_model = Kratos.Model()
             adjoint_simulation = AdjointFluidAnalysis(adjoint_model,project_parameters)
             adjoint_simulation.Run()
-            KratosMPI.mpi.world.barrier()
+            Kratos.DataCommunicator.GetDefault().Barrier()
             rank = adjoint_simulation._solver.main_model_part.GetCommunicator().MyPID()
             # remove files
             if rank == 0:

--- a/applications/HDF5Application/python_scripts/core/operations/xdmf.py
+++ b/applications/HDF5Application/python_scripts/core/operations/xdmf.py
@@ -24,7 +24,7 @@ class XdmfOutput(object):
     '''Output that creates the xdmf-file for the given h5-files.'''
 
     def __call__(self, model_part, hdf5_file):
-        model_part.GetCommunicator().Barrier()
+        model_part.GetCommunicator().GetDataCommunicator().Barrier()
         # write xdmf only on one rank!
         if model_part.GetCommunicator().MyPID() == 0:
             WriteXdmfFile(hdf5_file.GetFileName())

--- a/applications/ShallowWaterApplication/python_scripts/shallow_water_base_solver.py
+++ b/applications/ShallowWaterApplication/python_scripts/shallow_water_base_solver.py
@@ -282,7 +282,7 @@ class ShallowWaterBaseSolver(PythonSolver):
         else:
             element_num_nodes = 0
 
-        element_num_nodes = self.main_model_part.GetCommunicator().MaxAll(element_num_nodes)
+        element_num_nodes = self.main_model_part.GetCommunicator().GetDataCommunicator().MaxAll(element_num_nodes)
         return element_num_nodes
 
     def _GetConditionNumNodes(self):
@@ -291,7 +291,7 @@ class ShallowWaterBaseSolver(PythonSolver):
         else:
             condition_num_nodes = 0
 
-        condition_num_nodes = self.main_model_part.GetCommunicator().MaxAll(condition_num_nodes)
+        condition_num_nodes = self.main_model_part.GetCommunicator().GetDataCommunicator().MaxAll(condition_num_nodes)
         return condition_num_nodes
 
     def _ExecuteCheckAndPrepare(self):

--- a/applications/TrilinosApplication/python_scripts/trilinos_import_model_part_utility.py
+++ b/applications/TrilinosApplication/python_scripts/trilinos_import_model_part_utility.py
@@ -91,7 +91,7 @@ class TrilinosImportModelPartUtility():
                 if (KratosMPI.mpi.rank == 0):
                     KratosMultiphysics.Logger.PrintInfo("::[TrilinosImportModelPartUtility]::", "Metis partitioning not executed.")
 
-            KratosMPI.mpi.world.barrier()
+            KratosMultiphysics.DataCommunicator.GetDefault().Barrier()
 
             ## Reset as input file name the obtained Metis partition one
             if is_single_process_run:

--- a/applications/TrilinosApplication/python_scripts/trilinos_import_model_part_utility.py
+++ b/applications/TrilinosApplication/python_scripts/trilinos_import_model_part_utility.py
@@ -13,12 +13,12 @@ class TrilinosImportModelPartUtility():
     def __init__(self, main_model_part, settings):
         self.main_model_part = main_model_part
         self.settings = settings
+        self.comm = KratosMultiphysics.DataCommunicator.GetDefault()
 
     def ExecutePartitioningAndReading(self):
         warning_msg  = 'Calling "ExecutePartitioningAndReading" which is DEPRECATED\n'
         warning_msg += 'Please use "ImportModelPart" instead'
-        if (KratosMPI.mpi.rank == 0):
-            KratosMultiphysics.Logger.PrintWarning("TrilinosImportModelPartUtility", warning_msg)
+        KratosMultiphysics.Logger.PrintWarning("::[TrilinosImportModelPartUtility]::", warning_msg, data_communicator=self.comm)
 
         self.ImportModelPart()
 
@@ -27,7 +27,7 @@ class TrilinosImportModelPartUtility():
         input_type = model_part_import_settings["input_type"].GetString()
 
         # in single process runs, do not call metis (no partitioning is necessary)
-        is_single_process_run = (KratosMPI.mpi.size == 1)
+        is_single_process_run = (self.comm.Size() == 1)
 
         if input_type == "mdpa":
             input_filename = model_part_import_settings["input_filename"].GetString()
@@ -59,7 +59,7 @@ class TrilinosImportModelPartUtility():
                 import KratosMultiphysics.MetisApplication as KratosMetis
 
                 # Partition of the original .mdpa file
-                number_of_partitions = KratosMPI.mpi.size # Number of partitions equals the number of processors
+                number_of_partitions = self.comm.Size() # Number of partitions equals the number of processors
                 domain_size = self.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE]
                 verbosity = self.settings["echo_level"].GetInt()
 
@@ -71,7 +71,7 @@ class TrilinosImportModelPartUtility():
 
                 if not partition_in_memory:
                     ## Serial partition of the original .mdpa file
-                    if KratosMPI.mpi.rank == 0:
+                    if self.comm.Rank() == 0:
                         partitioner = KratosMetis.MetisDivideHeterogeneousInputProcess(model_part_io, number_of_partitions , domain_size, verbosity, sync_conditions)
                         partitioner.Execute()
 
@@ -84,20 +84,18 @@ class TrilinosImportModelPartUtility():
                     partitioner.Execute()
                     serial_model_part_io.ReadModelPart(self.main_model_part)
 
-                    if KratosMPI.mpi.rank == 0:
-                        KratosMultiphysics.Logger.PrintInfo("::[TrilinosImportModelPartUtility]::", "Metis divide finished.")
+                    KratosMultiphysics.Logger.PrintInfo("::[TrilinosImportModelPartUtility]::", "Metis divide finished.",data_communicator=self.comm)
 
             else:
-                if (KratosMPI.mpi.rank == 0):
-                    KratosMultiphysics.Logger.PrintInfo("::[TrilinosImportModelPartUtility]::", "Metis partitioning not executed.")
+                KratosMultiphysics.Logger.PrintInfo("::[TrilinosImportModelPartUtility]::", "Metis partitioning not executed.",data_communicator=self.comm)
 
-            KratosMultiphysics.DataCommunicator.GetDefault().Barrier()
+            self.comm.Barrier()
 
             ## Reset as input file name the obtained Metis partition one
             if is_single_process_run:
                 mpi_input_filename = input_filename
             else:
-                mpi_input_filename = input_filename + "_" + str(KratosMPI.mpi.rank)
+                mpi_input_filename = input_filename + "_" + str(self.comm.Rank())
             model_part_import_settings["input_filename"].SetString(mpi_input_filename)
 
             ## Read the new generated *.mdpa files
@@ -129,5 +127,4 @@ class TrilinosImportModelPartUtility():
         ParallelFillCommunicator = KratosTrilinos.ParallelFillCommunicator(self.main_model_part.GetRootModelPart())
         ParallelFillCommunicator.Execute()
 
-        if KratosMPI.mpi.rank == 0 :
-            KratosMultiphysics.Logger.PrintInfo("::[TrilinosImportModelPartUtility]::", "MPI communicators constructed.")
+        KratosMultiphysics.Logger.PrintInfo("::[TrilinosImportModelPartUtility]::", "MPI communicators constructed.")

--- a/applications/TrilinosApplication/test_examples/gather_modelpart_example/run_example.py
+++ b/applications/TrilinosApplication/test_examples/gather_modelpart_example/run_example.py
@@ -14,10 +14,12 @@ input_filename = "gather_model_part"
 number_of_partitions = 2
 domain_size = 2
 
+mpi_comm = DataCommunicator.GetDefault()
+
 # PRESSURE variable is used to demonstrate
 model_part.AddNodalSolutionStepVariable(PRESSURE)
 model_part.AddNodalSolutionStepVariable(PARTITION_INDEX)
-if mpi.rank == 0:
+if mpi_comm.Rank() == 0:
     model_part_io = ModelPartIO(input_filename)
     partitioner = MetisDivideHeterogeneousInputProcess(
         model_part_io,
@@ -26,10 +28,10 @@ if mpi.rank == 0:
         1,
         True)
     partitioner.Execute()
-mpi.world.barrier()
+mpi_comm.Barrier()
 
 ModelPartCommunicatorUtilities.SetMPICommunicator(model_part)
-my_input_filename = input_filename + "_" + str(mpi.rank)
+my_input_filename = input_filename + "_" + str(mpi_comm.Rank())
 model_part_io = ModelPartIO(my_input_filename)
 model_part_io.ReadModelPart(model_part)
 Comm = CreateCommunicator()
@@ -41,7 +43,7 @@ gather_model_part_util = GatherModelPartUtility(0, model_part, 0, gather_model_p
 
 def PrintPressureOnNodes(model_part):
     for node in model_part.Nodes:
-        if node.GetSolutionStepValue(PARTITION_INDEX) == mpi.rank:
+        if node.GetSolutionStepValue(PARTITION_INDEX) == mpi_comm.Rank():
             print("Local Node[", node.Id, "]: PRESSURE = ", node.GetSolutionStepValue(PRESSURE))
         else:
             print("Ghost Node[", node.Id, "]: PRESSURE = ", node.GetSolutionStepValue(PRESSURE))
@@ -49,72 +51,72 @@ def PrintPressureOnNodes(model_part):
 
 # first we assign some values on the local model part
 for node in model_part.Nodes:
-    if node.GetSolutionStepValue(PARTITION_INDEX) == mpi.rank:
+    if node.GetSolutionStepValue(PARTITION_INDEX) == mpi_comm.Rank():
         node.SetSolutionStepValue(PRESSURE, math.exp(-float(node.Id)))
 
-if mpi.rank == 0:
+if mpi_comm.Rank() == 0:
     print("\nNew pressure values written to local model part")
     print("==========================================")
     print("Local model part on process 0")
     print("==========================================")
     PrintPressureOnNodes(model_part)
-mpi.world.barrier()
-if mpi.rank == 1:
+mpi_comm.Barrier()
+if mpi_comm.Rank() == 1:
     print("==========================================")
     print("Local model part on process 1")
     print("==========================================")
     PrintPressureOnNodes(model_part)
-mpi.world.barrier()
-if mpi.rank == 0:
+mpi_comm.Barrier()
+if mpi_comm.Rank() == 0:
     print("==========================================")
     print("Gather model part on process 0")
     print("==========================================")
     PrintPressureOnNodes(gather_model_part)
     print("Calling GatherOnMaster(PRESSURE) ...")
-mpi.world.barrier()
+mpi_comm.Barrier()
 gather_model_part_util.GatherOnMaster(PRESSURE)
-if mpi.rank == 0:
+if mpi_comm.Rank() == 0:
     print("==========================================")
     print("Gather model part on process 0")
     print("==========================================")
     PrintPressureOnNodes(gather_model_part)
-mpi.world.barrier()
+mpi_comm.Barrier()
 
 
-if mpi.rank == 0:
+if mpi_comm.Rank() == 0:
     for node in gather_model_part.Nodes:
         node.SetSolutionStepValue(PRESSURE, math.exp(float(node.Id)))
 
-if mpi.rank == 0:
+if mpi_comm.Rank() == 0:
     print("\nNew pressure values written to gather model part")
     print("==========================================")
     print("Gather model part on process 0")
     print("==========================================")
     PrintPressureOnNodes(gather_model_part)
-mpi.world.barrier()
-if mpi.rank == 0:
+mpi_comm.Barrier()
+if mpi_comm.Rank() == 0:
     print("==========================================")
     print("Local model part on process 0")
     print("==========================================")
     PrintPressureOnNodes(model_part)
-mpi.world.barrier()
-if mpi.rank == 1:
+mpi_comm.Barrier()
+if mpi_comm.Rank() == 1:
     print("==========================================")
     print("Local model part on process 1")
     print("==========================================")
     PrintPressureOnNodes(model_part)
     print("Calling ScatterFromMaster(PRESSURE) ...")
-mpi.world.barrier()
+mpi_comm.Barrier()
 gather_model_part_util.ScatterFromMaster(PRESSURE)
-if mpi.rank == 0:
+if mpi_comm.Rank() == 0:
     print("==========================================")
     print("Local model part on process 0")
     print("==========================================")
     PrintPressureOnNodes(model_part)
-mpi.world.barrier()
-if mpi.rank == 1:
+mpi_comm.Barrier()
+if mpi_comm.Rank() == 1:
     print("==========================================")
     print("Local model part on process 1")
     print("==========================================")
     PrintPressureOnNodes(model_part)
-mpi.world.barrier()
+mpi_comm.Barrier()

--- a/applications/TrilinosApplication/tests/test_mpi_communicator.py
+++ b/applications/TrilinosApplication/tests/test_mpi_communicator.py
@@ -15,7 +15,7 @@ def GetFilePath(fileName):
 class TestMPICommunicator(KratosUnittest.TestCase):
 
     def setUp(self):
-        self.communicator = KratosMultiphysics.ParallelEnvironment.GetDefaultDataCommunicator()
+        self.communicator = KratosMultiphysics.DataCommunicator.GetDefault()
 
     def tearDown(self):
         rank = self.communicator.Rank()
@@ -198,7 +198,7 @@ class TestMPICommunicator(KratosUnittest.TestCase):
 
         self.world = KratosMultiphysics.ParallelEnvironment.GetDataCommunicator("World")
 
-        comm = main_model_part.GetCommunicator()
+        comm = main_model_part.GetCommunicator().GetDataCommunicator()
 
         self.assertEqual(comm.SumAll(1), self.world.Size())
         self.assertEqual(comm.SumAll(2.0), 2.0*self.world.Size())
@@ -211,7 +211,7 @@ class TestMPICommunicator(KratosUnittest.TestCase):
         main_model_part = current_model.CreateModelPart("MainModelPart")
 
         # this one is not set, so it should be a serial Communicator
-        comm = main_model_part.GetCommunicator()
+        comm = main_model_part.GetCommunicator().GetDataCommunicator()
 
         self.assertEqual(comm.SumAll(1), 1)
         self.assertEqual(comm.SumAll(2.0), 2.0)

--- a/applications/TrilinosApplication/tests/test_trilinos_levelset_convection.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_levelset_convection.py
@@ -103,8 +103,9 @@ class TestTrilinosLevelSetConvection(KratosUnittest.TestCase):
             max_distance = max(max_distance, d)
             min_distance = min(min_distance, d)
 
-        min_distance = self.model_part.GetCommunicator().MinAll(min_distance)
-        max_distance = self.model_part.GetCommunicator().MaxAll(max_distance)
+        comm = self.model_part.GetCommunicator().GetDataCommunicator()
+        min_distance = comm.MinAll(min_distance)
+        max_distance = comm.MaxAll(max_distance)
 
         self.assertAlmostEqual(max_distance, 0.7904255118014996)
         self.assertAlmostEqual(min_distance,-0.11710292469993094)

--- a/applications/TrilinosApplication/tests/test_trilinos_redistance.py
+++ b/applications/TrilinosApplication/tests/test_trilinos_redistance.py
@@ -94,8 +94,9 @@ class TestTrilinosRedistance(KratosUnittest.TestCase):
             max_distance = max(max_distance, d)
             min_distance = min(min_distance, d)
 
-        min_distance = self.model_part.GetCommunicator().MinAll(min_distance)
-        max_distance = self.model_part.GetCommunicator().MaxAll(max_distance)
+        comm = self.model_part.GetCommunicator().GetDataCommunicator()
+        min_distance = comm.MinAll(min_distance)
+        max_distance = comm.MaxAll(max_distance)
 
         self.assertAlmostEqual(max_distance, 0.44556526310761013) # Serial max_distance
         self.assertAlmostEqual(min_distance,-0.504972246827639) # Serial min_distance

--- a/applications/convection_diffusion_application/python_scripts/apply_thermal_face_process.py
+++ b/applications/convection_diffusion_application/python_scripts/apply_thermal_face_process.py
@@ -40,7 +40,7 @@ class ApplyThermalFaceProcess(KratosMultiphysics.Process):
             for prop in Model.GetModelPart(model_part_name).Properties:
                 if prop.Id > max_prop_id:
                     max_prop_id = prop.Id
-        model_part.GetCommunicator().MaxAll(max_prop_id)
+        max_prop_id = model_part.GetCommunicator().GetDataCommunicator().MaxAll(max_prop_id)
 
         # Create a new property with the user defined interface parameters
         thermal_interface_prop = KratosMultiphysics.Properties(max_prop_id + 1)

--- a/kratos/python_scripts/point_output_process.py
+++ b/kratos/python_scripts/point_output_process.py
@@ -122,9 +122,10 @@ class PointOutputProcess(KratosMultiphysics.Process):
         # Here we also check if the point has been found in more than one partition
         # In sich a case only one rank (the one with the larger PID) writes the output!
         my_rank = -1 # dummy to indicate that the point is not in my partition
+        comm = self.model_part.GetCommunicator().GetDataCommunicator()
         if found_id > -1: # the point lies in my partition
-            my_rank = self.model_part.GetCommunicator().MyPID()
-        writing_rank = self.model_part.GetCommunicator().MaxAll(my_rank) # The partition with the larger rank writes
+            my_rank = comm.Rank()
+        writing_rank = comm.MaxAll(my_rank) # The partition with the larger rank writes
 
         if my_rank == writing_rank:
 

--- a/kratos/python_scripts/restart_utility.py
+++ b/kratos/python_scripts/restart_utility.py
@@ -155,7 +155,7 @@ class RestartUtility(object):
             folder_path = self.__GetFolderPathSave()
             if not os.path.isdir(folder_path) and self.model_part.GetCommunicator().MyPID() == 0:
                 os.makedirs(folder_path)
-            self.model_part.GetCommunicator().Barrier()
+            self.model_part.GetCommunicator().GetDataCommunicator().Barrier()
 
 
     #### Protected functions ####

--- a/kratos/python_scripts/unv_output_process.py
+++ b/kratos/python_scripts/unv_output_process.py
@@ -34,7 +34,7 @@ class UnvOutputProcess(KratosMultiphysics.Process):
         #             kratos_utils.DeleteDirectoryIfExisting(folder_name)
         #         if not os.path.isdir(folder_name):
         #             os.mkdir(folder_name)
-        #     self.model_part.GetCommunicator().Barrier()
+        #     self.model_part.GetCommunicator().GetDataCommunicator().Barrier()
 
         # self.unv_io = KratosMultiphysics.UnvOutput(self.model_part, self.settings)
         self.unv_io = KratosMultiphysics.UnvOutput(self.model_part, "nxout")

--- a/kratos/python_scripts/vtk_output_process.py
+++ b/kratos/python_scripts/vtk_output_process.py
@@ -44,7 +44,7 @@ class VtkOutputProcess(KratosMultiphysics.Process):
                     kratos_utils.DeleteDirectoryIfExisting(folder_name)
                 if not os.path.isdir(folder_name):
                     os.mkdir(folder_name)
-            self.model_part.GetCommunicator().Barrier()
+            self.model_part.GetCommunicator().GetDataCommunicator().Barrier()
 
         self.vtk_io = KratosMultiphysics.VtkOutput(self.model_part, self.settings)
 


### PR DESCRIPTION
In this PR I am replacing uses of the old mpi-python interface and deprecated methods in MPICommunicator from scripts across the codebase. This is not comprehensive, but I believe should cover most commonly used mpi solvers.

I tried to separate the fixes by application to help with review. Feel free to contribute other changes to this branch, if you found something I missed.