### PR TITLE
[Core] Adding value_type typedef to PointerVector

### DIFF
--- a/kratos/containers/pointer_vector.h
+++ b/kratos/containers/pointer_vector.h
@@ -78,7 +78,8 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(PointerVector);
 
     /// data type stores in this container.
-    //typedef TDataType value_type;
+    typedef TDataType data_type;
+    typedef TDataType value_type;
     typedef TPointerType pointer;
     typedef const TPointerType const_pointer;
     typedef TDataType& reference;

--- a/kratos/containers/pointer_vector.h
+++ b/kratos/containers/pointer_vector.h
@@ -78,8 +78,7 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(PointerVector);
 
     /// data type stores in this container.
-    typedef TDataType data_type;
-    typedef TPointerType value_type;
+    typedef TDataType value_type;
     typedef TPointerType pointer;
     typedef const TPointerType const_pointer;
     typedef TDataType& reference;

--- a/kratos/containers/pointer_vector.h
+++ b/kratos/containers/pointer_vector.h
@@ -78,7 +78,7 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(PointerVector);
 
     /// data type stores in this container.
-    typedef TDataType value_type;
+    //typedef TDataType value_type;
     typedef TPointerType pointer;
     typedef const TPointerType const_pointer;
     typedef TDataType& reference;


### PR DESCRIPTION
Hi all,

I would like to change the typedef in the pointer_vector for the data_type to the value_type. This is then the same type as the std::vector has. To template classes with the container this would allow a consitant templatisation.