### PR TITLE
Forward declaration of DataCommunicator in logger.

### DIFF
--- a/kratos/input_output/logger_message.cpp
+++ b/kratos/input_output/logger_message.cpp
@@ -19,10 +19,16 @@
 
 // Project includes
 #include "input_output/logger_message.h"
-
+#include "includes/data_communicator.h"
 
 namespace Kratos
 {
+  LoggerMessage::MessageSource::MessageSource()
+  {
+    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
+    mRank = r_comm.Rank();
+  }
+
   std::string LoggerMessage::Info() const
   {
     return "LoggerMessage";

--- a/kratos/input_output/logger_message.h
+++ b/kratos/input_output/logger_message.h
@@ -31,7 +31,6 @@
 // Project includes
 #include "includes/kratos_export_api.h"
 #include "includes/code_location.h"
-#include "includes/data_communicator.h"
 
 namespace Kratos
 {
@@ -40,6 +39,8 @@ namespace Kratos
 
 ///@name Kratos Classes
 ///@{
+
+class DataCommunicator; // forward declaration to avoid a cyclic include dependency
 
 /// LoggerMessage class holdes message and the properties of the message.
 /** LoggerMessage holds the origin of the message, severity, level and
@@ -120,10 +121,7 @@ public:
   class MessageSource {
   public:
 
-  MessageSource() {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
-    mRank = r_comm.Rank();
-  }
+  MessageSource();
 
   MessageSource(int TheRank)
     : mRank(TheRank) {}

--- a/kratos/input_output/logger_table_output.cpp
+++ b/kratos/input_output/logger_table_output.cpp
@@ -19,8 +19,8 @@
 
 
 // Project includes
+#include "includes/data_communicator.h"
 #include "input_output/logger_table_output.h"
-
 
 namespace Kratos
 {


### PR DESCRIPTION
In preparing support for sending serialized objects through the DataCommunicator, I encountered a circular dependency between the data_communicator, the serializer and the logger. This is the simplest solution I could find to break it and allow compilation.