### PR TITLE
Defining FluidDynamicsApplication as a Python module

### DIFF
--- a/applications/FluidDynamicsApplication/FluidDynamicsApplication.py
+++ b/applications/FluidDynamicsApplication/FluidDynamicsApplication.py
@@ -1,11 +1,9 @@
 from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 from KratosFluidDynamicsApplication import *
+
+from KratosMultiphysics import _ImportApplicationAsModule
 application = KratosFluidDynamicsApplication()
 application_name = "KratosFluidDynamicsApplication"
 application_folder = "FluidDynamicsApplication"
 
-# The following lines are common for all applications
-from .. import application_importer
-import inspect
-caller = inspect.stack()[1]  # Information about the file that imported this, to check for unexpected imports
-application_importer.ImportApplication(application, application_name, application_folder, caller, __path__)
+_ImportApplicationAsModule(application, application_name, application_folder, __path__)

--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_analysis.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_analysis.py
@@ -3,8 +3,9 @@ from __future__ import absolute_import, division #makes KratosMultiphysics backw
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.FluidDynamicsApplication as KFluid
 
-from analysis_stage import AnalysisStage
-from fluid_dynamics_analysis import FluidDynamicsAnalysis
+from KratosMultiphysics.analysis_stage import AnalysisStage
+from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_adjoint_fluid
+from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
 
 class AdjointFluidAnalysis(AnalysisStage):
     '''Main script for adjoint sensitivity optimization in fluid dynamics simulations.'''
@@ -45,7 +46,6 @@ class AdjointFluidAnalysis(AnalysisStage):
         self._GetSolver().main_model_part.CloneTimeStep(self.time)
 
     def _CreateSolver(self):
-        import python_solvers_wrapper_adjoint_fluid
         return python_solvers_wrapper_adjoint_fluid.CreateSolver(self.model, self.project_parameters)
 
     def _CreateProcesses(self, parameter_name, initialization_order):

--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_fluid_solver.py
@@ -5,7 +5,8 @@ import sys
 import KratosMultiphysics
 from python_solver import PythonSolver
 
-import KratosFluidDynamicsApplication as KratosCFD
+import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
+from KratosMultiphysics.FluidDynamicsApplication import check_and_prepare_model_process_fluid
 
 def CreateSolver(model, custom_settings):
     return AdjointFluidSolver(model, custom_settings)
@@ -172,7 +173,6 @@ class AdjointFluidSolver(PythonSolver):
         prepare_model_part_settings.AddValue("volume_model_part_name",self.settings["volume_model_part_name"])
         prepare_model_part_settings.AddValue("skin_parts",self.settings["skin_parts"])
 
-        import check_and_prepare_model_process_fluid
         check_and_prepare_model_process_fluid.CheckAndPrepareModelProcess(self.main_model_part, prepare_model_part_settings).Execute()
 
         current_buffer_size = self.main_model_part.GetBufferSize()

--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_vmsmonolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_vmsmonolithic_solver.py
@@ -6,7 +6,7 @@ import KratosMultiphysics
 import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
 
 # Import base class file
-from adjoint_fluid_solver import AdjointFluidSolver
+from KratosMultiphysics.FluidDynamicsApplication.adjoint_fluid_solver import AdjointFluidSolver
 
 def CreateSolver(main_model_part, custom_settings):
     return AdjointVMSMonolithicSolver(main_model_part, custom_settings)

--- a/applications/FluidDynamicsApplication/python_scripts/compute_body_fitted_drag_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/compute_body_fitted_drag_process.py
@@ -5,7 +5,7 @@ import KratosMultiphysics
 import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
 
 # Import base class file
-from compute_drag_process import ComputeDragProcess
+from KratosMultiphysics.FluidDynamicsApplication.compute_drag_process import ComputeDragProcess
 
 def Factory(settings, model):
     if(type(settings) != KratosMultiphysics.Parameters):

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_dynamics_analysis.py
@@ -3,7 +3,8 @@ from __future__ import absolute_import, division #makes KratosMultiphysics backw
 import KratosMultiphysics as Kratos
 import KratosMultiphysics.FluidDynamicsApplication
 
-from analysis_stage import AnalysisStage
+from KratosMultiphysics.analysis_stage import AnalysisStage
+from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_fluid
 
 class FluidDynamicsAnalysis(AnalysisStage):
     '''Main script for fluid dynamics simulations using the navier_stokes family of python solvers.'''
@@ -35,7 +36,6 @@ class FluidDynamicsAnalysis(AnalysisStage):
         super(FluidDynamicsAnalysis,self).__init__(model,parameters)
 
     def _CreateSolver(self):
-        import python_solvers_wrapper_fluid
         return python_solvers_wrapper_fluid.CreateSolver(self.model, self.project_parameters)
 
     def _CreateProcesses(self, parameter_name, initialization_order):

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
@@ -3,10 +3,11 @@ import sys
 
 # Importing the Kratos Library
 import KratosMultiphysics
-from python_solver import PythonSolver
+from KratosMultiphysics.python_solver import PythonSolver
 
 # Import applications
 import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
+from KratosMultiphysics.FluidDynamicsApplication import check_and_prepare_model_process_fluid
 
 def CreateSolver(model, custom_settings):
     return FluidSolver(model, custom_settings)
@@ -192,7 +193,6 @@ class FluidSolver(PythonSolver):
         prepare_model_part_settings.AddValue("volume_model_part_name",self.settings["volume_model_part_name"])
         prepare_model_part_settings.AddValue("skin_parts",self.settings["skin_parts"])
 
-        import check_and_prepare_model_process_fluid
         check_and_prepare_model_process_fluid.CheckAndPrepareModelProcess(self.main_model_part, prepare_model_part_settings).Execute()
 
     def _ComputeDeltaTime(self):

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_solver.py
@@ -4,7 +4,10 @@ import KratosMultiphysics
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
 ## Import base class file
-from fluid_solver import FluidSolver
+from KratosMultiphysics.FluidDynamicsApplication.fluid_solver import FluidSolver
+
+import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
+from KratosMultiphysics.FluidDynamicsApplication import check_and_prepare_model_process_fluid
 
 def CreateSolver(model, custom_settings):
     return NavierStokesCompressibleSolver(model, custom_settings)
@@ -67,7 +70,6 @@ class NavierStokesCompressibleSolver(FluidSolver):
         self.min_buffer_size = 3
 
         ## Construct the linear solver
-        import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
         self.linear_solver = linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
 
         ## Set the element replace settings
@@ -189,7 +191,6 @@ class NavierStokesCompressibleSolver(FluidSolver):
         prepare_model_part_settings.AddValue("volume_model_part_name",self.settings["volume_model_part_name"])
         prepare_model_part_settings.AddValue("skin_parts",self.settings["skin_parts"])
 
-        import check_and_prepare_model_process_fluid
         check_and_prepare_model_process_fluid.CheckAndPrepareModelProcess(self.main_model_part, prepare_model_part_settings).Execute()
 
 

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -5,15 +5,13 @@ import KratosMultiphysics
 
 # Import applications
 import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
-try:
+from  KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable
+have_mesh_moving = CheckIfApplicationsAvailable("MeshMovingApplication")
+if have_mesh_moving:
     import KratosMultiphysics.MeshMovingApplication as KratosMeshMoving
-    have_mesh_moving = True
-except ImportError:
-    have_mesh_moving = False
-
 
 # Import base class file
-from fluid_solver import FluidSolver
+from KratosMultiphysics.FluidDynamicsApplication.fluid_solver import FluidSolver
 
 class EmbeddedFormulation(object):
     """Helper class to define embedded-dependent parameters."""

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
@@ -2,12 +2,13 @@ from __future__ import absolute_import, division  # makes KratosMultiphysics bac
 
 # Importing the Kratos Library
 import KratosMultiphysics
+import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
 
 # Import applications
 import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
 
 # Import base class file
-from fluid_solver import FluidSolver
+from KratosMultiphysics.FluidDynamicsApplication.fluid_solver import FluidSolver
 
 def CreateSolver(model, custom_settings):
     return NavierStokesSolverFractionalStep(model, custom_settings)
@@ -90,7 +91,6 @@ class NavierStokesSolverFractionalStep(FluidSolver):
         self.min_buffer_size = 3
 
         ## Construct the linear solvers
-        import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory
         self.pressure_linear_solver = linear_solver_factory.ConstructSolver(self.settings["pressure_linear_solver_settings"])
         self.velocity_linear_solver = linear_solver_factory.ConstructSolver(self.settings["velocity_linear_solver_settings"])
 

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -2,14 +2,13 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 
 # Importing the Kratos Library
 import KratosMultiphysics
+import KratosMultiphysics.kratos_utilities as KratosUtilities
 
 # Import applications
 import KratosMultiphysics.FluidDynamicsApplication as KratosCFD
-try:
+have_conv_diff = KratosUtilities.CheckIfApplicationsAvailable("ConvectionDiffusionApplication")
+if have_conv_diff:
     import KratosMultiphysics.ConvectionDiffusionApplication as KratosConvDiff
-    have_conv_diff = True
-except ImportError:
-    have_conv_diff = False
 
 # Import base class file
 from KratosMultiphysics.FluidDynamicsApplication.fluid_solver import FluidSolver

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_adjoint_vmsmonolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_adjoint_vmsmonolithic_solver.py
@@ -5,10 +5,10 @@ import KratosMultiphysics.mpi as KratosMPI
 
 # Import applications
 import KratosMultiphysics.TrilinosApplication as TrilinosApplication
-import KratosMultiphysics.FluidDynamicsApplication as FluidDynamicsApplication
 from KratosMultiphysics.TrilinosApplication import trilinos_linear_solver_factory
+import KratosMultiphysics.FluidDynamicsApplication as FluidDynamicsApplication
+from KratosMultiphysics.FluidDynamicsApplication.adjoint_vmsmonolithic_solver import AdjointVMSMonolithicSolver
 
-from adjoint_vmsmonolithic_solver import AdjointVMSMonolithicSolver
 from KratosMultiphysics.mpi.distributed_import_model_part_utility import DistributedImportModelPartUtility
 
 def CreateSolver(main_model_part, custom_settings):

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_embedded_solver.py
@@ -10,7 +10,7 @@ import KratosMultiphysics.FluidDynamicsApplication as KratosFluid   # Fluid dyna
 from KratosMultiphysics.TrilinosApplication import trilinos_linear_solver_factory
 
 # Import serial monolithic embedded solver
-import navier_stokes_embedded_solver
+from KratosMultiphysics.FluidDynamicsApplication import navier_stokes_embedded_solver
 
 from KratosMultiphysics.mpi.distributed_import_model_part_utility import DistributedImportModelPartUtility
 

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_fractionalstep.py
@@ -10,13 +10,13 @@ import KratosMultiphysics.FluidDynamicsApplication as KratosFluid   # Fluid dyna
 from KratosMultiphysics.TrilinosApplication import trilinos_linear_solver_factory
 
 # Import base class file
-import navier_stokes_solver_fractionalstep
+from KratosMultiphysics.FluidDynamicsApplication.navier_stokes_solver_fractionalstep import NavierStokesSolverFractionalStep
 from KratosMultiphysics.mpi.distributed_import_model_part_utility import DistributedImportModelPartUtility
 
 def CreateSolver(model, custom_settings):
     return TrilinosNavierStokesSolverFractionalStep(model, custom_settings)
 
-class TrilinosNavierStokesSolverFractionalStep(navier_stokes_solver_fractionalstep.NavierStokesSolverFractionalStep):
+class TrilinosNavierStokesSolverFractionalStep(NavierStokesSolverFractionalStep):
 
     @classmethod
     def GetDefaultSettings(cls):
@@ -79,7 +79,7 @@ class TrilinosNavierStokesSolverFractionalStep(navier_stokes_solver_fractionalst
     def __init__(self, model, custom_settings):
         self._validate_settings_in_baseclass=True # To be removed eventually
         # Note: deliberately calling the constructor of the base python solver (the parent of my parent)
-        super(navier_stokes_solver_fractionalstep.NavierStokesSolverFractionalStep,self).__init__(model,custom_settings)
+        super(NavierStokesSolverFractionalStep,self).__init__(model,custom_settings)
 
         self.element_name = "FractionalStep"
         self.condition_name = "WallCondition"

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
@@ -10,7 +10,7 @@ import KratosMultiphysics.FluidDynamicsApplication as KratosCFD     # Fluid dyna
 from KratosMultiphysics.TrilinosApplication import trilinos_linear_solver_factory
 
 # Import base class file
-import navier_stokes_solver_vmsmonolithic
+from KratosMultiphysics.FluidDynamicsApplication import navier_stokes_solver_vmsmonolithic
 from KratosMultiphysics.mpi.distributed_import_model_part_utility import DistributedImportModelPartUtility
 
 def CreateSolver(model, custom_settings):

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_test_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/cylinder_test_parameters.json
@@ -147,7 +147,7 @@
             }
         },{
             "python_module" : "compute_body_fitted_drag_process",
-                "kratos_module" : "KratosMultiphysics",
+                "kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
                 "process_name"  : "ComputeBodyFittedDragProcess",
                 "Parameters" : {
                     "model_part_name"           : "NoSlip2D_Cylinder",

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/one_element_test_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/one_element_test_parameters.json
@@ -133,15 +133,15 @@
             }
         },{
             "python_module" : "compute_body_fitted_drag_process",
-                "kratos_module" : "KratosMultiphysics",
-                "process_name"  : "ComputeBodyFittedDragProcess",
-                "Parameters" : {
-                    "model_part_name"           : "Structure",
-                    "interval"                  : [0.0, 1e30],
-                    "write_drag_output_file"    : true,
-                    "print_drag_to_screen"      : false,
-                    "print_format"              : "22.15e"
-                }
+            "kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
+            "process_name"  : "ComputeBodyFittedDragProcess",
+            "Parameters" : {
+                "model_part_name"           : "Structure",
+                "interval"                  : [0.0, 1e30],
+                "write_drag_output_file"    : true,
+                "print_drag_to_screen"      : false,
+                "print_format"              : "22.15e"
+            }
         }]
     }
 }

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_parameters.json
@@ -155,15 +155,15 @@
             }
         },{
             "python_module" : "compute_body_fitted_drag_process",
-                "kratos_module" : "KratosMultiphysics",
-                "process_name"  : "ComputeBodyFittedDragProcess",
-                "Parameters" : {
-                    "model_part_name"           : "NoSlip2D_Cylinder",
-                    "interval"                  : [0.0, 1e30],
-                    "write_drag_output_file"    : true,
-                    "print_drag_to_screen"      : false,
-                    "print_format"              : "22.15e"
-                }
+            "kratos_module" : "KratosMultiphysics.FluidDynamicsApplication",
+            "process_name"  : "ComputeBodyFittedDragProcess",
+            "Parameters" : {
+                "model_part_name"           : "NoSlip2D_Cylinder",
+                "interval"                  : [0.0, 1e30],
+                "write_drag_output_file"    : true,
+                "print_drag_to_screen"      : false,
+                "print_format"              : "22.15e"
+            }
         }]
     }
 }

--- a/applications/FluidDynamicsApplication/tests/adjoint_mpi_vms_sensitivity_2d.py
+++ b/applications/FluidDynamicsApplication/tests/adjoint_mpi_vms_sensitivity_2d.py
@@ -3,20 +3,17 @@ import KratosMultiphysics as Kratos
 import KratosMultiphysics.FluidDynamicsApplication
 import KratosMultiphysics.mpi as KratosMPI
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-from fluid_dynamics_analysis import FluidDynamicsAnalysis
-
+from  KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable
 
 missing_applications_message = ["Missing required application(s):",]
-have_required_applications = True
-
-try:
+have_required_applications = CheckIfApplicationsAvailable("HDF5Application")
+if have_required_applications:
     import KratosMultiphysics.HDF5Application as kh5
-except ImportError:
-    have_required_applications = False
+else:
     missing_applications_message.append("HDF5Application")
 
-from fluid_dynamics_analysis import FluidDynamicsAnalysis
-from adjoint_fluid_analysis import AdjointFluidAnalysis
+from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
+from KratosMultiphysics.FluidDynamicsApplication.adjoint_fluid_analysis import AdjointFluidAnalysis
 
 class ControlledExecutionScope:
     def __init__(self, scope):
@@ -30,7 +27,6 @@ class ControlledExecutionScope:
         os.chdir(self.currentPath)
 
 @KratosUnittest.skipUnless(have_required_applications," ".join(missing_applications_message))
-
 class AdjointMPIVMSSensitivity(KratosUnittest.TestCase):
 
     def setUp(self):

--- a/applications/FluidDynamicsApplication/tests/adjoint_vms_sensitivity_2d.py
+++ b/applications/FluidDynamicsApplication/tests/adjoint_vms_sensitivity_2d.py
@@ -4,17 +4,16 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.FluidDynamicsApplication
 import KratosMultiphysics.kratos_utilities as kratos_utils
 
+from  KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable
 missing_applications_message = ["Missing required application(s):",]
-have_required_applications = True
-
-try:
+have_required_applications = CheckIfApplicationsAvailable("HDF5Application")
+if have_required_applications:
     import KratosMultiphysics.HDF5Application as kh5
-except ImportError:
-    have_required_applications = False
+else:
     missing_applications_message.append("HDF5Application")
 
-from fluid_dynamics_analysis import FluidDynamicsAnalysis
-from adjoint_fluid_analysis import AdjointFluidAnalysis
+from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
+from KratosMultiphysics.FluidDynamicsApplication.adjoint_fluid_analysis import AdjointFluidAnalysis
 
 class ControlledExecutionScope:
     def __init__(self, scope):

--- a/applications/FluidDynamicsApplication/tests/artificial_compressibility_test.py
+++ b/applications/FluidDynamicsApplication/tests/artificial_compressibility_test.py
@@ -4,6 +4,8 @@ import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 import KratosMultiphysics.kratos_utilities as KratosUtilities
 import KratosMultiphysics.KratosUnittest as UnitTest
 
+from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_fluid
+
 class ArtificialCompressibilityTest(UnitTest.TestCase):
     def testArtificialCompressibility(self):
         self.setUp()
@@ -33,7 +35,6 @@ class ArtificialCompressibilityTest(UnitTest.TestCase):
             self.model = KratosMultiphysics.Model()
 
             ## Solver construction
-            import python_solvers_wrapper_fluid
             self.solver = python_solvers_wrapper_fluid.CreateSolver(self.model, self.ProjectParameters)
 
             self.solver.AddVariables()

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
@@ -1,5 +1,6 @@
 import KratosMultiphysics
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_fluid
 import KratosMultiphysics.KratosUnittest as UnitTest
 import KratosMultiphysics.kratos_utilities as KratosUtilities
 
@@ -56,7 +57,6 @@ class EmbeddedCouetteImposedTest(UnitTest.TestCase):
             self.model = KratosMultiphysics.Model()
 
             ## Solver construction
-            import python_solvers_wrapper_fluid
             self.solver = python_solvers_wrapper_fluid.CreateSolver(self.model, self.ProjectParameters)
 
             ## Set the "is_slip" field in the json settings (to avoid duplication it is set to false in all tests)

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
@@ -2,6 +2,7 @@ import KratosMultiphysics
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 import KratosMultiphysics.KratosUnittest as UnitTest
 import KratosMultiphysics.kratos_utilities as KratosUtilities
+from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_fluid
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
 
@@ -143,7 +144,6 @@ class EmbeddedCouetteTest(UnitTest.TestCase):
             self.model = KratosMultiphysics.Model()
 
             ## Solver construction
-            import python_solvers_wrapper_fluid
             self.solver = python_solvers_wrapper_fluid.CreateSolver(self.model, self.ProjectParameters)
 
             ## Set the "is_slip" field in the json settings (to avoid duplication it is set to false in all tests)

--- a/applications/FluidDynamicsApplication/tests/embedded_reservoir_discontinuous_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_reservoir_discontinuous_test.py
@@ -1,7 +1,9 @@
 import KratosMultiphysics
-import KratosMultiphysics.FluidDynamicsApplication
 import KratosMultiphysics.kratos_utilities as KratosUtilities
 import KratosMultiphysics.KratosUnittest as UnitTest
+
+import KratosMultiphysics.FluidDynamicsApplication
+from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
 
 class EmbeddedReservoirDiscontinuousTest(UnitTest.TestCase):
     def testEmbeddedReservoirDiscontinuous3D(self):
@@ -36,8 +38,7 @@ class EmbeddedReservoirDiscontinuousTest(UnitTest.TestCase):
                 self.ProjectParameters = KratosMultiphysics.Parameters(parameter_file.read())
 
             self.Model = KratosMultiphysics.Model()
-            import fluid_dynamics_analysis
-            self.simulation = fluid_dynamics_analysis.FluidDynamicsAnalysis(self.Model, self.ProjectParameters)
+            self.simulation = FluidDynamicsAnalysis(self.Model, self.ProjectParameters)
 
     def setUpDistanceField(self):
         # Get the model part containing the domain

--- a/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
@@ -4,6 +4,7 @@ import KratosMultiphysics.kratos_utilities as KratosUtilities
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
 
 import KratosMultiphysics.KratosUnittest as UnitTest
+from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_fluid
 
 @UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
 class EmbeddedReservoirTest(UnitTest.TestCase):
@@ -66,7 +67,6 @@ class EmbeddedReservoirTest(UnitTest.TestCase):
             self.model = KratosMultiphysics.Model()
 
             ## Solver construction
-            import python_solvers_wrapper_fluid
             self.solver = python_solvers_wrapper_fluid.CreateSolver(self.model, self.ProjectParameters)
 
             ## Set the "is_slip" field in the json settings (to avoid duplication it is set to false in all tests)

--- a/applications/FluidDynamicsApplication/tests/fluid_analysis_test.py
+++ b/applications/FluidDynamicsApplication/tests/fluid_analysis_test.py
@@ -1,7 +1,7 @@
 import KratosMultiphysics as km
 import KratosMultiphysics.FluidDynamicsApplication as kfd
 
-from fluid_dynamics_analysis import FluidDynamicsAnalysis
+from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 import KratosMultiphysics.kratos_utilities as kratos_utilities

--- a/applications/FluidDynamicsApplication/tests/fluid_analysis_without_solution.py
+++ b/applications/FluidDynamicsApplication/tests/fluid_analysis_without_solution.py
@@ -1,7 +1,4 @@
-from KratosMultiphysics import *
-from KratosMultiphysics.FluidDynamicsApplication import *
-
-from fluid_dynamics_analysis import FluidDynamicsAnalysis
+from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
 
 class FluidAnalysisWithoutSolution(FluidDynamicsAnalysis):
     """A fluid dynamics analyis variant that skips calls to solver.Predict() and solver.SolveSolutionStep().

--- a/applications/FluidDynamicsApplication/tests/hdf5_io_test.py
+++ b/applications/FluidDynamicsApplication/tests/hdf5_io_test.py
@@ -10,7 +10,7 @@ except ImportError:
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utilities
 
-from fluid_dynamics_analysis import FluidDynamicsAnalysis
+from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
 from fluid_analysis_without_solution import FluidAnalysisWithoutSolution
 
 class ControlledExecutionScope:

--- a/applications/FluidDynamicsApplication/tests/manufactured_solution_test.py
+++ b/applications/FluidDynamicsApplication/tests/manufactured_solution_test.py
@@ -2,9 +2,10 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 
 # Import kratos core and applications
 import KratosMultiphysics
-import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as KratosUtilities
+import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
+from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_fluid
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
 
@@ -138,7 +139,6 @@ class ManufacturedSolutionProblem:
         self.ProjectParameters["solver_settings"]["model_import_settings"]["input_filename"].SetString(self.input_file_name)
 
         ## Solver construction
-        import python_solvers_wrapper_fluid
         self.solver = python_solvers_wrapper_fluid.CreateSolver(self.model, self.ProjectParameters)
 
         self.solver.AddVariables()

--- a/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
+++ b/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
@@ -3,6 +3,7 @@ import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 import KratosMultiphysics.kratos_utilities as KratosUtilities
+from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_fluid
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
 
@@ -35,7 +36,6 @@ class NavierStokesWallConditionTest(UnitTest.TestCase):
             self.model = KratosMultiphysics.Model()
 
             ## Solver construction
-            import python_solvers_wrapper_fluid
             self.solver = python_solvers_wrapper_fluid.CreateSolver(self.model, self.ProjectParameters)
 
             self.solver.AddVariables()


### PR DESCRIPTION
To bring it in line with recent changes to the python import mechanism, we need to use absolute imports in the FluidDynamicsApplication scripts. I have fixed the imports on the main solvers and utilities and on everything that runs with the tests, but I am not convinced that I got everything... Please give it a try with some cases of your own (@KratosMultiphysics/altair too) and let me know if I missed something.

There is at least partial duplication between this PR and #5192. I have discussed it with @roigcarlo and I will try to merge #5192 with master and the changes here to see if we are still missing something.