### PR TITLE
Core/feature vector check

### DIFF
--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -46,6 +46,24 @@ KRATOS_ERROR << "The string \"" << SubString << "\" was not found in the given s
 " is not near to " << #b << " = " << b << " within the tolerance " << tolerance
 #define KRATOS_CHECK_DOUBLE_EQUAL(a,b) KRATOS_CHECK_NEAR(a,b,std::numeric_limits<double>::epsilon())
 
+#define KRATOS_CHECK_VECTOR_NEAR(a, b, tolerance) {                        \
+KRATOS_ERROR_IF_NOT(a.size() == b.size())                                  \
+<< "Check failed because vector arguments do not have the same size"       \
+<< "First argument has size " << a.size() << ". "                          \
+<< "Second argument has size " << b.size() << ". " << std::endl;           \
+for (std::size_t i = 0; i < a.size(); i++) {                               \
+   KRATOS_ERROR_IF( std::abs(a[i] - b[i]) > tolerance )                    \
+   << "Check failed because vector " << #a << " with values" << std::endl  \
+   << a << std::endl                                                       \
+   << "Is not near to vector " << #b << " with values" << std::endl        \
+   << b << std::endl                                                       \
+   << "Mismatch found in component " << i << ": " << std::endl             \
+   << a[i] << " not near to " << b[i]                                      \
+   << " within tolerance " << tolerance << "." << std::endl;               \
+}                                                                          \
+}
+#define KRATOS_CHECK_VECTOR_EQUAL(a, b) KRATOS_CHECK_VECTOR_NEAR(a,b,std::numeric_limits<double>::epsilon())
+
 #define KRATOS_CHECK_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage)                 \
 try {                                                                                   \
     TheStatement;                                                                       \
@@ -97,6 +115,9 @@ try {                                                                           
 #define KRATOS_DEBUG_CHECK_NEAR(a,b, tolerance) KRATOS_CHECK_NEAR(a,b, tolerance)
 #define KRATOS_DEBUG_CHECK_DOUBLE_EQUAL(a,b) KRATOS_CHECK_DOUBLE_EQUAL(a,b)
 
+#define KRATOS_DEBUG_CHECK_VECTOR_NEAR(a, b, tolerance) KRATOS_CHECK_VECTOR_NEAR(a, b, tolerance)
+#define KRATOS_DEBUG_CHECK_VECTOR_EQUAL(a, b) KRATOS_CHECK_VECTOR_EQUAL(a, b)
+
 #define KRATOS_DEBUG_CHECK_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage) KRATOS_CHECK_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage)
 
 #define KRATOS_DEBUG_CHECK_VARIABLE_KEY(TheVariable) KRATOS_CHECK_VARIABLE_KEY(TheVariable)
@@ -123,6 +144,9 @@ try {                                                                           
 
 #define KRATOS_DEBUG_CHECK_NEAR(a,b, tolerance) if(false) KRATOS_CHECK_NEAR(a,b, tolerance)
 #define KRATOS_DEBUG_CHECK_DOUBLE_EQUAL(a,b) if(false) KRATOS_CHECK_DOUBLE_EQUAL(a,b)
+
+#define KRATOS_DEBUG_CHECK_VECTOR_NEAR(a, b, tolerance) if (false) KRATOS_CHECK_VECTOR_NEAR(a, b, tolerance)
+#define KRATOS_DEBUG_CHECK_VECTOR_EQUAL(a, b) if (false) KRATOS_CHECK_VECTOR_EQUAL(a, b)
 
 #define KRATOS_DEBUG_CHECK_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage) if(false) KRATOS_CHECK_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage)
 

--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -48,21 +48,44 @@ KRATOS_ERROR << "The string \"" << SubString << "\" was not found in the given s
 
 #define KRATOS_CHECK_VECTOR_NEAR(a, b, tolerance) {                        \
 KRATOS_ERROR_IF_NOT(a.size() == b.size())                                  \
-<< "Check failed because vector arguments do not have the same size"       \
-<< "First argument has size " << a.size() << ". "                          \
-<< "Second argument has size " << b.size() << ". " << std::endl;           \
+<< "Check failed because vector arguments do not have the same size:"      \
+<< std::endl                                                               \
+<< "First argument has size " << a.size() << ", "                          \
+<< "second argument has size " << b.size() << "." << std::endl;            \
 for (std::size_t i = 0; i < a.size(); i++) {                               \
    KRATOS_ERROR_IF( std::abs(a[i] - b[i]) > tolerance )                    \
    << "Check failed because vector " << #a << " with values" << std::endl  \
    << a << std::endl                                                       \
-   << "Is not near to vector " << #b << " with values" << std::endl        \
+   << "Is not near vector " << #b << " with values" << std::endl           \
    << b << std::endl                                                       \
-   << "Mismatch found in component " << i << ": " << std::endl             \
-   << a[i] << " not near to " << b[i]                                      \
+   << "Mismatch found in component " << i << ":" << std::endl              \
+   << a[i] << " not near " << b[i]                                         \
    << " within tolerance " << tolerance << "." << std::endl;               \
 }                                                                          \
 }
 #define KRATOS_CHECK_VECTOR_EQUAL(a, b) KRATOS_CHECK_VECTOR_NEAR(a,b,std::numeric_limits<double>::epsilon())
+
+#define KRATOS_CHECK_MATRIX_NEAR(a, b, tolerance) {                              \
+KRATOS_ERROR_IF_NOT((a.size1() == b.size1()) || (a.size2() == b.size2()))        \
+<< "Check failed because matrix arguments do not have the same dimensions:"      \
+<< std::endl                                                                     \
+<< "First argument has dimensions (" << a.size1() << "," << a.size2() << "), "   \
+<< "second argument has dimensions (" << b.size1() << "," << b.size2() << ")."   \
+<< std::endl;                                                                    \
+for (std::size_t i = 0; i < a.size1(); i++) {                                    \
+    for (std::size_t j = 0; j < a.size2(); j++) {                                \
+       KRATOS_ERROR_IF( std::abs(a(i,j) - b(i,j)) > tolerance )                  \
+       << "Check failed because matrix " << #a << " with values" << std::endl    \
+       << a << std::endl                                                         \
+       << "Is not near matrix " << #b << " with values" << std::endl             \
+       << b << std::endl                                                         \
+       << "Mismatch found in component (" << i << "," << j << "): " << std::endl \
+       << a(i,j) << " not near " << b(i,j)                                       \
+       << " within tolerance " << tolerance << "." << std::endl;                 \
+    }                                                                            \
+}                                                                                \
+}
+#define KRATOS_CHECK_MATRIX_EQUAL(a, b) KRATOS_CHECK_MATRIX_NEAR(a,b,std::numeric_limits<double>::epsilon())
 
 #define KRATOS_CHECK_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage)                 \
 try {                                                                                   \
@@ -118,6 +141,9 @@ try {                                                                           
 #define KRATOS_DEBUG_CHECK_VECTOR_NEAR(a, b, tolerance) KRATOS_CHECK_VECTOR_NEAR(a, b, tolerance)
 #define KRATOS_DEBUG_CHECK_VECTOR_EQUAL(a, b) KRATOS_CHECK_VECTOR_EQUAL(a, b)
 
+#define KRATOS_DEBUG_CHECK_MATRIX_NEAR(a, b, tolerance) KRATOS_CHECK_MATRIX_NEAR(a, b, tolerance)
+#define KRATOS_DEBUG_CHECK_MATRIX_EQUAL(a, b) KRATOS_CHECK_MATRIX_EQUAL(a, b)
+
 #define KRATOS_DEBUG_CHECK_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage) KRATOS_CHECK_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage)
 
 #define KRATOS_DEBUG_CHECK_VARIABLE_KEY(TheVariable) KRATOS_CHECK_VARIABLE_KEY(TheVariable)
@@ -147,6 +173,9 @@ try {                                                                           
 
 #define KRATOS_DEBUG_CHECK_VECTOR_NEAR(a, b, tolerance) if (false) KRATOS_CHECK_VECTOR_NEAR(a, b, tolerance)
 #define KRATOS_DEBUG_CHECK_VECTOR_EQUAL(a, b) if (false) KRATOS_CHECK_VECTOR_EQUAL(a, b)
+
+#define KRATOS_DEBUG_CHECK_MATRIX_NEAR(a, b, tolerance) if (false) KRATOS_CHECK_MATRIX_NEAR(a, b, tolerance)
+#define KRATOS_DEBUG_CHECK_MATRIX_EQUAL(a, b) if (false) KRATOS_CHECK_MATRIX_EQUAL(a, b)
 
 #define KRATOS_DEBUG_CHECK_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage) if(false) KRATOS_CHECK_EXCEPTION_IS_THROWN(TheStatement, TheErrorMessage)
 

--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -66,7 +66,7 @@ for (std::size_t i = 0; i < a.size(); i++) {                               \
 #define KRATOS_CHECK_VECTOR_EQUAL(a, b) KRATOS_CHECK_VECTOR_NEAR(a,b,std::numeric_limits<double>::epsilon())
 
 #define KRATOS_CHECK_MATRIX_NEAR(a, b, tolerance) {                              \
-KRATOS_ERROR_IF_NOT((a.size1() == b.size1()) || (a.size2() == b.size2()))        \
+KRATOS_ERROR_IF_NOT((a.size1() == b.size1()) && (a.size2() == b.size2()))        \
 << "Check failed because matrix arguments do not have the same dimensions:"      \
 << std::endl                                                                     \
 << "First argument has dimensions (" << a.size1() << "," << a.size2() << "), "   \

--- a/kratos/tests/cpp_tests/sources/test_checks.cpp
+++ b/kratos/tests/cpp_tests/sources/test_checks.cpp
@@ -49,7 +49,7 @@ namespace Kratos {
 		KRATOS_TEST_CASE_IN_SUITE(VariableChecks, KratosCoreFastSuite)
         {
             Model current_model;
-            
+
             ModelPart& model_part = current_model.CreateModelPart("TestModelPart");
 
             model_part.AddNodalSolutionStepVariable(VELOCITY);
@@ -97,6 +97,61 @@ namespace Kratos {
             KRATOS_CHECK_EXCEPTION_IS_THROWN(
                 KRATOS_CHECK_DOF_IN_NODE(VELOCITY_X, r_node),
                 "Missing Degree of Freedom for VELOCITY_X in node 1.");
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(VectorChecks, KratosCoreFastSuite)
+        {
+            std::vector<double> v1{1.0, 2.0};
+            std::vector<double> v2{1.0, 1.99};
+            std::vector<double> v3{1.0, 2.0, 3.0};
+
+            KRATOS_CHECK_VECTOR_EQUAL(v1, v1);
+            KRATOS_CHECK_VECTOR_NEAR(v1, v2, 0.1);
+
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(
+                KRATOS_CHECK_VECTOR_EQUAL(v1, v3),
+                "Check failed because vector arguments do not have the same size"
+            );
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(
+                KRATOS_CHECK_VECTOR_NEAR(v1, v3, 0.1),
+                "Check failed because vector arguments do not have the same size"
+            );
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(
+                KRATOS_CHECK_VECTOR_EQUAL(v1,v2),
+                "Mismatch found in component 1:"
+            );
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(
+                KRATOS_CHECK_VECTOR_NEAR(v1,v2, 0.001),
+                "Mismatch found in component 1:"
+            );
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(MatrixChecks, KratosCoreFastSuite)
+        {
+            Matrix m1 = IdentityMatrix(2,2);
+            Matrix m2 = IdentityMatrix(2,2);
+            m2(0,1) = 0.01;
+            Matrix m3 = IdentityMatrix(3,3);
+
+            KRATOS_CHECK_MATRIX_EQUAL(m1, m1);
+            KRATOS_CHECK_MATRIX_NEAR(m1, m2, 0.1);
+
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(
+                KRATOS_CHECK_MATRIX_EQUAL(m1, m3),
+                "Check failed because matrix arguments do not have the same dimensions"
+            );
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(
+                KRATOS_CHECK_MATRIX_NEAR(m1, m3, 0.1),
+                "Check failed because matrix arguments do not have the same dimensions"
+            );
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(
+                KRATOS_CHECK_MATRIX_EQUAL(m1,m2),
+                "Mismatch found in component (0,1):"
+            );
+            KRATOS_CHECK_EXCEPTION_IS_THROWN(
+                KRATOS_CHECK_MATRIX_NEAR(m1,m2, 0.001),
+                "Mismatch found in component (0,1):"
+            );
         }
     }
 }  // namespace Kratos.

--- a/kratos/tests/cpp_tests/sources/test_checks.cpp
+++ b/kratos/tests/cpp_tests/sources/test_checks.cpp
@@ -128,10 +128,10 @@ namespace Kratos {
 
         KRATOS_TEST_CASE_IN_SUITE(MatrixChecks, KratosCoreFastSuite)
         {
-            Matrix m1 = IdentityMatrix(2,2);
-            Matrix m2 = IdentityMatrix(2,2);
+            Matrix m1 = IdentityMatrix(2);
+            Matrix m2 = IdentityMatrix(2);
             m2(0,1) = 0.01;
-            Matrix m3 = IdentityMatrix(3,3);
+            Matrix m3 = IdentityMatrix(3);
 
             KRATOS_CHECK_MATRIX_EQUAL(m1, m1);
             KRATOS_CHECK_MATRIX_NEAR(m1, m2, 0.1);


### PR DESCRIPTION
Adding helper macros `KRATOS_CHECK_VECTOR_NEAR`, `KRATOS_CHECK_MATRIX_NEAR` (and `EQUAL` and `DEBUG_CHECK` variants). They are essentially equivalent to the `DOUBLE` versions, but with integrated size checks and looping and are more informative in case of failure.

By request of @tteschemacher.