### PR TITLE
Parallel IO improvement 

### DIFF
--- a/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
+++ b/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
@@ -698,15 +698,6 @@ protected:
                   }
                 }
               }
-
-            //   for (SizeType i=0; i<NumElements; i++)
-            //   {
-            //       if ( std::includes(ElementsSorted[i].begin(), ElementsSorted[i].end(), tmp.begin(), tmp.end()) )
-            //       {
-            //           *itPart = rElemPartition[i];
-            //           break;
-            //       }
-            //   }
           }
 
           // Advance to next condition in connectivities array

--- a/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
+++ b/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
@@ -525,8 +525,8 @@ protected:
 
         // Fill the node Connectivities
         for(std::size_t i = 0; i < NumElements; i++) {
-            for (std::vector<SizeType>::const_iterator itNode = rElemConnectivities[i]->begin(); itNode != rElemConnectivities[i]->end(); ++itNode) {
-               rElemConnectivities[*itNode-1] = i;
+            for (std::vector<SizeType>::const_iterator itNode = rElemConnectivities[i].begin(); itNode != rElemConnectivities[i].end(); ++itNode) {
+               mNodeConnectivities[*itNode-1].insert(i);
             }
         }
 

--- a/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
+++ b/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
@@ -514,7 +514,6 @@ protected:
                        std::vector<idxtype>& rElemPartition)
     {
         SizeType NumElements = rElemConnectivities.size();
-        std::vector<int> PartitionWeights(BaseType::mNumberOfPartitions,0);
 
         // initialize ElementPartition
         rElemPartition.resize(NumElements,-1);
@@ -536,7 +535,6 @@ protected:
             if ( NeighbourNodes == itElem->size() )
             {
                 *itPart = MyPartition;
-                PartitionWeights[MyPartition]++;
             }
 
             // Advance to next element in connectivities array
@@ -582,7 +580,6 @@ protected:
                 int MajorityPartition = NeighbourPartitions[ FindMax(FoundNeighbours,NeighbourWeights) ];
                 {
                     *itPart = MajorityPartition;
-                    PartitionWeights[MajorityPartition]++;
                 }
             }
 
@@ -603,7 +600,6 @@ protected:
     {
       SizeType NumElements = rElemConnectivities.size();
       SizeType NumConditions = rCondConnectivities.size();
-      std::vector<int> PartitionWeights(BaseType::mNumberOfPartitions,0);
 
       // initialize CondPartition
       rCondPartition.resize(NumConditions,-1);
@@ -630,7 +626,6 @@ protected:
           if ( NeighbourNodes == itCond->size() )
           {
               *itPart = MyPartition;
-              PartitionWeights[MyPartition]++;
           }
 
           // Advance to next condition in connectivities array
@@ -674,7 +669,6 @@ protected:
               int MajorityPartition = NeighbourPartitions[ FindMax(FoundNeighbours,NeighbourWeights) ];
               {
                   *itPart = MajorityPartition;
-                  PartitionWeights[MajorityPartition]++;
               }
 
               // ensure conditions sharing nodes with an element have same partition as the element

--- a/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
+++ b/applications/MetisApplication/custom_processes/metis_divide_heterogeneous_input_process.h
@@ -520,7 +520,7 @@ protected:
         SizeType NumElements = rElemConnectivities.size();
 
         // initialize ElementPartition
-        mNodeConnectivities = std::vector(mNumNodes,std::unordered_set());
+        mNodeConnectivities = std::vector<std::unordered_set<std::size_t>>(mNumNodes,std::unordered_set<std::size_t>());
         rElemPartition.resize(NumElements,-1);
 
         // Fill the node Connectivities


### PR DESCRIPTION
This is a Draft!!

I (hopefully) improved the condition partitioner in the metis process to avoid having a search over the elements for each node. This improves the lecture and partition time of the `metis_divide_heterogeneous_input_process.h` considerably, and makes the memory based partitioner IO even faster.

The original problem is that ensuring that if a condition shared all its nodes with an element, that condition needs to fall in the same partition, we were iterating over all elements of the model for every condition we wanted to check, having a O(N^2) cost of the size of the model in the worst case and I suspect that something in terms of O(N^1.x) in a regular basis.

After the changes for a 3M Element mdpa:

|  | Old | New |
| :---         |     :---   |           :--- | 
| Disk       | 2947.88     | 1804.68    |
| Memory | 1243.80      | 167.19      |

As you can see the difference is considerable. The downside is that in order to suppress the loop I have to temporally store all the connectivities of a node ( during the lecture ), so I wanted to discuss first of this is acceptable in terms of memory and also confirm that I am not breaking anything. (Not sure of this is tested)

What do you think?



