### PR TITLE
[CoSim] Adding description / readme for py-only version

### DIFF
--- a/applications/CoSimulationApplication/custom_data_structure/README.md
+++ b/applications/CoSimulationApplication/custom_data_structure/README.md
@@ -1,0 +1,9 @@
+## CoSimulation Application PYTHON ONLY VERSION
+
+This is the description for the python-only version of the CoSimulationApplication.
+Kratos is only used as a **container for data** within the CoSimulationApplication, the CoSimApp itself is coded in python.
+For the python-only version, Kratos is replaced by pyKratos, which is a python version of Kratos that implements the basic features required for CoSimulation. The version of pyKratos within this folder is based on the [work of Riccardo Rossi](https://github.com/RiccardoRossi/pyKratos)
+
+In order to install the python-version, please follow the instructions in [configure_py_co_sim.sh](https://github.com/KratosMultiphysics/Kratos/blob/master/applications/CoSimulationApplication/custom_data_structure/configure_py_co_sim.sh). For this **no compilation** is required.
+
+The tests can be executed by running `python test_CoSimulationApplication.py` in the folder `tests`

--- a/applications/CoSimulationApplication/custom_data_structure/README.md
+++ b/applications/CoSimulationApplication/custom_data_structure/README.md
@@ -2,7 +2,7 @@
 
 This is the description for the python-only version of the CoSimulationApplication.
 Kratos is only used as a **container for data** within the CoSimulationApplication, the CoSimApp itself is coded in python.
-For the python-only version, Kratos is replaced by pyKratos, which is a python version of Kratos that implements the basic features required for CoSimulation. The version of pyKratos within this folder is based on the [work of Riccardo Rossi](https://github.com/RiccardoRossi/pyKratos)
+For the python-only version, Kratos is replaced by pyKratos, which is a python version of Kratos which implements the basic features (of KratosMultiphysics) required for CoSimulation. The version of pyKratos within this folder is based on the [work of Riccardo Rossi](https://github.com/RiccardoRossi/pyKratos)
 
 In order to install the python-version, please follow the instructions in [configure_py_co_sim.sh](https://github.com/KratosMultiphysics/Kratos/blob/master/applications/CoSimulationApplication/custom_data_structure/configure_py_co_sim.sh). For this **no compilation** is required.
 

--- a/applications/CoSimulationApplication/custom_data_structure/configure_py_co_sim.sh
+++ b/applications/CoSimulationApplication/custom_data_structure/configure_py_co_sim.sh
@@ -3,6 +3,11 @@
 # this file is supposed to be called from "cmake_build"
 # it configures and installs the python-only version of the CoSimulationApplication
 
+## Instructions:
+# Copy this file to "cmake_build" and run "sh configure_py_co_sim.sh"
+# => no compilation is required
+# => no paths have to be specified
+
 rm -f CMakeCache.txt
 rm -f *.cmake
 rm -rf CMakeFiles\


### PR DESCRIPTION
This PR adds more description for how to install the python-only version of the CoSimApp

IMO it is super easy, a file has to be copied and run, no paths or other things have to be specified

@joris13 @navaneethkn I hope this suits your needs
In any case I will contact you in the next days via mail to give you an outlook of what is the current status

related to #5140 