### PR TITLE
[Core] Continuous distance initialization with bounding box size

### DIFF
--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -406,6 +406,8 @@ namespace Kratos
 		const double char_length = std::sqrt(std::pow(max_x - min_x, 2) + std::pow(max_z - min_z, 2) + std::pow(max_z - min_z, 2));
 		KRATOS_ERROR_IF(char_length < std::numeric_limits<double>::epsilon())
 			<< "Domain characteristic length is close to zero. Check if there is any node in the model part." << std::endl;
+
+		return char_length;
 	}
 
 	template<>

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -40,18 +40,9 @@ namespace Kratos
 		// Initialize the intersected objects process
 		mFindIntersectedObjectsProcess.Initialize();
 
-		// Reset the nodal distance values
-		const double initial_distance = 1.0;
-
-		#pragma omp parallel for
-		for (int k = 0; k< static_cast<int> (mrVolumePart.NumberOfNodes()); ++k) {
-			ModelPart::NodesContainerType::iterator itNode = mrVolumePart.NodesBegin() + k;
-			itNode->Set(TO_SPLIT, false);
-			itNode->GetSolutionStepValue(DISTANCE) = initial_distance;
-		}
-
 		// Reset the Elemental distance to 1.0 which is the maximum distance in our normalized space.
 		// Also initialize the embedded velocity of the fluid element and the TO_SPLIT flag.
+		const double initial_distance = 1.0;
 		constexpr std::size_t num_nodes = TDim + 1;
 		array_1d<double,num_nodes> ElementalDistances;
 		for (unsigned int i_node = 0; i_node < num_nodes; ++i_node) {
@@ -197,7 +188,7 @@ namespace Kratos
 
 	template<std::size_t TDim>
 	unsigned int CalculateDiscontinuousDistanceToSkinProcess<TDim>::ComputeEdgesIntersections(
-		Element& rElement1, 
+		Element& rElement1,
 		const PointerVector<GeometricalObject>& rIntersectedObjects,
 		std::vector<unsigned int> &rCutEdgesVector,
       	std::vector<array_1d <double,3> > &rIntersectionPointsArray)
@@ -262,9 +253,9 @@ namespace Kratos
 
 	template<std::size_t TDim>
 	int CalculateDiscontinuousDistanceToSkinProcess<TDim>::ComputeEdgeIntersection(
-		const Element::GeometryType& rIntObjGeometry, 
-		const Element::NodeType& rEdgePoint1, 
-		const Element::NodeType& rEdgePoint2, 
+		const Element::GeometryType& rIntObjGeometry,
+		const Element::NodeType& rEdgePoint1,
+		const Element::NodeType& rEdgePoint2,
 		Point& rIntersectionPoint)
 	{
 		int intersection_flag = 0;
@@ -304,7 +295,7 @@ namespace Kratos
 
 	template<std::size_t TDim>
 	void CalculateDiscontinuousDistanceToSkinProcess<TDim>::ComputePlaneApproximation(
-		const Element& rElement1, 
+		const Element& rElement1,
 		const std::vector< array_1d<double,3> >& rPointsCoord,
 		array_1d<double,3>& rPlaneBasePointCoords,
 		array_1d<double,3>& rPlaneNormal)
@@ -375,7 +366,7 @@ namespace Kratos
 	Plane3D CalculateDiscontinuousDistanceToSkinProcess<2>::SetIntersectionPlane(
 		const std::vector<array_1d<double,3>> &rIntPtsVector)
 	{
-		// Since the Plane3D object only works in 3D, in 2D we set the intersection 
+		// Since the Plane3D object only works in 3D, in 2D we set the intersection
 		// plane by extruding the intersection point 0 in the z-direction.
 		array_1d<double,3> z_coord_pt = rIntPtsVector[0];
 		z_coord_pt[2] = 1.0;

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -385,7 +385,7 @@ namespace Kratos
 	{
 		// Get the background mesh model part
 		const auto &r_model_part = mFindIntersectedObjectsProcess.GetModelPart1();
-		KRATOS_ERROR_IF(r_model_part.NumberOfNodes() != 0)
+		KRATOS_ERROR_IF(r_model_part.NumberOfNodes() == 0)
 			<< "Background mesh model part has no nodes." << std::endl;
 
 		// Compute the domain characteristic length

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
@@ -172,6 +172,14 @@ protected:
      */
     Plane3D SetIntersectionPlane(const std::vector<array_1d<double,3>> &rIntPtsVector);
 
+    /**
+     * @brief Calculates the domain characteristic length
+     * This method computes the domain characteristic length as the norm of
+     * the diagonal vector that joins the maximum and minimum coordinates
+     * @return double the calculated characteristic length
+     */
+    double CalculateCharacteristicLength();
+
     ///@}
 private:
     ///@name Member Variables

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -64,7 +64,7 @@ namespace Kratos
 		double max_x(0.0), max_y(0.0), max_z(0.0);
 		double min_x(0.0), min_y(0.0), min_z(0.0);
 
-		#pragma omp parallel for reduction(max:max_x, max_y, max_z) reduction(min:min_x, min_y, min_z)
+		// #pragma omp parallel for reduction(max:max_x, max_y, max_z) reduction(min:min_x, min_y, min_z) // Activate this once Windows OpenMP standard suppors max and min reductions
 		for (int i_node = 0; i_node < static_cast<int>(ModelPart1.NumberOfNodes()); ++i_node) {
 			const auto it_node = ModelPart1.NodesBegin() + i_node;
 			max_x = (max_x < (*it_node)[0]) ? (*it_node)[0] : max_x;

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -60,24 +60,8 @@ namespace Kratos
 		// Get the volume model part from the base discontinuous distance process
 		ModelPart& ModelPart1 = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess).GetModelPart1();
 
-		// Compute the domain characteristic length
-		double max_x(0.0), max_y(0.0), max_z(0.0);
-		double min_x(0.0), min_y(0.0), min_z(0.0);
-
-		// #pragma omp parallel for reduction(max:max_x, max_y, max_z) reduction(min:min_x, min_y, min_z) // Activate this once Windows OpenMP standard suppors max and min reductions
-		for (int i_node = 0; i_node < static_cast<int>(ModelPart1.NumberOfNodes()); ++i_node) {
-			const auto it_node = ModelPart1.NodesBegin() + i_node;
-			max_x = (max_x < (*it_node)[0]) ? (*it_node)[0] : max_x;
-			max_y = (max_y < (*it_node)[1]) ? (*it_node)[1] : max_y;
-			max_z = (max_z < (*it_node)[2]) ? (*it_node)[2] : max_z;
-			min_x = (min_x > (*it_node)[0]) ? (*it_node)[0] : min_x;
-			min_y = (min_y > (*it_node)[1]) ? (*it_node)[1] : min_y;
-			min_z = (min_z > (*it_node)[2]) ? (*it_node)[2] : min_z;
-		}
-
-		const double char_length = std::sqrt(std::pow(max_x - min_x, 2) + std::pow(max_z - min_z, 2) + std::pow(max_z - min_z, 2));
-		KRATOS_ERROR_IF(char_length < std::numeric_limits<double>::epsilon())
-			<< "Domain characteristic length is close to zero. Check if there is any node in the model part." << std::endl;
+		// Calculate the domain characteristic length
+		const double char_length = this->CalculateCharacteristicLength();
 
 		// Initialize the nodal distance values to a maximum positive value
 		#pragma omp parallel for firstprivate(char_length)

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -64,7 +64,7 @@ namespace Kratos
 		double max_x(0.0), max_y(0.0), max_z(0.0);
 		double min_x(0.0), min_y(0.0), min_z(0.0);
 
-		#pragma omp parallel for reduction(max:max_x) reduction(max:max_y) reduction(max:max_z) reduction(min:min_x) reduction(min:min_y) reduction(min:min_z)
+		#pragma omp parallel for reduction(max:max_x, max_y, max_z) reduction(min:min_x, min_y, min_z)
 		for (int i_node = 0; i_node < static_cast<int>(ModelPart1.NumberOfNodes()); ++i_node) {
 			const auto it_node = ModelPart1.NodesBegin() + i_node;
 			max_x = (max_x < (*it_node)[0]) ? (*it_node)[0] : max_x;

--- a/kratos/tests/cpp_tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_discontinuous_distance_to_skin_process.cpp
@@ -27,7 +27,7 @@ namespace Testing {
     KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceProcessHorizontalPlane2D, KratosCoreFastSuite)
     {
         Model current_model;
-        
+
         // Generate the element
         ModelPart &fluid_part = current_model.CreateModelPart("Surface");
         fluid_part.AddNodalSolutionStepVariable(DISTANCE);
@@ -208,10 +208,10 @@ namespace Testing {
         // Check values
         const auto &r_dist_begin = (volume_part.ElementsBegin())->GetValue(ELEMENTAL_DISTANCES);
         const auto &r_dist_end = (volume_part.ElementsEnd() - 1)->GetValue(ELEMENTAL_DISTANCES);
-        KRATOS_CHECK_NEAR(r_dist_begin[0], 1.0, 1e-6);
-        KRATOS_CHECK_NEAR(r_dist_begin[1], 1.0, 1e-6);
-        KRATOS_CHECK_NEAR(r_dist_begin[2], 1.0, 1e-6);
-        KRATOS_CHECK_NEAR(r_dist_begin[3], 1.0, 1e-6);
+        KRATOS_CHECK_NEAR(r_dist_begin[0], 1.73205, 1e-6);
+        KRATOS_CHECK_NEAR(r_dist_begin[1], 1.73205, 1e-6);
+        KRATOS_CHECK_NEAR(r_dist_begin[2], 1.73205, 1e-6);
+        KRATOS_CHECK_NEAR(r_dist_begin[3], 1.73205, 1e-6);
         KRATOS_CHECK_NEAR(r_dist_end[0], -0.406059, 1e-6);
         KRATOS_CHECK_NEAR(r_dist_end[1], -0.489839, 1e-6);
         KRATOS_CHECK_NEAR(r_dist_end[2], 0.388306, 1e-6);
@@ -221,7 +221,7 @@ namespace Testing {
     KRATOS_TEST_CASE_IN_SUITE(DiscontinuousDistanceProcessHorizontalPlane3D, KratosCoreFastSuite)
     {
         Model current_model;
-        
+
         // Generate the evil element
         ModelPart& volume_part = current_model.CreateModelPart("Volume");
         volume_part.AddNodalSolutionStepVariable(DISTANCE);
@@ -308,9 +308,9 @@ namespace Testing {
         volume_part.CreateNewElement("Element3D4N", 1, {1, 2, 3, 4}, p_properties_0);
 
         // Generate the skin such that there is 4 intersection pts.
-        // Recall that with more than 3 intersection pts. the plane 
-        // approximation is used. Since the skin in here yields a 
-        // uniplanar intersection, the approximated plane is the 
+        // Recall that with more than 3 intersection pts. the plane
+        // approximation is used. Since the skin in here yields a
+        // uniplanar intersection, the approximated plane is the
         // same one as the original intersection one.
         ModelPart& skin_part = current_model.CreateModelPart("Skin");
         skin_part.AddNodalSolutionStepVariable(VELOCITY);
@@ -364,10 +364,10 @@ namespace Testing {
 
         // Check elemental distance values
         const auto &r_elem_dist = volume_part.ElementsBegin()->GetValue(ELEMENTAL_DISTANCES);
-        KRATOS_CHECK_NEAR(r_elem_dist[0], 1.0, 1e-10);
-        KRATOS_CHECK_NEAR(r_elem_dist[1], 1.0, 1e-10);
-        KRATOS_CHECK_NEAR(r_elem_dist[2], 1.0, 1e-10);
-        KRATOS_CHECK_NEAR(r_elem_dist[3], 1.0, 1e-10);
+        KRATOS_CHECK_NEAR(r_elem_dist[0], 1.00028, 1e-5);
+        KRATOS_CHECK_NEAR(r_elem_dist[1], 1.00028, 1e-5);
+        KRATOS_CHECK_NEAR(r_elem_dist[2], 1.00028, 1e-5);
+        KRATOS_CHECK_NEAR(r_elem_dist[3], 1.00028, 1e-5);
 
 
     }

--- a/kratos/tests/cpp_tests/processes/test_calculate_distance_to_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_distance_to_skin_process.cpp
@@ -4,11 +4,11 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
-//					 Ruben Zorrilla
+//                   Ruben Zorrilla
 //
 
 // Project includes
@@ -228,12 +228,13 @@ namespace Kratos {
 		// Compute distance
 		CalculateDistanceToSkinProcess<3>(volume_part, skin_part).Execute();
 
-		for (auto& node : volume_part.Nodes())
-			if (std::abs(node.GetSolutionStepValue(DISTANCE)) < 1.00e16) { // There are no propagation in this version so I avoid numeric_limit::max() one
-				auto distance = std::abs(node.Z() - 5.00);
-				KRATOS_CHECK_NEAR(node.GetSolutionStepValue(DISTANCE), distance, 1e-6);
+		for (auto& node : volume_part.Nodes()) {
+			if (node.Id() < 10) {
+				KRATOS_CHECK_NEAR(node.GetSolutionStepValue(DISTANCE), 17.3205, 1e-4);
+			} else {
+				KRATOS_CHECK_NEAR(node.GetSolutionStepValue(DISTANCE), std::abs(node.Z() - 5.00), 1e-6);
 			}
-
+		}
 	}
 
 	KRATOS_TEST_CASE_IN_SUITE(TetrahedraInCubeDistanceProcess, KratosCoreFastSuite)


### PR DESCRIPTION
This initializes the continuous distance in accordance to the background mesh bounding box size. This will avoid the potential issues that we have observed when solving problems that consider `std::numeric_limits<double>::max()` as default distance value.

I also realized that when we separated the continuous distance from the discontinuous one, we left the continuous distance initialization in there. I took the chance to remove it.