### PR TITLE
[PotentialFlow] Adding distance check to utilites

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
@@ -55,8 +55,13 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSy
     const int wake = r_this.GetValue(WAKE);
     const int kutta = r_this.GetValue(KUTTA);
 
+    BoundedVector<double,NumNodes> distances;
+    for(unsigned int i_node = 0; i_node<NumNodes; i_node++){
+        distances[i_node] = this->GetGeometry()[i_node].GetSolutionStepValue(GEOMETRY_DISTANCE);
+    }
+    const bool is_embedded = PotentialFlowUtilities::CheckIfElementIsCutByDistance<Dim,NumNodes>(distances);
 
-    if (this->Is(TO_SPLIT) && wake == 0 && kutta == 0)
+    if (is_embedded && wake == 0 && kutta == 0)
         CalculateEmbeddedLocalSystem(rLeftHandSideMatrix,rRightHandSideVector,rCurrentProcessInfo);
     else
         BaseType::CalculateLocalSystem(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo);

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_2d_wake_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_2d_wake_process.cpp
@@ -13,6 +13,7 @@
 // Project includes
 #include "define_2d_wake_process.h"
 #include "utilities/variable_utils.h"
+#include "custom_utilities/potential_flow_utilities.h"
 
 namespace Kratos {
 
@@ -152,7 +153,7 @@ void Define2DWakeProcess::MarkWakeElements()
             BoundedVector<double, 3> nodal_distances_to_wake = ComputeNodalDistancesToWake(*it_elem);
 
             // Selecting the cut (wake) elements
-            bool is_wake_element = CheckIfWakeElement(nodal_distances_to_wake);
+            const bool is_wake_element = PotentialFlowUtilities::CheckIfElementIsCutByDistance<2,3>(nodal_distances_to_wake);;
 
             // Mark wake element and save their nodal distances to the wake
             if (is_wake_element) {
@@ -224,28 +225,6 @@ const BoundedVector<double, 3> Define2DWakeProcess::ComputeNodalDistancesToWake(
         nodal_distances_to_wake[i] = distance_to_wake;
     }
     return nodal_distances_to_wake;
-}
-
-// This function checks whether the element is cut by the wake
-const bool Define2DWakeProcess::CheckIfWakeElement(const BoundedVector<double, 3>& rNodalDistancesToWake) const
-{
-    // Initialize counters
-    unsigned int number_of_nodes_with_positive_distance = 0;
-    unsigned int number_of_nodes_with_negative_distance = 0;
-
-    // Count how many element nodes are above and below the wake
-    for (unsigned int i = 0; i < rNodalDistancesToWake.size(); i++) {
-        if (rNodalDistancesToWake(i) < 0.0) {
-            number_of_nodes_with_negative_distance += 1;
-        }
-        else {
-            number_of_nodes_with_positive_distance += 1;
-        }
-    }
-
-    // Elements with nodes above and below the wake are wake elements
-    return number_of_nodes_with_negative_distance > 0 &&
-           number_of_nodes_with_positive_distance > 0;
 }
 
 // This function adds the trailing edge elements in the

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_2d_wake_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_2d_wake_process.h
@@ -118,8 +118,6 @@ private:
 
     const BoundedVector<double, 3> ComputeNodalDistancesToWake(const Element& rElement) const;
 
-    const bool CheckIfWakeElement(const BoundedVector<double, 3>& rNodalDistancesToWake) const;
-
     void AddTrailingEdgeAndWakeElements(std::vector<std::size_t>& rWakeElementsOrderedIds);
 
     void MarkKuttaElements() const;

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -175,6 +175,28 @@ double ComputeIncompressiblePressureCoefficient(const Element& rElement, const P
     return pressure_coefficient;
 }
 
+template <int Dim, int NumNodes>
+const bool CheckIfElementIsCutByDistance(const BoundedVector<double, NumNodes>& rNodalDistances)
+{
+    // Initialize counters
+    unsigned int number_of_nodes_with_positive_distance = 0;
+    unsigned int number_of_nodes_with_negative_distance = 0;
+
+    // Count how many element nodes are above and below the wake
+    for (unsigned int i = 0; i < rNodalDistances.size(); i++) {
+        if (rNodalDistances(i) < 0.0) {
+            number_of_nodes_with_negative_distance += 1;
+        }
+        else {
+            number_of_nodes_with_positive_distance += 1;
+        }
+    }
+
+    // Elements with nodes above and below the wake are wake elements
+    return number_of_nodes_with_negative_distance > 0 &&
+           number_of_nodes_with_positive_distance > 0;
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Template instantiation
 
@@ -191,5 +213,6 @@ template array_1d<double, 2> ComputeVelocityUpperWakeElement<2, 3>(const Element
 template array_1d<double, 2> ComputeVelocityLowerWakeElement<2, 3>(const Element& rElement);
 template array_1d<double, 2> ComputeVelocity<2, 3>(const Element& rElement);
 template double ComputeIncompressiblePressureCoefficient<2, 3>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
+template const bool CheckIfElementIsCutByDistance<2, 3>(const BoundedVector<double, 3>& rNodalDistances);
 } // namespace PotentialFlow
 } // namespace Kratos

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
@@ -50,5 +50,8 @@ array_1d<double, Dim> ComputeVelocity(const Element& rElement);
 template <int Dim, int NumNodes>
 double ComputeIncompressiblePressureCoefficient(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
 
+template <int Dim, int NumNodes>
+const bool CheckIfElementIsCutByDistance(const BoundedVector<double, NumNodes>& rNodalDistances);
+
 } // namespace PotentialFlow
 } // namespace Kratos

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_incompressible_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_incompressible_potential_element.cpp
@@ -194,7 +194,6 @@ namespace Kratos {
       Vector RHS = ZeroVector(3);
       Matrix LHS = ZeroMatrix(3, 3);
 
-      pElement->Set(TO_SPLIT);
       pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
       // Check the RHS values (the RHS is computed as the LHS x previous_solution,


### PR DESCRIPTION
Hi, 

In this PR I move the function to check whether an element is cut by a distance function from `define_2d_wake_process.cpp ` to `potential_flow_utilities.cpp`, to be used in other parts of the code.

Specifically i use it in the embedded element, to NOT depend on the `TO_SPLIT` flag, which is overriden if more than one CalculateDistanceToSkinProcess is used.