### PR TITLE
Generic variables list

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -8,6 +8,7 @@ endif(${MPI_NEEDED} MATCHES ON )
 ## Kratos main source code
 set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/containers/flags.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/containers/generic_variables_list.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/exact_mortar_segmentation_utility.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/global_variables.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/deprecated_variables.cpp;

--- a/kratos/containers/generic_variables_list.cpp
+++ b/kratos/containers/generic_variables_list.cpp
@@ -1,0 +1,57 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Riccardo Rossi
+//                   Jordi Cotela
+//
+
+// System includes
+
+
+// External includes
+
+
+// Project includes
+#include "includes/define.h"
+#include "containers/generic_variables_list.h"
+#include "includes/kratos_components.h"
+
+namespace Kratos
+{
+    void GenericVariablesList::AddVariable(const std::string& rVarName)
+    {
+        //ugly but needed: here we need to get the component type by checking the Kratos components
+        if(KratosComponents<Variable<bool>>::Has(rVarName))
+            mVariables.push_back(KratosComponents<Variable<bool>>::Get(rVarName));
+        else if(KratosComponents<Variable<int>>::Has(rVarName))
+            mVariables.push_back(KratosComponents<Variable<int>>::Get(rVarName));
+        else if(KratosComponents<Variable<unsigned int>>::Has(rVarName))
+            mVariables.push_back(KratosComponents<Variable<unsigned int>>::Get(rVarName));
+        else if(KratosComponents<Variable<double>>::Has(rVarName))
+            mVariables.push_back(KratosComponents<Variable<double>>::Get(rVarName));
+        else if(KratosComponents<Variable<array_1d<double,3>>>::Has(rVarName))
+            mVariables.push_back(KratosComponents<Variable<array_1d<double,3>>>::Get(rVarName));
+        else if(KratosComponents<Variable<Vector>>::Has(rVarName))
+            mVariables.push_back(KratosComponents<Variable<Vector>>::Get(rVarName));
+        else if(KratosComponents<Variable<Matrix>>::Has(rVarName))
+            mVariables.push_back(KratosComponents<Variable<Matrix>>::Get(rVarName));
+        else if(KratosComponents<variable_component_type>::Has(rVarName))
+            mVariables.push_back(KratosComponents<variable_component_type>::Get(rVarName));
+        else
+        {
+            KRATOS_ERROR << "variable " << rVarName << " not found as recognized variable type" << std::endl;
+        }
+        
+
+    }
+
+
+}  // namespace Kratos.
+
+

--- a/kratos/containers/generic_variables_list.h
+++ b/kratos/containers/generic_variables_list.h
@@ -33,7 +33,26 @@
 
 namespace Kratos
 {
-///@addtogroup ApplicationNameApplication
+
+class VariableNamePrinter : public boost::static_visitor<>
+{
+    public:
+        VariableNamePrinter(std::stringstream& rString) : mrString(rString)
+        {
+        }
+
+        template <class T>
+        void operator()(const T& rVar)
+        {
+            mrString << rVar.Name() << std::endl;
+        }
+
+    private:
+        std::stringstream& mrString;
+};
+
+
+///@addtogroup KratosCore
 ///@{
 
 ///@name Kratos Globals
@@ -55,8 +74,23 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
-/// Short class definition.
-/** Detail class definition.
+/// Generic Container of Variables
+/** This class defines a generic container to hold variables of any type.
+ * it is based on the variant/visitor paradigm.
+ * 
+ * the usage is something like
+ * 
+ *  GenericVariablesList vars;
+ *  vars.AddVariable(TEMPERATURE);
+ *  vars.AddVariable(VELOCITY);
+ *  vars.AddVariable(DISPLACEMENT_X);
+ *  vars.AddVariable(std::string("DISPLACEMENT_Z")); //note that we can add by the name
+ *
+ * operations are defined by creating a custom visitor with an operator specialized per every type
+ * which is then used as
+ *
+ *  MyTestVisitor aux(mp);
+ *   vars.ApplyVisitor( aux );
 */
 class GenericVariablesList
 {
@@ -104,7 +138,7 @@ public:
     ///@name Operators
     ///@{
     template<class TVistorType >
-    void ApplyVisitor(TVistorType& rVisitor)
+    void ApplyVisitor(TVistorType& rVisitor) const
     {
         for(const auto& rVarVariant : mVariables)
         {
@@ -132,7 +166,9 @@ public:
 
     /// Turn back information as a string.
     virtual std::string Info() const
-    {return "GenericVariableList containing :";}
+    {
+        return "GenericVariableList\n";
+    }
 
     /// Print information about this object.
     virtual void PrintInfo(std::ostream& rOStream) const
@@ -142,6 +178,12 @@ public:
     /// Print object's data.
     virtual void PrintData(std::ostream& rOStream) const
     {
+        std::stringstream msg;
+        msg << "GenericVariableList containing : " << std::endl;
+        
+        VariableNamePrinter aux(msg);
+        this->ApplyVisitor(aux);
+        rOStream << msg.str();
     }
 
     ///@}
@@ -155,6 +197,7 @@ protected:
     ///@name Protected static Member Variables
     ///@{
     std::vector< variable_variant_type > mVariables;
+
 
 
     ///@}
@@ -222,13 +265,6 @@ private:
     ///@}
     ///@name Un accessible methods
     ///@{
-
-    /// Assignment operator.
-    GenericVariablesList& operator=(GenericVariablesList const& rOther);
-
-    /// Copy constructor.
-    GenericVariablesList(GenericVariablesList const& rOther);
-
 
     ///@}
 

--- a/kratos/containers/generic_variables_list.h
+++ b/kratos/containers/generic_variables_list.h
@@ -1,0 +1,269 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Riccardo Rossi
+//                   Jordi Cotela
+//
+
+
+#if !defined(KRATOS_GENERIC_VARIABLES_LIST_H_INCLUDED )
+#define  KRATOS_GENERIC_VARIABLES_LIST_H_INCLUDED
+
+
+// System includes
+#include <string>
+#include <iostream>
+#include "boost/variant.hpp"
+#include "boost/visit_each.hpp"
+
+// External includes
+
+
+// Project includes
+#include "includes/define.h"
+#include "containers/variable.h"
+#include "containers/variable_component.h"
+#include "containers/vector_component_adaptor.h"
+
+namespace Kratos
+{
+///@addtogroup ApplicationNameApplication
+///@{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/// Short class definition.
+/** Detail class definition.
+*/
+class GenericVariablesList
+{
+public:
+    ///@name Type Definitions
+    ///@{
+    typedef VariableComponent<VectorComponentAdaptor<array_1d<double, 3> > > variable_component_type;
+
+    typedef boost::variant<
+        Variable<bool>,
+        Variable<int>,
+        Variable<unsigned int>,        
+        Variable<double>,
+        Variable<array_1d<double,3>>,
+        Variable<Vector>,
+        Variable<Matrix>,
+        variable_component_type        
+    > variable_variant_type;
+
+    using visitor_base_type = boost::static_visitor<> ;
+
+    /// Pointer definition of GenericVariablesList
+    KRATOS_CLASS_POINTER_DEFINITION(GenericVariablesList);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    GenericVariablesList()
+    {}
+
+    /// Destructor.
+    virtual ~GenericVariablesList()
+    {}
+
+    template<class TVarType>
+    void AddVariable(const TVarType& rVar){
+        mVariables.push_back(rVar);
+    }
+
+    void AddVariable(const std::string& rVarName);
+
+    ///@}
+    ///@name Operators
+    ///@{
+    template<class TVistorType >
+    void ApplyVisitor(TVistorType& rVisitor)
+    {
+        for(const auto& rVarVariant : mVariables)
+        {
+            boost::apply_visitor(rVisitor,rVarVariant);
+        }
+    }
+    ///@}
+    ///@name Operations
+    ///@{
+
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    virtual std::string Info() const
+    {return "GenericVariableList containing :";}
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream& rOStream) const
+    {
+    }
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const
+    {
+    }
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+    std::vector< variable_variant_type > mVariables;
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    GenericVariablesList& operator=(GenericVariablesList const& rOther);
+
+    /// Copy constructor.
+    GenericVariablesList(GenericVariablesList const& rOther);
+
+
+    ///@}
+
+}; // Class GenericVariablesList
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream,
+                GenericVariablesList& rThis)
+                {return rIStream;}
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                const GenericVariablesList& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_GENERIC_VARIABLES_LIST_H_INCLUDED  defined

--- a/kratos/tests/cpp_tests/containers/test_generic_variables_list.cpp
+++ b/kratos/tests/cpp_tests/containers/test_generic_variables_list.cpp
@@ -20,7 +20,7 @@ namespace Kratos
 namespace Testing
 {
 
-    class MyTestVisitor : public boost::static_visitor<>
+    class MyTestVisitor : public GenericVariablesList::visitor_base_type
     {
     public:
         //here i pass in the constructor a ModelPart reference...but it is NOt needed
@@ -35,9 +35,8 @@ namespace Testing
         {
             for (auto &node : mrModelPart.Nodes())
             {
-                KRATOS_WATCH(rVar)
-                auto& value = node.FastGetSolutionStepValue(rVar);
-                value = 1.0;
+                auto& r_value = node.FastGetSolutionStepValue(rVar);
+                r_value = 1.0;
             }
         }
 
@@ -46,9 +45,9 @@ namespace Testing
         {
             for (auto &node : mrModelPart.Nodes())
             {
-                auto &v = node.FastGetSolutionStepValue(rVar);
+                auto& r_value = node.FastGetSolutionStepValue(rVar);
                 for (unsigned int i = 0; i < 3; ++i)
-                    v[i] = -1.0;
+                    r_value[i] = -1.0;
             }
         }
 
@@ -90,8 +89,7 @@ KRATOS_TEST_CASE_IN_SUITE(GenericVariablesList, KratosCoreFastSuite)
     //NOTE: this is the part to be user-defined!!
     MyTestVisitor aux(mp);
     vars.ApplyVisitor( aux );
-
-
+   
 
     for (auto& rNode : mp.Nodes())
     {

--- a/kratos/tests/cpp_tests/containers/test_generic_variables_list.cpp
+++ b/kratos/tests/cpp_tests/containers/test_generic_variables_list.cpp
@@ -1,0 +1,110 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Riccardo Rossi
+
+#include "testing/testing.h"
+#include "containers/generic_variables_list.h"
+#include "containers/model.h"
+#include "includes/model_part.h"
+#include "includes/mpi_serializer.h"
+
+namespace Kratos
+{
+namespace Testing
+{
+
+    class MyTestVisitor : public boost::static_visitor<>
+    {
+    public:
+        //here i pass in the constructor a ModelPart reference...but it is NOt needed
+        MyTestVisitor(ModelPart &rModelPart) : mrModelPart(rModelPart)
+        {
+        }
+
+
+        //this method is good for both Variable<double> and compoents
+        template <class T>
+        void operator()(const T& rVar)
+        {
+            for (auto &node : mrModelPart.Nodes())
+            {
+                KRATOS_WATCH(rVar)
+                auto& value = node.FastGetSolutionStepValue(rVar);
+                value = 1.0;
+            }
+        }
+
+        //treat specially the case of array_1d variable
+        void operator()(const Variable < array_1d<double, 3> >& rVar)
+        {
+            for (auto &node : mrModelPart.Nodes())
+            {
+                auto &v = node.FastGetSolutionStepValue(rVar);
+                for (unsigned int i = 0; i < 3; ++i)
+                    v[i] = -1.0;
+            }
+        }
+
+        //unfortunately we need to also define cases where we want to do nothing
+        void operator()(const Variable < Vector >& rVar)
+        {}
+
+        void operator()(const Variable < Matrix >& rVar)
+        {}
+
+    private:
+        ModelPart &mrModelPart;
+    };
+
+
+KRATOS_TEST_CASE_IN_SUITE(GenericVariablesList, KratosCoreFastSuite)
+{
+    Model current_model;
+    ModelPart &mp = current_model.CreateModelPart("test");
+    mp.AddNodalSolutionStepVariable(TEMPERATURE);  //not to have an empty var list
+    mp.AddNodalSolutionStepVariable(DISPLACEMENT); //not to have an empty var list
+    mp.AddNodalSolutionStepVariable(VELOCITY);     //not to have an empty var list
+
+    mp.CreateNewNode(1, 1.0, 2.0, 3.0);
+    mp.CreateNewNode(2, 1.0, 2.0, 3.0);
+    mp.CreateNewNode(3, 1.0, 2.0, 3.0);
+
+
+
+
+    //now create a generic list of variables
+    GenericVariablesList vars;
+    vars.AddVariable(TEMPERATURE);
+    vars.AddVariable(VELOCITY);
+    vars.AddVariable(DISPLACEMENT_X);
+    vars.AddVariable(std::string("DISPLACEMENT_Z")); //note that we can add by the name
+
+    //define the functor to be applied onto all the vars types
+    //NOTE: this is the part to be user-defined!!
+    MyTestVisitor aux(mp);
+    vars.ApplyVisitor( aux );
+
+
+
+    for (auto& rNode : mp.Nodes())
+    {
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(TEMPERATURE), 1.0);
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(DISPLACEMENT_X), 1.0);
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(DISPLACEMENT_Y), 0.0); //NOT SET!!
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(DISPLACEMENT_Z), 1.0);
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(VELOCITY_X), -1.0);
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(VELOCITY_Y), -1.0); 
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(VELOCITY_Z), -1.0);
+
+    }
+}
+
+} // namespace Testing
+} // namespace Kratos


### PR DESCRIPTION
so this is an attempt to use a variant/visitor pattern to allow defining a "generic" variable list, able to contain variables of different types.

since we are limited to c++11 i had to use the boost::visitor implementation, however this is hidden in the "GenericVariablesList" class so we can easily change it at any time.

Please take a look at the test for an example of use, nevertheless the concept is quite simple, one can do something like

~~~cpp
    GenericVariablesList vars;
    vars.AddVariable(TEMPERATURE);
    vars.AddVariable(VELOCITY);
    vars.AddVariable(DISPLACEMENT_X);
    vars.AddVariable(std::string("DISPLACEMENT_Z")); //note that we can add by the name
~~~

and then define a function for each type by wrapping it within an helper "visitor" funciton, which is then applied as

~~~cpp
    MyTestVisitor aux(mp);
    vars.ApplyVisitor( aux );
~~~

I am defining this as "draft"and CC-ing a lot of people which i know have been dealing with this sort of things.

The thing i dislike the most in the current proposal is that one needs to define empty functions to be applied for all possible types...meaning also types that are not actually contained in the variable list.
One may simplify this by deriving the visitor from a visitor base class and making the method virtual, HOWEVER this would impede using templates in defining the operators ... which is a no go
