### PR TITLE
refactor(HDF5): clean up xdmf output

### DIFF
--- a/applications/EmpireApplication/tests/fsi_mok/ProjectParametersCFD.json
+++ b/applications/EmpireApplication/tests/fsi_mok/ProjectParametersCFD.json
@@ -250,16 +250,5 @@
                 }
             }
         ]
-    },
-    "python_module" : "hdf5_output_process",
-                        "kratos_module" : "KratosMultiphysics.HDF5Application",
-                        "process_name"  : "",
-                        "Parameters"    : {
-                            "model_part_name"                    : "FluidModelPart",
-                            "create_xdmf_file_level"             : 2,
-                            "save_h5_files_in_folder"            : true,
-                            "output_control_type"                : "step",
-                            "output_frequency"                   : 1,
-                            "nodal_solution_step_data_variables" : ["VELOCITY","PRESSURE","MESH_DISPLACEMENT","MESH_VELOCITY"]
-                        }
+    }
 }

--- a/applications/EmpireApplication/tests/fsi_wall/ProjectParametersCFD.json
+++ b/applications/EmpireApplication/tests/fsi_wall/ProjectParametersCFD.json
@@ -254,16 +254,5 @@
                     }
                 }
             ]
-    },
-    "python_module" : "hdf5_output_process",
-                        "kratos_module" : "KratosMultiphysics.HDF5Application",
-                        "process_name"  : "",
-                        "Parameters"    : {
-                            "model_part_name"                    : "FluidModelPart",
-                            "create_xdmf_file_level"             : 2,
-                            "save_h5_files_in_folder"            : true,
-                            "output_control_type"                : "step",
-                            "output_frequency"                   : 1,
-                            "nodal_solution_step_data_variables" : ["VELOCITY","PRESSURE","MESH_DISPLACEMENT","MESH_VELOCITY"]
-                        }
+    }
 }

--- a/applications/HDF5Application/README.md
+++ b/applications/HDF5Application/README.md
@@ -34,7 +34,7 @@ The HDF5 C libraries are used with the *HDF5Application*. If Kratos is configure
 3. Build Kratos
 
 ## Installing h5py
-This package is needed to use some of the python-files, e.g. `create_xdmf_file.py`
+This package is needed to use some of the python-files, e.g. `xdmf_utils.py`
 ```
     sudo apt-get install python-h5py / python3-h5py
 ```

--- a/applications/HDF5Application/python_scripts/core/operations/xdmf.py
+++ b/applications/HDF5Application/python_scripts/core/operations/xdmf.py
@@ -11,11 +11,11 @@ import KratosMultiphysics
 # in case the h5py-module is not installed (e.g. on clusters) we don't want it to crash the simulation!
 # => in such a case the xdmf can be created manually afterwards locally
 try:
-    import KratosMultiphysics.HDF5Application.create_xdmf_file
-    from KratosMultiphysics.HDF5Application.create_xdmf_file import WriteXdmfFile
+    import KratosMultiphysics.HDF5Application.xdmf_utils
+    from KratosMultiphysics.HDF5Application.xdmf_utils import WriteMultifileTemporalAnalysisToXdmf
 except ImportError:
     # if we failed to import, then assign a dummy function that does nothing.
-    WriteXdmfFile = lambda *args: None
+    WriteMultifileTemporalAnalysisToXdmf = lambda *args: None
     warn_msg = "XDMF-Writing is not available,\nOnly HDF5 files are written"
     KratosMultiphysics.Logger.PrintWarning(__name__, warn_msg)
 
@@ -27,7 +27,8 @@ class XdmfOutput(object):
         model_part.GetCommunicator().GetDataCommunicator().Barrier()
         # write xdmf only on one rank!
         if model_part.GetCommunicator().MyPID() == 0:
-            WriteXdmfFile(hdf5_file.GetFileName())
+            WriteMultifileTemporalAnalysisToXdmf(
+                hdf5_file.GetFileName(), "/ModelData", "/ResultsData")
 
 
 def Create(settings):

--- a/applications/HDF5Application/python_scripts/create_xdmf_file.py
+++ b/applications/HDF5Application/python_scripts/create_xdmf_file.py
@@ -24,6 +24,7 @@ def main():
                         default="/ModelData", help="internal HDF5 file path to the mesh")
     parser.add_argument("-r", "--results-path", dest="results_path", metavar="<results-path>",
                         default="/ResultsData", help="internal HDF5 file path to the results")
+    print('\nCreate XDMF:')
     args = parser.parse_args()
     if args.type == "multiple" and args.analysis == "temporal":
         WriteMultifileTemporalAnalysisToXdmf(

--- a/applications/HDF5Application/python_scripts/create_xdmf_file.py
+++ b/applications/HDF5Application/python_scripts/create_xdmf_file.py
@@ -1,151 +1,38 @@
-"""Create a file containing xdmf metadata for results stored in HDF5."""
+"""A script for creating XDMF files for results stored in HDF5.
+
+license: HDF5Application/license.txt
+"""
+
+
+from argparse import ArgumentParser
+
 
 import KratosMultiphysics
 import KratosMultiphysics.HDF5Application as KratosHDF5
-import KratosMultiphysics.HDF5Application.xdmf as xdmf
-import os, sys
-import warnings
-try:
-    with warnings.catch_warnings():
-        # suppressing an import-related warningfrom h5py
-        # problem appears when using it in a test with python >=3.6
-        warnings.simplefilter('ignore', category=ImportWarning)
-        import h5py
-except ModuleNotFoundError:
-    # If h5py is not found, then we delay the exception until name lookup is
-    # performed on the module. This allows the current module to still be used
-    # for testing purposes. Otherwise the tests must be skipped.
-    warn_msg = "h5py module was not found!"
-    KratosMultiphysics.Logger.PrintWarning(__name__, warn_msg)
-    class NonExistingModule(object):
-
-        def __init__(self, module_name):
-            self.module_name = module_name
-
-        def __getattr__(self, name):
-            raise ModuleNotFoundError("No module named '" + self.module_name + "'")
-    h5py = NonExistingModule('h5py')
+from KratosMultiphysics.HDF5Application.xdmf_utils import WriteMultifileTemporalAnalysisToXdmf
 
 
-def GenerateXdmfConnectivities(file_name):
-    with h5py.File(file_name, "r") as h5py_file:
-        has_xdmf = ("Xdmf" in h5py_file.get('/ModelData').keys())
-    if not has_xdmf:
-        KratosHDF5.HDF5XdmfConnectivitiesWriterProcess(file_name, "/ModelData").Execute()
+def main():
+    """Parse the command line arguments and write the corresponding XDMF file."""
+    parser = ArgumentParser(
+        description="Write an XDMF file for post-processing results in HDF5.")
+    parser.add_argument(dest="file_name", metavar="<filename>",
+                        help="path to an HDF5 file for which XDMF metadata should be written")
+    parser.add_argument("-t", "--type", dest="type", metavar="<type>",
+                        choices=['single', 'multiple'], default="multiple", help="type of HDF5 file")
+    parser.add_argument("-a", "--analysis", dest="analysis", metavar="<analysis>",
+                        choices=['static', 'temporal'], default="temporal", help="type of analysis")
+    parser.add_argument("-m", "--mesh-path", dest="mesh_path", metavar="<mesh-path>",
+                        default="/ModelData", help="internal HDF5 file path to the mesh")
+    parser.add_argument("-r", "--results-path", dest="results_path", metavar="<results-path>",
+                        default="/ResultsData", help="internal HDF5 file path to the results")
+    args = parser.parse_args()
+    if args.type == "multiple" and args.analysis == "temporal":
+        WriteMultifileTemporalAnalysisToXdmf(
+            args.file_name, args.mesh_path, args.results_path)
+    else:
+        raise RuntimeError("Unsupported command line options.")
 
 
-def GetSpatialGrid(h5py_file):
-    elements_path = "/ModelData/Xdmf/Elements/"
-    coordinates_path = "/ModelData/Nodes/Local/Coordinates"
-    spatial_grid = xdmf.SpatialGrid()
-    coords_data = xdmf.HDF5UniformDataItem(h5py_file.get(coordinates_path))
-    geom = xdmf.Geometry(coords_data)
-    elems_group = h5py_file.get(elements_path)
-    for name in elems_group.keys():
-        if isinstance(elems_group[name], h5py.Group):
-            single_elem_group = elems_group.get(name)
-            dim = single_elem_group.attrs["Dimension"]
-            num_points = single_elem_group.attrs["NumberOfNodes"]
-            cell_type = xdmf.TopologyCellType(dim, num_points)
-            connectivity_data = xdmf.HDF5UniformDataItem(h5py_file.get(elements_path + '/' + name + '/Connectivities'))
-            topology = xdmf.UniformMeshTopology(cell_type, connectivity_data)
-            spatial_grid.add_grid(xdmf.UniformGrid(name, geom, topology))
-    return spatial_grid
-
-
-def GetNodalResults(h5py_file):
-    results = {}
-    if "/ResultsData/NodalSolutionStepData" in h5py_file:
-        AddNodalData(h5py_file.get("/ResultsData/NodalSolutionStepData"), results)
-    if "/ResultsData/NodalDataValues" in h5py_file:
-        AddNodalData(h5py_file.get("/ResultsData/NodalDataValues"), results)
-
-    return list(results.values())
-
-def AddNodalData(results_group, results):
-    for variable_name in results_group.keys():
-        if isinstance(results_group[variable_name], h5py.Dataset):
-            if variable_name in results:
-                raise ValueError('Nodal result "' + variable_name + '" is already defined.')
-            data = xdmf.HDF5UniformDataItem(results_group.get(variable_name))
-            results[variable_name] = xdmf.NodalData(variable_name, data)
-
-def GetElementResults(h5py_file):
-    element_results_path = "/ResultsData/ElementDataValues"
-    results = []
-    if not element_results_path in h5py_file:
-        return results
-    results_group = h5py_file.get(element_results_path)
-    for variable_name in results_group.keys():
-        if isinstance(results_group[variable_name], h5py.Dataset):
-            data = xdmf.HDF5UniformDataItem(results_group.get(variable_name))
-            results.append(xdmf.ElementSolutionStepData(variable_name, data))
-    return results
-
-
-def GetListOfTimeLabels(file_name):
-    list_of_file_names = []
-    path, file_name = os.path.split(file_name)
-    if path == "": path = "." # os.listdir fails with empty path
-    time_prefix = file_name.replace(".h5", "-")
-    for name in os.listdir(path):
-        if name.find(time_prefix) == 0:
-            list_of_file_names.append(name)
-    list_of_time_labels = []
-    for name in list_of_file_names:
-        list_of_time_labels.append(name.replace(".h5", "")[len(time_prefix):])
-    list_of_time_labels.sort(key=float)
-    return list_of_time_labels
-
-
-def WriteXdmfFile(file_name):
-    #todo(msandre): generalize to WriteXdmfFile(xdmf_file_name, list_of_h5_file_paths):
-    temporal_grid = xdmf.TemporalGrid()
-    GenerateXdmfConnectivities(file_name)
-    # Get the initial spatial grid from the base file.
-    with h5py.File(file_name, "r") as h5py_file:
-        current_spatial_grid = GetSpatialGrid(h5py_file)
-    for current_time in GetListOfTimeLabels(file_name):
-        current_file_name = file_name.replace(".h5", "-" + current_time + ".h5")
-        try:
-            # Check if the current file has mesh information.
-            with h5py.File(current_file_name, "r") as h5py_file:
-                has_mesh = ("ModelData" in h5py_file.keys())
-                has_data = ("/ResultsData" in h5py_file.keys())
-        except OSError:
-            # in case this file cannot be opened skip it
-            # this can be the case if the file is already opened
-            warn_msg  = 'No xdmf-data was written for file:\n"'
-            warn_msg += current_file_name + '"'
-            KratosMultiphysics.Logger.PrintWarning("XDMF-Writing", warn_msg)
-            continue
-        if not has_data:
-            continue
-        if has_mesh:
-            GenerateXdmfConnectivities(current_file_name)
-        with h5py.File(current_file_name, "r") as h5py_file:
-            if has_mesh:
-                # Update current spatial grid
-                current_spatial_grid = GetSpatialGrid(h5py_file)
-            # Initialize the current grid with the spatial grid.
-            current_grid = xdmf.SpatialGrid()
-            for grid in current_spatial_grid.grids:
-                current_grid.add_grid(xdmf.UniformGrid(grid.name, grid.geometry, grid.topology))
-            # Add the (time-dependent) results.
-            for nodal_result in GetNodalResults(h5py_file):
-                current_grid.add_attribute(nodal_result)
-            for element_result in GetElementResults(h5py_file):
-                current_grid.add_attribute(element_result)
-        # Add the current grid to the temporal grid.
-        temporal_grid.add_grid(xdmf.Time(current_time), current_grid)
-    # Create the domain.
-    domain = xdmf.Domain(temporal_grid)
-    # Write.
-    raw_file_name = os.path.split(file_name)[1]
-    xdmf_file_name = raw_file_name.replace(".h5", ".xdmf")
-    xdmf.ET.ElementTree(xdmf.Xdmf(domain).create_xml_element()).write(xdmf_file_name)
-
-
-if __name__ == '__main__':
-    file_name = sys.argv[1]
-    WriteXdmfFile(file_name)
+if __name__ == "__main__":
+    main()

--- a/applications/HDF5Application/python_scripts/create_xdmf_file.py
+++ b/applications/HDF5Application/python_scripts/create_xdmf_file.py
@@ -7,8 +7,6 @@ license: HDF5Application/license.txt
 from argparse import ArgumentParser
 
 
-import KratosMultiphysics
-import KratosMultiphysics.HDF5Application as KratosHDF5
 from KratosMultiphysics.HDF5Application.xdmf_utils import WriteMultifileTemporalAnalysisToXdmf
 
 

--- a/applications/HDF5Application/python_scripts/user_defined_io_process.py
+++ b/applications/HDF5Application/python_scripts/user_defined_io_process.py
@@ -12,6 +12,7 @@ __all__ = ["Factory"]
 
 import KratosMultiphysics
 from KratosMultiphysics.HDF5Application import core
+from KratosMultiphysics.HDF5Application.utils import ParametersWrapper
 
 
 def Factory(settings, Model):
@@ -129,4 +130,4 @@ def Factory(settings, Model):
     algorithm, frequencies and IO operations can be configured by appending
     additional parameters to the json array.
     """
-    return core.Factory(settings["Parameters"], Model)
+    return core.Factory(ParametersWrapper(settings["Parameters"]), Model)

--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -294,10 +294,10 @@ def WriteMultifileTemporalAnalysisToXdmf(ospath, h5path_to_mesh, h5path_to_resul
     h5path_to_mesh -- the internal HDF5 file path to the mesh
     h5path_to_results -- the internal HDF5 file path to the results
     """
-    # Strip any suffixes from the path.
-    pat = ospath.rstrip(".h5").rstrip(".xdmf")
+    pat = ospath
     # Strip any time label from the file name.
     time_label = TimeLabel(pat)
+    pat = pat.rstrip('.h5').rstrip('.xdmf')
     if time_label:
         pat = pat.rstrip(time_label).rstrip("-")
     # Generate the temporal grid.

--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -1,0 +1,311 @@
+"""Utilities for creating XDMF metadata from results stored in HDF5.
+
+XDMF utilities are separate from the core xdmf to reduce core dependencies.
+
+See:
+- core.xdmf
+
+license: HDF5Application/license.txt
+"""
+
+
+import xml.etree.ElementTree as ET
+import os
+import warnings
+from itertools import chain
+from contextlib import contextmanager
+import re
+
+
+import KratosMultiphysics
+import KratosMultiphysics.HDF5Application as KratosHDF5
+from KratosMultiphysics.HDF5Application.core.xdmf import SpatialGrid
+from KratosMultiphysics.HDF5Application.core.xdmf import HDF5UniformDataItem
+from KratosMultiphysics.HDF5Application.core.xdmf import Geometry
+from KratosMultiphysics.HDF5Application.core.xdmf import TopologyCellType
+from KratosMultiphysics.HDF5Application.core.xdmf import UniformMeshTopology
+from KratosMultiphysics.HDF5Application.core.xdmf import UniformGrid
+from KratosMultiphysics.HDF5Application.core.xdmf import NodalData
+from KratosMultiphysics.HDF5Application.core.xdmf import ElementData
+from KratosMultiphysics.HDF5Application.core.xdmf import TemporalGrid
+from KratosMultiphysics.HDF5Application.core.xdmf import Time
+from KratosMultiphysics.HDF5Application.core.xdmf import Domain
+from KratosMultiphysics.HDF5Application.core.xdmf import Xdmf
+
+
+try:
+    with warnings.catch_warnings():
+        # suppressing an import-related warning from h5py
+        # problem appears when using it in a test with python >=3.6
+        warnings.simplefilter('ignore', category=ImportWarning)
+        import h5py
+except ModuleNotFoundError:
+    # If h5py is not found, then we delay the exception until name lookup is
+    # performed on the module. This allows the current module to still be used
+    # for testing purposes. Otherwise the tests must be skipped.
+    warn_msg = "h5py module was not found!"
+    KratosMultiphysics.Logger.PrintWarning(__name__, warn_msg)
+    class NonExistingModule(object):
+
+        def __init__(self, module_name):
+            self.module_name = module_name
+
+        def __getattr__(self, name):
+            raise ModuleNotFoundError(
+                "No module named '" + self.module_name + "'")
+    h5py = NonExistingModule('h5py')
+
+
+@contextmanager
+def TryOpenH5File(name, mode=None, driver=None, **kwds):
+    """A context manager wrapper for the opened file.
+
+    In case the file cannot be opened, yield None rather than raise an
+    exception.  This can be the case if the file is already opened.
+    """
+    try:
+        with h5py.File(name, mode, driver=driver, **kwds) as f:
+            yield f
+    except OSError:
+        warn_msg = 'No xdmf-data was written for file:\n"' + name + '"'
+        KratosMultiphysics.Logger.PrintWarning("XDMF", warn_msg)
+        yield None
+
+
+def RenumberConnectivitiesForXdmf(filename_or_list_of_filenames, h5path_to_mesh):
+    """Renumber mesh connectivities for XDMF.
+
+    Keyword arguments:
+    filename_or_list_of_filenames -- the HDF5 file(s) to renumber
+    h5path_to_mesh -- the internal HDF5 file path to the mesh
+
+    The mesh connectivities must be renumbered for XDMF by the node's array
+    index rather than its ID.  The renumbered connectivities are stored in
+    HDF5 and referenced by the XDMF Grid.  If a file cannot be opened, it is
+    skipped.
+
+    See:
+    - XdmfConnectivitiesWriterProcess.
+    """
+    for path in list(filename_or_list_of_filenames):
+        skip = True
+        with TryOpenH5File(path, "r") as f:
+            if not f:
+                continue
+            if h5path_to_mesh in f:
+                skip = "Xdmf" in f[h5path_to_mesh]
+        if not skip:
+            KratosHDF5.HDF5XdmfConnectivitiesWriterProcess(
+                path, h5path_to_mesh).Execute()
+
+
+def CreateXdmfSpatialGrid(h5_model_part):
+    """Return an XDMF Grid object corresponding to a mesh in an HDF5 file.
+
+    Keyword arguments:
+    h5_model_part -- the HDF5 group containing the model part
+
+    Expects:
+    - element connectivities in h5_model_part["Xdmf/Elements/<element-name>"].
+      Each connectivities has attributes "Dimension" and "NumberOfNodes".  For
+      example, "Element2D3N" has "Dimension" 2 and "NumberOfNodes" 3.  The
+      connectivities differ from the normal mdpa connectivities in that they
+      directly index the array of nodal coordinates.  Currently there is
+      no other way to post-process the mesh with Xdmf.
+
+    See:
+    - core.operations.ModelPartOutput,
+    - core.operations.PartitionedModelPartOutput,
+    - RenumberConnectivitiesForXdmf.
+    """
+    sgrid = SpatialGrid()
+    geom = Geometry(HDF5UniformDataItem(
+        h5_model_part["Nodes/Local/Coordinates"]))
+    for name, value in h5_model_part["Xdmf/Elements"].items():
+        cell_type = TopologyCellType(
+            value.attrs["Dimension"], value.attrs["NumberOfNodes"])
+        connectivities = HDF5UniformDataItem(value["Connectivities"])
+        topology = UniformMeshTopology(cell_type, connectivities)
+        sgrid.add_grid(UniformGrid(name, geom, topology))
+    return sgrid
+
+
+def Has_dtype(item): return hasattr(item[1], 'dtype')
+
+
+def XdmfNodalResults(h5_results):
+    """Return a list of XDMF Attribute objects for nodal results in an HDF5 file.
+
+    Keyword arguments:
+    h5_results -- the HDF5 group containing the results
+
+    Checks for results stored in data sets by variable name in:
+    - h5_results["NodalSolutionStepData/<variable-name>"]
+    - h5_results["NodalDataValues/<variable-name>"]
+
+    Expects:
+    - each result variable occurs only once
+
+    If no results are found, returns an empty list.
+
+    See:
+    - core.operations.NodalSolutionStepDataOutput,
+    - core.operations.NodalDataValueOutput.
+    """
+    results = {}
+    for path in ["NodalSolutionStepData", "NodalDataValues"]:
+        try:
+            grp = h5_results[path]
+        except KeyError:
+            continue
+        for variable, data in filter(Has_dtype, grp.items()):
+            if variable in results:
+                # A variable can exist in the nodal solution step data or
+                # non-historical nodal data value container, but not both.
+                raise RuntimeError('Nodal result variable "' +
+                                   variable + '" already exists.')
+            results[variable] = NodalData(variable, HDF5UniformDataItem(data))
+    return list(results.values())
+
+
+def XdmfElementResults(h5_results):
+    """Return a list of XDMF Attribute objects for element results in an HDF5 file.
+
+    Keyword arguments:
+    h5_results -- the HDF5 group containing the results
+
+    Checks for results stored by variable name in:
+    - h5_results["ElementDataValues/<variable>"]
+
+    If no results are found, returns an empty list.
+
+    See:
+    - core.operations.ElementDataValueOutput.
+    """
+    results_path = "ElementDataValues"
+    results = []
+    try:
+        grp = h5_results[results_path]
+    except KeyError:
+        return results
+    for variable, data in filter(Has_dtype, grp.items()):
+        r = ElementData(variable, HDF5UniformDataItem(data))
+        results.append(r)
+    return results
+
+
+def XdmfResults(h5_results):
+    """Return a list of XDMF Attribute objects for results in an HDF5 file.
+
+    Keyword arguments:
+    h5_results -- the HDF5 group containing the results
+    """
+    return list(
+        chain(
+            XdmfNodalResults(h5_results),
+            XdmfElementResults(h5_results)
+        )
+    )
+
+
+def TimeLabel(file_path):
+    """Return the time string from the file name.
+
+    E.g.:
+    'kratos-123.h5' -> '123'
+    'kratos-1.2.h5' -> '1.2'
+    'kratos-1.2e+00.h5' -> '1.2e+00'
+
+    Returns empty string if not found.
+    """
+    timepat = re.compile(r"\d+(\.\d+)?((e|E)(\+|-)\d+)?")
+    file_path = ".".join(file_path.split(".")[:-1]) # Strip any suffixes.
+    m = timepat.search(file_path)
+    if m:
+        return m.string[m.start():m.end()]
+    else:
+        return ""
+
+
+def FindMatchingFiles(pattern):
+    """Return a list of HDF5 files matching the given file name pattern.
+
+    For example, "./sim/kratos" matches:
+    - ./sim/kratos.h5
+    - ./sim/kratos-0.0000.h5
+    - ./sim/kratos-0.2000.h5
+    - etc.
+    """
+    path, _ = os.path.split(pattern)
+    if path == "":
+        path = "."  # os.listdir fails with empty path
+    def match(s): return s.startswith(pattern) and s.endswith(".h5")
+    return list(filter(match, os.listdir(path)))
+
+
+def CreateXdmfTemporalGridFromMultifile(list_of_h5_files, h5path_to_mesh, h5path_to_results):
+    """Return an XDMF Grid object for a list of temporal results in HDF5 files.
+
+    Keyword arguments:
+    list_of_h5_files -- the list of HDF5 files to be parsed
+    h5path_to_mesh -- the internal HDF5 file path to the mesh
+    h5path_to_results -- the internal HDF5 file path to the results
+
+    Expects:
+    - each file corresponds to a separate time step
+    - the first file includes a mesh.  Subsequent files may include their own
+      meshes.  If a file does not contain a mesh, it is assumed to have the
+      same mesh as the most recent file containing a mesh.
+    - meshes include XDMF mesh connectivities under the internal HDF5 file path
+      "<h5path_to_mesh>/Xdmf".  If XDMF connectivities are not found, the file is
+      skipped.  See RenumberConnectivitiesForXdmf.
+    - file names contain their time step as a substring. Optionally the first
+      file may omit the time step in which case it is assumed to be zero.
+
+    If a file cannot be opened, it is skipped.
+    """
+    tgrid = TemporalGrid()
+    for path in list_of_h5_files:
+        with TryOpenH5File(path, "r") as file_:
+            if not file_:
+                continue
+            if h5path_to_mesh in file_:
+                if not "Xdmf" in file_[h5path_to_mesh]:
+                    continue
+                sgrid = CreateXdmfSpatialGrid(file_[h5path_to_mesh])
+            current_sgrid = SpatialGrid()
+            for g in sgrid.grids:
+                current_sgrid.add_grid(UniformGrid(g.name, g.geometry, g.topology))
+            if h5path_to_results in file_:
+                for result in XdmfResults(file_[h5path_to_results]):
+                    current_sgrid.add_attribute(result)
+            time_label = TimeLabel(path)
+            if time_label == "":
+                time_label = "0.0"
+            tgrid.add_grid(Time(time_label), current_sgrid)
+    return tgrid
+
+
+def WriteMultifileTemporalAnalysisToXdmf(ospath, h5path_to_mesh, h5path_to_results):
+    """Write XDMF metadata for a temporal analysis from multiple HDF5 files.
+
+    Keyword arguments:
+    ospath -- path to one of the HDF5 files or the corresponding XDMF output file.
+    h5path_to_mesh -- the internal HDF5 file path to the mesh
+    h5path_to_results -- the internal HDF5 file path to the results
+    """
+    # Strip any suffixes from the path.
+    pat = ospath.rstrip(".h5").rstrip(".xdmf")
+    # Strip any time label from the file name.
+    time_label = TimeLabel(pat)
+    if time_label:
+        pat = pat.rstrip(time_label).rstrip("-")
+    # Generate the temporal grid.
+    list_of_files = FindMatchingFiles(pat)
+    RenumberConnectivitiesForXdmf(list_of_files, h5path_to_mesh)
+    temporal_grid = CreateXdmfTemporalGridFromMultifile(
+        list_of_files, h5path_to_mesh, h5path_to_results)
+    domain = Domain(temporal_grid)
+    xdmf = Xdmf(domain)
+    # Write the XML tree containing the XDMF metadata to the file.
+    ET.ElementTree(xdmf.create_xml_element()).write(pat + ".xdmf")

--- a/applications/HDF5Application/tests/test_HDF5Application.py
+++ b/applications/HDF5Application/tests/test_HDF5Application.py
@@ -5,6 +5,14 @@ from test_hdf5_core import TestOperations as TestHDF5Operations
 from test_hdf5_core import TestControllers as TestHDF5Controllers
 from test_hdf5_model_part_io import TestCase as TestHDF5ModelPartIO
 from test_hdf5_processes import TestHDF5Processes
+from test_hdf5_xdmf import TestTryOpenH5File
+from test_hdf5_xdmf import TestCreateXdmfSpatialGrid
+from test_hdf5_xdmf import TestXdmfNodalResults
+from test_hdf5_xdmf import TestXdmfElementResults
+from test_hdf5_xdmf import TestXdmfResults
+from test_hdf5_xdmf import TestTimeLabel
+from test_hdf5_xdmf import TestFindMatchingFiles
+from test_hdf5_xdmf import TestCreateXdmfTemporalGridFromMultifile
 import run_cpp_unit_tests
 
 def AssembleTestSuites():
@@ -16,6 +24,14 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestHDF5Controllers]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestHDF5ModelPartIO]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestHDF5Processes]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestTryOpenH5File]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCreateXdmfSpatialGrid]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestXdmfNodalResults]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestXdmfElementResults]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestXdmfResults]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestTimeLabel]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestFindMatchingFiles]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCreateXdmfTemporalGridFromMultifile]))
 
     nightSuite = suites['nightly']
     nightSuite.addTests(smallSuite)

--- a/applications/HDF5Application/tests/test_hdf5_processes.py
+++ b/applications/HDF5Application/tests/test_hdf5_processes.py
@@ -271,11 +271,12 @@ class TestHDF5Processes(KratosUnittest.TestCase):
                 }
             }
             ''')
-        patcher1 = patch('KratosMultiphysics.HDF5Application.create_xdmf_file.WriteXdmfFile', autospec=True)
+        patcher1 = patch(
+            'KratosMultiphysics.HDF5Application.xdmf_utils.WriteMultifileTemporalAnalysisToXdmf', autospec=True)
         patcher2 = patch(
             'KratosMultiphysics.kratos_utilities.DeleteFileIfExisting', autospec=True)
         patcher3 = patch('os.listdir', autospec=True)
-        WriteXdmfFile = patcher1.start()
+        WriteMultifileTemporalAnalysisToXdmf = patcher1.start()
         DeleteFileIfExisting = patcher2.start()
         listdir = patcher3.start()
         listdir.return_value = [
@@ -286,8 +287,9 @@ class TestHDF5Processes(KratosUnittest.TestCase):
         for time in [0.09999999, 0.19999998]:
             self.model_part.CloneTimeStep(time)
             process.ExecuteFinalizeSolutionStep()
-        self.assertEqual(WriteXdmfFile.call_count, 2)
-        WriteXdmfFile.assert_called_with('test_model_part.h5')
+        self.assertEqual(WriteMultifileTemporalAnalysisToXdmf.call_count, 2)
+        WriteMultifileTemporalAnalysisToXdmf.assert_called_with(
+            'test_model_part.h5', '/ModelData', '/ResultsData')
         DeleteFileIfExisting.assert_called_once_with(
             './test_model_part-0.1000.h5')
         patcher1.stop()

--- a/applications/HDF5Application/tests/test_hdf5_xdmf.py
+++ b/applications/HDF5Application/tests/test_hdf5_xdmf.py
@@ -1,0 +1,245 @@
+from collections import namedtuple
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+
+try:
+    import h5py
+except ModuleNotFoundError:
+    h5py = None
+
+
+import KratosMultiphysics
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+from KratosMultiphysics.HDF5Application.xdmf_utils import TryOpenH5File
+from KratosMultiphysics.HDF5Application.xdmf_utils import CreateXdmfSpatialGrid
+from KratosMultiphysics.HDF5Application.xdmf_utils import XdmfNodalResults
+from KratosMultiphysics.HDF5Application.xdmf_utils import XdmfElementResults
+from KratosMultiphysics.HDF5Application.xdmf_utils import XdmfResults
+from KratosMultiphysics.HDF5Application.xdmf_utils import TimeLabel
+from KratosMultiphysics.HDF5Application.xdmf_utils import FindMatchingFiles
+from KratosMultiphysics.HDF5Application.xdmf_utils import CreateXdmfTemporalGridFromMultifile
+from KratosMultiphysics.kratos_utilities import DeleteFileIfExisting
+
+
+class TestTryOpenH5File(KratosUnittest.TestCase):
+
+    def test_TryOpenH5File_NormalExecution(self):
+        ok = False
+        with TryOpenH5File("test.h5", "w", "core", backing_store=False) as f:
+            f.create_group("grp")
+            ok = True
+        self.assertTrue(ok)
+
+    def test_TryOpenH5File_OSError(self):
+        with TryOpenH5File("test.h5", "r", "core") as f:
+            self.assertTrue(f == None)
+
+    def test_TryOpenH5File_KeyError(self):
+        ok = False
+        try:
+            with TryOpenH5File("test.h5", "w", "core", backing_store=False) as f:
+                f["does-not-exist"]
+        except KeyError:
+            ok = True
+        self.assertTrue(ok)
+
+
+class TestCreateXdmfSpatialGrid(KratosUnittest.TestCase):
+
+    @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
+    def test_CreateXdmfSpatialGrid(self):
+        with h5py.File("kratos.h5", "a", "core", backing_store=False) as f:
+            f.create_dataset(
+                "/ModelPart/Nodes/Local/Coordinates", (15, 3), "float64")
+            elem2d4n = f.create_group("/ModelPart/Xdmf/Elements/Element2D4N")
+            elem2d4n.attrs["Dimension"] = 2
+            elem2d4n.attrs["NumberOfNodes"] = 4
+            elem2d4n.create_dataset("Connectivities", (10, 4), "int32")
+            sgrid = CreateXdmfSpatialGrid(f["/ModelPart"])
+        self.assertEqual(sgrid.grids[0].name, "Element2D4N")
+        self.assertEqual(sgrid.grids[0].geometry.coords.file_name, "kratos.h5")
+        self.assertEqual(
+            sgrid.grids[0].geometry.coords.name, "/ModelPart/Nodes/Local/Coordinates")
+        self.assertEqual(sgrid.grids[0].geometry.coords.dtype, "float64")
+        self.assertEqual(sgrid.grids[0].geometry.coords.dimensions, (15, 3))
+        self.assertEqual(sgrid.grids[0].topology.data.file_name, "kratos.h5")
+        self.assertEqual(sgrid.grids[0].topology.data.name,
+                         "/ModelPart/Xdmf/Elements/Element2D4N/Connectivities")
+        self.assertEqual(sgrid.grids[0].topology.data.dtype, "int32")
+        self.assertEqual(sgrid.grids[0].topology.data.dimensions, (10, 4))
+
+
+class TestXdmfNodalResults(KratosUnittest.TestCase):
+
+    @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
+    def test_XdmfNodalResults(self):
+        with h5py.File("kratos.h5", "a", "core", backing_store=False) as f:
+            f.create_dataset(
+                "/Results/NodalSolutionStepData/VELOCITY", (15, 3), "float64")
+            f.create_dataset(
+                "/Results/NodalDataValues/DENSITY", (15,), "float64")
+            results = XdmfNodalResults(f["/Results"])
+        self.assertEqual(results[0].name, "VELOCITY")
+        self.assertEqual(results[0].data.file_name, "kratos.h5")
+        self.assertEqual(results[0].data.name, "/Results/NodalSolutionStepData/VELOCITY")
+        self.assertEqual(results[0].data.dtype, "float64")
+        self.assertEqual(results[0].attribute_type, "Vector")
+        self.assertEqual(results[1].name, "DENSITY")
+        self.assertEqual(results[1].data.file_name, "kratos.h5")
+        self.assertEqual(results[1].data.name, "/Results/NodalDataValues/DENSITY")
+        self.assertEqual(results[1].data.dtype, "float64")
+        self.assertEqual(results[1].attribute_type, "Scalar")
+
+    @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
+    def test_XdmfNodalResults_RepeatedVariableException(self):
+        with h5py.File("kratos.h5", "a", "core", backing_store=False) as f:
+            f.create_dataset(
+                "/Results/NodalSolutionStepData/DENSITY", (15,), "float64")
+            f.create_dataset(
+                "/Results/NodalDataValues/DENSITY", (15,), "float64")
+            self.assertRaises(RuntimeError, XdmfNodalResults, f["/Results"])
+
+    @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
+    def test_XdmfNodalResults_NoResultsFound(self):
+        with h5py.File("kratos.h5", "a", "core", backing_store=False) as f:
+            f.create_group("/Results/NodalSolutionStepData")
+            results = XdmfNodalResults(f["/Results"])
+            self.assertEqual(len(results), 0)
+
+
+class TestXdmfElementResults(KratosUnittest.TestCase):
+
+    @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
+    def test_XdmfElementResults(self):
+        with h5py.File("kratos.h5", "a", "core", backing_store=False) as f:
+            f.create_dataset(
+                "/Results/ElementDataValues/DENSITY", (15,), "float64")
+            results = XdmfElementResults(f["/Results"])
+        self.assertEqual(results[0].name, "DENSITY")
+        self.assertEqual(results[0].data.file_name, "kratos.h5")
+        self.assertEqual(results[0].data.name, "/Results/ElementDataValues/DENSITY")
+        self.assertEqual(results[0].data.dtype, "float64")
+        self.assertEqual(results[0].attribute_type, "Scalar")
+
+    @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
+    def test_XdmfElementResults_NoResultsFound(self):
+        with h5py.File("kratos.h5", "a", "core", backing_store=False) as f:
+            f.create_group("/Results")
+            results = XdmfElementResults(f["/Results"])
+            self.assertEqual(len(results), 0)
+
+
+class TestXdmfResults(KratosUnittest.TestCase):
+
+    @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
+    def test_XdmfResults(self):
+        with h5py.File("kratos.h5", "a", "core", backing_store=False) as f:
+            f.create_group("/Results")
+            results = XdmfResults(f["/Results"])
+            self.assertEqual(len(results), 0)
+
+
+class TestTimeLabel(KratosUnittest.TestCase):
+
+    def test_TimeLabel(self):
+        self.assertEqual(TimeLabel("kratos.h5"), "")
+        self.assertEqual(TimeLabel("kratos-123.h5"), "123")
+        self.assertEqual(TimeLabel("kratos-1.2.h5"), "1.2")
+        self.assertEqual(TimeLabel("kratos-1.2e+00.h5"), "1.2e+00")
+        self.assertEqual(TimeLabel("kratos-1.2E+00.h5"), "1.2E+00")
+
+
+class TestFindMatchingFiles(KratosUnittest.TestCase):
+
+    def test_FindMatchingFiles(self):
+        patcher = patch("KratosMultiphysics.HDF5Application.xdmf_utils.os.listdir", autospec=True)
+        listdir = patcher.start()
+        listdir.return_value = ["./sim/kratos.h5",
+                                "./sim/kratos-0.0000.h5", "./sim/kratos-0.2000.h5"]
+        files = FindMatchingFiles("./sim/kratos")
+        self.assertEqual(len(files), 3)
+        self.assertTrue("./sim/kratos.h5" in files)
+        self.assertTrue("./sim/kratos-0.0000.h5" in files)
+        self.assertTrue("./sim/kratos-0.2000.h5" in files)
+        patcher.stop()
+
+
+class TestCreateXdmfTemporalGridFromMultifile(KratosUnittest.TestCase):
+
+    def setUp(self):
+        with h5py.File("kratos.h5") as f0:
+            f0.create_dataset(
+            "/ModelPart/Nodes/Local/Coordinates", (15, 3), "float64")
+            elem2d4n = f0.create_group("/ModelPart/Xdmf/Elements/Element2D4N")
+            elem2d4n.attrs["Dimension"] = 2
+            elem2d4n.attrs["NumberOfNodes"] = 4
+            elem2d4n.create_dataset("Connectivities", (10, 4), "int32")
+        with h5py.File("kratos-1.0.h5") as f1:
+            f1.create_dataset(
+            "/Results/NodalSolutionStepData/VELOCITY", (15, 3), "float64")
+
+    def tearDown(self):
+        DeleteFileIfExisting("kratos.h5")
+        DeleteFileIfExisting("kratos-1.0.h5")
+
+    @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
+    def test_CreateXdmfTemporalGridFromMultifile_OnlyOneMesh(self):
+        tgrid = CreateXdmfTemporalGridFromMultifile(
+            ["kratos.h5", "kratos-1.0.h5"], "/ModelPart", "/Results")
+        self.assertEqual(len(tgrid.times), 2)
+        self.assertEqual(len(tgrid.grids), 2)
+        time0 = tgrid.times[0]
+        sgrid0 = tgrid.grids[0]
+        ugrid0 = sgrid0.grids[0]
+        self.assertEqual(time0.time, "0.0")
+        self.assertEqual(ugrid0.name, "Element2D4N")
+        self.assertEqual(len(ugrid0.attributes), 0)
+        time1 = tgrid.times[1]
+        sgrid1 = tgrid.grids[1]
+        ugrid1 = sgrid1.grids[0]
+        self.assertEqual(time1.time, "1.0")
+        self.assertEqual(ugrid1.name, "Element2D4N")
+        self.assertEqual(len(ugrid1.attributes), 1)
+        result1 = ugrid1.attributes[0]
+        self.assertEqual(result1.name, "VELOCITY")
+
+    @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
+    def test_CreateXdmfTemporalGridFromMultifile_MoreThanOneMesh(self):
+        with h5py.File("kratos-1.0.h5", "w") as f:
+            f.create_dataset(
+            "/ModelPart/Nodes/Local/Coordinates", (20, 3), "float64")
+            elem2d4n = f.create_group("/ModelPart/Xdmf/Elements/Element3D3N")
+            elem2d4n.attrs["Dimension"] = 3
+            elem2d4n.attrs["NumberOfNodes"] = 3
+            elem2d4n.create_dataset("Connectivities", (8, 3), "int32")
+            f.create_dataset(
+            "/Results/NodalSolutionStepData/VELOCITY", (20, 3), "float64")
+        tgrid = CreateXdmfTemporalGridFromMultifile(
+            ["kratos.h5", "kratos-1.0.h5"], "/ModelPart", "/Results")
+        self.assertEqual(len(tgrid.times), 2)
+        self.assertEqual(len(tgrid.grids), 2)
+        sgrid0 = tgrid.grids[0]
+        ugrid0 = sgrid0.grids[0]
+        self.assertEqual(ugrid0.name, "Element2D4N")
+        sgrid1 = tgrid.grids[1]
+        ugrid1 = sgrid1.grids[0]
+        self.assertEqual(ugrid1.name, "Element3D3N")
+
+    @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
+    def test_CreateXdmfTemporalGridFromMultifile_XdmfNotFound(self):
+        with h5py.File("kratos-1.0.h5", "w") as f:
+            f.create_dataset(
+            "/ModelPart/Nodes/Local/Coordinates", (20, 3), "float64")
+            f.create_dataset(
+            "/Results/NodalSolutionStepData/VELOCITY", (20, 3), "float64")
+        tgrid = CreateXdmfTemporalGridFromMultifile(
+            ["kratos.h5", "kratos-1.0.h5"], "/ModelPart", "/Results")
+        self.assertEqual(len(tgrid.times), 1)
+        self.assertEqual(len(tgrid.grids), 1)
+        time0 = tgrid.times[0]
+        self.assertEqual(time0.time, "0.0")
+
+
+if __name__ == "__main__":
+    KratosUnittest.main()

--- a/applications/HDF5Application/tests/test_hdf5_xdmf.py
+++ b/applications/HDF5Application/tests/test_hdf5_xdmf.py
@@ -1,5 +1,3 @@
-from collections import namedtuple
-from unittest.mock import MagicMock
 from unittest.mock import patch
 
 
@@ -9,7 +7,6 @@ except ModuleNotFoundError:
     h5py = None
 
 
-import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 from KratosMultiphysics.HDF5Application.xdmf_utils import TryOpenH5File
 from KratosMultiphysics.HDF5Application.xdmf_utils import CreateXdmfSpatialGrid


### PR DESCRIPTION
- The utility functions in create_xdmf_file.py are refactored to be more
  general w.r.t different internal HDF5 paths.
- Large functions are split up.
- The file pattern matching of the input argument to create_xdmf_file is
  enhanced. Previously it was necessary to pass exactly the hdf5 file path
  without time. E.g.:

  python3 create_xdmf_file.py ./kratos.h5

  Now any of the following patterns are valid:

  python3 create_xdmf_file.py ./kratos
  python3 create_xdmf_file.py ./kratos.h5
  python3 create_xdmf_file.py ./kratos.xdmf
  python3 create_xdmf_file.py ./kratos-0.0000.h5
  python3 create_xdmf_file.py ./kratos-1.0000.h5
  etc...

- The behavior of the utility functions is documented and tests are added.
- The utility functions are moved to xdmf_utils.py.
- Command line options and help documentation are added to create_xdmf_file.py.
- It is easier to extend the xdmf output to support new storage layouts using
  the new structure without changing existing code.
- A missing ParametersWrapper is added to user_defined_io_process.py.


HDF5 tests are passing.

@philbucher there is something related to create_xdmf_file in the empire application. Can you check if these changes cause a conflict there? 