### PR TITLE
[MeshingApplication] Hesian metric not enforcing anisotropy respecta a variable by default

### DIFF
--- a/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
+++ b/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
@@ -497,8 +497,8 @@ void ComputeHessianSolMetricProcess::InitializeVariables(Parameters ThisParamete
     mThisParameters.AddValue("enforce_current", ThisParameters["enforce_current"]);
     mThisParameters.AddValue("anisotropy_remeshing", ThisParameters["anisotropy_remeshing"]);
     mThisParameters.AddValue("enforce_anisotropy_relative_variable", ThisParameters["enforce_anisotropy_relative_variable"]);
+    mThisParameters.AddValue("interpolation_error", ThisParameters["hessian_strategy_parameters"]["interpolation_error"]);
     mThisParameters.AddValue("estimate_interpolation_error", considered_parameters["hessian_strategy_parameters"]["estimate_interpolation_error"]);
-    mThisParameters.AddValue("interpolation_error", considered_parameters["hessian_strategy_parameters"]["interpolation_error"]);
     mThisParameters.AddValue("mesh_dependent_constant", considered_parameters["hessian_strategy_parameters"]["mesh_dependent_constant"]);
     mThisParameters.AddValue("hmin_over_hmax_anisotropic_ratio", considered_parameters["enforced_anisotropy_parameters"]["hmin_over_hmax_anisotropic_ratio"]);
     mThisParameters.AddValue("boundary_layer_max_distance", considered_parameters["enforced_anisotropy_parameters"]["boundary_layer_max_distance"]);

--- a/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
+++ b/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
@@ -456,7 +456,7 @@ Parameters ComputeHessianSolMetricProcess::GetDefaultParameters() const
         },
         "anisotropy_remeshing"                 : true,
         "enforce_anisotropy_relative_variable" : false,
-        "anisotropy_parameters":
+        "enforced_anisotropy_parameters":
         {
             "reference_variable_name"               : "DISTANCE",
             "hmin_over_hmax_anisotropic_ratio"      : 1.0,
@@ -500,14 +500,14 @@ void ComputeHessianSolMetricProcess::InitializeVariables(Parameters ThisParamete
     mThisParameters.AddValue("estimate_interpolation_error", considered_parameters["hessian_strategy_parameters"]["estimate_interpolation_error"]);
     mThisParameters.AddValue("interpolation_error", considered_parameters["hessian_strategy_parameters"]["interpolation_error"]);
     mThisParameters.AddValue("mesh_dependent_constant", considered_parameters["hessian_strategy_parameters"]["mesh_dependent_constant"]);
-    mThisParameters.AddValue("hmin_over_hmax_anisotropic_ratio", considered_parameters["anisotropy_parameters"]["hmin_over_hmax_anisotropic_ratio"]);
-    mThisParameters.AddValue("boundary_layer_max_distance", considered_parameters["anisotropy_parameters"]["boundary_layer_max_distance"]);
+    mThisParameters.AddValue("hmin_over_hmax_anisotropic_ratio", considered_parameters["enforced_anisotropy_parameters"]["hmin_over_hmax_anisotropic_ratio"]);
+    mThisParameters.AddValue("boundary_layer_max_distance", considered_parameters["enforced_anisotropy_parameters"]["boundary_layer_max_distance"]);
 
     // Interpolation type
-    mInterpolation = ConvertInter(considered_parameters["anisotropy_parameters"]["interpolation"].GetString());
+    mInterpolation = ConvertInter(considered_parameters["enforced_anisotropy_parameters"]["interpolation"].GetString());
 
     // Ratio reference variable
-    const std::string& r_variable_name = considered_parameters["anisotropy_parameters"]["reference_variable_name"].GetString();
+    const std::string& r_variable_name = considered_parameters["enforced_anisotropy_parameters"]["reference_variable_name"].GetString();
     KRATOS_ERROR_IF_NOT(KratosComponents<Variable<double>>::Has(r_variable_name)) << "Variable " << r_variable_name << " is not a double variable" << std::endl;
     mpRatioReferenceVariable = const_cast<Variable<double>*>(&KratosComponents<Variable<double>>::Get(r_variable_name));
 }

--- a/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
+++ b/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
@@ -93,9 +93,12 @@ template<SizeType TDim>
 array_1d<double, 3 * (TDim - 1)> ComputeHessianSolMetricProcess::ComputeHessianMetricTensor(
     const Vector& rHessian,
     const double AnisotropicRatio,
-    const double ElementMinSize, // This way we can impose as minimum as the previous size if we desire
-    const double ElementMaxSize, // This way we can impose as maximum as the previous size if we desire
-    const double NodalH
+    const double ElementMinSize,
+    const double ElementMaxSize,
+    const double NodalH,
+    const bool EstimateInterpolationError,
+    const double InterpolationError,
+    const double MeshDependentConstant
     )
 {
     /// The type of array considered for the tensor
@@ -108,9 +111,9 @@ array_1d<double, 3 * (TDim - 1)> ComputeHessianSolMetricProcess::ComputeHessianM
     const MatrixType hessian_matrix = MathUtils<double>::VectorToSymmetricTensor<Vector, MatrixType>(rHessian);
 
     // Calculating Metric parameters (using equation from remark 4.2.2 on Metric-Based Anisotropic Mesh Adaptation)
-    double interpolation_error = mInterpError;
-    if (mEstimateInterpError) {
-        interpolation_error = mMeshConstant * MathUtils<double>::Max(NodalH, NodalH * norm_frobenius(hessian_matrix)); // NOTE: To compute it properly instead of iterating over the nodes you should iterate over the elements and instead of ElementMaxSize you should iterate over the edges, this is equivalent when using nodes and computing NodalH previously
+    double interpolation_error = InterpolationError;
+    if (EstimateInterpolationError) {
+        interpolation_error = MeshDependentConstant * MathUtils<double>::Max(NodalH, NodalH * norm_frobenius(hessian_matrix)); // NOTE: To compute it properly instead of iterating over the nodes you should iterate over the elements and instead of ElementMaxSize you should iterate over the edges, this is equivalent when using nodes and computing NodalH previously
     }
 
     // Declaring the eigen system
@@ -126,7 +129,7 @@ array_1d<double, 3 * (TDim - 1)> ComputeHessianSolMetricProcess::ComputeHessianM
             eigen_values_matrix(i, i) = l_square_minus1;
         }
     } else { // Equation 4.4 from Metric-Based Anisotropic Mesh Adaptation
-        const double c_epsilon = mMeshConstant/interpolation_error;
+        const double c_epsilon = MeshDependentConstant/interpolation_error;
         const double min_ratio = 1.0/std::pow(ElementMinSize, 2);
         const double max_ratio = 1.0/std::pow(ElementMaxSize, 2);
 
@@ -353,18 +356,27 @@ double ComputeHessianSolMetricProcess::CalculateAnisotropicRatio(
 template<SizeType TDim>
 void ComputeHessianSolMetricProcess::CalculateMetric()
 {
+    const double minimal_size = mThisParameters["minimal_size"].GetDouble();                                         /// The minimal size of the elements
+    const double maximal_size = mThisParameters["maximal_size"].GetDouble();                                         /// The maximal size of the elements
+    const bool enforce_current = mThisParameters["enforce_current"].GetBool();                                       /// With this we choose if we inforce the current nodal size (NODAL_H)
+    const bool estimate_interpolation_error = mThisParameters["estimate_interpolation_error"].GetBool();             /// If the error of interpolation will be estimated
+    const double interpolation_error = mThisParameters["interpolation_error"].GetDouble();                           /// The error of interpolation allowed
+    const double mesh_dependent_constant = mThisParameters["mesh_dependent_constant"].GetDouble();                   /// The error of interpolation allowed
+    const double hmin_over_hmax_anisotropic_ratio = mThisParameters["hmin_over_hmax_anisotropic_ratio"].GetDouble(); /// The error of interpolation allowed
+    const double boundary_layer_max_distance = mThisParameters["boundary_layer_max_distance"].GetDouble();           /// The error of interpolation allowed
+
     /// The type of array considered for the tensor
     typedef typename std::conditional<TDim == 2, array_1d<double, 3>, array_1d<double, 6>>::type TensorArrayType;
 
     // Iterate in the nodes
     NodesArrayType& r_nodes_array = mThisModelPart.Nodes();
     const int num_nodes = static_cast<int>(r_nodes_array.size());
+    const auto it_node_begin = r_nodes_array.begin();
 
     // Tensor variable definition
     const Variable<TensorArrayType>& r_tensor_variable = KratosComponents<Variable<TensorArrayType>>::Get("METRIC_TENSOR_"+std::to_string(TDim)+"D");
 
     // Setting metric in case not defined
-    const auto it_node_begin = r_nodes_array.begin();
     if (!it_node_begin->Has(r_tensor_variable)) {
         // Declaring auxiliar vector
         const TensorArrayType aux_zero_vector = ZeroVector(3 * (TDim - 1));
@@ -372,8 +384,8 @@ void ComputeHessianSolMetricProcess::CalculateMetric()
     }
 
     // Ratio reference variable
-    KRATOS_ERROR_IF_NOT(KratosComponents<Variable<double>>::Has(mRatioReferenceVariable)) << "Variable " << mRatioReferenceVariable << " is not a double variable" << std::endl;
-    const auto& r_reference_var = KratosComponents<Variable<double>>::Get(mRatioReferenceVariable);
+    KRATOS_ERROR_IF(mpRatioReferenceVariable == NULL) << "Variable reference is not defined" << std::endl;
+    const auto& r_reference_var = *mpRatioReferenceVariable;
 
     #pragma omp parallel for
     for(int i = 0; i < num_nodes; ++i) {
@@ -383,15 +395,15 @@ void ComputeHessianSolMetricProcess::CalculateMetric()
 
         const double nodal_h = it_node->GetValue(NODAL_H);
 
-        const double element_min_size = ((mMinSize < nodal_h) && mEnforceCurrent) ? nodal_h : mMinSize;
-        const double element_max_size = ((mMaxSize > nodal_h) && mEnforceCurrent) ? nodal_h : mMaxSize;
+        const double element_minimal_size = ((minimal_size < nodal_h) && enforce_current) ? nodal_h : minimal_size;
+        const double element_maximal_size = ((maximal_size > nodal_h) && enforce_current) ? nodal_h : maximal_size;
 
         // Isotropic by default
         double ratio = 1.0;
 
         if (it_node->SolutionStepsDataHas(r_reference_var)) {
             const double ratio_reference = it_node->FastGetSolutionStepValue(r_reference_var);
-            ratio = CalculateAnisotropicRatio(ratio_reference, mAnisotropicRatio, mBoundLayer, mInterpolation);
+            ratio = CalculateAnisotropicRatio(ratio_reference, hmin_over_hmax_anisotropic_ratio, boundary_layer_max_distance, mInterpolation);
         }
 
         // For postprocess pourposes
@@ -404,11 +416,11 @@ void ComputeHessianSolMetricProcess::CalculateMetric()
         const double norm_metric = norm_2(r_metric);
         if (norm_metric > 0.0) { // NOTE: This means we combine differents metrics, at the same time means that the metric should be reseted each time
             const TensorArrayType& r_old_metric = it_node->GetValue(r_tensor_variable);
-            const TensorArrayType new_metric = ComputeHessianMetricTensor<TDim>(r_hessian, ratio, element_min_size, element_max_size, nodal_h);
+            const TensorArrayType new_metric = ComputeHessianMetricTensor<TDim>(r_hessian, ratio, element_minimal_size, element_maximal_size, nodal_h, estimate_interpolation_error, interpolation_error, mesh_dependent_constant);
 
             noalias(r_metric) = MetricsMathUtils<TDim>::IntersectMetrics(r_old_metric, new_metric);
         } else {
-            noalias(r_metric) = ComputeHessianMetricTensor<TDim>(r_hessian, ratio, element_min_size, element_max_size, nodal_h);
+            noalias(r_metric) = ComputeHessianMetricTensor<TDim>(r_hessian, ratio, element_minimal_size, element_maximal_size, nodal_h, estimate_interpolation_error, interpolation_error, mesh_dependent_constant);
         }
     }
 }
@@ -431,7 +443,7 @@ Parameters ComputeHessianSolMetricProcess::GetDefaultParameters() const
         "enforce_current"                     : false,
         "hessian_strategy_parameters":
         {
-            "metric_variable"                  : ["DISTANCE"],
+            "metric_variable"                      : ["DISTANCE"],
             "estimate_interpolation_error"         : false,
             "interpolation_error"                  : 1.0e-6,
             "mesh_dependent_constant"              : 0.28125
@@ -470,29 +482,25 @@ void ComputeHessianSolMetricProcess::InitializeVariables(Parameters ThisParamete
     // Get default variables
     Parameters default_parameters = GetDefaultParameters();
 
-    // Set variables
-    mMinSize = ThisParameters["minimal_size"].GetDouble();
-    mMaxSize = ThisParameters["maximal_size"].GetDouble();
-    mEnforceCurrent = ThisParameters["enforce_current"].GetBool();
-
     // In case we have isotropic remeshing (default values)
-    if (ThisParameters["anisotropy_remeshing"].GetBool() == false) {
-        mEstimateInterpError = default_parameters["hessian_strategy_parameters"]["estimate_interpolation_error"].GetBool();
-        mInterpError = default_parameters["hessian_strategy_parameters"]["interpolation_error"].GetDouble();
-        mMeshConstant = default_parameters["hessian_strategy_parameters"]["mesh_dependent_constant"].GetDouble();
-        mRatioReferenceVariable = default_parameters["anisotropy_parameters"]["reference_variable_name"].GetString();
-        mAnisotropicRatio = default_parameters["anisotropy_parameters"]["hmin_over_hmax_anisotropic_ratio"].GetDouble();
-        mBoundLayer = default_parameters["anisotropy_parameters"]["boundary_layer_max_distance"].GetDouble();
-        mInterpolation = ConvertInter(default_parameters["anisotropy_parameters"]["interpolation"].GetString());
-    } else {
-        mEstimateInterpError = ThisParameters["hessian_strategy_parameters"]["estimate_interpolation_error"].GetBool();
-        mInterpError = ThisParameters["hessian_strategy_parameters"]["interpolation_error"].GetDouble();
-        mMeshConstant = ThisParameters["hessian_strategy_parameters"]["mesh_dependent_constant"].GetDouble();
-        mRatioReferenceVariable = ThisParameters["anisotropy_parameters"]["reference_variable_name"].GetString();
-        mAnisotropicRatio = ThisParameters["anisotropy_parameters"]["hmin_over_hmax_anisotropic_ratio"].GetDouble();
-        mBoundLayer = ThisParameters["anisotropy_parameters"]["boundary_layer_max_distance"].GetDouble();
-        mInterpolation = ConvertInter(ThisParameters["anisotropy_parameters"]["interpolation"].GetString());
-    }
+    const bool default_values = !ThisParameters["anisotropy_remeshing"].GetBool();
+    const Parameters considered_parameters = default_values ? default_parameters : ThisParameters;
+    mThisParameters.AddValue("minimal_size", ThisParameters["minimal_size"]);
+    mThisParameters.AddValue("maximal_size", ThisParameters["maximal_size"]);
+    mThisParameters.AddValue("enforce_current", ThisParameters["enforce_current"]);
+    mThisParameters.AddValue("estimate_interpolation_error", considered_parameters["hessian_strategy_parameters"]["estimate_interpolation_error"]);
+    mThisParameters.AddValue("interpolation_error", considered_parameters["hessian_strategy_parameters"]["interpolation_error"]);
+    mThisParameters.AddValue("mesh_dependent_constant", considered_parameters["hessian_strategy_parameters"]["mesh_dependent_constant"]);
+    mThisParameters.AddValue("hmin_over_hmax_anisotropic_ratio", considered_parameters["anisotropy_parameters"]["hmin_over_hmax_anisotropic_ratio"]);
+    mThisParameters.AddValue("boundary_layer_max_distance", considered_parameters["anisotropy_parameters"]["boundary_layer_max_distance"]);
+
+    // Interpolation type
+    mInterpolation = ConvertInter(considered_parameters["anisotropy_parameters"]["interpolation"].GetString());
+
+    // Ratio reference variable
+    const std::string& r_variable_name = considered_parameters["anisotropy_parameters"]["reference_variable_name"].GetString();
+    KRATOS_ERROR_IF_NOT(KratosComponents<Variable<double>>::Has(r_variable_name)) << "Variable " << r_variable_name << " is not a double variable" << std::endl;
+    mpRatioReferenceVariable = const_cast<Variable<double>*>(&KratosComponents<Variable<double>>::Get(r_variable_name));
 }
 
 };// namespace Kratos.

--- a/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
+++ b/applications/MeshingApplication/custom_processes/metrics_hessian_process.cpp
@@ -29,6 +29,9 @@ ComputeHessianSolMetricProcess::ComputeHessianSolMetricProcess(
     // We push the list of double variables
     mrOriginVariableDoubleList.push_back(&rVariable);
 
+    // TODO: Remove this warning in the future
+    KRATOS_WARNING_IF("ComputeHessianSolMetricProcess", !ThisParameters.Has("enforce_anisotropy_relative_variable")) << "enforce_anisotropy_relative_variable not defined. By default is considered false" << std::endl;
+
     // We check the parameters
     Parameters default_parameters = GetDefaultParameters();
     ThisParameters.RecursivelyValidateAndAssignDefaults(default_parameters);
@@ -46,6 +49,9 @@ ComputeHessianSolMetricProcess::ComputeHessianSolMetricProcess(
 {
     // We push the components list
     mrOriginVariableComponentsList.push_back(&rVariable);
+
+    // TODO: Remove this warning in the future
+    KRATOS_WARNING_IF("ComputeHessianSolMetricProcess", !ThisParameters.Has("enforce_anisotropy_relative_variable")) << "enforce_anisotropy_relative_variable not defined. By default is considered false" << std::endl;
 
     // We check the parameters
     Parameters default_parameters = GetDefaultParameters();

--- a/applications/MeshingApplication/custom_processes/metrics_hessian_process.h
+++ b/applications/MeshingApplication/custom_processes/metrics_hessian_process.h
@@ -242,6 +242,8 @@ private:
      * @param EstimateInterpolationError If the error of interpolation will be estimated
      * @param InterpolationError The error of interpolation allowed
      * @param MeshDependentConstant The mesh constant to remesh (depends of the element type)
+     * @param AnisotropyRemeshing If we consider anisotropic remeshing
+     * @param EnforceAnisotropyRelativeVariable If we enforce a certain anisotropy relative toa  variable
      */
     template<SizeType TDim>
     array_1d<double, 3 * (TDim - 1)> ComputeHessianMetricTensor(
@@ -252,7 +254,9 @@ private:
         const double NodalH,
         const bool EstimateInterpolationError,
         const double InterpolationError,
-        const double MeshDependentConstant
+        const double MeshDependentConstant,
+        const bool AnisotropyRemeshing,
+        const bool EnforceAnisotropyRelativeVariable
         );
 
     /**

--- a/applications/MeshingApplication/custom_processes/metrics_hessian_process.h
+++ b/applications/MeshingApplication/custom_processes/metrics_hessian_process.h
@@ -215,20 +215,13 @@ private:
     ///@{
 
     ModelPart& mThisModelPart;                                  /// The model part to compute
+
     std::vector<Variable<double>*> mrOriginVariableDoubleList;  /// The scalar variable list to compute
     std::vector<ComponentType*> mrOriginVariableComponentsList; /// The scalar variable list to compute (components)
+    Variable<double>* mpRatioReferenceVariable = &DISTANCE;     /// Variable used to compute the anisotropic ratio
 
-    // TODO: Replace for Parameters
-    std::string mRatioReferenceVariable = "DISTANCE";          /// Variable used to compute the anisotropic ratio
-    double mMinSize;                                           /// The minimal size of the elements
-    double mMaxSize;                                           /// The maximal size of the elements
-    bool mEnforceCurrent;                                      /// With this we choose if we inforce the current nodal size (NODAL_H)
-    bool mEstimateInterpError;                                 /// If the error of interpolation will be estimated
-    double mInterpError;                                       /// The error of interpolation allowed
-    double mMeshConstant;                                      /// The mesh constant to remesh (depends of the element type)
-    double mAnisotropicRatio;                                  /// The minimal anisotropic ratio (0 < ratio < 1)
-    double mBoundLayer;                                        /// The boundary layer limit distance
-    Interpolation mInterpolation;                              /// The interpolation type
+    Parameters mThisParameters;                                 /// Here configurations are stored
+    Interpolation mInterpolation;                               /// The interpolation type
 
     ///@}
     ///@name Private Operators
@@ -243,17 +236,23 @@ private:
      * @details Note that when using the Hessian, more than one Metric can be defined simultaneously, so in consecuence we need to define the elipsoid which defines the volume of maximal intersection
      * @param Hessian The hessian tensor condensed already computed
      * @param AnisotropicRatio The anisotropic ratio
-     * @param ElementMinSize The min size of element
-     * @param ElementMaxSize The maximal size of the elements
+     * @param ElementMinSize The min size of element. This way we can impose as minimum as the previous size if we desire
+     * @param ElementMaxSize The maximal size of the elements. This way we can impose as maximum as the previous size if we desire
      * @param NodalH The size of the local node
+     * @param EstimateInterpolationError If the error of interpolation will be estimated
+     * @param InterpolationError The error of interpolation allowed
+     * @param MeshDependentConstant The mesh constant to remesh (depends of the element type)
      */
     template<SizeType TDim>
     array_1d<double, 3 * (TDim - 1)> ComputeHessianMetricTensor(
         const Vector& rHessian,
         const double AnisotropicRatio,
-        const double ElementMinSize, // This way we can impose as minimum as the previous size if we desire
-        const double ElementMaxSize, // This way we can impose as maximum as the previous size if we desire
-        const double NodalH
+        const double ElementMinSize,
+        const double ElementMaxSize,
+        const double NodalH,
+        const bool EstimateInterpolationError,
+        const double InterpolationError,
+        const double MeshDependentConstant
         );
 
     /**

--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -398,8 +398,8 @@ class MmgProcess(KratosMultiphysics.Process):
             hessian_parameters["hessian_strategy_parameters"].RemoveValue("metric_variable")
             hessian_parameters.AddValue("anisotropy_remeshing",self.settings["anisotropy_remeshing"])
             hessian_parameters.AddValue("enforce_anisotropy_relative_variable",self.settings["enforce_anisotropy_relative_variable"])
-            hessian_parameters.AddValue("anisotropy_parameters",self.settings["anisotropy_parameters"])
-            hessian_parameters["anisotropy_parameters"].RemoveValue("boundary_layer_min_size_ratio")
+            hessian_parameters.AddValue("enforced_anisotropy_parameters",self.settings["anisotropy_parameters"])
+            hessian_parameters["enforced_anisotropy_parameters"].RemoveValue("boundary_layer_min_size_ratio")
             for current_metric_variable in self.metric_variable:
                 self.metric_processes.append(MeshingApplication.ComputeHessianSolMetricProcess(self.main_model_part, current_metric_variable, hessian_parameters))
         elif self.strategy == "superconvergent_patch_recovery":

--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -131,7 +131,8 @@ class MmgProcess(KratosMultiphysics.Process):
                 "force_gradation_value"               : false,
                 "gradation_value"                     : 1.3
             },
-            "anisotropy_remeshing"             : true,
+            "anisotropy_remeshing"                 : true,
+            "enforce_anisotropy_relative_variable" : false,
             "anisotropy_parameters":{
                 "reference_variable_name"          : "DISTANCE",
                 "hmin_over_hmax_anisotropic_ratio" : 0.01,
@@ -396,6 +397,7 @@ class MmgProcess(KratosMultiphysics.Process):
             hessian_parameters.AddValue("hessian_strategy_parameters",self.settings["hessian_strategy_parameters"])
             hessian_parameters["hessian_strategy_parameters"].RemoveValue("metric_variable")
             hessian_parameters.AddValue("anisotropy_remeshing",self.settings["anisotropy_remeshing"])
+            hessian_parameters.AddValue("enforce_anisotropy_relative_variable",self.settings["enforce_anisotropy_relative_variable"])
             hessian_parameters.AddValue("anisotropy_parameters",self.settings["anisotropy_parameters"])
             hessian_parameters["anisotropy_parameters"].RemoveValue("boundary_layer_min_size_ratio")
             for current_metric_variable in self.metric_variable:

--- a/applications/MeshingApplication/tests/cpp_tests/test_metric_process.cpp
+++ b/applications/MeshingApplication/tests/cpp_tests/test_metric_process.cpp
@@ -258,7 +258,8 @@ namespace Kratos
             }
 
             // Compute metric
-            auto hessian_process = ComputeHessianSolMetricProcess(r_model_part, DISTANCE);
+            Parameters parameters = Parameters(R"({"enforce_anisotropy_relative_variable" : true})");
+            auto hessian_process = ComputeHessianSolMetricProcess(r_model_part, DISTANCE, parameters);
             hessian_process.Execute();
 
 //             // DEBUG
@@ -304,7 +305,8 @@ namespace Kratos
             }
 
             // Compute metric
-            auto hessian_process = ComputeHessianSolMetricProcess(r_model_part, DISTANCE);
+            Parameters parameters = Parameters(R"({"enforce_anisotropy_relative_variable" : true})");
+            auto hessian_process = ComputeHessianSolMetricProcess(r_model_part, DISTANCE, parameters);
             hessian_process.Execute();
 
 //             // DEBUG


### PR DESCRIPTION
Hessian metric is already anisotropic.

Before:

![imagen](https://user-images.githubusercontent.com/19991680/59764445-16685300-929c-11e9-97af-95f02a8ef5b8.png)

After:

![imagen](https://user-images.githubusercontent.com/19991680/59764467-208a5180-929c-11e9-8922-5a7db4c0b67e.png)
