### PR TITLE
Feature/geometrical sensitivity line elements

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -81,6 +81,7 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/divide_tetrahedra_3d_4.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/embedded_skin_utility.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/geometrical_sensitivity_utility.cpp;
+    ${CMAKE_CURRENT_SOURCE_DIR}/utilities/line_sensitivity_utility.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/brute_force_point_locator.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/variable_utils.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/assign_unique_model_part_collection_tag_utility.cpp;
@@ -189,7 +190,7 @@ target_compile_definitions(KratosVersion PRIVATE
 add_library(KratosCore SHARED ${KRATOS_CORE_SOURCES} ${KRATOS_CORE_TESTING_ENGINE_SOURCES} ${KRATOS_CORE_INPUT_OUTPUT_SOURCES} ${KRATOS_TEST_SOURCES} $<TARGET_OBJECTS:KratosVersion>)
 target_link_libraries(KratosCore PUBLIC gidpost)
 set_target_properties(KratosCore PROPERTIES COMPILE_DEFINITIONS "KRATOS_CORE=IMPORT,API")
-target_compile_definitions(KratosCore PRIVATE 
+target_compile_definitions(KratosCore PRIVATE
     KRATOS_MAJOR_VERSION=${KratosMultiphysics_MAJOR_VERSION}
     KRATOS_MINOR_VERSION=${KratosMultiphysics_MINOR_VERSION}
 )

--- a/kratos/tests/cpp_tests/utilities/test_line_geometrical_sensitivity.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_line_geometrical_sensitivity.cpp
@@ -1,0 +1,193 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:
+//
+
+#include "geometries/line_2d_2.h"
+#include "geometries/line_2d_3.h"
+#include "geometries/line_3d_2.h"
+#include "geometries/line_3d_3.h"
+#include "geometries/triangle_3d_3.h"
+#include "includes/checks.h"
+#include "utilities/line_sensitivity_utility.h"
+#include "utilities/math_utils.h"
+#include "testing/testing.h"
+
+namespace Kratos
+{
+namespace Testing
+{
+
+Geometry<Point>::Pointer CreateLine2D2N()
+{
+    Geometry<Point>::PointsArrayType points;
+    points.push_back(Kratos::make_shared<Point>(-1.2, 0.5, 0.0));
+    points.push_back(Kratos::make_shared<Point>(3.1, -1.0, 0.0));
+
+    return Geometry<Point>::Pointer(new Line2D2<Point>(points));
+}
+
+Geometry<Point>::Pointer CreateLine2D3N()
+{
+    Geometry<Point>::PointsArrayType points;
+    points.push_back(Kratos::make_shared<Point>(-1.2,  0.5, 0.0));
+    points.push_back(Kratos::make_shared<Point>( 0.7,  0.6, 0.0));
+    points.push_back(Kratos::make_shared<Point>( 3.1, -1.0, 0.0));
+
+    return Geometry<Point>::Pointer(new Line2D3<Point>(points));
+}
+
+Geometry<Point>::Pointer CreateLine3D2N()
+{
+    Geometry<Point>::PointsArrayType points;
+    points.push_back(Kratos::make_shared<Point>(-1.2, 0.5, -1.1));
+    points.push_back(Kratos::make_shared<Point>(3.1, -1.0, 0.9));
+
+    return Geometry<Point>::Pointer(new Line3D2<Point>(points));
+}
+
+Geometry<Point>::Pointer CreateLine3D3N()
+{
+    Geometry<Point>::PointsArrayType points;
+    points.push_back(Kratos::make_shared<Point>(-1.2,  0.5, -1.1));
+    points.push_back(Kratos::make_shared<Point>( 0.7,  0.6,  1.3));
+    points.push_back(Kratos::make_shared<Point>( 3.1, -1.0,  0.9));
+
+    return Geometry<Point>::Pointer(new Line3D3<Point>(points));
+}
+
+Geometry<Point>::Pointer CreateTriangle3D3N()
+{
+    Geometry<Point>::PointsArrayType points;
+    points.push_back(Kratos::make_shared<Point>(-1.2,  0.5, -1.1));
+    points.push_back(Kratos::make_shared<Point>( 0.7,  0.6,  1.3));
+    points.push_back(Kratos::make_shared<Point>( 3.1, -1.0,  0.9));
+
+    return Geometry<Point>::Pointer(new Triangle3D3<Point>(points));
+}
+
+DenseMatrix<double> GetJacobian(
+    const Geometry<Point>& rGeometry,
+    GeometryData::IntegrationMethod Quadrature,
+    unsigned int GaussPointIndex)
+{
+    const auto& rDN_De = rGeometry.ShapeFunctionLocalGradient(GaussPointIndex, Quadrature);
+    DenseMatrix<double> jacobian(rGeometry.WorkingSpaceDimension(), rGeometry.LocalSpaceDimension());
+    DenseMatrix<double> coordinates(rGeometry.WorkingSpaceDimension(), rGeometry.PointsNumber());
+
+    for (unsigned int i = 0; i < rGeometry.PointsNumber(); i++)
+    {
+        const auto& r_coordinates = rGeometry[i].Coordinates();
+        for (unsigned int d = 0; d < rGeometry.WorkingSpaceDimension(); d++)
+        {
+            coordinates(d,i) = r_coordinates[d];
+        }
+    }
+
+    noalias(jacobian) = prod(coordinates,rDN_De);
+    return jacobian;
+}
+
+double IntegrationPointWeight(
+    const Geometry<Point>& rGeometry,
+    GeometryData::IntegrationMethod Quadrature,
+    unsigned int GaussPointIndex)
+{
+    auto jacobian = GetJacobian(rGeometry, Quadrature, GaussPointIndex);
+    DenseMatrix<double> aux = prod(trans(jacobian), jacobian);
+    double determinant = MathUtils<double>::Det(aux);
+    return rGeometry.IntegrationPoints(Quadrature)[GaussPointIndex].Weight() * std::sqrt(determinant);
+}
+
+void CheckIntegrationPointWeightSensitivity(
+    Geometry<Point>::Pointer pGeometry,
+    GeometryData::IntegrationMethod Quadrature,
+    double Perturbation = 1e-7,
+    double Tolerance = 1e-7)
+{
+    auto& r_geometry = *pGeometry;
+    const auto& integration_points = r_geometry.IntegrationPoints(Quadrature);
+    const unsigned int num_integration_points = integration_points.size();
+
+    for (unsigned int g = 0; g < num_integration_points; g++)
+    {
+        const auto& r_DN_De = r_geometry.ShapeFunctionLocalGradient(g, Quadrature);
+        const auto jacobian = GetJacobian(r_geometry, Quadrature, g);
+        LineSensitivityUtility line_sensitivity(jacobian, r_DN_De);
+        double result;
+
+        double base_weight = IntegrationPointWeight(r_geometry, Quadrature, g);
+        ShapeParameter::Sequence s(r_geometry.PointsNumber(), r_geometry.WorkingSpaceDimension());
+        while(s)
+        {
+            const auto& deriv = s.CurrentValue();
+            r_geometry[deriv.NodeIndex].Coordinates()[deriv.Direction] += Perturbation;
+            double perturbed_weight = IntegrationPointWeight(r_geometry, Quadrature, g);
+
+            double finite_difference_sensitivity = (perturbed_weight-base_weight)/Perturbation;
+            line_sensitivity.CalculateSensitivity(deriv, result);
+            double obtained_sensitivity = result * integration_points[g].Weight();
+
+            KRATOS_CHECK_NEAR(obtained_sensitivity, finite_difference_sensitivity, Tolerance);
+
+            // undo perturbation for next step
+            r_geometry[deriv.NodeIndex].Coordinates()[deriv.Direction] -= Perturbation;
+            ++s;
+        }
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(LineGeometricalSensitivity_Line2D2N, KratosCoreFastSuite)
+{
+    auto p_geometry = CreateLine2D2N();
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_1);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_2);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_3);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_4);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(LineGeometricalSensitivity_Line2D3N, KratosCoreFastSuite)
+{
+    auto p_geometry = CreateLine2D3N();
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_1);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_2);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_3);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_4);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(LineGeometricalSensitivity_Line3D2N, KratosCoreFastSuite)
+{
+    auto p_geometry = CreateLine3D2N();
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_1);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_2);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_3);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_4);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(LineGeometricalSensitivity_Line3D3N, KratosCoreFastSuite)
+{
+    auto p_geometry = CreateLine3D3N();
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_1);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_2);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_3);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_4);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(SurfaceGeometricalSensitivity_Triangle3D3N, KratosCoreFastSuite)
+{
+    auto p_geometry = CreateTriangle3D3N();
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_1);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_2);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_3);
+    CheckIntegrationPointWeightSensitivity(p_geometry, GeometryData::GI_GAUSS_4);
+}
+
+} // namespace Testing
+} // namespace Kratos

--- a/kratos/utilities/line_sensitivity_utility.cpp
+++ b/kratos/utilities/line_sensitivity_utility.cpp
@@ -1,0 +1,65 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Jordi Cotela
+//
+
+#include "line_sensitivity_utility.h"
+#include "utilities/math_utils.h"
+
+namespace Kratos
+{
+
+LineSensitivityUtility::LineSensitivityUtility(
+    const JacobianType& rJ, const ShapeFunctionsLocalGradientType& rDN_De)
+    : mrJ(rJ), mrDN_De(rDN_De)
+{}
+
+void LineSensitivityUtility::CalculateSensitivity(
+    const ShapeParameter Deriv, double& rIntegrationWeightSensitivity) const
+{
+    const unsigned int physical_dimension = mrJ.size1();
+    const unsigned int parameter_dimension = mrJ.size2();
+    MatrixType derivatives_of_jacobian(physical_dimension, parameter_dimension);
+    noalias(derivatives_of_jacobian) = ZeroMatrix(physical_dimension, parameter_dimension);
+
+    for (unsigned int i = 0; i < physical_dimension; i++)
+    {
+        derivatives_of_jacobian(Deriv.Direction,i) = mrDN_De(Deriv.NodeIndex, i);
+    }
+
+    MatrixType jt_j_partial = prod(derivatives_of_jacobian, trans(mrJ));
+    jt_j_partial += prod(mrJ, trans(derivatives_of_jacobian));
+
+    double det_jt_j_partial = 0.0;
+    for (unsigned int i = 0; i < physical_dimension; i++)
+    {
+        for (unsigned int j = 0; j < parameter_dimension; j++)
+        {
+            det_jt_j_partial += mCofactorJtJ(i,j) * jt_j_partial(i,j);
+        }
+    }
+
+    rIntegrationWeightSensitivity = det_jt_j_partial / (2.0 * std::sqrt(mDetJtJ));
+}
+
+void LineSensitivityUtility::Initialize()
+{
+    const unsigned int parameter_dimension = mrJ.size2();
+
+    mJtJ.resize(parameter_dimension, parameter_dimension,false);
+    noalias(mJtJ) = prod(trans(mrJ), mrJ);
+
+    mCofactorJtJ.resize(parameter_dimension, parameter_dimension, false);
+    noalias(mCofactorJtJ) = MathUtils<double>::CofactorMatrix(mJtJ);
+
+    mDetJtJ = MathUtils<double>::Det(mJtJ);
+}
+
+}

--- a/kratos/utilities/line_sensitivity_utility.cpp
+++ b/kratos/utilities/line_sensitivity_utility.cpp
@@ -36,11 +36,11 @@ void LineSensitivityUtility::CalculateSensitivity(
         derivatives_of_jacobian(Deriv.Direction,i) = mrDN_De(Deriv.NodeIndex, i);
     }
 
-    MatrixType jt_j_partial = prod(derivatives_of_jacobian, trans(mrJ));
-    jt_j_partial += prod(mrJ, trans(derivatives_of_jacobian));
+    MatrixType jt_j_partial = prod(trans(derivatives_of_jacobian), mrJ);
+    jt_j_partial += prod(trans(mrJ), derivatives_of_jacobian);
 
     double det_jt_j_partial = 0.0;
-    for (unsigned int i = 0; i < physical_dimension; i++)
+    for (unsigned int i = 0; i < parameter_dimension; i++)
     {
         for (unsigned int j = 0; j < parameter_dimension; j++)
         {

--- a/kratos/utilities/line_sensitivity_utility.cpp
+++ b/kratos/utilities/line_sensitivity_utility.cpp
@@ -19,7 +19,9 @@ namespace Kratos
 LineSensitivityUtility::LineSensitivityUtility(
     const JacobianType& rJ, const ShapeFunctionsLocalGradientType& rDN_De)
     : mrJ(rJ), mrDN_De(rDN_De)
-{}
+{
+    this->Initialize();
+}
 
 void LineSensitivityUtility::CalculateSensitivity(
     const ShapeParameter Deriv, double& rIntegrationWeightSensitivity) const
@@ -29,7 +31,7 @@ void LineSensitivityUtility::CalculateSensitivity(
     MatrixType derivatives_of_jacobian(physical_dimension, parameter_dimension);
     noalias(derivatives_of_jacobian) = ZeroMatrix(physical_dimension, parameter_dimension);
 
-    for (unsigned int i = 0; i < physical_dimension; i++)
+    for (unsigned int i = 0; i < parameter_dimension; i++)
     {
         derivatives_of_jacobian(Deriv.Direction,i) = mrDN_De(Deriv.NodeIndex, i);
     }

--- a/kratos/utilities/line_sensitivity_utility.h
+++ b/kratos/utilities/line_sensitivity_utility.h
@@ -1,0 +1,83 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Jordi Cotela
+//
+
+#ifndef KRATOS_LINE_SENSITIVITY_UTILITY_H_INCLUDED
+#define KRATOS_LINE_SENSITIVITY_UTILITY_H_INCLUDED
+
+#include "includes/define.h"
+#include "utilities/geometrical_sensitivity_utility.h"
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+class KRATOS_API(KRATOS_CORE) LineSensitivityUtility
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    KRATOS_CLASS_POINTER_DEFINITION(LineSensitivityUtility);
+
+    typedef DenseMatrix<double> MatrixType;
+
+    typedef MatrixType JacobianType;
+
+    typedef MatrixType ShapeFunctionsLocalGradientType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    LineSensitivityUtility(const JacobianType& rJ, const ShapeFunctionsLocalGradientType& rDN_De);
+
+    ~LineSensitivityUtility() = default;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    void CalculateSensitivity(const ShapeParameter Deriv, double& rIntegrationWeightSensitivity) const;
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    const JacobianType& mrJ;
+
+    const ShapeFunctionsLocalGradientType& mrDN_De;
+
+    MatrixType mJtJ;
+
+    MatrixType mCofactorJtJ;
+
+    double mDetJtJ;
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    void Initialize();
+
+    ///@}
+
+}; // class LineSensitivityUtility
+
+///@}
+
+} // namespace Kratos
+
+#endif // KRATOS_LINE_SENSITIVITY_UTILITY_H_INCLUDED


### PR DESCRIPTION
This utility is the analogue of the `GeometricalSensitivityUtility` for geometries that do not have a square Jacobian (testing for lines in 2D, 3D, triangles in 3D).

Note that only the sensitivity related to the Jacobian (more precisely, to the integration point weight) is included in this PR. I am not implementing sensitivities for shape function gradients because they are not relevant for my target application and I do not have test cases to verify.

Suggestions for function, class and argument names are very welcome, since the naming in this PR is very confusing. The class is called `LineSensitivityUtility` but I am quite convinced that what I have implemented so far is also valid for triangles and quadrilaterals in 3D (I added one test for 3D triangles only). Also, the equivalent function in `GeometricalSensitivityUtility` computes the sensitivity for the determinant of the Jacobian and calls it as such. My Jacobian is not square, so my result is the "sensitivity of `sqrt( determinant(J^T * J))`" and I have no clue of how to convey that clearly with a name that fits on a single line...