### PR TITLE
[StructuralMechanics] import as py-module

### DIFF
--- a/applications/StructuralMechanicsApplication/StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/StructuralMechanicsApplication.py
@@ -1,10 +1,11 @@
+# makes KratosMultiphysics backward compatible with python 2.6 and 2.7
+from __future__ import print_function, absolute_import, division
+
+# Application dependent names and paths
+import KratosMultiphysics as KM
 from KratosStructuralMechanicsApplication import *
 application = KratosStructuralMechanicsApplication()
 application_name = "KratosStructuralMechanicsApplication"
 application_folder = "StructuralMechanicsApplication"
 
-# The following lines are common for all applications
-from .. import application_importer
-import inspect
-caller = inspect.stack()[1] # Information about the file that imported this, to check for unexpected imports
-application_importer.ImportApplication(application,application_name,application_folder,caller, __path__)
+KM._ImportApplicationAsModule(application, application_name, application_folder, __path__)


### PR DESCRIPTION
This PR brings StructuralMechanics up to date with the latest version of the python-interface of Kratos
**This will break old style imports**, but this has been decided to be pushed forward by the @KratosMultiphysics/technical-committee  and also I have been telling this for over half a year and hopefully everyone has updated their code
The interface works with this change since ~ Christmas this yeas

see #5255 

requires #5282 to be merged first