### PR TITLE
[Core] Adding method for custom folder import

### DIFF
--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -77,6 +77,17 @@ def _ImportApplicationAsModule(application, application_name, application_folder
     # Add application to kernel
     Kernel.ImportApplication(application)
 
+def _ImportApplicationAsModuleCustomFolder(application, application_name, application_folder, mod_path):
+    Kernel = KratosGlobals.Kernel
+
+    Logger.PrintInfo("", "Importing    " + application_name)
+
+    # adding the scripts in "APP_NAME/python_scripts" such that they are treated as a regular python-module
+    python_path = os.path.join(application_folder, 'python_scripts')
+    mod_path.append(python_path)
+
+    # Add application to kernel
+    Kernel.ImportApplication(application)
 
 def CheckForPreviousImport():
     warn_msg  = '"CheckForPreviousImport" is not needed any more and can be safely removed\n'

--- a/kratos/python_interface/application_importer.py
+++ b/kratos/python_interface/application_importer.py
@@ -6,9 +6,9 @@ from KratosMultiphysics import Logger
 
 
 def ImportApplication(application, application_name, application_folder, caller, mod_path=None):
-    Globals = KratosMultiphysics.KratosGlobals
-    Kernel = Globals.Kernel
-    applications_root = Globals.ApplicationsRoot
+    KratosGlobals = KratosMultiphysics.KratosGlobals
+    Kernel = KratosGlobals.Kernel
+    applications_root = KratosGlobals.ApplicationsRoot
 
     Logger.PrintInfo("", "Importing  " + application_name)
 


### PR DESCRIPTION
In my  CmakeListst.txt I add the folowing for an application outside the application folder:

~~~cmake
file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/NAME_APPLICATION.py" "# makes KratosMultiphysics backward compatible with python 2.6 and 2.7\nfrom __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7\nimport KratosMultiphysics as KM\nfrom KratosNAME_APPLICATION import *\napplication = KratosNAME_APPLICATION()\napplication_name = \"KratosNAME_APPLICATION\"\napplication_folder = \"${CMAKE_CURRENT_SOURCE_DIR}\"\n\nKM._ImportApplicationAsModuleCustomFolder(application, application_name, application_folder, __path__)")
~~~

This creates a custom *.py file to initialize as a module