### PR TITLE
[CoSim] improve class name

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_accelerator.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_accelerator.py
@@ -60,8 +60,9 @@ class CoSimulationConvergenceAccelerator(object):
     def UpdateSolution(self, residual, iteration_guess):
         raise NotImplementedError('"UpdateSolution" has to be implemented in the derived class!')
 
-    def _Name(self):
-        return self.__class__.__name__
+    @classmethod
+    def _ClassName(cls):
+        return cls.__name__
 
     @classmethod
     def _GetDefaultSettings(cls):

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_accelerator.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_accelerator.py
@@ -52,7 +52,7 @@ class CoSimulationConvergenceAccelerator(object):
         '''Function to print Info abt the Object
         Can be overridden in derived classes to print more information
         '''
-        cs_tools.cs_print_info("Convergence Accelerator", colors.bold(self._Name()))
+        cs_tools.cs_print_info("Convergence Accelerator", colors.bold(self._ClassName()))
 
     def Check(self):
         print("ConvAcc does not yet implement Check")

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_criteria.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_criteria.py
@@ -44,7 +44,7 @@ class CoSimulationConvergenceCriteria(object):
         raise NotImplementedError('"IsConverged" has to be implemented in the derived class!')
 
     def PrintInfo(self):
-        cs_tools.cs_print_info("Convergence Criteria", colors.bold(self._Name()))
+        cs_tools.cs_print_info("Convergence Criteria", colors.bold(self._ClassName()))
 
     def Check(self):
         print("ConvCrit does not implement Check yet!")

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_criteria.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_criteria.py
@@ -49,8 +49,9 @@ class CoSimulationConvergenceCriteria(object):
     def Check(self):
         print("ConvCrit does not implement Check yet!")
 
-    def _Name(self):
-        return self.__class__.__name__
+    @classmethod
+    def _ClassName(cls):
+        return cls.__name__
 
     @classmethod
     def _GetDefaultSettings(cls):

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
@@ -119,7 +119,7 @@ class CoSimulationCoupledSolver(co_simulation_solver_wrapper.CoSimulationSolverW
         to_solver = self.solver_wrappers[solver_name]
         input_data_list = self.coupling_sequence[solver_name]["input_data_list"]
         if self.echo_level > 2:
-            cs_tools.cs_print_info(self._Name(), 'Start Synchronizing Input for "{}"'.format(colors.blue(solver_name)))
+            cs_tools.cs_print_info(self._ClassName(), 'Start Synchronizing Input for "{}"'.format(colors.blue(solver_name)))
 
         for i in range(input_data_list.size()):
             i_input_data = input_data_list[i]
@@ -159,13 +159,13 @@ class CoSimulationCoupledSolver(co_simulation_solver_wrapper.CoSimulationSolverW
             self.__ApplyScaling(to_solver_data, i_input_data)
 
         if self.echo_level > 2:
-            cs_tools.cs_print_info(self._Name(), 'End Synchronizing Input for "{}"'.format(colors.blue(solver_name)))
+            cs_tools.cs_print_info(self._ClassName(), 'End Synchronizing Input for "{}"'.format(colors.blue(solver_name)))
 
     def _SynchronizeOutputData(self, solver_name):
         from_solver = self.solver_wrappers[solver_name]
         output_data_list = self.coupling_sequence[solver_name]["output_data_list"]
         if self.echo_level > 2:
-            cs_tools.cs_print_info(self._Name(), 'Start Synchronizing Output for "{}"'.format(colors.blue(solver_name)))
+            cs_tools.cs_print_info(self._ClassName(), 'Start Synchronizing Output for "{}"'.format(colors.blue(solver_name)))
 
         for i in range(output_data_list.size()):
             i_output_data = output_data_list[i]
@@ -205,7 +205,7 @@ class CoSimulationCoupledSolver(co_simulation_solver_wrapper.CoSimulationSolverW
             from_solver.ExportCouplingInterfaceData(from_solver_data)
 
         if self.echo_level > 2:
-            cs_tools.cs_print_info(self._Name(), 'End Synchronizing Output for "{}"'.format(colors.blue(solver_name)))
+            cs_tools.cs_print_info(self._ClassName(), 'End Synchronizing Output for "{}"'.format(colors.blue(solver_name)))
 
 
     def __GetDataTransferOperator(self, data_transfer_operator_name):
@@ -223,7 +223,7 @@ class CoSimulationCoupledSolver(co_simulation_solver_wrapper.CoSimulationSolverW
     def PrintInfo(self):
         super(CoSimulationCoupledSolver, self).PrintInfo()
 
-        cs_print_info(self._Name(), "Has the following components:")
+        cs_print_info(self._ClassName(), "Has the following components:")
         for solver in self.solver_wrappers.values():
             solver.PrintInfo()
 

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
@@ -41,12 +41,12 @@ class CoSimulationCouplingOperation(object):
     def PrintInfo(self):
         pass
 
+    def Check(self):
+        pass
+
     @classmethod
     def _ClassName(cls):
         return cls.__name__
-
-    def Check(self):
-        pass
 
     @classmethod
     def _GetDefaultSettings(cls):

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
@@ -41,8 +41,9 @@ class CoSimulationCouplingOperation(object):
     def PrintInfo(self):
         pass
 
-    def _Name(self):
-        return self.__class__.__name__
+    @classmethod
+    def _ClassName(cls):
+        return cls.__name__
 
     def Check(self):
         pass

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
@@ -46,8 +46,9 @@ class CoSimulationPredictor(object):
     def Check(self):
         print("The predictors do not yet implement Check!")
 
-    def _Name(self):
-        return self.__class__.__name__
+    @classmethod
+    def _ClassName(cls):
+        return cls.__name__
 
     def _UpdateData(self, updated_data):
         self.interface_data.SetData(updated_data)

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
@@ -41,7 +41,7 @@ class CoSimulationPredictor(object):
         '''Function to print Info abt the Object
         Can be overridden in derived classes to print more information
         '''
-        cs_tools.cs_print_info("Predictor", colors.bold(self._Name()))
+        cs_tools.cs_print_info("Predictor", colors.bold(self._ClassName()))
 
     def Check(self):
         print("The predictors do not yet implement Check!")
@@ -54,7 +54,7 @@ class CoSimulationPredictor(object):
         self.interface_data.SetData(updated_data)
 
         if self.echo_level > 3:
-            cs_tools.cs_print_info(self._Name(), "Computed prediction")
+            cs_tools.cs_print_info(self._ClassName(), "Computed prediction")
 
 
     # returns the buffer size needed by the predictor. Can be overridden in derived classes

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
@@ -46,20 +46,19 @@ class CoSimulationPredictor(object):
     def Check(self):
         print("The predictors do not yet implement Check!")
 
-    @classmethod
-    def _ClassName(cls):
-        return cls.__name__
-
     def _UpdateData(self, updated_data):
         self.interface_data.SetData(updated_data)
 
         if self.echo_level > 3:
             cs_tools.cs_print_info(self._ClassName(), "Computed prediction")
 
-
     # returns the buffer size needed by the predictor. Can be overridden in derived classes
     def _GetMinimumBufferSize(self):
         return 2
+
+    @classmethod
+    def _ClassName(cls):
+        return cls.__name__
 
     @classmethod
     def _GetDefaultSettings(cls):

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -123,10 +123,6 @@ class CoSimulationSolverWrapper(object):
         '''
         pass
 
-    @classmethod
-    def _ClassName(cls):
-        return cls.__name__
-
     def _AllocateHistoricalVariablesFromCouplingData(self):
         '''This function retrieves the historical variables that are needed for the ModelParts from the specified CouplingInterfaceDatas and allocates them on the ModelParts
         Note that it can only be called after the (Main-)ModelParts are created
@@ -154,6 +150,10 @@ class CoSimulationSolverWrapper(object):
         '''
         # TODO check if this method is necessary!
         return False
+
+    @classmethod
+    def _ClassName(cls):
+        return cls.__name__
 
     @classmethod
     def _GetIOName(cls):

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -123,8 +123,9 @@ class CoSimulationSolverWrapper(object):
         '''
         pass
 
-    def _Name(self):
-        return self.__class__.__name__
+    @classmethod
+    def _ClassName(cls):
+        return cls.__name__
 
     def _AllocateHistoricalVariablesFromCouplingData(self):
         '''This function retrieves the historical variables that are needed for the ModelParts from the specified CouplingInterfaceDatas and allocates them on the ModelParts

--- a/applications/CoSimulationApplication/python_scripts/convergence_accelerators/aitken.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_accelerators/aitken.py
@@ -48,7 +48,7 @@ class AitkenConvergenceAccelerator(CoSimulationConvergenceAccelerator):
         if k == 0:
             alpha = min( self.alpha_old, self.init_alpha_max )
             if self.echo_level > 3:
-                cs_tools.cs_print_info(self._Name(), ": Doing relaxation in the first iteration with initial factor = " + "{0:.1g}".format(alpha))
+                cs_tools.cs_print_info(self._ClassName(), ": Doing relaxation in the first iteration with initial factor = " + "{0:.1g}".format(alpha))
             return alpha * r
         else:
             r_diff = self.R[0] - self.R[1]
@@ -56,15 +56,15 @@ class AitkenConvergenceAccelerator(CoSimulationConvergenceAccelerator):
             denominator = np.inner( r_diff, r_diff )
             alpha = -self.alpha_old * numerator/denominator
             if self.echo_level > 3:
-                cs_tools.cs_print_info(self._Name(), ": Doing relaxation with factor = " + "{0:.1g}".format(alpha))
+                cs_tools.cs_print_info(self._ClassName(), ": Doing relaxation with factor = " + "{0:.1g}".format(alpha))
             if alpha > 20:
                 alpha = 20
                 if self.echo_level > 0:
-                    cs_tools.cs_print_warning(self._Name(), "dynamic relaxation factor reaches upper bound: 20")
+                    cs_tools.cs_print_warning(self._ClassName(), "dynamic relaxation factor reaches upper bound: 20")
             elif alpha < -2:
                 alpha = -2
                 if self.echo_level > 0:
-                    cs_tools.cs_print_warning(self._Name(), "dynamic relaxation factor reaches lower bound: -2")
+                    cs_tools.cs_print_warning(self._ClassName(), "dynamic relaxation factor reaches lower bound: -2")
             delta_x = alpha * self.R[0]
         self.alpha_old = alpha
 

--- a/applications/CoSimulationApplication/python_scripts/convergence_accelerators/anderson.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_accelerators/anderson.py
@@ -69,7 +69,7 @@ class AndersonConvergenceAccelerator(CoSimulationConvergenceAccelerator):
         if k == 0:
             ## For the first iteration, do relaxation only
             if self.echo_level > 3:
-                classprint(self._Name(), "Doing relaxation in the first iteration with factor = ", "{0:.1g}".format(self.alpha))
+                classprint(self._ClassName(), "Doing relaxation in the first iteration with factor = ", "{0:.1g}".format(self.alpha))
             return self.alpha * r
         else:
             self.F = np.empty( shape = (col, row) ) # will be transposed later
@@ -91,11 +91,11 @@ class AndersonConvergenceAccelerator(CoSimulationConvergenceAccelerator):
             if switch.is_integer() == True:
                 B = self.beta * np.identity(row) - (self.X + self.beta * self.F) @ A @ self.F.T
                 if self.echo_level > 3:
-                    classprint(self._Name(), blue("Compute B with Anderson"))
+                    classprint(self._ClassName(), blue("Compute B with Anderson"))
             else:
                 B = self.alpha * np.identity(row)
                 if self.echo_level > 3:
-                    classprint(self._Name(), red("Constant underrelaxtion"))
+                    classprint(self._ClassName(), red("Constant underrelaxtion"))
 
             delta_x = B @ r
 

--- a/applications/CoSimulationApplication/python_scripts/convergence_accelerators/constant_relaxation.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_accelerators/constant_relaxation.py
@@ -27,6 +27,6 @@ class ConstantRelaxationConvergenceAccelerator(CoSimulationConvergenceAccelerato
     # Computes the approximated update in each iteration.
     def UpdateSolution( self, r, x ):
         if self.echo_level > 3:
-            classprint(self._Name(), "Doing relaxation with factor = ", "{0:.1g}".format(self.alpha))
+            classprint(self._ClassName(), "Doing relaxation with factor = ", "{0:.1g}".format(self.alpha))
         delta_x = self.alpha * r
         return delta_x

--- a/applications/CoSimulationApplication/python_scripts/convergence_accelerators/iqnils.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_accelerators/iqnils.py
@@ -71,12 +71,12 @@ class IQNILSConvergenceAccelerator(CoSimulationConvergenceAccelerator):
             if k == 0:
                 ## For the first iteration in the first time step, do relaxation only
                 if self.echo_level > 3:
-                    cs_print_info(self._Name(), "Doing relaxation in the first iteration with factor = ", "{0:.1g}".format(self.alpha))
+                    cs_print_info(self._ClassName(), "Doing relaxation in the first iteration with factor = ", "{0:.1g}".format(self.alpha))
                 return self.alpha * r
             else:
                 if self.echo_level > 3:
-                    cs_print_info(self._Name(), "Doing multi-vector extrapolation")
-                    cs_print_info(self._Name(), "Number of new modes: ", col)
+                    cs_print_info(self._ClassName(), "Doing multi-vector extrapolation")
+                    cs_print_info(self._ClassName(), "Number of new modes: ", col)
                 self.V_new = np.empty( shape = (col, row) ) # will be transposed later
                 for i in range(0, col):
                     self.V_new[i] = self.R[i] - self.R[i + 1]
@@ -85,7 +85,7 @@ class IQNILSConvergenceAccelerator(CoSimulationConvergenceAccelerator):
 
                 ## Check the dimension of the newly constructed matrix
                 if ( V.shape[0] < V.shape[1] ) and self.echo_level > 0:
-                    cs_print_warning(self._Name(), ": "+ colors.red("WARNING: column number larger than row number!"))
+                    cs_print_warning(self._ClassName(), ": "+ colors.red("WARNING: column number larger than row number!"))
 
                 ## Construct matrix W(differences of predictions)
                 self.W_new = np.empty( shape = (col, row) ) # will be transposed later
@@ -105,8 +105,8 @@ class IQNILSConvergenceAccelerator(CoSimulationConvergenceAccelerator):
         else:  # previous vectors can be reused
             if k == 0: # first iteration
                 if self.echo_level > 3:
-                    cs_print_info(self._Name(), "Using matrices from previous time steps")
-                    cs_print_info(self._Name(), "Number of previous matrices: ", num_old_matrices)
+                    cs_print_info(self._ClassName(), "Using matrices from previous time steps")
+                    cs_print_info(self._ClassName(), "Number of previous matrices: ", num_old_matrices)
                 V = self.V_old
                 W = self.W_old
                 ## Solve least-squares problem
@@ -119,9 +119,9 @@ class IQNILSConvergenceAccelerator(CoSimulationConvergenceAccelerator):
             else:
                 ## For other iterations, construct new V and W matrices and combine them with old ones
                 if self.echo_level > 3:
-                    cs_print_info(self._Name(), "Doing multi-vector extrapolation")
-                    cs_print_info(self._Name(), "Number of new modes: ", col)
-                    cs_print_info(self._Name(), "Number of previous matrices: ", num_old_matrices)
+                    cs_print_info(self._ClassName(), "Doing multi-vector extrapolation")
+                    cs_print_info(self._ClassName(), "Number of new modes: ", col)
+                    cs_print_info(self._ClassName(), "Number of previous matrices: ", num_old_matrices)
                 ## Construct matrix V (differences of residuals)
                 self.V_new = np.empty( shape = (col, row) ) # will be transposed later
                 for i in range(0, col):
@@ -130,7 +130,7 @@ class IQNILSConvergenceAccelerator(CoSimulationConvergenceAccelerator):
                 V = np.hstack( (self.V_new, self.V_old) )
                 ## Check the dimension of the newly constructed matrix
                 if ( V.shape[0] < V.shape[1] ) and self.echo_level > 0:
-                    cs_print_warning(self._Name(), ": "+ colors.red("WARNING: column number larger than row number!"))
+                    cs_print_warning(self._ClassName(), ": "+ colors.red("WARNING: column number larger than row number!"))
 
                 ## Construct matrix W(differences of predictions)
                 self.W_new = np.empty( shape = (col, row) ) # will be transposed later
@@ -160,7 +160,7 @@ class IQNILSConvergenceAccelerator(CoSimulationConvergenceAccelerator):
         ## Clear the buffer
         if self.R and self.X:
             if self.echo_level > 3:
-                cs_print_info(self._Name(), "Cleaning")
+                cs_print_info(self._ClassName(), "Cleaning")
             self.R.clear()
             self.X.clear()
         self.V_new = []

--- a/applications/CoSimulationApplication/python_scripts/convergence_accelerators/mvqn.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_accelerators/mvqn.py
@@ -52,7 +52,7 @@ class MVQNConvergenceAccelerator(CoSimulationConvergenceAccelerator):
         row = len(r)
         k = col
         if self.echo_level > 3:
-            cs_tools.cs_print_info(self._Name(), "Number of new modes: ", col )
+            cs_tools.cs_print_info(self._ClassName(), "Number of new modes: ", col )
 
         ## For the first iteration
         if k == 0:
@@ -101,7 +101,7 @@ class MVQNConvergenceAccelerator(CoSimulationConvergenceAccelerator):
             for j in range(0, col):
                 self.J[i][j] = self.J_hat[i][j]
         if self.echo_level > 3:
-            cs_tools.cs_print_info(self._Name(), "Jacobian matrix updated!")
+            cs_tools.cs_print_info(self._ClassName(), "Jacobian matrix updated!")
         ## Clear the buffer
         if self.R and self.X:
             self.R.clear()

--- a/applications/CoSimulationApplication/python_scripts/convergence_criteria/relative_norm_initial_residual.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_criteria/relative_norm_initial_residual.py
@@ -53,13 +53,13 @@ class RelativeNormInitialResidualConvergenceCriteria(CoSimulationConvergenceCrit
                 info_msg += colors.green("ACHIEVED")
             else:
                 info_msg += colors.red("NOT ACHIEVED")
-            cs_tools.cs_print_info(self._Name(), info_msg)
+            cs_tools.cs_print_info(self._ClassName(), info_msg)
         if self.echo_level > 2:
             info_msg  = colors.bold("abs_norm") + " = " + str(abs_norm) + " | "
             info_msg += colors.bold("abs_tol")  + " = " + str(self.abs_tolerance) + " || "
             info_msg += colors.bold("rel_norm") + " = " + str(rel_norm) + " | "
             info_msg += colors.bold("rel_tol")  + " = " + str(self.rel_tolerance)
-            cs_tools.cs_print_info(self._Name(), info_msg)
+            cs_tools.cs_print_info(self._ClassName(), info_msg)
 
         return is_converged
 

--- a/applications/CoSimulationApplication/python_scripts/convergence_criteria/relative_norm_previous_residual.py
+++ b/applications/CoSimulationApplication/python_scripts/convergence_criteria/relative_norm_previous_residual.py
@@ -50,13 +50,13 @@ class RelativeNormPreviousResidualConvergenceCriteria(CoSimulationConvergenceCri
                 info_msg += colors.green("ACHIEVED")
             else:
                 info_msg += colors.red("NOT ACHIEVED")
-            cs_tools.cs_print_info(self._Name(), info_msg)
+            cs_tools.cs_print_info(self._ClassName(), info_msg)
         if self.echo_level > 2:
             info_msg  = colors.bold("abs_norm") + " = " + str(abs_norm) + " | "
             info_msg += colors.bold("abs_tol")  + " = " + str(self.abs_tolerance) + " || "
             info_msg += colors.bold("rel_norm") + " = " + str(rel_norm) + " | "
             info_msg += colors.bold("rel_tol")  + " = " + str(self.rel_tolerance)
-            cs_tools.cs_print_info(self._Name(), info_msg)
+            cs_tools.cs_print_info(self._ClassName(), info_msg)
 
         return is_converged
 

--- a/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
+++ b/applications/CoSimulationApplication/python_scripts/coupled_solvers/gauss_seidel_strong.py
@@ -72,7 +72,7 @@ class GaussSeidelStrongCoupledSolver(CoSimulationCoupledSolver):
     def SolveSolutionStep(self):
         for k in range(self.num_coupling_iterations):
             if self.echo_level > 0:
-                cs_tools.cs_print_info(self._Name(), colors.cyan("Coupling iteration:"), colors.bold(str(k+1)+" / " + str(self.num_coupling_iterations)))
+                cs_tools.cs_print_info(self._ClassName(), colors.cyan("Coupling iteration:"), colors.bold(str(k+1)+" / " + str(self.num_coupling_iterations)))
 
             for coupling_op in self.coupling_operations_dict.values():
                 coupling_op.InitializeCouplingIteration()
@@ -102,7 +102,7 @@ class GaussSeidelStrongCoupledSolver(CoSimulationCoupledSolver):
                 is_converged = is_converged and conv_crit.IsConverged()
             if is_converged:
                 if self.echo_level > 0:
-                    cs_tools.cs_print_info(self._Name(), colors.green("### CONVERGENCE WAS ACHIEVED ###"))
+                    cs_tools.cs_print_info(self._ClassName(), colors.green("### CONVERGENCE WAS ACHIEVED ###"))
                 return True
             else:
                 # TODO I think this should not be done in the last iterations if the solution does not converge in this timestep
@@ -110,7 +110,7 @@ class GaussSeidelStrongCoupledSolver(CoSimulationCoupledSolver):
                     conv_acc.ComputeAndApplyUpdate()
 
             if k+1 >= self.num_coupling_iterations and self.echo_level > 0:
-                cs_tools.cs_print_info(self._Name(), colors.red("XXX CONVERGENCE WAS NOT ACHIEVED XXX"))
+                cs_tools.cs_print_info(self._ClassName(), colors.red("XXX CONVERGENCE WAS NOT ACHIEVED XXX"))
                 return False
 
     def Check(self):

--- a/applications/CoSimulationApplication/python_scripts/solver_wrappers/kratos/kratos_base_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/solver_wrappers/kratos/kratos_base_wrapper.py
@@ -64,5 +64,5 @@ class KratosBaseWrapper(CoSimulationSolverWrapper):
 
 
     def PrintInfo(self):
-        cs_tools.cs_print_info("KratosSolver", self._Name())
+        cs_tools.cs_print_info("KratosSolver", self._ClassName())
         ## TODO print additional stuff with higher echo-level


### PR DESCRIPTION
reasons for this change:
- the solver-wrappers have an attribute `name`, i.e. the method `Name` was misleading
- now it can also be used in `classmethod`s