### PR TITLE
[Core] BDF coefficients process initialization

### DIFF
--- a/kratos/processes/compute_bdfcoefficients_process.h
+++ b/kratos/processes/compute_bdfcoefficients_process.h
@@ -56,14 +56,12 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
-/// Short class definition.
-/** Detail class definition.
-	calculate the nodal H for all the nodes depending on the min distance
-	of the neighbouring nodes.
-
-	lonely nodes are given the average value of the H
-*/
-
+/**
+ * @brief Auxiliary class to compute the BDF coefficients
+ * This class computes the BDF coefficients for the time step values stored
+ * in the ProcessInfo. It is valid for 1st and 2nd order BDF schemes and for
+ * non-constant delta time values.
+ */
 class ComputeBDFCoefficientsProcess
     : public Process
 {
@@ -87,10 +85,13 @@ public:
     }
 
     /// Destructor.
-    ~ComputeBDFCoefficientsProcess() override
-    {
-    }
+    ~ComputeBDFCoefficientsProcess() = default;
 
+    /// Assignment operator.
+    ComputeBDFCoefficientsProcess &operator=(ComputeBDFCoefficientsProcess const &rOther) = delete;
+
+    /// Copy constructor.
+    ComputeBDFCoefficientsProcess(ComputeBDFCoefficientsProcess const& rOther) = delete;
 
     ///@}
     ///@name Operators
@@ -100,7 +101,6 @@ public:
     {
         Execute();
     }
-
 
     ///@}
     ///@name Operations
@@ -158,7 +158,6 @@ public:
         KRATOS_CATCH("")
     }
 
-
     ///@}
     ///@name Access
     ///@{
@@ -185,56 +184,12 @@ public:
         rOStream << "ComputeBDFCoefficientsProcess";
     }
 
-    /// Print object's data.
-    void PrintData(std::ostream& rOStream) const override
-    {
-    }
-
-
     ///@}
     ///@name Friends
     ///@{
 
 
     ///@}
-
-protected:
-    ///@name Protected static Member Variables
-    ///@{
-
-
-    ///@}
-    ///@name Protected member Variables
-    ///@{
-
-
-    ///@}
-    ///@name Protected Operators
-    ///@{
-
-
-    ///@}
-    ///@name Protected Operations
-    ///@{
-
-
-    ///@}
-    ///@name Protected  Access
-    ///@{
-
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-
-
-    ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
@@ -243,12 +198,14 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
+
     ModelPart& mr_model_part;
     const unsigned int mtime_order;
 
     ///@}
     ///@name Private Operators
     ///@{
+
 
     ///@}
     ///@name Private Operations
@@ -269,15 +226,8 @@ private:
     ///@name Un accessible methods
     ///@{
 
-    /// Assignment operator.
-    ComputeBDFCoefficientsProcess& operator=(ComputeBDFCoefficientsProcess const& rOther);
-
-    /// Copy constructor.
-    //ComputeBDFCoefficientsProcess(ComputeBDFCoefficientsProcess const& rOther);
-
 
     ///@}
-
 }; // Class ComputeBDFCoefficientsProcess
 
 ///@}

--- a/kratos/processes/compute_bdfcoefficients_process.h
+++ b/kratos/processes/compute_bdfcoefficients_process.h
@@ -82,6 +82,8 @@ public:
     ComputeBDFCoefficientsProcess(ModelPart& model_part, unsigned int time_order)
         : mr_model_part(model_part), mtime_order(time_order)
     {
+        KRATOS_ERROR_IF(mtime_order == 0 || mtime_order > 2) << "Time order must be either \'1\' or \'2\'. Got " << mtime_order << std::endl;
+        mr_model_part.GetProcessInfo()[BDF_COEFFICIENTS] = ZeroVector(mtime_order + 1);
     }
 
     /// Destructor.
@@ -108,15 +110,15 @@ public:
     void Execute() override
     {
         KRATOS_TRY
-        
+
         ProcessInfo& rCurrentProcessInfo = mr_model_part.GetProcessInfo();
-        
+
         if (mtime_order == 2)
         {
             //calculate the BDF coefficients
             double Dt = rCurrentProcessInfo[DELTA_TIME];
             double OldDt = rCurrentProcessInfo.GetPreviousTimeStepInfo(1)[DELTA_TIME];
-            
+
             if(OldDt > 1e-10*Dt) //this should always be the case!!
             {
                 double Rho = OldDt / Dt;
@@ -308,6 +310,4 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_COMPUTE_BDF_COEFFICIENTS_PROCESS_INCLUDED  defined 
-
-
+#endif // KRATOS_COMPUTE_BDF_COEFFICIENTS_PROCESS_INCLUDED  defined

--- a/kratos/tests/cpp_tests/processes/test_compute_bdfcoefficients_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_compute_bdfcoefficients_process.cpp
@@ -38,13 +38,11 @@ namespace Kratos {
         const auto &r_bdf_coefs_1 = r_model_part.GetProcessInfo()[BDF_COEFFICIENTS];
         KRATOS_CHECK_NEAR(r_bdf_coefs_1[0], 0.0, tolerance);
         KRATOS_CHECK_NEAR(r_bdf_coefs_1[1], 0.0, tolerance);
-        KRATOS_CHECK_NEAR(r_bdf_coefs_1[2], 0.0, tolerance);
 
         // Check 1st order results
         bdf_coefs_proc_1.Execute();
         KRATOS_CHECK_NEAR(r_bdf_coefs_1[0],  5.0, tolerance);
         KRATOS_CHECK_NEAR(r_bdf_coefs_1[1], -5.0, tolerance);
-        KRATOS_CHECK_NEAR(r_bdf_coefs_1[2],  0.0, tolerance);
 
         // Set second order BDF coefficients process
         ComputeBDFCoefficientsProcess bdf_coefs_proc_2(r_model_part, 2);

--- a/kratos/tests/cpp_tests/processes/test_compute_bdfcoefficients_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_compute_bdfcoefficients_process.cpp
@@ -1,0 +1,61 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+// Project includes
+#include "testing/testing.h"
+#include "containers/model.h"
+#include "includes/checks.h"
+#include "processes/compute_bdfcoefficients_process.h"
+
+namespace Kratos {
+  namespace Testing {
+
+	KRATOS_TEST_CASE_IN_SUITE(ComputeBDFCoefficientsProcess, KratosCoreFastSuite)
+	{
+        const double tolerance = 1.0e-8;
+
+        // Create test model part
+        Model Model;
+        auto &r_model_part = Model.CreateModelPart("ModelPart");
+
+        // Set fake delta times to test
+        r_model_part.CloneTimeStep(0.1);
+        r_model_part.CloneTimeStep(0.3);
+
+        // Set first order BDF coefficients process
+        ComputeBDFCoefficientsProcess bdf_coefs_proc_1(r_model_part, 1);
+
+        // Check initialization
+        const auto &r_bdf_coefs_1 = r_model_part.GetProcessInfo()[BDF_COEFFICIENTS];
+        KRATOS_CHECK_NEAR(r_bdf_coefs_1[0], 0.0, tolerance);
+        KRATOS_CHECK_NEAR(r_bdf_coefs_1[1], 0.0, tolerance);
+        KRATOS_CHECK_NEAR(r_bdf_coefs_1[2], 0.0, tolerance);
+
+        // Check 1st order results
+        bdf_coefs_proc_1.Execute();
+        KRATOS_CHECK_NEAR(r_bdf_coefs_1[0],  5.0, tolerance);
+        KRATOS_CHECK_NEAR(r_bdf_coefs_1[1], -5.0, tolerance);
+        KRATOS_CHECK_NEAR(r_bdf_coefs_1[2],  0.0, tolerance);
+
+        // Set second order BDF coefficients process
+        ComputeBDFCoefficientsProcess bdf_coefs_proc_2(r_model_part, 2);
+
+        // Check 2nd order results
+        bdf_coefs_proc_2.Execute();
+        const auto &r_bdf_coefs_2 = r_model_part.GetProcessInfo()[BDF_COEFFICIENTS];
+        KRATOS_CHECK_NEAR(r_bdf_coefs_2[0], 25.0/3.0, tolerance);
+        KRATOS_CHECK_NEAR(r_bdf_coefs_2[1], -15.0, tolerance);
+        KRATOS_CHECK_NEAR(r_bdf_coefs_2[2], 20.0/3.0, tolerance);
+    }
+
+}
+}  // namespace Kratos.


### PR DESCRIPTION
This PR adds an initialization of the `BDF_COEFFICIENTS` vector in the ProcessInfo when the process is constructed. Before, such variable were initialized the first time the `Execute()` method was called. This was a potential source of memory leaks.

@dagmawibekel FYI this partially fixes what you reported in #4961 . 