### PR TITLE
[Core] deprecate old import mechanism

### DIFF
--- a/kratos/python_interface/application_importer.py
+++ b/kratos/python_interface/application_importer.py
@@ -20,15 +20,16 @@ def ImportApplication(application, application_name, application_folder, caller,
     constitutive_laws_path = os.path.join(python_path, 'constitutive_laws')
     sys.path.append(constitutive_laws_path)
 
+    warn_msg  = '\nThe python-import-mechanism used for application "' + application_name
+    warn_msg += '" is DEPRECATED!\n'
+    warn_msg += 'Please check the following website for instuctions on how to update it:\n'
+    warn_msg += 'https://github.com/KratosMultiphysics/Kratos/wiki/Applications-as-python-modules\n'
+    warn_msg += 'The old mechanism will be removed on 01.10.2019!\n'
+    Logger.PrintWarning('\n\x1b[1;31mDEPRECATION-WARNING\x1b[0m', warn_msg)
+
     # adding the scripts in "APP_NAME/python_scripts" such that they are treated as a regular python-module
     if mod_path is not None: # optional for backwards compatibility
         mod_path.append(python_path)
-    else:
-        warn_msg  = 'The python-import-mechanism used for application "' + application_name
-        warn_msg += '" is DEPRECATED!\n'
-        warn_msg += 'Please check the following website for instuctions on how to update it:\n'
-        warn_msg += 'https://github.com/KratosMultiphysics/Kratos/wiki/Applications-as-python-modules'
-        Logger.PrintWarning('DEPRECATION', warn_msg)
 
     # Add application to kernel
     Kernel.ImportApplication(application)


### PR DESCRIPTION
As discussed with @KratosMultiphysics/technical-committee, this PR deprecates the old import mechanism
=> This is done in order to facilitate changes like #5145 and others and to move towards real python-modules

Developers of apps that are not updated yet will have to change the way of importing python-scripts
e.g. `import structural_mechanics_analysis` will stop working and has to be updated to: 
`import KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis`

~1/3 of the applications have already been updated, but not all of them. The ones that have not been updated will get a large deprecation-warning once this is merged.

See [this entry in the Wiki](https://github.com/KratosMultiphysics/Kratos/wiki/Applications-as-python-modules) for how to update your applications