### PR TITLE
[Fluid] Non-historical nodal based EMBEDDED_VELOCITY

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
@@ -442,6 +442,14 @@ protected:
         Vector zero_vector(TNumNodes, 0.0);
         this->SetValue(ELEMENTAL_DISTANCES, zero_vector);
 
+        // Initialize the nodal EMBEDDED_VELOCITY variable (make it threadsafe)
+        const array_1d<double,3> zero_vel = ZeroVector(3);
+        for (auto &r_node : this->GetGeometry()) {
+            r_node.SetLock();
+            r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
+            r_node.UnSetLock();
+        }
+
         KRATOS_CATCH("");
     }
 
@@ -648,10 +656,6 @@ protected:
 
             // Add the normal component penalty contribution
             this->AddSystemNormalVelocityPenaltyContribution(rLeftHandSideMatrix, rRightHandSideVector, rData, rCurrentProcessInfo);
-
-            // Use the pressure as a Lagrange multiplier to enforce the no penetration condition
-            // this->AddSystemNormalVelocityLagrangeMultiplierContribution(rLeftHandSideMatrix, rRightHandSideVector, rData);
-
         } else {
 
             // If the element is not splitted, add the standard Navier-Stokes contribution
@@ -907,30 +911,9 @@ protected:
         const EmbeddedAusasElementDataStruct &rData,
         const ProcessInfo &rCurrentProcessInfo)
     {
+        const auto &r_geom = this->GetGeometry();
         constexpr unsigned int BlockSize = TDim + 1;
         constexpr unsigned int MatrixSize = TNumNodes * BlockSize;
-
-        array_1d<double, MatrixSize> prev_sol = ZeroVector(MatrixSize);
-        array_1d<double, MatrixSize> solution_jump = ZeroVector(MatrixSize);
-
-        // Obtain the previous iteration velocity solution
-        GetPreviousSolutionVector(rData, prev_sol);
-
-        // Compute the velocity diference to penalize
-        if (this->Has(EMBEDDED_VELOCITY)) {
-            const array_1d<double, 3> &embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-            array_1d<double, MatrixSize> aux_embedded_vel = ZeroVector(MatrixSize);
-
-            for (unsigned int i=0; i<TNumNodes; ++i) {
-                for (unsigned int comp=0; comp<TDim; ++comp) {
-                    aux_embedded_vel(i*BlockSize+comp) = embedded_vel(comp);
-                }
-            }
-
-            solution_jump = aux_embedded_vel - prev_sol;
-        } else {
-            solution_jump = - prev_sol;
-        }
 
         // Compute the penalty coefficient
         const double pen_coef = ComputePenaltyCoefficient(rData, rCurrentProcessInfo);
@@ -952,12 +935,16 @@ protected:
             // Compute and assemble the LHS contribution
             for (unsigned int i = 0; i < TNumNodes; ++i) {
                 for (unsigned int j = 0; j < TNumNodes; ++j) {
+                    const auto j_v = row(rData.v, j);
+                    const auto j_v_emb = r_geom[j].GetValue(EMBEDDED_VELOCITY);
                     for (unsigned int m = 0; m < TDim; ++m) {
                         const unsigned int row = i * BlockSize + m;
-
                         for (unsigned int n = 0; n < TDim; ++n) {
                             const unsigned int col = j * BlockSize + n;
-                            P_gamma(row, col) += pen_coef * w_gauss * aux_N(i) * side_normal(m) * side_normal(n) * aux_N(j);
+                            const double aux_val = pen_coef * w_gauss * aux_N(i) * side_normal(m) * side_normal(n) * aux_N(j);
+                            rLeftHandSideMatrix(row,col) += aux_val;
+                            rRightHandSideVector(row) -= aux_val * j_v(n);
+                            rRightHandSideVector(row) += aux_val * j_v_emb(n);
                         }
                     }
                 }
@@ -978,23 +965,21 @@ protected:
             // Compute and assemble the LHS contribution
             for (unsigned int i = 0; i < TNumNodes; ++i) {
                 for (unsigned int j = 0; j < TNumNodes; ++j) {
+                    const auto j_v = row(rData.v, j);
+                    const auto j_v_emb = r_geom[j].GetValue(EMBEDDED_VELOCITY);
                     for (unsigned int m = 0; m < TDim; ++m) {
                         const unsigned int row = i * BlockSize + m;
-
                         for (unsigned int n = 0; n < TDim; ++n) {
                             const unsigned int col = j * BlockSize + n;
-                            P_gamma(row, col) += pen_coef * w_gauss * aux_N(i) * side_normal(m) * side_normal(n) * aux_N(j);
+                            const double aux_val = pen_coef * w_gauss * aux_N(i) * side_normal(m) * side_normal(n) * aux_N(j);
+                            rLeftHandSideMatrix(row,col) += aux_val;
+                            rRightHandSideVector(row) -= aux_val * j_v(n);
+                            rRightHandSideVector(row) += aux_val * j_v_emb(n);
                         }
                     }
                 }
             }
         }
-
-        // LHS assembly
-        rLeftHandSideMatrix += P_gamma;
-
-        // RHS assembly
-        rRightHandSideVector += prod(P_gamma, solution_jump);
     }
 
     /**
@@ -1017,26 +1002,16 @@ protected:
         GetPreviousSolutionVector(rData, prev_sol);
 
         // Compute the velocity diference to penalize
-        if (this->Has(EMBEDDED_VELOCITY)) {
-            const array_1d<double, 3> &embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-            array_1d<double, MatrixSize> aux_embedded_vel = ZeroVector(MatrixSize);
-
-            for (unsigned int i=0; i<TNumNodes; ++i) {
-                for (unsigned int comp=0; comp<TDim; ++comp) {
-                    aux_embedded_vel(i*BlockSize+comp) = embedded_vel(comp);
-                }
+        const auto &r_geom = this->GetGeometry();
+        for (unsigned int i_node = 0; i_node < TNumNodes; ++i_node) {
+            const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+            for (unsigned int d = 0; d < TDim; ++d) {
+                prev_sol(i_node * BlockSize + d) -= r_i_emb_vel(d);
             }
-
-            solution_jump = aux_embedded_vel - prev_sol;
-        } else {
-            solution_jump = - prev_sol;
         }
 
         // Compute the penalty coefficient
         const double pen_coef = ComputePenaltyCoefficient(rData, rCurrentProcessInfo);
-
-        // Compute the RHS penalty contributions
-        array_1d<double, MatrixSize> P_gamma_RHS = ZeroVector(MatrixSize);
 
         // Contribution coming from the positive side penalty term
         const unsigned int n_int_pos_gauss = (rData.w_gauss_pos_int).size();
@@ -1055,7 +1030,7 @@ protected:
                     for (unsigned int m = 0; m < TDim; ++m) {
                         const unsigned int row = i * BlockSize + m;
                         for (unsigned int n = 0; n < TDim; ++n) {
-                            P_gamma_RHS(row) += pen_coef * w_gauss * aux_N(i) * side_normal(m) * side_normal(n) * aux_N(j) * solution_jump(row);
+                            rRightHandSideVector(row) -= pen_coef * w_gauss * aux_N(i) * side_normal(m) * side_normal(n) * aux_N(j) * solution_jump(row);
                         }
                     }
                 }
@@ -1079,123 +1054,12 @@ protected:
                     for (unsigned int m = 0; m < TDim; ++m) {
                         const unsigned int row = i * BlockSize + m;
                         for (unsigned int n = 0; n < TDim; ++n) {
-                            P_gamma_RHS(row) += pen_coef * w_gauss * aux_N(i) * side_normal(m) * side_normal(n) * aux_N(j) * solution_jump(row);
+                            rRightHandSideVector(row) -= pen_coef * w_gauss * aux_N(i) * side_normal(m) * side_normal(n) * aux_N(j) * solution_jump(row);
                         }
                     }
                 }
             }
         }
-
-        // RHS assembly
-        rRightHandSideVector += P_gamma_RHS;
-    }
-
-    /**
-    * This function adds the local system contribution of the no penetration imposition,
-    * by means of the pressure acting as a Lagrange multiplier.
-    * @param rLeftHandSideMatrix reference to the LHS matrix
-    * @param rRightHandSideVector reference to the RHS vector
-    * @param rData reference to element data structure
-    */
-    void AddSystemNormalVelocityLagrangeMultiplierContribution(
-        MatrixType &rLeftHandSideMatrix,
-        VectorType &rRightHandSideVector,
-        const EmbeddedAusasElementDataStruct &rData) {
-
-        constexpr unsigned int BlockSize = TDim + 1;
-        constexpr unsigned int MatrixSize = TNumNodes * BlockSize;
-
-        array_1d<double, MatrixSize> prev_sol = ZeroVector(MatrixSize);
-        array_1d<double, MatrixSize> solution_jump = ZeroVector(MatrixSize);
-
-        // Obtain the previous iteration velocity solution
-        GetPreviousSolutionVector(rData, prev_sol);
-
-        // Compute the velocity diference to penalize
-        if (this->Has(EMBEDDED_VELOCITY)) {
-            const array_1d<double, 3> &embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-            array_1d<double, MatrixSize> aux_embedded_vel = ZeroVector(MatrixSize);
-
-            for (unsigned int i=0; i<TNumNodes; ++i) {
-                for (unsigned int comp=0; comp<TDim; ++comp) {
-                    aux_embedded_vel(i*BlockSize+comp) = embedded_vel(comp);
-                }
-            }
-
-            solution_jump = prev_sol - aux_embedded_vel;
-        } else {
-            solution_jump = prev_sol;
-        }
-
-        // Compute the LHS and RHS penalty contributions
-        BoundedMatrix<double, MatrixSize, MatrixSize> auxLeftHandSideMatrix = ZeroMatrix(MatrixSize, MatrixSize);
-
-        // Drop the pressure rows and columns
-        for (unsigned int i=0; i<TNumNodes; ++i) {
-            const unsigned int aux = i*BlockSize + TDim;
-            for (unsigned int j=0; j<MatrixSize; ++j) {
-                rLeftHandSideMatrix(aux, j) = 0.0;
-                rLeftHandSideMatrix(j, aux) = 0.0;
-            }
-        }
-
-        // Contribution coming from the positive side Lagrange multiplier term
-        const unsigned int n_int_pos_gauss = (rData.w_gauss_pos_int).size();
-        for (unsigned int i_gauss = 0; i_gauss < n_int_pos_gauss; ++i_gauss) {
-            const double w_gauss = rData.w_gauss_pos_int(i_gauss);
-
-            // Get the positive side shape functions Gauss pt. values
-            const array_1d<double, TNumNodes> aux_N = row(rData.N_pos_int, i_gauss);
-
-            // Get the positive side Gauss pt. normal
-            const array_1d<double, 3> side_normal = rData.pos_int_unit_normals[i_gauss];
-
-            // Compute and assemble the LHS contribution
-            for (unsigned int i = 0; i < TNumNodes; ++i) {
-                const unsigned int row = i * BlockSize + TDim;
-
-                for (unsigned int j = 0; j < TNumNodes; ++j) {
-                    for (unsigned int m = 0; m < TDim; ++m) {
-                        const unsigned int col = j * BlockSize + m;
-                        const double aux_value = w_gauss * aux_N(i) * side_normal(m) * aux_N(j);
-                        auxLeftHandSideMatrix(row, col) += aux_value;
-                        auxLeftHandSideMatrix(col, row) += aux_value;
-                    }
-                }
-            }
-        }
-
-        // Contribution coming from the negative side Lagrange multiplier term
-        const unsigned int n_int_neg_gauss = (rData.w_gauss_neg_int).size();
-        for (unsigned int i_gauss = 0; i_gauss < n_int_neg_gauss; ++i_gauss) {
-            const double w_gauss = rData.w_gauss_neg_int(i_gauss);
-
-            // Get the negative side shape functions Gauss pt. values
-            const array_1d<double, TNumNodes> aux_N = row(rData.N_neg_int, i_gauss);
-
-            // Get the negative side Gauss pt. normal
-            const array_1d<double, 3> side_normal = rData.neg_int_unit_normals[i_gauss];
-
-            // Compute and assemble the LHS contribution
-            for (unsigned int i = 0; i < TNumNodes; ++i) {
-                const unsigned int row = i * BlockSize + TDim;
-
-                for (unsigned int j = 0; j < TNumNodes; ++j) {
-                    for (unsigned int m = 0; m < TDim; ++m) {
-                        const unsigned int col = j * BlockSize + m;
-                        const double aux_value = w_gauss * aux_N(i) * side_normal(m) * aux_N(j);
-                        auxLeftHandSideMatrix(row, col) += aux_value;
-                        auxLeftHandSideMatrix(col, row) += aux_value;
-                    }
-                }
-            }
-        }
-
-        // LHS assembly
-        rLeftHandSideMatrix += auxLeftHandSideMatrix;
-
-        // RHS assembly
-        rRightHandSideVector -= prod(auxLeftHandSideMatrix, solution_jump);
     }
 
     /**

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
@@ -439,15 +439,19 @@ protected:
         mpConstitutiveLaw->InitializeMaterial( GetProperties(), this->GetGeometry(), row( this->GetGeometry().ShapeFunctionsValues(), 0 ) );
 
         // Initialize the ELEMENTAL_DISTANCES variable (make it threadsafe)
-        Vector zero_vector(TNumNodes, 0.0);
-        this->SetValue(ELEMENTAL_DISTANCES, zero_vector);
+        if (!this->Has(ELEMENTAL_DISTANCES)) {
+            Vector zero_vector(TNumNodes, 0.0);
+            this->SetValue(ELEMENTAL_DISTANCES, zero_vector);
+        }
 
         // Initialize the nodal EMBEDDED_VELOCITY variable (make it threadsafe)
         const array_1d<double,3> zero_vel = ZeroVector(3);
         for (auto &r_node : this->GetGeometry()) {
-            r_node.SetLock();
-            r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
-            r_node.UnSetLock();
+            if (!r_node.Has(EMBEDDED_VELOCITY)) {
+                r_node.SetLock();
+                r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
+                r_node.UnSetLock();
+            }
         }
 
         KRATOS_CATCH("");

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.cpp
@@ -60,6 +60,25 @@ Element::Pointer EmbeddedFluidElement<TBaseElement>::Create(IndexType NewId,Geom
 }
 
 template <class TBaseElement>
+void EmbeddedFluidElement<TBaseElement>::Initialize()
+{
+    KRATOS_TRY;
+
+    // Call the base element initialize method to set the constitutive law
+    TBaseElement::Initialize();
+
+    // Initialize the nodal EMBEDDED_VELOCITY variable (make it threadsafe)
+    const array_1d<double,3> zero_vel = ZeroVector(3);
+    for (auto &r_node : this->GetGeometry()) {
+        r_node.SetLock();
+        r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
+        r_node.UnSetLock();
+    }
+
+    KRATOS_CATCH("");
+}
+
+template <class TBaseElement>
 void EmbeddedFluidElement<TBaseElement>::CalculateLocalSystem(
     MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector,
     ProcessInfo& rCurrentProcessInfo) {
@@ -210,11 +229,16 @@ void EmbeddedFluidElement<TBaseElement>::GetValueOnIntegrationPoints(
 {
     if (rVariable == EMBEDDED_VELOCITY) {
         const auto &r_geom = this->GetGeometry();
+        const auto &r_N_container = r_geom.ShapeFunctionsValues(this->GetIntegrationMethod());
         const auto &r_integration_points = r_geom.IntegrationPoints(this->GetIntegrationMethod());
         const std::size_t n_gauss_pts = r_integration_points.size();
         rValues.resize(n_gauss_pts);
         for (std::size_t i_gauss = 0; i_gauss < n_gauss_pts; ++i_gauss) {
-            rValues[i_gauss] = this->GetValue(EMBEDDED_VELOCITY);
+            const auto i_gauss_N = row(r_N_container, i_gauss);
+            rValues[i_gauss] = ZeroVector(3);
+            for (std::size_t i_node = 0; i_node < r_geom.PointsNumber(); ++i_node) {
+                rValues[i_gauss] += i_gauss_N[i_node] * r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+            }
         }
     } else {
         TBaseElement::GetValueOnIntegrationPoints(rVariable, rValues, rCurrentProcessInfo);
@@ -353,18 +377,13 @@ void EmbeddedFluidElement<TBaseElement>::AddSlipNormalPenaltyContribution(
     array_1d<double,LocalSize> values;
     this->GetCurrentValuesVector(rData,values);
 
-    // If there is embedded velocity, substract it to the previous iteration solution
-    if (this->Has(EMBEDDED_VELOCITY)) {
-        const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-        array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
-
-        for (unsigned int i = 0; i < NumNodes; ++i) {
-            for (unsigned int comp = 0; comp < Dim; ++comp) {
-                embedded_vel_exp(i*BlockSize + comp) = embedded_vel(comp);
-            }
+    // Substract the embedded nodal velocity to the previous iteration solution
+    const auto &r_geom = this->GetGeometry();
+    for (unsigned int i_node = 0; i_node < NumNodes; ++i_node) {
+        const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+        for (unsigned int d = 0; d < Dim; ++d) {
+            values(i_node * BlockSize + d) -= r_i_emb_vel(d);
         }
-
-        noalias(values) -= embedded_vel_exp;
     }
 
     // Compute the Nitsche normal imposition penalty coefficient
@@ -411,18 +430,13 @@ void EmbeddedFluidElement<TBaseElement>::AddSlipNormalSymmetricCounterpartContri
     array_1d<double,LocalSize> values;
     this->GetCurrentValuesVector(rData,values);
 
-    // If there is embedded velocity, substract it to the previous iteration solution
-    if (this->Has(EMBEDDED_VELOCITY)) {
-        const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-        array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
-
-        for (unsigned int i = 0; i < NumNodes; ++i) {
-            for (unsigned int comp = 0; comp < Dim; ++comp) {
-                embedded_vel_exp(i*BlockSize + comp) = embedded_vel(comp);
-            }
+    // Substract the embedded nodal velocity to the previous iteration solution
+    const auto &r_geom = this->GetGeometry();
+    for (unsigned int i_node = 0; i_node < NumNodes; ++i_node) {
+        const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+        for (unsigned int d = 0; d < Dim; ++d) {
+            values(i_node * BlockSize + d) -= r_i_emb_vel(d);
         }
-
-        noalias(values) -= embedded_vel_exp;
     }
 
     // Set if the shear stress term is adjoint consistent (1.0) or not (-1.0)
@@ -568,18 +582,16 @@ void EmbeddedFluidElement<TBaseElement>::AddSlipTangentialPenaltyContribution(
     noalias(rRHS) -= prod(aux_LHS_1, values);
     noalias(rRHS) -= prod(aux_LHS_2, values);
 
-    // If level set velocity is not 0, add its contribution to the RHS
-    if (this->Has(EMBEDDED_VELOCITY)) {
-        const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-        array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
-
-        for (unsigned int i = 0; i < NumNodes; ++i) {
-            for (unsigned int comp = 0; comp < Dim; ++comp) {
-                embedded_vel_exp(i*BlockSize + comp) = embedded_vel(comp);
-            }
+    // Add the level set velocity contribution to the RHS. Note that only LHS_2 is multiplied.
+    const auto &r_geom = this->GetGeometry();
+    array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
+    for (unsigned int i_node = 0; i_node < NumNodes; ++i_node) {
+        const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+        for (unsigned int d = 0; d < Dim; ++d) {
+            embedded_vel_exp(i_node * BlockSize + d) = r_i_emb_vel(d);
         }
-        noalias(rRHS) += prod(aux_LHS_2, embedded_vel_exp);
     }
+    noalias(rRHS) += prod(aux_LHS_2, embedded_vel_exp);
 }
 
 template <class TBaseElement>
@@ -655,19 +667,16 @@ void EmbeddedFluidElement<TBaseElement>::AddSlipTangentialSymmetricCounterpartCo
     noalias(rLHS) += aux_LHS_2;
 
     // RHS outside Nitsche contribution assembly
-    // If level set velocity is not 0, add its contribution to the RHS
-    if (this->Has(EMBEDDED_VELOCITY)) {
-        const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-        array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
-
-        for (unsigned int i = 0; i < NumNodes; ++i) {
-            for (unsigned int comp = 0; comp < Dim; ++comp) {
-                embedded_vel_exp(i*BlockSize + comp) = embedded_vel(comp);
-            }
+    // Add the level set velocity contribution to the RHS. Note that only LHS_2 is multiplied.
+    const auto &r_geom = this->GetGeometry();
+    array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
+    for (unsigned int i_node = 0; i_node < NumNodes; ++i_node) {
+        const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+        for (unsigned int d = 0; d < Dim; ++d) {
+            embedded_vel_exp(i_node * BlockSize + d) = r_i_emb_vel(d);
         }
-
-        noalias(rRHS) += prod(aux_LHS_2, embedded_vel_exp);
     }
+    noalias(rRHS) += prod(aux_LHS_2, embedded_vel_exp);
 
     // Note that since we work with a residualbased formulation, the RHS is f_gamma - LHS*prev_sol
     noalias(rRHS) -= prod(aux_LHS_1, values);
@@ -745,6 +754,15 @@ void EmbeddedFluidElement<TBaseElement>::AddBoundaryConditionPenaltyContribution
     array_1d<double,LocalSize> values;
     this->GetCurrentValuesVector(rData,values);
 
+    // Substract the embedded nodal velocity to the previous iteration solution
+    const auto &r_geom = this->GetGeometry();
+    for (unsigned int i_node = 0; i_node < NumNodes; ++i_node) {
+        const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+        for (unsigned int d = 0; d < Dim; ++d) {
+            values(i_node * BlockSize + d) -= r_i_emb_vel(d);
+        }
+    }
+
     // Set the penalty matrix
     BoundedMatrix<double,NumNodes,NumNodes> p_gamma = ZeroMatrix(NumNodes, NumNodes);
 
@@ -778,22 +796,6 @@ void EmbeddedFluidElement<TBaseElement>::AddBoundaryConditionPenaltyContribution
     }
 
     noalias(rLHS) += penalty_lhs;
-
-    // RHS penalty contribution assembly
-    if (this->Has(EMBEDDED_VELOCITY)) {
-        VectorType penalty_rhs = ZeroVector(LocalSize);
-        const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-        array_1d<double, LocalSize> aux_embedded_vel = ZeroVector(LocalSize);
-
-        for (unsigned int i=0; i<NumNodes; i++) {
-            for (unsigned int comp=0; comp<Dim; comp++) {
-                aux_embedded_vel(i*BlockSize+comp) = embedded_vel(comp);
-            }
-        }
-
-        noalias(rRHS) += prod(penalty_lhs, aux_embedded_vel);
-    }
-
     noalias(rRHS) -= prod(penalty_lhs, values); // Residual contribution assembly
 }
 
@@ -939,32 +941,27 @@ void EmbeddedFluidElement<TBaseElement>::AddBoundaryConditionModifiedNitscheCont
     // Note that since we work with a residualbased formulation, the RHS is f_gamma - LHS*prev_sol
     noalias(rRHS) -= prod(nitsche_lhs, values);
 
-    // Compute f_gamma if level set velocity is not 0
-    if (this->Has(EMBEDDED_VELOCITY)) {
-        nitsche_lhs.clear();
-
-        const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-        array_1d<double, LocalSize> aux_embedded_vel = ZeroVector(LocalSize);
-
-        for (unsigned int i=0; i<NumNodes; i++) {
-            aux_embedded_vel(i*BlockSize) = embedded_vel(0);
-            aux_embedded_vel(i*BlockSize+1) = embedded_vel(1);
-            aux_embedded_vel(i*BlockSize+2) = embedded_vel(2);
+    // Compute and assemble f_gamma (EMBEDDED_VELOCITY) contribution to the RHS
+    const auto &r_geom = this->GetGeometry();
+    array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
+    for (unsigned int i_node = 0; i_node < NumNodes; ++i_node) {
+        const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+        for (unsigned int d = 0; d < Dim; ++d) {
+            embedded_vel_exp(i_node * BlockSize + d) = r_i_emb_vel(d);
         }
+    }
 
-        // Asemble the RHS f_gamma contribution
-        for (unsigned int i=0; i<rData.NumNegativeNodes; i++) {
-            unsigned int out_node_row_id = rData.NegativeIndices[i];
-
-            for (unsigned int j=0; j<NumNodes; j++) {
-                for (unsigned int comp = 0; comp<Dim; comp++) {
-                    nitsche_lhs(out_node_row_id*BlockSize+comp, j*BlockSize+comp) = f_gamma(i,j);
-                }
+    nitsche_lhs.clear();
+    for (unsigned int i=0; i<rData.NumNegativeNodes; i++) {
+        unsigned int out_node_row_id = rData.NegativeIndices[i];
+        for (unsigned int j=0; j<NumNodes; j++) {
+            for (unsigned int comp = 0; comp<Dim; comp++) {
+                nitsche_lhs(out_node_row_id*BlockSize+comp, j*BlockSize+comp) = f_gamma(i,j);
             }
         }
-
-        noalias(rRHS) += prod(nitsche_lhs, aux_embedded_vel);
     }
+
+    noalias(rRHS) += prod(nitsche_lhs, embedded_vel_exp);
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.cpp
@@ -70,9 +70,11 @@ void EmbeddedFluidElement<TBaseElement>::Initialize()
     // Initialize the nodal EMBEDDED_VELOCITY variable (make it threadsafe)
     const array_1d<double,3> zero_vel = ZeroVector(3);
     for (auto &r_node : this->GetGeometry()) {
-        r_node.SetLock();
-        r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
-        r_node.UnSetLock();
+        if (!r_node.Has(EMBEDDED_VELOCITY)) {
+            r_node.SetLock();
+            r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
+            r_node.UnSetLock();
+        }
     }
 
     KRATOS_CATCH("");

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.h
@@ -171,6 +171,11 @@ public:
                             Geometry<NodeType>::Pointer pGeom,
                             Properties::Pointer pProperties) const override;
 
+    /// Set up the element for solution.
+    /** For EmbeddedFluidElement, this initializes the nodal imposed velocity (EMBEDDED_VELOCITY)
+     */
+    void Initialize() override;
+
     /// Calculates both LHS and RHS contributions
     /**
      * Computes the LHS and RHS elementar matrices. If the element is split

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
@@ -74,15 +74,19 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::Initialize()
     TBaseElement::Initialize();
 
     // Initialize the ELEMENTAL_DISTANCES variable (make it threadsafe)
-    Vector zero_vector(NumNodes, 0.0);
-    this->SetValue(ELEMENTAL_DISTANCES, zero_vector);
+    if (!this->Has(ELEMENTAL_DISTANCES)) {
+        Vector zero_vector(NumNodes, 0.0);
+        this->SetValue(ELEMENTAL_DISTANCES, zero_vector);
+    }
 
     // Initialize the nodal EMBEDDED_VELOCITY variable (make it threadsafe)
     const array_1d<double,3> zero_vel = ZeroVector(3);
     for (auto &r_node : this->GetGeometry()) {
-        r_node.SetLock();
-        r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
-        r_node.UnSetLock();
+        if (!r_node.Has(EMBEDDED_VELOCITY)) {
+            r_node.SetLock();
+            r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
+            r_node.UnSetLock();
+        }
     }
 
     KRATOS_CATCH("");

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
@@ -66,6 +66,29 @@ Element::Pointer EmbeddedFluidElementDiscontinuous<TBaseElement>::Create(
 }
 
 template <class TBaseElement>
+void EmbeddedFluidElementDiscontinuous<TBaseElement>::Initialize()
+{
+    KRATOS_TRY;
+
+    // Call the base element initialize method to set the constitutive law
+    TBaseElement::Initialize();
+
+    // Initialize the ELEMENTAL_DISTANCES variable (make it threadsafe)
+    Vector zero_vector(NumNodes, 0.0);
+    this->SetValue(ELEMENTAL_DISTANCES, zero_vector);
+
+    // Initialize the nodal EMBEDDED_VELOCITY variable (make it threadsafe)
+    const array_1d<double,3> zero_vel = ZeroVector(3);
+    for (auto &r_node : this->GetGeometry()) {
+        r_node.SetLock();
+        r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
+        r_node.UnSetLock();
+    }
+
+    KRATOS_CATCH("");
+}
+
+template <class TBaseElement>
 void EmbeddedFluidElementDiscontinuous<TBaseElement>::CalculateLocalSystem(
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
@@ -385,18 +408,13 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::AddNormalPenaltyContributi
     array_1d<double,LocalSize> values;
     this->GetCurrentValuesVector(rData, values);
 
-    // If there is embedded velocity, substract it to the previous iteration solution
-    if (this->Has(EMBEDDED_VELOCITY)){
-        const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-        array_1d<double, LocalSize> embedded_vel_exp(LocalSize, 0.0);
-
-        for (unsigned int i = 0; i < NumNodes; ++i){
-            for (unsigned int comp = 0; comp < Dim; ++comp){
-                embedded_vel_exp(i*BlockSize + comp) = embedded_vel(comp);
-            }
+    // Substract the embedded nodal velocity to the previous iteration solution
+    const auto &r_geom = this->GetGeometry();
+    for (unsigned int i_node = 0; i_node < NumNodes; ++i_node) {
+        const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+        for (unsigned int d = 0; d < Dim; ++d) {
+            values(i_node * BlockSize + d) -= r_i_emb_vel(d);
         }
-
-        noalias(values) -= embedded_vel_exp;
     }
 
     // Compute the Nitsche normal imposition penalty coefficient
@@ -461,18 +479,13 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::AddNormalSymmetricCounterp
     array_1d<double,LocalSize> values;
     this->GetCurrentValuesVector(rData,values);
 
-    // If there is embedded velocity, substract it to the previous iteration solution
-    if (this->Has(EMBEDDED_VELOCITY)) {
-        const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-        array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
-
-        for (unsigned int i = 0; i < NumNodes; ++i) {
-            for (unsigned int comp = 0; comp < Dim; ++comp) {
-                embedded_vel_exp(i*BlockSize + comp) = embedded_vel(comp);
-            }
+    // Substract the embedded nodal velocity to the previous iteration solution
+    const auto &r_geom = this->GetGeometry();
+    for (unsigned int i_node = 0; i_node < NumNodes; ++i_node) {
+        const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+        for (unsigned int d = 0; d < Dim; ++d) {
+            values(i_node * BlockSize + d) -= r_i_emb_vel(d);
         }
-
-        noalias(values) -= embedded_vel_exp;
     }
 
     // Set if the shear stress term is adjoint consistent (1.0) or not (-1.0)
@@ -701,18 +714,16 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::AddTangentialPenaltyContri
     noalias(rRHS) -= prod(aux_LHS_1, values);
     noalias(rRHS) -= prod(aux_LHS_2, values);
 
-    // If level set velocity is not 0, add its contribution to the RHS
-    if (this->Has(EMBEDDED_VELOCITY)) {
-        const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-        array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
-
-        for (unsigned int i = 0; i < NumNodes; ++i) {
-            for (unsigned int comp = 0; comp < Dim; ++comp) {
-                embedded_vel_exp(i*BlockSize + comp) = embedded_vel(comp);
-            }
+    // Add the level set velocity contribution to the RHS. Note that only LHS_2 is multiplied.
+    const auto &r_geom = this->GetGeometry();
+    array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
+    for (unsigned int i_node = 0; i_node < NumNodes; ++i_node) {
+        const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+        for (unsigned int d = 0; d < Dim; ++d) {
+            embedded_vel_exp(i_node * BlockSize + d) = r_i_emb_vel(d);
         }
-        noalias(rRHS) += prod(aux_LHS_2, embedded_vel_exp);
     }
+    noalias(rRHS) += prod(aux_LHS_2, embedded_vel_exp);
 }
 
 template <class TBaseElement>
@@ -826,19 +837,16 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::AddTangentialSymmetricCoun
     noalias(rLHS) += aux_LHS_2;
 
     // RHS outside Nitsche contribution assembly
-    // If level set velocity is not 0, add its contribution to the RHS
-    if (this->Has(EMBEDDED_VELOCITY)) {
-        const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-        array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
-
-        for (unsigned int i = 0; i < NumNodes; ++i) {
-            for (unsigned int comp = 0; comp < Dim; ++comp) {
-                embedded_vel_exp(i*BlockSize + comp) = embedded_vel(comp);
-            }
+    // Add the level set velocity contribution to the RHS. Note that only LHS_2 is multiplied.
+    const auto &r_geom = this->GetGeometry();
+    array_1d<double, LocalSize> embedded_vel_exp = ZeroVector(LocalSize);
+    for (unsigned int i_node = 0; i_node < NumNodes; ++i_node) {
+        const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+        for (unsigned int d = 0; d < Dim; ++d) {
+            embedded_vel_exp(i_node * BlockSize + d) = r_i_emb_vel(d);
         }
-
-        noalias(rRHS) += prod(aux_LHS_2, embedded_vel_exp);
     }
+    noalias(rRHS) += prod(aux_LHS_2, embedded_vel_exp);
 
     // Note that since we work with a residualbased formulation, the RHS is f_gamma - LHS*prev_sol
     noalias(rRHS) -= prod(aux_LHS_1, values);

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.h
@@ -171,6 +171,12 @@ public:
                             Geometry<NodeType>::Pointer pGeom,
                             Properties::Pointer pProperties) const override;
 
+    /// Set up the element for solution.
+    /** For EmbeddedFluidElementDiscontinuous, this initializes the discontinuous
+     * level set (ELEMENTAL_DISTANCES) and the nodal imposed velocity (EMBEDDED_VELOCITY)
+     */
+    void Initialize() override;
+
     /// Calculates both LHS and RHS contributions
     /**
      * Computes the LHS and RHS elementar matrices. If the element is split
@@ -292,7 +298,7 @@ protected:
     void InitializeGeometryData(EmbeddedDiscontinuousElementData& rData) const;
 
     /**
-     * @brief Non-intersected element geometry data fill 
+     * @brief Non-intersected element geometry data fill
      * This method sets the data structure geometry fields (shape functions, gradients, ...) for a non-intersected element.
      * @param rData reference to the element data structure
      */
@@ -300,7 +306,7 @@ protected:
 
     /**
      * @brief Intersected element geometry data fill
-     * This method sets the data structure geometry fields (shape functions, gradients, interface normals, ...) for an 
+     * This method sets the data structure geometry fields (shape functions, gradients, interface normals, ...) for an
      * intersected element. To do that, the modified shape functions utility is firstly created and then called to perform
      * all operations in both the positive and negative sides of the element.
      * @param rData reference to the element data structure

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_navier_stokes.h
@@ -646,6 +646,15 @@ protected:
         array_1d<double, MatrixSize> prev_sol = ZeroVector(MatrixSize);
         GetPreviousSolutionVector(rData, prev_sol);
 
+        // Substract the embedded nodal velocity to the previous iteration solution
+        const auto &r_geom = this->GetGeometry();
+        for (unsigned int i_node = 0; i_node < TNumNodes; ++i_node) {
+            const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+            for (unsigned int d = 0; d < TDim; ++d) {
+                prev_sol(i_node * BlockSize + d) -= r_i_emb_vel(d);
+            }
+        }
+
         // Set the penalty matrix
         MatrixType P_gamma(TNumNodes, TNumNodes);
         noalias(P_gamma) = ZeroMatrix(TNumNodes, TNumNodes);
@@ -681,21 +690,6 @@ protected:
         }
 
         noalias(rLeftHandSideMatrix) += auxLeftHandSideMatrix;
-
-        // RHS penalty contribution assembly
-        if (this->Has(EMBEDDED_VELOCITY)) {
-            const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-            array_1d<double, MatrixSize> aux_embedded_vel = ZeroVector(MatrixSize);
-
-            for (unsigned int i=0; i<TNumNodes; i++) {
-                for (unsigned int comp=0; comp<TDim; comp++) {
-                    aux_embedded_vel(i*BlockSize+comp) = embedded_vel(comp);
-                }
-            }
-
-            noalias(rRightHandSideVector) += prod(auxLeftHandSideMatrix, aux_embedded_vel);
-        }
-
         noalias(rRightHandSideVector) -= prod(auxLeftHandSideMatrix, prev_sol); // Residual contribution assembly
     }
 
@@ -784,31 +778,29 @@ protected:
         // Note that since we work with a residualbased formulation, the RHS is f_gamma - LHS*prev_sol
         noalias(rRightHandSideVector) -= prod(auxLeftHandSideMatrix, prev_sol);
 
-        // Compute f_gamma if level set velocity is not 0
-        if (this->Has(EMBEDDED_VELOCITY)) {
-            auxLeftHandSideMatrix.clear();
+        // Compute the level set velocity contribution
+        const auto &r_geom = this->GetGeometry();
+        for (unsigned int i_gauss = 0; i_gauss < n_gauss_total; ++i_gauss) {
+            // Current Gauss pt. intersection data
+            const auto N_cut = row(rData.N_pos_int, i_gauss);
+            const double weight = rData.w_gauss_pos_int(i_gauss);
 
-            const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-            array_1d<double, MatrixSize> aux_embedded_vel = ZeroVector(MatrixSize);
-
-            for (unsigned int i=0; i<TNumNodes; i++) {
-                aux_embedded_vel(i*BlockSize) = embedded_vel(0);
-                aux_embedded_vel(i*BlockSize+1) = embedded_vel(1);
-                aux_embedded_vel(i*BlockSize+2) = embedded_vel(2);
+            // Current Gauss pt. EMBEDDED_VELOCITY
+            array_1d<double,3> aux_emb_v = ZeroVector(3);
+            for (unsigned int i_node = 0; i_node < r_geom.PointsNumber(); ++i_node) {
+                aux_emb_v += N_cut(i_node) * r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
             }
 
-            // Asemble the RHS f_gamma contribution
-            for (unsigned int i=0; i<rData.n_neg; i++) {
-                unsigned int out_node_row_id = rData.out_vec_identifiers[i];
-
-                for (unsigned int j=0; j<TNumNodes; j++) {
-                    for (unsigned int comp = 0; comp<TDim; comp++) {
-                        auxLeftHandSideMatrix(out_node_row_id*BlockSize+comp, j*BlockSize+comp) = f_gamma(i,j);
+            // Assemble current Gauss pt. contribution
+            for (unsigned int i = 0; i < rData.n_neg; ++i) {
+                const unsigned int i_out_node_id = rData.out_vec_identifiers[i];
+                for (unsigned int j = 0; j < TNumNodes; ++j) {
+                    const double aux = weight * N_cut(i_out_node_id) * N_cut(j);
+                    for (unsigned int d = 0; d < TDim; ++d) {
+                        rRightHandSideVector(i_out_node_id * BlockSize + d) += aux * aux_emb_v(d);
                     }
                 }
             }
-
-            noalias(rRightHandSideVector) += prod(auxLeftHandSideMatrix, aux_embedded_vel);
         }
     }
 
@@ -861,6 +853,15 @@ protected:
         array_1d<double, MatrixSize> prev_sol = ZeroVector(MatrixSize);
         GetPreviousSolutionVector(rData, prev_sol);
 
+        // Substract the embedded nodal velocity to the previous iteration solution
+        const auto &r_geom = this->GetGeometry();
+        for (unsigned int i_node = 0; i_node < TNumNodes; ++i_node) {
+            const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+            for (unsigned int d = 0; d < TDim; ++d) {
+                prev_sol(i_node * BlockSize + d) -= r_i_emb_vel(d);
+            }
+        }
+
         // Nitsche coefficient computation
         const double eff_mu = BaseType::ComputeEffectiveViscosity(rData);
 
@@ -888,9 +889,7 @@ protected:
         const double cons_coef = (eff_mu + eff_mu + avg_rho*v_norm*rData.h + avg_rho*rData.h*rData.h/rData.dt)/(rData.h*penalty);
 
         // Declare auxiliar arrays
-        array_1d<double, MatrixSize> auxRightHandSideVector = ZeroVector(MatrixSize);
         BoundedMatrix<double, MatrixSize, MatrixSize> auxLeftHandSideMatrix = ZeroMatrix(MatrixSize, MatrixSize);
-
         const unsigned int n_gauss_total = (rData.w_gauss_pos_int).size();
 
         for (unsigned int i_gauss_int = 0; i_gauss_int < n_gauss_total; ++i_gauss_int) {
@@ -918,26 +917,11 @@ protected:
             noalias(auxLeftHandSideMatrix) += cons_coef*weight*aux_2;
         }
 
-        // If level set velocity is not 0, add its contribution to the RHS
-        if (this->Has(EMBEDDED_VELOCITY)) {
-            const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-            array_1d<double, MatrixSize> embedded_vel_exp = ZeroVector(MatrixSize);
-
-            for (unsigned int i=0; i<TNumNodes; ++i) {
-                for (unsigned int comp=0; comp<TDim; ++comp) {
-                    embedded_vel_exp(i*BlockSize+comp) = embedded_vel(comp);
-                }
-            }
-
-            noalias(auxRightHandSideVector) += prod(auxLeftHandSideMatrix, embedded_vel_exp);
-        }
-
         // LHS outside Nitche contribution assembly
         noalias(rLeftHandSideMatrix) += auxLeftHandSideMatrix;
 
         // RHS outside Nitche contribution assembly
         // Note that since we work with a residualbased formulation, the RHS is f_gamma - LHS*prev_sol
-        noalias(rRightHandSideVector) += auxRightHandSideVector;
         noalias(rRightHandSideVector) -= prod(auxLeftHandSideMatrix, prev_sol);
     }
 
@@ -959,13 +943,20 @@ protected:
         array_1d<double, MatrixSize> prev_sol = ZeroVector(MatrixSize);
         GetPreviousSolutionVector(rData, prev_sol);
 
+        // Substract the embedded nodal velocity to the previous iteration solution
+        const auto &r_geom = this->GetGeometry();
+        for (unsigned int i_node = 0; i_node < TNumNodes; ++i_node) {
+            const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+            for (unsigned int d = 0; d < TDim; ++d) {
+                prev_sol(i_node * BlockSize + d) -= r_i_emb_vel(d);
+            }
+        }
+
         // Set if the shear stress term is adjoint consistent (1.0) or not (-1.0)
         const double adjoint_consistency_term = -1.0;
 
         // Declare auxiliar arrays
-        array_1d<double, MatrixSize> auxRightHandSideVector = ZeroVector(MatrixSize);
         BoundedMatrix<double, MatrixSize, MatrixSize> auxLeftHandSideMatrix = ZeroMatrix(MatrixSize, MatrixSize);
-
         const unsigned int n_gauss_total = (rData.w_gauss_pos_int).size();
 
         for (unsigned int i_gauss_int = 0; i_gauss_int < n_gauss_total; ++i_gauss_int) {
@@ -1021,22 +1012,6 @@ protected:
         noalias(rLeftHandSideMatrix) -= auxLeftHandSideMatrix; // The minus sign comes from the Nitsche formulation
 
         // RHS outside Nitche contribution assembly
-        // If level set velocity is not 0, add its contribution to the RHS
-        if (this->Has(EMBEDDED_VELOCITY)) {
-            const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-            array_1d<double, MatrixSize> embedded_vel_exp = ZeroVector(MatrixSize);
-
-            for (unsigned int i=0; i<TNumNodes; ++i) {
-                for (unsigned int comp=0; comp<TDim; ++comp) {
-                    embedded_vel_exp(i*BlockSize+comp) = embedded_vel(comp);
-                }
-            }
-
-            noalias(auxRightHandSideVector) += prod(auxLeftHandSideMatrix, embedded_vel_exp);
-        }
-
-        // Note that since we work with a residualbased formulation, the RHS is f_gamma - LHS*prev_sol
-        noalias(rRightHandSideVector) -= auxRightHandSideVector;
         noalias(rRightHandSideVector) += prod(auxLeftHandSideMatrix, prev_sol);
     }
 
@@ -1119,23 +1094,20 @@ protected:
 
         // RHS outside Nitche contribution assembly
         // If level set velocity is not 0, add its contribution to the RHS
-        if (this->Has(EMBEDDED_VELOCITY)) {
-            const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-            array_1d<double, MatrixSize> embedded_vel_exp = ZeroVector(MatrixSize);
-
-            for (unsigned int i=0; i<TNumNodes; ++i) {
-                for (unsigned int comp=0; comp<TDim; ++comp) {
-                    embedded_vel_exp(i*BlockSize+comp) = embedded_vel(comp);
-                }
+        const auto &r_geom = this->GetGeometry();
+        array_1d<double, MatrixSize> embedded_vel_exp = ZeroVector(MatrixSize);
+        for (unsigned int i_node = 0; i_node < TNumNodes; ++i_node) {
+            const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+            for (unsigned int d = 0; d < TDim; ++d) {
+                embedded_vel_exp(i_node * BlockSize + d) -= r_i_emb_vel(d);
             }
-
-            noalias(auxRightHandSideVector) += prod(auxLeftHandSideMatrix_2, embedded_vel_exp);
         }
 
         // Note that since we work with a residualbased formulation, the RHS is f_gamma - LHS*prev_sol
         noalias(rRightHandSideVector) += auxRightHandSideVector;
         noalias(rRightHandSideVector) -= prod(auxLeftHandSideMatrix_1, prev_sol);
         noalias(rRightHandSideVector) -= prod(auxLeftHandSideMatrix_2, prev_sol);
+        noalias(auxRightHandSideVector) += prod(auxLeftHandSideMatrix_2, embedded_vel_exp);
     }
 
     /**
@@ -1222,23 +1194,20 @@ protected:
 
         // RHS outside Nitche contribution assembly
         // If level set velocity is not 0, add its contribution to the RHS
-        if (this->Has(EMBEDDED_VELOCITY)) {
-            const array_1d<double, 3 >& embedded_vel = this->GetValue(EMBEDDED_VELOCITY);
-            array_1d<double, MatrixSize> embedded_vel_exp = ZeroVector(MatrixSize);
-
-            for (unsigned int i=0; i<TNumNodes; ++i) {
-                for (unsigned int comp=0; comp<TDim; ++comp) {
-                    embedded_vel_exp(i*BlockSize+comp) = embedded_vel(comp);
-                }
+        const auto &r_geom = this->GetGeometry();
+        array_1d<double, MatrixSize> embedded_vel_exp = ZeroVector(MatrixSize);
+        for (unsigned int i_node = 0; i_node < TNumNodes; ++i_node) {
+            const auto &r_i_emb_vel = r_geom[i_node].GetValue(EMBEDDED_VELOCITY);
+            for (unsigned int d = 0; d < TDim; ++d) {
+                embedded_vel_exp(i_node * BlockSize + d) -= r_i_emb_vel(d);
             }
-
-            noalias(auxRightHandSideVector) += prod(auxLeftHandSideMatrix_2, embedded_vel_exp);
         }
 
         // Note that since we work with a residualbased formulation, the RHS is f_gamma - LHS*prev_sol
         noalias(rRightHandSideVector) -= auxRightHandSideVector;
         noalias(rRightHandSideVector) += prod(auxLeftHandSideMatrix_1, prev_sol);
         noalias(rRightHandSideVector) += prod(auxLeftHandSideMatrix_2, prev_sol);
+        noalias(auxRightHandSideVector) -= prod(auxLeftHandSideMatrix_2, embedded_vel_exp);
     }
 
     /**

--- a/applications/FluidDynamicsApplication/tests/EmbeddedPiston2DTest/EmbeddedPiston2DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedPiston2DTest/EmbeddedPiston2DTestParameters.json
@@ -31,7 +31,7 @@
                         "skin_output"         : false,
                         "plane_output"        : [],
                         "nodal_results"       : ["VELOCITY","PRESSURE","DISTANCE","MESH_VELOCITY"],
-                        "gauss_point_results" : ["EMBEDDED_VELOCITY"]
+                        "nodal_nonhistorical_results": ["EMBEDDED_VELOCITY"]
                     },
                     "point_data_configuration"  : []
                 }

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element.cpp
@@ -91,6 +91,12 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     model_part.CreateNewElement("TimeIntegratedQSVMS2D3N", 5, element_nodes, p_properties);
     model_part.CreateNewElement("EmbeddedQSVMS2D3N", 6, element_nodes, p_properties);
 
+    // Call the elements Initialize()
+    for (auto &r_elem : model_part.Elements()) {
+        r_elem.Initialize(); // Initialize the element to initialize the constitutive law
+        r_elem.Check(model_part.GetProcessInfo()); // Otherwise the constitutive law is not seen here
+    }
+
     // Define the nodal values
     Matrix reference_velocity(3,2);
     reference_velocity(0,0) = 0.0; reference_velocity(0,1) = 0.1;
@@ -134,8 +140,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     p_element->GetGeometry()[2].FastGetSolutionStepValue(DISTANCE) = 1.0;
 
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); i++) {
-        i->Initialize(); // Initialize the element to initialize the constitutive law
-        i->Check(model_part.GetProcessInfo()); // Otherwise the constitutive law is not seen here
         i->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
         // std::cout << i->Info() << std::setprecision(10) << std::endl;
@@ -164,7 +168,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
 
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); i++) {
         i->Set(SLIP, false);
-        i->Initialize(); // Initialize the element to initialize the constitutive law
         i->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
         //std::cout << i->Info() << std::setprecision(10) << std::endl;
@@ -191,7 +194,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     model_part.GetProcessInfo().SetValue(PENALTY_COEFFICIENT, 10.0);
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); ++i) {
         i->Set(SLIP, true);
-        i->Initialize(); // Initialize the element to initialize the constitutive law
         i->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
         //std::cout << i->Info() << std::setprecision(10) << std::endl;
@@ -220,10 +222,13 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     embedded_vel(1) = 2.0;
     embedded_vel(2) = 0.0;
 
+    // Set the nodal EMBEDDED_VELOCITY
+    for (auto &r_node : model_part.Nodes()) {
+        r_node.SetValue(EMBEDDED_VELOCITY, embedded_vel);
+    }
+
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); i++) {
         i->Set(SLIP, false);
-        i->SetValue(EMBEDDED_VELOCITY, embedded_vel);
-        i->Initialize(); // Initialize the element to initialize the constitutive law
         i->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
         //std::cout << i->Info() << std::setprecision(12) << std::endl;
@@ -245,13 +250,16 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     output_slip_embedded_velocity[5] = {-7.93660736037, 7100.52460294, 0.0250586369081, 6.05364431844, 7081.38462907, 0.121191652293, 25.4246297086, 28410.3594884, 0.420416377466}; // EmbeddedQSVMS
     counter = 0;
 
+    // Set the nodal EMBEDDED_VELOCITY
+    for (auto &r_node : model_part.Nodes()) {
+        r_node.SetValue(EMBEDDED_VELOCITY, embedded_vel);
+    }
+
     // Test slip cut element with embedded velocity
     model_part.GetProcessInfo().SetValue(SLIP_LENGTH, 1.0e+08);
     model_part.GetProcessInfo().SetValue(PENALTY_COEFFICIENT, 10.0);
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); i++) {
         i->Set(SLIP, true);
-        i->SetValue(EMBEDDED_VELOCITY, embedded_vel);
-        i->Initialize(); // Initialize the element to initialize the constitutive law
         i->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
         //std::cout << i->Info() << std::setprecision(12) << std::endl;

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element_discontinuous.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element_discontinuous.cpp
@@ -86,6 +86,12 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElementDiscontinuous2D3N, FluidDynamicsApplica
     model_part.CreateNewElement("EmbeddedSymbolicNavierStokesDiscontinuous2D3N", 1, element_nodes, p_properties);
     model_part.CreateNewElement("EmbeddedQSVMSDiscontinuous2D3N", 2, element_nodes, p_properties);
 
+    // Call the elements Initialize()
+    for (auto &r_elem : model_part.Elements()) {
+        r_elem.Initialize(); // Initialize the element to initialize the constitutive law
+        r_elem.Check(model_part.GetProcessInfo()); // Otherwise the constitutive law is not seen here
+    }
+
     // Define the nodal values
     Matrix reference_velocity(3,2);
     reference_velocity(0,0) = 0.0; reference_velocity(0,1) = 0.1;
@@ -129,8 +135,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElementDiscontinuous2D3N, FluidDynamicsApplica
     }
 
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); i++) {
-        i->Initialize(); // Initialize the element to initialize the constitutive law
-        i->Check(model_part.GetProcessInfo()); // Otherwise the constitutive law is not seen here
         i->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
         // std::cout << i->Info() << std::setprecision(10) << std::endl;
@@ -155,15 +159,11 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElementDiscontinuous2D3N, FluidDynamicsApplica
     for (auto it_elem = model_part.ElementsBegin(); it_elem != model_part.ElementsEnd(); ++it_elem) {
         it_elem->SetValue(ELEMENTAL_DISTANCES, elem_dist);
     }
-    p_element->GetGeometry()[0].FastGetSolutionStepValue(DISTANCE) = -1.0;
-    p_element->GetGeometry()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
-    p_element->GetGeometry()[2].FastGetSolutionStepValue(DISTANCE) =  0.5;
 
     model_part.GetProcessInfo().SetValue(SLIP_LENGTH, 0.0);
     model_part.GetProcessInfo().SetValue(PENALTY_COEFFICIENT, 10.0);
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); i++) {
         i->Set(SLIP, false);
-        i->Initialize(); // Initialize the element to initialize the constitutive law
         i->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
         // std::cout << i->Info() << std::setprecision(10) << std::endl;
@@ -186,7 +186,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElementDiscontinuous2D3N, FluidDynamicsApplica
     model_part.GetProcessInfo().SetValue(PENALTY_COEFFICIENT, 10.0);
     for (ModelPart::ElementIterator i = model_part.ElementsBegin(); i != model_part.ElementsEnd(); ++i) {
         i->Set(SLIP, true);
-        i->Initialize(); // Initialize the element to initialize the constitutive law
         i->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
         // std::cout << i->Info() << std::setprecision(10) << std::endl;

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_navier_stokes_element.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_navier_stokes_element.cpp
@@ -51,7 +51,6 @@ namespace Kratos {
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
 			modelPart.AddNodalSolutionStepVariable(VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(MESH_VELOCITY);
-			modelPart.AddNodalSolutionStepVariable(EMBEDDED_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(EXTERNAL_PRESSURE);
 
 			// Process info creation
@@ -93,7 +92,12 @@ namespace Kratos {
 				it_node->FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = pElemProp->GetValue(DYNAMIC_VISCOSITY);
 			}
 
+			array_1d<double, 3> embedded_vel;
+			embedded_vel(0) = 1.0;
+			embedded_vel(1) = 2.0;
+			embedded_vel(2) = 0.0;
 			for(unsigned int i=0; i<3; i++){
+				pElement->GetGeometry()[i].SetValue(EMBEDDED_VELOCITY, embedded_vel);
 				pElement->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE)    = 0.0;
 				pElement->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 1) = 0.0;
 				pElement->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 2) = 0.0;
@@ -109,11 +113,6 @@ namespace Kratos {
 			pElement->GetGeometry()[0].FastGetSolutionStepValue(DISTANCE) = -1.0;
 			pElement->GetGeometry()[1].FastGetSolutionStepValue(DISTANCE) = -1.0;
 			pElement->GetGeometry()[2].FastGetSolutionStepValue(DISTANCE) =  0.5;
-			array_1d<double, 3> embedded_vel;
-			embedded_vel(0) = 1.0;
-			embedded_vel(1) = 2.0;
-			embedded_vel(2) = 0.0;
-			pElement->SetValue(EMBEDDED_VELOCITY, embedded_vel);
 
 			// Compute RHS and LHS
 			Vector RHS = ZeroVector(9);
@@ -152,7 +151,6 @@ namespace Kratos {
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
 			modelPart.AddNodalSolutionStepVariable(VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(DISTANCE);
-			modelPart.AddNodalSolutionStepVariable(EMBEDDED_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(MESH_VELOCITY);
 
 			// Process info creation
@@ -196,7 +194,12 @@ namespace Kratos {
 				it_node->FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = pElemProp->GetValue(DYNAMIC_VISCOSITY);
 			}
 
+			array_1d<double, 3> embedded_vel;
+			embedded_vel(0) = 1.0;
+			embedded_vel(1) = 2.0;
+			embedded_vel(2) = 3.0;
 			for(unsigned int i=0; i<4; i++){
+				pElement->GetGeometry()[i].SetValue(EMBEDDED_VELOCITY, embedded_vel);
 				pElement->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE)    = 0.0;
 				pElement->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 1) = 0.0;
 				pElement->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 2) = 0.0;
@@ -213,11 +216,6 @@ namespace Kratos {
 			pElement->GetGeometry()[1].FastGetSolutionStepValue(DISTANCE) =  1.0;
 			pElement->GetGeometry()[2].FastGetSolutionStepValue(DISTANCE) = -1.0;
 			pElement->GetGeometry()[3].FastGetSolutionStepValue(DISTANCE) =  1.0;
-			array_1d<double, 3> embedded_vel;
-			embedded_vel(0) = 1.0;
-			embedded_vel(1) = 2.0;
-			embedded_vel(2) = 3.0;
-			pElement->SetValue(EMBEDDED_VELOCITY, embedded_vel);
 
 			// Compute RHS and LHS
 			Vector RHS = ZeroVector(16);

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
@@ -98,7 +98,7 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
                 distance = self.distance - node.Z
                 node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, 0, distance)
 
-        # Set the ELEMENTAL_VELOCITY in the intersected elements
+        # Set the EMBEDDED_VELOCITY in the intersected elements nodes
         for elem in self.main_model_part.Elements:
             n_pos = 0
             n_neg = 0
@@ -109,8 +109,8 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
                     n_pos += 1
 
             if ((n_pos != 0) and (n_neg != 0)):
-                embedded_velocity = KratosMultiphysics.Vector([self.embedded_velocity,0.0,0.0])
-                elem.SetValue(KratosMultiphysics.EMBEDDED_VELOCITY,embedded_velocity)
+                for node in elem.GetNodes():
+                    node.SetValue(KratosMultiphysics.EMBEDDED_VELOCITY, [self.embedded_velocity, 0.0, 0.0])
 
     def setUpNoSlipBoundaryConditions(self):
         # Set the inlet function

--- a/applications/FluidDynamicsApplication/tests/embedded_piston_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_piston_test.py
@@ -82,6 +82,9 @@ class CustomFluidDynamicsAnalysis(FluidDynamicsAnalysis):
         super(CustomFluidDynamicsAnalysis,self).ApplyBoundaryConditions()
 
         # Set the EMBEDDED_VELOCITY
+        for node in self._GetSolver().GetComputingModelPart().Nodes:
+            node.Set(KratosMultiphysics.VISITED, False)
+
         for element in self._GetSolver().GetComputingModelPart().Elements:
             # Check if the element is split
             n_pos = 0
@@ -93,9 +96,13 @@ class CustomFluidDynamicsAnalysis(FluidDynamicsAnalysis):
                     n_pos += 1
             # If it is split, set the EMBEDDED_VELOCITY
             if n_neg != 0 and n_pos != 0:
-                element.SetValue(KratosMultiphysics.EMBEDDED_VELOCITY, [vel,0.0,0.0])
+                for node in element.GetNodes():
+                    node.Set(KratosMultiphysics.VISITED, True)
+                    node.SetValue(KratosMultiphysics.EMBEDDED_VELOCITY, [vel,0.0,0.0])
             else:
-                element.SetValue(KratosMultiphysics.EMBEDDED_VELOCITY, [0.0,0.0,0.0])
+                for node in element.GetNodes():
+                    if not node.Is(KratosMultiphysics.VISITED):
+                        element.SetValue(KratosMultiphysics.EMBEDDED_VELOCITY, [0.0,0.0,0.0])
 
     def OutputSolutionStep(self):
         if self.print_output:
@@ -209,7 +216,7 @@ if __name__ == '__main__':
     test.setUp()
     test.A = 1.5
     test.w = 2.0 * math.pi
-    test.print_output = False
+    test.print_output = True
     test.print_reference_values = False
     test.work_folder = "EmbeddedPiston2DTest"
     test.reference_file = "reference_embedded_piston_2D"

--- a/applications/FluidDynamicsApplication/tests/embedded_piston_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_piston_test.py
@@ -216,7 +216,7 @@ if __name__ == '__main__':
     test.setUp()
     test.A = 1.5
     test.w = 2.0 * math.pi
-    test.print_output = True
+    test.print_output = False
     test.print_reference_values = False
     test.work_folder = "EmbeddedPiston2DTest"
     test.reference_file = "reference_embedded_piston_2D"

--- a/applications/FluidDynamicsApplication/tests/embedded_velocity_inlet_emulation_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_velocity_inlet_emulation_test.py
@@ -126,7 +126,8 @@ class EmbeddedVelocityInletEmulationTest(UnitTest.TestCase):
                 else:
                     n_pos += 1
             if (n_neg != 0 and n_pos != 0):
-                elem.SetValue(KratosMultiphysics.EMBEDDED_VELOCITY, embedded_velocity)
+                for node in elem.GetNodes():
+                    node.SetValue(KratosMultiphysics.EMBEDDED_VELOCITY, embedded_velocity)
             elif (n_neg == len(elem.GetNodes()) and deactivate_negative_elems):
                 elem.Set(KratosMultiphysics.ACTIVE, False)
 


### PR DESCRIPTION
From now on the EMBEDDED_VELOCITY will not be an elemental variable but a non-historical nodal one. This is a required change towards the FSI coupling. This PR modifies the imposition in the embedded elements and the tests accordingly.