### PR TITLE
[ContactStructuralMechanicsApplication] Hotfix several minor errors SPR contact

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
@@ -57,178 +57,144 @@ void ContactSPRErrorProcess<TDim>::CalculatePatch(
     Vector& rSigmaRecovered
     )
 {
-    // Defining tolerance
-    const double tolerance = std::numeric_limits<double>::epsilon();
+    // Contact interface node
+    if (itNode->Is(INTERFACE)) {
+        // Defining tolerance
+        const double tolerance = std::numeric_limits<double>::epsilon();
 
-    // Triangle and tetrahedra have only one GP by default
-    std::vector<Vector> stress_vector(1);
-    std::vector<array_1d<double,3>> coordinates_vector(1);
+        // Triangle and tetrahedra have only one GP by default
+        std::vector<Vector> stress_vector(1);
+        std::vector<array_1d<double,3>> coordinates_vector(1);
 
-    // Our interest is to assemble the system A and b to solve a local problem for the element and estimate the new element size
-    CompressedMatrix A = ZeroMatrix(SigmaSize * (TDim + 1), SigmaSize * (TDim + 1));
-    BoundedMatrix<double, SigmaSize * (TDim+1),1> b = ZeroMatrix(SigmaSize * (TDim+1), 1);
-    BoundedMatrix<double, SigmaSize, SigmaSize * (TDim+1)> p_k;
-    BoundedMatrix<double, 1, SigmaSize> N_k;
-    BoundedMatrix<double, 1, SigmaSize> T_k1;
-    BoundedMatrix<double, 1, SigmaSize> T_k2;  // in case of 3D: second tangential vector
-    BoundedMatrix<double, SigmaSize, 1> sigma;
+        // Our interest is to assemble the system A and b to solve a local problem for the element and estimate the new element size
+        CompressedMatrix A = ZeroMatrix(SigmaSize * (TDim + 1), SigmaSize * (TDim + 1));
+        BoundedMatrix<double, SigmaSize * (TDim+1),1> b = ZeroMatrix(SigmaSize * (TDim+1), 1);
+        BoundedMatrix<double, SigmaSize, SigmaSize * (TDim+1)> p_k;
+        BoundedMatrix<double, 1, SigmaSize> N_k;
+        BoundedMatrix<double, 1, SigmaSize> T_k1;
+        BoundedMatrix<double, 1, SigmaSize> T_k2;  // in case of 3D: second tangential vector
+        BoundedMatrix<double, SigmaSize, 1> sigma;
 
-    /* Computation A and b */
-    // PART 1: Contributions from the neighboring elements
-    auto& r_neigh_elements = itPatchNode->GetValue(NEIGHBOUR_ELEMENTS);
-    const array_1d<double, 3>& r_coordinates = itNode->Coordinates();
-    const array_1d<double, 3>& r_coordinates_patch_node = itPatchNode->Coordinates();
-    for( WeakElementItType it_elem = r_neigh_elements.begin(); it_elem != r_neigh_elements.end(); ++it_elem) {
+        /* Computation A and b */
+        // PART 1: Contributions from the neighboring elements
+        auto& r_neigh_elements = itPatchNode->GetValue(NEIGHBOUR_ELEMENTS);
+        const array_1d<double, 3>& r_coordinates = itNode->Coordinates();
+        const array_1d<double, 3>& r_coordinates_patch_node = itPatchNode->Coordinates();
+        for( WeakElementItType it_elem = r_neigh_elements.begin(); it_elem != r_neigh_elements.end(); ++it_elem) {
 
-        auto& r_process_info = BaseType::mThisModelPart.GetProcessInfo();
-        it_elem->GetValueOnIntegrationPoints(*BaseType::mpStressVariable,stress_vector, r_process_info);
-        it_elem->GetValueOnIntegrationPoints(INTEGRATION_COORDINATES, coordinates_vector, r_process_info);
+            auto& r_process_info = BaseType::mThisModelPart.GetProcessInfo();
+            it_elem->GetValueOnIntegrationPoints(*BaseType::mpStressVariable,stress_vector, r_process_info);
+            it_elem->GetValueOnIntegrationPoints(INTEGRATION_COORDINATES, coordinates_vector, r_process_info);
 
-        KRATOS_INFO_IF("ContactSPRErrorProcess", BaseType::mEchoLevel > 3)
-        << "\tElement: " << it_elem->Id() << std::endl
-        << "\tStress: " << stress_vector[0] << std::endl
-        << "\tX: " << coordinates_vector[0][0] << "\tY: " << coordinates_vector[0][1] << "\tZ: " << coordinates_vector[0][2] << std::endl;
+            KRATOS_INFO_IF("ContactSPRErrorProcess", BaseType::mEchoLevel > 3)
+            << "\tElement: " << it_elem->Id() << std::endl
+            << "\tStress: " << stress_vector[0] << std::endl
+            << "\tX: " << coordinates_vector[0][0] << "\tY: " << coordinates_vector[0][1] << "\tZ: " << coordinates_vector[0][2] << std::endl;
 
-        for( IndexType j = 0; j < SigmaSize; ++j)
-            sigma(j,0) = stress_vector[0][j];
+            for( IndexType j = 0; j < SigmaSize; ++j)
+                sigma(j,0) = stress_vector[0][j];
 
-        for ( IndexType j = 0; j < SigmaSize; ++j){
-            p_k(j, j * (TDim+1) + 0) = 1.0;
-            p_k(j, j * (TDim+1) + 1) = coordinates_vector[0][0] - r_coordinates_patch_node[0];
-            p_k(j, j * (TDim+1) + 2) = coordinates_vector[0][1] - r_coordinates_patch_node[1];
+            for ( IndexType j = 0; j < SigmaSize; ++j){
+                p_k(j, j * (TDim+1) + 0) = 1.0;
+                p_k(j, j * (TDim+1) + 1) = coordinates_vector[0][0] - r_coordinates_patch_node[0];
+                p_k(j, j * (TDim+1) + 2) = coordinates_vector[0][1] - r_coordinates_patch_node[1];
+                if(TDim == 3)
+                    p_k(j, j * (TDim+1) + 3) = coordinates_vector[0][2] - r_coordinates_patch_node[2];
+            }
+
+            // Finally we add the contributiosn to our local system (A, b)
+            noalias(A) += prod(trans(p_k), p_k);
+            noalias(b) += prod(trans(p_k), sigma);
+        }
+
+        // Computing A and b
+        BoundedMatrix<double, SigmaSize * (TDim + 1), 1> A1;
+        BoundedMatrix<double, 1, SigmaSize * (TDim + 1)> A2;
+        for (IndexType j = 0; j < SigmaSize; ++j){
+            p_k(j,j * (TDim + 1) + 1)= r_coordinates[0] - r_coordinates_patch_node[0];
+            p_k(j,j * (TDim + 1) + 2)= r_coordinates[1] - r_coordinates_patch_node[1];
             if(TDim == 3)
-                p_k(j, j * (TDim+1) + 3) = coordinates_vector[0][2] - r_coordinates_patch_node[2];
+                p_k(j,j * (TDim + 1) + 3)= r_coordinates[2] - r_coordinates_patch_node[2];
         }
 
-        // Finally we add the contributiosn to our local system (A, b)
-        noalias(A) += prod(trans(p_k), p_k);
-        noalias(b) += prod(trans(p_k), sigma);
-    }
+        // Set the r_normal and tangential vectors in Voigt Notation
+        const array_1d<double, 3>& r_normal = itNode->FastGetSolutionStepValue(NORMAL);
 
-    // Computing A and b
-    BoundedMatrix<double, SigmaSize * (TDim + 1), 1> A1;
-    BoundedMatrix<double, 1, SigmaSize * (TDim + 1)> A2;
-    for (IndexType j = 0; j < SigmaSize; ++j){
-        p_k(j,j * (TDim + 1) + 1)= r_coordinates[0] - r_coordinates_patch_node[0];
-        p_k(j,j * (TDim + 1) + 2)= r_coordinates[1] - r_coordinates_patch_node[1];
-        if(TDim == 3)
-            p_k(j,j * (TDim + 1) + 3)= r_coordinates[2] - r_coordinates_patch_node[2];
-    }
+        if(TDim == 2) {
+            N_k(0,0) = r_normal[0] * r_normal[0];
+            N_k(0,1) = r_normal[1] * r_normal[1];
+            N_k(0,2) = 2.0 * r_normal[0] * r_normal[1];
 
-    // Set the r_normal and tangential vectors in Voigt Notation
-    const array_1d<double, 3>& r_normal = itNode->FastGetSolutionStepValue(NORMAL);
+            T_k1(0,0) =  r_normal[0] * r_normal[1];
+            T_k1(0,1) = -r_normal[0] * r_normal[1];
+            T_k1(0,2) =  r_normal[1] * r_normal[1] - r_normal[0] * r_normal[0];
+        } else if (TDim == 3) {
+            N_k(0,0) = r_normal[0] * r_normal[0];
+            N_k(0,1) = r_normal[1] * r_normal[1];
+            N_k(0,2) = r_normal[2] * r_normal[2];
+            N_k(0,3) = 2.0 * r_normal[0] * r_normal[1];
+            N_k(0,4) = 2.0 * r_normal[1] * r_normal[2];
+            N_k(0,5) = 2.0 * r_normal[2] * r_normal[0];
 
-    if(TDim == 2) {
-        N_k(0,0) = r_normal[0] * r_normal[0];
-        N_k(0,1) = r_normal[1] * r_normal[1];
-        N_k(0,2) = 2.0 * r_normal[0] * r_normal[1];
+            // Set tangential vectors
+            array_1d<double, 3> t1 = ZeroVector(3);
+            array_1d<double, 3> t2 = ZeroVector(3);
 
-        T_k1(0,0) =  r_normal[0] * r_normal[1];
-        T_k1(0,1) = -r_normal[0] * r_normal[1];
-        T_k1(0,2) =  r_normal[1] * r_normal[1] - r_normal[0] * r_normal[0];
-    } else if (TDim == 3) {
-        N_k(0,0) = r_normal[0] * r_normal[0];
-        N_k(0,1) = r_normal[1] * r_normal[1];
-        N_k(0,2) = r_normal[2] * r_normal[2];
-        N_k(0,3) = 2.0 * r_normal[0] * r_normal[1];
-        N_k(0,4) = 2.0 * r_normal[1] * r_normal[2];
-        N_k(0,5) = 2.0 * r_normal[2] * r_normal[0];
+            if(std::abs(r_normal[0]) > tolerance || std::abs(r_normal[1]) > tolerance) {
+                const double norm = std::sqrt((t1[0]*t1[0]+t1[1]*t1[1]));
+                t1[0] = r_normal[1]/norm;
+                t1[1] = -r_normal[0]/norm;
 
-        // Set tangential vectors
-        array_1d<double, 3> t1 = ZeroVector(3);
-        array_1d<double, 3> t2 = ZeroVector(3);
+                t2[0] = -r_normal[0]*r_normal[2]/norm;
+                t2[1] = -r_normal[1]*r_normal[2]/norm;
+                t2[2] = r_normal[0]*r_normal[0]+r_normal[1]*r_normal[1]/norm;
+            } else{
+                t1[0] = 1.0;
+                t2[1] = 1.0;
+            }
 
-        if(std::abs(r_normal[0]) > tolerance || std::abs(r_normal[1]) > tolerance) {
-            const double norm = std::sqrt((t1[0]*t1[0]+t1[1]*t1[1]));
-            t1[0] = r_normal[1]/norm;
-            t1[1] = -r_normal[0]/norm;
+            T_k1(0,0) = r_normal[0]*t1[0];
+            T_k1(0,1) = r_normal[1]*t1[1];
+            T_k1(0,2) = r_normal[2]*t1[2];
+            T_k1(0,3) = r_normal[1]*t1[2]+r_normal[2]*t1[1];
+            T_k1(0,4) = r_normal[2]*t1[0]+r_normal[0]*t1[2];
+            T_k1(0,5) = r_normal[0]*t1[1]+r_normal[1]*t1[0];
 
-            t2[0] = -r_normal[0]*r_normal[2]/norm;
-            t2[1] = -r_normal[1]*r_normal[2]/norm;
-            t2[2] = r_normal[0]*r_normal[0]+r_normal[1]*r_normal[1]/norm;
-        } else{
-            t1[0] = 1.0;
-            t2[1] = 1.0;
+            T_k2(0,0) = r_normal[0]*t2[0];
+            T_k2(0,1) = r_normal[1]*t2[1];
+            T_k2(0,2) = r_normal[2]*t2[2];
+            T_k2(0,3) = r_normal[1]*t2[2]+r_normal[2]*t2[1];
+            T_k2(0,4) = r_normal[2]*t2[0]+r_normal[0]*t2[2];
+            T_k2(0,5) = r_normal[0]*t2[1]+r_normal[1]*t2[0];
         }
-
-        T_k1(0,0) = r_normal[0]*t1[0];
-        T_k1(0,1) = r_normal[1]*t1[1];
-        T_k1(0,2) = r_normal[2]*t1[2];
-        T_k1(0,3) = r_normal[1]*t1[2]+r_normal[2]*t1[1];
-        T_k1(0,4) = r_normal[2]*t1[0]+r_normal[0]*t1[2];
-        T_k1(0,5) = r_normal[0]*t1[1]+r_normal[1]*t1[0];
-
-        T_k2(0,0) = r_normal[0]*t2[0];
-        T_k2(0,1) = r_normal[1]*t2[1];
-        T_k2(0,2) = r_normal[2]*t2[2];
-        T_k2(0,3) = r_normal[1]*t2[2]+r_normal[2]*t2[1];
-        T_k2(0,4) = r_normal[2]*t2[0]+r_normal[0]*t2[2];
-        T_k2(0,5) = r_normal[0]*t2[1]+r_normal[1]*t2[0];
-    }
-
-    noalias(A1) = prod(trans(p_k),trans(N_k));
-    noalias(A2) = prod(N_k,p_k);
-    noalias(A) += mPenaltyNormal * prod(A1, A2);
-
-    noalias(A1) = prod(trans(p_k),trans(T_k1));
-    noalias(A2) = prod(T_k1,p_k);
-
-    // Finally we add the contributiosn to our local system (A, b)
-    noalias(A) += mPenaltyTangent*prod(A1, A2);
-    noalias(b) += mPenaltyNormal*prod(trans(p_k),trans(N_k)) * itNode->GetValue(CONTACT_PRESSURE);
-
-    //PART 2: Contributions from contact nodes: regard all nodes from the patch which are in contact
-    // Patch center node:
-    if (itPatchNode->Has(CONTACT_PRESSURE)){
-        const array_1d<double, 3>& r_normal_patch_node = itPatchNode->FastGetSolutionStepValue(NORMAL);
-        p_k(0,1)=0.0;
-        p_k(0,2)=0.0;
-        p_k(1,4)=0.0;
-        p_k(1,5)=0.0;
-        p_k(2,7)=0.0;
-        p_k(2,8)=0.0;
-        N_k(0,0) = r_normal_patch_node[0]*r_normal_patch_node[0];
-        N_k(0,1) = r_normal_patch_node[1]*r_normal_patch_node[1];
-        N_k(0,2) = 2.0 * r_normal_patch_node[0]*r_normal_patch_node[1];
-        T_k1(0,0) =  r_normal_patch_node[0]*r_normal_patch_node[1];
-        T_k1(0,1) = -r_normal_patch_node[0]*r_normal_patch_node[1];
-        T_k1(0,2) =  r_normal_patch_node[1]*r_normal_patch_node[1]-r_normal_patch_node[0]*r_normal_patch_node[0];
 
         noalias(A1) = prod(trans(p_k),trans(N_k));
         noalias(A2) = prod(N_k,p_k);
-        noalias(A) += mPenaltyNormal*prod(A1, A2);
+        noalias(A) += mPenaltyNormal * prod(A1, A2);
 
         noalias(A1) = prod(trans(p_k),trans(T_k1));
         noalias(A2) = prod(T_k1,p_k);
 
         // Finally we add the contributiosn to our local system (A, b)
         noalias(A) += mPenaltyTangent*prod(A1, A2);
-        // NOTE: Code commented. Could be of interest in the future
-//         noalias(A) += mPenaltyNormal*prod(prod(trans(p_k),trans(N_k)),prod(N_k,p_k));
-//         noalias(A) += mPenaltyTangent*prod(prod(prod(trans(p_k),trans(T_k1)),T_k1),p_k);
-        noalias(b) -= mPenaltyNormal*prod(trans(p_k),trans(N_k))*itPatchNode->GetValue(CONTACT_PRESSURE);
-    }
+        noalias(b) += mPenaltyNormal*prod(trans(p_k),trans(N_k)) * itNode->GetValue(CONTACT_PRESSURE);
 
-    // Neighboring nodes:
-    for( auto& i_neighbour_node : itPatchNode->GetValue(NEIGHBOUR_NODES)) {
-        if (i_neighbour_node.Has(CONTACT_PRESSURE)){
-            const array_1d<double, 3>& normal_neigh_node = i_neighbour_node.GetValue(NORMAL);
-            const double x_patch = r_coordinates_patch_node[0];
-            const double y_patch = r_coordinates_patch_node[1];
-            const double x_neigh = i_neighbour_node.X();
-            const double y_neigh = i_neighbour_node.Y();
-            p_k(0,1)= x_neigh-x_patch;
-            p_k(0,2)= y_neigh-y_patch;
-            p_k(1,4)= x_neigh-x_patch;
-            p_k(1,5)= y_neigh-y_patch;
-            p_k(2,7)= x_neigh-x_patch;
-            p_k(2,8)= y_neigh-y_patch;
-            N_k(0,0) = normal_neigh_node[0]*normal_neigh_node[0];
-            N_k(0,1) = normal_neigh_node[1]*normal_neigh_node[1];
-            N_k(0,2) = 2*normal_neigh_node[0]*normal_neigh_node[1];
-            T_k1(0,0) = normal_neigh_node[0]*normal_neigh_node[1];
-            T_k1(0,1) = -normal_neigh_node[0]*normal_neigh_node[1];
-            T_k1(0,2) = normal_neigh_node[1]*normal_neigh_node[1]-normal_neigh_node[0]*normal_neigh_node[0];
+        //PART 2: Contributions from contact nodes: regard all nodes from the patch which are in contact
+        // Patch center node:
+        if (itPatchNode->Has(CONTACT_PRESSURE)){
+            const array_1d<double, 3>& r_normal_patch_node = itPatchNode->FastGetSolutionStepValue(NORMAL);
+            p_k(0,1)=0.0;
+            p_k(0,2)=0.0;
+            p_k(1,4)=0.0;
+            p_k(1,5)=0.0;
+            p_k(2,7)=0.0;
+            p_k(2,8)=0.0;
+            N_k(0,0) = r_normal_patch_node[0]*r_normal_patch_node[0];
+            N_k(0,1) = r_normal_patch_node[1]*r_normal_patch_node[1];
+            N_k(0,2) = 2.0 * r_normal_patch_node[0]*r_normal_patch_node[1];
+            T_k1(0,0) =  r_normal_patch_node[0]*r_normal_patch_node[1];
+            T_k1(0,1) = -r_normal_patch_node[0]*r_normal_patch_node[1];
+            T_k1(0,2) =  r_normal_patch_node[1]*r_normal_patch_node[1]-r_normal_patch_node[0]*r_normal_patch_node[0];
 
             noalias(A1) = prod(trans(p_k),trans(N_k));
             noalias(A2) = prod(N_k,p_k);
@@ -239,33 +205,72 @@ void ContactSPRErrorProcess<TDim>::CalculatePatch(
 
             // Finally we add the contributiosn to our local system (A, b)
             noalias(A) += mPenaltyTangent*prod(A1, A2);
-            noalias(b) += mPenaltyNormal*prod(trans(p_k),trans(N_k))*i_neighbour_node.GetValue(CONTACT_PRESSURE);
+            // NOTE: Code commented. Could be of interest in the future
+    //         noalias(A) += mPenaltyNormal*prod(prod(trans(p_k),trans(N_k)),prod(N_k,p_k));
+    //         noalias(A) += mPenaltyTangent*prod(prod(prod(trans(p_k),trans(T_k1)),T_k1),p_k);
+            noalias(b) -= mPenaltyNormal*prod(trans(p_k),trans(N_k))*itPatchNode->GetValue(CONTACT_PRESSURE);
         }
+
+        // Neighboring nodes:
+        for( auto& i_neighbour_node : itPatchNode->GetValue(NEIGHBOUR_NODES)) {
+            if (i_neighbour_node.Has(CONTACT_PRESSURE)){
+                const array_1d<double, 3>& normal_neigh_node = i_neighbour_node.GetValue(NORMAL);
+                const double x_patch = r_coordinates_patch_node[0];
+                const double y_patch = r_coordinates_patch_node[1];
+                const double x_neigh = i_neighbour_node.X();
+                const double y_neigh = i_neighbour_node.Y();
+                p_k(0,1)= x_neigh-x_patch;
+                p_k(0,2)= y_neigh-y_patch;
+                p_k(1,4)= x_neigh-x_patch;
+                p_k(1,5)= y_neigh-y_patch;
+                p_k(2,7)= x_neigh-x_patch;
+                p_k(2,8)= y_neigh-y_patch;
+                N_k(0,0) = normal_neigh_node[0]*normal_neigh_node[0];
+                N_k(0,1) = normal_neigh_node[1]*normal_neigh_node[1];
+                N_k(0,2) = 2*normal_neigh_node[0]*normal_neigh_node[1];
+                T_k1(0,0) = normal_neigh_node[0]*normal_neigh_node[1];
+                T_k1(0,1) = -normal_neigh_node[0]*normal_neigh_node[1];
+                T_k1(0,2) = normal_neigh_node[1]*normal_neigh_node[1]-normal_neigh_node[0]*normal_neigh_node[0];
+
+                noalias(A1) = prod(trans(p_k),trans(N_k));
+                noalias(A2) = prod(N_k,p_k);
+                noalias(A) += mPenaltyNormal*prod(A1, A2);
+
+                noalias(A1) = prod(trans(p_k),trans(T_k1));
+                noalias(A2) = prod(T_k1,p_k);
+
+                // Finally we add the contributiosn to our local system (A, b)
+                noalias(A) += mPenaltyTangent*prod(A1, A2);
+                noalias(b) += mPenaltyNormal*prod(trans(p_k),trans(N_k))*i_neighbour_node.GetValue(CONTACT_PRESSURE);
+            }
+        }
+
+        // Computing coefficients a: A*a=b
+        KRATOS_INFO_IF("ContactSPRErrorProcess", BaseType::mEchoLevel > 3) << A << std::endl;
+
+        Vector coeff(SigmaSize * (TDim+1));
+        const Vector& r_b_vector = column(b, 0);
+        MathUtils<double>::Solve(A, coeff, r_b_vector);
+
+        for (IndexType j = 0; j < SigmaSize;++j){
+            p_k(j,j*(TDim + 1) + 1) = r_coordinates[0] - r_coordinates_patch_node[0];
+            p_k(j,j*(TDim + 1) + 2) = r_coordinates[1] - r_coordinates_patch_node[1];
+            if (TDim == 3)
+                p_k(j,j*(TDim + 1) + 3) = r_coordinates[2] - r_coordinates_patch_node[2];
+        }
+
+        BoundedMatrix<double, SigmaSize*(TDim + 1), 1> coeff_matrix;
+        for (IndexType i=0; i<SigmaSize*(TDim + 1); ++i)
+            coeff_matrix(i, 0) = coeff[i];
+
+        // Asssign the stress recovered
+        noalias(sigma) = prod(p_k, coeff_matrix);
+        noalias(rSigmaRecovered) = column(sigma,0);
+
+        KRATOS_INFO_IF("ContactSPRErrorProcess", BaseType::mEchoLevel > 1) <<" Recovered pressure: "<< prod(N_k,sigma) <<", LM: "<<itNode->GetValue(CONTACT_PRESSURE)<<std::endl;
+    } else { // Regular node
+        BaseType::CalculatePatch(itNode, itPatchNode, NeighbourSize, rSigmaRecovered);
     }
-
-    // Computing coefficients a: A*a=b
-    KRATOS_INFO_IF("ContactSPRErrorProcess", BaseType::mEchoLevel > 3) << A << std::endl;
-
-    Vector coeff(SigmaSize * (TDim+1));
-    const Vector& r_b_vector = column(b, 0);
-    MathUtils<double>::Solve(A, coeff, r_b_vector);
-
-    for (IndexType j = 0; j < SigmaSize;++j){
-        p_k(j,j*(TDim + 1) + 1) = r_coordinates[0] - r_coordinates_patch_node[0];
-        p_k(j,j*(TDim + 1) + 2) = r_coordinates[1] - r_coordinates_patch_node[1];
-        if (TDim == 3)
-            p_k(j,j*(TDim + 1) + 3) = r_coordinates[2] - r_coordinates_patch_node[2];
-    }
-
-    BoundedMatrix<double, SigmaSize*(TDim + 1), 1> coeff_matrix;
-    for (IndexType i=0; i<SigmaSize*(TDim + 1); ++i)
-        coeff_matrix(i, 0) = coeff[i];
-
-    // Asssign the stress recovered
-    noalias(sigma) = prod(p_k, coeff_matrix);
-    noalias(rSigmaRecovered) = column(sigma,0);
-
-    KRATOS_INFO_IF("ContactSPRErrorProcess", BaseType::mEchoLevel > 1) <<" Recovered pressure: "<< prod(N_k,sigma) <<", LM: "<<itNode->GetValue(CONTACT_PRESSURE)<<std::endl;
 }
 
 /***********************************************************************************/

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
@@ -58,7 +58,7 @@ void ContactSPRErrorProcess<TDim>::CalculatePatch(
     )
 {
     // Contact interface node
-    if (itNode->Is(INTERFACE)) {
+    if (itNode->Is(CONTACT)) {
         // Triangle and tetrahedra have only one GP by default
         std::vector<Vector> stress_vector(1);
         std::vector<array_1d<double,3>> coordinates_vector(1);

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
@@ -41,7 +41,7 @@ ContactSPRErrorProcess<TDim>::ContactSPRErrorProcess(
     mPenaltyNormal = ThisParameters["penalty_normal"].GetDouble();
     mPenaltyTangent = ThisParameters["penalty_tangential"].GetDouble();
 
-    BaseType::mStressVariable = KratosComponents<Variable<Vector>>::Get(ThisParameters["stress_vector_variable"].GetString());
+    BaseType::mpStressVariable = &const_cast<Variable<Vector>&>(KratosComponents<Variable<Vector>>::Get(ThisParameters["stress_vector_variable"].GetString()));
     BaseType::mEchoLevel = ThisParameters["echo_level"].GetInt();
 }
 
@@ -80,7 +80,7 @@ void ContactSPRErrorProcess<TDim>::CalculatePatch(
     for( WeakElementItType it_elem = r_neigh_elements.begin(); it_elem != r_neigh_elements.end(); ++it_elem) {
 
         auto& r_process_info = BaseType::mThisModelPart.GetProcessInfo();
-        it_elem->GetValueOnIntegrationPoints(BaseType::mStressVariable,stress_vector, r_process_info);
+        it_elem->GetValueOnIntegrationPoints(*BaseType::mpStressVariable,stress_vector, r_process_info);
         it_elem->GetValueOnIntegrationPoints(INTEGRATION_COORDINATES, coordinates_vector, r_process_info);
 
         KRATOS_INFO_IF("ContactSPRErrorProcess", BaseType::mEchoLevel > 3)

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
@@ -38,6 +38,7 @@ ContactSPRErrorProcess<TDim>::ContactSPRErrorProcess(
 
     ThisParameters.ValidateAndAssignDefaults(default_parameters);
 
+    // Penalty values
     mPenaltyNormal = ThisParameters["penalty_normal"].GetDouble();
     mPenaltyTangent = ThisParameters["penalty_tangential"].GetDouble();
 

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
@@ -180,19 +180,19 @@ void ContactSPRErrorProcess<TDim>::CalculatePatch(
     //PART 2: Contributions from contact nodes: regard all nodes from the patch which are in contact
     // Patch center node:
     if (itPatchNode->Has(CONTACT_PRESSURE)){
-        const array_1d<double, 3>& normal_patch_node = itPatchNode->FastGetSolutionStepValue(NORMAL);
+        const array_1d<double, 3>& r_normal_patch_node = itPatchNode->FastGetSolutionStepValue(NORMAL);
         p_k(0,1)=0.0;
         p_k(0,2)=0.0;
         p_k(1,4)=0.0;
         p_k(1,5)=0.0;
         p_k(2,7)=0.0;
         p_k(2,8)=0.0;
-        N_k(0,0) = normal_patch_node[0]*normal_patch_node[0];
-        N_k(0,1) = normal_patch_node[1]*normal_patch_node[1];
-        N_k(0,2) = 2.0 * normal_patch_node[0]*normal_patch_node[1];
-        T_k1(0,0) =  normal_patch_node[0]*normal_patch_node[1];
-        T_k1(0,1) = -normal_patch_node[0]*normal_patch_node[1];
-        T_k1(0,2) =  normal_patch_node[1]*normal_patch_node[1]-normal_patch_node[0]*normal_patch_node[0];
+        N_k(0,0) = r_normal_patch_node[0]*r_normal_patch_node[0];
+        N_k(0,1) = r_normal_patch_node[1]*r_normal_patch_node[1];
+        N_k(0,2) = 2.0 * r_normal_patch_node[0]*r_normal_patch_node[1];
+        T_k1(0,0) =  r_normal_patch_node[0]*r_normal_patch_node[1];
+        T_k1(0,1) = -r_normal_patch_node[0]*r_normal_patch_node[1];
+        T_k1(0,2) =  r_normal_patch_node[1]*r_normal_patch_node[1]-r_normal_patch_node[0]*r_normal_patch_node[0];
 
         noalias(A1) = prod(trans(p_k),trans(N_k));
         noalias(A2) = prod(N_k,p_k);

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
@@ -52,7 +52,7 @@ template<SizeType TDim>
 void ContactSPRErrorProcess<TDim>::CalculatePatch(
     NodeItType itNode,
     NodeItType itPatchNode,
-    SizeType NeighbourSize,
+    const SizeType NeighbourSize,
     Vector& rSigmaRecovered
     )
 {

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.cpp
@@ -247,7 +247,7 @@ void ContactSPRErrorProcess<TDim>::CalculatePatch(
     KRATOS_INFO_IF("ContactSPRErrorProcess", BaseType::mEchoLevel > 3) << A << std::endl;
 
     Vector coeff(SigmaSize * (TDim+1));
-    const Vector& r_b_vector = row(b, 0);
+    const Vector& r_b_vector = column(b, 0);
     MathUtils<double>::Solve(A, coeff, r_b_vector);
 
     for (IndexType j = 0; j < SigmaSize;++j){
@@ -263,7 +263,7 @@ void ContactSPRErrorProcess<TDim>::CalculatePatch(
 
     // Asssign the stress recovered
     noalias(sigma) = prod(p_k, coeff_matrix);
-    noalias(rSigmaRecovered) = row(sigma,0);
+    noalias(rSigmaRecovered) = column(sigma,0);
 
     KRATOS_INFO_IF("ContactSPRErrorProcess", BaseType::mEchoLevel > 1) <<" Recovered pressure: "<< prod(N_k,sigma) <<", LM: "<<itNode->GetValue(CONTACT_PRESSURE)<<std::endl;
 }

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.h
@@ -77,7 +77,7 @@ public:
     typedef Node <3>                                                                NodeType;
 
     /// Definition of the iterators
-    typedef GlobalPointersVector< Element >::iterator                         WeakElementItType;
+    typedef GlobalPointersVector< Element >::iterator                      WeakElementItType;
     typedef NodesArrayType::iterator                                              NodeItType;
     typedef ElementsArrayType::iterator                                        ElementItType;
 
@@ -95,18 +95,17 @@ public:
     ///@{
 
     /**
-     * This is the default constructor
+     * @brief This is the default constructor
      * @param rThisModelPart The model part to be computed
      * @param ThisParameters The input parameters
      */
-
     ContactSPRErrorProcess(
         ModelPart& rThisModelPart,
         Parameters ThisParameters = Parameters(R"({})")
         );
 
     /// Destructor.
-    virtual ~ContactSPRErrorProcess() {}
+    ~ContactSPRErrorProcess() override {}
 
     ///@}
     ///@name Operators
@@ -114,7 +113,7 @@ public:
 
     void operator()()
     {
-        BaseType::Execute();
+        this->Execute();
     }
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.h
@@ -136,19 +136,19 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    virtual std::string Info() const override
+    std::string Info() const override
     {
         return "ContactSPRErrorProcess";
     }
 
     /// Print information about this object.
-    virtual void PrintInfo(std::ostream& rOStream) const override
+    void PrintInfo(std::ostream& rOStream) const override
     {
         rOStream << "ContactSPRErrorProcess";
     }
 
     /// Print object"s data.
-    virtual void PrintData(std::ostream& rOStream) const override
+    void PrintData(std::ostream& rOStream) const override
     {
     }
 
@@ -181,7 +181,7 @@ protected:
     void CalculatePatch(
         NodeItType itNode,
         NodeItType itPatchNode,
-        SizeType NeighbourSize,
+        const SizeType NeighbourSize,
         Vector& rSigmaRecovered
         ) override;
 

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/contact_spr_error_process.h
@@ -220,6 +220,20 @@ private:
     ///@name Private Operations
     ///@{
 
+    /**
+     * @brief This method computes the tangents and normal matrices
+     * @param rNk Normal matrix
+     * @param rTk1 First tangent matrix
+     * @param rTk2 Second tangent matrix
+     * @param rNormal The normal vector
+     */
+    void ComputeNormalTangentMatrices(
+        BoundedMatrix<double, 1, SigmaSize>& rNk,
+        BoundedMatrix<double, 1, SigmaSize>& rTk1,
+        BoundedMatrix<double, 1, SigmaSize>& rTk2,
+        const array_1d<double, 3>& rNormal
+        );
+
     ///@}
     ///@name Private  Access
     ///@{

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/contact_error_mesh_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/contact_error_mesh_criteria.h
@@ -174,10 +174,10 @@ public:
 
         // Computing error
         if (process_info[DOMAIN_SIZE] == 2) {
-            SPRErrorProcess<2> compute_error_process = ContactSPRErrorProcess<2>(rModelPart, mThisParameters["compute_error_extra_parameters"]);
+            auto compute_error_process = ContactSPRErrorProcess<2>(rModelPart, mThisParameters["compute_error_extra_parameters"]);
             compute_error_process.Execute();
         } else {
-            SPRErrorProcess<3> compute_error_process = ContactSPRErrorProcess<3>(rModelPart, mThisParameters["compute_error_extra_parameters"]);
+            auto compute_error_process = ContactSPRErrorProcess<3>(rModelPart, mThisParameters["compute_error_extra_parameters"]);
             compute_error_process.Execute();
         }
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/contact_error_mesh_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/contact_error_mesh_criteria.h
@@ -170,10 +170,10 @@ public:
         ) override
     {
         // The process info
-        const ProcessInfo& process_info = rModelPart.GetProcessInfo();
+        const ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
 
         // Computing error
-        if (process_info[DOMAIN_SIZE] == 2) {
+        if (r_process_info[DOMAIN_SIZE] == 2) {
             auto compute_error_process = ContactSPRErrorProcess<2>(rModelPart, mThisParameters["compute_error_extra_parameters"]);
             compute_error_process.Execute();
         } else {
@@ -182,16 +182,16 @@ public:
         }
 
         // We get the estimated error
-        const double estimated_error = process_info[ERROR_RATIO];
+        const double estimated_error = r_process_info[ERROR_RATIO];
 
         // We check if converged
         const bool converged_error = (estimated_error > mErrorTolerance) ? false : true;
 
         if (converged_error) {
-            KRATOS_INFO_IF("ContactErrorMeshCriteria", rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) << "NL ITERATION: " << process_info[NL_ITERATION_NUMBER] << "\tThe error due to the mesh size: " << estimated_error << " is under the tolerance prescribed: " << mErrorTolerance << ". " << BOLDFONT(FGRN("No remeshing required")) << std::endl;
+            KRATOS_INFO_IF("ContactErrorMeshCriteria", rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0) << "NL ITERATION: " << r_process_info[NL_ITERATION_NUMBER] << "\tThe error due to the mesh size: " << estimated_error << " is under the tolerance prescribed: " << mErrorTolerance << ". " << BOLDFONT(FGRN("No remeshing required")) << std::endl;
         } else {
             KRATOS_INFO_IF("ContactErrorMeshCriteria", rModelPart.GetCommunicator().MyPID() == 0 && this->GetEchoLevel() > 0)
-            << "NL ITERATION: " << process_info[NL_ITERATION_NUMBER] << "\tThe error due to the mesh size: " << estimated_error << " is bigger than the tolerance prescribed: " << mErrorTolerance << ". "<< BOLDFONT(FRED("Remeshing required")) << std::endl;
+            << "NL ITERATION: " << r_process_info[NL_ITERATION_NUMBER] << "\tThe error due to the mesh size: " << estimated_error << " is bigger than the tolerance prescribed: " << mErrorTolerance << ". "<< BOLDFONT(FRED("Remeshing required")) << std::endl;
         }
 
         return converged_error;

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/contact_error_mesh_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/contact_error_mesh_criteria.h
@@ -20,6 +20,7 @@
 /* Project includes */
 #include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
+#include "utilities/variable_utils.h"
 #include "utilities/color_utilities.h"
 #include "solving_strategies/convergencecriterias/convergence_criteria.h"
 
@@ -150,6 +151,11 @@ public:
     void Initialize(ModelPart& rModelPart) override
     {
         BaseType::Initialize(rModelPart);
+
+        // Update normal of the conditions
+        ModelPart& r_contact_model_part = rModelPart.GetSubModelPart("Contact");
+        VariableUtils().SetFlag(CONTACT, true, r_contact_model_part.Nodes());
+        VariableUtils().SetFlag(CONTACT, true, r_contact_model_part.Conditions());
     }
 
     /**

--- a/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/base_solid_element.cpp
@@ -770,8 +770,8 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
             //Calculate Cauchy Stresses from the FE solution
             std::vector<Vector> sigma_FE_solution(number_of_nodes);
-            Variable<Vector> variable_stress = CAUCHY_STRESS_VECTOR;
-            CalculateOnIntegrationPoints(variable_stress, sigma_FE_solution, rCurrentProcessInfo);
+            const Variable<Vector>& r_variable_stress = CAUCHY_STRESS_VECTOR;
+            CalculateOnIntegrationPoints(r_variable_stress, sigma_FE_solution, rCurrentProcessInfo);
 
             // calculate the determinatn of the Jacobian in the current configuration
             Vector detJ(integration_points.size());
@@ -797,9 +797,9 @@ void BaseSolidElement::CalculateOnIntegrationPoints(
 
                 // sigma_recovered = sum(N_i * sigma_recovered_i)
                 for (IndexType node_number=0; node_number<number_of_nodes; node_number++) {
-                    const auto& sigma_recovered_node = GetGeometry()[node_number].GetValue(RECOVERED_STRESS);
+                    const auto& r_sigma_recovered_node = GetGeometry()[node_number].GetValue(RECOVERED_STRESS);
                     for (IndexType stress_component = 0; stress_component<strain_size; stress_component++) {
-                        sigma_recovered[stress_component] += this_kinematic_variables.N[node_number] * sigma_recovered_node[stress_component];
+                        sigma_recovered[stress_component] += this_kinematic_variables.N[node_number] * r_sigma_recovered_node[stress_component];
                     }
                 }
 

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
@@ -140,19 +140,25 @@ void SPRErrorProcess<TDim>::CalculateErrorEstimation(
     )
 {
     // Loop over all elements:
-    ElementsArrayType& elements_array = mThisModelPart.Elements();
-    const int num_elem = static_cast<int>(elements_array.size());
+    ElementsArrayType& r_elements_array = mThisModelPart.Elements();
+    const int num_elem = static_cast<int>(r_elements_array.size());
+    const auto it_elem_begin = r_elements_array.begin();
+
+    // Process info
+    const auto& r_process_info = mThisModelPart.GetProcessInfo();
 
     // Compute the error estimate per element
     double error_overall= 0.0;
     double energy_norm_overall = 0.0;
-    #pragma omp parallel for reduction(+:error_overall, energy_norm_overall)
-    for(int i_elem = 0; i_elem < num_elem; ++i_elem){
-        auto it_elem = elements_array.begin() + i_elem;
 
-        std::vector<double> error_integration_point;
-        const auto& process_info = mThisModelPart.GetProcessInfo();
-        it_elem->GetValueOnIntegrationPoints(ERROR_INTEGRATION_POINT, error_integration_point, process_info);
+    // Auxiliar GP vectors
+    std::vector<double> error_integration_point, strain_energy;
+
+    #pragma omp parallel for reduction(+:error_overall, energy_norm_overall) firstprivate(error_integration_point,strain_energy)
+    for(int i_elem = 0; i_elem < num_elem; ++i_elem){
+        auto it_elem = it_elem_begin + i_elem;
+
+        it_elem->GetValueOnIntegrationPoints(ERROR_INTEGRATION_POINT, error_integration_point, r_process_info);
 
         // The error_integration_point is printed
         if (mEchoLevel > 2) {
@@ -163,20 +169,20 @@ void SPRErrorProcess<TDim>::CalculateErrorEstimation(
 
         // We compute the error overall
         double error_energy_norm = 0.0;
-        for(IndexType i = 0;i < error_integration_point.size();++i)
+        for(IndexType i = 0;i < error_integration_point.size();++i) {
             error_energy_norm += error_integration_point[i];
+        }
         error_overall += error_energy_norm;
         error_energy_norm = std::sqrt(error_energy_norm);
         it_elem->SetValue(ELEMENT_ERROR, error_energy_norm);
 
-
         // We compute now the energy norm
-        std::vector<double> strain_energy;
-        it_elem->GetValueOnIntegrationPoints(STRAIN_ENERGY, strain_energy, process_info);
+        it_elem->GetValueOnIntegrationPoints(STRAIN_ENERGY, strain_energy, r_process_info);
 
         double energy_norm = 0.0;
-        for(IndexType i = 0;i < strain_energy.size(); ++i)
+        for(IndexType i = 0;i < strain_energy.size(); ++i) {
             energy_norm += 2.0 * strain_energy[i];
+        }
         energy_norm_overall += energy_norm;
         energy_norm= std::sqrt(energy_norm);
 
@@ -185,7 +191,7 @@ void SPRErrorProcess<TDim>::CalculateErrorEstimation(
 
     rErrorOverall = std::sqrt(error_overall);
     rEnergyNormOverall = std::sqrt(energy_norm_overall);
-    double error_percentage = rErrorOverall/std::sqrt((std::pow(rErrorOverall, 2) + std::pow(rEnergyNormOverall, 2)));
+    const double error_percentage = rErrorOverall/std::sqrt((std::pow(rErrorOverall, 2) + std::pow(rEnergyNormOverall, 2)));
 
     KRATOS_INFO_IF("SPRErrorProcess", mEchoLevel > 1)
         << "Overall error norm: " << rErrorOverall << std::endl

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
@@ -200,7 +200,7 @@ template<SizeType TDim>
 void SPRErrorProcess<TDim>::CalculatePatch(
     NodeItType itNode,
     NodeItType itPatchNode,
-    SizeType NeighbourSize,
+    const SizeType NeighbourSize,
     Vector& rSigmaRecovered
     )
 {

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
@@ -36,7 +36,7 @@ SPRErrorProcess<TDim>::SPRErrorProcess(
 
     ThisParameters.ValidateAndAssignDefaults(default_parameters);
 
-    mStressVariable = KratosComponents<Variable<Vector>>::Get(ThisParameters["stress_vector_variable"].GetString());
+    mpStressVariable = &const_cast<Variable<Vector>&>(KratosComponents<Variable<Vector>>::Get(ThisParameters["stress_vector_variable"].GetString()));
     mEchoLevel = ThisParameters["echo_level"].GetInt();
 }
 
@@ -216,7 +216,7 @@ void SPRErrorProcess<TDim>::CalculatePatch(
     auto& neigh_elements = itPatchNode->GetValue(NEIGHBOUR_ELEMENTS);
     for( WeakElementItType it_elem = neigh_elements.begin(); it_elem != neigh_elements.end(); ++it_elem) {
 
-        it_elem->GetValueOnIntegrationPoints(mStressVariable,stress_vector,mThisModelPart.GetProcessInfo());
+        it_elem->GetValueOnIntegrationPoints(*mpStressVariable,stress_vector,mThisModelPart.GetProcessInfo());
         it_elem->GetValueOnIntegrationPoints(INTEGRATION_COORDINATES,coordinates_vector,mThisModelPart.GetProcessInfo());
 
         KRATOS_INFO_IF("SPRErrorProcess", mEchoLevel > 3)

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.cpp
@@ -95,7 +95,7 @@ void SPRErrorProcess<TDim>::CalculateSuperconvergentStresses()
         KRATOS_DEBUG_ERROR_IF_NOT(it_node->Has(NEIGHBOUR_ELEMENTS)) << "SPRErrorProcess:: Search didn't work with elements" << std::endl;
         const SizeType neighbour_size = it_node->GetValue(NEIGHBOUR_ELEMENTS).size();
 
-        Vector sigma_recovered(SigmaSize, 0.0);
+        Vector sigma_recovered = ZeroVector(SigmaSize);
 
         if(neighbour_size > TDim) {
             CalculatePatch(it_node, it_node, neighbour_size,sigma_recovered);
@@ -107,7 +107,7 @@ void SPRErrorProcess<TDim>::CalculateSuperconvergentStresses()
             auto& neigh_nodes = it_node->GetValue(NEIGHBOUR_NODES);
             for(auto it_neighbour_nodes = neigh_nodes.begin(); it_neighbour_nodes != neigh_nodes.end(); it_neighbour_nodes++) {
 
-                Vector sigma_recovered_i(SigmaSize,0);
+                Vector sigma_recovered_i = ZeroVector(SigmaSize);
 
                 IndexType count_i = 0;
                 for(int i_node_loop = 0; i_node_loop < num_nodes; ++i_node_loop) { // FIXME: Avoid this double loop, extreamily expensive

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
@@ -171,9 +171,9 @@ protected:
     ///@name Protected member Variables
     ///@{
 
-    ModelPart& mThisModelPart;                               /// The model part to compute
-    Variable<Vector> mStressVariable = CAUCHY_STRESS_VECTOR; /// The stress variable considered
-    SizeType mEchoLevel;                                     /// The echo level
+    ModelPart& mThisModelPart;                                 /// The model part to compute
+    Variable<Vector>* mpStressVariable = &CAUCHY_STRESS_VECTOR; /// The stress variable considered
+    SizeType mEchoLevel;                                       /// The echo level
 
     ///@}
     ///@name Protected Operators
@@ -209,7 +209,7 @@ protected:
     virtual void CalculatePatch(
         NodeItType itNode,
         NodeItType itPatchNode,
-        SizeType NeighbourSize,
+        const SizeType NeighbourSize,
         Vector& rSigmaRecovered
         );
 

--- a/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/spr_error_process.h
@@ -171,9 +171,9 @@ protected:
     ///@name Protected member Variables
     ///@{
 
-    ModelPart& mThisModelPart;                                 /// The model part to compute
+    ModelPart& mThisModelPart;                                  /// The model part to compute
     Variable<Vector>* mpStressVariable = &CAUCHY_STRESS_VECTOR; /// The stress variable considered
-    SizeType mEchoLevel;                                       /// The echo level
+    SizeType mEchoLevel;                                        /// The echo level
 
     ///@}
     ///@name Protected Operators


### PR DESCRIPTION
Fixes the following:
- It was considering normal as non-historical variable (legacy)
- The Voigt components of the 3D normal matrix were wrong
- Separate evaluation between CONTACT nodes and non-CONTACT nodes
- Avoid one downcast of the process that I found
- Several minor memory errors
- Some minor changes toward AMatrix
- Some minor changes related with the r_ style for reference variables
- Minor optimizations