### PR TITLE
[Potentialflow] Updating test files up to standard

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_no_wake_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_no_wake_parameters.json
@@ -29,7 +29,7 @@
             "coarse_enough" : 5000,
             "krylov_type": "lgmres",
             "tolerance": 1e-9,
-            "verbosity": 3,
+            "verbosity": 0,
             "scaling": false
         },
         "auxiliary_variables_list" : ["NODAL_H","GEOMETRY_DISTANCE","DISTANCE"]

--- a/applications/CompressiblePotentialFlowApplication/tests/run_cpp_unit_tests.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/run_cpp_unit_tests.py
@@ -1,9 +1,0 @@
-from KratosMultiphysics import *
-from KratosMultiphysics.CompressiblePotentialFlowApplication import *
-
-def run():
-    Tester.SetVerbosity(Tester.Verbosity.PROGRESS) # TESTS_OUTPUTS
-    Tester.RunTestSuite("CompressiblePotentialApplicationFastSuite")
-
-if __name__ == '__main__':
-    run()

--- a/applications/CompressiblePotentialFlowApplication/tests/test_CompressiblePotentialFlowApplication.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/test_CompressiblePotentialFlowApplication.py
@@ -2,7 +2,6 @@
 import KratosMultiphysics
 from KratosMultiphysics import *
 from KratosMultiphysics.CompressiblePotentialFlowApplication import *
-import run_cpp_unit_tests
 
 ##### SMALL TESTS #####
 from potential_flow_test_factory import PotentialFlowTests
@@ -46,8 +45,12 @@ def AssembleTestSuites():
     return suites
 
 if __name__ == '__main__':
+    # Comment this to see Kratos Logger prints
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
+
     KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning cpp unit tests ...")
-    run_cpp_unit_tests.run()
+    KratosMultiphysics.Tester.SetVerbosity(KratosMultiphysics.Tester.Verbosity.PROGRESS) # TESTS_OUTPUTS
+    KratosMultiphysics.Tester.RunTestSuite("CompressiblePotentialApplicationFastSuite")
     KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished running cpp unit tests!")
     KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning python tests ...")
     KratosUnittest.runTests(AssembleTestSuites())


### PR DESCRIPTION
Hi,

After #5079, I do the same operation in the PotentialFlowApp. I also take the chance to avoid printing all the Kratos info by default (and setting verbosity to 0 in one test), in order to see the results of the tests at a glance.
