### PR TITLE
[PotentialFlow] Removing free stream velocity from default parameters

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/apply_far_field_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/apply_far_field_process.py
@@ -27,7 +27,6 @@ class ApplyFarFieldProcess(KratosMultiphysics.Process):
                 "speed_of_sound": 340,
                 "heat_capacity_ratio": 1.4,
                 "inlet_potential": 1.0,
-                "free_stream_velocity": [1.0,0.0,0],
                 "initialize_flow_field": true
             }  """ )
         settings.ValidateAndAssignDefaults(default_parameters)


### PR DESCRIPTION
Hi, 

This is a small PR to remove the free_stream_velocity from the parameters to force the user to define the far field conditions by means of the mach number and the angle of attack. 