### PR TITLE
Defining Core and Python libs for TrilinosApplication.

### DIFF
--- a/applications/TrilinosApplication/CMakeLists.txt
+++ b/applications/TrilinosApplication/CMakeLists.txt
@@ -34,22 +34,20 @@ if(TRILINOS_USE_AMGCL MATCHES ON)
     include_directories(${AMGCL_ROOT})
 endif(TRILINOS_USE_AMGCL MATCHES ON)
 
-# Generate variables with the sources
-set( KRATOS_TRILINOS_APPLICATION_SOURCES
+# Sources for the Trilinos application core
+set( KRATOS_TRILINOS_APPLICATION_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/trilinos_application.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/amgcl_mpi_solver_impl.cpp;
- 	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/trilinos_python_application.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_trilinos_space_to_python.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_trilinos_convergence_criterias_to_python.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_trilinos_schemes_to_python.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_trilinos_linear_solvers_to_python.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_trilinos_processes_to_python.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_trilinos_strategies_to_python.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_utilities_to_python.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_zoltan_processes_to_python.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/custom_factories/trilinos_linear_solver_factory.cpp
     ${CMAKE_SOURCE_DIR}/applications/FluidDynamicsApplication/fluid_dynamics_application_variables.cpp  #TODO: this should REALLY NOT BE HERE
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/mpi_normal_calculation_utilities.cpp;
+)
+
+# Sources for the Python module
+file(
+  GLOB_RECURSE
+  KRATOS_TRILINOS_PYTHON_INTERFACE_SOURCES
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/*.cpp
 )
 
 ## Kratos tests sources. Enabled by default
@@ -58,18 +56,22 @@ if(${KRATOS_BUILD_TESTING} MATCHES ON)
 endif(${KRATOS_BUILD_TESTING} MATCHES ON)
 
 # ###############################################################
-pybind11_add_module(KratosTrilinosApplication MODULE THIN_LTO ${KRATOS_TRILINOS_APPLICATION_SOURCES} ${KRATOS_TRILINOS_TEST_SOURCES})
-
+## TrilinosApplication core library (C++ parts)
+add_library( KratosTrilinosCore SHARED ${KRATOS_TRILINOS_APPLICATION_CORE_SOURCES} ${KRATOS_TRILINOS_TEST_SOURCES} )
 if (HAVE_PASTIX)
-    target_link_libraries(KratosTrilinosApplication PRIVATE KratosCore KratosMPICore ${TRILINOS_LIBRARIES} ${MPI_LIBRARIES} ${PASTIX_LIBRARIES} ${SCOTCH_LIBRARIES} ${BLAS_LIBRARIES} )
+    target_link_libraries(KratosTrilinosCore PRIVATE KratosCore KratosMPICore ${TRILINOS_LIBRARIES} ${MPI_LIBRARIES} ${PASTIX_LIBRARIES} ${SCOTCH_LIBRARIES} ${BLAS_LIBRARIES} )
     install(FILES ${PASTIX_LIBRARIES} DESTINATION libs )
 
     message("linking PASTIX in the AMGCL lib")
 else(HAVE_PASTIX)
-    target_link_libraries(KratosTrilinosApplication PRIVATE KratosCore KratosMPICore ${TRILINOS_LIBRARIES} ${MPI_LIBRARIES} )
+    target_link_libraries(KratosTrilinosCore PRIVATE KratosCore KratosMPICore ${TRILINOS_LIBRARIES} ${MPI_LIBRARIES} )
 endif(HAVE_PASTIX)
+set_target_properties( KratosTrilinosCore PROPERTIES COMPILE_DEFINITIONS "TRILINOS_APPLICATION=EXPORT,API")
 
-set_target_properties(KratosTrilinosApplication PROPERTIES PREFIX "")
+## TrilinosApplication python module
+pybind11_add_module( KratosTrilinosApplication MODULE THIN_LTO ${KRATOS_TRILINOS_PYTHON_INTERFACE_SOURCES} )
+target_link_libraries( KratosTrilinosApplication PRIVATE KratosTrilinosCore)
+set_target_properties( KratosTrilinosApplication PROPERTIES PREFIX "")
 
 # Changing the .dll suffix to .pyd
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -82,9 +84,11 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 if(USE_COTIRE MATCHES ON)
+    cotire(KratosTrilinosCore)
     cotire(KratosTrilinosApplication)
 endif(USE_COTIRE MATCHES ON)
 
+install(TARGETS KratosTrilinosCore DESTINATION libs )
 install(TARGETS KratosTrilinosApplication DESTINATION libs )
 
 # Kratos Testing. Install everything except sources

--- a/applications/TrilinosApplication/custom_factories/trilinos_linear_solver_factory.h
+++ b/applications/TrilinosApplication/custom_factories/trilinos_linear_solver_factory.h
@@ -57,7 +57,7 @@ namespace Kratos
  * @tparam TLinearSolverType The linear solver type
  */
 template <typename TSparseSpace, typename TLocalSpace, typename TLinearSolverType>
-class TrilinosLinearSolverFactory
+class KRATOS_API(TRILINOS_APPLICATION) TrilinosLinearSolverFactory
     : public LinearSolverFactory<TSparseSpace,TLocalSpace>
 {
     ///@name Type Definitions
@@ -118,7 +118,7 @@ typedef LinearSolverFactory<TrilinosSparseSpaceType,  TrilinosLocalSpaceType> Tr
 #define KRATOS_REGISTER_TRILINOS_LINEAR_SOLVER(name, reference) ; \
     KratosComponents<TrilinosLinearSolverFactoryType>::Add(name, reference);
 
-extern template class KratosComponents<TrilinosLinearSolverFactoryType>;
+KRATOS_API_EXTERN template class KRATOS_API(TRILINOS_APPLICATION) KratosComponents<TrilinosLinearSolverFactoryType>;
 
 }  // namespace Kratos.
 

--- a/applications/TrilinosApplication/custom_utilities/mpi_normal_calculation_utilities.h
+++ b/applications/TrilinosApplication/custom_utilities/mpi_normal_calculation_utilities.h
@@ -36,7 +36,7 @@ namespace Kratos
 ///@{
 
 /// Some tools to calculate face and nodal normals on an MPI partitioned environment
-class MPINormalCalculationUtils : public Process
+class KRATOS_API(TRILINOS_APPLICATION) MPINormalCalculationUtils : public Process
 {
 public:
     ///@name Type Definitions

--- a/applications/TrilinosApplication/trilinos_application.h
+++ b/applications/TrilinosApplication/trilinos_application.h
@@ -47,7 +47,7 @@ namespace Kratos {
 /// Short class definition.
 /** Detail class definition.
 */
-class KratosTrilinosApplication : public KratosApplication {
+class KRATOS_API(TRILINOS_APPLICATION) KratosTrilinosApplication : public KratosApplication {
    public:
     ///@name Type Definitions
     ///@{


### PR DESCRIPTION
I need this in order to invert the dependency between FluidDynamicsApplication and TrilinosApplication (I cannot link directly from FluidDynamics to the trilinos python module).

closes #4705 