### PR TITLE
trilinos application now links to mpi core.

### DIFF
--- a/applications/TrilinosApplication/CMakeLists.txt
+++ b/applications/TrilinosApplication/CMakeLists.txt
@@ -61,12 +61,12 @@ endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 pybind11_add_module(KratosTrilinosApplication MODULE THIN_LTO ${KRATOS_TRILINOS_APPLICATION_SOURCES} ${KRATOS_TRILINOS_TEST_SOURCES})
 
 if (HAVE_PASTIX)
-    target_link_libraries(KratosTrilinosApplication PRIVATE KratosCore ${TRILINOS_LIBRARIES} ${MPI_LIBRARIES} ${PASTIX_LIBRARIES} ${SCOTCH_LIBRARIES} ${BLAS_LIBRARIES} )
+    target_link_libraries(KratosTrilinosApplication PRIVATE KratosCore KratosMPICore ${TRILINOS_LIBRARIES} ${MPI_LIBRARIES} ${PASTIX_LIBRARIES} ${SCOTCH_LIBRARIES} ${BLAS_LIBRARIES} )
     install(FILES ${PASTIX_LIBRARIES} DESTINATION libs )
 
     message("linking PASTIX in the AMGCL lib")
 else(HAVE_PASTIX)
-    target_link_libraries(KratosTrilinosApplication PRIVATE KratosCore ${TRILINOS_LIBRARIES} ${MPI_LIBRARIES} )
+    target_link_libraries(KratosTrilinosApplication PRIVATE KratosCore KratosMPICore ${TRILINOS_LIBRARIES} ${MPI_LIBRARIES} )
 endif(HAVE_PASTIX)
 
 set_target_properties(KratosTrilinosApplication PROPERTIES PREFIX "")


### PR DESCRIPTION
It is required in order to use the MPICommunicator (and MPIDataCommunicator) from the TrilinosApplication. I could fix the DataCommunicator in order to avoid this dependency, but it would mean loosing the possibility to extract the underlying `MPI_Comm` from `MPIDataCommunicator`. After discussing it with @philbucher, we believe that the flexibility that this feature can provide outweighs the cost of adding the dependency (which already exists anyway, but we don't see because the MPICore module is automatically loaded at kratos startup in mpi runs).

@loumalouomega I know I told you not to do this in #4705, but it turns out it is actually necessary... I'm sorry for the noise.