### PR TITLE
[FSI] Towards thin-walled FSI coupling interface

### DIFF
--- a/applications/FSIapplication/tests/fsi_coupling_interface_test.py
+++ b/applications/FSIapplication/tests/fsi_coupling_interface_test.py
@@ -5,8 +5,18 @@ import KratosMultiphysics.kratos_utilities as KratosUtilities
 from KratosMultiphysics.FSIApplication import fsi_coupling_interface
 from KratosMultiphysics.FSIApplication import convergence_accelerator_factory
 
+try:
+    import KratosMultiphysics.StructuralMechanicsApplication as KratosStructural
+    structural_available = True
+except ImportError:
+    structural_available = False
+
 class FSICouplingInterfaceTest(UnitTest.TestCase):
     def test_fsi_coupling_interface(self):
+        # StructuralMechanicsApplication is required since we test the Mok benchmark .mdpa
+        # Note that this benchmark case requires to import the TotalLagrangianElement
+        if not structural_available:
+            self.skipTest("Missing required application: StructuralMechanicsApplication")
         self.print_output = False
         self.check_tolerance = 1.0e-10
         self.print_reference_values = False
@@ -41,8 +51,8 @@ class FSICouplingInterfaceTest(UnitTest.TestCase):
         {
             "model_part_name": "FSICouplingInterfaceStructure",
             "parent_model_part_name": "MainModelPart.StructureInterface2D_Solid_interface",
-            "input_variable_name": "POSITIVE_FACE_PRESSURE",
-            "output_variable_name": "DISPLACEMENT"
+            "input_variable_list": ["POSITIVE_FACE_PRESSURE"],
+            "output_variable_list": ["DISPLACEMENT"]
         }""")
         self.fsi_coupling_interface = fsi_coupling_interface.FSICouplingInterface(
             self.model,


### PR DESCRIPTION
This allows to set more than one variable as input /output. The final end is to set as output variables not only the `POSITIVE_FACE_PRESSURE`but the `NEGATIVE_FACE_PRESSURE` for the use of the FSI coupling interface with thin-walled structures.