### PR TITLE
Support for using the main model part in check and prepare.

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -34,7 +34,10 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
 
 
     def Execute(self):
-        self.volume_model_part = self.main_model_part.GetSubModelPart(self.volume_model_part_name)
+        if self.main_model_part.Name == self.volume_model_part_name:
+            self.volume_model_part = self.main_model_part
+        else:
+            self.volume_model_part = self.main_model_part.GetSubModelPart(self.volume_model_part_name)
 
         skin_parts = []
         for i in range(self.skin_name_list.size()):


### PR DESCRIPTION
In some tests (with very simple mdpa) I am trying to use the (only) model part as volume_model_part. This adds support for using it instead of trying to retrieve one of its submodelparts.