### PR TITLE
[Nightly][CLANG] disabling the buggy missing-braces warning

### DIFF
--- a/scripts/build/nightly/configure_clang.sh
+++ b/scripts/build/nightly/configure_clang.sh
@@ -9,7 +9,7 @@ cmake .. \
 -DCMAKE_CXX_COMPILER=${HOME}/CompiledLibs/clang-3.8.0-16.04-prebuilt/bin/clang++                \
 -DCMAKE_BUILD_TYPE=Custom                                                                      \
 -DCMAKE_C_FLAGS="${CMAKE_C_FLAGS} -msse3 -fopenmp"                                              \
--DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -msse3 -std=c++11 -fopenmp"                               \
+-DCMAKE_CXX_FLAGS="${CMAKE_CXX_FLAGS} -msse3 -std=c++11 -fopenmp -Wno-missing-braces"                               \
 -DBOOST_ROOT="${BOOST_DIR}"                                                                     \
 -DPYTHON_EXECUTABLE="/usr/bin/python${PYTHON_VERSION_S}.${PYTHON_VERSION_M}"                    \
 -DMESH_MOVING_APPLICATION=ON                                                                    \


### PR DESCRIPTION
This is a bug in CLANG < 6 => https://stackoverflow.com/questions/31555584/why-is-clang-warning-suggest-braces-around-initialization-of-subobject-wmis
I checked the code it complains about and it seems fine to me

Can you please check if this compiles @roigcarlo 