### PR TITLE
refactor(HDF5): added docstrings and parameters wrapper

### DIFF
--- a/applications/HDF5Application/python_scripts/core/__init__.py
+++ b/applications/HDF5Application/python_scripts/core/__init__.py
@@ -2,11 +2,17 @@
 
 license: HDF5Application/license.txt
 '''
+
+
+__all__ = ["Factory"]
+
+
 import KratosMultiphysics
 from . import processes, controllers, operations, file_io, utils
+from .utils import ParametersWrapper
 
 
-def _CreateControllerWithFileIO(settings, model):
+def CreateControllerWithFileIO(settings, model):
     default_setter = utils.DefaultSetter(settings)
     default_setter.AddString(
         'model_part_name', 'PLEASE_SPECIFY_MODEL_PART_NAME')
@@ -21,14 +27,14 @@ def _CreateControllerWithFileIO(settings, model):
     return controllers.Create(model_part, file_io.Create(settings['io_settings']), settings['controller_settings'])
 
 
-def _AssignOperationsToController(operations_settings, controller):
+def AssignOperationsToController(operations_settings, controller):
     if not operations_settings.IsArray():
         raise ValueError('Expected settings as an array')
     for settings in operations_settings:
         controller.Add(operations.Create(settings))
 
 
-def _AssignControllerToProcess(settings, controller, process):
+def AssignControllerToProcess(settings, controller, process):
     process_step = settings['process_step'].GetString()
     if process_step == 'initialize':
         process.AddInitialize(controller)
@@ -55,10 +61,10 @@ def Factory(settings, model):
         raise ValueError('Expected settings as an array')
     if settings.size() == 0:
         settings.Append(KratosMultiphysics.Parameters())
-    process = processes.OrderedAggregationProcess()
+    process = processes.ControllerProcess()
     for current_settings in settings:
-        controller = _CreateControllerWithFileIO(current_settings, model)
-        _AssignOperationsToController(
+        controller = CreateControllerWithFileIO(current_settings, model)
+        AssignOperationsToController(
             current_settings['list_of_operations'], controller)
-        _AssignControllerToProcess(current_settings, controller, process)
+        AssignControllerToProcess(current_settings, controller, process)
     return process

--- a/applications/HDF5Application/python_scripts/core/controllers.py
+++ b/applications/HDF5Application/python_scripts/core/controllers.py
@@ -1,5 +1,8 @@
 '''HDF5 controllers.
 
+This module contains the controllers which control the frequency of HDF5 IO
+operations.
+
 license: HDF5Application/license.txt
 '''
 import KratosMultiphysics

--- a/applications/HDF5Application/python_scripts/core/file_io.py
+++ b/applications/HDF5Application/python_scripts/core/file_io.py
@@ -10,10 +10,10 @@ import os
 
 class _FileIO(object):
 
-    def _FileSettings(self, identifier):
+    def _FileSettings(self, model_part):
         settings = KratosMultiphysics.Parameters()
         settings.AddEmptyValue('file_name').SetString(
-            self.filename_getter.Get(identifier))
+            self.filename_getter.Get(model_part))
         settings.AddEmptyValue('file_access_mode').SetString(
             self.file_access_mode)
         settings.AddEmptyValue('file_driver').SetString(self.file_driver)
@@ -23,14 +23,14 @@ class _FileIO(object):
 
 class _HDF5SerialFileIO(_FileIO):
 
-    def Get(self, identifier=None):
-        return KratosHDF5.HDF5FileSerial(self._FileSettings(identifier))
+    def Get(self, model_part=None):
+        return KratosHDF5.HDF5FileSerial(self._FileSettings(model_part))
 
 
 class _HDF5ParallelFileIO(_FileIO):
 
-    def Get(self, identifier=None):
-        return KratosHDF5.HDF5FileParallel(self._FileSettings(identifier))
+    def Get(self, model_part=None):
+        return KratosHDF5.HDF5FileParallel(self._FileSettings(model_part))
 
 
 class _HDF5MockFileIO(_FileIO):
@@ -42,8 +42,8 @@ class _HDF5MockFileIO(_FileIO):
 
         def GetFileName(self): return self.file_name
 
-    def Get(self, identifier=None):
-        settings = self._FileSettings(identifier)
+    def Get(self, model_part=None):
+        settings = self._FileSettings(model_part)
         file_name = settings['file_name'].GetString()
         return self.MockFile(file_name)
 
@@ -86,14 +86,14 @@ class _FilenameGetter(object):
         else:
             self.time_format = ''
 
-    def Get(self, identifier=None):
-        if hasattr(identifier, 'ProcessInfo'):
-            time = identifier.ProcessInfo[KratosMultiphysics.TIME]
+    def Get(self, model_part=None):
+        if hasattr(model_part, 'ProcessInfo'):
+            time = model_part.ProcessInfo[KratosMultiphysics.TIME]
             filename = format(time, self.time_format).join(self.filename_parts)
         else:
             filename = ''.join(self.filename_parts)
-        if hasattr(identifier, 'Name'):
-            filename = filename.replace('<identifier>', identifier.Name)
+        if hasattr(model_part, 'Name'):
+            filename = filename.replace('<model_part_name>', model_part.Name)
         if not filename.endswith('.h5'):
             filename += '.h5'
         return filename
@@ -104,8 +104,8 @@ class _FilenameGetterWithDirectoryInitialization(object):
     def __init__(self, settings):
         self.filename_getter = _FilenameGetter(settings)
 
-    def Get(self, identifier=None):
-        file_name = self.filename_getter.Get(identifier)
+    def Get(self, model_part=None):
+        file_name = self.filename_getter.Get(model_part)
         self._InitializeDirectory(file_name)
         return file_name
 

--- a/applications/HDF5Application/python_scripts/core/operations/model_part.py
+++ b/applications/HDF5Application/python_scripts/core/operations/model_part.py
@@ -7,14 +7,14 @@ import KratosMultiphysics.HDF5Application as KratosHDF5
 from .. import utils as _utils
 from importlib import import_module
 
-def _Prefix(pattern, identifier, time_format=''):
-    if hasattr(identifier, 'ProcessInfo'):
-        time = identifier.ProcessInfo[KratosMultiphysics.TIME]
+def _Prefix(pattern, model_part, time_format=''):
+    if hasattr(model_part, 'ProcessInfo'):
+        time = model_part.ProcessInfo[KratosMultiphysics.TIME]
         prefix = format(time, time_format).join(pattern.split('<time>'))
     else:
         prefix = pattern
-    if hasattr(identifier, 'Name'):
-        prefix = prefix.replace('<identifier>', identifier.Name)
+    if hasattr(model_part, 'Name'):
+        prefix = prefix.replace('<model_part_name>', model_part.Name)
     return prefix
 
 

--- a/applications/HDF5Application/python_scripts/core/processes.py
+++ b/applications/HDF5Application/python_scripts/core/processes.py
@@ -1,11 +1,26 @@
 '''HDF5 core processes.
 
+This module only contains the most general HDF5 IO processes which should not
+change frequently.
+
 license: HDF5Application/license.txt
 '''
+
+
+__all__ = ["ControllerProcess"]
+
+
 import KratosMultiphysics
 
 
-class OrderedAggregationProcess(KratosMultiphysics.Process):
+class OrderedOperationProcess(KratosMultiphysics.Process):
+    """A process for grouping operations.
+    
+    This implements a whole-part structural decomposition. The members are
+    operations or function objects with no arguments. They may be attached
+    to any of the process steps during construction and are called in the same
+    order at the corresponding step of the solution algorithm.
+    """
 
     def __init__(self):
         KratosMultiphysics.Process.__init__(self)
@@ -74,3 +89,12 @@ class OrderedAggregationProcess(KratosMultiphysics.Process):
 
     def AddFinalize(self, func):
         self.finalize_sequence.append(func)
+
+
+class ControllerProcess(OrderedOperationProcess):
+    """A process for grouping controllers.
+    
+    This adds a shorter more specific name for the process that groups
+    controllers.
+    """
+    pass

--- a/applications/HDF5Application/python_scripts/core/utils.py
+++ b/applications/HDF5Application/python_scripts/core/utils.py
@@ -2,6 +2,12 @@
 
 license: HDF5Application/license.txt
 '''
+
+
+__all__ = ['DefaultSetter', 'ParametersWrapper']
+
+
+from collections import Mapping
 import KratosMultiphysics
 
 
@@ -51,3 +57,91 @@ class DefaultSetter(object):
             array = self.settings[key]
             for value in values:
                 array.Append(value)
+
+
+class ParametersWrapper(Mapping):
+    '''A pythonic wrapper to KratosMultiphysics.Parameters.
+
+    The idea is to reduce boilerplate and improve call-site readability by
+    making Parameters more pythonic without breaking existing code.
+    '''
+
+    @property
+    def parameters(self):
+        return self._kratos_parameters
+
+    def __init__(self, params):
+        if isinstance(params, self.__class__):
+            self._kratos_parameters = params.parameters
+        elif isinstance(params, str):
+            self._kratos_parameters = KratosMultiphysics.Parameters(params)
+        else:
+            self._kratos_parameters = params
+
+    def __getitem__(self, key):
+        try:
+            param = self.parameters[key]
+        except:
+            raise KeyError
+        if param.IsString():
+            value = param.GetString()
+        elif param.IsDouble():
+            value = param.GetDouble()
+        elif param.IsBool():
+            value = param.GetBool()
+        elif param.IsInt():
+            value = param.GetInt()
+        else:
+            value = self.__class__(param)
+        return value
+
+    def convert_list_to_parameters(self, list_):
+        dummy_params = KratosMultiphysics.Parameters()
+        dummy_params.AddEmptyList('list')
+        params = dummy_params['list']
+        for v in list_:
+            if isinstance(v, list):
+                params.Append(self.convert_list_to_parameters(v))
+            else:
+                params.Append(self.convert_value_to_parameters(v))
+        return params
+
+    def convert_value_to_parameters(self, value):
+        params = KratosMultiphysics.Parameters()
+        if isinstance(value, str):
+            params.SetString(value)
+        elif isinstance(value, float):
+            params.SetDouble(value)
+        elif isinstance(value, bool):
+            params.SetBool(value)
+        elif isinstance(value, int):
+            params.SetInt(value)
+        elif isinstance(value, KratosMultiphysics.Parameters):
+            params = value
+        elif isinstance(value, self.__class__):
+            params = value.parameters
+        else:
+            raise TypeError()
+        return params
+
+    def __setitem__(self, key, value):
+        if isinstance(value, list):
+            params_object = self.convert_list_to_parameters(value)
+        else:
+            params_object = self.convert_value_to_parameters(value)
+        if self.parameters.IsArray() or self.parameters.Has(key):
+            self.parameters[key] = params_object
+        else:
+            self.parameters.AddValue(key, params_object)
+
+    def __iter__(self):
+        if self.parameters.IsArray():
+            yield from range(len(self))
+        else:
+            yield from self.parameters.keys()
+
+    def __len__(self):
+        return self.parameters.size()
+
+    def __str__(self):
+        return self.parameters.PrettyPrintJsonString()

--- a/applications/HDF5Application/python_scripts/initialization_from_hdf5_process.py
+++ b/applications/HDF5Application/python_scripts/initialization_from_hdf5_process.py
@@ -1,17 +1,67 @@
-'''Read model part data in the initialization step.
-
-This process provides the front end to the HDF5Application.core.
+"""Load simulation results in the initialization step from HDF5.
 
 license: HDF5Application/license.txt
-'''
+"""
+
+
+__all__ = ["Factory"]
+
+
 import KratosMultiphysics
-import KratosMultiphysics.HDF5Application.core as _core
-import KratosMultiphysics.HDF5Application.utils as _utils
+import KratosMultiphysics.HDF5Application.core as core
+from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
+from KratosMultiphysics.HDF5Application.utils import IsDistributed
+from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 
-def Factory(process_settings, Model):
-    """Return a process for initializing a model part from an existing HDF5 output file."""
-    default_settings = KratosMultiphysics.Parameters("""
+def Factory(settings, Model):
+    """Return the process for initialization from HDF5.
+    
+    The input settings are given in the following table:
+    +-------------------------------------+------------+---------------------------------+
+    | Setting                             | Type       | Default Value                   |
+    +-------------------------------------+------------+---------------------------------+
+    | "model_part_name"                   | String     | ""                              |
+    +-------------------------------------+------------+---------------------------------+
+    | "file_settings"                     | Parameters | "file_name": "<model_part_name>"|
+    |                                     |            | "echo_level":  0                |
+    +-------------------------------------+------------+---------------------------------+
+    | "nodal_solution_step_data_settings" | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
+    | "nodal_data_value_settings"         | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
+    | "element_data_value_settings"       | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
+    """
+    core_settings = CreateCoreSettings(settings["Parameters"])
+    return InitializationFromHDF5ProcessFactory(core_settings, Model)
+
+
+def InitializationFromHDF5ProcessFactory(core_settings, Model):
+    return core.Factory(core_settings, Model)
+
+
+def CreateCoreSettings(user_settings):
+    """Return the core settings."""
+    # Configure the defaults:
+    core_settings = ParametersWrapper("""
+        [{
+            "model_part_name" : "",
+            "process_step": "initialize",
+            "io_settings": {
+                "io_type": "serial_hdf5_file_io",
+                "file_name": "<model_part_name>.h5",
+                "file_access_mode": "read_only"
+            },
+            "list_of_operations": []
+        }]
+        """)
+    # Apply the user settings:
+    user_settings.ValidateAndAssignDefaults(
+        KratosMultiphysics.Parameters("""
             {
                 "model_part_name" : "MainModelPart",
                 "file_settings" : {},
@@ -19,38 +69,22 @@ def Factory(process_settings, Model):
                 "nodal_data_value_settings": {},
                 "element_data_value_settings" : {}
             }
-            """)
-    settings = process_settings["Parameters"]
-    settings.ValidateAndAssignDefaults(default_settings)
-    new_settings = KratosMultiphysics.Parameters('''
-            {
-               "list_of_controllers": [{
-                    "model_part_name" : "",
-                    "process_step": "initialize",
-                    "io_settings": {
-                        "io_type": "serial_hdf5_file_io",
-                        "file_name": "<identifier>.h5",
-                        "file_access_mode": "read_only"
-                    },
-                    "list_of_operations": [{
-                        "operation_type": "nodal_solution_step_data_input"
-                    },{
-                        "operation_type": "nodal_data_value_input"
-                    },{
-                        "operation_type": "element_data_value_input"
-                    }]
-                }]
-            }
-            ''')
-    model_part_name = settings["model_part_name"].GetString()
-    new_settings["list_of_controllers"][0]["model_part_name"].SetString(
-        model_part_name)
-    results_settings = new_settings["list_of_controllers"][0]
-    _utils.InsertSettings(
-        settings["file_settings"], results_settings["io_settings"])
-    if _utils.IsDistributed():
-        results_settings["io_settings"]["io_type"].SetString(
-            "parallel_hdf5_file_io")
-    _utils.InsertArrayOfSettings([settings["nodal_solution_step_data_settings"], settings["nodal_data_value_settings"],
-                                  settings["element_data_value_settings"]], results_settings["list_of_operations"])
-    return _core.Factory(new_settings["list_of_controllers"], Model)
+            """))
+    user_settings = ParametersWrapper(user_settings)
+    core_settings[0]["model_part_name"] = user_settings["model_part_name"]
+    for key in user_settings["file_settings"]:
+        core_settings[0]["io_settings"][key] = user_settings["file_settings"][key]
+    core_settings[0]["file_access_mode"] = "read_only"
+    if IsDistributed():
+        core_settings[0]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
+    else:
+        core_settings[0]["io_settings"]["io_type"] = "serial_hdf5_file_io"
+    core_settings[0]["list_of_operations"] = [
+        CreateOperationSettings("nodal_solution_step_data_input",
+                                user_settings["nodal_solution_step_data_settings"]),
+        CreateOperationSettings("nodal_data_value_input",
+                                user_settings["nodal_data_value_settings"]),
+        CreateOperationSettings("element_data_value_input",
+                                user_settings["element_data_value_settings"])
+    ]
+    return core_settings.parameters

--- a/applications/HDF5Application/python_scripts/multiple_mesh_temporal_output_process.py
+++ b/applications/HDF5Application/python_scripts/multiple_mesh_temporal_output_process.py
@@ -1,89 +1,125 @@
-'''Write a model part and its data at the end of each solution step.
+"""Store a model part and simulation results after each solution step with HDF5.
 
-This process provides the front end to the HDF5Application.core.
+This process:
+ - stores the initial model part in an .h5 file.
+ - stores the current model part and historical and non-historical results in
+   one .h5 file per output step.
+
+This process works with or without MPI.
 
 license: HDF5Application/license.txt
-'''
+"""
+
+
+__all__ = ["Factory"]
+
+
 import KratosMultiphysics
-import KratosMultiphysics.HDF5Application.core as _core
-import KratosMultiphysics.HDF5Application.utils as _utils
+from KratosMultiphysics.HDF5Application import core
+from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
+from KratosMultiphysics.HDF5Application.utils import IsDistributed
+from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 
-def Factory(process_settings, Model):
-    """Return a process for writing simulation results for multiple meshes to HDF5."""
-    default_settings = KratosMultiphysics.Parameters("""
+def Factory(settings, Model):
+    """Return a process for multiple mesh temporal output with HDF5.
+    
+    The input settings are given in the following table:
+    +-------------------------------------+------------+---------------------------------+
+    | Setting                             | Type       | Default Value                   |
+    +-------------------------------------+------------+---------------------------------+
+    | "model_part_name"                   | String     | ""                              |
+    +-------------------------------------+------------+---------------------------------+
+    | "file_settings"                     | Parameters | "file_name": "<model_part_name>"|
+    |                                     |            | "time_format": "0.4f"           |
+    |                                     |            | "file_access_mode": "exclusive" |
+    |                                     |            | "echo_level":  0                |
+    +-------------------------------------+------------+---------------------------------+
+    | "output_time_settings"              | Parameters | "time_frequency": 1.0           |
+    |                                     |            | "step_frequency": 1             |
+    +-------------------------------------+------------+---------------------------------+
+    | "model_part_output_settings"        | Parameters | "prefix": "/ModelData"          |
+    +-------------------------------------+------------+---------------------------------+
+    | "nodal_solution_step_data_settings" | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
+    | "nodal_data_value_settings"         | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
+    | "element_data_value_settings"       | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
+    """
+    core_settings = CreateCoreSettings(settings["Parameters"])
+    return MultipleMeshTemporalOutputProcessFactory(core_settings, Model)
+
+
+def MultipleMeshTemporalOutputProcessFactory(core_settings, Model):
+    return core.Factory(core_settings, Model)
+
+
+def CreateCoreSettings(user_settings):
+    """Return the core settings.
+    
+    The core setting "io_type" cannot be overwritten by the user. It is
+    automatically set depending on whether or not MPI is used.
+    """
+    # Configure the defaults:
+    core_settings = ParametersWrapper("""
+        [{
+            "model_part_name" : "",
+            "process_step": "before_solution_loop",
+            "io_settings": {
+                "io_type": "serial_hdf5_file_io",
+                "file_name": "<model_part_name>-<time>.h5"
+            },
+            "list_of_operations": []
+        },{
+            "model_part_name" : "",
+            "process_step": "finalize_solution_step",
+            "controller_settings": {
+                "controller_type": "temporal_controller"
+            },
+            "io_settings": {
+                "io_type": "serial_hdf5_file_io",
+                "file_name": "<model_part_name>-<time>.h5"
+            },
+            "list_of_operations": []
+        }]
+        """)
+    # Apply the user settings:
+    user_settings.ValidateAndAssignDefaults(
+        KratosMultiphysics.Parameters("""
             {
                 "model_part_name" : "MainModelPart",
                 "file_settings" : {},
+                "output_time_settings" : {},
                 "model_part_output_settings" : {},
                 "nodal_solution_step_data_settings" : {},
                 "nodal_data_value_settings": {},
-                "element_data_value_settings" : {},
-                "output_time_settings" : {}
+                "element_data_value_settings" : {}
             }
             """)
-    settings = process_settings["Parameters"]
-    settings.ValidateAndAssignDefaults(default_settings)
-    new_settings = KratosMultiphysics.Parameters('''
-            {
-               "list_of_controllers": [{
-                    "model_part_name" : "",
-                    "process_step": "before_solution_loop",
-                    "io_settings": {
-                        "io_type": "serial_hdf5_file_io",
-                        "file_name": "<identifier>-<time>.h5"
-                    },
-                    "list_of_operations": [{
-                        "operation_type": "model_part_output"
-                    },{
-                        "operation_type": "nodal_solution_step_data_output"
-                    },{
-                        "operation_type": "nodal_data_value_output"
-                    },{
-                        "operation_type": "element_data_value_output"
-                    }]
-                },{
-                    "model_part_name" : "",
-                    "process_step": "finalize_solution_step",
-                    "controller_settings": {
-                        "controller_type": "temporal_controller"
-                    },
-                    "io_settings": {
-                        "io_type": "serial_hdf5_file_io",
-                        "file_name": "<identifier>-<time>.h5"
-                    },
-                    "list_of_operations": [{
-                        "operation_type": "model_part_output"
-                    },{
-                        "operation_type": "nodal_solution_step_data_output"
-                    },{
-                        "operation_type": "nodal_data_value_output"
-                    },{
-                        "operation_type": "element_data_value_output"
-                    }]
-                }]
-            }
-            ''')
-    model_part_name = settings["model_part_name"].GetString()
-    for current_settings in new_settings["list_of_controllers"]:
-        current_settings["model_part_name"].SetString(model_part_name)
-    model_part_settings = new_settings["list_of_controllers"][0]
-    results_settings = new_settings["list_of_controllers"][1]
-    for io_settings in [model_part_settings["io_settings"], results_settings["io_settings"]]:
-        _utils.InsertSettings(settings["file_settings"], io_settings)
-        if _utils.IsDistributed():
-            io_settings["io_type"].SetString("parallel_hdf5_file_io")
-    list_of_operations_settings = [settings["model_part_output_settings"], settings["nodal_solution_step_data_settings"],
-                                   settings["nodal_data_value_settings"], settings["element_data_value_settings"]]
-    _utils.InsertArrayOfSettings(
-        list_of_operations_settings, model_part_settings["list_of_operations"])
-    _utils.InsertArrayOfSettings(
-        list_of_operations_settings, results_settings["list_of_operations"])
-    output_time_settings = settings["output_time_settings"]
-    _utils.InsertSettings(output_time_settings,
-                          results_settings["controller_settings"])
-    _utils.CheckForDeprecatedFilename(
-        output_time_settings, __name__, model_part_settings["io_settings"], results_settings["io_settings"])
-    _utils.CheckForDeprecatedTemporalSettings(
-        output_time_settings, __name__, results_settings["controller_settings"])
-    return _core.Factory(new_settings["list_of_controllers"], Model)
+    )
+    user_settings = ParametersWrapper(user_settings)
+    for i in core_settings:
+        core_settings[i]["model_part_name"] = user_settings["model_part_name"]
+        for key in user_settings["file_settings"]:
+            core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
+        if IsDistributed():
+            core_settings[i]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
+        else:
+            core_settings[i]["io_settings"]["io_type"] = "serial_hdf5_file_io"
+        core_settings[i]["list_of_operations"] = [
+            CreateOperationSettings("model_part_output",
+                                    user_settings["model_part_output_settings"]),
+            CreateOperationSettings("nodal_solution_step_data_output",
+                                    user_settings["nodal_solution_step_data_settings"]),
+            CreateOperationSettings("nodal_data_value_output",
+                                    user_settings["nodal_data_value_settings"]),
+            CreateOperationSettings("element_data_value_output",
+                                    user_settings["element_data_value_settings"])
+        ]
+    for key in user_settings["output_time_settings"]:
+        core_settings[1]["controller_settings"][key] = user_settings["output_time_settings"][key]
+    return core_settings.parameters

--- a/applications/HDF5Application/python_scripts/single_mesh_primal_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_primal_output_process.py
@@ -1,95 +1,129 @@
-'''Write a model part once and its data at the end of each solution step.
+"""Store primal simulation results for a single mesh with HDF5.
 
-ACCELERATION is written in the Bossak weighted form. For all other variables
-the behavior is the same as single_mesh_temporal_output_process.
+This process:
+ - stores the initial model part in an .h5 file.
+ - stores historical and non-historical results in one .h5 file per output step.
+   The variable ACCELERATION is stored in Bossak weighted form for 
+   time-dependent adjoint simulations.
 
-This process provides the front end to the HDF5Application.core.
+This process works with or without MPI.
 
 license: HDF5Application/license.txt
-'''
+"""
+
+
+__all__ = ["Factory"]
+
+
 import KratosMultiphysics
-import KratosMultiphysics.HDF5Application.core as _core
-import KratosMultiphysics.HDF5Application.utils as _utils
+import KratosMultiphysics.HDF5Application.core as core
+from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
+from KratosMultiphysics.HDF5Application.utils import IsDistributed
+from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 
-def Factory(process_settings, Model):
-    """Return a process for writing Bossak primal results for a single mesh to HDF5."""
-    default_settings = KratosMultiphysics.Parameters("""
-            {
-                "model_part_name" : "MainModelPart",
-                "file_settings" : {},
-                "model_part_output_settings" : {},
-                "nodal_solution_step_data_settings" : {},
-                "nodal_data_value_settings": {},
-                "element_data_value_settings" : {},
-                "output_time_settings" : {}
-            }
-            """)
-    settings = process_settings["Parameters"]
-    if settings.Has("alpha_bossak"):
-        depr_msg = '\nDEPRECATION-WARNING: "alpha_bossak" should be specified in "nodal_solution_step_data_settings". This will be removed in the future!\n'
-        KratosMultiphysics.Logger.PrintWarning(__name__, depr_msg)
-        _utils.InsertSingleSetting(
-            settings["nodal_solution_step_data_settings"], "alpha_bossak", settings["alpha_bossak"])
-        settings.RemoveValue("alpha_bossak")
-    settings.ValidateAndAssignDefaults(default_settings)
-    new_settings = KratosMultiphysics.Parameters('''
-            {
-               "list_of_controllers": [{
-                    "model_part_name" : "",
-                    "process_step": "before_solution_loop",
-                    "io_settings": {
-                        "io_type": "serial_hdf5_file_io",
-                        "file_name": "<identifier>.h5"
-                    },
-                    "list_of_operations": [{
-                        "operation_type": "model_part_output"
-                    },{
-                        "operation_type": "primal_bossak_output"
-                    },{
-                        "operation_type": "nodal_data_value_output"
-                    },{
-                        "operation_type": "element_data_value_output"
-                    }]
-                },{
-                    "model_part_name" : "",
-                    "process_step": "finalize_solution_step",
-                    "controller_settings": {
-                        "controller_type": "temporal_controller"
-                    },
-                    "io_settings": {
-                        "io_type": "serial_hdf5_file_io",
-                        "file_name": "<identifier>-<time>.h5"
-                    },
-                    "list_of_operations": [{
-                        "operation_type": "primal_bossak_output"
-                    },{
-                        "operation_type": "nodal_data_value_output"
-                    },{
-                        "operation_type": "element_data_value_output"
-                    }]
-                }]
-            }
-            ''')
-    model_part_name = settings["model_part_name"].GetString()
-    for current_settings in new_settings["list_of_controllers"]:
-        current_settings["model_part_name"].SetString(model_part_name)
-    model_part_settings = new_settings["list_of_controllers"][0]
-    results_settings = new_settings["list_of_controllers"][1]
-    for io_settings in [model_part_settings["io_settings"], results_settings["io_settings"]]:
-        _utils.InsertSettings(settings["file_settings"], io_settings)
-        if _utils.IsDistributed():
-            io_settings["io_type"].SetString("parallel_hdf5_file_io")
-    _utils.InsertArrayOfSettings(
-        [settings["model_part_output_settings"], settings["nodal_solution_step_data_settings"], settings["nodal_data_value_settings"],
-         settings["element_data_value_settings"]], model_part_settings["list_of_operations"])
-    _utils.InsertArrayOfSettings([settings["nodal_solution_step_data_settings"], settings["nodal_data_value_settings"],
-                                  settings["element_data_value_settings"]], results_settings["list_of_operations"])
-    output_time_settings = settings["output_time_settings"]
-    _utils.InsertSettings(output_time_settings,
-                          results_settings["controller_settings"])
-    _utils.CheckForDeprecatedFilename(
-        output_time_settings, __name__, model_part_settings["io_settings"], results_settings["io_settings"])
-    _utils.CheckForDeprecatedTemporalSettings(
-        output_time_settings, __name__, results_settings["controller_settings"])
-    return _core.Factory(new_settings["list_of_controllers"], Model)
+def Factory(settings, Model):
+    """Return a process for single mesh primal output with HDF5.
+    
+    The input settings are given in the following table:
+    +-------------------------------------+------------+---------------------------------+
+    | Setting                             | Type       | Default Value                   |
+    +-------------------------------------+------------+---------------------------------+
+    | "model_part_name"                   | String     | ""                              |
+    +-------------------------------------+------------+---------------------------------+
+    | "file_settings"                     | Parameters | "file_name": "<model_part_name>"|
+    |                                     |            | "time_format": "0.4f"           |
+    |                                     |            | "file_access_mode": "exclusive" |
+    |                                     |            | "echo_level":  0                |
+    +-------------------------------------+------------+---------------------------------+
+    | "output_time_settings"              | Parameters | "time_frequency": 1.0           |
+    |                                     |            | "step_frequency": 1             |
+    +-------------------------------------+------------+---------------------------------+
+    | "model_part_output_settings"        | Parameters | "prefix": "/ModelData"          |
+    +-------------------------------------+------------+---------------------------------+
+    | "nodal_solution_step_data_settings" | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    |                                     |            | "alpha_bossak": -0.3            |
+    +-------------------------------------+------------+---------------------------------+
+    | "nodal_data_value_settings"         | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
+    | "element_data_value_settings"       | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
+    """
+    core_settings = CreateCoreSettings(settings["Parameters"])
+    return SingleMeshPrimalOutputProcessFactory(core_settings, Model)
+
+
+def SingleMeshPrimalOutputProcessFactory(core_settings, Model):
+    return core.Factory(core_settings, Model)
+
+
+def CreateCoreSettings(user_settings):
+    """Return the core settings.
+    
+    The core setting "io_type" cannot be overwritten by the user. It is
+    automatically set depending on whether or not MPI is used.
+    """
+    # Configure the defaults:
+    core_settings = ParametersWrapper("""
+        [{
+            "model_part_name": "",
+            "process_step": "before_solution_loop",
+            "io_settings": {
+                "io_type": "serial_hdf5_file_io",
+                "file_name": "<model_part_name>.h5"
+            },
+            "list_of_operations": []
+        },{
+            "model_part_name" : "",
+            "process_step": "finalize_solution_step",
+            "controller_settings": {
+                "controller_type": "temporal_controller"
+            },
+            "io_settings": {
+                "io_type": "serial_hdf5_file_io",
+                "file_name": "<model_part_name>-<time>.h5"
+            },
+            "list_of_operations": []
+        }]
+        """)
+    # Apply the user settings:
+    user_settings.ValidateAndAssignDefaults(
+        KratosMultiphysics.Parameters("""
+        {
+            "model_part_name" : "MainModelPart",
+            "file_settings" : {},
+            "output_time_settings" : {},
+            "model_part_output_settings" : {},
+            "nodal_solution_step_data_settings" : {},
+            "nodal_data_value_settings": {},
+            "element_data_value_settings" : {}
+        }
+        """))
+    user_settings = ParametersWrapper(user_settings)
+    for i in core_settings:
+        core_settings[i]["model_part_name"] = user_settings["model_part_name"]
+        for key in user_settings["file_settings"]:
+            core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
+    if IsDistributed():
+        core_settings[0]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
+        core_settings[1]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
+    else:
+        core_settings[0]["io_settings"]["io_type"] = "serial_hdf5_file_io"
+        core_settings[1]["io_settings"]["io_type"] = "serial_hdf5_file_io"
+    core_settings[0]["list_of_operations"] = [
+        CreateOperationSettings("model_part_output", user_settings["model_part_output_settings"]),
+        CreateOperationSettings("primal_bossak_output", user_settings["nodal_solution_step_data_settings"]),
+        CreateOperationSettings("nodal_data_value_output", user_settings["nodal_data_value_settings"]),
+        CreateOperationSettings("element_data_value_output", user_settings["element_data_value_settings"])
+    ]
+    core_settings[1]["list_of_operations"] = [
+        CreateOperationSettings("primal_bossak_output", user_settings["nodal_solution_step_data_settings"]),
+        CreateOperationSettings("nodal_data_value_output", user_settings["nodal_data_value_settings"]),
+        CreateOperationSettings("element_data_value_output", user_settings["element_data_value_settings"])
+    ]
+    for key in user_settings["output_time_settings"]:
+        core_settings[1]["controller_settings"][key] = user_settings["output_time_settings"][key]
+    return core_settings.parameters

--- a/applications/HDF5Application/python_scripts/single_mesh_temporal_input_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_temporal_input_process.py
@@ -1,17 +1,70 @@
-'''Read model part data at the start of each solution step.
+"""Load simulation results before each solution step for a single mesh from HDF5.
 
-This process provides the front end to the HDF5Application.core.
+This process works with or without MPI.
 
 license: HDF5Application/license.txt
-'''
+"""
+
+
+__all__ = ["Factory"]
+
+
 import KratosMultiphysics
-import KratosMultiphysics.HDF5Application.core as _core
-import KratosMultiphysics.HDF5Application.utils as _utils
+import KratosMultiphysics.HDF5Application.core as core
+from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
+from KratosMultiphysics.HDF5Application.utils import IsDistributed
+from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 
-def Factory(process_settings, Model):
-    """Return a process to read a transient solution from HDF5."""
-    default_settings = KratosMultiphysics.Parameters("""
+def Factory(settings, Model):
+    """Return the process for single mesh temporal input with HDF5.
+    
+    The input settings are given in the following table:
+    +-------------------------------------+------------+-----------------------------------------+
+    | Setting                             | Type       | Default Value                           |
+    +-------------------------------------+------------+-----------------------------------------+
+    | "model_part_name"                   | String     | ""                                      |
+    +-------------------------------------+------------+-----------------------------------------+
+    | "file_settings"                     | Parameters | "file_name": "<model_part_name>-<time>" |
+    |                                     |            | "time_format": "0.4f"                   |
+    |                                     |            | "echo_level":  0                        |
+    +-------------------------------------+------------+-----------------------------------------+
+    | "nodal_solution_step_data_settings" | Parameters | "prefix": "/ResultsData"                |
+    |                                     |            | "list_of_variables": []                 |
+    +-------------------------------------+------------+-----------------------------------------+
+    | "nodal_data_value_settings"         | Parameters | "prefix": "/ResultsData"                |
+    |                                     |            | "list_of_variables": []                 |
+    +-------------------------------------+------------+-----------------------------------------+
+    | "element_data_value_settings"       | Parameters | "prefix": "/ResultsData"                |
+    |                                     |            | "list_of_variables": []                 |
+    +-------------------------------------+------------+-----------------------------------------+
+    """
+    core_settings = CreateCoreSettings(settings["Parameters"])
+    return SingleMeshTemporalInputProcessFactory(core_settings, Model)
+
+
+def SingleMeshTemporalInputProcessFactory(core_settings, Model):
+    return core.Factory(core_settings, Model)
+
+
+def CreateCoreSettings(user_settings):
+    """Return the core settings."""
+    # Configure the defaults:
+    core_settings = ParametersWrapper("""
+        [{
+            "model_part_name" : "",
+            "process_step": "initialize_solution_step",
+            "io_settings": {
+                "io_type": "serial_hdf5_file_io",
+                "file_name": "<model_part_name>-<time>.h5",
+                "file_access_mode": "read_only"
+            },
+            "list_of_operations": []
+        }]
+        """)
+    # Apply the user settings:
+    user_settings.ValidateAndAssignDefaults(
+        KratosMultiphysics.Parameters("""
             {
                 "model_part_name" : "MainModelPart",
                 "file_settings" : {},
@@ -20,44 +73,21 @@ def Factory(process_settings, Model):
                 "element_data_value_settings" : {}
             }
             """)
-    new_settings = KratosMultiphysics.Parameters('''
-            {
-               "list_of_controllers": [{
-                    "model_part_name" : "",
-                    "process_step": "initialize_solution_step",
-                    "io_settings": {
-                        "io_type": "serial_hdf5_file_io",
-                        "file_name": "<identifier>-<time>.h5",
-                        "file_access_mode": "read_only"
-                    },
-                    "list_of_operations": [{
-                        "operation_type": "nodal_solution_step_data_input"
-                    },{
-                        "operation_type": "nodal_data_value_input"
-                    },{
-                        "operation_type": "element_data_value_input"
-                    }]
-                }]
-            }
-            ''')
-    settings = process_settings["Parameters"]
-    if settings.Has('file_name'):
-        _utils.CheckForDeprecatedFilename(
-            settings, __name__, new_settings["list_of_controllers"][0]["io_settings"])
-        settings.RemoveValue('file_name')
-    if settings.Has('time_tag_precision'):
-        depr_msg = '\nDEPRECATION-WARNING: "time_tag_precision" is ignored, please use "time_format" in "file_settings"!\n'
-        KratosMultiphysics.Logger.PrintWarning(__name__, depr_msg)
-        settings.RemoveValue('time_tag_precision')
-    settings.ValidateAndAssignDefaults(default_settings)
-    model_part_name = settings["model_part_name"].GetString()
-    results_settings = new_settings["list_of_controllers"][0]
-    results_settings["model_part_name"].SetString(model_part_name)
-    _utils.InsertSettings(
-        settings["file_settings"], results_settings["io_settings"])
-    if _utils.IsDistributed():
-        results_settings["io_settings"]["io_type"].SetString(
-            "parallel_hdf5_file_io")
-    _utils.InsertArrayOfSettings([settings["nodal_solution_step_data_settings"], settings["nodal_data_value_settings"],
-                                  settings["element_data_value_settings"]], results_settings["list_of_operations"])
-    return _core.Factory(new_settings["list_of_controllers"], Model)
+    )
+    user_settings = ParametersWrapper(user_settings)
+    core_settings[0]["model_part_name"] = user_settings["model_part_name"]
+    for key in user_settings["file_settings"]:
+        core_settings[0]["io_settings"][key] = user_settings["file_settings"][key]
+    if IsDistributed():
+        core_settings[0]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
+    else:
+        core_settings[0]["io_settings"]["io_type"] = "serial_hdf5_file_io"
+    core_settings[0]["list_of_operations"] = [
+        CreateOperationSettings("nodal_solution_step_data_input",
+                                user_settings["nodal_solution_step_data_settings"]),
+        CreateOperationSettings("nodal_data_value_input",
+                                user_settings["nodal_data_value_settings"]),
+        CreateOperationSettings("element_data_value_input",
+                                user_settings["element_data_value_settings"]),
+    ]
+    return core_settings.parameters

--- a/applications/HDF5Application/python_scripts/single_mesh_temporal_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_temporal_output_process.py
@@ -1,87 +1,131 @@
-'''Write a model part once and its data at the end of each solution step.
+"""Store temporal simulation results for a single mesh with HDF5.
 
-This process provides the front end to the HDF5Application.core.
+This process:
+ - stores the initial model part in an .h5 file.
+ - stores historical and non-historical results in one .h5 file per output step.
+
+This process works with or without MPI.
 
 license: HDF5Application/license.txt
-'''
+"""
+
+
+__all__ = ["Factory"]
+
+
 import KratosMultiphysics
-import KratosMultiphysics.HDF5Application.core as _core
-import KratosMultiphysics.HDF5Application.utils as _utils
+import KratosMultiphysics.HDF5Application.core as core
+from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
+from KratosMultiphysics.HDF5Application.utils import IsDistributed
+from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
 
-def Factory(process_settings, Model):
-    """Return a process for writing simulation results for a single mesh to HDF5."""
-    default_settings = KratosMultiphysics.Parameters("""
-            {
-                "model_part_name" : "MainModelPart",
-                "file_settings" : {},
-                "model_part_output_settings" : {},
-                "nodal_solution_step_data_settings" : {},
-                "nodal_data_value_settings": {},
-                "element_data_value_settings" : {},
-                "output_time_settings" : {}
-            }
-            """)
-    settings = process_settings["Parameters"]
-    settings.ValidateAndAssignDefaults(default_settings)
-    new_settings = KratosMultiphysics.Parameters('''
-            {
-               "list_of_controllers": [{
-                    "model_part_name" : "",
-                    "process_step": "before_solution_loop",
-                    "io_settings": {
-                        "io_type": "serial_hdf5_file_io",
-                        "file_name": "<identifier>.h5"
-                    },
-                    "list_of_operations": [{
-                        "operation_type": "model_part_output"
-                    },{
-                        "operation_type": "nodal_solution_step_data_output"
-                    },{
-                        "operation_type": "nodal_data_value_output"
-                    },{
-                        "operation_type": "element_data_value_output"
-                    }]
-                },{
-                    "model_part_name" : "",
-                    "process_step": "finalize_solution_step",
-                    "controller_settings": {
-                        "controller_type": "temporal_controller"
-                    },
-                    "io_settings": {
-                        "io_type": "serial_hdf5_file_io",
-                        "file_name": "<identifier>-<time>.h5"
-                    },
-                    "list_of_operations": [{
-                        "operation_type": "nodal_solution_step_data_output"
-                    },{
-                        "operation_type": "nodal_data_value_output"
-                    },{
-                        "operation_type": "element_data_value_output"
-                    }]
-                }]
-            }
-            ''')
-    model_part_name = settings["model_part_name"].GetString()
-    for current_settings in new_settings["list_of_controllers"]:
-        current_settings["model_part_name"].SetString(model_part_name)
-    model_part_settings = new_settings["list_of_controllers"][0]
-    results_settings = new_settings["list_of_controllers"][1]
-    for io_settings in [model_part_settings["io_settings"], results_settings["io_settings"]]:
-        _utils.InsertSettings(settings["file_settings"], io_settings)
-        if _utils.IsDistributed():
-            io_settings["io_type"].SetString("parallel_hdf5_file_io")
-    _utils.InsertArrayOfSettings(
-        [settings["model_part_output_settings"], settings["nodal_solution_step_data_settings"], settings["nodal_data_value_settings"],
-         settings["element_data_value_settings"]], model_part_settings["list_of_operations"])
-    _utils.InsertArrayOfSettings([settings["nodal_solution_step_data_settings"], settings["nodal_data_value_settings"],
-                                  settings["element_data_value_settings"]], results_settings["list_of_operations"])
-    output_time_settings = settings["output_time_settings"]
-    _utils.InsertSettings(output_time_settings,
-                          results_settings["controller_settings"])
-    _utils.CheckForDeprecatedFilename(
-        output_time_settings, __name__, model_part_settings["io_settings"], results_settings["io_settings"])
-    _utils.CheckForDeprecatedTemporalSettings(
-        output_time_settings, __name__, results_settings["controller_settings"])
+def Factory(settings, Model):
+    """Return the process for single mesh temporal output with HDF5.
+    
+    The input settings are given in the following table:
+    +-------------------------------------+------------+------------------------------------+
+    | Setting                             | Type       | Default Value                      |
+    +-------------------------------------+------------+------------------------------------+
+    | "model_part_name"                   | String     | "MainModelPart"                    |
+    +-------------------------------------+------------+------------------------------------+
+    | "file_settings"                     | Parameters | "file_name": "<model_part_name>.h5"|
+    |                                     |            | "time_format": "0.4f"              |
+    |                                     |            | "file_access_mode": "exclusive"    |
+    |                                     |            | "echo_level":  0                   |
+    +-------------------------------------+------------+------------------------------------+
+    | "output_time_settings"              | Parameters | "time_frequency": 1.0              |
+    |                                     |            | "step_frequency": 1                |
+    +-------------------------------------+------------+------------------------------------+
+    | "model_part_output_settings"        | Parameters | "prefix": "/ModelData"             |
+    +-------------------------------------+------------+------------------------------------+
+    | "nodal_solution_step_data_settings" | Parameters | "prefix": "/ResultsData"           |
+    |                                     |            | "list_of_variables": []            |
+    +-------------------------------------+------------+------------------------------------+
+    | "nodal_data_value_settings"         | Parameters | "prefix": "/ResultsData"           |
+    |                                     |            | "list_of_variables": []            |
+    +-------------------------------------+------------+------------------------------------+
+    | "element_data_value_settings"       | Parameters | "prefix": "/ResultsData"           |
+    |                                     |            | "list_of_variables": []            |
+    +-------------------------------------+------------+------------------------------------+
+    """
+    core_settings = CreateCoreSettings(settings["Parameters"])
+    return SingleMeshTemporalOutputProcessFactory(core_settings, Model)
 
-    return _core.Factory(new_settings["list_of_controllers"], Model)
+
+def SingleMeshTemporalOutputProcessFactory(core_settings, Model):
+    return core.Factory(core_settings, Model)
+
+
+def CreateCoreSettings(user_settings):
+    """Return the core settings.
+    
+    The core setting "io_type" cannot be overwritten by the user. It is
+    automatically set depending on whether or not MPI is used.
+    """
+    # Configure the defaults:
+    core_settings = ParametersWrapper("""
+        [{
+            "model_part_name": "",
+            "process_step": "before_solution_loop",
+            "io_settings": {
+                "io_type": "serial_hdf5_file_io",
+                "file_name": "<model_part_name>.h5"
+            },
+            "list_of_operations": []
+        },{
+            "model_part_name" : "",
+            "process_step": "finalize_solution_step",
+            "controller_settings": {
+                "controller_type": "temporal_controller"
+            },
+            "io_settings": {
+                "io_type": "serial_hdf5_file_io",
+                "file_name": "<model_part_name>-<time>.h5"
+            },
+            "list_of_operations": []
+        }]
+        """)
+    # Apply the user settings:
+    user_settings.ValidateAndAssignDefaults(
+    KratosMultiphysics.Parameters("""
+    {
+        "model_part_name" : "MainModelPart",
+        "file_settings" : {},
+        "output_time_settings" : {},
+        "model_part_output_settings" : {},
+        "nodal_solution_step_data_settings" : {},
+        "nodal_data_value_settings": {},
+        "element_data_value_settings" : {}
+    }
+    """))
+    user_settings = ParametersWrapper(user_settings)
+    for i in core_settings:
+        core_settings[i]["model_part_name"] = user_settings["model_part_name"]
+        for key in user_settings["file_settings"]:
+            core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
+        if IsDistributed():
+            core_settings[i]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
+        else:
+            core_settings[i]["io_settings"]["io_type"] = "serial_hdf5_file_io"
+    core_settings[0]["list_of_operations"] = [
+        CreateOperationSettings("model_part_output",
+                                user_settings["model_part_output_settings"]),
+        CreateOperationSettings("nodal_solution_step_data_output",
+                                user_settings["nodal_solution_step_data_settings"]),
+        CreateOperationSettings("nodal_data_value_output",
+                                user_settings["nodal_data_value_settings"]),
+        CreateOperationSettings("element_data_value_output",
+                                user_settings["element_data_value_settings"])
+    ]
+    core_settings[1]["list_of_operations"] = [
+        CreateOperationSettings("nodal_solution_step_data_output",
+                                user_settings["nodal_solution_step_data_settings"]),
+        CreateOperationSettings("nodal_data_value_output",
+                                user_settings["nodal_data_value_settings"]),
+        CreateOperationSettings("element_data_value_output",
+                                user_settings["element_data_value_settings"])
+    ]
+    for key in user_settings["output_time_settings"]:
+        core_settings[1]["controller_settings"][key] = user_settings["output_time_settings"][key]
+    return core_settings.parameters

--- a/applications/HDF5Application/python_scripts/single_mesh_xdmf_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_xdmf_output_process.py
@@ -1,128 +1,168 @@
-'''Write simulation data with Xdmf for post-processing.
+"""Store temporal simulation results for a single mesh with HDF5 and Xdmf.
 
-This process extends the single_mesh_temporal_output_process by also writing an
-Xdmf file after every result output. This allows the results to be
-post-processed with tools such as Paraview and VisIt.
+This process:
+ - removes existing .h5 files at the start of the simulation.
+ - stores the initial model part in an .h5 file.
+ - stores historical and non-historical results in one .h5 file per output step.
+ - stores Xdmf metadata for post-processing (e.g., Paraview or VisIt).
 
-This process provides the front end to the HDF5Application.core.
+This process works with or without MPI.
 
 license: HDF5Application/license.txt
 
 Main authors:
     Philipp Bucher
     Michael Andre
-'''
+"""
+
+
+__all__ = ["Factory"]
+
+
 import KratosMultiphysics
-import KratosMultiphysics.HDF5Application.core as _core
-import KratosMultiphysics.HDF5Application.utils as _utils
+from KratosMultiphysics.HDF5Application import core
+from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
+from KratosMultiphysics.HDF5Application.utils import IsDistributed
+from KratosMultiphysics.HDF5Application.utils import CreateOperationSettings
 
-
-def Factory(process_settings, Model):
-    """Return a process for writing simulation results for a single mesh to HDF5.
-    It also creates the xdmf-file on the fly
+def Factory(settings, Model):
+    """Return a process for single mesh temporal results output with Xdmf and HDF5.
+    
+    The input settings are given in the following table:
+    +-------------------------------------+------------+---------------------------------+
+    | Setting                             | Type       | Default Value                   |
+    +-------------------------------------+------------+---------------------------------+
+    | "model_part_name"                   | String     | ""                              |
+    +-------------------------------------+------------+---------------------------------+
+    | "file_settings"                     | Parameters | "file_name": "<model_part_name>"|
+    |                                     |            | "time_format": "0.4f"           |
+    |                                     |            | "file_access_mode": "truncate"  |
+    |                                     |            | "echo_level":  0                |
+    +-------------------------------------+------------+---------------------------------+
+    | "output_time_settings"              | Parameters | "time_frequency": 1.0           |
+    |                                     |            | "step_frequency": 1             |
+    +-------------------------------------+------------+---------------------------------+
+    | "model_part_output_settings"        | Parameters | "prefix": "/ModelData"          |
+    +-------------------------------------+------------+---------------------------------+
+    | "nodal_solution_step_data_settings" | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
+    | "nodal_data_value_settings"         | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
+    | "element_data_value_settings"       | Parameters | "prefix": "/ResultsData"        |
+    |                                     |            | "list_of_variables": []         |
+    +-------------------------------------+------------+---------------------------------+
     """
-    if not isinstance(process_settings, KratosMultiphysics.Parameters):
-        raise Exception(
-            "expected input shall be a Parameters object, encapsulating a json string")
+    core_settings = CreateCoreSettings(settings["Parameters"])
+    return SingleMeshXdmfOutputProcessFactory(core_settings, Model)
 
-    default_settings = KratosMultiphysics.Parameters("""
-            {
-                "model_part_name" : "MainModelPart",
-                "file_settings" : {},
-                "model_part_output_settings" : {},
-                "nodal_solution_step_data_settings" : {},
-                "nodal_data_value_settings": {},
-                "element_data_value_settings" : {},
-                "output_time_settings" : {}
-            }
-            """)
-    settings = process_settings["Parameters"]
-    settings.ValidateAndAssignDefaults(default_settings)
-    new_settings = KratosMultiphysics.Parameters('''
-            {
-               "list_of_controllers": [{
-                    "model_part_name" : "",
-                    "process_step": "initialize",
-                    "io_settings": {
-                        "io_type": "mock_hdf5_file_io",
-                        "file_name": "<identifier>.h5"
-                    },
-                    "list_of_operations": [{
-                        "module_name": "operations.system",
-                        "operation_type": "delete_old_h5_files"
-                    }]
-                },{
-                    "model_part_name" : "",
-                    "process_step": "before_solution_loop",
-                    "io_settings": {
-                        "io_type": "serial_hdf5_file_io",
-                        "file_name": "<identifier>.h5",
-                        "file_access_mode": "truncate"
-                    },
-                    "list_of_operations": [{
-                        "operation_type": "model_part_output"
-                    },{
-                        "operation_type": "nodal_solution_step_data_output"
-                    },{
-                        "operation_type": "nodal_data_value_output"
-                    },{
-                        "operation_type": "element_data_value_output"
-                    }]
-                },{
-                    "model_part_name" : "",
-                    "process_step": "finalize_solution_step",
-                    "controller_settings": {
-                        "controller_type": "temporal_controller"
-                    },
-                    "io_settings": {
-                        "io_type": "serial_hdf5_file_io",
-                        "file_name": "<identifier>-<time>.h5",
-                        "file_access_mode": "truncate"
-                    },
-                    "list_of_operations": [{
-                        "operation_type": "nodal_solution_step_data_output"
-                    },{
-                        "operation_type": "nodal_data_value_output"
-                    },{
-                        "operation_type": "element_data_value_output"
-                    }]
-                },{
-                    "model_part_name" : "",
-                    "process_step": "finalize_solution_step",
-                    "controller_settings": {
-                        "controller_type": "temporal_controller"
-                    },
-                    "io_settings": {
-                        "io_type": "mock_hdf5_file_io",
-                        "file_name": "<identifier>.h5"
-                    },
-                    "list_of_operations": [{
-                        "module_name": "operations.xdmf",
-                        "operation_type": "xdmf_output"
-                    }]
-                }]
-            }
-            ''')
-    model_part_name = settings["model_part_name"].GetString()
-    for current_settings in new_settings["list_of_controllers"]:
-        current_settings["model_part_name"].SetString(model_part_name)
-    model_part_settings = new_settings["list_of_controllers"][1]
-    results_settings = new_settings["list_of_controllers"][2]
-    for io_settings in [model_part_settings["io_settings"], results_settings["io_settings"]]:
-        _utils.InsertSettings(settings["file_settings"], io_settings)
-        if _utils.IsDistributed():
-            io_settings["io_type"].SetString("parallel_hdf5_file_io")
-    _utils.InsertArrayOfSettings(
-        [settings["model_part_output_settings"], settings["nodal_solution_step_data_settings"], settings["nodal_data_value_settings"],
-         settings["element_data_value_settings"]], model_part_settings["list_of_operations"])
-    _utils.InsertArrayOfSettings([settings["nodal_solution_step_data_settings"], settings["nodal_data_value_settings"],
-                                  settings["element_data_value_settings"]], results_settings["list_of_operations"])
-    output_time_settings = settings["output_time_settings"]
-    _utils.InsertSettings(output_time_settings,
-                          results_settings["controller_settings"])
-    _utils.CheckForDeprecatedFilename(
-        output_time_settings, __name__, model_part_settings["io_settings"], results_settings["io_settings"])
-    _utils.CheckForDeprecatedTemporalSettings(
-        output_time_settings, __name__, results_settings["controller_settings"])
 
-    return _core.Factory(new_settings["list_of_controllers"], Model)
+def SingleMeshXdmfOutputProcessFactory(core_settings, Model):
+    return core.Factory(core_settings, Model)
+
+
+def CreateCoreSettings(user_settings):
+    """Return the core settings.
+    
+    The core setting "io_type" cannot be overwritten by the user. It is
+    automatically set depending on whether or not MPI is used.
+    """
+    # Configure the defaults:
+    core_settings = ParametersWrapper("""
+        [{
+            "model_part_name" : "",
+            "process_step": "initialize",
+            "io_settings": {
+                "io_type": "mock_hdf5_file_io",
+                "file_name": "<model_part_name>.h5"
+            },
+            "list_of_operations": [{
+                "module_name": "operations.system",
+                "operation_type": "delete_old_h5_files"
+            }]
+        },{
+            "model_part_name": "",
+            "process_step": "before_solution_loop",
+            "io_settings": {
+                "io_type": "serial_hdf5_file_io",
+                "file_name": "<model_part_name>.h5",
+                "file_access_mode": "truncate"
+            },
+            "list_of_operations": []
+        },{
+            "model_part_name" : "",
+            "process_step": "finalize_solution_step",
+            "controller_settings": {
+                "controller_type": "temporal_controller"
+            },
+            "io_settings": {
+                "io_type": "serial_hdf5_file_io",
+                "file_name": "<model_part_name>-<time>.h5",
+                "file_access_mode": "truncate"
+            },
+            "list_of_operations": []
+        },{
+            "model_part_name" : "",
+            "process_step": "finalize_solution_step",
+            "controller_settings": {
+                "controller_type": "temporal_controller"
+            },
+            "io_settings": {
+                "io_type": "mock_hdf5_file_io",
+                "file_name": "<model_part_name>.h5"
+            },
+            "list_of_operations": [{
+                "module_name": "operations.xdmf",
+                "operation_type": "xdmf_output"
+            }]
+        }]
+        """)
+    # Apply the user settings:
+    user_settings.ValidateAndAssignDefaults(
+        KratosMultiphysics.Parameters("""
+        {
+            "model_part_name" : "MainModelPart",
+            "file_settings" : {},
+            "output_time_settings" : {},
+            "model_part_output_settings" : {},
+            "nodal_solution_step_data_settings" : {},
+            "nodal_data_value_settings": {},
+            "element_data_value_settings" : {}
+        }
+        """))
+    user_settings = ParametersWrapper(user_settings)
+    for i in core_settings:
+        core_settings[i]["model_part_name"] = user_settings["model_part_name"]
+        for key in user_settings["file_settings"]:
+            core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
+    core_settings[0]["io_settings"]["io_type"] = "mock_hdf5_file_io"
+    core_settings[3]["io_settings"]["io_type"] = "mock_hdf5_file_io"
+    if IsDistributed():
+        core_settings[1]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
+        core_settings[2]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
+    else:
+        core_settings[1]["io_settings"]["io_type"] = "serial_hdf5_file_io"
+        core_settings[2]["io_settings"]["io_type"] = "serial_hdf5_file_io"
+    core_settings[1]["list_of_operations"] = [
+        CreateOperationSettings("model_part_output",
+                                user_settings["model_part_output_settings"]),
+        CreateOperationSettings("nodal_solution_step_data_output",
+                                user_settings["nodal_solution_step_data_settings"]),
+        CreateOperationSettings("nodal_data_value_output",
+                                user_settings["nodal_data_value_settings"]),
+        CreateOperationSettings("element_data_value_output",
+                                user_settings["element_data_value_settings"])
+    ]
+    core_settings[2]["list_of_operations"] = [
+        CreateOperationSettings("nodal_solution_step_data_output",
+                                user_settings["nodal_solution_step_data_settings"]),
+        CreateOperationSettings("nodal_data_value_output",
+                                user_settings["nodal_data_value_settings"]),
+        CreateOperationSettings("element_data_value_output",
+                                user_settings["element_data_value_settings"])
+    ]
+    for key in user_settings["output_time_settings"]:
+        core_settings[2]["controller_settings"][key] = user_settings["output_time_settings"][key]
+        core_settings[3]["controller_settings"][key] = user_settings["output_time_settings"][key]
+    return core_settings.parameters

--- a/applications/HDF5Application/python_scripts/user_defined_io_process.py
+++ b/applications/HDF5Application/python_scripts/user_defined_io_process.py
@@ -1,15 +1,132 @@
-'''Construct a user-defined input/output process.
+"""Construct a user-defined HDF5 IO process.
 
-This factory is for advanced use cases. It allows users to define a custom 
-input/output process via json settings which are passed directly to
-HDF5Application.core.
+This process:
+ - passes the json parameters directly to the core factory.
 
 license: HDF5Application/license.txt
-'''
+"""
+
+
+__all__ = ["Factory"]
+
+
 import KratosMultiphysics
-import KratosMultiphysics.HDF5Application.core as _core
+from KratosMultiphysics.HDF5Application import core
 
-def Factory(process_settings, Model):
-    """Construct a user-defined input/output process for HDF5."""
 
-    return _core.Factory(process_settings["Parameters"], Model)
+def Factory(settings, Model):
+    """Return a user-defined input/output process for HDF5.
+    
+    The input settings are a json array of parameters which maps to the
+    structure of the HDF5 IO python core.
+    
+    The settings of each array item are given in the following table:
+    +-----------------------+------------+-------------------------------------------+
+    | Setting               | Type       | Default Value                             |
+    +-----------------------+------------+-------------------------------------------+
+    | "model_part_name"     | String     | "PLEASE_SPECIFY_MODEL_PART_NAME"          |
+    +-----------------------+------------+-------------------------------------------+
+    | "process_step"        | String     | "initialize"                              |
+    +-----------------------+------------+-------------------------------------------+
+    | "controller_settings" | Parameters | {                                         |
+    |                       |            |   "controller_type": "default_controller" |
+    |                       |            | }                                         |
+    +-----------------------+------------+-------------------------------------------+
+    | "io_settings"         | Parameters | "echo_level": 0                           |
+    |                       |            | "file_access_mode": "exclusive"           |
+    |                       |            | "file_driver": "sec2"                     |
+    |                       |            | "file_name": "kratos"                     |
+    |                       |            | "io_type": "serial_hdf5_file_io"          |
+    +-----------------------+------------+-------------------------------------------+
+    | "list_of_operations"  | Parameters | [{                                        |
+    |                       | Array      |   "operation_type": "model_part_output"   |
+    |                       |            |   "prefix": "/ModelData"                  |
+    |                       |            | }]                                        |
+    +-----------------------+------------+-------------------------------------------+
+
+    
+    For example:
+        '''
+        [{
+            "model_part_name" : "MainModelPart",
+            "process_step": "finalize_solution_step",
+            "controller_settings": {
+                "controller_type": "temporal_controller",
+                "time_frequency": 0.5
+            },
+            "io_settings": {
+                "file_name": "results/<model_part_name>-<time>.h5"
+            },
+            "list_of_operations": [{
+                "operation_type": "model_part_output"
+            },{
+                "operation_type": "nodal_solution_step_data_output",
+                "list_of_variables": ["DISPLACEMENT"]
+            }]
+        }]
+        '''
+
+    will store the model part and displacement every 0.5s in the following
+    directory tree structure:
+
+        ./results/MainModelPart-0.000.h5
+        ./results/MainModelPart-0.500.h5
+        ./results/MainModelPart-1.000.h5
+        ...
+
+    and internal file tree structure in each .h5 file:
+        /ModelData/Conditions
+        /ModelData/Elements
+        ...
+        /ResultsData/NodalSolutionStepData/DISPLACEMENT
+    
+    In the above example, the nonterminal symbols <model_part_name> and <time>
+    are automatically replaced by the name of the model part and the current
+    time.
+
+    Alternatively, the simulations results can be stored in a single .h5 file
+    containing the directory tree structure of the above example:
+
+        '''
+        [{
+            "model_part_name" : "MainModelPart",
+            "process_step": "finalize_solution_step",
+            "controller_settings": {
+                "controller_type": "temporal_controller",
+                "time_frequency": 0.5
+            },
+            "io_settings": {
+                "file_name": "results.h5",
+                "file_access_mode": "read_write"
+            },
+            "list_of_operations": [{
+                "prefix": "/<time>/<model_part_name>/ModelData",
+                "operation_type": "model_part_output"
+            },{
+                "prefix": "/<time>/<model_part_name>/ResultsData",
+                "operation_type": "nodal_solution_step_data_output",
+                "list_of_variables": ["DISPLACEMENT"]
+            }]
+        }]
+        '''
+
+    will store the model part and displacement every 0.5s in the following
+    directory tree structure:
+
+        ./results.h5
+
+    and internal file tree structure in each .h5 file:
+        /0.000/MainModelPart/ModelData/...
+        /0.000/MainModelPart/ResultsData/...
+        ...
+        /0.500/MainModelPart/ModelData/...
+        /0.500/MainModelPart/ResultsData/...
+        ...
+        /1.000/MainModelPart/ModelData/...
+        /1.000/MainModelPart/ResultsData/...
+
+    Different groupings of model parts, files, locations within the solution
+    algorithm, frequencies and IO operations can be configured by appending
+    additional parameters to the json array.
+    """
+    return core.Factory(settings["Parameters"], Model)

--- a/applications/HDF5Application/python_scripts/utils.py
+++ b/applications/HDF5Application/python_scripts/utils.py
@@ -1,58 +1,36 @@
-'''HDF5 process utilities.
+"""HDF5 custom IO process utilities.
 
 license: HDF5Application/license.txt
-'''
+"""
+
+
+__all__ = [
+    "DefaultSetter",
+    "ParametersWrapper",
+    "IsDistributed",
+    "CreateOperationSettings",
+]
+
+
 import KratosMultiphysics
+from KratosMultiphysics.HDF5Application.core.utils import DefaultSetter
+from KratosMultiphysics.HDF5Application.core.utils import ParametersWrapper
 
 
 def IsDistributed():
     return KratosMultiphysics.DataCommunicator.GetDefault().IsDistributed()
 
 
-def InsertSingleSetting(dest, key, parameters):
-    if dest.Has(key):
-        dest[key] = parameters
-    else:
-        dest.AddValue(key, parameters)
+def CreateOperationSettings(operation_type, user_settings):
+    """Return core settings for an operation type.
 
-
-def InsertSettings(src, dest):
-    for key, parameters in src.items():
-        InsertSingleSetting(dest, key, parameters)
-
-
-def InsertArrayOfSettings(src, dest):
-    for current_src, current_dest in zip(src, dest):
-        InsertSettings(current_src, current_dest)
-
-
-def CheckForDeprecatedFilename(deprecated_settings, module_name, *new_io_settings):
-    if deprecated_settings.Has("file_name"):
-        depr_msg = '\nDEPRECATION-WARNING: "file_name" should be specified in "file_settings". This will be removed in the future!\n'
-        KratosMultiphysics.Logger.PrintWarning(module_name, depr_msg)
-        file_name = deprecated_settings["file_name"].GetString().replace(
-            ".h5", "")
-        for io_settings in new_io_settings:
-            new_file_name = io_settings["file_name"].GetString().replace(
-                "<identifier>", file_name)
-            io_settings["file_name"].SetString(new_file_name)
-
-
-def CheckForDeprecatedTemporalSettings(deprecated_settings, module_name, *new_controller_settings):
-    if deprecated_settings.Has("time_tag_precision"):
-        depr_msg = '\nDEPRECATION-WARNING: "time_tag_precision" is ignored, please use "time_format" in "file_settings"!\n'
-        KratosMultiphysics.Logger.PrintWarning(module_name, depr_msg)
-
-    if deprecated_settings.Has("output_time_frequency"):
-        depr_msg = '\nDEPRECATION-WARNING: "output_time_frequency" is deprecated, please use "time_frequency"!\n'
-        KratosMultiphysics.Logger.PrintWarning(module_name, depr_msg)
-        for controller_settings in new_controller_settings:
-            InsertSingleSetting(controller_settings, "time_frequency",
-                                deprecated_settings["output_time_frequency"])
-
-    if deprecated_settings.Has("output_step_frequency"):
-        depr_msg = '\nDEPRECATION-WARNING: "output_step_frequency" is deprecated, please use "step_frequency"!\n'
-        KratosMultiphysics.Logger.PrintWarning(module_name, depr_msg)
-        for controller_settings in new_controller_settings:
-            InsertSingleSetting(controller_settings, "step_frequency",
-                                deprecated_settings["output_step_frequency"])
+    See core.operations.
+    """
+    core_settings = ParametersWrapper("""
+    {
+        "operation_type": "%s"
+    }
+    """ % operation_type)
+    for key in user_settings:
+        core_settings[key] = user_settings[key]
+    return core_settings

--- a/applications/HDF5Application/tests/test_hdf5_core_mpi.py
+++ b/applications/HDF5Application/tests/test_hdf5_core_mpi.py
@@ -37,7 +37,7 @@ class TestOperations(KratosUnittest.TestCase):
         settings = KratosMultiphysics.Parameters('''
             {
                 "operation_type": "partitioned_model_part_output",
-                "prefix": "/ModelData/<identifier>/<time>",
+                "prefix": "/ModelData/<model_part_name>/<time>",
                 "time_format": "0.2f"
             }
             ''')

--- a/applications/HDF5Application/tests/test_hdf5_processes.py
+++ b/applications/HDF5Application/tests/test_hdf5_processes.py
@@ -1,5 +1,6 @@
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
+import KratosMultiphysics.HDF5Application.core as core
 import KratosMultiphysics.HDF5Application.single_mesh_temporal_output_process as single_mesh_temporal_output_process
 import KratosMultiphysics.HDF5Application.multiple_mesh_temporal_output_process as multiple_mesh_temporal_output_process
 import KratosMultiphysics.HDF5Application.single_mesh_primal_output_process as single_mesh_primal_output_process
@@ -53,11 +54,11 @@ class TestHDF5Processes(KratosUnittest.TestCase):
                         "echo_level": 1
                     },
                     "model_part_output_settings": {
-                        "prefix": "/ModelData/<identifier>"
+                        "prefix": "/ModelData/<model_part_name>"
                     },
                     "nodal_solution_step_data_settings": {
                         "list_of_variables": ["DISPLACEMENT"],
-                        "prefix": "/ResultsData/<identifier>/<time>",
+                        "prefix": "/ResultsData/<model_part_name>/<time>",
                         "time_format": "0.2f"
                     },
                     "element_data_value_settings": {


### PR DESCRIPTION
The docstrings provide a summary of the json settings for configuring each
HDF5 IO process. The parameters wrapper was added to improve readability
when mapping user parameters to core parameters while keeping the amount of
code about the same. Minor renaming of classes and variables was also done.

The behavior of each process is not modified. The frequency of Xdmf output in
the HDF5-Xdmf output process was adjusted to only write metadata if HDF5 data
was written. Previously it was writing at every step.

Old deprecation warnings were also removed.