### PR TITLE
Convdiff/feature adjoint volume source

### DIFF
--- a/applications/convection_diffusion_application/custom_elements/laplacian_element.cpp
+++ b/applications/convection_diffusion_application/custom_elements/laplacian_element.cpp
@@ -85,9 +85,9 @@ void LaplacianElement::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, Vec
     noalias(rRightHandSideVector) = ZeroVector(number_of_points); //resetting RHS
 
     //reading integration points and local gradients
-    const GeometryType::IntegrationPointsArrayType& integration_points = r_geometry.IntegrationPoints();
-    const GeometryType::ShapeFunctionsGradientsType& DN_De = r_geometry.ShapeFunctionsLocalGradients();
-    const Matrix& N_gausspoint = r_geometry.ShapeFunctionsValues();
+    const GeometryType::IntegrationPointsArrayType& integration_points = r_geometry.IntegrationPoints(this->GetIntegrationMethod());
+    const GeometryType::ShapeFunctionsGradientsType& DN_De = r_geometry.ShapeFunctionsLocalGradients(this->GetIntegrationMethod());
+    const Matrix& N_gausspoint = r_geometry.ShapeFunctionsValues(this->GetIntegrationMethod());
 
     Element::GeometryType::JacobiansType J0;
     Matrix DN_DX(number_of_points,dim);
@@ -102,7 +102,7 @@ void LaplacianElement::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, Vec
         nodal_conductivity[node_element] = r_geometry[node_element].FastGetSolutionStepValue(r_diffusivity_var);
     }
 
-    r_geometry.Jacobian(J0);
+    r_geometry.Jacobian(J0,this->GetIntegrationMethod());
     double DetJ0;
 
     for(std::size_t i_point = 0; i_point<integration_points.size(); ++i_point)
@@ -219,6 +219,13 @@ int LaplacianElement::Check(const ProcessInfo& rCurrentProcessInfo)
     }
 
     return Element::Check(rCurrentProcessInfo);
+}
+
+//************************************************************************************
+//************************************************************************************
+Element::IntegrationMethod LaplacianElement::GetIntegrationMethod() const
+{
+    return GeometryData::GI_GAUSS_2;
 }
 
 } // Namespace Kratos

--- a/applications/convection_diffusion_application/custom_elements/laplacian_element.cpp
+++ b/applications/convection_diffusion_application/custom_elements/laplacian_element.cpp
@@ -225,7 +225,7 @@ int LaplacianElement::Check(const ProcessInfo& rCurrentProcessInfo)
 //************************************************************************************
 Element::IntegrationMethod LaplacianElement::GetIntegrationMethod() const
 {
-    return GeometryData::GI_GAUSS_2;
+    return GeometryData::GI_GAUSS_1;
 }
 
 } // Namespace Kratos

--- a/applications/convection_diffusion_application/custom_elements/laplacian_element.h
+++ b/applications/convection_diffusion_application/custom_elements/laplacian_element.h
@@ -104,6 +104,7 @@ public:
     ///@name Inquiry
     ///@{
 
+    IntegrationMethod GetIntegrationMethod() const override;
 
     ///@}
     ///@name Input and output

--- a/applications/convection_diffusion_application/python_scripts/adjoint_diffusion_solver.py
+++ b/applications/convection_diffusion_application/python_scripts/adjoint_diffusion_solver.py
@@ -112,6 +112,7 @@ class AdjointDiffusionSolver(PythonSolver):
             primal_model_part = self.model.GetModelPart(self.primal_model_part_name)
             variable_utils = kratos.VariableUtils()
             variable_utils.CopyModelPartNodalVar(kratos.TEMPERATURE, primal_model_part, self.model_part, 0)
+            variable_utils.CopyModelPartNodalVar(kratos.HEAT_FLUX, primal_model_part, self.model_part, 0)
             variable_utils.CopyModelPartNodalVar(kratos.FACE_HEAT_FLUX, primal_model_part, self.model_part, 0)
 
             self.ImportMaterials()

--- a/applications/convection_diffusion_application/python_scripts/python_solvers_wrapper_convection_diffusion.py
+++ b/applications/convection_diffusion_application/python_scripts/python_solvers_wrapper_convection_diffusion.py
@@ -45,7 +45,7 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
         err_msg += "Available options are: \"OpenMP\", \"MPI\""
         raise Exception(err_msg)
 
-    module_full = 'KratosMultiphysics.convection_diffusion_application.' + solver_module_name
+    module_full = 'KratosMultiphysics.ConvectionDiffusionApplication.' + solver_module_name
     solver = import_module(module_full).CreateSolver(model, solver_settings)
 
     return solver

--- a/applications/convection_diffusion_application/tests/adjoint_diffusion_test/ProjectParametersAdjoint.json
+++ b/applications/convection_diffusion_application/tests/adjoint_diffusion_test/ProjectParametersAdjoint.json
@@ -75,7 +75,7 @@
                         "node_output"         : false,
                         "skin_output"         : false,
                         "plane_output"        : [],
-                        "nodal_results"       : ["TEMPERATURE","ADJOINT_HEAT_TRANSFER","SHAPE_SENSITIVITY"],
+                        "nodal_results"       : ["TEMPERATURE","ADJOINT_HEAT_TRANSFER","SHAPE_SENSITIVITY","HEAT_FLUX","CONDUCTIVITY"],
                         "gauss_point_results" : []
                     },
                     "point_data_configuration"  : []

--- a/applications/convection_diffusion_application/tests/adjoint_diffusion_test/ProjectParametersPrimal.json
+++ b/applications/convection_diffusion_application/tests/adjoint_diffusion_test/ProjectParametersPrimal.json
@@ -71,6 +71,16 @@
                 "value"           : 0.0,
                 "constrained"     : false
             }
+        },{
+            "python_module" : "assign_scalar_variable_process",
+            "kratos_module" : "KratosMultiphysics",
+            "process_name"  : "AssignScalarVariableProcess",
+            "Parameters"    : {
+                "model_part_name" : "Parts_solid",
+                "variable_name"   : "HEAT_FLUX",
+                "value"           : 0.0,
+                "constrained"     : false
+            }
         }]
     },
     "output_processes" : {
@@ -97,7 +107,7 @@
                         "node_output"         : false,
                         "skin_output"         : false,
                         "plane_output"        : [],
-                        "nodal_results"       : ["TEMPERATURE"],
+                        "nodal_results"       : ["TEMPERATURE","HEAT_FLUX"],
                         "gauss_point_results" : []
                     },
                     "point_data_configuration"  : []

--- a/applications/convection_diffusion_application/tests/adjoint_heat_diffusion_test.py
+++ b/applications/convection_diffusion_application/tests/adjoint_heat_diffusion_test.py
@@ -20,6 +20,8 @@ class AdjointHeatDiffusionTest(unittest.TestCase):
         self.print_output = False
         self.node_ids_to_test = range(1,10)
 
+        self.volume_source = 0.0
+
     def tearDown(self):
 
         with unittest.WorkFolderScope(self.work_folder, __file__):
@@ -30,6 +32,10 @@ class AdjointHeatDiffusionTest(unittest.TestCase):
                 DeleteFileIfExisting("diffusion_test_primal.post.bin")
                 DeleteFileIfExisting("diffusion_test_adjoint.post.bin")
 
+    def testAdjointHeatDiffusionWithSourceTerm(self):
+        self.volume_source = 200.0
+        self.testAdjointHeatDiffusion()
+
     def testAdjointHeatDiffusion(self):
         model = kratos.Model()
         settings = kratos.Parameters(r'''{}''')
@@ -37,6 +43,12 @@ class AdjointHeatDiffusionTest(unittest.TestCase):
         with unittest.WorkFolderScope(self.work_folder, __file__):
             with open(self.primal_parameter_file_name,'r') as primal_parameter_file:
                 settings.AddValue("primal_settings", kratos.Parameters(primal_parameter_file.read()))
+
+            # enable volume source if needed
+            other_processes_list = settings["primal_settings"]["processes"]["list_other_processes"]
+            for i in range(other_processes_list.size()):
+                if other_processes_list[i]["process_name"].GetString() == "AssignScalarVariableProcess" and other_processes_list[i]["Parameters"]["variable_name"].GetString() == "HEAT_FLUX":
+                    other_processes_list[i]["Parameters"]["value"].SetDouble(self.volume_source)
 
             self.primalSolution(model, settings["primal_settings"])
 
@@ -53,7 +65,7 @@ class AdjointHeatDiffusionTest(unittest.TestCase):
             for node_id,fd_sensitivity in zip(self.node_ids_to_test, finite_difference_results):
                 node = adjoint_model_part.Nodes[node_id]
                 adjoint_sensitivity = node.GetSolutionStepValue(kratos.SHAPE_SENSITIVITY,0)
-                #print(node_id, adjoint_sensitivity, fd_sensitivity)
+                #print(node_id, adjoint_sensitivity, fd_sensitivity, adjoint_sensitivity-fd_sensitivity)
                 self.assertAlmostEqual(adjoint_sensitivity[0], fd_sensitivity[0], delta=self.check_tolerance)
                 self.assertAlmostEqual(adjoint_sensitivity[1], fd_sensitivity[1], delta=self.check_tolerance)
 
@@ -87,7 +99,11 @@ class AdjointHeatDiffusionTest(unittest.TestCase):
             self.primalSolution(model_y,settings)
             y_temp = self.average_temperature_objective(model_y.GetModelPart(model_part_name+"."+objective_model_part_name))
 
-            results.append([(x_temp-base_temp)/self.perturbation_magnitude, (y_temp-base_temp)/self.perturbation_magnitude])
+            result = kratos.Array3()
+            result[0] = (x_temp-base_temp)/self.perturbation_magnitude
+            result[1] = (y_temp-base_temp)/self.perturbation_magnitude
+
+            results.append(result)
 
         return results
 

--- a/applications/convection_diffusion_application/tests/test_ConvectionDiffusionApplication.py
+++ b/applications/convection_diffusion_application/tests/test_ConvectionDiffusionApplication.py
@@ -59,6 +59,7 @@ def AssembleTestSuites():
     smallSuite.addTest(ThermalCouplingTest('testDirichletNeumann'))
     smallSuite.addTest(ApplyThermalFaceProcessTest('testThermalFaceProcess'))
     smallSuite.addTest(AdjointHeatDiffusionTest('testAdjointHeatDiffusion'))
+    smallSuite.addTest(AdjointHeatDiffusionTest('testAdjointHeatDiffusionWithSourceTerm'))
 
     ### Adding Small Tests
     smallSuite.addTest(TBasicConvectionDiffusionStationaryTest('test_execution'))


### PR DESCRIPTION
Simple PR adding support for shape sensitivity calculation when a volume source term is present in the adjoint diffusion problem, plus a small test using the existing geometry.

Note that the exact integration of a (potentially piecewise linear) source term requires increasing the integration order of the laplacian element from GI_GAUSS_1 to GI_GAUSS_2.