### PR TITLE
[Core] VTK improvements

### DIFF
--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -71,11 +71,12 @@ VtkOutput::VtkOutput(
     }
 
     const auto& r_local_mesh = rModelPart.GetCommunicator().LocalMesh();
+    const auto& r_data_comm = rModelPart.GetCommunicator().GetDataCommunicator();
 
-    const int num_elements = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(static_cast<int>(r_local_mesh.NumberOfElements()));
-    const int num_conditions = rModelPart.GetCommunicator().GetDataCommunicator().SumAll(static_cast<int>(r_local_mesh.NumberOfConditions()));
+    const int num_elements = r_data_comm.SumAll(static_cast<int>(r_local_mesh.NumberOfElements()));
+    const int num_conditions = r_data_comm.SumAll(static_cast<int>(r_local_mesh.NumberOfConditions()));
 
-    KRATOS_WARNING_IF("VtkOutput", num_elements > 0 && num_conditions > 0) << "Modelpart \"" << rModelPart.Name() << "\" has both elements and conditions.\nGiving precedence to elements and writing only elements!" << std::endl;
+    KRATOS_WARNING_IF("VtkOutput", num_elements > 0 && num_conditions > 0) << r_data_comm << "Modelpart \"" << rModelPart.Name() << "\" has both elements and conditions.\nGiving precedence to elements and writing only elements!" << std::endl;
 }
 
 /***********************************************************************************/
@@ -527,7 +528,7 @@ void VtkOutput::WriteNodalContainerResults(
         const auto& var_to_write = KratosComponents<Variable<array_1d<double, 9>>>::Get(rVariableName);
         WriteNodalVectorValues(rNodes, var_to_write, IsHistoricalValue, rFileStream);
     } else {
-        KRATOS_WARNING_ONCE(rVariableName) << "Variable \"" << rVariableName << "\" is "
+        KRATOS_WARNING_ONCE(rVariableName) << mrModelPart.GetCommunicator().GetDataCommunicator() << "Variable \"" << rVariableName << "\" is "
             << "not suitable for VtkOutput, skipping it" << std::endl;
     }
 }
@@ -569,7 +570,7 @@ void VtkOutput::WriteGeometricalContainerResults(
         const auto& var_to_write = KratosComponents<Variable<array_1d<double, 9>>>::Get(rVariableName);
         WriteVectorContainerVariable(rContainer, var_to_write, rFileStream);
     } else {
-        KRATOS_WARNING_ONCE(rVariableName) << "Variable \"" << rVariableName << "\" is "
+        KRATOS_WARNING_ONCE(rVariableName) << mrModelPart.GetCommunicator().GetDataCommunicator() << "Variable \"" << rVariableName << "\" is "
             << "not suitable for VtkOutput, skipping it" << std::endl;
     }
 }
@@ -641,8 +642,8 @@ void VtkOutput::WriteVectorSolutionStepVariable(
     std::ofstream& rFileStream) const
 {
     if (rContainer.size() == 0) {
-        KRATOS_WARNING("VtkOutput") << "Empty container!" << std::endl;
-        return void();
+        KRATOS_WARNING("VtkOutput") << mrModelPart.GetCommunicator().GetDataCommunicator() << "Empty container!" << std::endl;
+        return;
     }
 
     const int res_size = static_cast<int>((rContainer.begin()->FastGetSolutionStepValue(rVariable)).size());
@@ -706,8 +707,8 @@ void VtkOutput::WriteVectorContainerVariable(
     std::ofstream& rFileStream) const
 {
     if (rContainer.size() == 0) {
-        KRATOS_WARNING("VtkOutput") << "Empty container!" << std::endl;
-        return void();
+        KRATOS_WARNING("VtkOutput") << mrModelPart.GetCommunicator().GetDataCommunicator() << "Empty container!" << std::endl;
+        return;
     }
 
     const int res_size = static_cast<int>((rContainer.begin()->GetValue(rVariable)).size());

--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -823,6 +823,7 @@ void VtkOutput::WriteModelPartWithoutNodesToFile(ModelPart& rModelPart)
 
 Parameters VtkOutput::GetDefaultParameters()
 {
+    // IMPORTANT: when "output_control_type" is "time", then paraview will not be able to group them
     Parameters default_parameters = Parameters(R"(
     {
         "model_part_name"                    : "PLEASE_SPECIFY_MODEL_PART_NAME",

--- a/kratos/input_output/vtk_output.h
+++ b/kratos/input_output/vtk_output.h
@@ -62,6 +62,11 @@ public:
     ///@{
 
     /**
+     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
+     */
+    static Parameters GetDefaultParameters();
+
+    /**
      * @brief Prints mrModelPart in VTK format together with the results
      */
     void PrintOutput();
@@ -385,11 +390,6 @@ private:
      * @param rModelPart modelpart which is beging output
      */
     void WriteModelPartWithoutNodesToFile(ModelPart& rModelPart);
-
-    /**
-     * @brief This method provides the defaults parameters to avoid conflicts between the different constructors
-     */
-    Parameters GetDefaultParameters();
 
     ///@}
 };

--- a/kratos/python/add_io_to_python.cpp
+++ b/kratos/python/add_io_to_python.cpp
@@ -311,6 +311,7 @@ void  AddIOToPython(pybind11::module& m)
     py::class_<VtkOutput, VtkOutput::Pointer, IO>(m, "VtkOutput")
         .def(py::init< ModelPart&, Parameters >())
         .def("PrintOutput", &VtkOutput::PrintOutput)
+        .def_static("GetDefaultParameters", &VtkOutput::GetDefaultParameters)
         ;
 
     py::class_<UnvOutput, UnvOutput::Pointer>(m, "UnvOutput")

--- a/kratos/python_scripts/vtk_output_process.py
+++ b/kratos/python_scripts/vtk_output_process.py
@@ -11,37 +11,15 @@ class VtkOutputProcess(KratosMultiphysics.Process):
     def __init__(self, model, settings ):
         KratosMultiphysics.Process.__init__(self)
 
-        # IMPORTANT: when "output_control_type" is "time",
-        # then paraview will not be able to group them
-        default_parameters = KratosMultiphysics.Parameters("""{
-            "model_part_name"                    : "PLEASE_SPECIFY_MODEL_PART_NAME",
-            "file_format"                        : "ascii",
-            "output_precision"                   : 7,
-            "output_control_type"                : "step",
-            "output_frequency"                   : 1.0,
-            "output_sub_model_parts"             : false,
-            "folder_name"                        : "VTK_Output",
-            "custom_name_prefix"                 : "",
-            "save_output_files_in_folder"        : true,
-            "nodal_solution_step_data_variables" : [],
-            "nodal_data_value_variables"         : [],
-            "nodal_flags"                        : [],
-            "element_data_value_variables"       : [],
-            "element_flags"                      : [],
-            "condition_data_value_variables"     : [],
-            "condition_flags"                    : [],
-            "gauss_point_variables"              : []
-        }""")
-
         model_part_name = settings["model_part_name"].GetString()
         self.model_part = model[model_part_name]
 
-        self.settings = settings
-        self.settings.ValidateAndAssignDefaults(default_parameters)
+        # default settings can be found in "vtk_output.cpp"
+        self.vtk_io = KratosMultiphysics.VtkOutput(self.model_part, settings) # this also validates the settings
 
-        if self.settings["save_output_files_in_folder"].GetBool():
+        if settings["save_output_files_in_folder"].GetBool():
             if self.model_part.GetCommunicator().MyPID() == 0:
-                folder_name = self.settings["folder_name"].GetString()
+                folder_name = settings["folder_name"].GetString()
                 if not self.model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED]:
                     import KratosMultiphysics.kratos_utilities as kratos_utils
                     kratos_utils.DeleteDirectoryIfExisting(folder_name)
@@ -49,10 +27,8 @@ class VtkOutputProcess(KratosMultiphysics.Process):
                     os.mkdir(folder_name)
             self.model_part.GetCommunicator().GetDataCommunicator().Barrier()
 
-        self.vtk_io = KratosMultiphysics.VtkOutput(self.model_part, self.settings)
-
-        self.output_frequency = self.settings["output_frequency"].GetDouble()
-        self.output_control = self.settings["output_control_type"].GetString()
+        self.output_frequency = settings["output_frequency"].GetDouble()
+        self.output_control = settings["output_control_type"].GetString()
         self.next_output = 0.0
 
         self.__ScheduleNextOutput() # required here esp for restart


### PR DESCRIPTION
This PR includes several improvements:
- fixes the vtk-files not properly written in case of restart
- passing the data-comm to the logger (can you please have a look at this @jcotela ?
- Moving the nasty warning abt elements/conditions to the constructor => only printed once
- nodes can be written on the deformed and undeformed configuration => default is the UNDEFORMED now, this is the behavior change (use warping on paraview to get the deformed config, same idea as in GiD
- the python-wrapper was cleaned, now the settings are only existing once (in C, since vtk is also used from C directly)
- Bugfix in MPI when writing also the submodelparts => was a deadlock! (in theory, haven't tested/experienced it)