### PR TITLE
[Core] Timer ordered (making @marcnunezc happy)

### DIFF
--- a/kratos/utilities/timer.cpp
+++ b/kratos/utilities/timer.cpp
@@ -101,13 +101,17 @@ Timer::Timer(){}
 
 void Timer::Start(std::string const& rIntervalName)
 {
-    msTimeTable[rIntervalName].SetStartTime(GetTime());
+    const std::string internal_name = GetInternalName(rIntervalName);
+    msInternalNameDatabase.insert(std::pair<std::string, std::string>(rIntervalName, internal_name));
+    msTimeTable[internal_name].SetStartTime(GetTime());
+    ++msCounter;
 }
 
 void Timer::Stop(std::string const& rIntervalName)
 {
     const double stop_time = GetTime();
-    ContainerType::iterator it_time_data = msTimeTable.find(rIntervalName);
+    const std::string& r_name = msInternalNameDatabase[rIntervalName];
+    ContainerType::iterator it_time_data = msTimeTable.find(r_name);
 
     if(it_time_data == msTimeTable.end())
         return;
@@ -115,7 +119,7 @@ void Timer::Stop(std::string const& rIntervalName)
     it_time_data->second.Update(stop_time);
 
     if (msPrintIntervalInformation) {
-        PrintIntervalInformation(rIntervalName, it_time_data->second.GetStartTime(), stop_time);
+        PrintIntervalInformation(r_name, it_time_data->second.GetStartTime(), stop_time);
     }
 }
 
@@ -163,10 +167,11 @@ void Timer::SetPrintIntervalInformation(bool const PrintIntervalInformation)
 
 void Timer::PrintIntervalInformation(std::string const& rIntervalName, const double StartTime, const double StopTime)
 {
+    const std::string& r_name = msInternalNameDatabase[rIntervalName];
     if (msOutputFile.is_open())
-        PrintIntervalInformation(msOutputFile, rIntervalName, StartTime, StopTime);
+        PrintIntervalInformation(msOutputFile, r_name, StartTime, StopTime);
     if(msPrintOnScreen)
-        PrintIntervalInformation(std::cout, rIntervalName, StartTime, StopTime);
+        PrintIntervalInformation(std::cout, r_name, StartTime, StopTime);
 }
 
 void Timer::PrintIntervalInformation(std::ostream& rOStream, std::string const& rIntervalName, const double StartTime, const double StopTime)
@@ -218,8 +223,21 @@ void Timer::PrintTimingInformation(std::ostream& rOStream)
     }
 }
 
+std::string Timer::GetInternalName(const std::string& rName)
+{
+    std::string initial_string = std::to_string(msCounter);
+    for (std::size_t i = 0; i < (NumberOfZeros - initial_string.size()); ++i) {
+        initial_string = "0" + initial_string;
+    }
+    std::string internal_name = initial_string + "." + rName;
+
+    return internal_name;
+}
+
+Timer::InternalNameDatabaseType Timer::msInternalNameDatabase;
 Timer::ContainerType Timer::msTimeTable;
 std::ofstream Timer::msOutputFile;
+std::size_t Timer::msCounter = 0;
 bool Timer::msPrintOnScreen = false;
 bool Timer::msPrintIntervalInformation = true;
 const std::chrono::steady_clock::time_point Timer::mStartTime = std::chrono::steady_clock::now();

--- a/kratos/utilities/timer.cpp
+++ b/kratos/utilities/timer.cpp
@@ -226,7 +226,8 @@ void Timer::PrintTimingInformation(std::ostream& rOStream)
 std::string Timer::GetInternalName(const std::string& rName)
 {
     std::string initial_string = std::to_string(msCounter);
-    for (std::size_t i = 0; i < (NumberOfZeros - initial_string.size()); ++i) {
+    const std::size_t size_string = initial_string.size();
+    for (std::size_t i = 0; i < (NumberOfZeros - size_string); ++i) {
         initial_string = "0" + initial_string;
     }
     std::string internal_name = initial_string + "." + rName;

--- a/kratos/utilities/timer.cpp
+++ b/kratos/utilities/timer.cpp
@@ -101,10 +101,13 @@ Timer::Timer(){}
 
 void Timer::Start(std::string const& rIntervalName)
 {
-    const std::string internal_name = GetInternalName(rIntervalName);
-    msInternalNameDatabase.insert(std::pair<std::string, std::string>(rIntervalName, internal_name));
-    msTimeTable[internal_name].SetStartTime(GetTime());
-    ++msCounter;
+    const auto it_internal_name = msInternalNameDatabase.find(rIntervalName);
+    if(it_internal_name == msInternalNameDatabase.end()) {
+        const std::string internal_name = GetInternalName(rIntervalName);
+        msInternalNameDatabase.insert(std::pair<std::string, std::string>(rIntervalName, internal_name));
+        msTimeTable[internal_name].SetStartTime(GetTime());
+        ++msCounter;
+    }
 }
 
 void Timer::Stop(std::string const& rIntervalName)

--- a/kratos/utilities/timer.h
+++ b/kratos/utilities/timer.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <iostream>
 #include <fstream>
+#include <map>
 #include <unordered_map>
 #include <chrono>
 
@@ -121,8 +122,14 @@ public:
     /// The type of float used to store the time
     typedef double TimeType;
 
-    /// The timer data container type (unordered_map)
-    typedef std::unordered_map<std::string, TimerData> ContainerType;
+    /// The timer data container type (map)
+    typedef std::map<std::string, TimerData> ContainerType;
+
+    /// This is used to know the internal name used for the time table
+    typedef std::unordered_map<std::string, std::string> InternalNameDatabaseType;
+
+    /// The number of 0 in the internal name
+    static constexpr std::size_t NumberOfZeros = 3;
 
     ///@}
     ///@name Life Cycle
@@ -316,13 +323,17 @@ private:
     ///@name Static Member Variables
     ///@{
 
-    static ContainerType msTimeTable;       /// The time tables
+    static InternalNameDatabaseType msInternalNameDatabase;        /// The names used on the time tables
 
-    static std::ofstream msOutputFile;      /// The file to be written
+    static ContainerType msTimeTable;                              /// The time tables
 
-    static bool msPrintOnScreen;            /// If the information is printed on screen
+    static std::ofstream msOutputFile;                             /// The file to be written
 
-    static bool msPrintIntervalInformation; /// If the information of the interval is printed
+    static std::size_t msCounter;                                  /// Counter of the instances
+
+    static bool msPrintOnScreen;                                   /// If the information is printed on screen
+
+    static bool msPrintIntervalInformation;                        /// If the information of the interval is printed
 
     static const std::chrono::steady_clock::time_point mStartTime; /// The starting time
 
@@ -333,6 +344,13 @@ private:
     ///@}
     ///@name Private Operators
     ///@{
+
+    /**
+     * @brief This method returns the internal name used on the table
+     * @param rName The base name
+     * @return The internal name
+     */
+    static std::string GetInternalName(const std::string& rName);
 
     ///@}
     ///@name Private Operations


### PR DESCRIPTION
This PR makes the timer to order the intervals according to creation. It just adds a identification number in front of the interval name:

![imagen](https://user-images.githubusercontent.com/19991680/61557408-73eeeb80-aa64-11e9-8658-3960dcdcce10.png)
