### PR TITLE
[Core] Read Materials - checking if variables and tables exist

### DIFF
--- a/kratos/tests/auxiliar_files_for_python_unnitest/materials_files/material_without_tables_and_variables.json
+++ b/kratos/tests/auxiliar_files_for_python_unnitest/materials_files/material_without_tables_and_variables.json
@@ -1,0 +1,21 @@
+{
+	"properties": [{
+		"model_part_name": "Inlets",
+		"properties_id": 1,
+		"Material": {
+			"name": "steel",
+			"constitutive_law": {
+				"name": "LinearElastic3DLaw"
+			}
+		}
+	}, {
+		"model_part_name": "Outlet",
+		"properties_id": 2,
+		"Material": {
+			"name": "steel",
+			"constitutive_law": {
+				"name": "KratosMultiphysics.FluidDynamicsApplication.Newtonian2DLaw"
+			}
+		}
+	}]
+}

--- a/kratos/tests/test_materials_input.py
+++ b/kratos/tests/test_materials_input.py
@@ -142,6 +142,20 @@ class TestMaterialsInput(KratosUnittest.TestCase):
         with self.assertRaisesRegex(Exception, expected_error_msg):
             read_materials_process.Factory(test_settings, current_model)
 
+    def test_input_without_tables_and_variables(self):
+        self._prepare_test()
+        self.test_settings["Parameters"]["materials_filename"].SetString(GetFilePath("auxiliar_files_for_python_unnitest/materials_files/material_without_tables_and_variables.json"))
+
+        KratosMultiphysics.ReadMaterialsUtility(self.test_settings, self.current_model)
+        for elem in self.current_model["Inlets"].Elements:
+            self.assertEqual(elem.Properties.Id, 1)
+        for cond in self.current_model["Inlets"].Conditions:
+            self.assertEqual(cond.Properties.Id, 1)
+        for elem in self.current_model["Outlet"].Elements:
+            self.assertEqual(elem.Properties.Id, 2)
+        for cond in self.current_model["Outlet"].Conditions:
+            self.assertEqual(cond.Properties.Id, 2)
+
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/utilities/read_materials_utility.cpp
+++ b/kratos/utilities/read_materials_utility.cpp
@@ -128,12 +128,17 @@ void ReadMaterialsUtility::AssignPropertyBlock(Parameters Data)
 
         // Compute the size using the iterators
         std::size_t variables_size = 0;
-        for(auto it=Data["Material"]["Variables"].begin(); it!=Data["Material"]["Variables"].end(); ++it)
-            ++variables_size;
-
+        if (Data["Material"].Has("Variables")) {
+            for(auto it=Data["Material"]["Variables"].begin(); it!=Data["Material"]["Variables"].end(); ++it) {
+                ++variables_size;
+            }
+        }
         std::size_t tables_size = 0;
-        for(auto it=Data["Material"]["Tables"].begin(); it!=Data["Material"]["Tables"].end(); ++it)
-            ++tables_size;
+        if (Data["Material"].Has("Tables")) {
+            for(auto it=Data["Material"]["Tables"].begin(); it!=Data["Material"]["Tables"].end(); ++it) {
+                ++tables_size;
+            }
+        }
 
         KRATOS_WARNING_IF("ReadMaterialsUtility", variables_size > 0 && p_prop->HasVariables())
             << "WARNING:: The properties ID: " << property_id << " already has variables." << std::endl;

--- a/kratos/utilities/read_materials_utility.cpp
+++ b/kratos/utilities/read_materials_utility.cpp
@@ -199,7 +199,7 @@ void ReadMaterialsUtility::AssignPropertyBlock(Parameters Data)
                 p_prop->SetValue(variable, value.GetInt());
             } else if(KratosComponents<Variable<array_1d<double, 3> > >::Has(variable_name)) {
                 const Variable<array_1d<double, 3>>& variable = KratosComponents<Variable<array_1d<double, 3>>>().Get(variable_name);
-                array_1d<double, 3> temp(3, 0.0);
+                array_1d<double, 3> temp = ZeroVector(3);
                 const Vector& value_variable = value.GetVector();
                 KRATOS_ERROR_IF(value_variable.size() != 3) << "The vector of variable " << variable_name << " has size " << value_variable.size() << " and it is supposed to be 3" << std::endl;
                 for (IndexType index = 0; index < 3; ++index)

--- a/kratos/utilities/read_materials_utility.cpp
+++ b/kratos/utilities/read_materials_utility.cpp
@@ -253,13 +253,13 @@ void ReadMaterialsUtility::AssignPropertyBlock(Parameters Data)
             std::string output_var_name = table_param["output_variable"].GetString();
             TrimComponentName(output_var_name);
 
-            const auto input_var = KratosComponents<Variable<double>>().Get(input_var_name);
-            const auto output_var = KratosComponents<Variable<double>>().Get(output_var_name);
+            const auto& r_input_var = KratosComponents<Variable<double>>().Get(input_var_name);
+            const auto& r_output_var = KratosComponents<Variable<double>>().Get(output_var_name);
             for (IndexType i = 0; i < table_param["data"].size(); ++i) {
                 table.insert(table_param["data"][i][0].GetDouble(),
                             table_param["data"][i][1].GetDouble());
             }
-            p_prop->SetTable(input_var, output_var, table);
+            p_prop->SetTable(r_input_var, r_output_var, table);
         }
     } else {
         KRATOS_INFO("Read materials") << "No tables defined for material ID: " << property_id << std::endl;

--- a/kratos/utilities/read_materials_utility.cpp
+++ b/kratos/utilities/read_materials_utility.cpp
@@ -186,47 +186,47 @@ void ReadMaterialsUtility::AssignPropertyBlock(Parameters Data)
 
             // We don't just copy the values, we do some tyransformation depending of the destination variable
             if (KratosComponents<Variable<double> >::Has(variable_name)) {
-                const Variable<double>& variable = KratosComponents<Variable<double>>().Get(variable_name);
-                CheckIfOverwritingValue(*p_prop, variable, value.GetDouble());
-                p_prop->SetValue(variable, value.GetDouble());
+                const Variable<double>& r_variable = KratosComponents<Variable<double>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, r_variable, value.GetDouble());
+                p_prop->SetValue(r_variable, value.GetDouble());
             } else if(KratosComponents<Variable<bool> >::Has(variable_name)) {
-                const Variable<bool>& variable = KratosComponents<Variable<bool>>().Get(variable_name);
-                CheckIfOverwritingValue(*p_prop, variable, value.GetBool());
-                p_prop->SetValue(variable, value.GetBool());
+                const Variable<bool>& r_variable = KratosComponents<Variable<bool>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, r_variable, value.GetBool());
+                p_prop->SetValue(r_variable, value.GetBool());
             } else if(KratosComponents<Variable<int> >::Has(variable_name)) {
-                const Variable<int>& variable = KratosComponents<Variable<int>>().Get(variable_name);
-                CheckIfOverwritingValue(*p_prop, variable, value.GetInt());
-                p_prop->SetValue(variable, value.GetInt());
+                const Variable<int>& r_variable = KratosComponents<Variable<int>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, r_variable, value.GetInt());
+                p_prop->SetValue(r_variable, value.GetInt());
             } else if(KratosComponents<Variable<array_1d<double, 3> > >::Has(variable_name)) {
-                const Variable<array_1d<double, 3>>& variable = KratosComponents<Variable<array_1d<double, 3>>>().Get(variable_name);
+                const Variable<array_1d<double, 3>>& r_variable = KratosComponents<Variable<array_1d<double, 3>>>().Get(variable_name);
                 array_1d<double, 3> temp = ZeroVector(3);
-                const Vector& value_variable = value.GetVector();
-                KRATOS_ERROR_IF(value_variable.size() != 3) << "The vector of variable " << variable_name << " has size " << value_variable.size() << " and it is supposed to be 3" << std::endl;
+                const Vector& r_value_variable = value.GetVector();
+                KRATOS_ERROR_IF(r_value_variable.size() != 3) << "The vector of variable " << variable_name << " has size " << r_value_variable.size() << " and it is supposed to be 3" << std::endl;
                 for (IndexType index = 0; index < 3; ++index)
-                    temp[index] = value_variable[index];
-                CheckIfOverwritingValue(*p_prop, variable, temp);
-                p_prop->SetValue(variable, temp);
+                    temp[index] = r_value_variable[index];
+                CheckIfOverwritingValue(*p_prop, r_variable, temp);
+                p_prop->SetValue(r_variable, temp);
             } else if(KratosComponents<Variable<array_1d<double, 6> > >::Has(variable_name)) {
-                const Variable<array_1d<double, 6>>& variable = KratosComponents<Variable<array_1d<double, 6>>>().Get(variable_name);
+                const Variable<array_1d<double, 6>>& r_variable = KratosComponents<Variable<array_1d<double, 6>>>().Get(variable_name);
                 array_1d<double, 6> temp(6, 0.0);
-                const Vector& value_variable = value.GetVector();
-                KRATOS_ERROR_IF(value_variable.size() != 6) << "The vector of variable " << variable_name << " has size " << value_variable.size() << " and it is supposed to be 6" << std::endl;
+                const Vector& r_value_variable = value.GetVector();
+                KRATOS_ERROR_IF(r_value_variable.size() != 6) << "The vector of variable " << variable_name << " has size " << r_value_variable.size() << " and it is supposed to be 6" << std::endl;
                 for (IndexType index = 0; index < 6; ++index)
-                    temp[index] = value_variable[index];
-                CheckIfOverwritingValue(*p_prop, variable, temp);
-                p_prop->SetValue(variable, temp);
+                    temp[index] = r_value_variable[index];
+                CheckIfOverwritingValue(*p_prop, r_variable, temp);
+                p_prop->SetValue(r_variable, temp);
             } else if(KratosComponents<Variable<Vector > >::Has(variable_name)) {
-                const Variable<Vector>& variable = KratosComponents<Variable<Vector>>().Get(variable_name);
-                CheckIfOverwritingValue(*p_prop, variable, value.GetVector());
-                p_prop->SetValue(variable, value.GetVector());
+                const Variable<Vector>& r_variable = KratosComponents<Variable<Vector>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, r_variable, value.GetVector());
+                p_prop->SetValue(r_variable, value.GetVector());
             } else if(KratosComponents<Variable<Matrix> >::Has(variable_name)) {
-                const Variable<Matrix>& variable = KratosComponents<Variable<Matrix>>().Get(variable_name);
-                CheckIfOverwritingValue(*p_prop, variable, value.GetMatrix());
-                p_prop->SetValue(variable, value.GetMatrix());
+                const Variable<Matrix>& r_variable = KratosComponents<Variable<Matrix>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, r_variable, value.GetMatrix());
+                p_prop->SetValue(r_variable, value.GetMatrix());
             } else if(KratosComponents<Variable<std::string> >::Has(variable_name)) {
-                const Variable<std::string>& variable = KratosComponents<Variable<std::string>>().Get(variable_name);
-                CheckIfOverwritingValue(*p_prop, variable, value.GetString());
-                p_prop->SetValue(variable, value.GetString());
+                const Variable<std::string>& r_variable = KratosComponents<Variable<std::string>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, r_variable, value.GetString());
+                p_prop->SetValue(r_variable, value.GetString());
             } else {
                 KRATOS_ERROR << "Value type for \"" << variable_name << "\" not defined";
             }

--- a/kratos/utilities/read_materials_utility.cpp
+++ b/kratos/utilities/read_materials_utility.cpp
@@ -176,80 +176,88 @@ void ReadMaterialsUtility::AssignPropertyBlock(Parameters Data)
     }
 
     // Add / override the values of material parameters in the p_properties
-    Parameters variables = Data["Material"]["Variables"];
-    for (auto iter = variables.begin(); iter != variables.end(); ++iter) {
-        const Parameters value = variables.GetValue(iter.name());
+    if (Data["Material"].Has("Variables")) {
+        Parameters variables = Data["Material"]["Variables"];
+        for (auto iter = variables.begin(); iter != variables.end(); ++iter) {
+            const Parameters value = variables.GetValue(iter.name());
 
-        std::string variable_name = iter.name();
-        TrimComponentName(variable_name);
+            std::string variable_name = iter.name();
+            TrimComponentName(variable_name);
 
-        // We don't just copy the values, we do some tyransformation depending of the destination variable
-        if (KratosComponents<Variable<double> >::Has(variable_name)) {
-            const Variable<double>& variable = KratosComponents<Variable<double>>().Get(variable_name);
-            CheckIfOverwritingValue(*p_prop, variable, value.GetDouble());
-            p_prop->SetValue(variable, value.GetDouble());
-        } else if(KratosComponents<Variable<bool> >::Has(variable_name)) {
-            const Variable<bool>& variable = KratosComponents<Variable<bool>>().Get(variable_name);
-            CheckIfOverwritingValue(*p_prop, variable, value.GetBool());
-            p_prop->SetValue(variable, value.GetBool());
-        } else if(KratosComponents<Variable<int> >::Has(variable_name)) {
-            const Variable<int>& variable = KratosComponents<Variable<int>>().Get(variable_name);
-            CheckIfOverwritingValue(*p_prop, variable, value.GetInt());
-            p_prop->SetValue(variable, value.GetInt());
-        } else if(KratosComponents<Variable<array_1d<double, 3> > >::Has(variable_name)) {
-            const Variable<array_1d<double, 3>>& variable = KratosComponents<Variable<array_1d<double, 3>>>().Get(variable_name);
-            array_1d<double, 3> temp(3, 0.0);
-            const Vector& value_variable = value.GetVector();
-            KRATOS_ERROR_IF(value_variable.size() != 3) << "The vector of variable " << variable_name << " has size " << value_variable.size() << " and it is supposed to be 3" << std::endl;
-            for (IndexType index = 0; index < 3; ++index)
-                temp[index] = value_variable[index];
-            CheckIfOverwritingValue(*p_prop, variable, temp);
-            p_prop->SetValue(variable, temp);
-        } else if(KratosComponents<Variable<array_1d<double, 6> > >::Has(variable_name)) {
-            const Variable<array_1d<double, 6>>& variable = KratosComponents<Variable<array_1d<double, 6>>>().Get(variable_name);
-            array_1d<double, 6> temp(6, 0.0);
-            const Vector& value_variable = value.GetVector();
-            KRATOS_ERROR_IF(value_variable.size() != 6) << "The vector of variable " << variable_name << " has size " << value_variable.size() << " and it is supposed to be 6" << std::endl;
-            for (IndexType index = 0; index < 6; ++index)
-                temp[index] = value_variable[index];
-            CheckIfOverwritingValue(*p_prop, variable, temp);
-            p_prop->SetValue(variable, temp);
-        } else if(KratosComponents<Variable<Vector > >::Has(variable_name)) {
-            const Variable<Vector>& variable = KratosComponents<Variable<Vector>>().Get(variable_name);
-            CheckIfOverwritingValue(*p_prop, variable, value.GetVector());
-            p_prop->SetValue(variable, value.GetVector());
-        } else if(KratosComponents<Variable<Matrix> >::Has(variable_name)) {
-            const Variable<Matrix>& variable = KratosComponents<Variable<Matrix>>().Get(variable_name);
-            CheckIfOverwritingValue(*p_prop, variable, value.GetMatrix());
-            p_prop->SetValue(variable, value.GetMatrix());
-        } else if(KratosComponents<Variable<std::string> >::Has(variable_name)) {
-            const Variable<std::string>& variable = KratosComponents<Variable<std::string>>().Get(variable_name);
-            CheckIfOverwritingValue(*p_prop, variable, value.GetString());
-            p_prop->SetValue(variable, value.GetString());
-        } else {
-            KRATOS_ERROR << "Value type for \"" << variable_name << "\" not defined";
+            // We don't just copy the values, we do some tyransformation depending of the destination variable
+            if (KratosComponents<Variable<double> >::Has(variable_name)) {
+                const Variable<double>& variable = KratosComponents<Variable<double>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, variable, value.GetDouble());
+                p_prop->SetValue(variable, value.GetDouble());
+            } else if(KratosComponents<Variable<bool> >::Has(variable_name)) {
+                const Variable<bool>& variable = KratosComponents<Variable<bool>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, variable, value.GetBool());
+                p_prop->SetValue(variable, value.GetBool());
+            } else if(KratosComponents<Variable<int> >::Has(variable_name)) {
+                const Variable<int>& variable = KratosComponents<Variable<int>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, variable, value.GetInt());
+                p_prop->SetValue(variable, value.GetInt());
+            } else if(KratosComponents<Variable<array_1d<double, 3> > >::Has(variable_name)) {
+                const Variable<array_1d<double, 3>>& variable = KratosComponents<Variable<array_1d<double, 3>>>().Get(variable_name);
+                array_1d<double, 3> temp(3, 0.0);
+                const Vector& value_variable = value.GetVector();
+                KRATOS_ERROR_IF(value_variable.size() != 3) << "The vector of variable " << variable_name << " has size " << value_variable.size() << " and it is supposed to be 3" << std::endl;
+                for (IndexType index = 0; index < 3; ++index)
+                    temp[index] = value_variable[index];
+                CheckIfOverwritingValue(*p_prop, variable, temp);
+                p_prop->SetValue(variable, temp);
+            } else if(KratosComponents<Variable<array_1d<double, 6> > >::Has(variable_name)) {
+                const Variable<array_1d<double, 6>>& variable = KratosComponents<Variable<array_1d<double, 6>>>().Get(variable_name);
+                array_1d<double, 6> temp(6, 0.0);
+                const Vector& value_variable = value.GetVector();
+                KRATOS_ERROR_IF(value_variable.size() != 6) << "The vector of variable " << variable_name << " has size " << value_variable.size() << " and it is supposed to be 6" << std::endl;
+                for (IndexType index = 0; index < 6; ++index)
+                    temp[index] = value_variable[index];
+                CheckIfOverwritingValue(*p_prop, variable, temp);
+                p_prop->SetValue(variable, temp);
+            } else if(KratosComponents<Variable<Vector > >::Has(variable_name)) {
+                const Variable<Vector>& variable = KratosComponents<Variable<Vector>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, variable, value.GetVector());
+                p_prop->SetValue(variable, value.GetVector());
+            } else if(KratosComponents<Variable<Matrix> >::Has(variable_name)) {
+                const Variable<Matrix>& variable = KratosComponents<Variable<Matrix>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, variable, value.GetMatrix());
+                p_prop->SetValue(variable, value.GetMatrix());
+            } else if(KratosComponents<Variable<std::string> >::Has(variable_name)) {
+                const Variable<std::string>& variable = KratosComponents<Variable<std::string>>().Get(variable_name);
+                CheckIfOverwritingValue(*p_prop, variable, value.GetString());
+                p_prop->SetValue(variable, value.GetString());
+            } else {
+                KRATOS_ERROR << "Value type for \"" << variable_name << "\" not defined";
+            }
         }
+    } else {
+        KRATOS_INFO("Read materials") << "No variables defined for material ID: " << property_id << std::endl;
     }
 
     // Add / override tables in the p_properties
-    Parameters tables = Data["Material"]["Tables"];
-    for (auto iter = tables.begin(); iter != tables.end(); ++iter) {
-        auto table_param = tables.GetValue(iter.name());
-        // Case table is double, double. TODO(marandra): Does it make sense to consider other cases?
-        Table<double> table;
+    if (Data["Material"].Has("Tables")) {
+        Parameters tables = Data["Material"]["Tables"];
+        for (auto iter = tables.begin(); iter != tables.end(); ++iter) {
+            auto table_param = tables.GetValue(iter.name());
+            // Case table is double, double. TODO(marandra): Does it make sense to consider other cases?
+            Table<double> table;
 
-        std::string input_var_name = table_param["input_variable"].GetString();
-        TrimComponentName(input_var_name);
-        std::string output_var_name = table_param["output_variable"].GetString();
-        TrimComponentName(output_var_name);
+            std::string input_var_name = table_param["input_variable"].GetString();
+            TrimComponentName(input_var_name);
+            std::string output_var_name = table_param["output_variable"].GetString();
+            TrimComponentName(output_var_name);
 
-        const auto input_var = KratosComponents<Variable<double>>().Get(input_var_name);
-        const auto output_var = KratosComponents<Variable<double>>().Get(output_var_name);
-        for (IndexType i = 0; i < table_param["data"].size(); ++i) {
-            table.insert(table_param["data"][i][0].GetDouble(),
-                         table_param["data"][i][1].GetDouble());
+            const auto input_var = KratosComponents<Variable<double>>().Get(input_var_name);
+            const auto output_var = KratosComponents<Variable<double>>().Get(output_var_name);
+            for (IndexType i = 0; i < table_param["data"].size(); ++i) {
+                table.insert(table_param["data"][i][0].GetDouble(),
+                            table_param["data"][i][1].GetDouble());
+            }
+            p_prop->SetTable(input_var, output_var, table);
         }
-        p_prop->SetTable(input_var, output_var, table);
+    } else {
+        KRATOS_INFO("Read materials") << "No tables defined for material ID: " << property_id << std::endl;
     }
 }
 


### PR DESCRIPTION
This is a small proposal: allow to have a json input file where variables and tables are not defined for a specific material. I throw a warning if that is the case.

I know we could just have an empty array in the json file but we would lose retro-compatibility in @KratosMultiphysics/altair side and I think the change is reasonable..