### PR TITLE
[Core][Hotfix] Non-historical NODAL_H calculation synchronization

### DIFF
--- a/kratos/processes/find_nodal_h_process.cpp
+++ b/kratos/processes/find_nodal_h_process.cpp
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //  Collaborator:    Vicente Mataix Ferrandiz
-//                    
+//
 //
 
 // System includes
@@ -27,39 +27,38 @@ template<bool THistorical>
 void FindNodalHProcess<THistorical>::Execute()
 {
     KRATOS_TRY
-    
-    // Check if variables are available       
+
+    // Check if variables are available
     if (THistorical) {
         KRATOS_ERROR_IF_NOT(mrModelPart.NodesBegin()->SolutionStepsDataHas( NODAL_H )) << "Variable NODAL_H not in the model part!" << std::endl;
     }
-    
-    #pragma omp parallel for 
+
+    #pragma omp parallel for
     for(int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); ++i) {
         auto it_node = mrModelPart.NodesBegin() + i;
         SetInitialValue(it_node);
     }
-    
+
     for(IndexType i=0; i < mrModelPart.Elements().size(); ++i) {
         auto it_element = mrModelPart.ElementsBegin() + i;
         auto& r_geom = it_element->GetGeometry();
         const SizeType number_of_nodes = r_geom.size();
-        
+
         for(IndexType k = 0; k < number_of_nodes-1; ++k) {
             double& r_h1 = GetHValue(r_geom[k]);
             for(IndexType l=k+1; l < number_of_nodes; ++l) {
                 double hedge = norm_2(r_geom[l].Coordinates() - r_geom[k].Coordinates());
                 double& r_h2 = GetHValue(r_geom[l]);
-                
-                // Get minimum between the existent value and the considered edge length 
+
+                // Get minimum between the existent value and the considered edge length
                 SetHValue(r_geom[k], std::min(r_h1, hedge));
                 SetHValue(r_geom[l], std::min(r_h2, hedge));
             }
         }
     }
-    
-    if (THistorical) {
-        mrModelPart.GetCommunicator().SynchronizeCurrentDataToMin(NODAL_H);
-    }
+
+    // Synchronize between processes
+    SynchronizeValues();
 
     KRATOS_CATCH("")
 }
@@ -122,6 +121,24 @@ template<>
 void FindNodalHProcess<false>::SetInitialValue(NodeIterator itNode)
 {
     itNode->SetValue(NODAL_H, std::numeric_limits<double>::max());
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<>
+void FindNodalHProcess<true>::SynchronizeValues()
+{
+    mrModelPart.GetCommunicator().SynchronizeCurrentDataToMin(NODAL_H);
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template <>
+void FindNodalHProcess<false>::SynchronizeValues()
+{
+    mrModelPart.GetCommunicator().SynchronizeNonHistoricalDataToMin(NODAL_H);
 }
 
 /***********************************************************************************/

--- a/kratos/processes/find_nodal_h_process.cpp
+++ b/kratos/processes/find_nodal_h_process.cpp
@@ -33,12 +33,14 @@ void FindNodalHProcess<THistorical>::Execute()
         KRATOS_ERROR_IF_NOT(mrModelPart.NodesBegin()->SolutionStepsDataHas( NODAL_H )) << "Variable NODAL_H not in the model part!" << std::endl;
     }
 
+    // Initialize NODAL_H values
     #pragma omp parallel for
     for(int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); ++i) {
         auto it_node = mrModelPart.NodesBegin() + i;
         SetInitialValue(it_node);
     }
 
+    // Calculate the NODAL_H values
     for(IndexType i=0; i < mrModelPart.Elements().size(); ++i) {
         auto it_element = mrModelPart.ElementsBegin() + i;
         auto& r_geom = it_element->GetGeometry();

--- a/kratos/processes/find_nodal_h_process.h
+++ b/kratos/processes/find_nodal_h_process.h
@@ -2,14 +2,14 @@
 //    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
-//                   Multi-Physics 
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Riccardo Rossi
 //  Collaborator:    Vicente Mataix Ferrandiz
-//                    
+//
 //
 
 #if !defined(KRATOS_FIND_NODAL_H_PROCESS_INCLUDED )
@@ -56,16 +56,16 @@ struct FindNodalHSettings
     constexpr static bool SaveAsNonHistoricalVariable = false;
 };
 
-/** 
+/**
  * @class FindNodalHProcess
- * @ingroup KratosCore 
+ * @ingroup KratosCore
  * @brief Computes NODAL_H
  * @details Calculate the NODAL_H for all the nodes by means of the element sides minimum length
  * @author Riccardo Rossi
  * @author Vicente Mataix Ferrandiz
  */
 template<bool THistorical = true>
-class KRATOS_API(KRATOS_CORE) FindNodalHProcess 
+class KRATOS_API(KRATOS_CORE) FindNodalHProcess
     : public Process
 {
 public:
@@ -74,13 +74,13 @@ public:
 
     /// Index type definition
     typedef std::size_t IndexType;
-    
+
     /// Size type definition
     typedef std::size_t SizeType;
-    
+
     /// The definition of the node
     typedef Node<3> NodeType;
-    
+
     /// The definition of the node iterator
     typedef ModelPart::NodeIterator NodeIterator;
 
@@ -92,16 +92,13 @@ public:
     ///@{
 
     /// Default constructor.
-    explicit FindNodalHProcess(ModelPart& rModelPart) 
+    explicit FindNodalHProcess(ModelPart& rModelPart)
         : mrModelPart(rModelPart)
     {
     }
 
     /// Destructor.
-    ~FindNodalHProcess() override
-    {
-    }
-
+    ~FindNodalHProcess() override = default;
 
     ///@}
     ///@name Operators
@@ -111,7 +108,6 @@ public:
     {
         Execute();
     }
-
 
     ///@}
     ///@name Operations
@@ -150,51 +146,12 @@ public:
     {
     }
 
-
     ///@}
     ///@name Friends
     ///@{
 
 
     ///@}
-
-protected:
-    ///@name Protected static Member Variables
-    ///@{
-
-
-    ///@}
-    ///@name Protected member Variables
-    ///@{
-
-
-    ///@}
-    ///@name Protected Operators
-    ///@{
-
-
-    ///@}
-    ///@name Protected Operations
-    ///@{
-
-
-    ///@}
-    ///@name Protected  Access
-    ///@{
-
-
-    ///@}
-    ///@name Protected Inquiry
-    ///@{
-
-
-    ///@}
-    ///@name Protected LifeCycle
-    ///@{
-
-
-    ///@}
-
 private:
     ///@name Static Member Variables
     ///@{
@@ -203,7 +160,7 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
-    
+
     ModelPart& mrModelPart;  /// The model part were to compute the NODAL_H
 
     ///@}
@@ -220,7 +177,7 @@ private:
      * @return The current value of NODAL_H
      */
     double& GetHValue(NodeType& rNode);
-    
+
     /**
      * @brief This method sets the current value of the NODAL_H to the given one
      * @param rNode The node iterator to be get
@@ -230,12 +187,19 @@ private:
         NodeType& rNode,
         const double Value
         );
-    
+
     /**
      * @brief This method sets the current value of the NODAL_H to the maximum
      * @param itNode The node iterator to be set
      */
     void SetInitialValue(NodeIterator itNode);
+
+    /**
+     * @brief NODAL_H synchornization
+     * In parallel runs, this method does the synchronization to the minimum
+     * NODAL_H value between processes.
+     */
+    void SynchronizeValues();
 
     ///@}
     ///@name Private  Access
@@ -257,13 +221,10 @@ private:
     /// Copy constructor.
     //FindNodalHProcess(FindNodalHProcess const& rOther);
 
-
     ///@}
-
 }; // Class FindNodalHProcess
 
 ///@}
-
 ///@name Type Definitions
 ///@{
 
@@ -294,6 +255,4 @@ inline std::ostream& operator << (std::ostream& rOStream,
 
 }  // namespace Kratos.
 
-#endif // KRATOS_FIND_NODAL_H_PROCESS_INCLUDED  defined 
-
-
+#endif // KRATOS_FIND_NODAL_H_PROCESS_INCLUDED  defined

--- a/kratos/tests/cpp_tests/processes/test_find_nodal_h_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_find_nodal_h_process.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:   BSD License
-//      Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Vicente Mataix Ferrandiz
 //
@@ -25,11 +25,11 @@
 /* Processes */
 #include "processes/find_nodal_h_process.h"
 
-namespace Kratos 
+namespace Kratos
 {
-    namespace Testing 
+    namespace Testing
     {
-        typedef Node<3>                                                    NodeType;
+        typedef Node<3> NodeType;
 
         void GiDIODebugNodalH(ModelPart& ThisModelPart)
         {
@@ -43,9 +43,9 @@ namespace Kratos
             gid_io.InitializeResults(label, ThisModelPart.GetMesh());
             gid_io.WriteNodalResults(NODAL_H, ThisModelPart.Nodes(), label, 0);
         }
-        
-        /** 
-        * Checks the correct work of the nodal gradient compute
+
+        /**
+        * Checks the correct work of the nodal H compute
         * Test triangle
         */
         KRATOS_TEST_CASE_IN_SUITE(NodalH1, KratosCoreFastSuite)
@@ -54,101 +54,166 @@ namespace Kratos
 
             ModelPart& this_model_part = current_model.CreateModelPart("Main");
             this_model_part.SetBufferSize(2);
-            
+
             this_model_part.AddNodalSolutionStepVariable(NODAL_H);
-            
+
             Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
-            
+
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
             process_info[NL_ITERATION_NUMBER] = 1;
-            
-            // First we create the nodes 
+
+            // First we create the nodes
             NodeType::Pointer p_node_1 = this_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
             NodeType::Pointer p_node_2 = this_model_part.CreateNewNode(2, 1.0 , 0.0 , 0.0);
             NodeType::Pointer p_node_3 = this_model_part.CreateNewNode(3, 1.0 , 1.0 , 0.0);
             NodeType::Pointer p_node_4 = this_model_part.CreateNewNode(4, 0.0 , 1.0 , 0.0);
             NodeType::Pointer p_node_5 = this_model_part.CreateNewNode(5, 2.0 , 0.0 , 0.0);
             NodeType::Pointer p_node_6 = this_model_part.CreateNewNode(6, 2.0 , 1.0 , 0.0);
-            
+
             // Now we create the "conditions"
             std::vector<NodeType::Pointer> element_nodes_0 (3);
             element_nodes_0[0] = p_node_1;
             element_nodes_0[1] = p_node_2;
             element_nodes_0[2] = p_node_3;
             Triangle2D3 <NodeType> triangle_0( PointerVector<NodeType>{element_nodes_0} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_1 (3);
             element_nodes_1[0] = p_node_1;
             element_nodes_1[1] = p_node_3;
             element_nodes_1[2] = p_node_4;
             Triangle2D3 <NodeType> triangle_1( PointerVector<NodeType>{element_nodes_1} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_2 (3);
             element_nodes_2[0] = p_node_2;
             element_nodes_2[1] = p_node_5;
             element_nodes_2[2] = p_node_3;
             Triangle2D3 <NodeType> triangle_2( PointerVector<NodeType>{element_nodes_2} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_3 (3);
             element_nodes_3[0] = p_node_5;
             element_nodes_3[1] = p_node_6;
             element_nodes_3[2] = p_node_3;
             Triangle2D3 <NodeType> triangle_3( PointerVector<NodeType>{element_nodes_3} );
-            
+
             Element::Pointer p_elem_0 = this_model_part.CreateNewElement("Element2D3N", 1, triangle_0, p_elem_prop);
             Element::Pointer p_elem_1 = this_model_part.CreateNewElement("Element2D3N", 2, triangle_1, p_elem_prop);
             Element::Pointer p_elem_2 = this_model_part.CreateNewElement("Element2D3N", 3, triangle_2, p_elem_prop);
             Element::Pointer p_elem_3 = this_model_part.CreateNewElement("Element2D3N", 4, triangle_3, p_elem_prop);
-                         
+
             // Compute NodalH
             auto process = FindNodalHProcess<FindNodalHSettings::SaveAsHistoricalVariable>(this_model_part);
             process.Execute();
-            
-//             // DEBUG         
+
+//             // DEBUG
 //             GiDIODebugNodalH(this_model_part);
-            
+
             const double tolerance = 1.0e-4;
             KRATOS_CHECK_LESS_EQUAL(p_node_1->FastGetSolutionStepValue(NODAL_H) - 1.0, tolerance);
             KRATOS_CHECK_LESS_EQUAL(p_node_2->FastGetSolutionStepValue(NODAL_H) - 1.0, tolerance);
             KRATOS_CHECK_LESS_EQUAL(p_node_5->FastGetSolutionStepValue(NODAL_H) - 1.0, tolerance);
             KRATOS_CHECK_LESS_EQUAL(p_node_6->FastGetSolutionStepValue(NODAL_H) - 1.0, tolerance);
         }
-        
-        /** 
-        * Checks the correct work of the nodal gradient compute
+
+        /**
+        * Checks the correct work of the nodal H non-historical compute
+        * Test triangle
+        */
+        KRATOS_TEST_CASE_IN_SUITE(NodalH1NonHistorical, KratosCoreFastSuite)
+        {
+            Model current_model;
+
+            ModelPart& this_model_part = current_model.CreateModelPart("Main");
+            this_model_part.SetBufferSize(1);
+
+            auto p_elem_prop = this_model_part.CreateNewProperties(0);
+
+            // First we create the nodes
+            auto p_node_1 = this_model_part.CreateNewNode(1, 0.0 , 0.0 , 0.0);
+            auto p_node_2 = this_model_part.CreateNewNode(2, 1.0 , 0.0 , 0.0);
+            auto p_node_3 = this_model_part.CreateNewNode(3, 1.0 , 1.0 , 0.0);
+            auto p_node_4 = this_model_part.CreateNewNode(4, 0.0 , 1.0 , 0.0);
+            auto p_node_5 = this_model_part.CreateNewNode(5, 2.0 , 0.0 , 0.0);
+            auto p_node_6 = this_model_part.CreateNewNode(6, 2.0 , 1.0 , 0.0);
+
+            // Now we create the "conditions"
+            std::vector<NodeType::Pointer> element_nodes_0 (3);
+            element_nodes_0[0] = p_node_1;
+            element_nodes_0[1] = p_node_2;
+            element_nodes_0[2] = p_node_3;
+            Triangle2D3<NodeType> triangle_0( PointerVector<NodeType>{element_nodes_0} );
+
+            std::vector<NodeType::Pointer> element_nodes_1 (3);
+            element_nodes_1[0] = p_node_1;
+            element_nodes_1[1] = p_node_3;
+            element_nodes_1[2] = p_node_4;
+            Triangle2D3<NodeType> triangle_1( PointerVector<NodeType>{element_nodes_1} );
+
+            std::vector<NodeType::Pointer> element_nodes_2 (3);
+            element_nodes_2[0] = p_node_2;
+            element_nodes_2[1] = p_node_5;
+            element_nodes_2[2] = p_node_3;
+            Triangle2D3<NodeType> triangle_2( PointerVector<NodeType>{element_nodes_2} );
+
+            std::vector<NodeType::Pointer> element_nodes_3 (3);
+            element_nodes_3[0] = p_node_5;
+            element_nodes_3[1] = p_node_6;
+            element_nodes_3[2] = p_node_3;
+            Triangle2D3<NodeType> triangle_3( PointerVector<NodeType>{element_nodes_3} );
+
+            auto p_elem_0 = this_model_part.CreateNewElement("Element2D3N", 1, triangle_0, p_elem_prop);
+            auto p_elem_1 = this_model_part.CreateNewElement("Element2D3N", 2, triangle_1, p_elem_prop);
+            auto p_elem_2 = this_model_part.CreateNewElement("Element2D3N", 3, triangle_2, p_elem_prop);
+            auto p_elem_3 = this_model_part.CreateNewElement("Element2D3N", 4, triangle_3, p_elem_prop);
+
+            // Compute NodalH
+            auto process = FindNodalHProcess<FindNodalHSettings::SaveAsNonHistoricalVariable>(this_model_part);
+            process.Execute();
+
+            // // DEBUG
+            // GiDIODebugNodalH(this_model_part);
+
+            const double tolerance = 1.0e-4;
+            KRATOS_CHECK_LESS_EQUAL(p_node_1->GetValue(NODAL_H) - 1.0, tolerance);
+            KRATOS_CHECK_LESS_EQUAL(p_node_2->GetValue(NODAL_H) - 1.0, tolerance);
+            KRATOS_CHECK_LESS_EQUAL(p_node_5->GetValue(NODAL_H) - 1.0, tolerance);
+            KRATOS_CHECK_LESS_EQUAL(p_node_6->GetValue(NODAL_H) - 1.0, tolerance);
+        }
+
+        /**
+        * Checks the correct work of the nodal H compute
         * Test tetrahedra
         */
         KRATOS_TEST_CASE_IN_SUITE(NodalH2, KratosCoreFastSuite)
         {
             Model current_model;
-            
+
             ModelPart& this_model_part = current_model.CreateModelPart("Main");
             this_model_part.SetBufferSize(2);
-            
+
             this_model_part.AddNodalSolutionStepVariable(NODAL_H);
-            
+
             Properties::Pointer p_elem_prop = this_model_part.CreateNewProperties(0);
-            
+
             auto& process_info = this_model_part.GetProcessInfo();
             process_info[STEP] = 1;
             process_info[NL_ITERATION_NUMBER] = 1;
-            
-            // First we create the nodes 
+
+            // First we create the nodes
             NodeType::Pointer p_node_1 = this_model_part.CreateNewNode(1 , 0.0 , 1.0 , 1.0);
             NodeType::Pointer p_node_2 = this_model_part.CreateNewNode(2 , 0.0 , 1.0 , 0.0);
             NodeType::Pointer p_node_3 = this_model_part.CreateNewNode(3 , 0.0 , 0.0 , 1.0);
             NodeType::Pointer p_node_4 = this_model_part.CreateNewNode(4 , 1.0 , 1.0 , 1.0);
             NodeType::Pointer p_node_5 = this_model_part.CreateNewNode(5 , 0.0 , 0.0 , 0.0);
             NodeType::Pointer p_node_6 = this_model_part.CreateNewNode(6 , 1.0 , 1.0 , 0.0);
-            
+
             NodeType::Pointer p_node_7 = this_model_part.CreateNewNode(7 , 1.0 , 0.0 , 1.0);
             NodeType::Pointer p_node_8 = this_model_part.CreateNewNode(8 , 1.0 , 0.0 , 0.0);
             NodeType::Pointer p_node_9 = this_model_part.CreateNewNode(9 , 2.0 , 1.0 , 1.0);
             NodeType::Pointer p_node_10 = this_model_part.CreateNewNode(10 , 2.0 , 1.0 , 0.0);
             NodeType::Pointer p_node_11 = this_model_part.CreateNewNode(11 , 2.0 , 0.0 , 1.0);
             NodeType::Pointer p_node_12 = this_model_part.CreateNewNode(12 , 2.0 , 0.0 , 0.0);
-            
+
             // Now we create the "conditions"
             std::vector<NodeType::Pointer> element_nodes_0 (4);
             element_nodes_0[0] = p_node_12;
@@ -156,84 +221,84 @@ namespace Kratos
             element_nodes_0[2] = p_node_8;
             element_nodes_0[3] = p_node_9;
             Tetrahedra3D4 <NodeType> tetrahedra_0( PointerVector<NodeType>{element_nodes_0} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_1 (4);
             element_nodes_1[0] = p_node_4;
             element_nodes_1[1] = p_node_6;
             element_nodes_1[2] = p_node_9;
             element_nodes_1[3] = p_node_7;
             Tetrahedra3D4 <NodeType> tetrahedra_1( PointerVector<NodeType>{element_nodes_1} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_2 (4);
             element_nodes_2[0] = p_node_11;
             element_nodes_2[1] = p_node_7;
             element_nodes_2[2] = p_node_9;
             element_nodes_2[3] = p_node_8;
             Tetrahedra3D4 <NodeType> tetrahedra_2( PointerVector<NodeType>{element_nodes_2} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_3 (4);
             element_nodes_3[0] = p_node_5;
             element_nodes_3[1] = p_node_3;
             element_nodes_3[2] = p_node_8;
             element_nodes_3[3] = p_node_6;
             Tetrahedra3D4 <NodeType> tetrahedra_3( PointerVector<NodeType>{element_nodes_3} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_4 (4);
             element_nodes_4[0] = p_node_4;
             element_nodes_4[1] = p_node_6;
             element_nodes_4[2] = p_node_7;
             element_nodes_4[3] = p_node_3;
             Tetrahedra3D4 <NodeType> tetrahedra_4( PointerVector<NodeType>{element_nodes_4} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_5 (4);
             element_nodes_5[0] = p_node_2;
             element_nodes_5[1] = p_node_3;
             element_nodes_5[2] = p_node_5;
             element_nodes_5[3] = p_node_6;
             Tetrahedra3D4 <NodeType> tetrahedra_5( PointerVector<NodeType>{element_nodes_5} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_6 (4);
             element_nodes_6[0] = p_node_10;
             element_nodes_6[1] = p_node_9;
             element_nodes_6[2] = p_node_6;
             element_nodes_6[3] = p_node_8;
             Tetrahedra3D4 <NodeType> tetrahedra_6( PointerVector<NodeType>{element_nodes_6} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_7 (4);
             element_nodes_7[0] = p_node_7;
             element_nodes_7[1] = p_node_8;
             element_nodes_7[2] = p_node_3;
             element_nodes_7[3] = p_node_6;
             Tetrahedra3D4 <NodeType> tetrahedra_7( PointerVector<NodeType>{element_nodes_7} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_8 (4);
             element_nodes_8[0] = p_node_7;
             element_nodes_8[1] = p_node_8;
             element_nodes_8[2] = p_node_6;
             element_nodes_8[3] = p_node_9;
             Tetrahedra3D4 <NodeType> tetrahedra_8( PointerVector<NodeType>{element_nodes_8} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_9 (4);
             element_nodes_9[0] = p_node_4;
             element_nodes_9[1] = p_node_1;
             element_nodes_9[2] = p_node_6;
             element_nodes_9[3] = p_node_3;
             Tetrahedra3D4 <NodeType> tetrahedra_9( PointerVector<NodeType>{element_nodes_9} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_10 (4);
             element_nodes_10[0] = p_node_9;
             element_nodes_10[1] = p_node_12;
             element_nodes_10[2] = p_node_11;
             element_nodes_10[3] = p_node_8;
             Tetrahedra3D4 <NodeType> tetrahedra_10( PointerVector<NodeType>{element_nodes_10} );
-            
+
             std::vector<NodeType::Pointer> element_nodes_11 (4);
             element_nodes_11[0] = p_node_3;
             element_nodes_11[1] = p_node_2;
             element_nodes_11[2] = p_node_1;
             element_nodes_11[3] = p_node_6;
             Tetrahedra3D4 <NodeType> tetrahedra_11( PointerVector<NodeType>{element_nodes_11} );
-            
+
             Element::Pointer p_elem_0 = this_model_part.CreateNewElement("Element3D4N", 1, tetrahedra_0, p_elem_prop);
             Element::Pointer p_elem_1 = this_model_part.CreateNewElement("Element3D4N", 2, tetrahedra_1, p_elem_prop);
             Element::Pointer p_elem_2 = this_model_part.CreateNewElement("Element3D4N", 3, tetrahedra_2, p_elem_prop);
@@ -246,14 +311,14 @@ namespace Kratos
             Element::Pointer p_elem_9 = this_model_part.CreateNewElement("Element3D4N", 10, tetrahedra_9, p_elem_prop);
             Element::Pointer p_elem_10 = this_model_part.CreateNewElement("Element3D4N", 11, tetrahedra_10, p_elem_prop);
             Element::Pointer p_elem_11 = this_model_part.CreateNewElement("Element3D4N", 12, tetrahedra_11, p_elem_prop);
-                      
+
             // Compute NodalH
             auto process = FindNodalHProcess<FindNodalHSettings::SaveAsHistoricalVariable>(this_model_part);
             process.Execute();
-            
-//             // DEBUG         
+
+//             // DEBUG
 //             GiDIODebugNodalH(this_model_part);
-            
+
             const double tolerance = 1.0e-4;
             KRATOS_CHECK_LESS_EQUAL(p_node_1->FastGetSolutionStepValue(NODAL_H) - 1.0, tolerance);
             KRATOS_CHECK_LESS_EQUAL(p_node_2->FastGetSolutionStepValue(NODAL_H) - 1.0, tolerance);


### PR DESCRIPTION
The non-historical `NODAL_H` was not synchronized. I created a `SynchronizeValues` method, which is specialized according to the template argument, to that purpose.

I took the chance to also add a cpp test of the non-historical calculation.