### PR TITLE
[PotentialFlow] Using Kratos warning instead of std::cout

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.cpp
@@ -643,9 +643,7 @@ void CompressiblePotentialFlowElement<Dim, NumNodes>::CheckWakeCondition() const
     ComputeVelocityLowerWakeElement(lower_wake_velocity);
     const double vlownorm = inner_prod(lower_wake_velocity, lower_wake_velocity);
 
-    if (std::abs(vupnorm - vlownorm) > 0.1)
-        std::cout << "WAKE CONDITION NOT FULFILLED IN ELEMENT # " << this->Id()
-                  << std::endl;
+    KRATOS_WARNING_IF("CompressibleElement", std::abs(vupnorm - vlownorm) > 0.1) << "WAKE CONDITION NOT FULFILLED IN ELEMENT # " << this->Id() << std::endl;
 }
 
 template <int Dim, int NumNodes>

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
@@ -560,9 +560,7 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::CheckWakeCondition() con
     lower_wake_velocity = PotentialFlowUtilities::ComputeVelocityLowerWakeElement<Dim,NumNodes>(*this);
     const double vlownorm = inner_prod(lower_wake_velocity, lower_wake_velocity);
 
-    if (std::abs(vupnorm - vlownorm) > 0.1)
-        std::cout << "WAKE CONDITION NOT FULFILLED IN ELEMENT # " << this->Id()
-                  << std::endl;
+    KRATOS_WARNING_IF("IncompressibleElement", std::abs(vupnorm - vlownorm) > 0.1) << "WAKE CONDITION NOT FULFILLED IN ELEMENT # " << this->Id() << std::endl;
 }
 
 template <int Dim, int NumNodes>


### PR DESCRIPTION
Small PR to use KRATOS_WARNING instead of std::cout.