### PR TITLE
setting lock to avoid corruption error

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
@@ -572,23 +572,26 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::ComputePotentialJump(con
 {
     const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
     const double free_stream_velocity_norm = sqrt(inner_prod(free_stream_velocity, free_stream_velocity));
+    const double reference_chord = rCurrentProcessInfo[REFERENCE_CHORD];
 
     array_1d<double, NumNodes> distances;
     GetWakeDistances(distances);
 
-    for (unsigned int i = 0; i < NumNodes; i++)
-    {
-        double aux_potential = GetGeometry()[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
-        double potential = GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
+    auto r_geometry = GetGeometry();
+    for (unsigned int i = 0; i < NumNodes; i++){
+        double aux_potential = r_geometry[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
+        double potential = r_geometry[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
         double potential_jump = aux_potential - potential;
 
-        if (distances[i] > 0)
-        {
-            GetGeometry()[i].SetValue(POTENTIAL_JUMP, -2.0 / free_stream_velocity_norm * (potential_jump));
+        if (distances[i] > 0){
+            r_geometry[i].SetLock();
+            r_geometry[i].SetValue(POTENTIAL_JUMP, - (2.0 * potential_jump) / (free_stream_velocity_norm * reference_chord));
+            r_geometry[i].UnSetLock();
         }
-        else
-        {
-            GetGeometry()[i].SetValue(POTENTIAL_JUMP, 2.0 / free_stream_velocity_norm * (potential_jump));
+        else{
+            r_geometry[i].SetLock();
+            r_geometry[i].SetValue(POTENTIAL_JUMP, (2.0 * potential_jump) / (free_stream_velocity_norm * reference_chord));
+            r_geometry[i].UnSetLock();
         }
     }
 }


### PR DESCRIPTION
Small PR to fix the corruption error that appears from time to time in the ComputePotentialJump function in the incompressible potential element.

This function is called from Finalize, which is called in parallel. We were writing a value from different elements to the same node at the same time.