### PR TITLE
[PotentialFlow] Removing dependece on Structural App

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
@@ -3,7 +3,6 @@ from __future__ import print_function, absolute_import, division #makes KratosMu
 import KratosMultiphysics
 import KratosMultiphysics.CompressiblePotentialFlowApplication as KCPFApp
 from KratosMultiphysics.CompressiblePotentialFlowApplication.potential_flow_solver import PotentialFlowSolver
-from KratosMultiphysics.StructuralMechanicsApplication import ReplaceMultipleElementsAndConditionsProcess
 
 def CreateSolver(model, custom_settings):
     return PotentialFlowAdjointSolver(model, custom_settings)
@@ -17,6 +16,8 @@ class PotentialFlowAdjointSolver(PotentialFlowSolver):
         custom_settings.RemoveValue("sensitivity_settings")
         # Construct the base solver.
         super(PotentialFlowAdjointSolver, self).__init__(model, custom_settings)
+        self.element_name = "AdjointPotentialFlowElement"
+        self.condition_name = "AdjointPotentialWallCondition"
 
         KratosMultiphysics.Logger.PrintInfo("::[PotentialFlowAdjointSolver]:: ", "Construction finished")
 
@@ -62,25 +63,25 @@ class PotentialFlowAdjointSolver(PotentialFlowSolver):
 
         KratosMultiphysics.Logger.PrintInfo("::[PotentialFlowAdjointSolver]:: ", "Finished initialization.")
 
-    def PrepareModelPart(self):
-        super(PotentialFlowAdjointSolver, self).PrepareModelPart()
-       # defines how the primal elements should be replaced with their adjoint counterparts
-        replacement_settings = KratosMultiphysics.Parameters("""
-            {
-                "element_name_table" :
-                {
-                    "IncompressiblePotentialFlowElement2D3N" : "AdjointPotentialFlowElement2D3N"
-                },
-                "condition_name_table" :
-                {
-                    "PotentialWallCondition2D2N"             : "AdjointPotentialWallCondition2D2N"
-                }
-            }
-        """)
+    # def PrepareModelPart(self):
+    #     super(PotentialFlowAdjointSolver, self).PrepareModelPart()
+    #    # defines how the primal elements should be replaced with their adjoint counterparts
+    #     replacement_settings = KratosMultiphysics.Parameters("""
+    #         {
+    #             "element_name_table" :
+    #             {
+    #                 "IncompressiblePotentialFlowElement2D3N" : "AdjointPotentialFlowElement2D3N"
+    #             },
+    #             "condition_name_table" :
+    #             {
+    #                 "PotentialWallCondition2D2N"             : "AdjointPotentialWallCondition2D2N"
+    #             }
+    #         }
+    #     """)
 
-        ReplaceMultipleElementsAndConditionsProcess(self.main_model_part, replacement_settings).Execute()
+    #     ReplaceMultipleElementsAndConditionsProcess(self.main_model_part, replacement_settings).Execute()
 
-        KratosMultiphysics.Logger.PrintInfo("::[PotentialFlowAdjointSolver]:: ", "ModelPart prepared for Solver.")
+    #     KratosMultiphysics.Logger.PrintInfo("::[PotentialFlowAdjointSolver]:: ", "ModelPart prepared for Solver.")
 
     def InitializeSolutionStep(self):
         super(PotentialFlowAdjointSolver, self).InitializeSolutionStep()

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
@@ -31,9 +31,9 @@ class PotentialFlowAdjointSolver(PotentialFlowSolver):
         custom_settings.RemoveValue("sensitivity_settings")
         # Construct the base solver.
         super(PotentialFlowAdjointSolver, self).__init__(model, custom_settings)
-        self.element_name = "AdjointPotentialFlowElement"
-        self.condition_name = "AdjointPotentialWallCondition"
-
+        self.formulation = PotentialFlowAdjointFormulation(self.settings["formulation"])
+        self.element_name = self.formulation.element_name
+        self.condition_name = self.formulation.condition_name
         KratosMultiphysics.Logger.PrintInfo("::[PotentialFlowAdjointSolver]:: ", "Construction finished")
 
     def AddVariables(self):

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
@@ -31,9 +31,11 @@ class PotentialFlowAdjointSolver(PotentialFlowSolver):
         custom_settings.RemoveValue("sensitivity_settings")
         # Construct the base solver.
         super(PotentialFlowAdjointSolver, self).__init__(model, custom_settings)
+
         self.formulation = PotentialFlowAdjointFormulation(self.settings["formulation"])
         self.element_name = self.formulation.element_name
         self.condition_name = self.formulation.condition_name
+
         KratosMultiphysics.Logger.PrintInfo("::[PotentialFlowAdjointSolver]:: ", "Construction finished")
 
     def AddVariables(self):
@@ -77,26 +79,6 @@ class PotentialFlowAdjointSolver(PotentialFlowSolver):
         self.response_function.Initialize()
 
         KratosMultiphysics.Logger.PrintInfo("::[PotentialFlowAdjointSolver]:: ", "Finished initialization.")
-
-    # def PrepareModelPart(self):
-    #     super(PotentialFlowAdjointSolver, self).PrepareModelPart()
-    #    # defines how the primal elements should be replaced with their adjoint counterparts
-    #     replacement_settings = KratosMultiphysics.Parameters("""
-    #         {
-    #             "element_name_table" :
-    #             {
-    #                 "IncompressiblePotentialFlowElement2D3N" : "AdjointPotentialFlowElement2D3N"
-    #             },
-    #             "condition_name_table" :
-    #             {
-    #                 "PotentialWallCondition2D2N"             : "AdjointPotentialWallCondition2D2N"
-    #             }
-    #         }
-    #     """)
-
-    #     ReplaceMultipleElementsAndConditionsProcess(self.main_model_part, replacement_settings).Execute()
-
-    #     KratosMultiphysics.Logger.PrintInfo("::[PotentialFlowAdjointSolver]:: ", "ModelPart prepared for Solver.")
 
     def InitializeSolutionStep(self):
         super(PotentialFlowAdjointSolver, self).InitializeSolutionStep()

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
@@ -3,6 +3,21 @@ from __future__ import print_function, absolute_import, division #makes KratosMu
 import KratosMultiphysics
 import KratosMultiphysics.CompressiblePotentialFlowApplication as KCPFApp
 from KratosMultiphysics.CompressiblePotentialFlowApplication.potential_flow_solver import PotentialFlowSolver
+from KratosMultiphysics.CompressiblePotentialFlowApplication.potential_flow_solver import PotentialFlowFormulation
+
+class PotentialFlowAdjointFormulation(PotentialFlowFormulation):
+    def _SetUpIncompressibleElement(self, formulation_settings):
+        default_settings = KratosMultiphysics.Parameters(r"""{
+            "element_type": "incompressible"
+        }""")
+        formulation_settings.ValidateAndAssignDefaults(default_settings)
+
+        self.element_name = "AdjointPotentialFlowElement"
+        self.condition_name = "AdjointPotentialWallCondition"
+
+    def _SetUpEmbeddedIncompressibleElement(self, formulation_settings):
+        raise RuntimeError("Adjoint embedded element currently not implemented")
+
 
 def CreateSolver(model, custom_settings):
     return PotentialFlowAdjointSolver(model, custom_settings)

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -8,7 +8,6 @@ import KratosMultiphysics.CompressiblePotentialFlowApplication as KCPFApp
 from KratosMultiphysics.FluidDynamicsApplication.fluid_solver import FluidSolver
 
 class PotentialFlowFormulation(object):
-    """Helper class to define embedded-dependent parameters."""
     def __init__(self, formulation_settings):
         self.element_name = None
         self.condition_name = None
@@ -20,7 +19,7 @@ class PotentialFlowFormulation(object):
             elif element_type == "embedded_incompressible":
                 self._SetUpEmbeddedIncompressibleElement(formulation_settings)
         else:
-            raise RuntimeError("Argument \'element_type\' not found in stabilization settings.")
+            raise RuntimeError("Argument \'element_type\' not found in formulation settings.")
 
 
     def _SetUpIncompressibleElement(self, formulation_settings):

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -16,7 +16,6 @@ import os
 
 # Check other applications dependency
 hdf5_is_available = kratos_utilities.CheckIfApplicationsAvailable("HDF5Application")
-structural_mechanics_is_available = kratos_utilities.CheckIfApplicationsAvailable("StructuralMechanicsApplication")
 
 class WorkFolderScope:
     def __init__(self, work_folder):
@@ -38,8 +37,6 @@ class PotentialFlowTests(UnitTest.TestCase):
     def test_Naca0012SmallAdjoint(self):
         if not hdf5_is_available:
             self.skipTest("Missing required application: HDF5Application")
-        if not structural_mechanics_is_available:
-            self.skipTest("Missing required application: StructuralMechanicsApplication")
         file_name = "naca0012_small_sensitivities"
         settings_file_name_primal = file_name + "_primal_parameters.json"
         settings_file_name_adjoint = file_name + "_adjoint_parameters.json"


### PR DESCRIPTION
Hi, 
This is a small PR to remove the dependance on the Structural App in the Potential Flow App (and thus having to compile it).

This dependence was introduced in order to use the ReplaceMultipleElementsAndConditions from the StructuralApp in the adjoint solver. 

This function is useful when there is a lot of different options in the adjoint analysis, like in the structural app :
https://github.com/KratosMultiphysics/Kratos/blob/164be5b3b1736584b4f986cc60aa00859d1cc470/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py#L51-L71

However for the PotentialFlow case there are not as many options (currently only one), so I am changing it by means of a PotentialFlowAdjointFormulation, following the FluidDynApp design. 