### PR TITLE
Need include <iostream> to compile (windows)

### DIFF
--- a/external_libraries/intrusive_ptr/intrusive_ptr.hpp
+++ b/external_libraries/intrusive_ptr/intrusive_ptr.hpp
@@ -3,6 +3,7 @@
 
 #include <cstddef>
 #include <functional>
+#include <iostream>
 
 
 namespace Kratos


### PR DESCRIPTION
I couldn't compile without it!

Windows
Boost 1.66
VS2019