### PR TITLE
Setting fixed lenght of numerical tag for vtk output files

### DIFF
--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -166,11 +166,11 @@ std::string VtkOutput::GetOutputFileName(const ModelPart& rModelPart, const bool
     std::stringstream ss;
     const std::string output_control = mOutputSettings["output_control_type"].GetString();
     if (output_control == "step") {
-        ss << std::setprecision(mDefaultPrecision)<< std::setfill('0')
+        ss << std::fixed << std::setprecision(mDefaultPrecision)<< std::setfill('0')
            << rModelPart.GetProcessInfo()[STEP];
         label = ss.str();
     } else if(output_control == "time") {
-        ss << std::setprecision(mDefaultPrecision) << std::setfill('0')
+        ss << std::fixed << std::setprecision(mDefaultPrecision) << std::setfill('0')
            << rModelPart.GetProcessInfo()[TIME];
         label = ss.str();
     } else {


### PR DESCRIPTION
That should change the vtk name of the output to print trailing 0 if the print time / step is lower than the precision added.

So:
```
Result-0.0005
Result-0.001
Result-0.0015
Result-0.002
```
Will become:
```
Result-0.0005
Result-0.0010
Result-0.0015
Result-0.0020
```

I've noticed that without this paraview does a lexicographical ordering which messes up with the ordering