### PR TITLE
[MPI] restrict import of MPI-Core to distributed runs

### DIFF
--- a/kratos/mpi/python_scripts/mpi_module_init.py
+++ b/kratos/mpi/python_scripts/mpi_module_init.py
@@ -1,6 +1,14 @@
 from __future__ import absolute_import
 import sys
 
+import KratosMultiphysics as KM
+
+if hasattr(KM, 'KratosGlobals'):
+    # if "KratosGlobals" does not exist it means that this is the initialization
+    # of MPI that is explicitly called from the init of Kratos
+    if not KM.KratosGlobals.Kernel.IsDistributedRun():
+        raise ImportError("MPI can only be imported in a distributed run!")
+
 if sys.platform.startswith('linux'):
     # Note: from Python 3.3 onwards, dll load flags are available from module os
     # from Python 3.6 onwards, module DLFCN no longer exists


### PR DESCRIPTION
@jcotela this is what we discussed the other day.
With this we can restrict the usage of MPI to distributed runs, which is the correct way to go in my opinion.

I.e. if someone runs Kratos without MPI and tries to import MPI (`import KratosMultiphysics.mpi`) it will crash