### PR TITLE
[StructuralMechanics] using absolute imports

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_analysis.py
@@ -6,10 +6,10 @@ import KratosMultiphysics.StructuralMechanicsApplication as SMA
 
 # Other imports
 import sys
-from . import python_solvers_wrapper_adaptative_remeshing_structural
+from KratosMultiphysics.StructuralMechanicsApplication import python_solvers_wrapper_adaptative_remeshing_structural
 
 # Import the base structural analysis
-from .structural_mechanics_analysis import StructuralMechanicsAnalysis as BaseClass
+from KratosMultiphysics.StructuralMechanicsApplicationstructural_mechanics_analysis import StructuralMechanicsAnalysis as BaseClass
 
 
 class AdaptativeRemeshingStructuralMechanicsAnalysis(BaseClass):

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_implicit_dynamic_solver.py
@@ -14,11 +14,11 @@ else:
     missing_meshing_dependencies = False
 
 # Import base class file
-from . import structural_mechanics_implicit_dynamic_solver
+from KratosMultiphysics.StructuralMechanicsApplication import structural_mechanics_implicit_dynamic_solver
 
 # Import auxiliar methods
-from . import auxiliar_methods_adaptative_solvers
-from . import adaptative_remeshing_structural_mechanics_utilities
+from KratosMultiphysics.StructuralMechanicsApplication import auxiliar_methods_adaptative_solvers
+from KratosMultiphysics.StructuralMechanicsApplication import adaptative_remeshing_structural_mechanics_utilities
 
 def CreateSolver(model, custom_settings):
     return AdaptativeRemeshingImplicitMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_static_solver.py
@@ -14,11 +14,11 @@ else:
     missing_meshing_dependencies = False
 
 # Import base class file
-from . import structural_mechanics_static_solver
+from KratosMultiphysics.StructuralMechanicsApplication import structural_mechanics_static_solver
 
 # Import auxiliar methods
-from . import auxiliar_methods_adaptative_solvers
-from . import adaptative_remeshing_structural_mechanics_utilities
+from KratosMultiphysics.StructuralMechanicsApplication import auxiliar_methods_adaptative_solvers
+from KratosMultiphysics.StructuralMechanicsApplication import adaptative_remeshing_structural_mechanics_utilities
 
 def CreateSolver(model, custom_settings):
     return AdaptativeRemeshingStaticMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_utilities.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_utilities.py
@@ -5,7 +5,7 @@ import KratosMultiphysics
 
 # Import applications
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
-from . import convergence_criteria_factory
+from KratosMultiphysics.StructuralMechanicsApplication import convergence_criteria_factory
 
 try:
     import KratosMultiphysics.MeshingApplication as MeshingApplication

--- a/applications/StructuralMechanicsApplication/python_scripts/rve_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/rve_analysis.py
@@ -3,7 +3,7 @@ from __future__ import print_function, absolute_import, division
 
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication
-from .structural_mechanics_analysis import StructuralMechanicsAnalysis
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
 
 
 class RVEAnalysis(StructuralMechanicsAnalysis):

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
@@ -6,7 +6,7 @@ import KratosMultiphysics
 # Import applications
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
-from .structural_mechanics_solver import MechanicalSolver
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return StructuralMechanicsAdjointStaticSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_analysis.py
@@ -2,7 +2,7 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 
 # Importing Kratos
 import KratosMultiphysics
-from. import python_solvers_wrapper_structural as structural_solvers
+from KratosMultiphysics.StructuralMechanicsApplication import python_solvers_wrapper_structural as structural_solvers
 
 # Importing the base class
 from KratosMultiphysics.analysis_stage import AnalysisStage

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Import base class file
-from .structural_mechanics_solver import MechanicalSolver
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(main_model_part, custom_settings):
     return EigenSolver(main_model_part, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_explicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_explicit_dynamic_solver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Import base class file
-from .structural_mechanics_solver import MechanicalSolver
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return ExplicitMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_formfinding_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_formfinding_solver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Import base class file
-from .structural_mechanics_solver import MechanicalSolver
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(main_model_part, custom_settings):
     return FormfindingMechanicalSolver(main_model_part, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_harmonic_analysis_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_harmonic_analysis_solver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Import base class file
-from .structural_mechanics_solver import MechanicalSolver
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return HarmonicAnalysisSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
 # Import base class file
-from .structural_mechanics_solver import MechanicalSolver
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return ImplicitMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -10,8 +10,8 @@ import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsA
 from KratosMultiphysics.python_solver import PythonSolver
 
 # Other imports
-from KratosMultiphysics.StructuralMechanicsApplication. import check_and_prepare_model_process_structural
-from KratosMultiphysics.StructuralMechanicsApplication. import convergence_criteria_factory
+from KratosMultiphysics.StructuralMechanicsApplication import check_and_prepare_model_process_structural
+from KratosMultiphysics.StructuralMechanicsApplication import convergence_criteria_factory
 from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
 
 class MechanicalSolver(PythonSolver):

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -10,8 +10,8 @@ import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsA
 from KratosMultiphysics.python_solver import PythonSolver
 
 # Other imports
-from . import check_and_prepare_model_process_structural
-from . import convergence_criteria_factory
+from KratosMultiphysics.StructuralMechanicsApplication. import check_and_prepare_model_process_structural
+from KratosMultiphysics.StructuralMechanicsApplication. import convergence_criteria_factory
 from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
 
 class MechanicalSolver(PythonSolver):

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -4,7 +4,7 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 import KratosMultiphysics
 
 # Import base class file
-from .structural_mechanics_solver import MechanicalSolver
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return StaticMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
@@ -5,7 +5,7 @@ from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 from KratosMultiphysics import Parameters, Logger
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
-from .structural_mechanics_analysis import StructuralMechanicsAnalysis
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
 
 import time as timer
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response_function_factory.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response_function_factory.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
 # importing the Kratos Library
-from . import structural_response
+from KratosMultiphysics.StructuralMechanicsApplication. import structural_response
 
 def CreateResponseFunction(response_id, response_settings, model):
     response_type = response_settings["response_type"].GetString()

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response_function_factory.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response_function_factory.py
@@ -1,7 +1,7 @@
 from __future__ import print_function, absolute_import, division
 
 # importing the Kratos Library
-from KratosMultiphysics.StructuralMechanicsApplication. import structural_response
+from KratosMultiphysics.StructuralMechanicsApplication import structural_response
 
 def CreateResponseFunction(response_id, response_settings, model):
     response_type = response_settings["response_type"].GetString()

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
@@ -8,7 +8,7 @@ import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsA
 import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 
 # Import base class file
-from .trilinos_structural_mechanics_solver import TrilinosMechanicalSolver
+from KratosMultiphysics.StructuralMechanicsApplication.trilinos_structural_mechanics_solver import TrilinosMechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return TrilinosImplicitMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
@@ -11,7 +11,7 @@ import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 from KratosMultiphysics.TrilinosApplication import trilinos_linear_solver_factory
 
 # Import base class file
-from .structural_mechanics_solver import MechanicalSolver
+from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_solver import MechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return TrilinosMechanicalSolver(model, custom_settings)

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_static_solver.py
@@ -7,7 +7,7 @@ import KratosMultiphysics
 import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 
 # Import base class file
-from .trilinos_structural_mechanics_solver import TrilinosMechanicalSolver
+from KratosMultiphysics.StructuralMechanicsApplication.trilinos_structural_mechanics_solver import TrilinosMechanicalSolver
 
 def CreateSolver(model, custom_settings):
     return TrilinosStaticMechanicalSolver(model, custom_settings)


### PR DESCRIPTION
@adityaghantasala made me aware that absolute explicit imports are preferred in PEP8:
https://stackoverflow.com/questions/4209641/absolute-vs-explicit-relative-import-of-python-module

Hence I would like to update StructuralMechanics right away before others start following this