### PR TITLE
[Fluid][Hotfix] Distance modification set is modified flag to true

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -147,6 +147,7 @@ void DistanceModificationProcess::ExecuteInitializeSolutionStep() {
             // Modify the discontinuous distance field
             this->ModifyDiscontinuousDistance();
         }
+        mIsModified = true;
 
         // If proceeds (depending on the formulation), perform the deactivation
         // Deactivates the full negative elements and sets the inner values to 0


### PR DESCRIPTION
The is modified flag was always true, so even though the user asked the process to be done once, the distance was checked and modified each time step.