### PR TITLE
[Core] Hotfix find global neighbours

### DIFF
--- a/kratos/processes/find_global_nodal_neighbours_process.h
+++ b/kratos/processes/find_global_nodal_neighbours_process.h
@@ -147,7 +147,7 @@ public:
                 auto& neighbours = it->GetValue(NEIGHBOUR_NODES);
                 neighbours.shrink_to_fit();
                 std::sort(neighbours.ptr_begin(), neighbours.ptr_end(),
-                          [](GlobalPointer<Node<3>>& gp1, GlobalPointer<Node<3>>& gp2)
+                          [](GlobalPointer<Node<3>> const& gp1, GlobalPointer<Node<3>> const& gp2)
                             {
                                 return gp1->Id() < gp2->Id();
                             }


### PR DESCRIPTION
This was failing in centos (gcc 4.8 :( )