### PR TITLE
[Nightly] Deactivating EmpireApp

### DIFF
--- a/scripts/build/nightly/configure_clang.sh
+++ b/scripts/build/nightly/configure_clang.sh
@@ -18,7 +18,6 @@ cmake .. \
 -DDAM_APPLICATION=ON                                                                            \
 -DDEM_APPLICATION=ON                                                                            \
 -DCO_SIMULATION_APPLICATION=ON                                                                  \
--DEMPIRE_APPLICATION=ON                                                                         \
 -DEXTERNAL_SOLVERS_APPLICATION=ON                                                               \
 -DFSI_APPLICATION=ON                                                                            \
 -DFLUID_DYNAMICS_APPLICATION=ON                                                                 \

--- a/scripts/build/nightly/configure_gcc.sh
+++ b/scripts/build/nightly/configure_gcc.sh
@@ -18,7 +18,6 @@ cmake .. \
 -DDAM_APPLICATION=ON                                                                            \
 -DDEM_APPLICATION=ON                                                                            \
 -DCO_SIMULATION_APPLICATION=ON                                                                  \
--DEMPIRE_APPLICATION=ON                                                                         \
 -DEXTERNAL_SOLVERS_APPLICATION=ON                                                               \
 -DFSI_APPLICATION=ON                                                                            \
 -DFLUID_DYNAMICS_APPLICATION=ON                                                                 \


### PR DESCRIPTION
This app is legacy, but cannot be removed yet bcs it is still in use
However there will be no more development so I suggest do save the time in the nightly build

BTW @roigcarlo I haven't received a nightly report from clang in a while, could you please have a look?

FYI @AndreasWinterstein @adityaghantasala @mpentek 