### PR TITLE
[Trilinos] importing MPI-Core

### DIFF
--- a/applications/TrilinosApplication/TrilinosApplication.py
+++ b/applications/TrilinosApplication/TrilinosApplication.py
@@ -1,5 +1,6 @@
 from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import KratosMultiphysics as KM
+import KratosMultiphysics.mpi # importing the MPI-Core, since the TrilinosApp directly links to it
 from KratosTrilinosApplication import *
 application = KratosTrilinosApplication()
 application_name = "KratosTrilinosApplication"


### PR DESCRIPTION
The trilinos-app directly uses things from the MPI-Core
If the MPI-Core is not imported by the time the trilinos-app is imported, then it segfaults due to undefined symbols.

The proposed solution is an easy fix, but I think it is not a bad solution, since there is no way we can use it without first importing the MPI-Core

Note that we will need this in more and more applications, basically each time we use things from the MPI-Core directly