### PR TITLE
[ShapeOpt] Introduced scaling of response functions

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/communicator_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/communicator_factory.py
@@ -192,25 +192,25 @@ class Communicator:
     # --------------------------------------------------------------------------
     def __translateValueToStandardForm(self, response_id, value):
         response_type = self.list_of_responses[response_id]["type"]
-        factor = self.list_of_responses[response_id]["scaling_factor"]
+        scaling_factor = self.list_of_responses[response_id]["scaling_factor"]
 
         if response_type in self.supported_objective_types:
             if response_type == "maximization":
-                return -factor*value
+                return -scaling_factor*value
             else:
-                return factor*value
+                return scaling_factor*value
         else:
             reference_value = self.list_of_responses[response_id]["reference_value"]
 
             if response_type == ">" or response_type == ">=":
-                return factor*(reference_value-value)
+                return scaling_factor*(reference_value-value)
             else:
-                return factor*(value-reference_value)
+                return scaling_factor*(value-reference_value)
 
     # --------------------------------------------------------------------------
     def __translateGradientToStandardForm(self, response_id, gradient):
         response_type = self.list_of_responses[response_id]["type"]
-        factor = self.list_of_responses[response_id]["scaling_factor"]
+        scaling_factor = self.list_of_responses[response_id]["scaling_factor"]
 
         gradient.update({key: [factor*value[0],factor*value[1],factor*value[2]] for key, value in gradient.items()})
 

--- a/applications/ShapeOptimizationApplication/python_scripts/communicator_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/communicator_factory.py
@@ -140,6 +140,9 @@ class Communicator:
             if constraint["type"].GetString() not in self.supported_constraint_types:
                 raise RuntimeError("Unsupported type defined for the following constraint: " + constraint_id)
 
+            if constraint["reference"].GetString() not in self.supported_constraint_references:
+                raise RuntimeError("Unsupported reference defined for the following constraint: " + constraint_id)
+
             if  constraint["reference"].GetString() == "specified_value":
                 self.list_of_responses[constraint_id] = { "type"                 : constraint["type"].GetString(),
                                                           "value"                : None,

--- a/applications/ShapeOptimizationApplication/python_scripts/communicator_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/communicator_factory.py
@@ -154,7 +154,7 @@ class Communicator:
                                                           "value"                : None,
                                                           "standardized_value"   : None,
                                                           "standardized_gradient": None,
-                                                          "reference_value"      : "waiting_for_initial_value" }
+                                                          "reference_value"      : None }
             else:
                 raise RuntimeError("Unsupported reference defined for the following constraint: " + constraint_id)
 
@@ -174,10 +174,13 @@ class Communicator:
     # --------------------------------------------------------------------------
     def __isResponseWaitingForInitialValueAsReference(self, response_id):
         response = self.list_of_responses[response_id]
-        if "reference_value" in response and response["reference_value"] == "waiting_for_initial_value":
-            return True
-        else:
-            return False
+        is_reference_defined = "reference" in response
+        if is_reference_defined:
+            is_reference_initial_value = (response["reference"].GetString() == "initial_value")
+            is_reference_value_missing = (response["reference_value"] is None)
+            if is_reference_initial_value and is_reference_value_missing:
+                return True
+        return False
 
     # --------------------------------------------------------------------------
     def __setValueAsReference(self, response_id, value):

--- a/applications/ShapeOptimizationApplication/python_scripts/communicator_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/communicator_factory.py
@@ -212,10 +212,10 @@ class Communicator:
         response_type = self.list_of_responses[response_id]["type"]
         scaling_factor = self.list_of_responses[response_id]["scaling_factor"]
 
-        gradient.update({key: [factor*value[0],factor*value[1],factor*value[2]] for key, value in gradient.items()})
+        gradient = {key: [scaling_factor*value[0],scaling_factor*value[1],scaling_factor*value[2]] for key, value in gradient.items()}
 
         if response_type == "maximization" or response_type == ">" or response_type == ">=":
-            gradient.update({key: [-value[0],-value[1],-value[2]] for key, value in gradient.items()})
+            gradient = {key: [-value[0],-value[1],-value[2]] for key, value in gradient.items()}
         return gradient
 
     # --------------------------------------------------------------------------

--- a/applications/ShapeOptimizationApplication/python_scripts/optimizer_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/optimizer_factory.py
@@ -70,6 +70,7 @@ def ValidateObjectives(objectives):
         {
             "identifier"                          : "NO_IDENTIFIER_SPECIFIED",
             "type"                                : "minimization",
+            "scaling_factor"                      : 1.0,
             "use_kratos"                          : false,
             "kratos_response_settings"            : {},
             "project_gradient_on_surface_normals" : false
@@ -83,6 +84,7 @@ def ValidateConstraints(constraints):
         {
             "identifier"                          : "NO_IDENTIFIER_SPECIFIED",
             "type"                                : "<",
+            "scaling_factor"                      : 1.0,
             "reference"                           : "initial_value",
             "reference_value"                     : 1.0,
             "use_kratos"                          : false,

--- a/applications/ShapeOptimizationApplication/python_scripts/optimizer_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/optimizer_factory.py
@@ -26,6 +26,27 @@ import algorithm_factory
 # ==============================================================================
 def CreateOptimizer(optimization_settings, model, external_analyzer=EmptyAnalyzer()):
 
+    ValidateSettings(optimization_settings)
+
+    model_part_controller = model_part_controller_factory.CreateController(optimization_settings["model_settings"], model)
+
+    analyzer = analyzer_factory.CreateAnalyzer(optimization_settings, model_part_controller, external_analyzer)
+
+    communicator = communicator_factory.CreateCommunicator(optimization_settings)
+
+    if optimization_settings["design_variables"]["type"].GetString() == "vertex_morphing":
+        return VertexMorphingMethod(optimization_settings, model_part_controller, analyzer, communicator)
+    else:
+        raise NameError("The following type of design variables is not supported by the optimizer: " + variable_type)
+
+# ------------------------------------------------------------------------------
+def ValidateSettings(optimization_settings):
+    ValidateTopLevelSettings(optimization_settings)
+    ValidateObjectives(optimization_settings["objectives"])
+    ValidateConstraints(optimization_settings["constraints"])
+
+# ------------------------------------------------------------------------------
+def ValidateTopLevelSettings(optimization_settings):
     default_settings = Parameters("""
     {
         "model_settings" : { },
@@ -42,16 +63,33 @@ def CreateOptimizer(optimization_settings, model, external_analyzer=EmptyAnalyze
 
     optimization_settings.ValidateAndAssignDefaults(default_settings)
 
-    model_part_controller = model_part_controller_factory.CreateController(optimization_settings["model_settings"], model)
+# ------------------------------------------------------------------------------
+def ValidateObjectives(objectives):
+    for itr in range(objectives.size()):
+        default_settings = Parameters("""
+        {
+            "identifier"                          : "NO_IDENTIFIER_SPECIFIED",
+            "type"                                : "minimization",
+            "use_kratos"                          : false,
+            "kratos_response_settings"            : {},
+            "project_gradient_on_surface_normals" : false
+        }""")
+        objectives[itr].ValidateAndAssignDefaults(default_settings)
 
-    analyzer = analyzer_factory.CreateAnalyzer(optimization_settings, model_part_controller, external_analyzer)
-
-    communicator = communicator_factory.CreateCommunicator(optimization_settings)
-
-    if optimization_settings["design_variables"]["type"].GetString() == "vertex_morphing":
-        return VertexMorphingMethod(optimization_settings, model_part_controller, analyzer, communicator)
-    else:
-        raise NameError("The following type of design variables is not supported by the optimizer: " + variable_type)
+# ------------------------------------------------------------------------------
+def ValidateConstraints(constraints):
+    for itr in range(constraints.size()):
+        default_settings = Parameters("""
+        {
+            "identifier"                          : "NO_IDENTIFIER_SPECIFIED",
+            "type"                                : "<",
+            "reference"                           : "initial_value",
+            "reference_value"                     : 1.0,
+            "use_kratos"                          : false,
+            "kratos_response_settings"            : {},
+            "project_gradient_on_surface_normals" : false
+        }""")
+        constraints[itr].ValidateAndAssignDefaults(default_settings)
 
 # ==============================================================================
 class VertexMorphingMethod:

--- a/applications/ShapeOptimizationApplication/python_scripts/optimizer_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/optimizer_factory.py
@@ -42,8 +42,8 @@ def CreateOptimizer(optimization_settings, model, external_analyzer=EmptyAnalyze
 # ------------------------------------------------------------------------------
 def ValidateSettings(optimization_settings):
     ValidateTopLevelSettings(optimization_settings)
-    ValidateObjectives(optimization_settings["objectives"])
-    ValidateConstraints(optimization_settings["constraints"])
+    ValidateObjectiveSettings(optimization_settings["objectives"])
+    ValidateConstraintSettings(optimization_settings["constraints"])
 
 # ------------------------------------------------------------------------------
 def ValidateTopLevelSettings(optimization_settings):
@@ -64,34 +64,34 @@ def ValidateTopLevelSettings(optimization_settings):
     optimization_settings.ValidateAndAssignDefaults(default_settings)
 
 # ------------------------------------------------------------------------------
-def ValidateObjectives(objectives):
-    for itr in range(objectives.size()):
-        default_settings = Parameters("""
-        {
-            "identifier"                          : "NO_IDENTIFIER_SPECIFIED",
-            "type"                                : "minimization",
-            "scaling_factor"                      : 1.0,
-            "use_kratos"                          : false,
-            "kratos_response_settings"            : {},
-            "project_gradient_on_surface_normals" : false
-        }""")
-        objectives[itr].ValidateAndAssignDefaults(default_settings)
+def ValidateObjectiveSettings(settings):
+    default_settings = Parameters("""
+    {
+        "identifier"                          : "NO_IDENTIFIER_SPECIFIED",
+        "type"                                : "minimization",
+        "scaling_factor"                      : 1.0,
+        "use_kratos"                          : false,
+        "kratos_response_settings"            : {},
+        "project_gradient_on_surface_normals" : false
+    }""")
+    for itr in range(settings.size()):
+        settings[itr].ValidateAndAssignDefaults(default_settings)
 
 # ------------------------------------------------------------------------------
-def ValidateConstraints(constraints):
-    for itr in range(constraints.size()):
-        default_settings = Parameters("""
-        {
-            "identifier"                          : "NO_IDENTIFIER_SPECIFIED",
-            "type"                                : "<",
-            "scaling_factor"                      : 1.0,
-            "reference"                           : "initial_value",
-            "reference_value"                     : 1.0,
-            "use_kratos"                          : false,
-            "kratos_response_settings"            : {},
-            "project_gradient_on_surface_normals" : false
-        }""")
-        constraints[itr].ValidateAndAssignDefaults(default_settings)
+def ValidateConstraintSettings(settings):
+    default_settings = Parameters("""
+    {
+        "identifier"                          : "NO_IDENTIFIER_SPECIFIED",
+        "type"                                : "<",
+        "scaling_factor"                      : 1.0,
+        "reference"                           : "initial_value",
+        "reference_value"                     : 1.0,
+        "use_kratos"                          : false,
+        "kratos_response_settings"            : {},
+        "project_gradient_on_surface_normals" : false
+    }""")
+    for itr in range(settings.size()):
+        settings[itr].ValidateAndAssignDefaults(default_settings)
 
 # ==============================================================================
 class VertexMorphingMethod:


### PR DESCRIPTION
This PR:

- provides a generic option to scale all response functions. The scaling is realized completely within the communicator and part of the translation to the standard format.

- cleans the communicator a bit

- slightly improves the check against default values in the optimizer_factory, so that by default, the scaling factor is 1.