### PR TITLE
explicit time integration for membrane element

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/prestress_membrane_element.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/prestress_membrane_element.cpp
@@ -743,6 +743,12 @@ void PrestressMembraneElement::CalculateAll(
                     noalias(rRightHandSideVector) -= int_reference_weight* prod(trans(B), strain_deformation);
                 }
             }
+            else
+            {
+                CalculateAndAddBodyForce(rRightHandSideVector, point_number, int_reference_weight);
+                // operation performed: rRighthandSideVector -= Weight* IntForce
+                noalias(rRightHandSideVector) -= int_reference_weight* prod(trans(B), strain_deformation);
+            }
         }
     } // end loop over integration points
 
@@ -1503,6 +1509,129 @@ void PrestressMembraneElement::InitializeFormfinding(const unsigned int rIntegra
             this->SetValue(LAMBDA_MAX,1.2);
     }
 }
+
+void PrestressMembraneElement::CalculateLumpedMassVector(VectorType& rMassVector)
+{
+    KRATOS_TRY
+    auto& r_geom = GetGeometry();
+    const unsigned int dimension = r_geom.WorkingSpaceDimension();
+    const unsigned int number_of_nodes = r_geom.size();
+    const unsigned int local_size = dimension*number_of_nodes;
+
+    if (rMassVector.size() != local_size) {
+        rMassVector.resize(local_size, false);
+    }
+
+    const double total_mass = mTotalDomainInitialSize * GetProperties()[THICKNESS] * StructuralMechanicsElementUtilities::GetDensityForMassMatrixComputation(*this);;
+
+    Vector lump_fact;
+    lump_fact = GetGeometry().LumpingFactors(lump_fact);
+
+    for (unsigned int i = 0; i < number_of_nodes; ++i) {
+        const double temp = lump_fact[i] * total_mass;
+
+        for (unsigned int j = 0; j < 3; ++j)
+        {
+            const unsigned int index = i * 3 + j;
+            rMassVector[index] = temp;
+        }
+    }
+    KRATOS_CATCH("")
+}
+
+
+
+void PrestressMembraneElement::AddExplicitContribution(
+    const VectorType& rRHSVector,
+    const Variable<VectorType>& rRHSVariable,
+    Variable<double >& rDestinationVariable,
+    const ProcessInfo& rCurrentProcessInfo
+)
+{
+    KRATOS_TRY;
+
+    auto& r_geom = GetGeometry();
+    const unsigned int dimension = r_geom.WorkingSpaceDimension();
+    const unsigned int number_of_nodes = r_geom.size();
+    const unsigned int local_size = dimension*number_of_nodes;
+
+    if (rDestinationVariable == NODAL_MASS) {
+        VectorType element_mass_vector(local_size);
+        CalculateLumpedMassVector(element_mass_vector);
+
+        for (SizeType i = 0; i < number_of_nodes; ++i) {
+            double& r_nodal_mass = r_geom[i].GetValue(NODAL_MASS);
+            int index = i * dimension;
+
+            #pragma omp atomic
+            r_nodal_mass += element_mass_vector(index);
+        }
+    }
+
+    KRATOS_CATCH("")
+}
+
+void PrestressMembraneElement::AddExplicitContribution(
+    const VectorType& rRHSVector, const Variable<VectorType>& rRHSVariable,
+    Variable<array_1d<double, 3>>& rDestinationVariable,
+    const ProcessInfo& rCurrentProcessInfo
+)
+{
+    KRATOS_TRY;
+
+    auto& r_geom = GetGeometry();
+    const unsigned int dimension = r_geom.WorkingSpaceDimension();
+    const unsigned int number_of_nodes = r_geom.size();
+    const unsigned int local_size = dimension*number_of_nodes;
+
+    if (rRHSVariable == RESIDUAL_VECTOR && rDestinationVariable == FORCE_RESIDUAL) {
+
+        Vector damping_residual_contribution = ZeroVector(local_size);
+        Vector current_nodal_velocities = ZeroVector(local_size);
+        GetFirstDerivativesVector(current_nodal_velocities);
+        Matrix damping_matrix;
+        ProcessInfo temp_process_information; // cant pass const ProcessInfo
+        CalculateDampingMatrix(damping_matrix, temp_process_information);
+        // current residual contribution due to damping
+        noalias(damping_residual_contribution) = prod(damping_matrix, current_nodal_velocities);
+
+        for (SizeType i = 0; i < number_of_nodes; ++i) {
+            SizeType index = dimension * i;
+            array_1d<double, 3>& r_force_residual = GetGeometry()[i].FastGetSolutionStepValue(FORCE_RESIDUAL);
+            for (size_t j = 0; j < dimension; ++j) {
+                #pragma omp atomic
+                r_force_residual[j] += rRHSVector[index + j] - damping_residual_contribution[index + j];
+            }
+        }
+    } else if (rDestinationVariable == NODAL_INERTIA) {
+
+        // Getting the vector mass
+        VectorType mass_vector(local_size);
+        CalculateLumpedMassVector(mass_vector);
+
+        for (SizeType i = 0; i < number_of_nodes; ++i) {
+            double& r_nodal_mass = GetGeometry()[i].GetValue(NODAL_MASS);
+            array_1d<double, 3>& r_nodal_inertia = GetGeometry()[i].GetValue(NODAL_INERTIA);
+            SizeType index = i * dimension;
+
+            #pragma omp atomic
+            r_nodal_mass += mass_vector[index];
+
+            for (SizeType k = 0; k < dimension; ++k) {
+                #pragma omp atomic
+                r_nodal_inertia[k] += 0.0;
+            }
+        }
+    }
+
+    KRATOS_CATCH("")
+}
+
+
+
+
+
+
 //***********************************************************************************
 //***********************************************************************************
 int PrestressMembraneElement::Check(const ProcessInfo& rCurrentProcessInfo)

--- a/applications/StructuralMechanicsApplication/custom_elements/prestress_membrane_element.hpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/prestress_membrane_element.hpp
@@ -134,6 +134,40 @@ namespace Kratos
 
     int Check(const ProcessInfo& rCurrentProcessInfo) override;
 
+
+        /**
+     * @brief This function is designed to make the element to assemble an rRHS vector identified by a variable rRHSVariable by assembling it to the nodes on the variable rDestinationVariable (double version)
+     * @details The "AddEXplicit" FUNCTIONS THE ONLY FUNCTIONS IN WHICH AN ELEMENT IS ALLOWED TO WRITE ON ITS NODES.
+     * The caller is expected to ensure thread safety hence SET/UNSETLOCK MUST BE PERFORMED IN THE STRATEGY BEFORE CALLING THIS FUNCTION
+     * @param rRHSVector input variable containing the RHS vector to be assembled
+     * @param rRHSVariable variable describing the type of the RHS vector to be assembled
+     * @param rDestinationVariable variable in the database to which the rRHSVector will be assembled
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void AddExplicitContribution(
+        const VectorType& rRHSVector,
+        const Variable<VectorType>& rRHSVariable,
+        Variable<double >& rDestinationVariable,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    /**
+     * @brief This function is designed to make the element to assemble an rRHS vector identified by a variable rRHSVariable by assembling it to the nodes on the variable (array_1d<double, 3>) version rDestinationVariable.
+     * @details The "AddEXplicit" FUNCTIONS THE ONLY FUNCTIONS IN WHICH AN ELEMENT IS ALLOWED TO WRITE ON ITS NODES.
+     * The caller is expected to ensure thread safety hence SET/UNSETLOCK MUST BE PERFORMED IN THE STRATEGY BEFORE CALLING THIS FUNCTION
+     * @param rRHSVector input variable containing the RHS vector to be assembled
+     * @param rRHSVariable variable describing the type of the RHS vector to be assembled
+     * @param rDestinationVariable variable in the database to which the rRHSVector will be assembled
+     * @param rCurrentProcessInfo the current process info instance
+     */
+    void AddExplicitContribution(const VectorType& rRHSVector,
+        const Variable<VectorType>& rRHSVariable,
+        Variable<array_1d<double, 3> >& rDestinationVariable,
+        const ProcessInfo& rCurrentProcessInfo
+        ) override;
+
+    void CalculateLumpedMassVector(VectorType& rMassVector);
+
 private:
     ///@name Static Member Variables
     std::vector<ConstitutiveLaw::Pointer> mConstitutiveLawVector;

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_membrane.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_membrane.py
@@ -6,12 +6,23 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 class BasePatchTestMembrane(KratosUnittest.TestCase):
 
-    def _add_variables(self,mp):
+    def _add_variables(self,mp,explicit_dynamics=False):
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION)
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.ACCELERATION)
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.VOLUME_ACCELERATION)
+        if explicit_dynamics:
+            mp.AddNodalSolutionStepVariable(StructuralMechanicsApplication.MIDDLE_VELOCITY)
+            mp.AddNodalSolutionStepVariable(StructuralMechanicsApplication.FRACTIONAL_ACCELERATION)
+            mp.AddNodalSolutionStepVariable(StructuralMechanicsApplication.FRACTIONAL_ANGULAR_ACCELERATION)
+            mp.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_MASS)
+            mp.AddNodalSolutionStepVariable(KratosMultiphysics.FORCE_RESIDUAL)
+            mp.AddNodalSolutionStepVariable(KratosMultiphysics.RESIDUAL_VECTOR)
+            mp.AddNodalSolutionStepVariable(StructuralMechanicsApplication.MIDDLE_ANGULAR_VELOCITY)
+            mp.AddNodalSolutionStepVariable(StructuralMechanicsApplication.NODAL_INERTIA)
+            mp.AddNodalSolutionStepVariable(KratosMultiphysics.MOMENT_RESIDUAL)
+
 
     def _add_dofs(self,mp):
         # Adding the dofs AND their corresponding reaction!
@@ -226,6 +237,15 @@ class BasePatchTestMembrane(KratosUnittest.TestCase):
         strategy.Check()
         strategy.Solve()
 
+    def _create_dynamic_explicit_strategy(mp,scheme_name):
+        if (scheme_name=='central_differences'):
+            scheme = StructuralMechanicsApplication.ExplicitCentralDifferencesScheme(0.00,0.00,0.00)
+        elif scheme_name=='multi_stage':
+            scheme = StructuralMechanicsApplication.ExplicitMultiStageKimScheme(0.33333333333333333)
+
+        strategy = StructuralMechanicsApplication.MechanicalExplicitStrategy(mp,scheme,0,0,1)
+        strategy.SetEchoLevel(0)
+        return strategy
 
     def _check_static_results(self,node,displacement_results):
         #check that the results are exact on the node
@@ -256,11 +276,11 @@ class BasePatchTestMembrane(KratosUnittest.TestCase):
         mp.ProcessInfo[KratosMultiphysics.IS_RESTARTED] = False
 
 
-    def _set_up_system_3d3n(self,current_model):
+    def _set_up_system_3d3n(self,current_model,explicit_dynamics=False):
         mp = current_model.CreateModelPart("Structure")
         mp.SetBufferSize(2)
 
-        self._add_variables(mp)
+        self._add_variables(mp,explicit_dynamics)
         self._apply_material_properties(mp)
         self._create_nodes_3d3n(mp)
         self._add_dofs(mp)
@@ -407,6 +427,45 @@ class DynamicPatchTestMembrane(BasePatchTestMembrane):
             self._check_dynamic_results(mp.Nodes[9],step-1,displacement_results)
 
         #self.__post_process(mp)
+
+    def test_membrane_3d3n_dynamic_explicit(self):
+
+        displacement_results = [-0.0002841599939540823,-0.0011349887342934934,-0.002540748817246621,
+                -0.004486283106381001,-0.006952490877638977,-0.009915186333892944,-0.013343609643875768,
+                -0.017199017551113673,-0.021433683516078342,-0.025990540792088512,-0.03080359387145972,
+                -0.0357991109971861,-0.04089750763614265,-0.04601575056299923,-0.05107006212101212,
+                -0.05597868657695468,-0.0606644929233863,-0.0650572252543451,-0.06909526517143542,
+                -0.07272683204340089,-0.07591060817216749,-0.07861583005624559,-0.08082192886443668,
+                -0.08251782999198577,-0.08370103245035691,-0.0843765851212886,-0.0845560614007888,
+                -0.08425661021793271,-0.08350013389169322,-0.08231261559304502,-0.08072359445158465,
+                -0.07876576681569612,-0.07647467907426633,-0.07388847105969688,-0.07104762886242932,
+                -0.06799471079549385,-0.0647740188006934,-0.0614311982085442,-0.05801275994687986,
+                -0.054565529754844445,-0.051136037733349404,-0.04776986804045347,-0.044510992460366265,
+                -0.041401112982577225,-0.03847903770465099,-0.03578011175897693,-0.03333572108221476,
+                -0.031172882231822595,-0.029313926602011157,-0.027776282718925252]
+
+
+        current_model = KratosMultiphysics.Model()
+        mp = self._set_up_system_3d3n(current_model,explicit_dynamics=True)
+        mp.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE] = 3
+
+
+        #time integration parameters
+        dt = 0.01
+        time = 0.0
+        end_time = 0.5
+        step = 0
+
+        self._set_and_fill_buffer(mp,3,dt)
+        strategy_expl = BasePatchTestMembrane._create_dynamic_explicit_strategy(mp,'central_differences')
+        while(time <= end_time):
+            time = time + dt
+            step = step + 1
+            mp.CloneTimeStep(time)
+            strategy_expl.Solve()
+            self._check_dynamic_results(mp.Nodes[10],step-1,displacement_results)
+
+
 
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
Hi, two things are changed with the PR.

1. the RighthandSideVector is now calculated even if `IS_FORMFINDING` is not defined. This was  a really strange behaviour ....
2. it is now possible to use the Membrane element in combination with an explicit time integration


:metal: 