### PR TITLE
[Core] Find global nodal element neighbours - fix const error in centos

### DIFF
--- a/kratos/processes/find_global_nodal_elemental_neighbours_process.cpp
+++ b/kratos/processes/find_global_nodal_elemental_neighbours_process.cpp
@@ -123,7 +123,7 @@ namespace Kratos
 
         GlobalPointerCommunicator<Element> pointer_comm(mrComm, constructor_functor );
         auto id_proxy = pointer_comm.Apply(
-                [](GlobalPointer<Element>& gp){return gp->Id();}
+                [](GlobalPointer<Element> const& gp){return gp->Id();}
         );
 
         #pragma omp parallel for
@@ -133,7 +133,7 @@ namespace Kratos
             auto& neighbours = it->GetValue(NEIGHBOUR_ELEMENTS);
             neighbours.shrink_to_fit();
             std::sort(neighbours.ptr_begin(), neighbours.ptr_end(),
-                [&id_proxy](GlobalPointer<Element>& gp1, GlobalPointer<Element>& gp2)
+                [&id_proxy](GlobalPointer<Element> const& gp1, GlobalPointer<Element> const& gp2)
                 {
                     return id_proxy.Get(gp1) < id_proxy.Get(gp2);
                 }

--- a/kratos/utilities/pointer_communicator.h
+++ b/kratos/utilities/pointer_communicator.h
@@ -89,6 +89,14 @@ public:
             return mNonLocalData[gp];
     }
 
+    TSendType Get(GlobalPointer<TPointerDataType> const& gp)
+    {
+        if(gp.GetRank() == mCurrentRank)
+            return mUserFunctor(gp);
+        else
+            return mNonLocalData[gp];
+    }
+
     void Update()
     {
         mpPointerComm->Update(mUserFunctor, mNonLocalData);


### PR DESCRIPTION
This was throwing an error in our centos 6 machine. I added a const version of get for ResultsProxy.

![image](https://user-images.githubusercontent.com/25667299/59495565-d8c88c00-8e8f-11e9-866b-f9a1a9bdd741.png)

@KratosMultiphysics/altair 