### PR TITLE
cps/adding 3d wake process

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
@@ -1,0 +1,437 @@
+import KratosMultiphysics
+import KratosMultiphysics.CompressiblePotentialFlowApplication as CPFApp
+import math
+
+
+def DotProduct(A,B):
+    result = 0
+    for i,j in zip(A,B):
+        result += i*j
+    return result
+
+def Factory(settings, Model):
+    if(not isinstance(settings, KratosMultiphysics.Parameters)):
+        raise Exception(
+            "expected input shall be a Parameters object, encapsulating a json string")
+
+    return DefineWakeProcess3D(Model, settings["Parameters"])
+
+class DefineWakeProcess3D(KratosMultiphysics.Process):
+    def __init__(self, Model, settings):
+        KratosMultiphysics.Process.__init__(self)
+
+        # Check default settings
+        default_settings = KratosMultiphysics.Parameters(r'''{
+            "model_part_name": "",
+            "wing_tips_model_part_name": "",
+            "body_model_part_name": "",
+            "wake_stl_file_name" : "",
+            "wake_normal": [0.0,0.0,1.0],
+            "output_wake": true,
+            "epsilon": 1e-9
+        }''')
+        settings.ValidateAndAssignDefaults(default_settings)
+
+        self.model = Model
+
+        trailing_edge_model_part_name = settings["model_part_name"].GetString()
+        if trailing_edge_model_part_name == "":
+            err_msg = "Empty model_part_name in DefineWakeProcess3D\n"
+            err_msg += "Please specify the model part that contains the trailing edge nodes"
+            raise Exception(err_msg)
+        self.trailing_edge_model_part = Model[trailing_edge_model_part_name]
+
+        wing_tips_model_part_name = settings["wing_tips_model_part_name"].GetString()
+        if wing_tips_model_part_name == "":
+            err_msg = "Empty model_part_name in DefineWakeProcess3D\n"
+            err_msg += "Please specify the model part that contains the wing tips nodes"
+            raise Exception(err_msg)
+        self.wing_tips_model_part = Model[wing_tips_model_part_name]
+
+        body_model_part_name = settings["body_model_part_name"].GetString()
+        if body_model_part_name == "":
+            err_msg = "Empty model_part_name in DefineWakeProcess3D\n"
+            err_msg += "Please specify the model part that contains the body nodes"
+            raise Exception(err_msg)
+        self.body_model_part = Model[body_model_part_name]
+
+        self.wake_stl_file_name = settings["wake_stl_file_name"].GetString()
+        if self.wake_stl_file_name == "":
+            err_msg = "Empty wake_stl_file_name in DefineWakeProcess3D\n"
+            err_msg += "Please specify the stl file name that contains the wake surface nodes"
+            raise Exception(err_msg)
+
+        self.epsilon = settings["epsilon"].GetDouble()
+        self.output_wake = settings["output_wake"].GetBool()
+
+        # For now plane wake surfaces are considered.
+        # TODO: Generalize this to curved wake surfaces
+        self.wake_normal = settings["wake_normal"].GetVector()
+        if( abs(DotProduct(self.wake_normal,self.wake_normal) - 1) > self.epsilon ):
+            raise Exception('The wake normal should be a unitary vector')
+
+        self.fluid_model_part = self.trailing_edge_model_part.GetRootModelPart()
+        self.fluid_model_part.ProcessInfo.SetValue(CPFApp.WAKE_NORMAL,self.wake_normal)
+
+    def ExecuteInitialize(self):
+
+        self.__SetWakeAndSpanDirections()
+        # Save the trailing edge and wing tip nodes for further computations
+        self.__MarkTrailingEdgeAndWingTipNodes()
+        # Save the lower surface normals to help mark kutta elements later on
+        self.__ComputeLowerSurfaceNormals()
+        # Read wake from stl and create the wake model part
+        self.__CreateWakeModelPart()
+        # Check which elements are cut and mark them as wake
+        self.__MarkWakeElements()
+        # Mark the elements touching the trailing edge from below as kutta
+        self.__MarkKuttaElements()
+        # Output the wake in GiD for visualization
+        if(self.output_wake):
+            self.__VisualizeWake()
+        # Output element ids in the terminal
+        self.__TerminalPrint()
+
+    def __SetWakeAndSpanDirections(self):
+        free_stream_velocity = self.fluid_model_part.ProcessInfo.GetValue(CPFApp.FREE_STREAM_VELOCITY)
+        if(free_stream_velocity.Size() != 3):
+            raise Exception('The free stream velocity should be a vector with 3 components!')
+        self.wake_direction = KratosMultiphysics.Vector(3)
+        vnorm = math.sqrt(
+            free_stream_velocity[0]**2 + free_stream_velocity[1]**2 + free_stream_velocity[2]**2)
+        self.wake_direction[0] = free_stream_velocity[0]/vnorm
+        self.wake_direction[1] = free_stream_velocity[1]/vnorm
+        self.wake_direction[2] = free_stream_velocity[2]/vnorm
+
+        # span_direction = wake_normal x wake_direction
+        self.span_direction = KratosMultiphysics.Vector(3)
+        self.span_direction[0] = self.wake_normal[1] * self.wake_direction[2] - self.wake_normal[2] * self.wake_direction[1]
+        self.span_direction[1] = self.wake_normal[2] * self.wake_direction[0] - self.wake_normal[0] * self.wake_direction[2]
+        self.span_direction[0] = self.wake_normal[0] * self.wake_direction[1] - self.wake_normal[1] * self.wake_direction[0]
+
+    def __MarkTrailingEdgeAndWingTipNodes(self):
+        # Mark trailing edge nodes
+        for node in self.trailing_edge_model_part.Nodes:
+            node.SetValue(CPFApp.TRAILING_EDGE, True)
+
+        # Mark wing tip nodes
+        for node in self.wing_tips_model_part.Nodes:
+            node.SetValue(CPFApp.WING_TIP, True)
+            # Compute the local span direction for later
+            # TODO: Generalize this for more than one lifting surface
+            for other_node in self.wing_tips_model_part.Nodes:
+                wing_span_direction = other_node - node
+                if(DotProduct(wing_span_direction,wing_span_direction) > self.epsilon):
+                    node.SetValue(CPFApp.WING_SPAN_DIRECTION, wing_span_direction)
+
+    def __ComputeLowerSurfaceNormals(self):
+        for cond in self.body_model_part.Conditions:
+            # The surface normal points outisde the domain
+            surface_normal = cond.GetGeometry().Normal()
+            projection = DotProduct(surface_normal, self.wake_normal)
+            # The surface normal in the same direction as the wake normal belongs to the lower_surface
+            if(projection > 0.0):
+                for node in cond.GetNodes():
+                    node.SetValue(KratosMultiphysics.NORMAL,surface_normal)
+
+    # This function imports the stl file containing the wake and creates the wake model part out of it.
+    # TODO: implement an automatic generation of the wake
+    def __CreateWakeModelPart(self):
+        from stl import mesh #this requires numpy-stl
+        wake_stl_mesh = mesh.Mesh.from_multi_file(self.wake_stl_file_name)
+        self.wake_model_part = self.model.CreateModelPart("wake_model_part")
+
+        dummy_property = self.wake_model_part.Properties[0]
+        node_id = 1
+        elem_id = 1
+
+        # Looping over stl meshes
+        for stl_mesh in wake_stl_mesh:
+            for vertex in stl_mesh.points:
+                node1 = self.wake_model_part.CreateNewNode(node_id, float(vertex[0]), float(vertex[1]), float(vertex[2]))
+                node_id+=1
+                node2 = self.wake_model_part.CreateNewNode(node_id, float(vertex[3]), float(vertex[4]), float(vertex[5]))
+                node_id+=1
+                node3 = self.wake_model_part.CreateNewNode(node_id, float(vertex[6]), float(vertex[7]), float(vertex[8]))
+                node_id+=1
+
+                self.wake_model_part.CreateNewElement("Element3D3N", elem_id,  [
+                                              node1.Id, node2.Id, node3.Id], dummy_property)
+                elem_id += 1
+
+    # Check which elements are cut and mark them as wake
+    def __MarkWakeElements(self):
+        KratosMultiphysics.Logger.PrintInfo('...Selecting wake elements...')
+
+        # Mark cut elements and compute elemental distances
+        # Attention: Note that in this process a negative distance is assigned to nodes
+        # laying on the wake. In 2D it is done viceversa.
+        distance_calculator = KratosMultiphysics.CalculateDistanceToSkinProcess3D(
+            self.fluid_model_part, self.wake_model_part)
+        distance_calculator.Execute()
+
+        #List to store trailing edge elements id
+        self.trailing_edge_element_id_list = []
+
+        for elem in self.fluid_model_part.Elements:
+            # Mark and save the elements touching the trailing edge
+            self.__MarkTrailingEdgeElement(elem)
+
+            # Cut elements are wake
+            if(elem.Is(KratosMultiphysics.TO_SPLIT)):
+                # Mark wake element
+                elem.SetValue(CPFApp.WAKE, True)
+                # Save wake elemental distances
+                wake_elemental_distances = elem.GetValue(KratosMultiphysics.ELEMENTAL_DISTANCES)
+                # Check tolerances
+                for i in range(len(wake_elemental_distances)):
+                    if(abs(wake_elemental_distances[i]) < self.epsilon ):
+                        if(wake_elemental_distances[i] < 0.0):
+                            wake_elemental_distances[i] = -self.epsilon
+                        else:
+                            wake_elemental_distances[i] = self.epsilon
+                # Save wake elemental distances
+                elem.SetValue(CPFApp.WAKE_ELEMENTAL_DISTANCES,wake_elemental_distances)
+                # Save wake nodal distances
+                counter = 0
+                for node in elem.GetNodes():
+                    node.SetValue(CPFApp.WAKE_DISTANCE,wake_elemental_distances[counter])
+                    counter += 1
+                # Mark nodes above and below the wake with WATER_PRESSURE variable for visualization
+                counter = 0
+                for node in elem.GetNodes():
+                    if(wake_elemental_distances[counter] > 0.0):
+                        node.SetValue(KratosMultiphysics.WATER_PRESSURE, 1.0)
+                    else:
+                        node.SetValue(KratosMultiphysics.WATER_PRESSURE, -1.0)#
+                    counter +=1
+
+        self.__SaveTrailingEdgeElements()
+        KratosMultiphysics.Logger.PrintInfo('...Selecting wake elements finished...')
+
+    def __MarkTrailingEdgeElement(self, elem):
+        # This function marks the elements touching the trailing
+        # edge and saves them in the trailing_edge_element_id_list
+        # for further computations
+        for elnode in elem.GetNodes():
+            if(elnode.GetValue(CPFApp.TRAILING_EDGE)):
+                elem.SetValue(CPFApp.TRAILING_EDGE_ELEMENT, True)
+                self.trailing_edge_element_id_list.append(elem.Id)
+                break
+
+    def __SaveTrailingEdgeElements(self):
+        # This function stores the trailing edge elements
+        # in its submodelpart.
+        if(self.fluid_model_part.HasSubModelPart("trailing_edge_model_part")):
+            for elem in self.trailing_edge_model_part.Elements:
+                elem.Set(KratosMultiphysics.TO_ERASE)
+            self.trailing_edge_model_part.RemoveElements(KratosMultiphysics.TO_ERASE)
+        else:
+            self.trailing_edge_model_part = self.fluid_model_part.CreateSubModelPart("trailing_edge_model_part")
+        self.trailing_edge_model_part.AddElements(self.trailing_edge_element_id_list)
+
+    def __MarkKuttaElements(self):
+        # This function selects the kutta elements. Kutta elements
+        # are touching the trailing edge from below.
+
+        # Loop over elements touching the trailing edge
+        for elem in self.trailing_edge_model_part.Elements:
+            # Check if it is a wing tip element
+            wing_tip = self.__CheckIfWingTipElement(elem)
+            if wing_tip:
+                # Wing tip elements are set to normal
+                # TODO: Check what to do with wing tip elements
+                # and tip vortice elements in general
+                elem.SetValue(CPFApp.WAKE, False)
+            else:
+                trailing_edge_node, number_of_non_te_nodes = self.__GetATrailingEdgeNodeAndNumberOfNonTENodes(elem)
+                nodal_distances = self.__ComputeNodalDistancesToWakeAndLowerSurface(elem, trailing_edge_node, number_of_non_te_nodes)
+                self.__CheckIfKuttaElement(elem, nodal_distances, number_of_non_te_nodes)
+
+    def __CheckIfWingTipElement(self, elem):
+        # Wing tip elements are elements with one node at the wing tip
+        # and with the rest of the nodes on the side of the wing and wake.
+        wing_tip = False
+
+        # Checking if the element has a node at the wing tip
+        for elnode in elem.GetNodes():
+            if(elnode.GetValue(CPFApp.WING_TIP)):
+                wing_tip = True
+                wing_tip_node = elnode
+                wing_span_direction = elnode.GetValue(CPFApp.WING_SPAN_DIRECTION)
+
+        if(wing_tip):
+            for elnode in elem.GetNodes():
+                if not (elnode.GetValue(CPFApp.WING_TIP)):
+                    # Checking if the rest of the nodes are on the side
+                    distance = elnode - wing_tip_node
+                    wing_span_projection = DotProduct(distance, wing_span_direction)
+                    # A positive wing_span_projection means that the node is not on the side
+                    # but actually laying somewhere above or below the wing and/or wake
+                    if(wing_span_projection > 0.0):
+                        wing_tip = False
+
+        return wing_tip
+
+    def __GetATrailingEdgeNodeAndNumberOfNonTENodes(self,elem):
+        # This function returns a trailing edge node (note that
+        # an element may have more than one trailing edge node)
+        # and the number of nodes that are not trailing edge.
+        number_of_te_nodes = 0
+        for elnode in elem.GetNodes():
+            if(elnode.GetValue(CPFApp.TRAILING_EDGE)):
+                trailing_edge_node = elnode
+                number_of_te_nodes += 1
+
+        number_of_non_te_nodes = 4 - number_of_te_nodes
+
+        return trailing_edge_node, number_of_non_te_nodes
+
+    def __ComputeNodalDistancesToWakeAndLowerSurface(self, elem, trailing_edge_node, number_of_non_te_nodes):
+        # This function computes the distance of the element nodes
+        # to the wake and the wing lower surface
+
+        # Only computing the distances of the nodes that are not trailing edge
+        nodal_distances_to_te = KratosMultiphysics.Vector(number_of_non_te_nodes)
+        counter = 0
+        for elnode in elem.GetNodes():
+            # Looping only over non traling edge nodes
+            if not (elnode.GetValue(CPFApp.TRAILING_EDGE)):
+                # Compute the distance vector from the trailing edge to the node
+                distance_vector = elnode - trailing_edge_node
+
+                # Compute the distance in the free stream direction
+                free_stream_direction_distance = DotProduct(distance_vector, self.wake_direction)
+
+                # Node laying either above or below the lower surface
+                if(free_stream_direction_distance < 0.0):
+                    # Compute the distance in the lower surface normal direction
+                    distance = DotProduct(distance_vector, trailing_edge_node.GetValue(KratosMultiphysics.NORMAL))
+                # Node laying either above or below the wake
+                else:
+                    # Compute the distance in the wake normal direction
+                    distance = DotProduct(distance_vector, self.wake_normal)
+
+                # Nodes laying on the wake or on the lower surface have a negative distance
+                if(abs(distance) < self.epsilon):
+                    distance = -self.epsilon
+
+                nodal_distances_to_te[counter] = distance
+                counter += 1
+
+        return nodal_distances_to_te
+
+    def __CheckIfKuttaElement(self, elem, nodal_distances, number_of_non_te_nodes):
+        # This function checks whether the element is kutta
+
+        # Count number of nodes above and below the wake and lower surface
+        number_of_nodes_with_positive_distance, number_of_nodes_with_negative_distance = self.__CountNodes(nodal_distances)
+
+        # Elements with all non trailing edge nodes below the wake and the lower surface are kutta
+        if(number_of_nodes_with_negative_distance > number_of_non_te_nodes - 1):
+            elem.SetValue(CPFApp.KUTTA, True)
+            elem.SetValue(CPFApp.WAKE, False)
+        # Elements with nodes above and below the wake are wake elements
+        elif(number_of_nodes_with_positive_distance > 0 and number_of_nodes_with_negative_distance > 0):
+            # Wake elements touching the trailing edge are marked as structure
+            # TODO: change STRUCTURE to a more meaningful variable name
+            elem.Set(KratosMultiphysics.STRUCTURE)
+            pass
+        # Elements with all non trailing edge nodes above the wake and the lower surface are normal
+        elif(number_of_nodes_with_positive_distance > number_of_non_te_nodes - 1):
+            elem.SetValue(CPFApp.WAKE, False)
+
+    def __CountNodes(self, distances_to_te):
+        # This function counts the number of nodes that are above and below
+        # the wake and the lower surface
+
+        # Initialize counters
+        number_of_nodes_with_positive_distance = 0
+        number_of_nodes_with_negative_distance = 0
+
+        # Count how many element nodes are above and below the wake
+        for nodal_distance_to_wake in distances_to_te:
+            if(nodal_distance_to_wake < 0.0):
+                number_of_nodes_with_negative_distance += 1
+            else:
+                number_of_nodes_with_positive_distance += 1
+
+        return number_of_nodes_with_positive_distance, number_of_nodes_with_negative_distance
+
+    def __VisualizeWake(self):
+        # To visualize the wake
+        number_of_nodes = self.fluid_model_part.NumberOfNodes()
+        number_of_elements = self.fluid_model_part.NumberOfElements()
+
+        node_id = number_of_nodes + 1
+        for node in self.wake_model_part.Nodes:
+            node.Id = node_id
+            node.SetValue(KratosMultiphysics.REACTION_WATER_PRESSURE, 1.0)
+            node_id += 1
+
+        counter = number_of_elements + 1
+        for elem in self.wake_model_part.Elements:
+            elem.Id = counter
+            counter +=1
+
+        from gid_output_process import GiDOutputProcess
+        output_file = "representation_of_wake"
+        gid_output =  GiDOutputProcess(self.wake_model_part,
+                                output_file,
+                                KratosMultiphysics.Parameters("""
+                                    {
+                                        "result_file_configuration": {
+                                            "gidpost_flags": {
+                                                "GiDPostMode": "GiD_PostAscii",
+                                                "WriteDeformedMeshFlag": "WriteUndeformed",
+                                                "WriteConditionsFlag": "WriteConditions",
+                                                "MultiFileFlag": "SingleFile"
+                                            },
+                                            "file_label": "time",
+                                            "output_control_type": "step",
+                                            "output_frequency": 1.0,
+                                            "body_output": true,
+                                            "node_output": false,
+                                            "skin_output": false,
+                                            "plane_output": [],
+                                            "nodal_results": [],
+                                            "nodal_nonhistorical_results": ["REACTION_WATER_PRESSURE"],
+                                            "nodal_flags_results": [],
+                                            "gauss_point_results": [],
+                                            "additional_list_files": []
+                                        }
+                                    }
+                                    """)
+                                )
+
+        gid_output.ExecuteInitialize()
+        gid_output.ExecuteBeforeSolutionLoop()
+        gid_output.ExecuteInitializeSolutionStep()
+        gid_output.PrintOutput()
+        gid_output.ExecuteFinalizeSolutionStep()
+        gid_output.ExecuteFinalize()
+
+    def __TerminalPrint(self):
+        # Print trailing_edge_model_part elements
+        for elem in self.trailing_edge_model_part.Elements:
+            if(elem.GetValue(CPFApp.WAKE)):
+                #print(elem.Id)
+                pass
+            elif(elem.GetValue(CPFApp.KUTTA)):
+                #print(elem.Id)
+                pass
+            else:
+                #print(elem.Id)
+                pass
+
+        # Print fluid_model_part elements
+        for elem in self.fluid_model_part.Elements:
+            if(elem.GetValue(CPFApp.WAKE)):
+                print(elem.Id)
+                pass
+            elif(elem.GetValue(CPFApp.KUTTA)):
+                #print(elem.Id)
+                pass
+            else:
+                #print(elem.Id)
+                pass

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -79,6 +79,58 @@ class PotentialFlowTests(UnitTest.TestCase):
         with WorkFolderScope(work_folder):
             self._runTest(settings_file_name)
 
+    def test_WakeProcess3DSmall(self):
+        # This tests a simple small 3D model
+        settings_file_name = "small_3d_parameters.json"
+        work_folder = "wake_process_3d_tests/15_elements_small_test"
+
+        with WorkFolderScope(work_folder):
+            self._runTest(settings_file_name)
+            reference_wake_elements_id_list = [2, 4, 9, 13, 15]
+            self._validateWakeProcess(reference_wake_elements_id_list, "WAKE")
+            reference_kutta_elements_id_list = [1, 10, 14]
+            self._validateWakeProcess(reference_kutta_elements_id_list, "KUTTA")
+
+    def test_WakeProcess3DNodesOnWake(self):
+        # This tests a model with nodes laying on the wake
+        settings_file_name = "small_3d_parameters.json"
+        work_folder = "wake_process_3d_tests/25_elements_nodes_on_wake_test"
+
+        with WorkFolderScope(work_folder):
+            self._runTest(settings_file_name)
+            reference_wake_elements_id_list = [1, 2, 3, 4, 5, 6]
+            self._validateWakeProcess(reference_wake_elements_id_list, "WAKE")
+            reference_kutta_elements_id_list = [13, 14, 15, 17, 18, 19, 20, 21, 22, 23]
+            self._validateWakeProcess(reference_kutta_elements_id_list, "KUTTA")
+
+    def test_WakeProcess3DKuttaNodesAboveTheWake(self):
+        # This tests a model with some kutta nodes above the wake
+        settings_file_name = "small_3d_parameters.json"
+        work_folder = "wake_process_3d_tests/24_elements_kutta_node_above_wake_test"
+
+        with WorkFolderScope(work_folder):
+            self._runTest(settings_file_name)
+            reference_wake_elements_id_list = [2, 4, 8, 16, 17, 19, 20]
+            self._validateWakeProcess(reference_wake_elements_id_list, "WAKE")
+            reference_kutta_elements_id_list = [10, 11, 12, 13, 14, 15, 18, 23, 24]
+            self._validateWakeProcess(reference_kutta_elements_id_list, "KUTTA")
+
+    def _validateWakeProcess(self,reference_element_id_list, variable_name):
+        variable = KratosMultiphysics.KratosGlobals.GetVariable(variable_name)
+        solution_element_id_list = []
+        for elem in self.main_model_part.Elements:
+            if(elem.GetValue(variable)):
+                solution_element_id_list.append(elem.Id)
+        self._validateIdList(solution_element_id_list, reference_element_id_list)
+
+    def _validateIdList(self, solution_element_id_list, reference_element_id_list):
+        if(abs(len(reference_element_id_list) - len(solution_element_id_list)) > 0.1):
+            raise Exception('Lists have different lengths', ' reference_element_id_list = ',
+                            reference_element_id_list, ' solution_element_id_list = ', solution_element_id_list)
+        else:
+            for i in range(len(reference_element_id_list)):
+                self._check_results(solution_element_id_list[i], reference_element_id_list[i], 0.0, 1e-9)
+
     def _runTest(self,settings_file_name):
         model = KratosMultiphysics.Model()
         with open(settings_file_name,'r') as settings_file:
@@ -146,9 +198,9 @@ class PotentialFlowTests(UnitTest.TestCase):
                                     "skin_output"         : false,
                                     "plane_output"        : [],
                                     "nodal_results"       : ["VELOCITY_POTENTIAL","AUXILIARY_VELOCITY_POTENTIAL"],
-                                    "nodal_nonhistorical_results": ["TRAILING_EDGE","wAKE_DISTANCE"],
+                                    "nodal_nonhistorical_results": ["TRAILING_EDGE","WAKE_DISTANCE"],
                                     "elemental_conditional_flags_results": ["STRUCTURE"],
-                                    "gauss_point_results" : ["PRESSURE_COEFFICIENT","VELOCITY","VELOCITY_LOWER","PRESSURE_LOWER","WAKE","WAKE_ELEMENTAL_DISTANCES","KUTTA"]
+                                    "gauss_point_results" : ["PRESSURE_COEFFICIENT","VELOCITY","WAKE","WAKE_ELEMENTAL_DISTANCES","KUTTA"]
                                 },
                                 "point_data_configuration"  : []
                             }

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/15_elements_small_test/small_3d.mdpa
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/15_elements_small_test/small_3d.mdpa
@@ -1,0 +1,163 @@
+Begin ModelPartData
+//  VARIABLE_NAME value
+End ModelPartData
+
+Begin Properties 0
+End Properties
+
+Begin Properties 1
+    DENSITY 1.225
+End Properties
+
+Begin Nodes
+    1       10.00000        0.00000        0.00000
+    2        5.00000        0.00000        5.00000
+    3        0.00000        0.00000        0.00000
+    4       10.00000        0.00000       10.00000
+    5       10.00000       10.00000        0.00000
+    6        5.00000        5.62636        7.83333
+    7        5.00000       10.00000        5.00000
+    8        0.00000        0.00000       10.00000
+    9        0.00000       10.00000        0.00000
+   10       10.00000       10.00000       10.00000
+   11        0.00000       10.00000       10.00000
+End Nodes
+
+
+Begin Elements Element3D4N// GUI group identifier: Parts Auto1
+        1          1          3          2          1          5
+        2          1          1          2          4         10
+        3          1          7         10         11          6
+        4          1          7         10          6          5
+        5          1         11          7          6          8
+        6          1          2          8          4          6
+        7          1          4          2          6         10
+        8          1          2          8          6          7
+        9          1          6          2          7          5
+       10          1          9          5          7          2
+       11          1          8          4          6         11
+       12          1          6          4         10         11
+       13          1          2          6         10          5
+       14          1          2          3          9          5
+       15          1          2          1          5         10
+End Elements
+
+Begin Conditions SurfaceCondition3D3N// GUI group identifier: _HIDDEN__SKIN_
+    1 0 3 1 5
+    2 0 5 9 3
+    3 0 1 4 10
+    4 0 10 5 1
+    5 0 4 8 11
+    6 0 11 10 4
+    7 0 8 2 7
+    8 0 7 11 8
+    9 0 2 3 9
+    10 0 9 7 2
+    11 0 3 2 1
+    12 0 2 8 4
+    13 0 1 2 4
+    14 0 9 7 5
+    15 0 7 11 10
+    16 0 5 7 10
+End Conditions
+
+Begin SubModelPart MainModelPart // Group Parts Auto1 // Subtree Parts
+    Begin SubModelPartNodes
+            1
+            2
+            3
+            4
+            5
+            6
+            7
+            8
+            9
+           10
+           11
+    End SubModelPartNodes
+    Begin SubModelPartElements
+            1
+            2
+            3
+            4
+            5
+            6
+            7
+            8
+            9
+           10
+           11
+           12
+           13
+           14
+           15
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart PotentialWallCondition3D_Far_field_Auto1 // Group Far field Auto1 // Subtree PotentialWallCondition3D
+    Begin SubModelPartNodes
+            1
+            2
+            3
+            4
+            5
+            7
+            8
+            9
+           10
+           11
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+                 1
+                 2
+                 3
+                 4
+                 5
+                 6
+                 7
+                 8
+                11
+                12
+                13
+                14
+                15
+                16
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart Wake3D_Wake_Auto1 // Group Wake Auto1 // Subtree Wake3D
+    Begin SubModelPartNodes
+            2
+            7
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart Tip3D_Wing_Tips_Auto1 // Group Wing Tips Auto1 // Subtree Tip3D
+    Begin SubModelPartNodes
+            2
+            7
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart Body3D_Body_Auto1 // Group Body Auto1 // Subtree Body3D
+    Begin SubModelPartNodes
+            2
+            3
+            7
+            9
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+                 9
+                10
+    End SubModelPartConditions
+End SubModelPart

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/15_elements_small_test/small_3d_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/15_elements_small_test/small_3d_parameters.json
@@ -1,0 +1,47 @@
+{
+    "problem_data"     : {
+        "problem_name"  : "small_3d",
+        "parallel_type" : "OpenMP",
+        "echo_level"    : 0,
+        "start_time"    : 0.0,
+        "end_time"      : 1
+    },
+    "solver_settings"  : {
+        "model_part_name"        : "FluidModelPart",
+        "domain_size"            : 3,
+        "solver_type"            : "potential_flow",
+        "model_import_settings"  : {
+            "input_type"     : "mdpa",
+            "input_filename" : "small_3d"
+        },
+        "maximum_iterations"     : 10,
+        "echo_level"             : 0,
+        "volume_model_part_name" : "MainModelPart",
+        "skin_parts"             : ["PotentialWallCondition3D_Far_field_Auto1","Body3D_Body_Auto1"],
+        "no_skin_parts"          : ["Wake3D_Wake_Auto1","Tip3D_Wing_Tips_Auto1"],
+        "auxiliary_variables_list" : ["DISTANCE"]
+    },
+    "processes"        : {
+        "boundary_conditions_process_list" : [{
+            "python_module" : "apply_far_field_process",
+            "kratos_module" : "KratosMultiphysics.CompressiblePotentialFlowApplication",
+            "Parameters"    : {
+                "model_part_name" : "PotentialWallCondition3D_Far_field_Auto1",
+                "angle_of_attack" : 0.0,
+                "mach_infinity"   : 0.03,
+                "speed_of_sound"  : 340.0
+            }
+        },{
+            "python_module" : "define_wake_process_3d",
+            "kratos_module" : "KratosMultiphysics.CompressiblePotentialFlowApplication",
+            "Parameters"    : {
+                "model_part_name" : "Wake3D_Wake_Auto1",
+                "wing_tips_model_part_name": "Tip3D_Wing_Tips_Auto1",
+                "body_model_part_name": "Body3D_Body_Auto1",
+                "wake_stl_file_name" : "wake_stl.stl",
+                "output_wake": false,
+                "epsilon"         : 1e-6
+            }
+        }]
+    }
+}

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/15_elements_small_test/small_3d_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/15_elements_small_test/small_3d_parameters.json
@@ -36,7 +36,6 @@
             "kratos_module" : "KratosMultiphysics.CompressiblePotentialFlowApplication",
             "Parameters"    : {
                 "model_part_name" : "Wake3D_Wake_Auto1",
-                "wing_tips_model_part_name": "Tip3D_Wing_Tips_Auto1",
                 "body_model_part_name": "Body3D_Body_Auto1",
                 "wake_stl_file_name" : "wake_stl.stl",
                 "output_wake": false,

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/15_elements_small_test/wake_stl.stl
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/15_elements_small_test/wake_stl.stl
@@ -1,0 +1,30 @@
+solid GiD
+  facet normal               0              -0               1  
+    outer loop
+      vertex               5               0               5
+      vertex              10               0               5
+      vertex             7.5               5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex              10              10               5
+      vertex               5              10               5
+      vertex             7.5               5               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex             7.5               5               5
+      vertex              10               0               5
+      vertex              10              10               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex               5               0               5
+      vertex             7.5               5               5
+      vertex               5              10               5
+    endloop
+  endfacet
+endsolid GiD

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/24_elements_kutta_node_above_wake_test/small_3d.mdpa
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/24_elements_kutta_node_above_wake_test/small_3d.mdpa
@@ -1,0 +1,199 @@
+Begin ModelPartData
+//  VARIABLE_NAME value
+End ModelPartData
+
+Begin Properties 0
+End Properties
+
+Begin Properties 1
+    DENSITY 1.225
+End Properties
+
+Begin Nodes
+    1       10.00000       10.00000        0.00000
+    2        5.25000        5.34504        2.05833
+    3        5.00000       10.00000        5.00000
+    4        6.97687        4.60316        7.06749
+    5       10.00000        0.00000        0.00000
+    6        0.00000       10.00000        0.00000
+    7       10.00000       10.00000       10.00000
+    8        5.00000        0.00000        5.00000
+    9        1.00000       10.00000       10.00000
+   10        0.00000        0.00000        0.00000
+   11       10.00000        0.00000       10.00000
+   12        0.00000       10.00000       10.00000
+   13        1.00000        0.00000       10.00000
+   14        0.00000        0.00000       10.00000
+End Nodes
+
+
+Begin Elements Element3D4N// GUI group identifier: Parts Auto1
+        1          1          8         13         11          4
+        2          1         11          8          4          5
+        3          1          3          7          9          4
+        4          1          3          7          4          5
+        5          1         13         11          4          9
+        6          1          8         13          4          3
+        7          1          7          9          4         11
+        8          1          4          7         11          5
+        9          1          9          3          4         13
+       10          1         14          8         10          6
+       11          1          6          1          3          2
+       12          1          1          3          2          5
+       13          1          3          6          2         12
+       14          1         10          8          5          2
+       15          1         10          8          2          6
+       16          1          8          5          2          4
+       17          1          2          8          4          3
+       18          1          2          8          3         12
+       19          1          4          2          3          5
+       20          1          3          1          7          5
+       21          1          5         10          2          1
+       22          1          2         10          6          1
+       23          1          8          2          6         12
+       24          1         14         12          8          6
+End Elements
+
+Begin Conditions SurfaceCondition3D3N// GUI group identifier: _HIDDEN__SKIN_
+    1 0 14 8 10
+    2 0 8 13 11
+    3 0 10 8 5
+    4 0 8 11 5
+    5 0 5 1 10
+    6 0 1 6 10
+    7 0 11 7 5
+    8 0 7 1 5
+    9 0 13 9 11
+    10 0 9 7 11
+    11 0 8 3 13
+    12 0 3 9 13
+    13 0 14 12 8
+    14 0 12 3 8
+    15 0 10 6 14
+    16 0 6 12 14
+    17 0 12 3 6
+    18 0 3 9 7
+    19 0 6 3 1
+    20 0 3 7 1
+End Conditions
+
+Begin SubModelPart MainModelPart // Group Parts Auto1 // Subtree Parts
+    Begin SubModelPartNodes
+            1
+            2
+            3
+            4
+            5
+            6
+            7
+            8
+            9
+           10
+           11
+           12
+           13
+           14
+    End SubModelPartNodes
+    Begin SubModelPartElements
+            1
+            2
+            3
+            4
+            5
+            6
+            7
+            8
+            9
+           10
+           11
+           12
+           13
+           14
+           15
+           16
+           17
+           18
+           19
+           20
+           21
+           22
+           23
+           24
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart PotentialWallCondition3D_Far_field_Auto1 // Group Far field Auto1 // Subtree PotentialWallCondition3D
+    Begin SubModelPartNodes
+            1
+            3
+            5
+            6
+            7
+            8
+            9
+           10
+           11
+           12
+           13
+           14
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+                 1
+                 2
+                 3
+                 4
+                 5
+                 6
+                 7
+                 8
+                 9
+                10
+                15
+                16
+                17
+                18
+                19
+                20
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart Wake3D_Wake_Auto1 // Group Wake Auto1 // Subtree Wake3D
+    Begin SubModelPartNodes
+            3
+            8
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart Tip3D_Wing_Tips_Auto1 // Group Wing Tips Auto1 // Subtree Tip3D
+    Begin SubModelPartNodes
+            3
+            8
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart Body3D_Body_Auto1 // Group Body Auto1 // Subtree Body3D
+    Begin SubModelPartNodes
+            3
+            8
+            9
+           12
+           13
+           14
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+                11
+                12
+                13
+                14
+    End SubModelPartConditions
+End SubModelPart

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/24_elements_kutta_node_above_wake_test/small_3d_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/24_elements_kutta_node_above_wake_test/small_3d_parameters.json
@@ -1,0 +1,47 @@
+{
+    "problem_data"     : {
+        "problem_name"  : "small_3d",
+        "parallel_type" : "OpenMP",
+        "echo_level"    : 0,
+        "start_time"    : 0.0,
+        "end_time"      : 1
+    },
+    "solver_settings"  : {
+        "model_part_name"        : "FluidModelPart",
+        "domain_size"            : 3,
+        "solver_type"            : "potential_flow",
+        "model_import_settings"  : {
+            "input_type"     : "mdpa",
+            "input_filename" : "small_3d"
+        },
+        "maximum_iterations"     : 10,
+        "echo_level"             : 0,
+        "volume_model_part_name" : "MainModelPart",
+        "skin_parts"             : ["PotentialWallCondition3D_Far_field_Auto1","Body3D_Body_Auto1"],
+        "no_skin_parts"          : ["Wake3D_Wake_Auto1","Tip3D_Wing_Tips_Auto1"],
+        "auxiliary_variables_list" : ["DISTANCE"]
+    },
+    "processes"        : {
+        "boundary_conditions_process_list" : [{
+            "python_module" : "apply_far_field_process",
+            "kratos_module" : "KratosMultiphysics.CompressiblePotentialFlowApplication",
+            "Parameters"    : {
+                "model_part_name" : "PotentialWallCondition3D_Far_field_Auto1",
+                "angle_of_attack" : 0.0,
+                "mach_infinity"   : 0.03,
+                "speed_of_sound"  : 340.0
+            }
+        },{
+            "python_module" : "define_wake_process_3d",
+            "kratos_module" : "KratosMultiphysics.CompressiblePotentialFlowApplication",
+            "Parameters"    : {
+                "model_part_name" : "Wake3D_Wake_Auto1",
+                "wing_tips_model_part_name": "Tip3D_Wing_Tips_Auto1",
+                "body_model_part_name": "Body3D_Body_Auto1",
+                "wake_stl_file_name" : "wake_stl.stl",
+                "output_wake": false,
+                "epsilon"         : 1e-6
+            }
+        }]
+    }
+}

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/24_elements_kutta_node_above_wake_test/small_3d_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/24_elements_kutta_node_above_wake_test/small_3d_parameters.json
@@ -36,7 +36,6 @@
             "kratos_module" : "KratosMultiphysics.CompressiblePotentialFlowApplication",
             "Parameters"    : {
                 "model_part_name" : "Wake3D_Wake_Auto1",
-                "wing_tips_model_part_name": "Tip3D_Wing_Tips_Auto1",
                 "body_model_part_name": "Body3D_Body_Auto1",
                 "wake_stl_file_name" : "wake_stl.stl",
                 "output_wake": false,

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/24_elements_kutta_node_above_wake_test/wake_stl.stl
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/24_elements_kutta_node_above_wake_test/wake_stl.stl
@@ -1,0 +1,786 @@
+solid GiD
+  facet normal               0              -0               1  
+    outer loop
+      vertex               5               0               5
+      vertex               6               0               5
+      vertex               5               1               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex              10               3               5
+      vertex              10               4               5
+      vertex       9.1339746             3.5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex               9              10               5
+      vertex               8              10               5
+      vertex      8.69084134      9.02209965               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex               5               6               5
+      vertex               5               5               5
+      vertex       5.8660254             5.5               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex       9.1339746             3.5               5
+      vertex              10               4               5
+      vertex       9.1339746             4.5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex              10               3               5
+      vertex       9.1339746             3.5               5
+      vertex       9.1339746             2.5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      8.69084134      9.02209965               5
+      vertex               8              10               5
+      vertex      7.53993874      8.79301672               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex       9.1339746             4.5               5
+      vertex              10               4               5
+      vertex              10               5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex              10               3               5
+      vertex       9.1339746             2.5               5
+      vertex              10               2               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      7.53993874      8.79301672               5
+      vertex               8              10               5
+      vertex               7              10               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex       9.1339746             4.5               5
+      vertex              10               5               5
+      vertex       9.1339746             5.5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex              10               2               5
+      vertex       9.1339746             2.5               5
+      vertex       9.1116455      1.41666667               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex       9.1339746             5.5               5
+      vertex              10               5               5
+      vertex              10               6               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex       9.1116455      1.41666667               5
+      vertex       9.1339746             2.5               5
+      vertex      8.26794919               2               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex              10               2               5
+      vertex       9.1116455      1.41666667               5
+      vertex              10               1               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      8.26794919               2               5
+      vertex       9.1339746             2.5               5
+      vertex      8.26794919               3               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex       9.1116455      1.41666667               5
+      vertex      8.26794919               2               5
+      vertex      8.26794919               1               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex              10               1               5
+      vertex       9.1116455      1.41666667               5
+      vertex               9               0               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      8.26794919               2               5
+      vertex      8.26794919               3               5
+      vertex      7.40192379             2.5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      8.26794919               1               5
+      vertex      8.26794919               2               5
+      vertex      7.41662451      1.21591821               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      7.40192379             2.5               5
+      vertex      8.26794919               3               5
+      vertex      7.40192379             3.5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      8.26794919               2               5
+      vertex      7.40192379             2.5               5
+      vertex      7.41662451      1.21591821               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      7.40192379             3.5               5
+      vertex      8.26794919               3               5
+      vertex      8.26794919               4               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      7.41662451      1.21591821               5
+      vertex      7.40192379             2.5               5
+      vertex      6.53589838               2               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      8.26794919               4               5
+      vertex      8.26794919               3               5
+      vertex       9.1339746             3.5               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      7.40192379             3.5               5
+      vertex      8.26794919               4               5
+      vertex      7.40192379             4.5               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      6.53589838               2               5
+      vertex      7.40192379             2.5               5
+      vertex      6.53589838               3               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex       9.1339746             3.5               5
+      vertex      8.26794919               3               5
+      vertex       9.1339746             2.5               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      7.40192379             4.5               5
+      vertex      8.26794919               4               5
+      vertex      8.26794919               5               5
+    endloop
+  endfacet
+  facet normal              -0              -0               1  
+    outer loop
+      vertex      6.53589838               3               5
+      vertex      7.40192379             2.5               5
+      vertex      7.40192379             3.5               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      8.26794919               5               5
+      vertex      8.26794919               4               5
+      vertex       9.1339746             4.5               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      6.53589838               3               5
+      vertex      7.40192379             3.5               5
+      vertex      6.53589838               4               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex       9.1339746             4.5               5
+      vertex      8.26794919               4               5
+      vertex       9.1339746             3.5               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      8.26794919               5               5
+      vertex       9.1339746             4.5               5
+      vertex       9.1339746             5.5               5
+    endloop
+  endfacet
+  facet normal              -0              -0               1  
+    outer loop
+      vertex      6.53589838               4               5
+      vertex      7.40192379             3.5               5
+      vertex      7.40192379             4.5               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      6.53589838               4               5
+      vertex      7.40192379             4.5               5
+      vertex      6.53589838               5               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      6.53589838               5               5
+      vertex      7.40192379             4.5               5
+      vertex      7.40192379             5.5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      6.53589838               4               5
+      vertex      6.53589838               5               5
+      vertex      5.66987298             4.5               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      7.40192379             5.5               5
+      vertex      7.40192379             4.5               5
+      vertex      8.26794919               5               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      5.66987298             4.5               5
+      vertex      6.53589838               5               5
+      vertex       5.8660254             5.5               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex       5.8660254             5.5               5
+      vertex      6.53589838               5               5
+      vertex      6.71898126      5.94401436               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      6.71898126      5.94401436               5
+      vertex      6.53589838               5               5
+      vertex      7.40192379             5.5               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      6.71898126      5.94401436               5
+      vertex      7.40192379             5.5               5
+      vertex       7.5325023      6.44807123               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex       5.8660254             5.5               5
+      vertex      6.71898126      5.94401436               5
+      vertex      5.89262181      6.49018344               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex       7.5325023      6.44807123               5
+      vertex      7.40192379             5.5               5
+      vertex      8.32513936      5.85587283               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      6.71898126      5.94401436               5
+      vertex       7.5325023      6.44807123               5
+      vertex      6.66961187      6.93221227               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      8.32513936      5.85587283               5
+      vertex      7.40192379             5.5               5
+      vertex      8.26794919               5               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      8.32513936      5.85587283               5
+      vertex      8.26794919               5               5
+      vertex       9.1339746             5.5               5
+    endloop
+  endfacet
+  facet normal              -0              -0               1  
+    outer loop
+      vertex      8.32513936      5.85587283               5
+      vertex       9.1339746             5.5               5
+      vertex      9.07832679      6.47062779               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      9.07832679      6.47062779               5
+      vertex       9.1339746             5.5               5
+      vertex              10               6               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      8.32513936      5.85587283               5
+      vertex      8.39465807      6.95341588               5
+      vertex       7.5325023      6.44807123               5
+    endloop
+  endfacet
+  facet normal              -0              -0               1  
+    outer loop
+      vertex      6.66961187      6.93221227               5
+      vertex       7.5325023      6.44807123               5
+      vertex      7.52481448       7.4454097               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      6.71898126      5.94401436               5
+      vertex      6.66961187      6.93221227               5
+      vertex      5.89262181      6.49018344               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      5.89262181      6.49018344               5
+      vertex      6.66961187      6.93221227               5
+      vertex      5.85288413      7.46393735               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      5.85288413      7.46393735               5
+      vertex      6.66961187      6.93221227               5
+      vertex      6.73375389      7.92384211               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      5.89262181      6.49018344               5
+      vertex      5.85288413      7.46393735               5
+      vertex               5               7               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex               5               7               5
+      vertex      5.85288413      7.46393735               5
+      vertex               5               8               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex       5.8660254             5.5               5
+      vertex      5.89262181      6.49018344               5
+      vertex               5               6               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      7.52481448       7.4454097               5
+      vertex       7.5325023      6.44807123               5
+      vertex      8.39465807      6.95341588               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      6.66961187      6.93221227               5
+      vertex      7.52481448       7.4454097               5
+      vertex      6.73375389      7.92384211               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      6.73375389      7.92384211               5
+      vertex      7.52481448       7.4454097               5
+      vertex      7.53993874      8.79301672               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      5.85288413      7.46393735               5
+      vertex      6.73375389      7.92384211               5
+      vertex      5.86864832      8.58194314               5
+    endloop
+  endfacet
+  facet normal              -0              -0               1  
+    outer loop
+      vertex      5.86864832      8.58194314               5
+      vertex      6.73375389      7.92384211               5
+      vertex      6.62525189      9.10387937               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      5.85288413      7.46393735               5
+      vertex      5.86864832      8.58194314               5
+      vertex               5               8               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      8.39465807      6.95341588               5
+      vertex      8.32513936      5.85587283               5
+      vertex      9.07832679      6.47062779               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      8.39465807      6.95341588               5
+      vertex      9.07832679      6.47062779               5
+      vertex      9.23605174      7.41944002               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      9.23605174      7.41944002               5
+      vertex      9.07832679      6.47062779               5
+      vertex              10               7               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      9.23605174      7.41944002               5
+      vertex              10               7               5
+      vertex              10               8               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      8.39465807      6.95341588               5
+      vertex      9.23605174      7.41944002               5
+      vertex      8.38158245      8.02408188               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      9.23605174      7.41944002               5
+      vertex              10               8               5
+      vertex      9.22352684       8.3154993               5
+    endloop
+  endfacet
+  facet normal              -0              -0               1  
+    outer loop
+      vertex      8.38158245      8.02408188               5
+      vertex      9.23605174      7.41944002               5
+      vertex      9.22352684       8.3154993               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      8.38158245      8.02408188               5
+      vertex      9.22352684       8.3154993               5
+      vertex      8.69084134      9.02209965               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      8.69084134      9.02209965               5
+      vertex      9.22352684       8.3154993               5
+      vertex              10               9               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      8.39465807      6.95341588               5
+      vertex      8.38158245      8.02408188               5
+      vertex      7.52481448       7.4454097               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      9.22352684       8.3154993               5
+      vertex              10               8               5
+      vertex              10               9               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      6.62525189      9.10387937               5
+      vertex      6.73375389      7.92384211               5
+      vertex      7.53993874      8.79301672               5
+    endloop
+  endfacet
+  facet normal              -0              -0               1  
+    outer loop
+      vertex      6.62525189      9.10387937               5
+      vertex      7.53993874      8.79301672               5
+      vertex               7              10               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      5.86864832      8.58194314               5
+      vertex      6.62525189      9.10387937               5
+      vertex               6              10               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      6.53589838               4               5
+      vertex      5.66987298             4.5               5
+      vertex      5.66987298             3.5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      5.66987298             3.5               5
+      vertex      5.66987298             4.5               5
+      vertex               5               4               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex               5               4               5
+      vertex      5.66987298             4.5               5
+      vertex               5               5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      5.66987298             3.5               5
+      vertex               5               4               5
+      vertex               5               3               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex               5               5               5
+      vertex      5.66987298             4.5               5
+      vertex       5.8660254             5.5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      5.66987298             3.5               5
+      vertex               5               3               5
+      vertex      5.85295586      2.55598564               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      5.85295586      2.55598564               5
+      vertex               5               3               5
+      vertex               5               2               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      5.66987298             3.5               5
+      vertex      5.85295586      2.55598564               5
+      vertex      6.53589838               3               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      6.53589838               3               5
+      vertex      5.85295586      2.55598564               5
+      vertex      6.53589838               2               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      6.53589838               2               5
+      vertex      5.85295586      2.55598564               5
+      vertex      5.64766961      1.60638563               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      5.64766961      1.60638563               5
+      vertex      5.85295586      2.55598564               5
+      vertex               5               2               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      5.64766961      1.60638563               5
+      vertex               5               2               5
+      vertex               5               1               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      5.64766961      1.60638563               5
+      vertex               5               1               5
+      vertex      6.26669875     0.970383973               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      6.53589838               2               5
+      vertex      5.64766961      1.60638563               5
+      vertex      6.26669875     0.970383973               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      6.26669875     0.970383973               5
+      vertex               5               1               5
+      vertex               6               0               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex      6.53589838               2               5
+      vertex      6.26669875     0.970383973               5
+      vertex      7.41662451      1.21591821               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      6.53589838               4               5
+      vertex      5.66987298             3.5               5
+      vertex      6.53589838               3               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex               9               0               5
+      vertex              10               0               5
+      vertex              10               1               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex               5              10               5
+      vertex               5               9               5
+      vertex               6              10               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex               7               0               5
+      vertex               8               0               5
+      vertex      7.41662451      1.21591821               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      8.26794919               1               5
+      vertex      7.41662451      1.21591821               5
+      vertex               8               0               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex               7              10               5
+      vertex               6              10               5
+      vertex      6.62525189      9.10387937               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex              10               9               5
+      vertex              10              10               5
+      vertex               9              10               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex               6               0               5
+      vertex               7               0               5
+      vertex      6.26669875     0.970383973               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      8.69084134      9.02209965               5
+      vertex      7.53993874      8.79301672               5
+      vertex      8.38158245      8.02408188               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex       9.1116455      1.41666667               5
+      vertex      8.26794919               1               5
+      vertex               9               0               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex               5               9               5
+      vertex               5               8               5
+      vertex      5.86864832      8.58194314               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex               9              10               5
+      vertex      8.69084134      9.02209965               5
+      vertex              10               9               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex               8               0               5
+      vertex               9               0               5
+      vertex      8.26794919               1               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex              10               6               5
+      vertex              10               7               5
+      vertex      9.07832679      6.47062779               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex               5               7               5
+      vertex               5               6               5
+      vertex      5.89262181      6.49018344               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex      7.52481448       7.4454097               5
+      vertex      8.38158245      8.02408188               5
+      vertex      7.53993874      8.79301672               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex               5               9               5
+      vertex      5.86864832      8.58194314               5
+      vertex               6              10               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex      7.41662451      1.21591821               5
+      vertex      6.26669875     0.970383973               5
+      vertex               7               0               5
+    endloop
+  endfacet
+endsolid GiD

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/25_elements_nodes_on_wake_test/small_3d.mdpa
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/25_elements_nodes_on_wake_test/small_3d.mdpa
@@ -1,0 +1,206 @@
+Begin ModelPartData
+//  VARIABLE_NAME value
+End ModelPartData
+
+Begin Properties 0
+End Properties
+
+Begin Properties 1
+    DENSITY 1.225
+End Properties
+
+Begin Nodes
+    1        0.00000       10.00000       10.00000
+    2        5.00000       10.00000        5.00000
+    3        0.00000        0.00000       10.00000
+    4        0.00000       10.00000        0.00000
+    5       10.00000       10.00000       10.00000
+    6        7.50000        5.00000        5.00000
+    7        5.00000        4.37364        2.16667
+    8       10.00000       10.00000        5.00000
+    9       10.00000        5.00000        7.50000
+   10        5.00000        0.00000        5.00000
+   11        0.00000        0.00000        0.00000
+   12       10.00000        0.00000       10.00000
+   13       10.00000       10.00000        0.00000
+   14       10.00000        0.00000        5.00000
+   15       10.00000        0.00000        0.00000
+End Nodes
+
+
+Begin Elements Element3D4N// GUI group identifier: Parts Auto1
+        1          1          8          9          5          2
+        2          1          8          2          6          9
+        3          1          6          8          9         14
+        4          1          9          6         14         10
+        5          1         12          9         14         10
+        6          1          2          6          9         10
+        7          1          9          5          2          1
+        8          1         12          9         10          3
+        9          1         12          5          9          1
+       10          1          9          2         10          3
+       11          1          2          9          1          3
+       12          1         12          9          3          1
+       13          1          8          6          2         15
+       14          1         10          6         14         15
+       15          1          2         13          8         15
+       16          1          6         14         15          8
+       17          1         10          6         15          2
+       18          1         11         10         15          7
+       19          1         11         10          7          4
+       20          1         10         15          7          2
+       21          1          7         10          2          4
+       22          1          2          7          4         13
+       23          1          2          7         13         15
+       24          1          7          4         13         11
+       25          1          7         13         15         11
+End Elements
+
+Begin Conditions SurfaceCondition3D3N// GUI group identifier: _HIDDEN__SKIN_
+    1 0 11 15 13
+    2 0 13 4 11
+    3 0 12 3 1
+    4 0 1 5 12
+    5 0 3 10 2
+    6 0 2 1 3
+    7 0 10 11 4
+    8 0 4 2 10
+    9 0 12 14 9
+    10 0 8 5 9
+    11 0 9 14 8
+    12 0 12 9 5
+    13 0 15 13 8
+    14 0 8 14 15
+    15 0 11 10 15
+    16 0 10 14 15
+    17 0 4 2 13
+    18 0 2 8 13
+    19 0 12 14 10
+    20 0 10 3 12
+    21 0 5 8 2
+    22 0 2 1 5
+End Conditions
+
+Begin SubModelPart MainModelPart // Group Parts Auto1 // Subtree Parts
+    Begin SubModelPartNodes
+            1
+            2
+            3
+            4
+            5
+            6
+            7
+            8
+            9
+           10
+           11
+           12
+           13
+           14
+           15
+    End SubModelPartNodes
+    Begin SubModelPartElements
+            1
+            2
+            3
+            4
+            5
+            6
+            7
+            8
+            9
+           10
+           11
+           12
+           13
+           14
+           15
+           16
+           17
+           18
+           19
+           20
+           21
+           22
+           23
+           24
+           25
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart PotentialWallCondition3D_Far_field_Auto1 // Group Far field Auto1 // Subtree PotentialWallCondition3D
+    Begin SubModelPartNodes
+            1
+            2
+            3
+            4
+            5
+            8
+            9
+           10
+           11
+           12
+           13
+           14
+           15
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+                 1
+                 2
+                 3
+                 4
+                 5
+                 6
+                 9
+                10
+                11
+                12
+                13
+                14
+                15
+                16
+                17
+                18
+                19
+                20
+                21
+                22
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart Wake3D_Wake_Auto1 // Group Wake Auto1 // Subtree Wake3D
+    Begin SubModelPartNodes
+            2
+           10
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart Tip3D_Wing_Tips_Auto1 // Group Wing Tips Auto1 // Subtree Tip3D
+    Begin SubModelPartNodes
+            2
+           10
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart
+Begin SubModelPart Body3D_Body_Auto1 // Group Body Auto1 // Subtree Body3D
+    Begin SubModelPartNodes
+            2
+            4
+           10
+           11
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+                 7
+                 8
+    End SubModelPartConditions
+End SubModelPart

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/25_elements_nodes_on_wake_test/small_3d_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/25_elements_nodes_on_wake_test/small_3d_parameters.json
@@ -1,0 +1,47 @@
+{
+    "problem_data"     : {
+        "problem_name"  : "small_3d",
+        "parallel_type" : "OpenMP",
+        "echo_level"    : 0,
+        "start_time"    : 0.0,
+        "end_time"      : 1
+    },
+    "solver_settings"  : {
+        "model_part_name"        : "FluidModelPart",
+        "domain_size"            : 3,
+        "solver_type"            : "potential_flow",
+        "model_import_settings"  : {
+            "input_type"     : "mdpa",
+            "input_filename" : "small_3d"
+        },
+        "maximum_iterations"     : 10,
+        "echo_level"             : 0,
+        "volume_model_part_name" : "MainModelPart",
+        "skin_parts"             : ["PotentialWallCondition3D_Far_field_Auto1","Body3D_Body_Auto1"],
+        "no_skin_parts"          : ["Wake3D_Wake_Auto1","Tip3D_Wing_Tips_Auto1"],
+        "auxiliary_variables_list" : ["DISTANCE"]
+    },
+    "processes"        : {
+        "boundary_conditions_process_list" : [{
+            "python_module" : "apply_far_field_process",
+            "kratos_module" : "KratosMultiphysics.CompressiblePotentialFlowApplication",
+            "Parameters"    : {
+                "model_part_name" : "PotentialWallCondition3D_Far_field_Auto1",
+                "angle_of_attack" : 0.0,
+                "mach_infinity"   : 0.03,
+                "speed_of_sound"  : 340.0
+            }
+        },{
+            "python_module" : "define_wake_process_3d",
+            "kratos_module" : "KratosMultiphysics.CompressiblePotentialFlowApplication",
+            "Parameters"    : {
+                "model_part_name" : "Wake3D_Wake_Auto1",
+                "wing_tips_model_part_name": "Tip3D_Wing_Tips_Auto1",
+                "body_model_part_name": "Body3D_Body_Auto1",
+                "wake_stl_file_name" : "wake_stl.stl",
+                "output_wake": false,
+                "epsilon"         : 1e-6
+            }
+        }]
+    }
+}

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/25_elements_nodes_on_wake_test/small_3d_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/25_elements_nodes_on_wake_test/small_3d_parameters.json
@@ -36,7 +36,6 @@
             "kratos_module" : "KratosMultiphysics.CompressiblePotentialFlowApplication",
             "Parameters"    : {
                 "model_part_name" : "Wake3D_Wake_Auto1",
-                "wing_tips_model_part_name": "Tip3D_Wing_Tips_Auto1",
                 "body_model_part_name": "Body3D_Body_Auto1",
                 "wake_stl_file_name" : "wake_stl.stl",
                 "output_wake": false,

--- a/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/25_elements_nodes_on_wake_test/wake_stl.stl
+++ b/applications/CompressiblePotentialFlowApplication/tests/wake_process_3d_tests/25_elements_nodes_on_wake_test/wake_stl.stl
@@ -1,0 +1,30 @@
+solid GiD
+  facet normal               0              -0               1  
+    outer loop
+      vertex               5               0               5
+      vertex              10               0               5
+      vertex             7.5               5               5
+    endloop
+  endfacet
+  facet normal               0               0               1  
+    outer loop
+      vertex              10              10               5
+      vertex               5              10               5
+      vertex             7.5               5               5
+    endloop
+  endfacet
+  facet normal              -0               0               1  
+    outer loop
+      vertex             7.5               5               5
+      vertex              10               0               5
+      vertex              10              10               5
+    endloop
+  endfacet
+  facet normal               0              -0               1  
+    outer loop
+      vertex               5               0               5
+      vertex             7.5               5               5
+      vertex               5              10               5
+    endloop
+  endfacet
+endsolid GiD


### PR DESCRIPTION
This PR is a follow up of https://github.com/KratosMultiphysics/Kratos/pull/5252 covering point 2 (add the first version of the define_wake_process_3d.py). I have a first proposal and I would like to discuss it especially with @marcnunezc and @rubenzorrilla.

This PR only adds the file define_wake_process_3d.py and its tests. Tests are added to check some corner cases (nodes laying on the wake and nodes from kutta elements above the wake but below the lower surface of the wing). There is also a list of TODOs (improvements) marked as comments that I will list also here below.

**The goal:** Implement a first version of the wake process that:

1. Selects elements cut by the wake as WAKE
2. Selects the KUTTA elements (touching the trailing edge from below and not cut)
3. Selects the wake_kutta elements (wake elements touching the trailing edge) (still marked as STRUCTURE)

The first version is thought to work the most simple case: "infinite wings" (wings going from side to side of the domain) with a straight trailing edge. This is considered to be a straight extension from the 2d case.

To show that it works, here is an example. The kutta_wake elements:
![kutta_wake_elems](https://user-images.githubusercontent.com/28628414/61528925-4ed88980-aa20-11e9-938f-12a3037c6cb0.png)

Another view:

![kutta_wake_elems2](https://user-images.githubusercontent.com/28628414/61528982-72033900-aa20-11e9-91cb-537b61a33173.png)

The kutta elements:

![kutta_elements](https://user-images.githubusercontent.com/28628414/61528991-7cbdce00-aa20-11e9-8c70-f9576a2d7816.png)

All wake elements:

![wake_elements](https://user-images.githubusercontent.com/28628414/61529000-834c4580-aa20-11e9-9771-68e8bd002318.png)

**The big question mark is whether it is ok to be using the CalculateDistanceToSkinProcess3D instead of the 
CalculateDiscontinuousDistanceToSkinProcess3D.** I refer here to https://github.com/KratosMultiphysics/Kratos/issues/5278

Note that this first version is in python cause implementation is faster but of course it will be eventually migrated once the algorithm of the process is consolidated.

List of TODOs and improvements in this process:

- Automatize the generation of the wake. Right now the wake is imported as an stl mesh. The goal is to automatically generate the wake from the trailing edge. Here I would like to thank @rubenzorrilla and @philbucher for their awesome ideas.
- Make it work for non straight trailing edges: here we need to check whether the current criteria to select the KUTTA elements still holds.
- Make it work with wings with finite span. Here there is some previous work required. We need to know what we want to do/try with the elements one the side of the wake, specially the ones touching the wing tips.
- Generalize for more than one lifting surface. (This comes later in the future but it might be a good idea to try this in 2D first with two airfoils and two wakes).
- Migrate to C++
