### PR TITLE
[StructuralMechanics] removing ComputingModelPart - Step 1

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -64,7 +64,12 @@ class MechanicalSolver(PythonSolver):
         if model_part_name == "":
             raise Exception('Please specify a model_part name!')
 
-        # This will be changed once the Model is fully supported!
+        # Only needed during the transition of removing the ComputingModelPart
+        if self.settings["problem_domain_sub_model_part_list"].size() == 0:
+            self.settings["problem_domain_sub_model_part_list"].Append(model_part_name)
+        if self.settings["processes_sub_model_part_list"].size() == 0:
+            self.settings["processes_sub_model_part_list"].Append(model_part_name)
+
         if self.model.HasModelPart(model_part_name):
             self.main_model_part = self.model[model_part_name]
         else:
@@ -114,8 +119,8 @@ class MechanicalSolver(PythonSolver):
             "residual_absolute_tolerance": 1.0e-9,
             "max_iteration": 10,
             "linear_solver_settings": { },
-            "problem_domain_sub_model_part_list": ["solid"],
-            "processes_sub_model_part_list": [""],
+            "problem_domain_sub_model_part_list": [],
+            "processes_sub_model_part_list": [],
             "auxiliary_variables_list" : [],
             "auxiliary_dofs_list" : [],
             "auxiliary_reaction_list" : []


### PR DESCRIPTION
This is the first step towards removing the ComputingModelPart in StructuralMechanics, as discussed with @RiccardoRossi at the Workshop in March

In short, the MainModelPart will be used for the construction of the ComputingModelPart 
=> this means that the MainModelPart and the ComputingModelPart will be the same, **only if the user has not specified the submodelparts to be added to the ComputingModelPart**, which is so far always done (otherwise would not work)
I am doing this for a while already also with very complex models and had no problems with it.

The plan is to remove this setting from the Interface in the next step, such that the defaults that I am adding here (=> MainModellPart == ComputingModelPart) will be used

@KratosMultiphysics/structural-mechanics since we have used this for a while already, I would like you to take a look and point out potential compilcations.

@loumalouomega I know you are having some troubles with this, please let me know if you foresee major problems

In the meantime I will also remove the usage of the ComputingModelPart from the AnalysisStage, such that we can get rid of it for good in all of Kratos

FYI @KratosMultiphysics/technical-committee 