### PR TITLE
[StructuralMechanics] proper python imports

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_analysis.py
@@ -6,9 +6,11 @@ import KratosMultiphysics.StructuralMechanicsApplication as SMA
 
 # Other imports
 import sys
+from . import python_solvers_wrapper_adaptative_remeshing_structural
 
 # Import the base structural analysis
-from structural_mechanics_analysis import StructuralMechanicsAnalysis as BaseClass
+from .structural_mechanics_analysis import StructuralMechanicsAnalysis as BaseClass
+
 
 class AdaptativeRemeshingStructuralMechanicsAnalysis(BaseClass):
     """
@@ -148,7 +150,6 @@ class AdaptativeRemeshingStructuralMechanicsAnalysis(BaseClass):
             KM.Logger.GetDefaultOutput().SetSeverity(KM.Logger.Severity.WARNING)
 
         ## Solver construction
-        import python_solvers_wrapper_adaptative_remeshing_structural
         return python_solvers_wrapper_adaptative_remeshing_structural.CreateSolver(self.model, self.project_parameters)
 
     def _CreateProcesses(self, parameter_name, initialization_order):

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_implicit_dynamic_solver.py
@@ -14,10 +14,11 @@ else:
     missing_meshing_dependencies = False
 
 # Import base class file
-import structural_mechanics_implicit_dynamic_solver
+from . import structural_mechanics_implicit_dynamic_solver
 
 # Import auxiliar methods
-import auxiliar_methods_adaptative_solvers
+from . import auxiliar_methods_adaptative_solvers
+from . import adaptative_remeshing_structural_mechanics_utilities
 
 def CreateSolver(model, custom_settings):
     return AdaptativeRemeshingImplicitMechanicalSolver(model, custom_settings)
@@ -28,7 +29,6 @@ class AdaptativeRemeshingImplicitMechanicalSolver(structural_mechanics_implicit_
     """
     def __init__(self, model, custom_settings):
         # Set defaults and validate custom settings.
-        import adaptative_remeshing_structural_mechanics_utilities
         self.adaptative_remeshing_utilities = adaptative_remeshing_structural_mechanics_utilities.AdaptativeRemeshingMechanicalUtilities()
         adaptative_remesh_parameters = self.adaptative_remeshing_utilities.GetDefaultParameters()
 

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_static_solver.py
@@ -14,10 +14,11 @@ else:
     missing_meshing_dependencies = False
 
 # Import base class file
-import structural_mechanics_static_solver
+from . import structural_mechanics_static_solver
 
 # Import auxiliar methods
-import auxiliar_methods_adaptative_solvers
+from . import auxiliar_methods_adaptative_solvers
+from . import adaptative_remeshing_structural_mechanics_utilities
 
 def CreateSolver(model, custom_settings):
     return AdaptativeRemeshingStaticMechanicalSolver(model, custom_settings)
@@ -28,7 +29,6 @@ class AdaptativeRemeshingStaticMechanicalSolver(structural_mechanics_static_solv
     """
     def __init__(self, model, custom_settings):
         # Set defaults and validate custom settings.
-        import adaptative_remeshing_structural_mechanics_utilities
         self.adaptative_remeshing_utilities = adaptative_remeshing_structural_mechanics_utilities.AdaptativeRemeshingMechanicalUtilities()
         adaptative_remesh_parameters = self.adaptative_remeshing_utilities.GetDefaultParameters()
 

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_utilities.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_utilities.py
@@ -5,6 +5,7 @@ import KratosMultiphysics
 
 # Import applications
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
+from . import convergence_criteria_factory
 
 try:
     import KratosMultiphysics.MeshingApplication as MeshingApplication
@@ -84,7 +85,6 @@ class AdaptativeRemeshingMechanicalUtilities(object):
                 return adaptative_error_criteria
 
         # Regular convergence criteria
-        import convergence_criteria_factory
         convergence_criterion = convergence_criteria_factory.convergence_criterion(conv_settings)
 
         # If we combine the regular convergence criteria with adaptative

--- a/applications/StructuralMechanicsApplication/python_scripts/automatic_rayleigh_parameters_computation_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/automatic_rayleigh_parameters_computation_process.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 
 # Importing the Kratos Library
 import KratosMultiphysics as KM
+from KratosMultiphysics import eigen_solver_factory
 
 import KratosMultiphysics.StructuralMechanicsApplication as SMA
 
@@ -71,14 +72,6 @@ class AutomaticRayleighComputationProcess(KM.Process):
         self -- It signifies an instance of a class.
         """
 
-        import KratosMultiphysics.kratos_utilities as kratos_utils
-        if kratos_utils.CheckIfApplicationsAvailable("ExternalSolversApplication"):
-            from KratosMultiphysics import ExternalSolversApplication
-        elif kratos_utils.CheckIfApplicationsAvailable("EigenSolversApplication"):
-            from KratosMultiphysics import EigenSolversApplication
-        else:
-            raise Exception("ExternalSolversApplication or EigenSolversApplication not available")
-
         # The general damping ratios
         damping_ratio_0 = self.settings["damping_ratio_0"].GetDouble()
         damping_ratio_1 = self.settings["damping_ratio_1"].GetDouble()
@@ -122,7 +115,6 @@ class AutomaticRayleighComputationProcess(KM.Process):
             # If not computed eigen values already
             if not existing_computation:
                 KM.Logger.PrintInfo("::[MechanicalSolver]::", "EIGENVALUE_VECTOR not previously computed. Computing automatically, take care")
-                from KratosMultiphysics import eigen_solver_factory
                 eigen_linear_solver = eigen_solver_factory.ConstructSolver(self.settings["eigen_system_settings"])
                 builder_and_solver = KM.ResidualBasedBlockBuilderAndSolver(eigen_linear_solver)
                 eigen_scheme = SMA.EigensolverDynamicScheme()

--- a/applications/StructuralMechanicsApplication/python_scripts/rve_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/rve_analysis.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication
-from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
+from .structural_mechanics_analysis import StructuralMechanicsAnalysis
 
 
 class RVEAnalysis(StructuralMechanicsAnalysis):

--- a/applications/StructuralMechanicsApplication/python_scripts/simplified_nodal_contact_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/simplified_nodal_contact_process.py
@@ -3,6 +3,8 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 # Importing the Kratos Library
 import KratosMultiphysics
 
+import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
+
 def Factory(settings, Model):
     if not isinstance(settings, KratosMultiphysics.Parameters):
         raise Exception("Expected input shall be a Parameters object, encapsulating a json string")
@@ -114,7 +116,6 @@ class SimplifiedNodalContactProcess(KratosMultiphysics.Process):
         distance_linear_solver_settings = KratosMultiphysics.Parameters( """{
                                        "solver_type" : "amgcl"
                                    } """)
-        import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
         distance_linear_solver = linear_solver_factory.ConstructSolver(distance_linear_solver_settings)
 
         max_iterations=30

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
@@ -6,7 +6,7 @@ import KratosMultiphysics
 # Import applications
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
-from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
+from .structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return StructuralMechanicsAdjointStaticSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_analysis.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 
 # Importing Kratos
 import KratosMultiphysics
-import KratosMultiphysics.StructuralMechanicsApplication.python_solvers_wrapper_structural as structural_solvers
+from. import python_solvers_wrapper_structural as structural_solvers
 
 # Importing the base class
 from KratosMultiphysics.analysis_stage import AnalysisStage

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Import base class file
-from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
+from .structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(main_model_part, custom_settings):
     return EigenSolver(main_model_part, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_explicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_explicit_dynamic_solver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Import base class file
-from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
+from .structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return ExplicitMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_formfinding_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_formfinding_solver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Import base class file
-from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
+from .structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(main_model_part, custom_settings):
     return FormfindingMechanicalSolver(main_model_part, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_harmonic_analysis_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_harmonic_analysis_solver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Import base class file
-from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
+from .structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return HarmonicAnalysisSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Import base class file
-from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
+from .structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return ImplicitMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -9,6 +9,11 @@ import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsA
 # Importing the base class
 from KratosMultiphysics.python_solver import PythonSolver
 
+# Other imports
+from . import check_and_prepare_model_process_structural
+from . import convergence_criteria_factory
+from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
+
 class MechanicalSolver(PythonSolver):
     """The base class for structural mechanics solvers.
 
@@ -334,7 +339,6 @@ class MechanicalSolver(PythonSolver):
         params.AddValue("problem_domain_sub_model_part_list",self.settings["problem_domain_sub_model_part_list"])
         params.AddValue("processes_sub_model_part_list",self.settings["processes_sub_model_part_list"])
         # Assign mesh entities from domain and process sub model parts to the computing model part.
-        import check_and_prepare_model_process_structural
         check_and_prepare_model_process_structural.CheckAndPrepareModelProcess(self.model, params).Execute()
 
         # Import constitutive laws.
@@ -405,14 +409,12 @@ class MechanicalSolver(PythonSolver):
         return conv_params
 
     def _create_convergence_criterion(self):
-        import convergence_criteria_factory
         convergence_criterion = convergence_criteria_factory.convergence_criterion(self._get_convergence_criterion_settings())
         return convergence_criterion.mechanical_convergence_criterion
 
     def _create_linear_solver(self):
         linear_solver_configuration = self.settings["linear_solver_settings"]
         if linear_solver_configuration.Has("solver_type"): # user specified a linear solver
-            from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
             return linear_solver_factory.ConstructSolver(linear_solver_configuration)
         else:
             # using a default linear solver (selecting the fastest one available)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -4,7 +4,7 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 import KratosMultiphysics
 
 # Import base class file
-from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
+from .structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return StaticMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
@@ -5,7 +5,7 @@ from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 from KratosMultiphysics import Parameters, Logger
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
-from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
+from .structural_mechanics_analysis import StructuralMechanicsAnalysis
 
 import time as timer
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response_function_factory.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response_function_factory.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
 # importing the Kratos Library
-from KratosMultiphysics.StructuralMechanicsApplication import structural_response
+from . import structural_response
 
 def CreateResponseFunction(response_id, response_settings, model):
     response_type = response_settings["response_type"].GetString()

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
@@ -8,7 +8,7 @@ import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsA
 import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 
 # Import base class file
-from KratosMultiphysics.StructuralMechanicsApplication.trilinos_structural_mechanics_solver import TrilinosMechanicalSolver
+from .trilinos_structural_mechanics_solver import TrilinosMechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return TrilinosImplicitMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
@@ -11,7 +11,7 @@ import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 from KratosMultiphysics.TrilinosApplication import trilinos_linear_solver_factory
 
 # Import base class file
-from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
+from .structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return TrilinosMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_static_solver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 
 # Import base class file
-from KratosMultiphysics.StructuralMechanicsApplication.trilinos_structural_mechanics_solver import TrilinosMechanicalSolver
+from .trilinos_structural_mechanics_solver import TrilinosMechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return TrilinosStaticMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/tests/rayleigh_process_test/test_rayleigh_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/rayleigh_process_test/test_rayleigh_parameters.json
@@ -78,7 +78,7 @@
                 "value"            : 1.61473e-08
             }
         },{
-            "kratos_module" : "KratosMultiphysics",
+            "kratos_module" : "KratosMultiphysics.StructuralMechanicsApplication",
             "python_module" : "automatic_rayleigh_parameters_computation_process",
             "process_name"  : "AutomaticRayleighComputationProcess",
             "Parameters"    : {

--- a/applications/StructuralMechanicsApplication/tests/restart_tests.py
+++ b/applications/StructuralMechanicsApplication/tests/restart_tests.py
@@ -2,11 +2,10 @@ import os
 
 # Import Kratos
 import KratosMultiphysics
-import KratosMultiphysics.StructuralMechanicsApplication
 
 # Import KratosUnittest
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-import structural_mechanics_analysis
+from KratosMultiphysics.StructuralMechanicsApplication import structural_mechanics_analysis
 
 import KratosMultiphysics.kratos_utilities as kratos_utils
 

--- a/applications/StructuralMechanicsApplication/tests/structural_response_function_test_factory.py
+++ b/applications/StructuralMechanicsApplication/tests/structural_response_function_test_factory.py
@@ -6,7 +6,7 @@ import os
 import KratosMultiphysics
 from KratosMultiphysics.StructuralMechanicsApplication import *
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-import structural_response_function_factory
+from KratosMultiphysics.StructuralMechanicsApplication import structural_response_function_factory
 
 import KratosMultiphysics.kratos_utilities as kratos_utils
 

--- a/applications/StructuralMechanicsApplication/tests/test_adjoint_sensitivity_analysis_beam_3d2n_structure.py
+++ b/applications/StructuralMechanicsApplication/tests/test_adjoint_sensitivity_analysis_beam_3d2n_structure.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division #makes KratosMu
 from KratosMultiphysics import *
 from KratosMultiphysics.StructuralMechanicsApplication import *
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-import structural_mechanics_analysis
+from KratosMultiphysics.StructuralMechanicsApplication import structural_mechanics_analysis
 import KratosMultiphysics.kratos_utilities as kratos_utilities
 
 if kratos_utilities.CheckIfApplicationsAvailable("HDF5Application"):

--- a/applications/StructuralMechanicsApplication/tests/test_adjoint_sensitivity_analysis_shell_3d3n_structure.py
+++ b/applications/StructuralMechanicsApplication/tests/test_adjoint_sensitivity_analysis_shell_3d3n_structure.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division #makes KratosMu
 from KratosMultiphysics import *
 from KratosMultiphysics.StructuralMechanicsApplication import *
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-import structural_mechanics_analysis
+from KratosMultiphysics.StructuralMechanicsApplication import structural_mechanics_analysis
 import KratosMultiphysics.kratos_utilities as kratos_utilities
 
 if kratos_utilities.CheckIfApplicationsAvailable("HDF5Application"):

--- a/applications/StructuralMechanicsApplication/tests/test_adjoint_sensitivity_analysis_truss_3d2n_structure.py
+++ b/applications/StructuralMechanicsApplication/tests/test_adjoint_sensitivity_analysis_truss_3d2n_structure.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division #makes KratosMu
 from KratosMultiphysics import *
 from KratosMultiphysics.StructuralMechanicsApplication import *
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-import structural_mechanics_analysis
+from KratosMultiphysics.StructuralMechanicsApplication import structural_mechanics_analysis
 import KratosMultiphysics.kratos_utilities as kratos_utilities
 
 if kratos_utilities.CheckIfApplicationsAvailable("HDF5Application"):

--- a/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
+++ b/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
@@ -6,6 +6,8 @@ import KratosMultiphysics.ExternalSolversApplication as ExternalSolversApplicati
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils
 
+from KratosMultiphysics.StructuralMechanicsApplication import structural_mechanics_analysis
+
 from math import sqrt
 from cmath import phase
 import os
@@ -210,7 +212,6 @@ class HarmonicAnalysisTestsWithHDF5(KratosUnittest.TestCase):
         if not kratos_utils.CheckIfApplicationsAvailable("HDF5Application"):
             self.skipTest("HDF5Application not found: Skipping harmonic analysis mdpa test")
 
-        import structural_mechanics_analysis
         with ControlledExecutionScope(os.path.dirname(os.path.realpath(__file__))):
             #run simulation and write to hdf5 file
             model = KratosMultiphysics.Model()

--- a/applications/StructuralMechanicsApplication/tests/test_postprocess_eigenvalues_process.py
+++ b/applications/StructuralMechanicsApplication/tests/test_postprocess_eigenvalues_process.py
@@ -4,8 +4,8 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils
-import postprocess_eigenvalues_process
-from compare_two_files_check_process import CompareTwoFilesCheckProcess
+from KratosMultiphysics.StructuralMechanicsApplication import postprocess_eigenvalues_process
+from KratosMultiphysics.compare_two_files_check_process import CompareTwoFilesCheckProcess
 
 import os
 


### PR DESCRIPTION
This makes StructuralMechanics ready for being uses as a proper python module

Note that this does NOT break "old-style" imports, this will be a separate PR
Tests are working but please have a look yourselves

FYI @KratosMultiphysics/technical-committee 