### PR TITLE
Introducing a helper object to deduce MPI message size and type.

### DIFF
--- a/kratos/mpi/includes/mpi_message.h
+++ b/kratos/mpi/includes/mpi_message.h
@@ -23,6 +23,8 @@
 namespace Kratos
 {
 
+namespace {
+
 template<class TDataType> struct MPIDataType;
 
 template<> struct MPIDataType<int>
@@ -72,8 +74,6 @@ template<> struct MPIDataType<Flags::BlockType>
         return MPI_INT64_T;
     }
 };
-
-namespace {
 
 template<class TDataType> class ValueMessage
 {

--- a/kratos/mpi/includes/mpi_message.h
+++ b/kratos/mpi/includes/mpi_message.h
@@ -1,0 +1,184 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main author:     Jordi Cotela
+//
+
+#ifndef KRATOS_MPI_MESSAGE_H_INCLUDED
+#define KRATOS_MPI_MESSAGE_H_INCLUDED
+
+#include <string>
+#include <vector>
+#include "mpi.h"
+
+#include "containers/array_1d.h"
+#include "containers/flags.h"
+
+namespace Kratos
+{
+
+template<class TDataType> struct MPIDataType;
+
+template<> struct MPIDataType<int>
+{
+    static inline MPI_Datatype DataType()
+    {
+        return MPI_INT;
+    }
+};
+
+template<> struct MPIDataType<unsigned int>
+{
+    static inline MPI_Datatype DataType()
+    {
+        return MPI_UNSIGNED;
+    }
+};
+
+template<> struct MPIDataType<long unsigned int>
+{
+    static inline MPI_Datatype DataType()
+    {
+        return MPI_UNSIGNED_LONG;
+    }
+};
+
+template<> struct MPIDataType<double>
+{
+    static inline MPI_Datatype DataType()
+    {
+        return MPI_DOUBLE;
+    }
+};
+
+template<> struct MPIDataType<std::string>
+{
+    static inline MPI_Datatype DataType()
+    {
+        return MPI_CHAR;
+    }
+};
+
+template<> struct MPIDataType<Flags::BlockType>
+{
+    static inline MPI_Datatype DataType()
+    {
+        return MPI_INT64_T;
+    }
+};
+
+namespace {
+
+template<class TDataType> class ValueMessage
+{
+public:
+    static inline void* Buffer(TDataType& rValue)
+    {
+        return &rValue;
+    }
+
+    static inline const void* Buffer(const TDataType& rValue)
+    {
+        return &rValue;
+    }
+
+    static inline int Size(const TDataType&)
+    {
+        return 1;
+    }
+};
+
+template<class TDataType> class VectorMessage
+{
+public:
+    static inline void* Buffer(std::vector<TDataType>& rValue)
+    {
+        return rValue.data();
+    }
+
+    static inline const void* Buffer(const std::vector<TDataType>& rValue)
+    {
+        return rValue.data();
+    }
+
+    static inline int Size(const std::vector<TDataType>& rValue)
+    {
+        return rValue.size() * ValueMessage<TDataType>::Size(rValue[0]);
+    }
+};
+
+template<class TDataType, std::size_t Dimension> class ArrayMessage
+{
+public:
+    static inline void* Buffer(array_1d<TDataType,Dimension>& rValues)
+    {
+        #ifdef KRATOS_USE_AMATRIX
+        return rValues.data();
+        #else
+        return rValues.data().data();
+        #endif
+    }
+
+    static inline const void* Buffer(const array_1d<TDataType,Dimension>& rValues)
+    {
+        #ifdef KRATOS_USE_AMATRIX
+        return rValues.data();
+        #else
+        return rValues.data().data();
+        #endif
+    }
+
+    static inline int Size(const array_1d<TDataType,Dimension>& rValues)
+    {
+        return Dimension * ValueMessage<TDataType>::Size(rValues[0]);
+    }
+};
+
+class StringMessage
+{
+public:
+    static inline void* Buffer(std::string& rValue)
+    {
+        // Note: this uses the fact that the C++11 standard defines std::strings to
+        // be contiguous in memory to perform MPI communication (based on char*) in place.
+        // In older C++, this cannot be expected to be always the case, so a copy of the
+        // string would be required.
+        return const_cast<char *>(rValue.data());
+    }
+
+    static inline const void* Buffer(const std::string& rValue)
+    {
+        return rValue.data();
+    }
+
+    static inline int Size(const std::string& rValues)
+    {
+        return rValues.size();
+    }
+};
+
+}
+
+template<class TDataType> class MPIMessage;
+
+template<> class MPIMessage<int>: public ValueMessage<int>, public MPIDataType<int> {};
+template<> class MPIMessage<Flags::BlockType>: public ValueMessage<Flags::BlockType>, public MPIDataType<Flags::BlockType> {};
+template<> class MPIMessage<unsigned int>: public ValueMessage<unsigned int>, public MPIDataType<unsigned int> {};
+template<> class MPIMessage<long unsigned int>: public ValueMessage<long unsigned int>, public MPIDataType<long unsigned int> {};
+template<> class MPIMessage<double>: public ValueMessage<double>, public MPIDataType<double> {};
+
+template<> class MPIMessage<std::string>: public StringMessage, public MPIDataType<std::string> {};
+
+template<class ValueType> class MPIMessage< std::vector<ValueType> >: public VectorMessage<ValueType>, public MPIDataType<ValueType> {};
+template<class ValueType, std::size_t Dimension> class MPIMessage<array_1d<ValueType,Dimension>>: public ArrayMessage<ValueType,Dimension>, public MPIDataType<ValueType> {};
+
+
+} // namespace Kratos
+
+#endif // KRATOS_MPI_MESSAGE_H_INCLUDED

--- a/kratos/mpi/includes/mpi_message.h
+++ b/kratos/mpi/includes/mpi_message.h
@@ -33,6 +33,7 @@ template<> struct MPIDataType<int>
     {
         return MPI_INT;
     }
+    static constexpr int LengthPerObject = 1;
 };
 
 template<> struct MPIDataType<unsigned int>
@@ -41,6 +42,7 @@ template<> struct MPIDataType<unsigned int>
     {
         return MPI_UNSIGNED;
     }
+    static constexpr int LengthPerObject = 1;
 };
 
 template<> struct MPIDataType<long unsigned int>
@@ -49,6 +51,7 @@ template<> struct MPIDataType<long unsigned int>
     {
         return MPI_UNSIGNED_LONG;
     }
+    static constexpr int LengthPerObject = 1;
 };
 
 template<> struct MPIDataType<double>
@@ -57,6 +60,7 @@ template<> struct MPIDataType<double>
     {
         return MPI_DOUBLE;
     }
+    static constexpr int LengthPerObject = 1;
 };
 
 template<> struct MPIDataType<std::string>
@@ -65,6 +69,7 @@ template<> struct MPIDataType<std::string>
     {
         return MPI_CHAR;
     }
+    static constexpr int LengthPerObject = 1;
 };
 
 template<> struct MPIDataType<Flags::BlockType>
@@ -73,6 +78,7 @@ template<> struct MPIDataType<Flags::BlockType>
     {
         return MPI_INT64_T;
     }
+    static constexpr int LengthPerObject = 1;
 };
 
 template<class TDataType> class ValueMessage
@@ -109,7 +115,7 @@ public:
 
     static inline int Size(const std::vector<TDataType>& rValue)
     {
-        return rValue.size() * ValueMessage<TDataType>::Size(rValue[0]);
+        return rValue.size() * MPIDataType<TDataType>::LengthPerObject;
     }
 };
 
@@ -136,7 +142,7 @@ public:
 
     static inline int Size(const array_1d<TDataType,Dimension>& rValues)
     {
-        return Dimension * ValueMessage<TDataType>::Size(rValues[0]);
+        return Dimension * MPIDataType<TDataType>::LengthPerObject;
     }
 };
 

--- a/kratos/mpi/sources/mpi_data_communicator.cpp
+++ b/kratos/mpi/sources/mpi_data_communicator.cpp
@@ -11,6 +11,7 @@
 //
 
 #include "mpi/includes/mpi_data_communicator.h"
+#include "mpi/includes/mpi_message.h"
 
 #ifndef KRATOS_MPI_DATA_COMMUNICATOR_DEFINE_REDUCE_INTERFACE_FOR_TYPE
 #define KRATOS_MPI_DATA_COMMUNICATOR_DEFINE_REDUCE_INTERFACE_FOR_TYPE(type)                                 \
@@ -1089,242 +1090,27 @@ template<class TDataType> void MPIDataCommunicator::PrepareGathervReturn(
     }
 }
 
-// MPI_Datatype wrappers
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const int&) const
+// MPI_Datatype wrapper
+template<class TValue> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const TValue&) const
 {
-    return MPI_INT;
-}
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const unsigned int&) const
-{
-    return MPI_UNSIGNED;
-}
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const long unsigned int&) const
-{
-    return MPI_UNSIGNED_LONG;
-}
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const double&) const
-{
-    return MPI_DOUBLE;
-}
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const array_1d<double,3>&) const
-{
-    return MPI_DOUBLE;
-}
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const std::vector<int>&) const
-{
-    return MPI_INT;
-}
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const std::vector<unsigned int>&) const
-{
-    return MPI_UNSIGNED;
-}
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const std::vector<long unsigned int>&) const
-{
-    return MPI_UNSIGNED_LONG;
-}
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const std::vector<double>&) const
-{
-    return MPI_DOUBLE;
-}
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const std::string&) const
-{
-    return MPI_CHAR;
-}
-
-template<> inline MPI_Datatype MPIDataCommunicator::MPIDatatype(const Flags::BlockType&) const
-{
-    return MPI_INT64_T;
+    return MPIMessage<TValue>::DataType();
 }
 
 // Buffer argument deduction
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(int& rValues) const
+template<class TContainer> inline void* MPIDataCommunicator::MPIBuffer(TContainer& rValues) const
 {
-    return &rValues;
+    return MPIMessage<TContainer>::Buffer(rValues);
 }
 
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const int& rValues) const
+template<class TContainer> inline const void* MPIDataCommunicator::MPIBuffer(const TContainer& rValues) const
 {
-    return &rValues;
-}
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(unsigned int& rValues) const
-{
-    return &rValues;
-}
-
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const unsigned int& rValues) const
-{
-    return &rValues;
-}
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(long unsigned int& rValues) const
-{
-    return &rValues;
-}
-
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const long unsigned int& rValues) const
-{
-    return &rValues;
-}
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(double& rValues) const
-{
-    return &rValues;
-}
-
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const double& rValues) const
-{
-    return &rValues;
-}
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(array_1d<double,3>& rValues) const
-{
-    #ifdef KRATOS_USE_AMATRIX
-    return rValues.data();
-    #else
-    return rValues.data().data();
-    #endif
-}
-
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const array_1d<double,3>& rValues) const
-{
-    #ifdef KRATOS_USE_AMATRIX
-    return rValues.data();
-    #else
-    return rValues.data().data();
-    #endif
-}
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(std::vector<int>& rValues) const
-{
-    return rValues.data();
-}
-
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const std::vector<int>& rValues) const
-{
-    return rValues.data();
-}
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(std::vector<unsigned int>& rValues) const
-{
-    return rValues.data();
-}
-
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const std::vector<unsigned int>& rValues) const
-{
-    return rValues.data();
-}
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(std::vector<long unsigned int>& rValues) const
-{
-    return rValues.data();
-}
-
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const std::vector<long unsigned int>& rValues) const
-{
-    return rValues.data();
-}
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(std::vector<double>& rValues) const
-{
-    return rValues.data();
-}
-
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const std::vector<double>& rValues) const
-{
-    return rValues.data();
-}
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(std::string& rValues) const
-{
-    // Note: this uses the fact that the C++11 standard defines std::strings to
-    // be contiguous in memory to perform MPI communication (based on char*) in place.
-    // In older C++, this cannot be expected to be always the case, so a copy of the
-    // string would be required.
-    return const_cast<char *>(rValues.data());
-}
-
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const std::string& rValues) const
-{
-    return rValues.data();
-}
-
-template<> inline void* MPIDataCommunicator::MPIBuffer(Flags::BlockType& rValues) const
-{
-    return &rValues;
-}
-
-template<> inline const void* MPIDataCommunicator::MPIBuffer(const Flags::BlockType& rValues) const
-{
-    return &rValues;
+    return MPIMessage<TContainer>::Buffer(rValues);
 }
 
 // MPI message size deduction
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const int& rValues) const
+template<class TContainer> inline int MPIDataCommunicator::MPIMessageSize(const TContainer& rValues) const
 {
-    return 1;
-}
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const unsigned int& rValues) const
-{
-    return 1;
-}
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const long unsigned int& rValues) const
-{
-    return 1;
-}
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const double& rValues) const
-{
-    return 1;
-}
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const array_1d<double,3>& rValues) const
-{
-    return 3;
-}
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const std::vector<int>& rValues) const
-{
-    return rValues.size();
-}
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const std::vector<unsigned int>& rValues) const
-{
-    return rValues.size();
-}
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const std::vector<long unsigned int>& rValues) const
-{
-    return rValues.size();
-}
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const std::vector<double>& rValues) const
-{
-    return rValues.size();
-}
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const std::string& rValues) const
-{
-    return rValues.size();
-}
-
-template<> inline int MPIDataCommunicator::MPIMessageSize(const Flags::BlockType& rValues) const
-{
-    return 1;
+    return MPIMessage<TContainer>::Size(rValues);
 }
 
 }


### PR DESCRIPTION
This is an attempt to remove duplicate code for MPI buffer/size deduction in MPIDataCommunicator.