### PR TITLE
[HotFix][Core] FindIntersectedGeometricalObjects clear method

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_processes/find_intersected_geometrical_objects_with_obb_for_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/find_intersected_geometrical_objects_with_obb_for_contact_search_process.cpp
@@ -141,9 +141,9 @@ void FindIntersectedGeometricalObjectsWithOBBContactSearchProcess::SetOctreeBoun
 
     // TODO: Octree needs refactoring to work with BoundingBox. Pooyan.
 #ifdef KRATOS_USE_AMATRIX   // This macro definition is for the migration period and to be removed afterward please do not use it
-    BaseType::mOctree.SetBoundingBox(low.data(), high.data());
+    GetOctreePointer()->SetBoundingBox(low.data(), high.data());
 #else
-    BaseType::mOctree.SetBoundingBox(low.data().data(), high.data().data());
+    GetOctreePointer()->SetBoundingBox(low.data().data(), high.data().data());
 #endif // ifdef KRATOS_USE_AMATRIX
 }
 

--- a/kratos/processes/apply_ray_casting_process.cpp
+++ b/kratos/processes/apply_ray_casting_process.cpp
@@ -96,9 +96,9 @@ namespace Kratos
 
             // Creating the ray
             double ray[3] = {r_coords[0], r_coords[1], r_coords[2]};
-			auto pOctree = mpFindIntersectedObjectsProcess->GetOctreePointer();
-            pOctree->NormalizeCoordinates(ray);
-            ray[i_direction] = 0; // Starting from the lower extreme
+			auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
+			rp_octree->NormalizeCoordinates(ray);
+			ray[i_direction] = 0; // Starting from the lower extreme
 
             this->GetRayIntersections(ray, i_direction, intersections);
 
@@ -154,7 +154,7 @@ namespace Kratos
 		this->GetExtraRayOrigins(rCoords, extra_ray_origs);
 
 		// Get the pointer to the base Octree binary
-		auto p_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
+		auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
 
 		// Loop the extra rays to compute its color
 		unsigned int n_ray_pos = 0; // Positive rays counter
@@ -165,7 +165,7 @@ namespace Kratos
 				// Creating the ray
 				const auto aux_ray = extra_ray_origs[i_ray];
 				double ray[3] = {aux_ray[0], aux_ray[1], aux_ray[2]};
-				p_octree->NormalizeCoordinates(ray);
+				rp_octree->NormalizeCoordinates(ray);
 				ray[i_direction] = 0; // Starting from the lower extreme
 				this->CorrectExtraRayOrigin(ray); // Avoid extra ray normalized coordinates to be larger than 1 or 0
 				this->GetRayIntersections(ray, i_direction, intersections);
@@ -280,14 +280,14 @@ namespace Kratos
         rIntersections.clear();
 
 		// Get the octree from the parent discontinuous distance process
-        auto pOctree = mpFindIntersectedObjectsProcess->GetOctreePointer();
+        auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
 
 		// Compute the normalized ray key
-        OctreeType::key_type ray_key[3] = {pOctree->CalcKeyNormalized(ray[0]), pOctree->CalcKeyNormalized(ray[1]), pOctree->CalcKeyNormalized(ray[2])};
+		OctreeType::key_type ray_key[3] = {rp_octree->CalcKeyNormalized(ray[0]), rp_octree->CalcKeyNormalized(ray[1]), rp_octree->CalcKeyNormalized(ray[2])};
 
-        // Getting the entrance cell from lower extreme
+		// Getting the entrance cell from lower extreme
         OctreeType::key_type cell_key[3];
-        auto cell = pOctree->pGetCell(ray_key);
+        auto cell = rp_octree->pGetCell(ray_key);
         while (cell) {
 			// Get the current cell intersections
             const int cell_int = this->GetCellIntersections(cell, ray, ray_key, direction, rIntersections);
@@ -296,7 +296,7 @@ namespace Kratos
 			// And if it exists, go to the next cell
             if (cell->GetNeighbourKey(1 + direction * 2, cell_key)) {
                 ray_key[direction] = cell_key[direction];
-                cell = pOctree->pGetCell(ray_key);
+                cell = rp_octree->pGetCell(ray_key);
                 ray_key[direction] -= 1 ; // The key returned by GetNeighbourKey is inside the cell (minkey +1), to ensure that the corresponding cell get in pGetCell is the right one.
             } else {
                 cell = NULL;
@@ -343,12 +343,12 @@ namespace Kratos
 		double ray_point2[3] = {ray[0], ray[1], ray[2]};
 		double normalized_coordinate;
 
-		auto pOctree = mpFindIntersectedObjectsProcess->GetOctreePointer();
-		pOctree->CalculateCoordinateNormalized(ray_key[direction], normalized_coordinate);
+		auto &rp_octree = mpFindIntersectedObjectsProcess->GetOctreePointer();
+		rp_octree->CalculateCoordinateNormalized(ray_key[direction], normalized_coordinate);
 		ray_point1[direction] = normalized_coordinate;
-		ray_point2[direction] = ray_point1[direction] + pOctree->CalcSizeNormalized(cell);
-		pOctree->ScaleBackToOriginalCoordinate(ray_point1);
-		pOctree->ScaleBackToOriginalCoordinate(ray_point2);
+		ray_point2[direction] = ray_point1[direction] + rp_octree->CalcSizeNormalized(cell);
+		rp_octree->ScaleBackToOriginalCoordinate(ray_point1);
+		rp_octree->ScaleBackToOriginalCoordinate(ray_point2);
 
 		// This is a workaround to avoid the z-component in 2D
 		if (TDim == 2){

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -94,6 +94,7 @@ namespace Kratos
 		this->Initialize();
 		this->FindIntersections();
 		this->CalculateDistances(this->GetIntersections());
+		this->Clear();
 	}
 
 	/// Turn back information as a string.

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -91,10 +91,10 @@ namespace Kratos
 	template<std::size_t TDim>
 	void CalculateDiscontinuousDistanceToSkinProcess<TDim>::Execute()
 	{
+		this->Clear();
 		this->Initialize();
 		this->FindIntersections();
 		this->CalculateDistances(this->GetIntersections());
-		this->Clear();
 	}
 
 	/// Turn back information as a string.

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -221,14 +221,6 @@ namespace Kratos
 			rDistancePoint);
 	}
 
-	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::Execute()
-	{
-		this->Initialize();
-		this->FindIntersections();
-		this->CalculateDistances(this->GetIntersections());
-	}
-
 	/// Turn back information as a string.
 	template<std::size_t TDim>
 	std::string CalculateDistanceToSkinProcess<TDim>::Info() const

--- a/kratos/processes/calculate_distance_to_skin_process.h
+++ b/kratos/processes/calculate_distance_to_skin_process.h
@@ -169,12 +169,6 @@ public:
      */
     virtual void CalculateRayDistances();
 
-    /**
-     * @brief Executes the CalculateDistanceToSkinProcess
-     * This method automatically does all the calls required to compute the signed distance function.
-     */
-    void Execute() override;
-
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/processes/find_intersected_geometrical_objects_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_process.cpp
@@ -167,8 +167,6 @@ void FindIntersectedGeometricalObjectsProcess::Clear()
     mIntersectedObjects.clear();
     OctreePointerType aux_ptr = Kratos::make_unique<OctreeType>();
     mpOctree.swap(aux_ptr);
-    // delete mpOctree;
-    // mpOctree = new OctreeType();
 }
 
 /***********************************************************************************/

--- a/kratos/processes/find_intersected_geometrical_objects_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_process.cpp
@@ -154,7 +154,7 @@ ModelPart& FindIntersectedGeometricalObjectsProcess::GetModelPart2()
 /***********************************************************************************/
 /***********************************************************************************/
 
-FindIntersectedGeometricalObjectsProcess::OctreeType* FindIntersectedGeometricalObjectsProcess::GetOctreePointer()
+FindIntersectedGeometricalObjectsProcess::OctreePointerType& FindIntersectedGeometricalObjectsProcess::GetOctreePointer()
 {
     return mpOctree;
 }
@@ -165,8 +165,10 @@ FindIntersectedGeometricalObjectsProcess::OctreeType* FindIntersectedGeometrical
 void FindIntersectedGeometricalObjectsProcess::Clear()
 {
     mIntersectedObjects.clear();
-    delete mpOctree;
-    mpOctree = new OctreeType();
+    OctreePointerType aux_ptr = Kratos::make_unique<OctreeType>();
+    mpOctree.swap(aux_ptr);
+    // delete mpOctree;
+    // mpOctree = new OctreeType();
 }
 
 /***********************************************************************************/

--- a/kratos/processes/find_intersected_geometrical_objects_process.h
+++ b/kratos/processes/find_intersected_geometrical_objects_process.h
@@ -497,7 +497,7 @@ protected:
 
     ModelPart& mrModelPartIntersected;  /// Model part intersected
     ModelPart& mrModelPartIntersecting; /// Model part intersecting
-    OctreeType mOctree;                 /// The octree structucture that performs the search
+    OctreeType *mpOctree;               /// The octree structucture that performs the search
     Flags mOptions;                     /// Local flags
 
     ///@}

--- a/kratos/processes/find_intersected_geometrical_objects_process.h
+++ b/kratos/processes/find_intersected_geometrical_objects_process.h
@@ -336,6 +336,7 @@ public:
     using ConfigurationType = Internals::DistanceSpatialContainersConfigure;
     using CellType = OctreeBinaryCell<ConfigurationType>;
     using OctreeType = OctreeBinary<CellType>;
+    using OctreePointerType = unique_ptr<OctreeType>;
     using CellNodeDataType = typename ConfigurationType::cell_node_data_type;
     typedef std::vector<typename OctreeType::cell_type*> OtreeCellVectorType;
 
@@ -439,7 +440,7 @@ public:
      * @brief This method returns the Octree conatined in the class
      * @return The octree contained in this process
      */
-    virtual OctreeBinary<OctreeBinaryCell<ConfigurationType>>* GetOctreePointer();
+    virtual OctreePointerType& GetOctreePointer();
 
     /**
      * @brief This clears the database
@@ -497,8 +498,8 @@ protected:
 
     ModelPart& mrModelPartIntersected;  /// Model part intersected
     ModelPart& mrModelPartIntersecting; /// Model part intersecting
-    OctreeType *mpOctree;               /// The octree structucture that performs the search
     Flags mOptions;                     /// Local flags
+    OctreePointerType mpOctree;         /// The octree structucture that performs the search
 
     ///@}
     ///@name Protected Operators

--- a/kratos/processes/find_intersected_geometrical_objects_with_obb_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_with_obb_process.cpp
@@ -162,9 +162,9 @@ void FindIntersectedGeometricalObjectsWithOBBProcess::SetOctreeBoundingBox()
 
     // TODO: Octree needs refactoring to work with BoundingBox. Pooyan.
 #ifdef KRATOS_USE_AMATRIX   // This macro definition is for the migration period and to be removed afterward please do not use it
-    BaseType::mOctree.SetBoundingBox(low.data(), high.data());
+    BaseType::mpOctree->SetBoundingBox(low.data(), high.data());
 #else
-    BaseType::mOctree.SetBoundingBox(low.data().data(), high.data().data());
+    BaseType::mpOctree->SetBoundingBox(low.data().data(), high.data().data());
 #endif // ifdef KRATOS_USE_AMATRIX
 }
 

--- a/kratos/processes/find_intersected_geometrical_objects_with_obb_process.cpp
+++ b/kratos/processes/find_intersected_geometrical_objects_with_obb_process.cpp
@@ -162,9 +162,9 @@ void FindIntersectedGeometricalObjectsWithOBBProcess::SetOctreeBoundingBox()
 
     // TODO: Octree needs refactoring to work with BoundingBox. Pooyan.
 #ifdef KRATOS_USE_AMATRIX   // This macro definition is for the migration period and to be removed afterward please do not use it
-    BaseType::mpOctree->SetBoundingBox(low.data(), high.data());
+    GetOctreePointer()->SetBoundingBox(low.data(), high.data());
 #else
-    BaseType::mpOctree->SetBoundingBox(low.data().data(), high.data().data());
+    GetOctreePointer()->SetBoundingBox(low.data().data(), high.data().data());
 #endif // ifdef KRATOS_USE_AMATRIX
 }
 

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -329,12 +329,14 @@ void  AddProcessesToPython(pybind11::module& m)
     // Discontinuous distance computation methods
     py::class_<CalculateDiscontinuousDistanceToSkinProcess<2>, CalculateDiscontinuousDistanceToSkinProcess<2>::Pointer, Process>(m,"CalculateDiscontinuousDistanceToSkinProcess2D")
         .def(py::init<ModelPart&, ModelPart&>())
+        .def("Clear", &CalculateDiscontinuousDistanceToSkinProcess<2>::Clear)
         .def("CalculateEmbeddedVariableFromSkin", CalculateDiscontinuousEmbeddedVariableFromSkinArray<2>)
         .def("CalculateEmbeddedVariableFromSkin", CalculateDiscontinuousEmbeddedVariableFromSkinDouble<2>)
         ;
 
     py::class_<CalculateDiscontinuousDistanceToSkinProcess<3>, CalculateDiscontinuousDistanceToSkinProcess<3>::Pointer, Process>(m,"CalculateDiscontinuousDistanceToSkinProcess3D")
         .def(py::init<ModelPart&, ModelPart&>())
+        .def("Clear", &CalculateDiscontinuousDistanceToSkinProcess<3>::Clear)
         .def("CalculateEmbeddedVariableFromSkin", CalculateDiscontinuousEmbeddedVariableFromSkinArray<3>)
         .def("CalculateEmbeddedVariableFromSkin", CalculateDiscontinuousEmbeddedVariableFromSkinDouble<3>)
         ;
@@ -343,6 +345,7 @@ void  AddProcessesToPython(pybind11::module& m)
     py::class_<CalculateDistanceToSkinProcess<2>, CalculateDistanceToSkinProcess<2>::Pointer, Process>(m,"CalculateDistanceToSkinProcess2D")
         .def(py::init<ModelPart&, ModelPart&>())
         .def(py::init<ModelPart&, ModelPart&, double>())
+        .def("Clear", &CalculateDistanceToSkinProcess<2>::Clear)
         .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinArray<2>)
         .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinDouble<2>)
     ;
@@ -350,6 +353,7 @@ void  AddProcessesToPython(pybind11::module& m)
     py::class_<CalculateDistanceToSkinProcess<3>, CalculateDistanceToSkinProcess<3>::Pointer, Process>(m,"CalculateDistanceToSkinProcess3D")
         .def(py::init<ModelPart&, ModelPart&>())
         .def(py::init<ModelPart&, ModelPart&, double>())
+        .def("Clear", &CalculateDistanceToSkinProcess<3>::Clear)
         .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinArray<2>)
         .def("CalculateEmbeddedVariableFromSkin", CalculateEmbeddedVariableFromSkinDouble<2>)
     ;


### PR DESCRIPTION
While doing FSI I discovered that the distance calculation methods used to increase the elapsed time to compute the level set each time the `Execute()` method was called. This didn't happen when the distance calculation object was instantiated and destroyed each time it is required. However, if the instance of the processes was kept, the calculation time used to increase.

The problem was that there was no call to the `Clear()` method. I think that the `insert` of the Octree used to insert the entities on top of the existent ones, increasing thus the time spent in the search. This PR includes a call to the `Clear()` method of the `FindIntersectedGeometricalObjectsProcess`, which has been enhanced to also empty the Octree. Since the Octree has no clear method, what we do now is to create a new empty one once the level-set has been computed. This has required to change the member variable to a raw pointer to the Octree.

I also took the chance to remove a useless `override` in the continuous level set process.

I did some tests and the elapsed time is now more or less "constant" for each `Execute()` call.