### PR TITLE
[Core] Moving and exposing naive elemental distance calculation to discontinuous process

### DIFF
--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -30,8 +30,8 @@ namespace Kratos
 	}
 
 	template<std::size_t TDim>
-	CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateDiscontinuousDistanceToSkinProcess(ModelPart& rVolumePart, ModelPart& rSkinPart, bool UsePlaneOptimization)
-		: mFindIntersectedObjectsProcess(rVolumePart, rSkinPart), mUsePlaneOptimization(UsePlaneOptimization), mrSkinPart(rSkinPart), mrVolumePart(rVolumePart)
+	CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateDiscontinuousDistanceToSkinProcess(ModelPart& rVolumePart, ModelPart& rSkinPart, bool UseIntersectionPlaneOptimization)
+		: mFindIntersectedObjectsProcess(rVolumePart, rSkinPart), mUseIntersectionPlaneOptimization(UseIntersectionPlaneOptimization), mrSkinPart(rSkinPart), mrVolumePart(rVolumePart)
 	{
 	}
 
@@ -82,7 +82,7 @@ namespace Kratos
 		const int number_of_elements = (mFindIntersectedObjectsProcess.GetModelPart1()).NumberOfElements();
 		auto& r_elements = (mFindIntersectedObjectsProcess.GetModelPart1()).ElementsArray();
 
-		if (mUsePlaneOptimization) {
+		if (mUseIntersectionPlaneOptimization) {
 			#pragma omp parallel for schedule(dynamic)
 			for (int i = 0; i < number_of_elements; ++i) {
 				CalculateElementalDistances(*(r_elements[i]), rIntersectedObjects[i]);

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -30,6 +30,12 @@ namespace Kratos
 	}
 
 	template<std::size_t TDim>
+	CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateDiscontinuousDistanceToSkinProcess(ModelPart& rVolumePart, ModelPart& rSkinPart, bool UsePlaneOptimization)
+		: mFindIntersectedObjectsProcess(rVolumePart, rSkinPart), mrSkinPart(rSkinPart), mrVolumePart(rVolumePart), mUsePlaneOptimization(UsePlaneOptimization)
+	{
+	}
+
+	template<std::size_t TDim>
 	CalculateDiscontinuousDistanceToSkinProcess<TDim>::~CalculateDiscontinuousDistanceToSkinProcess()
 	{
 	}
@@ -76,10 +82,17 @@ namespace Kratos
 		const int number_of_elements = (mFindIntersectedObjectsProcess.GetModelPart1()).NumberOfElements();
 		auto& r_elements = (mFindIntersectedObjectsProcess.GetModelPart1()).ElementsArray();
 
-		#pragma omp parallel for schedule(dynamic)
-		for (int i = 0; i < number_of_elements; ++i) {
-			CalculateElementalDistances(*(r_elements[i]), rIntersectedObjects[i]);
-			CalculateNaiveElementalDistances(*(r_elements[i]), rIntersectedObjects[i]);
+		if (mUsePlaneOptimization) {
+			#pragma omp parallel for schedule(dynamic)
+			for (int i = 0; i < number_of_elements; ++i) {
+				CalculateElementalDistances(*(r_elements[i]), rIntersectedObjects[i]);
+			}
+		}
+		else {
+			#pragma omp parallel for schedule(dynamic)
+			for (int i = 0; i < number_of_elements; ++i) {
+				CalculateNaiveElementalDistances(*(r_elements[i]), rIntersectedObjects[i]);
+			}
 		}
 	}
 

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp
@@ -31,7 +31,7 @@ namespace Kratos
 
 	template<std::size_t TDim>
 	CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateDiscontinuousDistanceToSkinProcess(ModelPart& rVolumePart, ModelPart& rSkinPart, bool UsePlaneOptimization)
-		: mFindIntersectedObjectsProcess(rVolumePart, rSkinPart), mrSkinPart(rSkinPart), mrVolumePart(rVolumePart), mUsePlaneOptimization(UsePlaneOptimization)
+		: mFindIntersectedObjectsProcess(rVolumePart, rSkinPart), mUsePlaneOptimization(UsePlaneOptimization), mrSkinPart(rSkinPart), mrVolumePart(rVolumePart)
 	{
 	}
 

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
@@ -130,16 +130,6 @@ public:
         const Variable<double> &rEmbeddedVariable);
 
     /**
-     * @brief Computes the discontinuous elemental distance
-     * This method firstly computes the elemental distances. The base discontinuous
-     * distance class is not used in this case since a naive elemental distance
-     * (avoiding the complexities implemented in the base class) is enough to serve
-     * as base to compute the continuous distance field.
-     * @param rIntersectedObjects array containing pointers to the intersecting objects
-     */
-    void CalculateNaiveElementalDistances(std::vector<PointerVector<GeometricalObject>> &rIntersectedObjects);
-
-    /**
      * @brief Calculate embedded variable from skin array specialization
      * This method calls the specialization method for two double variables
      * @param rVariable origin array variable in the skin mesh
@@ -210,6 +200,18 @@ private:
      */
     void CalculateElementalDistances(
         Element& rElement1,
+        PointerVector<GeometricalObject>& rIntersectedObjects);
+
+    /**
+     * @brief Computes the discontinuous elemental distance
+     * This method firstly computes the elemental distances. The base discontinuous
+     * distance class is not used in this case since a naive elemental distance
+     * (avoiding the complexities implemented in the base class) is enough to serve
+     * as base to compute the continuous distance field.
+     * @param rIntersectedObjects array containing pointers to the intersecting objects
+     */
+    void CalculateNaiveElementalDistances(
+        Element& rElement,
         PointerVector<GeometricalObject>& rIntersectedObjects);
 
     /**

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
@@ -58,6 +58,12 @@ public:
         ModelPart& rVolumePart,
         ModelPart& rSkinPart);
 
+    /// Constructor using plane optimization flag
+    CalculateDiscontinuousDistanceToSkinProcess(
+        ModelPart& rVolumePart,
+        ModelPart& rSkinPart,
+        bool UsePlaneOptimiztion);
+
     /// Destructor.
     ~CalculateDiscontinuousDistanceToSkinProcess() override;
 
@@ -159,6 +165,11 @@ public:
 
     ///@}
 protected:
+    ///@name Member Variables
+    ///@{
+    bool mUsePlaneOptimization = true;
+    ///@}
+
     ///@name Protected Operations
     ///@{
 

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
@@ -130,6 +130,16 @@ public:
         const Variable<double> &rEmbeddedVariable);
 
     /**
+     * @brief Computes the discontinuous elemental distance
+     * This method firstly computes the elemental distances. The base discontinuous
+     * distance class is not used in this case since a naive elemental distance
+     * (avoiding the complexities implemented in the base class) is enough to serve
+     * as base to compute the continuous distance field.
+     * @param rIntersectedObjects array containing pointers to the intersecting objects
+     */
+    void CalculateNaiveElementalDistances(std::vector<PointerVector<GeometricalObject>> &rIntersectedObjects);
+
+    /**
      * @brief Calculate embedded variable from skin array specialization
      * This method calls the specialization method for two double variables
      * @param rVariable origin array variable in the skin mesh
@@ -201,6 +211,34 @@ private:
     void CalculateElementalDistances(
         Element& rElement1,
         PointerVector<GeometricalObject>& rIntersectedObjects);
+
+    /**
+     * @brief Calculate the nodal distance for a given node
+     * Given a list of the objects intersecting an element, this method computes the
+     * minimum distance for a given node of such element. This is done by computing the
+     * point-triangle (3D) or the point-line (2D) distance.
+     * @param rNode reference to the node of interest
+     * @param rIntersectedObjects list containing pointers to all the intersecting objects of an element
+     * @param Epsilon zero distance threshold
+     * @return double the nodal distance of the node of interest
+     */
+
+    double CalculateDistanceToNode(
+        Node<3> &rNode,
+        PointerVector<GeometricalObject> &rIntersectedObjects,
+        const double Epsilon);
+
+    /**
+     * @brief Calculates the distance to an intersecting object
+     * This method computes the distance from a point to an intersecting object
+     * @param rIntObjGeom reference to the intersecting object
+     * @param rDistancePoint point to compute the distance to
+     * @return double obtained distance value
+     */
+
+    double inline CalculatePointDistance(
+        const Element::GeometryType &rIntObjGeom,
+        const Point &rDistancePoint);
 
     /**
      * @brief Computes the edges intersections in one element

--- a/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
+++ b/kratos/processes/calculate_discontinuous_distance_to_skin_process.h
@@ -62,7 +62,7 @@ public:
     CalculateDiscontinuousDistanceToSkinProcess(
         ModelPart& rVolumePart,
         ModelPart& rSkinPart,
-        bool UsePlaneOptimiztion);
+        bool UseIntersectionPlaneOptimization);
 
     /// Destructor.
     ~CalculateDiscontinuousDistanceToSkinProcess() override;
@@ -167,7 +167,7 @@ public:
 protected:
     ///@name Member Variables
     ///@{
-    bool mUsePlaneOptimization = true;
+    bool mUseIntersectionPlaneOptimization = true;
     ///@}
 
     ///@name Protected Operations

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -77,7 +77,7 @@ namespace Kratos
 	{
 		// Compute the discontinuous (elemental) distance field
 		// Use the base class elemental distance computation (includes plane optimization)
-		CalculateDiscontinuousDistanceToSkinProcess<TDim>::mUsePlaneOptimization = false;
+		CalculateDiscontinuousDistanceToSkinProcess<TDim>::mUseIntersectionPlaneOptimization = false;
 		CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateDistances(rIntersectedObjects);
 
 		// Get the minimum elemental distance value for each node

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -76,15 +76,10 @@ namespace Kratos
 		std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects)
 	{
 		// Compute the discontinuous (elemental) distance field
-		const bool use_base_elemental_distance = false;
+		// Use the base class elemental distance computation (includes plane optimization)
+		CalculateDiscontinuousDistanceToSkinProcess<TDim>::mUsePlaneOptimization = false;
+		CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateDistances(rIntersectedObjects);
 
-		if (use_base_elemental_distance) {
-			// Use the base class elemental distance computation (includes plane optimization)
-			CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateDistances(rIntersectedObjects);
-		} else {
-			// Use a naive elemental distance computation (without plane optimization)
-			CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateNaiveElementalDistances(rIntersectedObjects);
-		}
 		// Get the minimum elemental distance value for each node
 		this->CalculateNodalDistances();
 		// Perform raycasting to sign the previous distance field

--- a/kratos/processes/calculate_distance_to_skin_process.cpp
+++ b/kratos/processes/calculate_distance_to_skin_process.cpp
@@ -77,98 +77,18 @@ namespace Kratos
 	{
 		// Compute the discontinuous (elemental) distance field
 		const bool use_base_elemental_distance = false;
+
 		if (use_base_elemental_distance) {
 			// Use the base class elemental distance computation (includes plane optimization)
 			CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateDistances(rIntersectedObjects);
 		} else {
 			// Use a naive elemental distance computation (without plane optimization)
-			this->CalculateElementalDistances(rIntersectedObjects);
+			CalculateDiscontinuousDistanceToSkinProcess<TDim>::CalculateNaiveElementalDistances(rIntersectedObjects);
 		}
 		// Get the minimum elemental distance value for each node
 		this->CalculateNodalDistances();
 		// Perform raycasting to sign the previous distance field
 		this->CalculateRayDistances();
-	}
-
-	template<std::size_t TDim>
-	void CalculateDistanceToSkinProcess<TDim>::CalculateElementalDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects)
-	{
-		const int number_of_elements = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess.GetModelPart1()).NumberOfElements();
-		auto& r_elements = (CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess.GetModelPart1()).ElementsArray();
-
-		#pragma omp parallel for schedule(dynamic)
-		for (int i = 0; i < number_of_elements; ++i) {
-			Element &r_element = *(r_elements[i]);
-			PointerVector<GeometricalObject>& r_element_intersections = rIntersectedObjects[i];
-
-			// Check if the element has intersections
-			if (r_element_intersections.empty()) {
-				r_element.Set(TO_SPLIT, false);
-			} else {
-				// This function assumes tetrahedra element and triangle intersected object as input at this moment
-				constexpr int number_of_tetrahedra_points = TDim + 1;
-				constexpr double epsilon = std::numeric_limits<double>::epsilon();
-				Vector &elemental_distances = r_element.GetValue(ELEMENTAL_DISTANCES);
-
-				if (elemental_distances.size() != number_of_tetrahedra_points){
-					elemental_distances.resize(number_of_tetrahedra_points, false);
-				}
-
-				for (int i = 0; i < number_of_tetrahedra_points; i++) {
-					elemental_distances[i] = this->CalculateDistanceToNode(r_element.GetGeometry()[i], r_element_intersections, epsilon);
-				}
-
-				bool has_positive_distance = false;
-				bool has_negative_distance = false;
-				for (int i = 0; i < number_of_tetrahedra_points; i++){
-					if (elemental_distances[i] > epsilon) {
-						has_positive_distance = true;
-					} else {
-						has_negative_distance = true;
-					}
-				}
-
-				r_element.Set(TO_SPLIT, has_positive_distance && has_negative_distance);
-			}
-		}
-	}
-
-	template<std::size_t TDim>
-	double CalculateDistanceToSkinProcess<TDim>::CalculateDistanceToNode(
-		Node<3> &rNode,
-		PointerVector<GeometricalObject>& rIntersectedObjects,
-		const double Epsilon)
-	{
-		// Initialize result distance value
-		double result_distance = std::numeric_limits<double>::max();
-
-		// For each intersecting object of the element, compute its nodal distance
-		for (auto it_int_obj : rIntersectedObjects.GetContainer()) {
-			// Compute the intersecting object distance to the current element node
-			const auto &r_int_obj_geom = it_int_obj->GetGeometry();
-			const double distance = this->CalculatePointDistance(r_int_obj_geom, rNode);
-
-			// Check that the computed distance is the minimum obtained one
-			if (std::abs(result_distance) > distance) {
-				if (distance < Epsilon) {
-					result_distance = -Epsilon; // Avoid values near to 0.0
-				} else {
-					result_distance = distance;
-					std::vector<array_1d<double,3>> plane_pts;
-					for (unsigned int i_node = 0; i_node < r_int_obj_geom.PointsNumber(); ++i_node){
-						plane_pts.push_back(r_int_obj_geom[i_node]);
-					}
-					Plane3D plane = this->SetIntersectionPlane(plane_pts);
-
-					// Check the distance sign using the distance to the intersection plane
-					if (plane.CalculateSignedDistance(rNode) < 0.0){
-						result_distance = -result_distance;
-					}
-				}
-			}
-		}
-
-		return result_distance;
 	}
 
 	template<std::size_t TDim>
@@ -196,29 +116,6 @@ namespace Kratos
 	{
 		ApplyRayCastingProcess<TDim> ray_casting_process(CalculateDiscontinuousDistanceToSkinProcess<TDim>::mFindIntersectedObjectsProcess, mRayCastingRelativeTolerance);
 		ray_casting_process.Execute();
-	}
-
-	template<>
-	double inline CalculateDistanceToSkinProcess<2>::CalculatePointDistance(
-		const Element::GeometryType &rIntObjGeom,
-		const Point &rDistancePoint)
-	{
-		return GeometryUtils::PointDistanceToLineSegment3D(
-			rIntObjGeom[0],
-			rIntObjGeom[1],
-			rDistancePoint);
-	}
-
-	template<>
-	double inline CalculateDistanceToSkinProcess<3>::CalculatePointDistance(
-		const Element::GeometryType &rIntObjGeom,
-		const Point &rDistancePoint)
-	{
-		return GeometryUtils::PointDistanceToTriangle3D(
-			rIntObjGeom[0],
-			rIntObjGeom[1],
-			rIntObjGeom[2],
-			rDistancePoint);
 	}
 
 	template<std::size_t TDim>

--- a/kratos/processes/calculate_distance_to_skin_process.h
+++ b/kratos/processes/calculate_distance_to_skin_process.h
@@ -123,31 +123,6 @@ public:
     void CalculateDistances(std::vector<PointerVector<GeometricalObject>>& rIntersectedObjects) override;
 
     /**
-     * @brief Computes the discontinuous elemental distance
-     * This method firstly computes the elemental distances. The base discontinuous
-     * distance class is not used in this case since a naive elemental distance
-     * (avoiding the complexities implemented in the base class) is enough to serve
-     * as base to compute the continuous distance field.
-     * @param rIntersectedObjects array containing pointers to the intersecting objects
-     */
-    void CalculateElementalDistances(std::vector<PointerVector<GeometricalObject>> &rIntersectedObjects);
-
-    /**
-     * @brief Calculate the nodal distance for a given node
-     * Given a list of the objects intersecting an element, this method computes the
-     * minimum distance for a given node of such element. This is done by computing the
-     * point-triangle (3D) or the point-line (2D) distance.
-     * @param rNode reference to the node of interest
-     * @param rIntersectedObjects list containing pointers to all the intersecting objects of an element
-     * @param Epsilon zero distance threshold
-     * @return double the nodal distance of the node of interest
-     */
-    double CalculateDistanceToNode(
-        Node<3> &rNode,
-        PointerVector<GeometricalObject> &rIntersectedObjects,
-        const double Epsilon);
-
-    /**
      * @brief Initialize the nodal distance values
      * This method initializes the nodal (continuous) distance values to a maximum positive value
      */
@@ -208,17 +183,6 @@ private:
     ///@}
     ///@name Private Operations
     ///@{
-
-    /**
-     * @brief Calculates the distance to an intersecting object
-     * This method computes the distance from a point to an intersecting object
-     * @param rIntObjGeom reference to the intersecting object
-     * @param rDistancePoint point to compute the distance to
-     * @return double obtained distance value
-     */
-    double inline CalculatePointDistance(
-        const Element::GeometryType &rIntObjGeom,
-        const Point &rDistancePoint);
 
     ///@}
     ///@name Private  Access

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -329,12 +329,14 @@ void  AddProcessesToPython(pybind11::module& m)
     // Discontinuous distance computation methods
     py::class_<CalculateDiscontinuousDistanceToSkinProcess<2>, CalculateDiscontinuousDistanceToSkinProcess<2>::Pointer, Process>(m,"CalculateDiscontinuousDistanceToSkinProcess2D")
         .def(py::init<ModelPart&, ModelPart&>())
+        .def(py::init<ModelPart&, ModelPart&, bool>())
         .def("CalculateEmbeddedVariableFromSkin", CalculateDiscontinuousEmbeddedVariableFromSkinArray<2>)
         .def("CalculateEmbeddedVariableFromSkin", CalculateDiscontinuousEmbeddedVariableFromSkinDouble<2>)
         ;
 
     py::class_<CalculateDiscontinuousDistanceToSkinProcess<3>, CalculateDiscontinuousDistanceToSkinProcess<3>::Pointer, Process>(m,"CalculateDiscontinuousDistanceToSkinProcess3D")
         .def(py::init<ModelPart&, ModelPart&>())
+        .def(py::init<ModelPart&, ModelPart&, bool>())
         .def("CalculateEmbeddedVariableFromSkin", CalculateDiscontinuousEmbeddedVariableFromSkinArray<3>)
         .def("CalculateEmbeddedVariableFromSkin", CalculateDiscontinuousEmbeddedVariableFromSkinDouble<3>)
         ;


### PR DESCRIPTION
Hi,

This PR is related to #5278, #5261 and #5279. I would say this is a "low impact" proposal to allow us to account for corner cases while using the **discontinuous distance process**, such as: skin_model_part going thorugh a node, or the skin_model_part laying on the face of a tetrahedron. 

In this PR I am moving the naive elemental distance calculation that was used in the continuous distance process to the discontinuous process. This is now controlled by a flag `UsePlaneOptimization` in the discontinuous process that can be set by the user at python level. Now the naive elemental distance calculation can be used with the DiscontinuousProcess.

Note that **by default**, the behaviour of both the discontinuous and continuous processes **remains the same as before.**  

The idea is to be able to get the following behaviour for the kind of edge cases mentioned in the PRs above. For instance, in the following case, the skin_model_part, which is a line, is passing through the node in the middle:
![image](https://user-images.githubusercontent.com/32136457/63506282-83cf7480-c4d5-11e9-8bef-7b69efb65c0d.png)

With the current Plane Optimization approach, none of these elements are considered "split". This has to do with what is considered "intersection" in the discontinuous process (only intersections_id = 1 are considered):
https://github.com/KratosMultiphysics/Kratos/blob/852493c70b9519364b6024c211a54ce05d2f624d/kratos/processes/calculate_discontinuous_distance_to_skin_process.cpp#L217-L238
I tried to add other "intersections_id" here, but I realized that more changes in the code would be required, so I went for the option added in this PR as a first approach, which was mentioned by @rubenzorrilla  in https://github.com/KratosMultiphysics/Kratos/pull/5261#issuecomment-520783581 as a possible solution. 

If the naive elemental distance approach is used, an epsilon is introduced in the node in the middle and the elements that are cut are set correctly:

![image](https://user-images.githubusercontent.com/32136457/63507799-d9f1e700-c4d8-11e9-84ef-e8f6a0efefe5.png)

As mentioned above, what I did in this PR is to 1) move the naive elemental distance calculation to the discontinuous process 2) add a flag to be able to use these approach at python level. I also adapted the ZeroHorizontalPlane test from the continuous distance process to the discontinuous suite.



