### PR TITLE
Mpi/cleanup api

### DIFF
--- a/kratos/mpi/includes/mpi_data_communicator.h
+++ b/kratos/mpi/includes/mpi_data_communicator.h
@@ -157,7 +157,7 @@ namespace Kratos
  *
  *  @see DataCommunicator in the KratosCore for the full interface and a serial do-nothing implementation.
  */
-class MPIDataCommunicator: public DataCommunicator
+class KRATOS_API(KRATOS_MPI_CORE) MPIDataCommunicator: public DataCommunicator
 {
   public:
     ///@name Type Definitions

--- a/kratos/mpi/utilities/gather_modelpart_utility.h
+++ b/kratos/mpi/utilities/gather_modelpart_utility.h
@@ -22,7 +22,7 @@
 
 namespace Kratos
 {
-class GatherModelPartUtility
+class KRATOS_API(KRATOS_MPI_CORE) GatherModelPartUtility
 {
 public:
 

--- a/kratos/mpi/utilities/mpi_normal_calculation_utilities.h
+++ b/kratos/mpi/utilities/mpi_normal_calculation_utilities.h
@@ -20,7 +20,6 @@
 
 // Project includes
 #include "includes/model_part.h"
-#include "processes/process.h"
 
 
 namespace Kratos
@@ -48,7 +47,7 @@ namespace Kratos
 ///@{
 
 /// Some tools to calculate face and nodal normals on an MPI partitioned environment
-class KRATOS_API(TRILINOS_APPLICATION) MPINormalCalculationUtils : public Process
+class MPINormalCalculationUtils
 {
 public:
     ///@name Type Definitions
@@ -102,13 +101,13 @@ public:
     ///@{
 
     /// Turn back information as a string.
-    std::string Info() const override;
+    std::string Info() const;
 
     /// Print information about this object.
-    void PrintInfo(std::ostream& rOStream) const override;
+    void PrintInfo(std::ostream& rOStream) const;
 
     /// Print object's data.
-    void PrintData(std::ostream& rOStream) const override;
+    void PrintData(std::ostream& rOStream) const;
 
 
     ///@}

--- a/kratos/mpi/utilities/mpi_normal_calculation_utilities.h
+++ b/kratos/mpi/utilities/mpi_normal_calculation_utilities.h
@@ -47,7 +47,7 @@ namespace Kratos
 ///@{
 
 /// Some tools to calculate face and nodal normals on an MPI partitioned environment
-class MPINormalCalculationUtils
+class KRATOS_API(KRATOS_MPI_CORE) MPINormalCalculationUtils
 {
 public:
     ///@name Type Definitions

--- a/kratos/mpi/utilities/parallel_fill_communicator.h
+++ b/kratos/mpi/utilities/parallel_fill_communicator.h
@@ -49,7 +49,7 @@ class ModelPart;
  * and to fill the communication plan (coloring) so to allow the communication to be performed correctly
  * It fills the Ghost and Local lists and performs the coloring, then it updates the MPI communicator
  */
-class ParallelFillCommunicator
+class KRATOS_API(KRATOS_MPI_CORE) ParallelFillCommunicator
 {
 public:
     ///@name Type Definitions


### PR DESCRIPTION
Adding (and correcting a wrong instance) of KRATOS_API in the MPI core.

I also eliminated a derivation from Process (which was not really needed) to silence a clang compilation warning (`MPINormalCalculationUtils::Check` was hiding `Process::Check`)