### PR TITLE
[Core][MixedUPLinearSolver] removing dependency

### DIFF
--- a/kratos/linear_solvers/mixedup_linear_solver.h
+++ b/kratos/linear_solvers/mixedup_linear_solver.h
@@ -21,7 +21,6 @@
 // Project includes
 #include "includes/define.h"
 #include "reorderer.h"
-#include "solving_strategies/builder_and_solvers/builder_and_solver.h"
 #include "includes/model_part.h"
 #include "linear_solvers/iterative_solver.h"
 #include <boost/numeric/ublas/vector.hpp>


### PR DESCRIPTION
While changing sth in Scheme, I noticed that the linear-solver-factory had to be recompiled
=> there is an unnecessary include of BuilderAndSolver that can be removed