### PR TITLE
Mpi/feature value sendrecv

### DIFF
--- a/kratos/includes/data_communicator.h
+++ b/kratos/includes/data_communicator.h
@@ -126,12 +126,24 @@ virtual void ScanSum(const std::vector<type>& rLocalValues, std::vector<type>& r
  */
 #ifndef KRATOS_BASE_DATA_COMMUNICATOR_DECLARE_SENDRECV_INTERFACE_FOR_TYPE
 #define KRATOS_BASE_DATA_COMMUNICATOR_DECLARE_SENDRECV_INTERFACE_FOR_TYPE(type)                                 \
+virtual type SendRecvImpl(                                                                                      \
+    const type rSendValues, const int SendDestination, const int SendTag,                                       \
+    const int RecvSource, const int RecvTag) const {                                                            \
+    KRATOS_ERROR_IF( (Rank() != SendDestination) || (Rank() != RecvSource))                                     \
+    << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;    \
+    return rSendValues;                                                                                         \
+}                                                                                                               \
 virtual std::vector<type> SendRecvImpl(                                                                         \
     const std::vector<type>& rSendValues, const int SendDestination, const int SendTag,                         \
     const int RecvSource, const int RecvTag) const {                                                            \
     KRATOS_ERROR_IF( (Rank() != SendDestination) || (Rank() != RecvSource))                                     \
     << "Communication between different ranks is not possible with a serial DataCommunicator." << std::endl;    \
     return rSendValues;                                                                                         \
+}                                                                                                               \
+virtual void SendRecvImpl(                                                                                      \
+    const type rSendValues, const int SendDestination, const int SendTag,                                       \
+    type& rRecvValues, const int RecvSource, const int RecvTag) const {                                         \
+    rRecvValues = SendRecvImpl(rSendValues, SendDestination, SendTag, RecvSource, RecvTag);                     \
 }                                                                                                               \
 virtual void SendRecvImpl(                                                                                      \
     const std::vector<type>& rSendValues, const int SendDestination, const int SendTag,                         \

--- a/kratos/mpi/includes/mpi_data_communicator.h
+++ b/kratos/mpi/includes/mpi_data_communicator.h
@@ -62,9 +62,15 @@ void ScanSum(const std::vector<type>& rLocalValues, std::vector<type>& rGlobalVa
 
 #ifndef KRATOS_MPI_DATA_COMMUNICATOR_DECLARE_SENDRECV_INTERFACE_FOR_TYPE
 #define KRATOS_MPI_DATA_COMMUNICATOR_DECLARE_SENDRECV_INTERFACE_FOR_TYPE(type)               \
+type SendRecvImpl(                                                                           \
+    const type SendValue, const int SendDestination, const int SendTag,                      \
+    const int RecvSource, const int RecvTag) const override;                                 \
 std::vector<type> SendRecvImpl(const std::vector<type>& rSendValues,                         \
     const int SendDestination, const int SendTag,                                            \
     const int RecvSource, const int RecvTag) const override;                                 \
+void SendRecvImpl(                                                                           \
+    const type SendValue, const int SendDestination, const int SendTag,                      \
+    type& RecvValue, const int RecvSource, const int RecvTag) const override;                \
 void SendRecvImpl(                                                                           \
     const std::vector<type>& rSendValues, const int SendDestination, const int SendTag,      \
     std::vector<type>& rRecvValues, const int RecvSource, const int RecvTag) const override; \
@@ -341,6 +347,11 @@ class MPIDataCommunicator: public DataCommunicator
     template<class TDataType> void SendRecvDetail(
         const TDataType& rSendMessage, const int SendDestination, const int SendTag,
         TDataType& rRecvMessage, const int RecvSource, const int RecvTag) const;
+
+    template<class TDataType> TDataType SendRecvDetail(
+        const TDataType& rSendMessage,
+        const int SendDestination, const int SendTag,
+        const int RecvSource, const int RecvTag) const;
 
     template<class TDataType> std::vector<TDataType> SendRecvDetail(
         const std::vector<TDataType>& rSendMessage,

--- a/kratos/mpi/sources/mpi_data_communicator.cpp
+++ b/kratos/mpi/sources/mpi_data_communicator.cpp
@@ -99,6 +99,12 @@ void MPIDataCommunicator::ScanSum(                                              
 
 #ifndef KRATOS_MPI_DATA_COMMUNICATOR_DEFINE_SENDRECV_INTERFACE_FOR_TYPE
 #define KRATOS_MPI_DATA_COMMUNICATOR_DEFINE_SENDRECV_INTERFACE_FOR_TYPE(type)           \
+type MPIDataCommunicator::SendRecvImpl(                                                 \
+    const type SendValue,                                                               \
+    const int SendDestination, const int SendTag,                                       \
+    const int RecvSource, const int RecvTag) const {                                    \
+    return SendRecvDetail(SendValue, SendDestination, SendTag, RecvSource, RecvTag);    \
+}                                                                                       \
 std::vector<type> MPIDataCommunicator::SendRecvImpl(                                    \
     const std::vector<type>& rSendValues,                                               \
     const int SendDestination, const int SendTag,                                       \
@@ -109,6 +115,11 @@ void MPIDataCommunicator::SendRecvImpl(                                         
     const std::vector<type>& rSendValues, const int SendDestination, const int SendTag, \
     std::vector<type>& rRecvValues, const int RecvSource, const int RecvTag) const {    \
     SendRecvDetail(rSendValues,SendDestination,SendTag,rRecvValues,RecvSource,RecvTag); \
+}                                                                                       \
+void MPIDataCommunicator::SendRecvImpl(                                                 \
+    const type SendValue, const int SendDestination, const int SendTag,                 \
+    type& rRecvValue, const int RecvSource, const int RecvTag) const {                  \
+    SendRecvDetail(SendValue,SendDestination,SendTag,rRecvValue,RecvSource,RecvTag);    \
 }                                                                                       \
 void MPIDataCommunicator::SendImpl(const std::vector<type>& rSendValues,                \
     const int SendDestination, const int SendTag) const {                               \
@@ -596,6 +607,16 @@ template<class TDataType> void MPIDataCommunicator::SendRecvDetail(
         MPIDatatype(rRecvMessage), RecvSource, RecvTag,
         mComm, MPI_STATUS_IGNORE);
     CheckMPIErrorCode(ierr, "MPI_Sendrecv");
+}
+
+template<class TDataType> TDataType MPIDataCommunicator::SendRecvDetail(
+    const TDataType& rSendMessage,
+    const int SendDestination, const int SendTag,
+    const int RecvSource, const int RecvTag) const
+{
+    TDataType recv_values;
+    SendRecvDetail(rSendMessage,SendDestination, SendTag ,recv_values,RecvSource, RecvTag);
+    return recv_values;
 }
 
 template<class TDataType> std::vector<TDataType> MPIDataCommunicator::SendRecvDetail(

--- a/kratos/mpi/tests/sources/test_mpi_data_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_mpi_data_communicator.cpp
@@ -1253,18 +1253,28 @@ template<typename T> void MPIDataCommunicatorSendRecvIntegralTypeTest()
     const int send_rank = world_rank + 1 == world_size ? 0 : world_rank + 1;
     const int recv_rank = world_rank == 0 ? world_size - 1 : world_rank - 1;
 
-    std::vector<T> send_buffer{(T)world_rank, (T)world_rank};
+    T send_value(world_rank);
+    T recv_value(999);
+    std::vector<T> send_buffer{send_value, send_value};
     std::vector<T> recv_buffer{999, 999};
 
     if (world_size > 1)
     {
-        // two-buffer version
+        const T expected_recv = world_rank > 0 ? world_rank - 1 : world_size - 1;
+
+        // value two-buffer version
+        mpi_world_communicator.SendRecv(send_value, send_rank, 0, recv_value, recv_rank, 0);
+        KRATOS_CHECK_EQUAL(recv_value, expected_recv);
+
+        // value return version
+        T return_value = mpi_world_communicator.SendRecv(send_value, send_rank, 0, recv_rank, 0);
+        KRATOS_CHECK_EQUAL(return_value, expected_recv);
+
+        // vector two-buffer version
         mpi_world_communicator.SendRecv(send_buffer, send_rank, 0, recv_buffer, recv_rank, 0);
 
-        // return version
+        // vector return version
         std::vector<T> return_buffer = mpi_world_communicator.SendRecv(send_buffer, send_rank, recv_rank);
-
-        const T expected_recv = world_rank > 0 ? world_rank - 1 : world_size - 1;
 
         KRATOS_CHECK_EQUAL(return_buffer.size(), 2);
         for (int i = 0; i < 2; i++)
@@ -1299,18 +1309,28 @@ KRATOS_DISTRIBUTED_TEST_CASE_IN_SUITE(MPIDataCommunicatorSendRecvDouble, KratosM
     const int send_rank = world_rank + 1 == world_size ? 0 : world_rank + 1;
     const int recv_rank = world_rank == 0 ? world_size - 1 : world_rank - 1;
 
+    double send_value(2.0*world_rank);
+    double recv_value(-1.0);
     std::vector<double> send_buffer{2.0*world_rank, 2.0*world_rank};
     std::vector<double> recv_buffer{-1.0, -1.0};
 
     if (world_size > 1)
     {
+        const double expected_recv = world_rank > 0 ? 2.0*(world_rank - 1) : 2.0*(world_size - 1);
+
+        // value two-buffer version
+        mpi_world_communicator.SendRecv(send_value, send_rank, 0, recv_value, recv_rank, 0);
+        KRATOS_CHECK_EQUAL(recv_value, expected_recv);
+
+        // value return version
+        double return_value = mpi_world_communicator.SendRecv(send_value, send_rank, 0, recv_rank, 0);
+        KRATOS_CHECK_EQUAL(return_value, expected_recv);
+
         // two-buffer version
         mpi_world_communicator.SendRecv(send_buffer, send_rank, 0, recv_buffer, recv_rank, 0);
 
         // return version
         std::vector<double> return_buffer = mpi_world_communicator.SendRecv(send_buffer, send_rank, recv_rank);
-
-        const double expected_recv = world_rank > 0 ? 2.0*(world_rank - 1) : 2.0*(world_size - 1);
 
         KRATOS_CHECK_EQUAL(return_buffer.size(), 2);
         for (int i = 0; i < 2; i++)


### PR DESCRIPTION
#5210 communicates some sizes as single values using SendRecv. This was currently going through the serializer, so I am adding SendRecv functions for the value type (`int` as opposed to `std::vector<int>` and so on) and related tests.