### PR TITLE
Mpi/default rank and size

### DIFF
--- a/kratos/includes/parallel_environment.h
+++ b/kratos/includes/parallel_environment.h
@@ -49,6 +49,22 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
     ///@name Access
     ///@{
 
+    /// Retrieve a registered DataCommunicator instance.
+    /** @param rName The name used to register the string. */
+    static DataCommunicator& GetDataCommunicator(const std::string& rName);
+
+    /// Retrieve the default DataCommunicator instance.
+    static DataCommunicator& GetDefaultDataCommunicator();
+
+    /// Set a new default DataCommunicator instance.
+    /** @param rName The name the new default DataCommunicator was registered with. */
+    static void SetDefaultDataCommunicator(const std::string& rName);
+
+    /// Get the rank of the current process, as given by the default DataCommunicator.
+    static int GetDefaultRank();
+
+    /// Get the MPI Comm size, as given by the default DataCommunicator.
+    static int GetDefaultSize();
 
     ///@}
     ///@name Operations
@@ -58,12 +74,6 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
         const std::string& rName,
         const DataCommunicator& rPrototype,
         const bool Default = DoNotMakeDefault);
-
-    static DataCommunicator& GetDataCommunicator(const std::string& rName);
-
-    static DataCommunicator& GetDefaultDataCommunicator();
-
-    static void SetDefaultDataCommunicator(const std::string& rName);
 
     ///@}
     ///@name Inquiry

--- a/kratos/includes/parallel_environment.h
+++ b/kratos/includes/parallel_environment.h
@@ -126,6 +126,8 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
 
     static ParallelEnvironment& GetInstance();
 
+    void SetAsDefault(std::unordered_map<std::string, DataCommunicator::UniquePointer>::iterator& rThisCommunicator);
+
     ///@}
     ///@name Private Input and output
     ///@{
@@ -146,6 +148,9 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
     std::unordered_map<std::string, DataCommunicator::UniquePointer> mDataCommunicators;
 
     std::unordered_map<std::string, DataCommunicator::UniquePointer>::iterator mDefaultCommunicator;
+
+    int mDefaultRank;
+    int mDefaultSize;
 
     static ParallelEnvironment* mpInstance;
     static bool mDestroyed;

--- a/kratos/includes/parallel_environment.h
+++ b/kratos/includes/parallel_environment.h
@@ -81,6 +81,8 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
 
     static bool HasDataCommunicator(const std::string& rName);
 
+    static std::string GetDefaultDataCommunicatorName();
+
     ///@}
     ///@name Input and output
     ///@{

--- a/kratos/includes/parallel_environment.h
+++ b/kratos/includes/parallel_environment.h
@@ -70,6 +70,11 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
     ///@name Operations
     ///@{
 
+    /// Add a new DataCommunicator instance to the ParallelEnvironment.
+    /** @param rName The name to be used to identify the DataCommunicator within ParallelEnvironment.
+     *  @param rPrototype The DataCommunicator instance.
+     *  @param Default If set to ParallelEnvironment::MakeDefault (a.k.a. true), the provided DataCommunicator will also be made default.
+     */
     static void RegisterDataCommunicator(
         const std::string& rName,
         const DataCommunicator& rPrototype,
@@ -79,8 +84,11 @@ class KRATOS_API(KRATOS_CORE) ParallelEnvironment
     ///@name Inquiry
     ///@{
 
+    /// Check if a DataCommunicator is registered as rName.
     static bool HasDataCommunicator(const std::string& rName);
 
+    /// Get the registered name of the current default.
+    /** This is a convenience function to help with temporarily changing the default DataCommunicator. */
     static std::string GetDefaultDataCommunicatorName();
 
     ///@}

--- a/kratos/input_output/logger_message.cpp
+++ b/kratos/input_output/logger_message.cpp
@@ -19,14 +19,13 @@
 
 // Project includes
 #include "input_output/logger_message.h"
-#include "includes/data_communicator.h"
+#include "includes/parallel_environment.h"
 
 namespace Kratos
 {
   LoggerMessage::MessageSource::MessageSource()
   {
-    const DataCommunicator& r_comm = DataCommunicator::GetDefault();
-    mRank = r_comm.Rank();
+    mRank = ParallelEnvironment::GetDefaultRank();
   }
 
   std::string LoggerMessage::Info() const

--- a/kratos/mpi/python/kratos_mpi_python.cpp
+++ b/kratos/mpi/python/kratos_mpi_python.cpp
@@ -29,12 +29,12 @@ namespace Python {
 
 void InitializeMPIParallelRun()
 {
-    // Define the World DataCommunicator as a wrapper for MPI_COMM_WORLD and make it the default.
-    ParallelEnvironment::RegisterDataCommunicator("World", MPIDataCommunicator(MPI_COMM_WORLD), ParallelEnvironment::MakeDefault);
-
     // Initialize MPI
     MPIEnvironment& mpi_environment = MPIEnvironment::Instance();
     mpi_environment.Initialize();
+
+    // Define the World DataCommunicator as a wrapper for MPI_COMM_WORLD and make it the default.
+    ParallelEnvironment::RegisterDataCommunicator("World", MPIDataCommunicator(MPI_COMM_WORLD), ParallelEnvironment::MakeDefault);
 }
 
 PYBIND11_MODULE(KratosMPI, m)

--- a/kratos/mpi/tests/test_mpi_data_communicator_python.py
+++ b/kratos/mpi/tests/test_mpi_data_communicator_python.py
@@ -1,5 +1,5 @@
 import KratosMultiphysics as Kratos
-import KratosMultiphysics.mpi as mpi #TODO remove once the test script accepts a command-line argument.
+import KratosMultiphysics.mpi as mpi
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 
@@ -12,14 +12,6 @@ class TestMPIDataCommunicatorPython(UnitTest.TestCase):
 
     def tearDown(self):
         pass
-
-    def testDataCommunicatorRetrievalFromParallelEnvironment(self):
-        default_comm = Kratos.ParallelEnvironment.GetDefaultDataCommunicator()
-
-        self.assertTrue(Kratos.ParallelEnvironment.HasDataCommunicator("World"))
-
-        # if we imported mpi, default should be "World" (wrapping MPI_COMM_WORLD)
-        self.assertTrue(default_comm.IsDistributed())
 
     def testDataCommunicatorRetrievalFromDataCommunicator(self):
         default_comm = Kratos.DataCommunicator.GetDefault()

--- a/kratos/mpi/tests/test_mpi_data_communicator_python.py
+++ b/kratos/mpi/tests/test_mpi_data_communicator_python.py
@@ -1,5 +1,4 @@
 import KratosMultiphysics as Kratos
-import KratosMultiphysics.mpi as mpi
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 
@@ -13,6 +12,7 @@ class TestMPIDataCommunicatorPython(UnitTest.TestCase):
     def tearDown(self):
         pass
 
+    @UnitTest.skipIf(not Kratos.IsDistributedRun(), "This test is designed for distributed runs only.")
     def testDataCommunicatorRetrievalFromDataCommunicator(self):
         default_comm = Kratos.DataCommunicator.GetDefault()
 

--- a/kratos/mpi/tests/test_parallel_environment.py
+++ b/kratos/mpi/tests/test_parallel_environment.py
@@ -2,7 +2,7 @@ import KratosMultiphysics as Kratos
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 
-class TestMPIDataCommunicatorPython(UnitTest.TestCase):
+class TestParallelEnvironment(UnitTest.TestCase):
 
     def setUp(self):
         self.world = Kratos.DataCommunicator.GetDefault()

--- a/kratos/mpi/tests/test_parallel_environment.py
+++ b/kratos/mpi/tests/test_parallel_environment.py
@@ -1,5 +1,4 @@
 import KratosMultiphysics as Kratos
-import KratosMultiphysics.mpi as mpi
 
 import KratosMultiphysics.KratosUnittest as UnitTest
 

--- a/kratos/mpi/tests/test_parallel_environment.py
+++ b/kratos/mpi/tests/test_parallel_environment.py
@@ -23,6 +23,7 @@ class TestMPIDataCommunicatorPython(UnitTest.TestCase):
 
     def testDefaultRankAndSize(self):
         default_comm = Kratos.ParallelEnvironment.GetDefaultDataCommunicator()
+        original_default_name = Kratos.ParallelEnvironment.GetDefaultDataCommunicatorName()
         self.assertEqual(default_comm.Rank(), Kratos.ParallelEnvironment.GetDefaultRank())
         self.assertEqual(default_comm.Size(), Kratos.ParallelEnvironment.GetDefaultSize())
 
@@ -33,7 +34,7 @@ class TestMPIDataCommunicatorPython(UnitTest.TestCase):
         self.assertEqual(new_default.Size(), 1)
 
         # Restore the original default
-        Kratos.ParallelEnvironment.SetDefaultDataCommunicator("World")
+        Kratos.ParallelEnvironment.SetDefaultDataCommunicator(original_default_name)
         self.assertEqual(default_comm.Rank(), Kratos.ParallelEnvironment.GetDefaultRank())
         self.assertEqual(default_comm.Size(), Kratos.ParallelEnvironment.GetDefaultSize())
 

--- a/kratos/mpi/tests/test_parallel_environment.py
+++ b/kratos/mpi/tests/test_parallel_environment.py
@@ -12,6 +12,7 @@ class TestMPIDataCommunicatorPython(UnitTest.TestCase):
     def tearDown(self):
         pass
 
+    @UnitTest.skipIf(not Kratos.IsDistributedRun(), "This test is designed for distributed runs only.")
     def testDataCommunicatorRetrievalFromParallelEnvironment(self):
         default_comm = Kratos.ParallelEnvironment.GetDefaultDataCommunicator()
 

--- a/kratos/mpi/tests/test_parallel_environment.py
+++ b/kratos/mpi/tests/test_parallel_environment.py
@@ -1,0 +1,41 @@
+import KratosMultiphysics as Kratos
+import KratosMultiphysics.mpi as mpi
+
+import KratosMultiphysics.KratosUnittest as UnitTest
+
+class TestMPIDataCommunicatorPython(UnitTest.TestCase):
+
+    def setUp(self):
+        self.world = Kratos.DataCommunicator.GetDefault()
+        self.rank = self.world.Rank()
+        self.size = self.world.Size()
+
+    def tearDown(self):
+        pass
+
+    def testDataCommunicatorRetrievalFromParallelEnvironment(self):
+        default_comm = Kratos.ParallelEnvironment.GetDefaultDataCommunicator()
+
+        self.assertTrue(Kratos.ParallelEnvironment.HasDataCommunicator("World"))
+
+        # if we imported mpi, default should be "World" (wrapping MPI_COMM_WORLD)
+        self.assertTrue(default_comm.IsDistributed())
+
+    def testDefaultRankAndSize(self):
+        default_comm = Kratos.ParallelEnvironment.GetDefaultDataCommunicator()
+        self.assertEqual(default_comm.Rank(), Kratos.ParallelEnvironment.GetDefaultRank())
+        self.assertEqual(default_comm.Size(), Kratos.ParallelEnvironment.GetDefaultSize())
+
+        # Change the default, see if it still works
+        Kratos.ParallelEnvironment.SetDefaultDataCommunicator("Serial")
+        new_default = Kratos.ParallelEnvironment.GetDefaultDataCommunicator()
+        self.assertEqual(new_default.Rank(), 0)
+        self.assertEqual(new_default.Size(), 1)
+
+        # Restore the original default
+        Kratos.ParallelEnvironment.SetDefaultDataCommunicator("World")
+        self.assertEqual(default_comm.Rank(), Kratos.ParallelEnvironment.GetDefaultRank())
+        self.assertEqual(default_comm.Size(), Kratos.ParallelEnvironment.GetDefaultSize())
+
+if __name__ == "__main__":
+    UnitTest.main()

--- a/kratos/python/add_parallel_environment_to_python.cpp
+++ b/kratos/python/add_parallel_environment_to_python.cpp
@@ -36,6 +36,7 @@ void AddParallelEnvironmentToPython(pybind11::module &m)
     .def_static("GetDefaultRank",&ParallelEnvironment::GetDefaultRank)
     .def_static("GetDefaultSize",&ParallelEnvironment::GetDefaultSize)
     .def_static("HasDataCommunicator",&ParallelEnvironment::HasDataCommunicator)
+    .def_static("GetDefaultDataCommunicatorName",&ParallelEnvironment::GetDefaultDataCommunicatorName)
     .def_static("Info", []() {
         std::stringstream ss;
         ParallelEnvironment::PrintInfo(ss);

--- a/kratos/python/add_parallel_environment_to_python.cpp
+++ b/kratos/python/add_parallel_environment_to_python.cpp
@@ -33,6 +33,8 @@ void AddParallelEnvironmentToPython(pybind11::module &m)
     .def_static("GetDataCommunicator",&ParallelEnvironment::GetDataCommunicator, py::return_value_policy::reference)
     .def_static("GetDefaultDataCommunicator",&ParallelEnvironment::GetDefaultDataCommunicator, py::return_value_policy::reference)
     .def_static("SetDefaultDataCommunicator",&ParallelEnvironment::SetDefaultDataCommunicator)
+    .def_static("GetDefaultRank",&ParallelEnvironment::GetDefaultRank)
+    .def_static("GetDefaultSize",&ParallelEnvironment::GetDefaultSize)
     .def_static("HasDataCommunicator",&ParallelEnvironment::HasDataCommunicator)
     .def_static("Info", []() {
         std::stringstream ss;

--- a/kratos/sources/parallel_environment.cpp
+++ b/kratos/sources/parallel_environment.cpp
@@ -22,15 +22,6 @@ namespace Kratos {
 
 // Public interface of ParallelEnvironment ////////////////////////////////////
 
-void ParallelEnvironment::RegisterDataCommunicator(
-    const std::string& Name,
-    const DataCommunicator& rPrototype,
-    const bool Default)
-{
-    ParallelEnvironment& env = GetInstance();
-    env.RegisterDataCommunicatorDetail(Name, rPrototype, Default);
-}
-
 DataCommunicator& ParallelEnvironment::GetDataCommunicator(const std::string& rName)
 {
     const ParallelEnvironment& env = GetInstance();
@@ -47,6 +38,27 @@ void ParallelEnvironment::SetDefaultDataCommunicator(const std::string& rName)
 {
     ParallelEnvironment& env = GetInstance();
     env.SetDefaultDataCommunicatorDetail(rName);
+}
+
+int ParallelEnvironment::GetDefaultRank()
+{
+    const ParallelEnvironment& env = GetInstance();
+    return env.mDefaultRank;
+}
+
+int ParallelEnvironment::GetDefaultSize()
+{
+    const ParallelEnvironment& env = GetInstance();
+    return env.mDefaultSize;
+}
+
+void ParallelEnvironment::RegisterDataCommunicator(
+    const std::string& Name,
+    const DataCommunicator& rPrototype,
+    const bool Default)
+{
+    ParallelEnvironment& env = GetInstance();
+    env.RegisterDataCommunicatorDetail(Name, rPrototype, Default);
 }
 
 bool ParallelEnvironment::HasDataCommunicator(const std::string& rName)

--- a/kratos/sources/parallel_environment.cpp
+++ b/kratos/sources/parallel_environment.cpp
@@ -106,6 +106,15 @@ ParallelEnvironment& ParallelEnvironment::GetInstance()
     return *mpInstance;
 }
 
+void ParallelEnvironment::SetAsDefault(
+    std::unordered_map<std::string, DataCommunicator::UniquePointer>::iterator& rThisCommunicator)
+{
+    mDefaultCommunicator = rThisCommunicator;
+    const auto& r_comm = *(rThisCommunicator->second);
+    mDefaultRank = r_comm.Rank();
+    mDefaultSize = r_comm.Size();
+}
+
 void ParallelEnvironment::Create()
 {
     static ParallelEnvironment parallel_environment;
@@ -127,7 +136,7 @@ void ParallelEnvironment::RegisterDataCommunicatorDetail(
 
         if (Default == MakeDefault)
         {
-            mDefaultCommunicator = pair_iterator;
+            SetAsDefault(pair_iterator);
         }
     }
     else {
@@ -159,7 +168,7 @@ void ParallelEnvironment::SetDefaultDataCommunicatorDetail(const std::string& rN
     << "Trying to set \"" << rName << "\" as the default DataCommunicator,"
     << " but no registered DataCommunicator with that name has been found." << std::endl;
 
-    mDefaultCommunicator = found;
+    SetAsDefault(found);
 }
 
 bool ParallelEnvironment::HasDataCommunicatorDetail(const std::string& rName) const

--- a/kratos/sources/parallel_environment.cpp
+++ b/kratos/sources/parallel_environment.cpp
@@ -67,6 +67,12 @@ bool ParallelEnvironment::HasDataCommunicator(const std::string& rName)
     return env.HasDataCommunicatorDetail(rName);
 }
 
+std::string ParallelEnvironment::GetDefaultDataCommunicatorName()
+{
+    const ParallelEnvironment& env = GetInstance();
+    return env.mDefaultCommunicator->first;
+}
+
 std::string ParallelEnvironment::Info()
 {
     const ParallelEnvironment& env = GetInstance();
@@ -156,7 +162,7 @@ void ParallelEnvironment::RegisterDataCommunicatorDetail(
         << "Trying to register a new DataCommunicator with name " << Name
         << " but a DataCommunicator with the same name already exists: "
         << *(found->second)
-        << " The second object has not been added." << std::endl;
+        << " The provided DataCommunicator has not been added." << std::endl;
     }
 }
 


### PR DESCRIPTION
This is a request from some time ago: the ParallelEnvironment stores the MPI rank and size (according to the current default DataCommunicator) to be used instead of an MPI call for quick MPI checks. This PR also makes use of this feature to avoid a potential MPI call every time a Logger message is spawned.

A simple test is included, and some doxygen has been added to the public ParallelEnvironment interface.