### PR TITLE
[Fluid][Hotfix] Keep sign in discontinuous distance modification

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -293,7 +293,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance(){
             Vector &r_elem_dist = it_elem->GetValue(ELEMENTAL_DISTANCES);
             for (unsigned int i_node = 0; i_node < r_elem_dist.size(); ++i_node){
                 if (std::abs(r_elem_dist(i_node)) < tol_d){
-                    r_elem_dist(i_node) = -tol_d;
+                    r_elem_dist(i_node) = r_elem_dist(i_node) > 0.0 ? tol_d : -tol_d;
                 }
             }
         }

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -326,7 +326,7 @@ void DistanceModificationProcess::ModifyDiscontinuousDistance(){
                             aux_modified_distances_ids.push_back(it_elem->Id());
                             aux_modified_elemental_distances.push_back(r_elem_dist);
                         }
-                        r_elem_dist(i_node) = -tol_d;
+                        r_elem_dist(i_node) = r_elem_dist(i_node) > 0.0 ? tol_d : -tol_d;
                     }
                 }
             }


### PR DESCRIPTION
So far, we were always changing the sign when the discontinuous distance threshold was not satisfied. I consider this an unexpected behaviour that might yield unexpected holes in the original skin. Having this in mind, I've changed the behaviour to always keep the original distance sign.