### PR TITLE
[CoSim] improve data handling

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
@@ -29,7 +29,6 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
         super(CoSimulationCoupledSolver, self).__init__(settings, solver_name)
 
         self.solver_wrappers = self.__CreateSolverWrappers()
-        self._AllocateHistoricalVariablesFromCouplingData()
 
         self.coupling_sequence = self.__GetSolverCoSimulationDetails()
 

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
@@ -58,13 +58,17 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
             # we use the Echo_level of the coupling solver, since IO is needed by the coupling
             # and not by the (physics-) solver
 
-        super(CoSimulationCoupledSolver, self).Initialize()
-
         for predictor in self.predictors_list:
             predictor.Initialize()
 
         for coupling_operation in self.coupling_operations_dict.values():
             coupling_operation.Initialize()
+
+    def InitializeCouplingInterfaceData(self):
+        super(CoSimulationCoupledSolver, self).InitializeCouplingInterfaceData()
+
+        for solver in self.solver_wrappers.values():
+            solver.InitializeCouplingInterfaceData()
 
     def Finalize(self):
         for solver in self.solver_wrappers.values():

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -42,7 +42,11 @@ class CoSimulationSolverWrapper(object):
 
 
     def Initialize(self):
+        pass
+
+    def InitializeCouplingInterfaceData(self):
         # Initializing of the CouplingInterfaceData can only be done after the meshes are read
+        # and all ModelParts are created
         for data in self.data_dict.values():
             data.Initialize()
 

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -21,7 +21,7 @@ class CoSimulationSolverWrapper(object):
         The derived classes should do the following things in their constructors:
         1. call the base-class constructor (i.e. the constructor of this class => CoSimulationSolverWrapper)
         2. create the ModelParts required for the CoSimulation
-        3. call "_AllocateHistoricalVariablesFromCouplingData" to allocate the nodal historical variables on the previously created ModelParts
+        3. Optional: call "_AllocateHistoricalVariablesFromCouplingData" to allocate the nodal historical variables on the previously created ModelParts (this should not be necessary for Kratos)
            => this has to be done before the meshes/coupling-interfaces are read/received/imported (due to how the memory allocation of Kratos works for historical nodal values)
         """
 
@@ -35,7 +35,7 @@ class CoSimulationSolverWrapper(object):
 
         self.name = name
         self.echo_level = self.settings["echo_level"].GetInt()
-        self.data_dict = {data_name : CouplingInterfaceData(data_config, self.model) for (data_name, data_config) in self.settings["data"].items()}
+        self.data_dict = {data_name : CouplingInterfaceData(data_config, self.model, data_name) for (data_name, data_config) in self.settings["data"].items()}
 
         # The IO is only used if the corresponding solver is used in coupling and it initialized from the "higher instance, i.e. the coupling-solver
         self.io = None

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -40,20 +40,8 @@ class CoSimulationSolverWrapper(object):
         # The IO is only used if the corresponding solver is used in coupling and it initialized from the "higher instance, i.e. the coupling-solver
         self.io = None
 
-        self.__allocate_hist_vars_called = False # internal variable to check that "_AllocateHistoricalVariablesFromCouplingData" was called
-
 
     def Initialize(self):
-        """Initializes the Solver Wrapper
-
-        The derived classes should do the following things this function:
-        1. read/receive/import the meshes/coupling-interfaces
-        2. call the base-class Initialize, which initializes the CouplingInterfaceDatas, for which the Coupling-interfaces have to be available
-        """
-
-        if not self.__allocate_hist_vars_called:
-            raise Exception('"_AllocateHistoricalVariablesFromCouplingData" was not called from solver "{}"'.format(self.name))
-
         # Initializing of the CouplingInterfaceData can only be done after the meshes are read
         for data in self.data_dict.values():
             data.Initialize()
@@ -122,25 +110,6 @@ class CoSimulationSolverWrapper(object):
         '''This function can be filled if desired, e.g. to print settings at higher echo-levels
         '''
         pass
-
-    def _AllocateHistoricalVariablesFromCouplingData(self):
-        '''This function retrieves the historical variables that are needed for the ModelParts from the specified CouplingInterfaceDatas and allocates them on the ModelParts
-        Note that it can only be called after the (Main-)ModelParts are created
-        '''
-        for data in self.data_dict.values():
-            hist_var_dict = data.GetHistoricalVariableDict()
-            for full_model_part_name, variable in hist_var_dict.items():
-                main_model_part_name = full_model_part_name.split(".")[0]
-                if not self.model.HasModelPart(main_model_part_name):
-                    raise Exception('ModelPart "{}" does not exist in solver "{}"!'.format(main_model_part_name, self.name))
-                main_model_part = self.model[main_model_part_name]
-                if not main_model_part.HasNodalSolutionStepVariable(variable):
-                    if self.echo_level > 0:
-                        cs_tools.cs_print_info("CoSimulationSolverWrapper", 'Allocating historical variable "{}" in ModelPart "{}" for solver "{}"'.format(variable.Name(), main_model_part_name, self.name))
-                    main_model_part.AddNodalSolutionStepVariable(variable)
-
-        self.__allocate_hist_vars_called = True
-
 
     def Check(self):
         print("!!!WARNING!!! your solver does not implement Check!!!")

--- a/applications/CoSimulationApplication/python_scripts/co_simulation_analysis.py
+++ b/applications/CoSimulationApplication/python_scripts/co_simulation_analysis.py
@@ -55,6 +55,7 @@ class CoSimulationAnalysis(AnalysisStage):
 
     def Initialize(self):
         self._GetSolver().Initialize()
+        self._GetSolver().InitializeCouplingInterfaceData()
         self._GetSolver().Check()
 
         if self.echo_level > 0:

--- a/applications/CoSimulationApplication/python_scripts/co_simulation_tools.py
+++ b/applications/CoSimulationApplication/python_scripts/co_simulation_tools.py
@@ -80,3 +80,20 @@ def CreateDataTransferOperators(data_transfer_operators_settings_dict, parent_ec
         data_transfer_operators[data_transfer_operators_name] = CreateDataTransferOperator(data_transfer_operators_settings)
 
     return data_transfer_operators
+
+def AllocateHistoricalVariablesFromCouplingData(data_list, model, solver_name, echo_level):
+    '''This function retrieves the historical variables that are needed for the ModelParts from the
+    specified CouplingInterfaceDatas and allocates them on the ModelParts
+    Note that it can only be called after the (Main-)ModelParts are created
+    '''
+    for data in data_list:
+        hist_var_dict = data.GetHistoricalVariableDict()
+        for full_model_part_name, variable in hist_var_dict.items():
+            main_model_part_name = full_model_part_name.split(".")[0]
+            if not model.HasModelPart(main_model_part_name):
+                raise Exception('ModelPart "{}" does not exist in solver "{}"!'.format(main_model_part_name, solver_name))
+            main_model_part = model[main_model_part_name]
+            if not main_model_part.HasNodalSolutionStepVariable(variable):
+                if echo_level > 0:
+                    cs_tools.cs_print_info("CoSimulationSolverWrapper", 'Allocating historical variable "{}" in ModelPart "{}" for solver "{}"'.format(variable.Name(), main_model_part_name, solver_name))
+                main_model_part.AddNodalSolutionStepVariable(variable)

--- a/applications/CoSimulationApplication/python_scripts/co_simulation_tools.py
+++ b/applications/CoSimulationApplication/python_scripts/co_simulation_tools.py
@@ -81,7 +81,7 @@ def CreateDataTransferOperators(data_transfer_operators_settings_dict, parent_ec
 
     return data_transfer_operators
 
-def AllocateHistoricalVariablesFromCouplingData(data_list, model, solver_name, echo_level):
+def AllocateHistoricalVariablesFromCouplingData(data_list, model, solver_name):
     '''This function retrieves the historical variables that are needed for the ModelParts from the
     specified CouplingInterfaceDatas and allocates them on the ModelParts
     Note that it can only be called after the (Main-)ModelParts are created
@@ -94,6 +94,24 @@ def AllocateHistoricalVariablesFromCouplingData(data_list, model, solver_name, e
                 raise Exception('ModelPart "{}" does not exist in solver "{}"!'.format(main_model_part_name, solver_name))
             main_model_part = model[main_model_part_name]
             if not main_model_part.HasNodalSolutionStepVariable(variable):
-                if echo_level > 0:
-                    cs_tools.cs_print_info("CoSimulationSolverWrapper", 'Allocating historical variable "{}" in ModelPart "{}" for solver "{}"'.format(variable.Name(), main_model_part_name, solver_name))
+                cs_print_info("CoSimTools", 'Allocating historical variable "{}" in ModelPart "{}" for solver "{}"'.format(variable.Name(), main_model_part_name, solver_name))
                 main_model_part.AddNodalSolutionStepVariable(variable)
+
+def CreateMainModelPartsFromCouplingData(data_list, model, solver_name):
+    '''This function creates the Main-ModelParts that are used in the specified CouplingInterfaceDatas
+    '''
+    for data in data_list:
+        main_model_part_name = data.model_part_name.split(".")[0]
+        if not model.HasModelPart(main_model_part_name):
+            model.CreateModelPart(main_model_part_name)
+            cs_print_info("CoSimTools", 'Created ModelPart "{}" for solver "{}"'.format(main_model_part_name, solver_name))
+
+def RecursiveCreateModelParts(model_part, model_part_name):
+    '''This function creates a hierarchy of SubModelParts on a given ModelPart
+    '''
+    model_part_name, *sub_model_part_names = model_part_name.split(".")
+    if not model_part.HasSubModelPart(model_part_name):
+        cs_print_info("CoSimTools", 'Created "{}" as SubModelPart of "{}"'.format(model_part_name, model_part.Name))
+        model_part = model_part.CreateSubModelPart(model_part_name)
+    if len(sub_model_part_names) > 0:
+        RecursiveCreateModelParts(model_part, ".".join(sub_model_part_names))

--- a/applications/CoSimulationApplication/python_scripts/coupling_interface_data.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_interface_data.py
@@ -13,7 +13,7 @@ class CouplingInterfaceData(object):
     """This class serves as interface to the data structure (Model and ModelPart)
     that holds the data used during CoSimulation
     """
-    def __init__(self, custom_settings, model):
+    def __init__(self, custom_settings, model, name="default"):
 
         default_config = KM.Parameters("""{
             "model_part_name" : "",
@@ -25,6 +25,7 @@ class CouplingInterfaceData(object):
 
         self.settings = custom_settings
         self.model = model
+        self.name = name
         self.model_part_name = self.settings["model_part_name"].GetString()
         if self.model_part_name == "":
             raise Exception('No "model_part_name" was specified!')

--- a/applications/CoSimulationApplication/python_scripts/solver_wrappers/kratos/kratos_base_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/solver_wrappers/kratos/kratos_base_wrapper.py
@@ -29,8 +29,6 @@ class KratosBaseWrapper(CoSimulationSolverWrapper):
         # this creates the AnalysisStage, creates the MainModelParts and allocates the historial Variables on the MainModelParts:
         self._analysis_stage = self._CreateAnalysisStage()
 
-        self._AllocateHistoricalVariablesFromCouplingData()
-
     def Initialize(self):
         self._analysis_stage.Initialize() # this reades the Meshes
         super(KratosBaseWrapper, self).Initialize()


### PR DESCRIPTION
While doing the Coupling FEM-MPM & FEM-DEM I struggled several times with hen-egg problems related to automatic variable allocation and non-existing ModelParts

=> This PR moves those things to the tools, now the usage in the solvers is optional. For Kratos I think this is not necessary, only for external solvers where we want to hide some things. 
Hiding those things (creation of ModelParts and allocation of Variables) can be dangerous, since there we directly use the ModelParts for solving.

Furthermore the Initialization of the CouplingInterfaceData is explicitly/separately done after the initialization of the solvers, for the same reason. If we don't do this we enforce quite a strong limitation on Kratos, which IMO should not be the case

We can discuss this also in person

@bodhinandach with this your test works
@KlausBSautter with this change hopefully we can get your stuff to work

Also the CouplingInterfaceData has a name now, which is needed for the IO in the next PR

related to #5140 