### PR TITLE
[Core] App-Template: Split into core/py-interface

### DIFF
--- a/kratos/templates/classes/condition_template.h
+++ b/kratos/templates/classes/condition_template.h
@@ -121,7 +121,7 @@ public:
      * @param pProperties: the properties assigned to the new condition
      * @return a Pointer to the new condition
      */
-    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const;
+    Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
 
     /**
      * creates a new condition pointer
@@ -130,7 +130,7 @@ public:
      * @param pProperties: the properties assigned to the new condition
      * @return a Pointer to the new condition
      */
-    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const;
+    Condition::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     /**
      * creates a new condition pointer and clones the previous condition data
@@ -139,7 +139,7 @@ public:
      * @param pProperties: the properties assigned to the new condition
      * @return a Pointer to the new condition
      */
-    Condition::Pointer Clone(IndexType NewId, NodesArrayType const& ThisNodes) const;
+    Condition::Pointer Clone(IndexType NewId, NodesArrayType const& ThisNodes) const override;
 
     /**
      * this determines the condition equation ID vector for all condition

--- a/kratos/templates/classes/element_template.h
+++ b/kratos/templates/classes/element_template.h
@@ -121,7 +121,7 @@ public:
      * @param pProperties: the properties assigned to the new element
      * @return a Pointer to the new element
      */
-    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const;
+    Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
 
     /**
      * creates a new element pointer
@@ -130,7 +130,7 @@ public:
      * @param pProperties: the properties assigned to the new element
      * @return a Pointer to the new element
      */
-    Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const;
+    Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
 
     /**
      * creates a new element pointer and clones the previous element data
@@ -139,7 +139,7 @@ public:
      * @param pProperties: the properties assigned to the new element
      * @return a Pointer to the new element
      */
-    Element::Pointer Clone(IndexType NewId, NodesArrayType const& ThisNodes) const;
+    Element::Pointer Clone(IndexType NewId, NodesArrayType const& ThisNodes) const override;
 
     /**
      * this determines the elemental equation ID vector for all elemental

--- a/kratos/templates/template_application/CMakeLists.txt.in
+++ b/kratos/templates/template_application/CMakeLists.txt.in
@@ -7,41 +7,68 @@ include(pybind11Tools)
 
 include_directories( ${CMAKE_SOURCE_DIR}/kratos )
 
-# generate variables with the sources
-set( KRATOS_@{APP_NAME_CAPS}_APPLICATION_SOURCES
+## @{APP_NAME_CAMEL} Core sources
+file(GLOB_RECURSE KRATOS_@{APP_NAME_CAPS}_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/@{APP_NAME_LOW}_application.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/@{APP_NAME_LOW}_application_variables.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/@{APP_NAME_LOW}_python_application.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_utilities_to_python.cpp@{APP_SOURCE_LIST}
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_strategies_to_python.cpp@{APP_SOURCE_LIST}
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/*.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/*.cpp
 )
 
-# define library Kratos which defines the basic python interface
-pybind11_add_module(Kratos@{APP_NAME_CAMEL}Application MODULE THIN_LTO ${KRATOS_@{APP_NAME_CAPS}_APPLICATION_SOURCES})
-target_link_libraries(Kratos@{APP_NAME_CAMEL}Application PRIVATE KratosCore @{APP_DEPEND_LIST})
+## @{APP_NAME_CAMEL} testing sources
+if(${KRATOS_BUILD_TESTING} MATCHES ON)
+    file(GLOB_RECURSE KRATOS_@{APP_NAME_CAPS}_APPLICATION_TESTING_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tests/*.cpp)
+endif(${KRATOS_BUILD_TESTING} MATCHES ON)
+
+## @{APP_NAME_CAMEL} python interface sources
+file(GLOB_RECURSE KRATOS_@{APP_NAME_CAPS}_APPLICATION_PYTHON_INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/*.cpp)
+
+add_library(Kratos@{APP_NAME_CAMEL}Core SHARED ${KRATOS_@{APP_NAME_CAPS}_APPLICATION_CORE} ${KRATOS_@{APP_NAME_CAPS}_APPLICATION_TESTING_SOURCES})
+target_link_libraries(Kratos@{APP_NAME_CAMEL}Core PUBLIC KratosCore)
+set_target_properties(Kratos@{APP_NAME_CAMEL}Core PROPERTIES COMPILE_DEFINITIONS "@{APP_NAME_CAPS}_APPLICATION=EXPORT,API")
+
+###############################################################
+## define library Kratos which defines the basic python interface
+pybind11_add_module(Kratos@{APP_NAME_CAMEL}Application MODULE THIN_LTO ${KRATOS_@{APP_NAME_CAPS}_APPLICATION_PYTHON_INTERFACE})
+target_link_libraries(Kratos@{APP_NAME_CAMEL}Application PRIVATE Kratos@{APP_NAME_CAMEL}Core)
 set_target_properties(Kratos@{APP_NAME_CAMEL}Application PROPERTIES PREFIX "")
 
-if(USE_COTIRE MATCHES ON)
-    cotire(Kratos@{APP_NAME_CAMEL}Application)
-endif(USE_COTIRE MATCHES ON)
-
-install(TARGETS Kratos@{APP_NAME_CAMEL}Application DESTINATION libs )
-
-# changing the .dll suffix to .pyd (Windows)
+# changing the .dll suffix to .pyd
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set_target_properties(Kratos@{APP_NAME_CAMEL}Application PROPERTIES SUFFIX .pyd)
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
-# changing the .dylib suffix to .so (OS X)
+# changing the .dylib suffix to .so
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_target_properties(Kratos@{APP_NAME_CAMEL}Application PROPERTIES SUFFIX .so)
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
-# install the python files
 if(${INSTALL_PYTHON_FILES} MATCHES ON)
-  get_filename_component (CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
-  install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python_scripts DESTINATION applications/${CURRENT_DIR_NAME}  FILES_MATCHING PATTERN "*.py"  PATTERN ".svn" EXCLUDE)
+    get_filename_component (CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python_scripts DESTINATION applications/${CURRENT_DIR_NAME} FILES_MATCHING PATTERN "*.py")
 endif(${INSTALL_PYTHON_FILES} MATCHES ON)
+
+# Kratos Testing. Install everything except sources to ensure that reference and configuration files are copied.
+if(${INSTALL_TESTING_FILES} MATCHES ON )
+    get_filename_component (CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+    install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/tests DESTINATION applications/${CURRENT_DIR_NAME}
+        PATTERN "*.git" EXCLUDE
+        PATTERN "*.c" EXCLUDE
+        PATTERN "*.h" EXCLUDE
+        PATTERN "*.cpp" EXCLUDE
+        PATTERN "*.hpp" EXCLUDE
+  )
+endif(${INSTALL_TESTING_FILES} MATCHES ON)
+
+if(USE_COTIRE MATCHES ON)
+    cotire(Kratos@{APP_NAME_CAMEL}Core)
+    cotire(Kratos@{APP_NAME_CAMEL}Application)
+endif(USE_COTIRE MATCHES ON)
+
+install(TARGETS Kratos@{APP_NAME_CAMEL}Core DESTINATION libs )
+install(TARGETS Kratos@{APP_NAME_CAMEL}Application DESTINATION libs )
 
 # Add to the KratosMultiphisics Python module
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/@{APP_NAME_CAMEL}Application.py" DESTINATION "KratosMultiphysics/@{APP_NAME_CAMEL}Application" RENAME "__init__.py")

--- a/kratos/templates/template_application/CMakeLists.txt.in
+++ b/kratos/templates/template_application/CMakeLists.txt.in
@@ -35,16 +35,17 @@ pybind11_add_module(Kratos@{APP_NAME_CAMEL}Application MODULE THIN_LTO ${KRATOS_
 target_link_libraries(Kratos@{APP_NAME_CAMEL}Application PRIVATE Kratos@{APP_NAME_CAMEL}Core)
 set_target_properties(Kratos@{APP_NAME_CAMEL}Application PROPERTIES PREFIX "")
 
-# changing the .dll suffix to .pyd
+# changing the .dll suffix to .pyd (Windows)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
     set_target_properties(Kratos@{APP_NAME_CAMEL}Application PROPERTIES SUFFIX .pyd)
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 
-# changing the .dylib suffix to .so
+# changing the .dylib suffix to .so (OS X)
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     set_target_properties(Kratos@{APP_NAME_CAMEL}Application PROPERTIES SUFFIX .so)
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
+# install the python files
 if(${INSTALL_PYTHON_FILES} MATCHES ON)
     get_filename_component (CURRENT_DIR_NAME ${CMAKE_CURRENT_SOURCE_DIR} NAME)
     install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/python_scripts DESTINATION applications/${CURRENT_DIR_NAME} FILES_MATCHING PATTERN "*.py")

--- a/kratos/templates/template_application/custom_python/test_python_application.cpp.in
+++ b/kratos/templates/template_application/custom_python/test_python_application.cpp.in
@@ -21,6 +21,7 @@
 
 // Project includes
 #include "includes/define_python.h"
+#include "@{APP_NAME_LOW}_application.h"
 #include "@{APP_NAME_LOW}_application_variables.h"
 #include "custom_python/add_custom_strategies_to_python.h"
 #include "custom_python/add_custom_utilities_to_python.h"

--- a/kratos/templates/template_application/custom_python/test_python_application.cpp.in
+++ b/kratos/templates/template_application/custom_python/test_python_application.cpp.in
@@ -20,8 +20,7 @@
 
 
 // Project includes
-#include "includes/define.h"
-#include "@{APP_NAME_LOW}_application.h"
+#include "includes/define_python.h"
 #include "@{APP_NAME_LOW}_application_variables.h"
 #include "custom_python/add_custom_strategies_to_python.h"
 #include "custom_python/add_custom_utilities_to_python.h"


### PR DESCRIPTION
closes #4576

I used GLOB_RECURSE right away, I think it is a good idea to directly use it for new apps
plus the install for the testing-files was missing

also did some minor corrections