### PR TITLE
[ShapeOpt] individual filter radius for penalty filtering

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -56,7 +56,7 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
         self.mapper_settings = optimization_settings["design_variables"]["filter"]
 
         # change the default value of penalty filtering to the filter radius of the mapper.
-        if self.algorithm_settings["filter_penalty_term"].GetBool()
+        if self.algorithm_settings["filter_penalty_term"].GetBool():
             if self.algorithm_settings["penalty_filter_radius"].GetDouble() == -1.0:
                 raise RuntimeError("The parameter `penalty_filter_radius` is missing in order to filter the penalty term!")
 

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -121,7 +121,7 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
         if self.filter_penalty_term:
             penalty_filter_radius = self.algorithm_settings["penalty_filter_radius"].GetDouble()
             filter_radius = self.mapper_settings["filter_radius"].GetDouble()
-            if abs(filter_radius - penalty_filter_radius) < 1e-9:
+            if abs(filter_radius - penalty_filter_radius) > 1e-9:
                 penalty_filter_settings = self.mapper_settings.Clone()
                 penalty_filter_settings["filter_radius"].SetDouble(self.algorithm_settings["penalty_filter_radius"].GetDouble())
                 self.penalty_filter = mapper_factory.CreateMapper(self.design_surface, self.design_surface, penalty_filter_settings)

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -55,7 +55,7 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
         self.optimization_settings = optimization_settings
         self.mapper_settings = optimization_settings["design_variables"]["filter"]
 
-        # change the default value of penalty filtering to the filter radious of the mapper.
+        # change the default value of penalty filtering to the filter radius of the mapper.
         if self.algorithm_settings["penalty_filter_radius"].GetDouble() == -1.0:
             self.algorithm_settings["penalty_filter_radius"].SetDouble(self.mapper_settings["filter_radius"].GetDouble())
 

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -47,7 +47,7 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
                 "step_size"                  : 1.0
             },
             "filter_penalty_term"           : false,
-            "penalty_filter_radius" : -1.0
+            "penalty_filter_radius"         : -1.0
         }""")
         self.algorithm_settings =  optimization_settings["optimization_algorithm"]
         self.algorithm_settings.RecursivelyValidateAndAssignDefaults(default_algorithm_settings)

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -35,7 +35,6 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
             "bead_direction"                : [],
             "bead_side"                     : "both",
             "fix_boundaries"                : [],
-            "filter_penalty_term"           : false,
             "estimated_lagrange_multiplier" : 1.0,
             "max_total_iterations"          : 10000,
             "max_outer_iterations"          : 10000,
@@ -47,7 +46,7 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
                 "normalize_search_direction" : true,
                 "step_size"                  : 1.0
             },
-            "penalty_filtering" : false,
+            "filter_penalty_term"           : false,
             "penalty_filter_radius" : -1.0
         }""")
         self.algorithm_settings =  optimization_settings["optimization_algorithm"]

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -56,8 +56,9 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
         self.mapper_settings = optimization_settings["design_variables"]["filter"]
 
         # change the default value of penalty filtering to the filter radius of the mapper.
-        if self.algorithm_settings["penalty_filter_radius"].GetDouble() == -1.0:
-            self.algorithm_settings["penalty_filter_radius"].SetDouble(self.mapper_settings["filter_radius"].GetDouble())
+        if self.algorithm_settings["filter_penalty_term"].GetBool()
+            if self.algorithm_settings["penalty_filter_radius"].GetDouble() == -1.0:
+                raise RuntimeError("The parameter `penalty_filter_radius` is missing in order to filter the penalty term!")
 
         self.analyzer = analyzer
         self.communicator = communicator
@@ -118,8 +119,10 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
         self.mapper = mapper_factory.CreateMapper(self.design_surface, self.design_surface, self.mapper_settings)
         self.mapper.Initialize()
 
-        if  self.filter_penalty_term:
-            if self.algorithm_settings["penalty_filter_radius"].GetDouble() != self.mapper_settings["filter_radius"].GetDouble() :
+        if self.filter_penalty_term:
+            penalty_filter_radius = self.algorithm_settings["penalty_filter_radius"].GetDouble()
+            filter_radius = self.mapper_settings["filter_radius"].GetDouble()
+            if abs(filter_radius - penalty_filter_radius) < 1e-9:
                 penalty_filter_settings = self.mapper_settings.Clone()
                 penalty_filter_settings["filter_radius"].SetDouble(self.algorithm_settings["penalty_filter_radius"].GetDouble())
                 self.penalty_filter = mapper_factory.CreateMapper(self.design_surface, self.design_surface, penalty_filter_settings)

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -55,7 +55,6 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
         self.optimization_settings = optimization_settings
         self.mapper_settings = optimization_settings["design_variables"]["filter"]
 
-        # change the default value of penalty filtering to the filter radius of the mapper.
         if self.algorithm_settings["filter_penalty_term"].GetBool():
             if self.algorithm_settings["penalty_filter_radius"].GetDouble() == -1.0:
                 raise RuntimeError("The parameter `penalty_filter_radius` is missing in order to filter the penalty term!")


### PR DESCRIPTION
This adds the possibility to use an individual filter radius for the filtering of the penalty term in bead optimization.

This allows for a certain control of the minimum bead width, however it is not a strong imposition of the minimal width.