### PR TITLE
Updated mpi test detection and launching.

### DIFF
--- a/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
+++ b/applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication.py
@@ -122,16 +122,16 @@ if __name__ == '__main__':
     run_cpp_unit_tests.run()
     KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished running cpp unit tests!")
 
-    KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning mpi python tests ...")
-    try:
-        import KratosMultiphysics.mpi as KratosMPI
-        import KratosMultiphysics.MetisApplication as MetisApplication
-        import KratosMultiphysics.TrilinosApplication as TrilinosApplication
-        p = subprocess.Popen(["mpiexec", "-np", "2", "python3", "test_FluidDynamicsApplication_mpi.py"], stdout=subprocess.PIPE)
+    import os.path
+    import kratos_utilities
+    if kratos_utilities.IsMPIAvailable():
+        KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning mpi python tests ...")
+        p = subprocess.Popen(
+            ["mpiexec", "-np", "2", "python3", "test_FluidDynamicsApplication_mpi.py"],
+            stdout=subprocess.PIPE,
+            cwd=os.path.dirname(__file__))
         p.wait()
         KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished mpi python tests!")
-    except ImportError:
-        KratosMultiphysics.Logger.PrintInfo("Unittests", "mpi is not available!")
 
     KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning python tests ...")
     KratosUnittest.runTests(AssembleTestSuites())


### PR DESCRIPTION
Cleaning up the fluid python tests after #4874 to properly detect and launch mpi tests if possible.

@philbucher I found a bug in the current approach: if I launch the test from a "main" test runner (testing multiple applications) I need to specify the working folder to the subprocesses, so that they can find the mpi script to launch. I believe this would also be needed for other applications with a separate mpi test file.