### PR TITLE
[Core] VariableUtils UpdateCurrentPosition method

### DIFF
--- a/kratos/python/add_utilities_to_python.cpp
+++ b/kratos/python/add_utilities_to_python.cpp
@@ -192,6 +192,20 @@ void CalculateDistancesFlag3D(ParallelDistanceCalculator<3>& rParallelDistanceCa
     rParallelDistanceCalculator.CalculateDistances(rModelPart, rDistanceVar, rAreaVar, max_levels, max_distance, Options);
 }
 
+void VariableUtilsUpdateCurrentPositionNoVariable(
+    VariableUtils &rVariableUtils,
+    const ModelPart::NodesContainerType &rNodes)
+{
+    rVariableUtils.UpdateCurrentPosition(rNodes);
+}
+
+void VariableUtilsUpdateCurrentPositionWithVariable(
+    VariableUtils &rVariableUtils,
+    const ModelPart::NodesContainerType &rNodes,
+    const VariableUtils::ArrayVarType &rUpdateVariable)
+{
+    rVariableUtils.UpdateCurrentPosition(rNodes, rUpdateVariable);
+}
 
 void AddUtilitiesToPython(pybind11::module& m)
 {
@@ -424,6 +438,8 @@ void AddUtilitiesToPython(pybind11::module& m)
         .def("CheckDofs", &VariableUtils::CheckDofs)
         .def("UpdateCurrentToInitialConfiguration", &VariableUtils::UpdateCurrentToInitialConfiguration)
         .def("UpdateInitialToCurrentConfiguration", &VariableUtils::UpdateInitialToCurrentConfiguration)
+        .def("UpdateCurrentPosition", VariableUtilsUpdateCurrentPositionNoVariable)
+        .def("UpdateCurrentPosition", VariableUtilsUpdateCurrentPositionWithVariable)
         ;
 
     // This is required to recognize the different overloads of NormalCalculationUtils::CalculateOnSimplex

--- a/kratos/python/add_utilities_to_python.cpp
+++ b/kratos/python/add_utilities_to_python.cpp
@@ -192,7 +192,7 @@ void CalculateDistancesFlag3D(ParallelDistanceCalculator<3>& rParallelDistanceCa
     rParallelDistanceCalculator.CalculateDistances(rModelPart, rDistanceVar, rAreaVar, max_levels, max_distance, Options);
 }
 
-void VariableUtilsUpdateCurrentPositionNoVariable(
+void VariableUtilsUpdateCurrentPosition(
     VariableUtils &rVariableUtils,
     const ModelPart::NodesContainerType &rNodes)
 {
@@ -438,7 +438,7 @@ void AddUtilitiesToPython(pybind11::module& m)
         .def("CheckDofs", &VariableUtils::CheckDofs)
         .def("UpdateCurrentToInitialConfiguration", &VariableUtils::UpdateCurrentToInitialConfiguration)
         .def("UpdateInitialToCurrentConfiguration", &VariableUtils::UpdateInitialToCurrentConfiguration)
-        .def("UpdateCurrentPosition", VariableUtilsUpdateCurrentPositionNoVariable)
+        .def("UpdateCurrentPosition", VariableUtilsUpdateCurrentPosition)
         .def("UpdateCurrentPosition", VariableUtilsUpdateCurrentPositionWithVariable)
         ;
 

--- a/kratos/utilities/variable_utils.cpp
+++ b/kratos/utilities/variable_utils.cpp
@@ -467,4 +467,23 @@ void VariableUtils::UpdateInitialToCurrentConfiguration(const ModelPart::NodesCo
     KRATOS_CATCH("");
 }
 
+void VariableUtils::UpdateCurrentPosition(
+    const ModelPart::NodesContainerType &rNodes,
+    const ArrayVarType &rUpdateVariable)
+{
+    KRATOS_TRY;
+
+    const int num_nodes = rNodes.size();
+    const auto nodes_begin = rNodes.begin();
+
+    #pragma omp parallel for firstprivate(nodes_begin)
+    for (int i_node = 0; i_node < num_nodes; ++i_node) {
+        const auto it_node  = nodes_begin + i_node;
+        const auto update_coords = it_node->FastGetSolutionStepValue(rUpdateVariable);
+        noalias(it_node->Coordinates()) = (it_node->GetInitialPosition()).Coordinates() + update_coords;
+    }
+
+    KRATOS_CATCH("");
+}
+
 } /* namespace Kratos.*/

--- a/kratos/utilities/variable_utils.cpp
+++ b/kratos/utilities/variable_utils.cpp
@@ -479,8 +479,8 @@ void VariableUtils::UpdateCurrentPosition(
     #pragma omp parallel for firstprivate(nodes_begin)
     for (int i_node = 0; i_node < num_nodes; ++i_node) {
         const auto it_node  = nodes_begin + i_node;
-        const auto update_coords = it_node->FastGetSolutionStepValue(rUpdateVariable);
-        noalias(it_node->Coordinates()) = (it_node->GetInitialPosition()).Coordinates() + update_coords;
+        const auto &r_update_coords = it_node->FastGetSolutionStepValue(rUpdateVariable);
+        noalias(it_node->Coordinates()) = (it_node->GetInitialPosition()).Coordinates() + r_update_coords;
     }
 
     KRATOS_CATCH("");

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -944,6 +944,7 @@ public:
      * For each node, this method takes the value of the provided variable and updates the
      * current position as the initial position (X0, Y0, Z0) plus such variable value
      * @param rNodes
+     * @param rUpdateVariable variable to retrieve the updating values from
      */
     void UpdateCurrentPosition(
         const ModelPart::NodesContainerType &rNodes,

--- a/kratos/utilities/variable_utils.h
+++ b/kratos/utilities/variable_utils.h
@@ -934,10 +934,20 @@ public:
     void UpdateCurrentToInitialConfiguration(const ModelPart::NodesContainerType& rNodes);
 
     /**
-     * @brief This method updates the initial nodal coordinates to the current coordinates
      * @param rNodes the nodes to be updated
+     * @brief This method updates the initial nodal coordinates to the current coordinates
      */
     void UpdateInitialToCurrentConfiguration(const ModelPart::NodesContainerType& rNodes);
+
+    /**
+     * @brief This method updates the current coordinates
+     * For each node, this method takes the value of the provided variable and updates the
+     * current position as the initial position (X0, Y0, Z0) plus such variable value
+     * @param rNodes
+     */
+    void UpdateCurrentPosition(
+        const ModelPart::NodesContainerType &rNodes,
+        const ArrayVarType &rUpdateVariable = DISPLACEMENT);
 
     ///@}
     ///@name Acces


### PR DESCRIPTION
This PR adds a new method to the variable utils: `UpdateCurrentPosition`. It is intended to be used to update the current nodal coordinates according to a variable value. If the reference variable is not provided, it takes `DISPLACEMENT` as default. Tests have been also added.