### PR TITLE
[CoSim] pyKratos can be used in testing

### DIFF
--- a/applications/CoSimulationApplication/custom_data_structure/KratosMultiphysics.py
+++ b/applications/CoSimulationApplication/custom_data_structure/KratosMultiphysics.py
@@ -23,6 +23,20 @@ from .QuadriateralElement import QuadrilateralElement
 from .TriangleElement import TriangleElement
 from .Logger import Logger
 
+print("""              _  __          _
+  _ __  _   _| |/ /_ __ __ _| |_ ___  ___
+ | '_ \| | | | ' /| '__/ _` | __/ _ \/ __|
+ | |_) | |_| | . \| | | (_| | || (_) \__ \\
+ | .__/ \__, |_|\_\_|  \__,_|\__\___/|___/
+ |_|    |___/
+""", end='')
+print("""
+    KRATOS  / ___|___/ ___|(_)_ __ ___  _   _| | __ _| |_(_) ___  _ __
+           | |   / _ \___ \| | '_ ` _ \| | | | |/ _` | __| |/ _ \| '_ \\
+           | |__| (_) |__) | | | | | | | |_| | | (_| | |_| | (_) | | | |
+            \____\___/____/|_|_| |_| |_|\__,_|_|\__,_|\__|_|\___/|_| |_|
+""")
+
 class KratosGlobals(object):
     def HasVariable(var_name):
         return var_name in globals()

--- a/applications/CoSimulationApplication/python_scripts/co_simulation_tools.py
+++ b/applications/CoSimulationApplication/python_scripts/co_simulation_tools.py
@@ -15,6 +15,13 @@ def cs_print_warning(label, *args):
     KM.Logger.PrintWarning(colors.red("Warning: ")+colors.bold(label), " ".join(map(str,args)))
 
 
+def UsingPyKratos():
+    for i_path in KM.__path__:
+        if "pyKratos" in i_path:
+            return True
+    return False
+
+
 def SettingsTypeCheck(settings):
     if not isinstance(settings, KM.Parameters):
         raise TypeError("Expected input shall be a Parameters object, encapsulating a json string")

--- a/applications/CoSimulationApplication/tests/co_simulation_test_case.py
+++ b/applications/CoSimulationApplication/tests/co_simulation_test_case.py
@@ -6,6 +6,9 @@ import KratosMultiphysics.kratos_utilities as kratos_utils
 
 from KratosMultiphysics.CoSimulationApplication.co_simulation_analysis import CoSimulationAnalysis
 
+from KratosMultiphysics.CoSimulationApplication.co_simulation_tools import UsingPyKratos
+using_pykratos = UsingPyKratos()
+
 import os
 
 class CoSimulationTestCase(KratosUnittest.TestCase):
@@ -21,12 +24,13 @@ class CoSimulationTestCase(KratosUnittest.TestCase):
         with open(full_parameter_file_name, 'r') as parameter_file:
             self.cosim_parameters = KM.Parameters(parameter_file.read())
 
-        # To avoid many prints
-        echo_level = self.cosim_parameters["problem_data"]["echo_level"].GetInt()
-        if (echo_level == 0):
-            KM.Logger.GetDefaultOutput().SetSeverity(KM.Logger.Severity.WARNING)
-        else:
-            KM.Logger.GetDefaultOutput().SetSeverity(KM.Logger.Severity.INFO)
+        if not using_pykratos:
+            # To avoid many prints
+            echo_level = self.cosim_parameters["problem_data"]["echo_level"].GetInt()
+            if (echo_level == 0):
+                KM.Logger.GetDefaultOutput().SetSeverity(KM.Logger.Severity.WARNING)
+            else:
+                KM.Logger.GetDefaultOutput().SetSeverity(KM.Logger.Severity.INFO)
 
     def _runTest(self):
         CoSimulationAnalysis(self.cosim_parameters).Run()

--- a/applications/CoSimulationApplication/tests/co_simulation_test_factory.py
+++ b/applications/CoSimulationApplication/tests/co_simulation_test_factory.py
@@ -4,6 +4,7 @@ import KratosMultiphysics as KM
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils
 
+import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
 import co_simulation_test_case
 
 try:
@@ -14,15 +15,20 @@ except ImportError:
 
 have_fsi_dependencies = kratos_utils.CheckIfApplicationsAvailable("FluidDynamicsApplication", "StructuralMechanicsApplication", "MappingApplication", "MeshMovingApplication", "ExternalSolversApplication")
 
+using_pykratos = cs_tools.UsingPyKratos()
+
 class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
     '''This class contains "small" CoSimulation-Cases, small enough to run in the nightly suite
     '''
     def test_MokFSI_mvqn(self):
-        self.name = "mvqn"
         if not numpy_available:
             self.skipTest("Numpy not available")
+        if using_pykratos:
+            self.skipTest("This test cannot be run with pyKratos!")
         if not have_fsi_dependencies:
             self.skipTest("FSI dependencies are not available!")
+
+        self.name = "mvqn"
         with KratosUnittest.WorkFolderScope(".", __file__):
             self._createTest("fsi_mok", "cosim_mok_fsi")
             self.__ManipulateSettings()
@@ -31,11 +37,14 @@ class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
             self._runTest()
 
     def test_MokFSI_aitken(self):
-        self.name = "aitken"
         if not numpy_available:
             self.skipTest("Numpy not available")
+        if using_pykratos:
+            self.skipTest("This test cannot be run with pyKratos!")
         if not have_fsi_dependencies:
             self.skipTest("FSI dependencies are not available!")
+
+        self.name = "aitken"
         with KratosUnittest.WorkFolderScope(".", __file__):
             self._createTest("fsi_mok", "cosim_mok_fsi")
             self.__ManipulateSettings()
@@ -95,8 +104,11 @@ class TestCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
     def test_WallFSI(self):
         if not numpy_available:
             self.skipTest("Numpy not available")
+        if using_pykratos:
+            self.skipTest("This test cannot be run with pyKratos!")
         if not have_fsi_dependencies:
             self.skipTest("FSI dependencies are not available!")
+
         with KratosUnittest.WorkFolderScope(".", __file__):
             self._createTest("fsi_wall", "cosim_wall_weak_coupling_fsi")
             self._runTest()

--- a/applications/CoSimulationApplication/tests/co_simulation_test_factory.py
+++ b/applications/CoSimulationApplication/tests/co_simulation_test_factory.py
@@ -4,7 +4,7 @@ import KratosMultiphysics as KM
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils
 
-import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
+from KratosMultiphysics.CoSimulationApplication.co_simulation_tools import UsingPyKratos
 import co_simulation_test_case
 
 try:
@@ -15,7 +15,7 @@ except ImportError:
 
 have_fsi_dependencies = kratos_utils.CheckIfApplicationsAvailable("FluidDynamicsApplication", "StructuralMechanicsApplication", "MappingApplication", "MeshMovingApplication", "ExternalSolversApplication")
 
-using_pykratos = cs_tools.UsingPyKratos()
+using_pykratos = UsingPyKratos()
 
 class TestSmallCoSimulationCases(co_simulation_test_case.CoSimulationTestCase):
     '''This class contains "small" CoSimulation-Cases, small enough to run in the nightly suite

--- a/applications/CoSimulationApplication/tests/test_coupling_interface_data.py
+++ b/applications/CoSimulationApplication/tests/test_coupling_interface_data.py
@@ -5,6 +5,9 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 from KratosMultiphysics.CoSimulationApplication.coupling_interface_data import CouplingInterfaceData
 
+from KratosMultiphysics.CoSimulationApplication.co_simulation_tools import UsingPyKratos
+using_pykratos = UsingPyKratos()
+
 # The expected definitions are here to make the handling of the
 # multiline-stings easier (no need to deal with indentation)
 coupling_interface_data_str = '''CouplingInterfaceData:
@@ -56,12 +59,13 @@ class TestCouplingInterfaceData(KratosUnittest.TestCase):
             elem.SetValue(KM.DENSITY, ElementScalarValue(elem_id))
             elem.SetValue(KM.FORCE, ElementVectorValue(elem_id))
 
-        for i in range(num_conds):
-            cond_id = i+1
-            cond = self.mp.CreateNewCondition("LineCondition2D2N", cond_id, [1,2], props)
+        if not using_pykratos: # pyKratos does not have Conditions
+            for i in range(num_conds):
+                cond_id = i+1
+                cond = self.mp.CreateNewCondition("LineCondition2D2N", cond_id, [1,2], props)
 
-            cond.SetValue(KM.YOUNG_MODULUS, ConditionScalarValue(cond_id))
-            cond.SetValue(KM.ROTATION, ConditionVectorValue(cond_id))
+                cond.SetValue(KM.YOUNG_MODULUS, ConditionScalarValue(cond_id))
+                cond.SetValue(KM.ROTATION, ConditionVectorValue(cond_id))
 
         self.mp[KM.NODAL_MASS] = model_part_scalar_value
         self.mp[KM.TORQUE] = model_part_vector_value
@@ -324,6 +328,8 @@ class TestCouplingInterfaceData(KratosUnittest.TestCase):
         self.__CheckSetGetData(set_data_vec, coupling_data_vec)
 
     def test_GetSetConditionalData(self):
+        if using_pykratos:
+            self.skipTest("This test cannot be run with pyKratos!")
         settings_scal = KM.Parameters("""{
             "model_part_name" : "mp_4_test",
             "location"        : "condition",


### PR DESCRIPTION
With this PR the tests can be run when CoSim is configured with pyKratos
The tests that are not possible to be executed are properly skipped now (e.g. the ones that use Kratos)

@adityaghantasala I would a good way of checking for pyKratos

related to #5140 