### PR TITLE
[Fluid][Potential] Non-historical NODAL_H in distance modification process

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/level_set_remeshing_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/level_set_remeshing_process.py
@@ -175,8 +175,6 @@ class LevelSetRemeshingProcess(KratosMultiphysics.Process):
         ''' This function modifies the distance field to avoid ill defined cuts.
         '''
         ini_time = time.time()
-        find_nodal_h = KratosMultiphysics.FindNodalHProcess(self.main_model_part)
-        find_nodal_h.Execute()
         KratosMultiphysics.FluidDynamicsApplication.DistanceModificationProcess(self.main_model_part,self.distance_modification_parameters).Execute()
         KratosMultiphysics.Logger.PrintInfo('LevelSetRemeshing','Modify distance time: ',time.time()-ini_time)
 

--- a/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_no_wake_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_no_wake_parameters.json
@@ -32,7 +32,7 @@
             "verbosity": 0,
             "scaling": false
         },
-        "auxiliary_variables_list" : ["NODAL_H","GEOMETRY_DISTANCE","DISTANCE"]
+        "auxiliary_variables_list" : ["GEOMETRY_DISTANCE","DISTANCE"]
     },
     "processes"            : {
         "initial_conditions_process_list"  : [],

--- a/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_modification_process.cpp
@@ -117,15 +117,18 @@ void DistanceModificationProcess::Execute()
     this->ExecuteInitializeSolutionStep();
 }
 
-void DistanceModificationProcess::ExecuteInitialize() {
-
+void DistanceModificationProcess::ExecuteInitialize()
+{
     KRATOS_TRY;
 
-    // Continuous distance field required variables check
     if (mContinuousDistance){
+        // Continuous distance modification historical variables check
         const auto& r_node = *mrModelPart.NodesBegin();
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(NODAL_H, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISTANCE, r_node);
+
+        // Compute NODAL_H (used for computing the distance tolerance)
+        FindNodalHProcess<FindNodalHSettings::SaveAsNonHistoricalVariable> nodal_h_calculator(mrModelPart);
+        nodal_h_calculator.Execute();
     }
 
     KRATOS_CATCH("");
@@ -141,9 +144,6 @@ void DistanceModificationProcess::ExecuteInitializeSolutionStep() {
     if(!mIsModified){
         // Modify the nodal distance values to avoid bad intersections
         if (mContinuousDistance) {
-            // Compute NODAL_H (used for computing the distance tolerance)
-            FindNodalHProcess<FindNodalHSettings::SaveAsHistoricalVariable> nodal_h_calculator(mrModelPart);
-            nodal_h_calculator.Execute();
             // Modify the continuous distance field
             this->ModifyDistance();
         } else {
@@ -194,7 +194,7 @@ void DistanceModificationProcess::ModifyDistance() {
         #pragma omp parallel for
         for (int k = 0; k < static_cast<int>(r_nodes.size()); ++k) {
             auto it_node = r_nodes.begin() + k;
-            const double h = it_node->FastGetSolutionStepValue(NODAL_H);
+            const double h = it_node->GetValue(NODAL_H);
             const double tol_d = mDistanceThreshold*h;
             double& d = it_node->FastGetSolutionStepValue(DISTANCE);
 
@@ -232,7 +232,7 @@ void DistanceModificationProcess::ModifyDistance() {
             std::vector<double> aux_modified_distance_values;
 
             for (auto it_node = nodes_begin; it_node < nodes_end; ++it_node) {
-                const double h = it_node->FastGetSolutionStepValue(NODAL_H);
+                const double h = it_node->GetValue(NODAL_H);
                 const double tol_d = mDistanceThreshold*h;
                 double &d = it_node->FastGetSolutionStepValue(DISTANCE);
 
@@ -500,22 +500,22 @@ void DistanceModificationProcess::SetDiscontinuousDistanceToSplitFlag()
     }
 }
 
-void DistanceModificationProcess::CheckAndStoreVariablesList(const std::vector<std::string>& rVariableStringArray) 
+void DistanceModificationProcess::CheckAndStoreVariablesList(const std::vector<std::string>& rVariableStringArray)
 {
-    const auto& r_node = *mrModelPart.NodesBegin(); 
+    const auto& r_node = *mrModelPart.NodesBegin();
     for (std::size_t i_variable=0; i_variable < rVariableStringArray.size(); i_variable++){
         if (KratosComponents<Variable<double>>::Has(rVariableStringArray[i_variable])) {
             const auto& r_double_var  = KratosComponents<Variable<double>>::Get(rVariableStringArray[i_variable]);
             KRATOS_CHECK_DOF_IN_NODE(r_double_var, r_node);
             KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(r_double_var, r_node)
 
-            mDoubleVariablesList.push_back(&r_double_var);               
+            mDoubleVariablesList.push_back(&r_double_var);
         }
         else if (KratosComponents<ComponentType>::Has(rVariableStringArray[i_variable])){
             const auto& r_component_var  = KratosComponents<ComponentType>::Get(rVariableStringArray[i_variable]);
             KRATOS_CHECK_DOF_IN_NODE(r_component_var, r_node);
             KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(r_component_var, r_node)
-            
+
             mComponentVariablesList.push_back(&r_component_var);
         }
         else if (KratosComponents<Variable<array_1d<double,3>>>::Has(rVariableStringArray[i_variable])){

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -267,7 +267,6 @@ class NavierStokesEmbeddedMonolithicSolver(FluidSolver):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ACCELERATION)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.MESH_VELOCITY)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.BODY_FORCE)
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_H)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_AREA)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION_WATER_PRESSURE)

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_distance_modification_process.cpp
@@ -33,7 +33,6 @@ void TriangleModelPartForDistanceModification(
     ModelPart& rModelPart) {
 
     rModelPart.SetBufferSize(3);
-    rModelPart.AddNodalSolutionStepVariable(NODAL_H);
     rModelPart.AddNodalSolutionStepVariable(DISTANCE);
     Properties::Pointer p_properties = rModelPart.CreateNewProperties(0);
 


### PR DESCRIPTION
This PR does the required modifications to consider the NODAL_H as a non-historical variable in the `DistanceModificationProcess` (related to #5159). I did also detect that the NODAL_H was computed each time the continuous distance correction was performed, something that it's not required. From  now on it is only done in the `ExecuteInitialize`, which is assumed to be called in case re-meshing occurs.

@KratosMultiphysics/potential-flow-team I also detected that you were computing the NODAL_H twice in the `level_set_remeshing_process.py`, outside the distance modification process and in the `Execute()` of the distance modification process call. However, I found no test of this script so please guys check it with your local machine cases.