### PR TITLE
Cps/adding auxiliary historical variables list

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.cpp
@@ -28,7 +28,7 @@ Condition::Pointer AdjointPotentialWallCondition<TPrimalCondition>::Create(
 
 template <class TPrimalCondition>
 Condition::Pointer AdjointPotentialWallCondition<TPrimalCondition>::Create(
-    IndexType NewId, Condition::GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const 
+    IndexType NewId, Condition::GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
 {
     return Kratos::make_intrusive<AdjointPotentialWallCondition<TPrimalCondition>>(
             NewId, pGeom, pProperties);
@@ -36,7 +36,7 @@ Condition::Pointer AdjointPotentialWallCondition<TPrimalCondition>::Create(
 
 template <class TPrimalCondition>
 
-Condition::Pointer AdjointPotentialWallCondition<TPrimalCondition>::Clone(IndexType NewId, NodesArrayType const& rThisNodes) const 
+Condition::Pointer AdjointPotentialWallCondition<TPrimalCondition>::Clone(IndexType NewId, NodesArrayType const& rThisNodes) const
 {
     Condition::Pointer pNewCondition = Create(NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
 
@@ -47,20 +47,20 @@ Condition::Pointer AdjointPotentialWallCondition<TPrimalCondition>::Clone(IndexT
 }
 
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::Initialize() 
-{   
+void AdjointPotentialWallCondition<TPrimalCondition>::Initialize()
+{
     mpPrimalCondition->Initialize();
 }
 
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) 
+void AdjointPotentialWallCondition<TPrimalCondition>::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
 {
     mpPrimalCondition->Data() = this->Data();
     mpPrimalCondition->Set(Flags(*this));
     mpPrimalCondition->InitializeSolutionStep(rCurrentProcessInfo);
 }
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::GetValuesVector(Vector& rValues, int Step) 
+void AdjointPotentialWallCondition<TPrimalCondition>::GetValuesVector(Vector& rValues, int Step)
 {
 
     KRATOS_TRY
@@ -70,14 +70,14 @@ void AdjointPotentialWallCondition<TPrimalCondition>::GetValuesVector(Vector& rV
 
     bool is_kutta=false;
     for(unsigned int i=0; i<TNumNodes; i++){
-        if (GetGeometry()[i].FastGetSolutionStepValue(DISTANCE)<0.0){
+        if (GetGeometry()[i].GetValue(DISTANCE)<0.0){
             is_kutta=true;
             break;
         }
     }
     for(unsigned int i=0; i<TNumNodes; i++){
         if(is_kutta){
-            if(GetGeometry()[i].FastGetSolutionStepValue(DISTANCE)<0.0)
+            if(GetGeometry()[i].GetValue(DISTANCE)<0.0)
                 rValues[i] = GetGeometry()[i].FastGetSolutionStepValue(ADJOINT_VELOCITY_POTENTIAL);
             else
                 rValues[i] = GetGeometry()[i].FastGetSolutionStepValue(ADJOINT_AUXILIARY_VELOCITY_POTENTIAL);
@@ -92,7 +92,7 @@ void AdjointPotentialWallCondition<TPrimalCondition>::GetValuesVector(Vector& rV
 
 template <class TPrimalCondition>
 void AdjointPotentialWallCondition<TPrimalCondition>::CalculateLeftHandSide(MatrixType &rLeftHandSideMatrix,
-                            ProcessInfo &rCurrentProcessInfo) 
+                            ProcessInfo &rCurrentProcessInfo)
 {
     VectorType RHS;
     this->CalculateLocalSystem(rLeftHandSideMatrix, RHS, rCurrentProcessInfo);
@@ -102,7 +102,7 @@ void AdjointPotentialWallCondition<TPrimalCondition>::CalculateLeftHandSide(Matr
 template <class TPrimalCondition>
 void AdjointPotentialWallCondition<TPrimalCondition>::CalculateSensitivityMatrix(const Variable<array_1d<double,3> >& rDesignVariable,
                                         Matrix& rOutput,
-                                        const ProcessInfo& rCurrentProcessInfo) 
+                                        const ProcessInfo& rCurrentProcessInfo)
 {
     if (rOutput.size1() != TNumNodes)
         rOutput.resize(TDim*TNumNodes, TNumNodes, false);
@@ -112,8 +112,8 @@ void AdjointPotentialWallCondition<TPrimalCondition>::CalculateSensitivityMatrix
 template <class TPrimalCondition>
 void AdjointPotentialWallCondition<TPrimalCondition>::CalculateLocalSystem(MatrixType &rLeftHandSideMatrix,
                             VectorType &rRightHandSideVector,
-                            ProcessInfo &rCurrentProcessInfo) 
-{               
+                            ProcessInfo &rCurrentProcessInfo)
+{
     if (rLeftHandSideMatrix.size1() != TNumNodes)
         rLeftHandSideMatrix.resize(TNumNodes, TNumNodes, false);
     if (rRightHandSideVector.size() != TNumNodes)
@@ -123,7 +123,7 @@ void AdjointPotentialWallCondition<TPrimalCondition>::CalculateLocalSystem(Matri
 
 /// Check that all data required by this condition is available and reasonable
 template <class TPrimalCondition>
-int AdjointPotentialWallCondition<TPrimalCondition>::Check(const ProcessInfo& rCurrentProcessInfo) 
+int AdjointPotentialWallCondition<TPrimalCondition>::Check(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 
@@ -153,8 +153,8 @@ int AdjointPotentialWallCondition<TPrimalCondition>::Check(const ProcessInfo& rC
 
 template <class TPrimalCondition>
 void AdjointPotentialWallCondition<TPrimalCondition>::EquationIdVector(EquationIdVectorType& rResult,
-                                ProcessInfo& rCurrentProcessInfo) 
-{   
+                                ProcessInfo& rCurrentProcessInfo)
+{
     if (rResult.size() != TNumNodes)
         rResult.resize(TNumNodes, false);
 
@@ -179,7 +179,7 @@ void AdjointPotentialWallCondition<TPrimalCondition>::EquationIdVector(EquationI
 
 template <class TPrimalCondition>
 void AdjointPotentialWallCondition<TPrimalCondition>::GetDofList(DofsVectorType& ConditionDofList,
-                        ProcessInfo& CurrentProcessInfo) 
+                        ProcessInfo& CurrentProcessInfo)
 {
     if (ConditionDofList.size() != TNumNodes)
     ConditionDofList.resize(TNumNodes);
@@ -204,14 +204,14 @@ void AdjointPotentialWallCondition<TPrimalCondition>::GetDofList(DofsVectorType&
 }
 
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) 
+void AdjointPotentialWallCondition<TPrimalCondition>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
 {
     mpPrimalCondition -> FinalizeSolutionStep(rCurrentProcessInfo);
 }
 
 /// Turn back information as a string.
 template <class TPrimalCondition>
-std::string AdjointPotentialWallCondition<TPrimalCondition>::Info() const 
+std::string AdjointPotentialWallCondition<TPrimalCondition>::Info() const
 {
     std::stringstream buffer;
     this->PrintInfo(buffer);
@@ -220,28 +220,28 @@ std::string AdjointPotentialWallCondition<TPrimalCondition>::Info() const
 
 /// Print information about this object.
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::PrintInfo(std::ostream& rOStream) const 
+void AdjointPotentialWallCondition<TPrimalCondition>::PrintInfo(std::ostream& rOStream) const
 {
     rOStream << "AdjointPotentialWallCondition" << TDim << "D #" << this->Id();
 }
 
 /// Print object's data.
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::PrintData(std::ostream& rOStream) const 
+void AdjointPotentialWallCondition<TPrimalCondition>::PrintData(std::ostream& rOStream) const
 {
     this->pGetGeometry()->PrintData(rOStream);
 }
 
 
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::save(Serializer& rSerializer) const 
+void AdjointPotentialWallCondition<TPrimalCondition>::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition );
     rSerializer.save("mpPrimalCondition", mpPrimalCondition);
 }
 
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::load(Serializer& rSerializer) 
+void AdjointPotentialWallCondition<TPrimalCondition>::load(Serializer& rSerializer)
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
     rSerializer.load("mpPrimalCondition", mpPrimalCondition);

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_2d_wake_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_2d_wake_process.cpp
@@ -165,7 +165,7 @@ void Define2DWakeProcess::MarkWakeElements()
                 auto r_geometry = it_elem->GetGeometry();
                 for (unsigned int i = 0; i < it_elem->GetGeometry().size(); i++) {
                     r_geometry[i].SetLock();
-                    r_geometry[i].FastGetSolutionStepValue(DISTANCE) = nodal_distances_to_wake(i);
+                    r_geometry[i].SetValue(DISTANCE, nodal_distances_to_wake(i));
                     r_geometry[i].UnSetLock();
                 }
             }

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
@@ -88,7 +88,7 @@ class ComputeLiftProcess(KratosMultiphysics.Process):
 
         node_velocity_potential_te = te.GetSolutionStepValue(CPFApp.VELOCITY_POTENTIAL)
         node_auxiliary_velocity_potential_te = te.GetSolutionStepValue(CPFApp.AUXILIARY_VELOCITY_POTENTIAL)
-        if(te.GetSolutionStepValue(KratosMultiphysics.DISTANCE) > 0.0):
+        if(te.GetValue(KratosMultiphysics.DISTANCE) > 0.0):
             potential_jump_phi_minus_psi_te = node_velocity_potential_te - node_auxiliary_velocity_potential_te
         else:
             potential_jump_phi_minus_psi_te = node_auxiliary_velocity_potential_te - node_velocity_potential_te

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_2d.py
@@ -116,7 +116,7 @@ class DefineWakeProcess2D(KratosMultiphysics.Process):
                         KratosMultiphysics.ELEMENTAL_DISTANCES, distances_to_wake)
                     counter=0
                     for node in elem.GetNodes():
-                        node.SetSolutionStepValue(KratosMultiphysics.DISTANCE,distances_to_wake[counter])
+                        node.SetValue(KratosMultiphysics.DISTANCE,distances_to_wake[counter])
                         counter += 1
         self.__SaveTrailingEdgeElements()
 

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -88,7 +88,8 @@ class PotentialFlowSolver(FluidSolver):
             "volume_model_part_name": "volume_model_part",
             "skin_parts":[""],
             "no_skin_parts": [""],
-            "move_mesh_flag": false
+            "move_mesh_flag": false,
+            "auxiliary_variables_list" : []
         }''')
 
         settings.ValidateAndAssignDefaults(default_settings)
@@ -116,15 +117,15 @@ class PotentialFlowSolver(FluidSolver):
         # Degrees of freedom
         self.main_model_part.AddNodalSolutionStepVariable(KCPFApp.VELOCITY_POTENTIAL)
         self.main_model_part.AddNodalSolutionStepVariable(KCPFApp.AUXILIARY_VELOCITY_POTENTIAL)
-        # Embedded variables
-        self.main_model_part.AddNodalSolutionStepVariable(KCPFApp.GEOMETRY_DISTANCE)
+
         # Kratos variables
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.FLAG_VARIABLE) # Required for variational_distance_process
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE_GRADIENT)
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_H) # Required for modify_distance_process
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY) # Required for modify_distance_process
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PRESSURE) # Required for modify_distance_process
+
+        # Add variables that the user defined in the ProjectParameters
+        for i in range(self.settings["auxiliary_variables_list"].size()):
+            variable_name = self.settings["auxiliary_variables_list"][i].GetString()
+            variable = KratosMultiphysics.KratosGlobals.GetVariable(variable_name)
+            self.main_model_part.AddNodalSolutionStepVariable(variable)
 
         KratosMultiphysics.Logger.PrintInfo("::[PotentialFlowSolver]:: ", "Variables ADDED")
 

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -118,9 +118,6 @@ class PotentialFlowSolver(FluidSolver):
         self.main_model_part.AddNodalSolutionStepVariable(KCPFApp.VELOCITY_POTENTIAL)
         self.main_model_part.AddNodalSolutionStepVariable(KCPFApp.AUXILIARY_VELOCITY_POTENTIAL)
 
-        # Kratos variables
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
-
         # Add variables that the user defined in the ProjectParameters
         for i in range(self.settings["auxiliary_variables_list"].size()):
             variable_name = self.settings["auxiliary_variables_list"][i].GetString()

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
@@ -62,7 +62,7 @@ namespace Kratos {
       // Create model_part
       Model this_model;
       ModelPart& model_part = this_model.CreateModelPart("Main", 3);
-      model_part.AddNodalSolutionStepVariable(DISTANCE);
+      //model_part.AddNodalSolutionStepVariable(DISTANCE);
 
       // Set model_part properties
       BoundedVector<double, 3> free_stream_velocity = ZeroVector(3);

--- a/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_no_wake_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_no_wake_parameters.json
@@ -32,7 +32,7 @@
             "verbosity": 3,
             "scaling": false
         },
-        "auxiliary_variables_list" : ["NODAL_H","GEOMETRY_DISTANCE"]
+        "auxiliary_variables_list" : ["NODAL_H","GEOMETRY_DISTANCE","DISTANCE"]
     },
     "processes"            : {
         "initial_conditions_process_list"  : [],

--- a/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_no_wake_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_no_wake_parameters.json
@@ -31,8 +31,8 @@
             "tolerance": 1e-9,
             "verbosity": 3,
             "scaling": false
-        }
-
+        },
+        "auxiliary_variables_list" : ["NODAL_H","GEOMETRY_DISTANCE"]
     },
     "processes"            : {
         "initial_conditions_process_list"  : [],

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -140,8 +140,8 @@ class PotentialFlowTests(UnitTest.TestCase):
                                     "node_output"         : false,
                                     "skin_output"         : false,
                                     "plane_output"        : [],
-                                    "nodal_results"       : ["VELOCITY_POTENTIAL","AUXILIARY_VELOCITY_POTENTIAL","DISTANCE"],
-                                    "nodal_nonhistorical_results": ["TRAILING_EDGE"],
+                                    "nodal_results"       : ["VELOCITY_POTENTIAL","AUXILIARY_VELOCITY_POTENTIAL"],
+                                    "nodal_nonhistorical_results": ["TRAILING_EDGE","DISTANCE"],
                                     "elemental_conditional_flags_results": ["STRUCTURE"],
                                     "gauss_point_results" : ["PRESSURE_COEFFICIENT","VELOCITY","VELOCITY_LOWER","PRESSURE_LOWER","WAKE","ELEMENTAL_DISTANCES","KUTTA"]
                                 },


### PR DESCRIPTION
Right now we have many historical variables that are only used in the embedded case:

https://github.com/KratosMultiphysics/Kratos/blob/6fbc5e8e0e866f5183267d5ea84cac6ed9713a79/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py#L119-L127

This brings a large overhead in terms of memory for the rest of simulations where the variables are not needed and anyway added. Following the recommendation of @msandre I have added an auxiliary variables list that allows to add variables only when needed.

Also the variable DISTANCE was always defined as historical even though it was not needed.