### PR TITLE
[Structural] Making GetBodyForce virtual

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.h
@@ -865,7 +865,7 @@ protected:
      * @param PointNumber The id of the integration point considered
      * @return The vector of body forces
      */
-    array_1d<double, 3> GetBodyForce(
+    virtual array_1d<double, 3> GetBodyForce(
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
         const IndexType PointNumber
         ) const;


### PR DESCRIPTION
The title of the PR says it all. I want to create a new element derived from small_displacement which gets the density in a different way as it is done in the base_solid_element but the GetBodyForce method is not virtual.