### PR TITLE
[PfemFluid] Tests kratos_module corrected

### DIFF
--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Bingham/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Bingham/ProjectParameters.json
@@ -52,7 +52,7 @@
     },
     "problem_process_list"     : [{
         "help"          : "This process applies meshing to the problem domains",
-        "kratos_module" : "KratosMultiphysics.DelaunayMeshingApplication",
+        "kratos_module" : "KratosMultiphysics.PfemFluidDynamicsApplication",
         "python_module" : "remesh_fluid_domains_process",
         "process_name"  : "RemeshFluidDomainsProcess",
         "Parameters"    : {

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_FSI/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_FSI/ProjectParameters.json
@@ -60,7 +60,7 @@
     },
     "problem_process_list"     : [{
         "help"          : "This process applies meshing to the problem domains",
-        "kratos_module" : "KratosMultiphysics.DelaunayMeshingApplication",
+        "kratos_module" : "KratosMultiphysics.PfemFluidDynamicsApplication",
         "python_module" : "remesh_fluid_domains_process",
         "process_name"  : "RemeshFluidDomainsProcess",
         "Parameters"    : {

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Newtonian_Sloshing/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Newtonian_Sloshing/ProjectParameters.json
@@ -56,7 +56,7 @@
     },
     "problem_process_list"     : [{
         "help"          : "This process applies meshing to the problem domains",
-        "kratos_module" : "KratosMultiphysics.DelaunayMeshingApplication",
+        "kratos_module" : "KratosMultiphysics.PfemFluidDynamicsApplication",
         "python_module" : "remesh_fluid_domains_process",
         "process_name"  : "RemeshFluidDomainsProcess",
         "Parameters"    : {

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_muIrheology/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_muIrheology/ProjectParameters.json
@@ -52,7 +52,7 @@
     },
     "problem_process_list"     : [{
         "help"          : "This process applies meshing to the problem domains",
-        "kratos_module" : "KratosMultiphysics.DelaunayMeshingApplication",
+        "kratos_module" : "KratosMultiphysics.PfemFluidDynamicsApplication",
         "python_module" : "remesh_fluid_domains_process",
         "process_name"  : "RemeshFluidDomainsProcess",
         "Parameters"    : {

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_3D_Newtonian_Sloshing/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_3D_Newtonian_Sloshing/ProjectParameters.json
@@ -56,7 +56,7 @@
     },
     "problem_process_list"     : [{
         "help"          : "This process applies meshing to the problem domains",
-        "kratos_module" : "KratosMultiphysics.DelaunayMeshingApplication",
+        "kratos_module" : "KratosMultiphysics.PfemFluidDynamicsApplication",
         "python_module" : "remesh_fluid_domains_process",
         "process_name"  : "RemeshFluidDomainsProcess",
         "Parameters"    : {


### PR DESCRIPTION
The "kratos_module" key was not properly defined for some processes in the tests. That caused an import error when using the import_module.