### PR TITLE
[MeshMoving][HotFix] FM-ALE check mesh BCs

### DIFF
--- a/applications/MeshMovingApplication/custom_utilities/fixed_mesh_ale_utilities.cpp
+++ b/applications/MeshMovingApplication/custom_utilities/fixed_mesh_ale_utilities.cpp
@@ -419,10 +419,19 @@ namespace Kratos
                     if (r_node.Is(VISITED)) {
                         const auto &r_d_0 = r_node.FastGetSolutionStepValue(DISPLACEMENT, 0);
                         const auto &r_d_1 = r_node.FastGetSolutionStepValue(DISPLACEMENT, 1);
-                        noalias(r_node.FastGetSolutionStepValue(MESH_DISPLACEMENT, 0)) = r_d_0 - r_d_1;
-                        r_node.Fix(MESH_DISPLACEMENT_X);
-                        r_node.Fix(MESH_DISPLACEMENT_Y);
-                        r_node.Fix(MESH_DISPLACEMENT_Z);
+                        auto &r_mesh_disp = r_node.FastGetSolutionStepValue(MESH_DISPLACEMENT, 0);
+                        if (!r_node.IsFixed(MESH_DISPLACEMENT_X)) {
+                            r_node.Fix(MESH_DISPLACEMENT_X);
+                            r_mesh_disp[0] = r_d_0[0] - r_d_1[0];
+                        }
+                        if (!r_node.IsFixed(MESH_DISPLACEMENT_Y)) {
+                            r_node.Fix(MESH_DISPLACEMENT_Y);
+                            r_mesh_disp[1] = r_d_0[1] - r_d_1[1];
+                        }
+                        if (!r_node.IsFixed(MESH_DISPLACEMENT_Z)) {
+                            r_node.Fix(MESH_DISPLACEMENT_Z);
+                            r_mesh_disp[2] = r_d_0[2] - r_d_1[2];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Before this changes, the mesh boundary conditions were always overwritten by the embedded body ones coming from the embedded structure. With this change we give priority to the ones defined by de user.

This means that if the user fixes the boundary mesh displacement to 0 it will remain to zero even though the embedded moving boundary intersects it.