### PR TITLE
Moving Communicator implementation to cpp

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -22,6 +22,7 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/variables.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/kratos_application.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/integration_rules.cpp;
+    ${CMAKE_CURRENT_SOURCE_DIR}/sources/communicator.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/mmio.c;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/serializer.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/sources/kernel.cpp;

--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -29,12 +29,10 @@
 // External includes
 
 // Project includes
-#include "includes/data_communicator.h"
 #include "includes/define.h"
 #include "includes/condition.h"
 #include "includes/element.h"
 #include "includes/mesh.h"
-#include "includes/parallel_environment.h"
 
 namespace Kratos
 {
@@ -58,9 +56,12 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
-/// Short class definition.
+// Forward declaration of DataCommunicator
+class DataCommunicator;
 
-/** Detail class definition.
+/// The Commmunicator class manages communication for distributed ModelPart instances.
+/** The base Communicator class only holds the required data (local and remote mesh interfaces)
+ *  for communication. The actual communication is implemented in the derived MPICommunicator.
  */
 class Communicator
 {
@@ -169,68 +170,24 @@ public:
     ///@{
 
     /// Default constructor.
-    Communicator() : mNumberOfColors(1)
-        , mpLocalMesh(MeshType::Pointer(new MeshType))
-        , mpGhostMesh(MeshType::Pointer(new MeshType))
-        , mpInterfaceMesh(MeshType::Pointer(new MeshType))
-        , mrDataCommunicator(ParallelEnvironment::GetDataCommunicator("Serial"))
-
-    {
-        MeshType mesh;
-        mLocalMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
-        mGhostMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
-        mInterfaceMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
-    }
+    Communicator();
 
     /// Constructor using a custom DataCommunicator.
     /** This constructor is intended for use from derived classes,
      *  since the base Communicator class will often not use the communicator at all.
      *  @param rDataCommunicator Reference to a DataCommunicator.
      */
-    Communicator(const DataCommunicator& rDataCommunicator)
-        : mNumberOfColors(1)
-        , mpLocalMesh(MeshType::Pointer(new MeshType))
-        , mpGhostMesh(MeshType::Pointer(new MeshType))
-        , mpInterfaceMesh(MeshType::Pointer(new MeshType))
-        , mrDataCommunicator(rDataCommunicator)
-    {
-        MeshType mesh;
-        mLocalMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
-        mGhostMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
-        mInterfaceMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
-    }
+    Communicator(const DataCommunicator& rDataCommunicator);
 
     /// Copy constructor.
-
-    Communicator(Communicator const& rOther)
-        : mNumberOfColors(rOther.mNumberOfColors)
-        , mNeighbourIndices(rOther.mNeighbourIndices)
-        , mpLocalMesh(MeshType::Pointer(rOther.mpLocalMesh))
-        , mpGhostMesh(MeshType::Pointer(rOther.mpGhostMesh))
-        , mpInterfaceMesh(MeshType::Pointer(rOther.mpInterfaceMesh))
-        , mLocalMeshes(rOther.mLocalMeshes)
-        , mGhostMeshes(rOther.mGhostMeshes)
-        , mInterfaceMeshes(rOther.mInterfaceMeshes)
-        , mrDataCommunicator(rOther.mrDataCommunicator)
-    {
-    }
-
-    virtual Communicator::Pointer Create(const DataCommunicator& rDataCommunicator) const
-    {
-        KRATOS_TRY
-
-        return Kratos::make_shared<Communicator>(rDataCommunicator);
-
-        KRATOS_CATCH("");
-    }
-
-    virtual Communicator::Pointer Create() const
-    {
-        return Create(ParallelEnvironment::GetDataCommunicator("Serial"));
-    }
+    Communicator(Communicator const& rOther);
 
     /// Destructor.
     virtual ~Communicator() = default;
+
+    virtual Communicator::Pointer Create(const DataCommunicator& rDataCommunicator) const;
+
+    virtual Communicator::Pointer Create() const;
 
     ///@}
     ///@name Operators
@@ -243,731 +200,255 @@ public:
     ///@name Access
     ///@{
 
-    virtual bool IsDistributed() const
-    {
-        return false;
-    }
+    virtual bool IsDistributed() const;
 
-    virtual int MyPID() const
-    {
-        return mrDataCommunicator.Rank();
-    }
+    virtual int MyPID() const;
 
-    virtual int TotalProcesses() const
-    {
-        return mrDataCommunicator.Size();
-    }
+    virtual int TotalProcesses() const;
 
-    SizeType GetNumberOfColors() const
-    {
-        return mNumberOfColors;
-    }
+    SizeType GetNumberOfColors() const;
 
-    void SetNumberOfColors(SizeType NewNumberOfColors)
-    {
-        if (mNumberOfColors == NewNumberOfColors)
-            return;
+    void SetNumberOfColors(SizeType NewNumberOfColors);
 
-        mNumberOfColors = NewNumberOfColors;
-        MeshType mesh;
+    NeighbourIndicesContainerType& NeighbourIndices();
 
-        mLocalMeshes.clear();
-        mGhostMeshes.clear();
-        mInterfaceMeshes.clear();
+    NeighbourIndicesContainerType const& NeighbourIndices() const;
 
-        for (IndexType i = 0; i < mNumberOfColors; i++)
-        {
-            mLocalMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
-            mGhostMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
-            mInterfaceMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
-        }
-    }
+    /// Set the local mesh pointer to the given mesh
+    void SetLocalMesh(MeshType::Pointer pGivenMesh);
 
-    NeighbourIndicesContainerType& NeighbourIndices()
-    {
-        return mNeighbourIndices;
-    }
+    /// Returns pointer to the mesh storing all local entites
+    MeshType::Pointer pLocalMesh();
 
-    NeighbourIndicesContainerType const& NeighbourIndices() const
-    {
-        return mNeighbourIndices;
-    }
+    /// Returns pointer to the mesh storing all ghost entites
+    MeshType::Pointer pGhostMesh();
 
-    // Set the local mesh pointer to the given mesh
-    void SetLocalMesh(MeshType::Pointer pGivenMesh)
-    {
-        mpLocalMesh = pGivenMesh;
-    }
+    /// Returns pointer to the mesh storing all interface entites
+    MeshType::Pointer pInterfaceMesh();
 
-    // Returns pointer to the mesh storing all local entites
+    /// Returns a constant pointer to the mesh storing all local entites
+    const MeshType::Pointer pLocalMesh() const;
 
-    MeshType::Pointer pLocalMesh()
-    {
-        return mpLocalMesh;
-    }
+    /// Returns a constant pointer to the mesh storing all ghost entites
+    const MeshType::Pointer pGhostMesh() const;
 
-    // Returns pointer to the mesh storing all ghost entites
+    /// Returns a constant pointer to the mesh storing all interface entites
+    const MeshType::Pointer pInterfaceMesh() const;
 
-    MeshType::Pointer pGhostMesh()
-    {
-        return mpGhostMesh;
-    }
+    MeshType::Pointer pLocalMesh(IndexType ThisIndex);
 
-    // Returns pointer to the mesh storing all interface entites
+    MeshType::Pointer pGhostMesh(IndexType ThisIndex);
 
-    MeshType::Pointer pInterfaceMesh()
-    {
-        return mpInterfaceMesh;
-    }
+    MeshType::Pointer pInterfaceMesh(IndexType ThisIndex);
 
-    // Returns a constant pointer to the mesh storing all local entites
+    const MeshType::Pointer pLocalMesh(IndexType ThisIndex) const;
 
-    const MeshType::Pointer pLocalMesh() const
-    {
-        return mpLocalMesh;
-    }
+    const MeshType::Pointer pGhostMesh(IndexType ThisIndex) const;
 
-    // Returns a constant pointer to the mesh storing all ghost entites
+    const MeshType::Pointer pInterfaceMesh(IndexType ThisIndex) const;
 
-    const MeshType::Pointer pGhostMesh() const
-    {
-        return mpGhostMesh;
-    }
+    /// Returns the reference to the mesh storing all local entites
+    MeshType& LocalMesh();
 
-    // Returns a constant pointer to the mesh storing all interface entites
+    /// Returns the reference to the mesh storing all ghost entites
+    MeshType& GhostMesh();
 
-    const MeshType::Pointer pInterfaceMesh() const
-    {
-        return mpInterfaceMesh;
-    }
+    /// Returns the reference to the mesh storing all interface entites
+    MeshType& InterfaceMesh();
 
-    MeshType::Pointer pLocalMesh(IndexType ThisIndex)
-    {
-        return mLocalMeshes(ThisIndex);
-    }
+    /// Returns a constant reference to the mesh storing all local entites
+    MeshType const& LocalMesh() const;
 
-    MeshType::Pointer pGhostMesh(IndexType ThisIndex)
-    {
-        return mGhostMeshes(ThisIndex);
-    }
+    /// Returns a constant reference to the mesh storing all ghost entites
+    MeshType const& GhostMesh() const;
 
-    MeshType::Pointer pInterfaceMesh(IndexType ThisIndex)
-    {
-        return mInterfaceMeshes(ThisIndex);
-    }
+    /// Returns a constant reference to the mesh storing all interface entites
+    MeshType const& InterfaceMesh() const;
 
-    const MeshType::Pointer pLocalMesh(IndexType ThisIndex) const
-    {
-        return mLocalMeshes(ThisIndex);
-    }
+    MeshType& LocalMesh(IndexType ThisIndex);
 
-    const MeshType::Pointer pGhostMesh(IndexType ThisIndex) const
-    {
-        return mGhostMeshes(ThisIndex);
-    }
+    MeshType& GhostMesh(IndexType ThisIndex);
 
-    const MeshType::Pointer pInterfaceMesh(IndexType ThisIndex) const
-    {
-        return mInterfaceMeshes(ThisIndex);
-    }
+    MeshType& InterfaceMesh(IndexType ThisIndex);
 
-    // Returns the reference to the mesh storing all local entites
+    MeshType const& LocalMesh(IndexType ThisIndex) const;
 
-    MeshType& LocalMesh()
-    {
-        return *mpLocalMesh;
-    }
+    MeshType const& GhostMesh(IndexType ThisIndex) const;
 
-    // Returns the reference to the mesh storing all ghost entites
+    MeshType const& InterfaceMesh(IndexType ThisIndex) const;
 
-    MeshType& GhostMesh()
-    {
-        return *mpGhostMesh;
-    }
+    MeshesContainerType& LocalMeshes();
 
-    // Returns the reference to the mesh storing all interface entites
+    MeshesContainerType& GhostMeshes();
 
-    MeshType& InterfaceMesh()
-    {
-        return *mpInterfaceMesh;
-    }
+    MeshesContainerType& InterfaceMeshes();
 
-    // Returns a constant reference to the mesh storing all local entites
+    MeshesContainerType const& LocalMeshes() const;
 
-    MeshType const& LocalMesh() const
-    {
-        return *mpLocalMesh;
-    }
+    MeshesContainerType const& GhostMeshes() const;
 
-    // Returns a constant reference to the mesh storing all ghost entites
+    MeshesContainerType const& InterfaceMeshes() const;
 
-    MeshType const& GhostMesh() const
-    {
-        return *mpGhostMesh;
-    }
-
-    // Returns a constant reference to the mesh storing all interface entites
-
-    MeshType const& InterfaceMesh() const
-    {
-        return *mpInterfaceMesh;
-    }
-
-    MeshType& LocalMesh(IndexType ThisIndex)
-    {
-        return mLocalMeshes[ThisIndex];
-    }
-
-    MeshType& GhostMesh(IndexType ThisIndex)
-    {
-        return mGhostMeshes[ThisIndex];
-    }
-
-    MeshType& InterfaceMesh(IndexType ThisIndex)
-    {
-        return mInterfaceMeshes[ThisIndex];
-    }
-
-    MeshType const& LocalMesh(IndexType ThisIndex) const
-    {
-        return mLocalMeshes[ThisIndex];
-    }
-
-    MeshType const& GhostMesh(IndexType ThisIndex) const
-    {
-        return mGhostMeshes[ThisIndex];
-    }
-
-    MeshType const& InterfaceMesh(IndexType ThisIndex) const
-    {
-        return mInterfaceMeshes[ThisIndex];
-    }
-
-    MeshesContainerType& LocalMeshes()
-    {
-        return mLocalMeshes;
-    }
-
-    MeshesContainerType& GhostMeshes()
-    {
-        return mGhostMeshes;
-    }
-
-    MeshesContainerType& InterfaceMeshes()
-    {
-        return mInterfaceMeshes;
-    }
-
-    MeshesContainerType const& LocalMeshes() const
-    {
-        return mLocalMeshes;
-    }
-
-    MeshesContainerType const& GhostMeshes() const
-    {
-        return mGhostMeshes;
-    }
-
-    MeshesContainerType const& InterfaceMeshes() const
-    {
-        return mInterfaceMeshes;
-    }
+    virtual const DataCommunicator& GetDataCommunicator() const;
 
     ///@}
     ///@name Operations
     ///@{
 
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
-    void Barrier() const
-    {
-        mrDataCommunicator.Barrier();
-    }
+    void Barrier() const;
 
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
-    bool SumAll(int& rValue) const
-    {
-        rValue = mrDataCommunicator.SumAll(rValue);
-        return true;
-    }
+    bool SumAll(int& rValue) const;
 
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
-    bool SumAll(double& rValue) const
-    {
-        rValue = mrDataCommunicator.SumAll(rValue);
-        return true;
-    }
+    bool SumAll(double& rValue) const;
 
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
-    bool SumAll(array_1d<double, 3>& rValue) const
-    {
-        rValue = mrDataCommunicator.SumAll(rValue);
-        return true;
-    }
+    bool SumAll(array_1d<double, 3>& rValue) const;
 
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
-    bool MinAll(int& rValue) const
-    {
-        rValue = mrDataCommunicator.MinAll(rValue);
-        return true;
-    }
+    bool MinAll(int& rValue) const;
 
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
-    bool MinAll(double& rValue) const
-    {
-        rValue = mrDataCommunicator.MinAll(rValue);
-        return true;
-    }
+    bool MinAll(double& rValue) const;
 
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
-    bool MaxAll(int& rValue) const
-    {
-        rValue = mrDataCommunicator.MaxAll(rValue);
-        return true;
-    }
+    bool MaxAll(int& rValue) const;
 
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
-    bool MaxAll(double& rValue) const
-    {
-        rValue = mrDataCommunicator.MaxAll(rValue);
-        return true;
-    }
+    bool MaxAll(double& rValue) const;
 
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
-    bool ScanSum(const double& send_partial, double& receive_accumulated) const
-    {
-        receive_accumulated = mrDataCommunicator.ScanSum(send_partial);
-        return true;
-    }
+    bool ScanSum(const double& send_partial, double& receive_accumulated) const;
 
     KRATOS_DEPRECATED_MESSAGE("This function is deprecated, please retrieve the DataCommunicator with GetDataCommunicator and use it directly.")
-    bool ScanSum(const int& send_partial, int& receive_accumulated) const
-    {
-        receive_accumulated = mrDataCommunicator.ScanSum(send_partial);
-        return true;
-    }
+    bool ScanSum(const int& send_partial, int& receive_accumulated) const;
 
-    virtual bool SynchronizeNodalSolutionStepsData()
-    {
-        // #if defined(KRATOS_USING_MPI )
-        // 	std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
+    virtual bool SynchronizeNodalSolutionStepsData();
 
-    }
+    virtual bool SynchronizeDofs();
 
-    virtual bool SynchronizeDofs()
-    {
-        // #if defined(KRATOS_USING_MPI )
-        // 	std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
+    virtual bool SynchronizeVariable(Variable<int> const& rThisVariable);
 
-    }
+    virtual bool SynchronizeVariable(Variable<double> const& rThisVariable);
 
-    virtual bool SynchronizeVariable(Variable<int> const& rThisVariable)
-    {
-        // #if defined(KRATOS_USING_MPI )
-        //  std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
-    }
+    virtual bool SynchronizeVariable(Variable<bool> const& rThisVariable);
 
-    virtual bool SynchronizeVariable(Variable<double> const& rThisVariable)
-    {
-        // #if defined(KRATOS_USING_MPI )
-        //  std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
-    }
+    virtual bool SynchronizeVariable(Variable<array_1d<double, 3 > > const& rThisVariable);
 
-    virtual bool SynchronizeVariable(Variable<bool> const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeVariable(Variable<array_1d<double, 4 > > const& rThisVariable);
 
-    virtual bool SynchronizeVariable(Variable<array_1d<double, 3 > > const& rThisVariable)
-    {
-        // #if defined(KRATOS_USING_MPI )
-        //  std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
-    }
+    virtual bool SynchronizeVariable(Variable<array_1d<double, 6 > > const& rThisVariable);
 
-    virtual bool SynchronizeVariable(Variable<array_1d<double, 4 > > const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeVariable(Variable<array_1d<double, 9 > > const& rThisVariable);
 
-    virtual bool SynchronizeVariable(Variable<array_1d<double, 6 > > const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeVariable(Variable<Vector> const& rThisVariable);
 
-    virtual bool SynchronizeVariable(Variable<array_1d<double, 9 > > const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeVariable(Variable<Matrix> const& rThisVariable);
 
-    virtual bool SynchronizeVariable(Variable<Vector> const& rThisVariable)
-    {
-        // #if defined(KRATOS_USING_MPI )
-        //  std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
-    }
+    virtual bool SynchronizeNonHistoricalVariable(Variable<int> const& rThisVariable);
 
-    virtual bool SynchronizeVariable(Variable<Matrix> const& rThisVariable)
-    {
-        // #if defined(KRATOS_USING_MPI )
-        //  std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
-    }
+    virtual bool SynchronizeNonHistoricalVariable(Variable<double> const& rThisVariable);
 
-    virtual bool SynchronizeNonHistoricalVariable(Variable<int> const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeNonHistoricalVariable(Variable<bool> const& rThisVariable);
 
-    virtual bool SynchronizeNonHistoricalVariable(Variable<double> const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeNonHistoricalVariable(Variable<array_1d<double, 3 > > const& rThisVariable);
 
-    virtual bool SynchronizeNonHistoricalVariable(Variable<bool> const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeNonHistoricalVariable(Variable<array_1d<double, 4 > > const& rThisVariable);
 
-    virtual bool SynchronizeNonHistoricalVariable(Variable<array_1d<double, 3 > > const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeNonHistoricalVariable(Variable<array_1d<double, 6 > > const& rThisVariable);
 
-    virtual bool SynchronizeNonHistoricalVariable(Variable<array_1d<double, 4 > > const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeNonHistoricalVariable(Variable<array_1d<double, 9 > > const& rThisVariable);
 
-    virtual bool SynchronizeNonHistoricalVariable(Variable<array_1d<double, 6 > > const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeNonHistoricalVariable(Variable<Vector> const& rThisVariable);
 
-    virtual bool SynchronizeNonHistoricalVariable(Variable<array_1d<double, 9 > > const& rThisVariable)
-    {
-        return true;
-    }
-
-    virtual bool SynchronizeNonHistoricalVariable(Variable<Vector> const& rThisVariable)
-    {
-        return true;
-    }
-
-    virtual bool SynchronizeNonHistoricalVariable(Variable<Matrix> const& rThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeNonHistoricalVariable(Variable<Matrix> const& rThisVariable);
 
     /// Synchronize variable in nodal solution step data to the minimum value across all processes.
     /** @param ThisVariable The variable to be synchronized.
      */
-    virtual bool SynchronizeCurrentDataToMin(Variable<double> const& ThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeCurrentDataToMin(Variable<double> const& ThisVariable);
 
     /// Synchronize variable in nodal data to the minimum value across all processes.
     /** @param ThisVariable The variable to be synchronized.
      */
-    virtual bool SynchronizeNonHistoricalDataToMin(Variable<double> const& ThisVariable)
-    {
-        return true;
-    }
+    virtual bool SynchronizeNonHistoricalDataToMin(Variable<double> const& ThisVariable);
 
-    virtual bool SynchronizeElementalFlags()
-    {
-        return true;
-    }
+    virtual bool SynchronizeElementalFlags();
 
-    virtual bool AssembleCurrentData(Variable<int> const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
+    virtual bool AssembleCurrentData(Variable<int> const& ThisVariable);
 
-    }
+    virtual bool AssembleCurrentData(Variable<double> const& ThisVariable);
 
-    virtual bool AssembleCurrentData(Variable<double> const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
+    virtual bool AssembleCurrentData(Variable<array_1d<double, 3 > > const& ThisVariable);
 
-    }
+    virtual bool AssembleCurrentData(Variable<Vector> const& ThisVariable);
 
-    virtual bool AssembleCurrentData(Variable<array_1d<double, 3 > > const& ThisVariable)
-    {
-        // #if defined(KRATOS_USING_MPI )
-        // 	std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
+    virtual bool AssembleCurrentData(Variable<Matrix> const& ThisVariable);
 
-    }
+    virtual bool AssembleNonHistoricalData(Variable<int> const& ThisVariable);
 
-    virtual bool AssembleCurrentData(Variable<Vector> const& ThisVariable)
-    {
-        // #if defined(KRATOS_USING_MPI )
-        // 	std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
+    virtual bool AssembleNonHistoricalData(Variable<double> const& ThisVariable);
 
-    }
+    virtual bool AssembleNonHistoricalData(Variable<array_1d<double, 3 > > const& ThisVariable);
 
-    virtual bool AssembleCurrentData(Variable<Matrix> const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
+    virtual bool AssembleNonHistoricalData(Variable<DenseVector<array_1d<double,3> > > const& ThisVariable);
 
-    }
+    virtual bool AssembleNonHistoricalData(Variable<Vector> const& ThisVariable);
 
-    virtual bool AssembleNonHistoricalData(Variable<int> const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
+    virtual bool AssembleNonHistoricalData(Variable<Matrix> const& ThisVariable);
 
-    }
+    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<int> const& ThisVariable);
 
-    virtual bool AssembleNonHistoricalData(Variable<double> const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
+    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<double> const& ThisVariable);
 
-    }
+    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<array_1d<double, 3 > > const& ThisVariable);
 
-    virtual bool AssembleNonHistoricalData(Variable<array_1d<double, 3 > > const& ThisVariable)
-    {
-        // #if defined(KRATOS_USING_MPI )
-        // 	std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
+    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<DenseVector<array_1d<double,3> > > const& ThisVariable);
 
-    }
+    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<DenseVector<int> > const& ThisVariable);
 
+    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<Vector> const& ThisVariable);
 
-    virtual bool AssembleNonHistoricalData(Variable<DenseVector<array_1d<double,3> > > const& ThisVariable)
-    {
-        // #if defined(KRATOS_USING_MPI )
-        //  std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
+    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<Matrix> const& ThisVariable);
 
-    }
+    virtual bool TransferObjects(std::vector<NodesContainerType>& SendObjects, std::vector<NodesContainerType>& RecvObjects);
 
-    virtual bool AssembleNonHistoricalData(Variable<Vector> const& ThisVariable)
-    {
-        // #if defined(KRATOS_USING_MPI )
-        // 	std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        // #endif
-        return true;
+    virtual bool TransferObjects(std::vector<ElementsContainerType>& SendObjects, std::vector<ElementsContainerType>& RecvObjects);
 
-    }
+    virtual bool TransferObjects(std::vector<ConditionsContainerType>& SendObjects, std::vector<ConditionsContainerType>& RecvObjects);
 
-    virtual bool AssembleNonHistoricalData(Variable<Matrix> const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
+    virtual bool TransferObjects(std::vector<NodesContainerType>& SendObjects, std::vector<NodesContainerType>& RecvObjects,Kratos::Serializer& particleSerializer);
 
-    }
+    virtual bool TransferObjects(std::vector<ElementsContainerType>& SendObjects, std::vector<ElementsContainerType>& RecvObjects,Kratos::Serializer& particleSerializer);
 
-    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<int> const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
+    virtual bool TransferObjects(std::vector<ConditionsContainerType>& SendObjects, std::vector<ConditionsContainerType>& RecvObjects,Kratos::Serializer& particleSerializer);
 
-    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<double> const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
+    virtual bool SynchronizeOrNodalFlags(const Flags& TheFlags);
 
-    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<array_1d<double, 3 > > const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
+    virtual bool SynchronizeAndNodalFlags(const Flags& TheFlags);
 
-    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<DenseVector<array_1d<double,3> > > const& ThisVariable)
-    {
-    /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
+    virtual bool SynchronizeNodalFlags();
 
-    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<DenseVector<int> > const& ThisVariable)
-    {
-    /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
-
-    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<Vector> const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
-
-    virtual bool SynchronizeElementalNonHistoricalVariable(Variable<Matrix> const& ThisVariable)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
-
-    virtual bool TransferObjects(std::vector<NodesContainerType>& SendObjects, std::vector<NodesContainerType>& RecvObjects)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
-
-    virtual bool TransferObjects(std::vector<ElementsContainerType>& SendObjects, std::vector<ElementsContainerType>& RecvObjects)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
-
-    virtual bool TransferObjects(std::vector<ConditionsContainerType>& SendObjects, std::vector<ConditionsContainerType>& RecvObjects)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
-
-    virtual bool TransferObjects(std::vector<NodesContainerType>& SendObjects, std::vector<NodesContainerType>& RecvObjects,Kratos::Serializer& particleSerializer)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
-
-    virtual bool TransferObjects(std::vector<ElementsContainerType>& SendObjects, std::vector<ElementsContainerType>& RecvObjects,Kratos::Serializer& particleSerializer)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
-
-    virtual bool TransferObjects(std::vector<ConditionsContainerType>& SendObjects, std::vector<ConditionsContainerType>& RecvObjects,Kratos::Serializer& particleSerializer)
-    {
-        /*#if defined(KRATOS_USING_MPI )
-                std::cout << "WARNING: Using serial communicator with MPI defined. Use ModelPart::SetCommunicator to set its communicator to MPICommunicator" << std::endl;
-        #endif*/
-        return true;
-    }
-
-    virtual bool SynchronizeOrNodalFlags(const Flags& TheFlags)
-    {
-        return true;
-    }
-
-    virtual bool SynchronizeAndNodalFlags(const Flags& TheFlags)
-    {
-        return true;
-    }
-
-    virtual bool SynchronizeNodalFlags()
-    {
-        return true;
-    }
-
-    void Clear()
-    {
-        mNumberOfColors = 0;
-        mNeighbourIndices.clear();
-        mpLocalMesh->MeshType::Clear();
-        mpGhostMesh->MeshType::Clear();
-        mpInterfaceMesh->MeshType::Clear();
-        mLocalMeshes.clear();
-        mGhostMeshes.clear();
-        mInterfaceMeshes.clear();
-    }
-
-    ///@}
-    ///@name Access
-    ///@{
-
-    virtual const DataCommunicator& GetDataCommunicator() const
-    {
-        return mrDataCommunicator;
-    }
+    void Clear();
 
     ///@}
     ///@name Inquiry
     ///@{
 
+    /// Turn back information as a string.
+    virtual std::string Info() const;
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream& rOStream) const;
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const;
 
     ///@}
     ///@name Input and output
     ///@{
-
-    /// Turn back information as a string.
-
-    virtual std::string Info() const
-    {
-        return "Communicator";
-    }
-
-    /// Print information about this object.
-
-    virtual void PrintInfo(std::ostream& rOStream) const
-    {
-        rOStream << Info();
-    }
-
-    /// Print object's data.
-
-    virtual void PrintData(std::ostream& rOStream) const
-    {
-        for (IndexType i = 0; i < mLocalMeshes.size(); i++)
-        {
-            rOStream << "    Local Mesh " << i << " : " << std::endl;
-            LocalMesh(i).PrintData(rOStream);
-            rOStream << "    Ghost Mesh " << i << " : " << std::endl;
-            GhostMesh(i).PrintData(rOStream);
-            rOStream << "    Interface Mesh " << i << " : " << std::endl;
-            InterfaceMesh(i).PrintData(rOStream);
-        }
-    }
-
 
     ///@}
     ///@name Friends

--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -63,7 +63,7 @@ class DataCommunicator;
 /** The base Communicator class only holds the required data (local and remote mesh interfaces)
  *  for communication. The actual communication is implemented in the derived MPICommunicator.
  */
-class Communicator
+class KRATOS_API(KRATOS_CORE) Communicator
 {
 public:
     ///@name  Enum's

--- a/kratos/mpi/tests/sources/test_mpi_communicator.cpp
+++ b/kratos/mpi/tests/sources/test_mpi_communicator.cpp
@@ -15,9 +15,9 @@
 
 #include "containers/model.h"
 #include "includes/model_part.h"
+#include "includes/parallel_environment.h"
 #include "mpi/includes/mpi_communicator.h"
 #include "mpi/utilities/parallel_fill_communicator.h"
-
 
 #include "testing/testing.h"
 

--- a/kratos/sources/communicator.cpp
+++ b/kratos/sources/communicator.cpp
@@ -1,0 +1,653 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//                   Riccardo Rossi
+//
+//
+
+#include "includes/communicator.h"
+#include "includes/data_communicator.h"
+#include "includes/parallel_environment.h"
+
+namespace Kratos
+{
+
+// Life cycle and creation ////////////////////////////////////////////////////
+
+// Default constructor
+Communicator::Communicator()
+    : mNumberOfColors(1)
+    , mpLocalMesh(MeshType::Pointer(new MeshType))
+    , mpGhostMesh(MeshType::Pointer(new MeshType))
+    , mpInterfaceMesh(MeshType::Pointer(new MeshType))
+    , mrDataCommunicator(ParallelEnvironment::GetDataCommunicator("Serial"))
+{
+    MeshType mesh;
+    mLocalMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+    mGhostMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+    mInterfaceMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+}
+
+// Constructor with custom DataCommunicator.
+Communicator::Communicator(const DataCommunicator& rDataCommunicator)
+    : mNumberOfColors(1)
+    , mpLocalMesh(MeshType::Pointer(new MeshType))
+    , mpGhostMesh(MeshType::Pointer(new MeshType))
+    , mpInterfaceMesh(MeshType::Pointer(new MeshType))
+    , mrDataCommunicator(rDataCommunicator)
+{
+    MeshType mesh;
+    mLocalMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+    mGhostMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+    mInterfaceMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+}
+
+// Copy constructor.
+Communicator::Communicator(Communicator const& rOther)
+    : mNumberOfColors(rOther.mNumberOfColors)
+    , mNeighbourIndices(rOther.mNeighbourIndices)
+    , mpLocalMesh(MeshType::Pointer(rOther.mpLocalMesh))
+    , mpGhostMesh(MeshType::Pointer(rOther.mpGhostMesh))
+    , mpInterfaceMesh(MeshType::Pointer(rOther.mpInterfaceMesh))
+    , mLocalMeshes(rOther.mLocalMeshes)
+    , mGhostMeshes(rOther.mGhostMeshes)
+    , mInterfaceMeshes(rOther.mInterfaceMeshes)
+    , mrDataCommunicator(rOther.mrDataCommunicator)
+{}
+
+Communicator::Pointer Communicator::Create(const DataCommunicator& rDataCommunicator) const
+{
+    KRATOS_TRY
+
+    return Kratos::make_shared<Communicator>(rDataCommunicator);
+
+    KRATOS_CATCH("");
+}
+
+Communicator::Pointer Communicator::Create() const
+{
+    return Create(ParallelEnvironment::GetDataCommunicator("Serial"));
+}
+
+// Public Access //////////////////////////////////////////////////////////////
+
+bool Communicator::IsDistributed() const
+{
+    return false;
+}
+
+int Communicator::MyPID() const
+{
+    return mrDataCommunicator.Rank();
+}
+
+int Communicator::TotalProcesses() const
+{
+    return mrDataCommunicator.Size();
+}
+
+Communicator::SizeType Communicator::GetNumberOfColors() const
+{
+    return mNumberOfColors;
+}
+
+void Communicator::SetNumberOfColors(SizeType NewNumberOfColors)
+{
+    if (mNumberOfColors == NewNumberOfColors)
+        return;
+
+    mNumberOfColors = NewNumberOfColors;
+    MeshType mesh;
+
+    mLocalMeshes.clear();
+    mGhostMeshes.clear();
+    mInterfaceMeshes.clear();
+
+    for (IndexType i = 0; i < mNumberOfColors; i++)
+    {
+        mLocalMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+        mGhostMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+        mInterfaceMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+    }
+}
+
+Communicator::NeighbourIndicesContainerType& Communicator::NeighbourIndices()
+{
+    return mNeighbourIndices;
+}
+
+Communicator::NeighbourIndicesContainerType const& Communicator::NeighbourIndices() const
+{
+    return mNeighbourIndices;
+}
+
+// Set the local mesh pointer to the given mesh
+void Communicator::SetLocalMesh(MeshType::Pointer pGivenMesh)
+{
+    mpLocalMesh = pGivenMesh;
+}
+
+// Returns pointer to the mesh storing all local entites
+Communicator::MeshType::Pointer Communicator::pLocalMesh()
+{
+    return mpLocalMesh;
+}
+
+// Returns pointer to the mesh storing all ghost entites
+Communicator::MeshType::Pointer Communicator::pGhostMesh()
+{
+    return mpGhostMesh;
+}
+
+// Returns pointer to the mesh storing all interface entites
+Communicator::MeshType::Pointer Communicator::pInterfaceMesh()
+{
+    return mpInterfaceMesh;
+}
+
+// Returns a constant pointer to the mesh storing all local entites
+const Communicator::MeshType::Pointer Communicator::pLocalMesh() const
+{
+    return mpLocalMesh;
+}
+
+// Returns a constant pointer to the mesh storing all ghost entites
+const Communicator::MeshType::Pointer Communicator::pGhostMesh() const
+{
+    return mpGhostMesh;
+}
+
+// Returns a constant pointer to the mesh storing all interface entites
+const Communicator::MeshType::Pointer Communicator::pInterfaceMesh() const
+{
+    return mpInterfaceMesh;
+}
+
+Communicator::MeshType::Pointer Communicator::pLocalMesh(IndexType ThisIndex)
+{
+    return mLocalMeshes(ThisIndex);
+}
+
+Communicator::MeshType::Pointer Communicator::pGhostMesh(IndexType ThisIndex)
+{
+    return mGhostMeshes(ThisIndex);
+}
+
+Communicator::MeshType::Pointer Communicator::pInterfaceMesh(IndexType ThisIndex)
+{
+    return mInterfaceMeshes(ThisIndex);
+}
+
+const Communicator::MeshType::Pointer Communicator::pLocalMesh(IndexType ThisIndex) const
+{
+    return mLocalMeshes(ThisIndex);
+}
+
+const Communicator::MeshType::Pointer Communicator::pGhostMesh(IndexType ThisIndex) const
+{
+    return mGhostMeshes(ThisIndex);
+}
+
+const Communicator::MeshType::Pointer Communicator::pInterfaceMesh(IndexType ThisIndex) const
+{
+    return mInterfaceMeshes(ThisIndex);
+}
+
+// Returns the reference to the mesh storing all local entites
+Communicator::MeshType& Communicator::LocalMesh()
+{
+    return *mpLocalMesh;
+}
+
+// Returns the reference to the mesh storing all ghost entites
+Communicator::MeshType& Communicator::GhostMesh()
+{
+    return *mpGhostMesh;
+}
+
+// Returns the reference to the mesh storing all interface entites
+Communicator::MeshType& Communicator::InterfaceMesh()
+{
+    return *mpInterfaceMesh;
+}
+
+// Returns a constant reference to the mesh storing all local entites
+Communicator::MeshType const& Communicator::LocalMesh() const
+{
+    return *mpLocalMesh;
+}
+
+// Returns a constant reference to the mesh storing all ghost entites
+Communicator::MeshType const& Communicator::GhostMesh() const
+{
+    return *mpGhostMesh;
+}
+
+// Returns a constant reference to the mesh storing all interface entites
+Communicator::MeshType const& Communicator::InterfaceMesh() const
+{
+    return *mpInterfaceMesh;
+}
+
+Communicator::MeshType& Communicator::LocalMesh(IndexType ThisIndex)
+{
+    return mLocalMeshes[ThisIndex];
+}
+
+Communicator::MeshType& Communicator::GhostMesh(IndexType ThisIndex)
+{
+    return mGhostMeshes[ThisIndex];
+}
+
+Communicator::MeshType& Communicator::InterfaceMesh(IndexType ThisIndex)
+{
+    return mInterfaceMeshes[ThisIndex];
+}
+
+Communicator::MeshType const& Communicator::LocalMesh(IndexType ThisIndex) const
+{
+    return mLocalMeshes[ThisIndex];
+}
+
+Communicator::MeshType const& Communicator::GhostMesh(IndexType ThisIndex) const
+{
+    return mGhostMeshes[ThisIndex];
+}
+
+Communicator::MeshType const& Communicator::InterfaceMesh(IndexType ThisIndex) const
+{
+    return mInterfaceMeshes[ThisIndex];
+}
+
+Communicator::MeshesContainerType& Communicator::LocalMeshes()
+{
+    return mLocalMeshes;
+}
+
+Communicator::MeshesContainerType& Communicator::GhostMeshes()
+{
+    return mGhostMeshes;
+}
+
+Communicator::MeshesContainerType& Communicator::InterfaceMeshes()
+{
+    return mInterfaceMeshes;
+}
+
+Communicator::MeshesContainerType const& Communicator::LocalMeshes() const
+{
+    return mLocalMeshes;
+}
+
+Communicator::MeshesContainerType const& Communicator::GhostMeshes() const
+{
+    return mGhostMeshes;
+}
+
+Communicator::MeshesContainerType const& Communicator::InterfaceMeshes() const
+{
+    return mInterfaceMeshes;
+}
+
+const DataCommunicator& Communicator::GetDataCommunicator() const
+{
+    return mrDataCommunicator;
+}
+
+// Public Operatrions /////////////////////////////////////////////////////////
+
+void Communicator::Barrier() const
+{
+    mrDataCommunicator.Barrier();
+}
+
+bool Communicator::SumAll(int& rValue) const
+{
+    rValue = mrDataCommunicator.SumAll(rValue);
+    return true;
+}
+
+bool Communicator::SumAll(double& rValue) const
+{
+    rValue = mrDataCommunicator.SumAll(rValue);
+    return true;
+}
+
+bool Communicator::SumAll(array_1d<double, 3>& rValue) const
+{
+    rValue = mrDataCommunicator.SumAll(rValue);
+    return true;
+}
+
+bool Communicator::MinAll(int& rValue) const
+{
+    rValue = mrDataCommunicator.MinAll(rValue);
+    return true;
+}
+
+bool Communicator::MinAll(double& rValue) const
+{
+    rValue = mrDataCommunicator.MinAll(rValue);
+    return true;
+}
+
+bool Communicator::MaxAll(int& rValue) const
+{
+    rValue = mrDataCommunicator.MaxAll(rValue);
+    return true;
+}
+
+bool Communicator::MaxAll(double& rValue) const
+{
+    rValue = mrDataCommunicator.MaxAll(rValue);
+    return true;
+}
+
+bool Communicator::ScanSum(const double& send_partial, double& receive_accumulated) const
+{
+    receive_accumulated = mrDataCommunicator.ScanSum(send_partial);
+    return true;
+}
+
+bool Communicator::ScanSum(const int& send_partial, int& receive_accumulated) const
+{
+    receive_accumulated = mrDataCommunicator.ScanSum(send_partial);
+    return true;
+}
+
+bool Communicator::SynchronizeNodalSolutionStepsData()
+{
+    return true;
+}
+
+bool Communicator::SynchronizeDofs()
+{
+    return true;
+}
+
+bool Communicator::SynchronizeVariable(Variable<int> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeVariable(Variable<double> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeVariable(Variable<bool> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeVariable(Variable<array_1d<double, 3 > > const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeVariable(Variable<array_1d<double, 4 > > const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeVariable(Variable<array_1d<double, 6 > > const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeVariable(Variable<array_1d<double, 9 > > const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeVariable(Variable<Vector> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeVariable(Variable<Matrix> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalVariable(Variable<int> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalVariable(Variable<double> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalVariable(Variable<bool> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalVariable(Variable<array_1d<double, 3 > > const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalVariable(Variable<array_1d<double, 4 > > const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalVariable(Variable<array_1d<double, 6 > > const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalVariable(Variable<array_1d<double, 9 > > const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalVariable(Variable<Vector> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalVariable(Variable<Matrix> const& rThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeCurrentDataToMin(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNonHistoricalDataToMin(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeElementalFlags()
+{
+    return true;
+}
+
+bool Communicator::AssembleCurrentData(Variable<int> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::AssembleCurrentData(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::AssembleCurrentData(Variable<array_1d<double, 3 > > const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::AssembleCurrentData(Variable<Vector> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::AssembleCurrentData(Variable<Matrix> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::AssembleNonHistoricalData(Variable<int> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::AssembleNonHistoricalData(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::AssembleNonHistoricalData(Variable<array_1d<double, 3 > > const& ThisVariable)
+{
+    return true;
+}
+
+
+bool Communicator::AssembleNonHistoricalData(Variable<DenseVector<array_1d<double,3> > > const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::AssembleNonHistoricalData(Variable<Vector> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::AssembleNonHistoricalData(Variable<Matrix> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeElementalNonHistoricalVariable(Variable<int> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeElementalNonHistoricalVariable(Variable<double> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeElementalNonHistoricalVariable(Variable<array_1d<double, 3 > > const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeElementalNonHistoricalVariable(Variable<DenseVector<array_1d<double,3> > > const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeElementalNonHistoricalVariable(Variable<DenseVector<int> > const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeElementalNonHistoricalVariable(Variable<Vector> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeElementalNonHistoricalVariable(Variable<Matrix> const& ThisVariable)
+{
+    return true;
+}
+
+bool Communicator::TransferObjects(std::vector<NodesContainerType>& SendObjects, std::vector<NodesContainerType>& RecvObjects)
+{
+    return true;
+}
+
+bool Communicator::TransferObjects(std::vector<ElementsContainerType>& SendObjects, std::vector<ElementsContainerType>& RecvObjects)
+{
+    return true;
+}
+
+bool Communicator::TransferObjects(std::vector<ConditionsContainerType>& SendObjects, std::vector<ConditionsContainerType>& RecvObjects)
+{
+    return true;
+}
+
+bool Communicator::TransferObjects(std::vector<NodesContainerType>& SendObjects, std::vector<NodesContainerType>& RecvObjects,Kratos::Serializer& particleSerializer)
+{
+    return true;
+}
+
+bool Communicator::TransferObjects(std::vector<ElementsContainerType>& SendObjects, std::vector<ElementsContainerType>& RecvObjects,Kratos::Serializer& particleSerializer)
+{
+    return true;
+}
+
+bool Communicator::TransferObjects(std::vector<ConditionsContainerType>& SendObjects, std::vector<ConditionsContainerType>& RecvObjects,Kratos::Serializer& particleSerializer)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeOrNodalFlags(const Flags& TheFlags)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeAndNodalFlags(const Flags& TheFlags)
+{
+    return true;
+}
+
+bool Communicator::SynchronizeNodalFlags()
+{
+    return true;
+}
+
+void Communicator::Clear()
+{
+    mNumberOfColors = 0;
+    mNeighbourIndices.clear();
+    mpLocalMesh->MeshType::Clear();
+    mpGhostMesh->MeshType::Clear();
+    mpInterfaceMesh->MeshType::Clear();
+    mLocalMeshes.clear();
+    mGhostMeshes.clear();
+    mInterfaceMeshes.clear();
+}
+
+// Inquiry ////////////////////////////////////////////////////////////////////
+
+std::string Communicator::Info() const
+{
+    return "Communicator";
+}
+
+void Communicator::PrintInfo(std::ostream& rOStream) const
+{
+    rOStream << Info();
+}
+
+void Communicator::PrintData(std::ostream& rOStream) const
+{
+    for (IndexType i = 0; i < mLocalMeshes.size(); i++)
+    {
+        rOStream << "    Local Mesh " << i << " : " << std::endl;
+        LocalMesh(i).PrintData(rOStream);
+        rOStream << "    Ghost Mesh " << i << " : " << std::endl;
+        GhostMesh(i).PrintData(rOStream);
+        rOStream << "    Interface Mesh " << i << " : " << std::endl;
+        InterfaceMesh(i).PrintData(rOStream);
+    }
+}
+
+} // namespace Kratos

--- a/kratos/sources/communicator.cpp
+++ b/kratos/sources/communicator.cpp
@@ -73,7 +73,7 @@ Communicator::Pointer Communicator::Create(const DataCommunicator& rDataCommunic
 
 Communicator::Pointer Communicator::Create() const
 {
-    return Create(ParallelEnvironment::GetDataCommunicator("Serial"));
+    return Kratos::make_shared<Communicator>();
 }
 
 // Public Access //////////////////////////////////////////////////////////////


### PR DESCRIPTION
Essentially what it says in the title. I believe this is useful as a way to avoid recompiling everything that uses a ModelPart every time something changes in the DataCommunicator.

I discussed with @philbucher forward-declaring Communicator in ModelPart as a less intrusive, alternative solution, but I could not make it work because some ModelPart functions have Communicator::Pointer types in their signature).