### PR TITLE
[Core][Geometry] Adding functions for normal and unit normal

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -808,8 +808,8 @@ public:
         KRATOS_ERROR_IF(dimension == local_space_dimension) << "Remember the normal can be computed just in geometries with a local dimension: "<< this->LocalSpaceDimension() << "smaller than the spatial dimension: " << this->WorkingSpaceDimension() << std::endl;
 
         // We define the normal and tangents
-        array_1d<double,3> tangent_xi(3, 0.0);
-        array_1d<double,3> tangent_eta(3, 0.0);
+        array_1d<double,3> tangent_xi = ZeroVector(3);
+        array_1d<double,3> tangent_eta = ZeroVector(3);
 
         Matrix j_node = ZeroMatrix( dimension, local_space_dimension );
         this->Jacobian( j_node, rPointLocalCoordinates);
@@ -866,8 +866,8 @@ public:
             << this->WorkingSpaceDimension() << std::endl;
 
         // We define the normal and tangents
-        array_1d<double, 3> tangent_xi(3, 0.0);
-        array_1d<double, 3> tangent_eta(3, 0.0);
+        array_1d<double, 3> tangent_xi = ZeroVector(3);
+        array_1d<double, 3> tangent_eta = ZeroVector(3);
 
         Matrix j_node = ZeroMatrix(dimension, local_space_dimension);
         this->Jacobian(j_node, IntegrationPointIndex, ThisMethod);

--- a/kratos/tests/cpp_tests/geometries/test_triangle_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_triangle_3d_3.cpp
@@ -714,5 +714,39 @@ namespace Testing
         TestAllShapeFunctionsLocalGradients(*geom);
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(Triangle3D3Normal, KratosCoreGeometriesFastSuite) {
+        Geometry<Point> geom(Triangle3D3<Point>(
+            std::make_shared<Point>(0.55, -0.25, 0.0),
+            std::make_shared<Point>(0.50, -0.25, 0.0),
+            std::make_shared<Point>(0.50, 0.25, 0.0))
+        );
+        auto normal = geom.Normal(0);
+
+        array_1d<double, 3> cross_norm(3, 0.0);
+        cross_norm[2] = 1.0;
+        array_1d<double, 3> cross(3, 0.0);
+        MathUtils<double>::CrossProduct(cross, cross_norm, normal);
+
+        KRATOS_WATCH(normal)
+        KRATOS_CHECK_NEAR(cross[0], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(cross[1], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(cross[2], 0.0, TOLERANCE);
+
+        KRATOS_WATCH(cross)
+
+        normal /= norm_2(normal);
+
+        auto unit_normal = geom.UnitNormal(0);
+
+        KRATOS_CHECK_NEAR(unit_normal[0], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(unit_normal[1], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(unit_normal[2], -1.0, TOLERANCE);
+
+        KRATOS_WATCH(unit_normal)
+        KRATOS_CHECK_NEAR(unit_normal[0], normal[0], TOLERANCE);
+        KRATOS_CHECK_NEAR(unit_normal[1], normal[1], TOLERANCE);
+        KRATOS_CHECK_NEAR(unit_normal[2], normal[2], TOLERANCE);
+    }
+
 } // namespace Testing.
 } // namespace Kratos.


### PR DESCRIPTION
Hi all,

I would like to complete the normal and the unit normal functions in the geometry base class to make them accessable via the integration point index. It is a bit more efficient than calling it with the coordinates, because then the shape functions would not have to be computed each time.