### PR TITLE
[SDEM] remove define_output

### DIFF
--- a/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_analysis.py
+++ b/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_analysis.py
@@ -491,8 +491,8 @@ class SwimmingDEMAnalysis(AnalysisStage):
 
     def _Print(self):
         os.chdir(self.post_path)
-        import define_output
-        self.drag_list = define_output.DefineDragList()
+        # import define_output
+        # self.drag_list = define_output.DefineDragList()
         self.drag_file_output_list = []
 
         if self.particles_results_counter.Tick():

--- a/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_analysis.py
+++ b/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_analysis.py
@@ -491,6 +491,7 @@ class SwimmingDEMAnalysis(AnalysisStage):
 
     def _Print(self):
         os.chdir(self.post_path)
+        # TODO: to fix or delete
         # import define_output
         # self.drag_list = define_output.DefineDragList()
         self.drag_file_output_list = []


### PR DESCRIPTION
this import is unrequired and causes and issue with the current fluiddem interface development.