### PR TITLE
Templated CrossProduct with return, adding test.

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
@@ -749,9 +749,11 @@ namespace Kratos
 
             MathUtils<double>::CrossProduct(c, b, a);
             MathUtils<double>::UnitCrossProduct(d, b, a);
+            array_1d<double,3> e = MathUtils<double>::CrossProduct(b, a);
 
             KRATOS_CHECK_EQUAL(c[2], 2.0);
             KRATOS_CHECK_EQUAL(d[2], 1.0);
+            KRATOS_CHECK_EQUAL(e[2], 2.0);
         }
 
         /** Checks if it calculates the orthonormal base

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -856,12 +856,13 @@ public:
      * @param b Second input vector
      * @return The resulting vector
      */
-    static inline Vector CrossProduct(
-        const Vector& a,
-        const Vector& b
+    template<class T>
+    static inline T CrossProduct(
+        const T& a,
+        const T& b
         )
     {
-        Vector c(3);
+        T c(a);
 
         c[0] = a[1]*b[2] - a[2]*b[1];
         c[1] = a[2]*b[0] - a[0]*b[2];


### PR DESCRIPTION
Making return version of `MathUtils<double>::CrossProduct` templated on argument type as for the version with three arguments. Adding a test for the same function.