### PR TITLE
[PotentialFlow] Removing external solvers app import

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_analysis.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_analysis.py
@@ -3,9 +3,6 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 # Importing Kratos
 import KratosMultiphysics
 
-# Importing the solvers
-import KratosMultiphysics.ExternalSolversApplication
-
 # Importing the base class
 from KratosMultiphysics.analysis_stage import AnalysisStage
 


### PR DESCRIPTION
We had the import of the ExternalSolversApplication in the potential_flow_analysis but I dont think we are using it, is it ok if we remove it?