### PR TITLE
Radiation terms for the adjoint thermal face condition.

### DIFF
--- a/applications/ConvectionDiffusionApplication/convection_diffusion_application.h
+++ b/applications/ConvectionDiffusionApplication/convection_diffusion_application.h
@@ -244,8 +244,8 @@ private:
     const FluxCondition<3>  mFluxCondition3D3N;
     const FluxCondition<4>  mFluxCondition3D4N;
 
-    const AdjointThermalFace<ThermalFace> mAdjointThermalFace2D2N;
-    const AdjointThermalFace<ThermalFace> mAdjointThermalFace3D3N;
+    const AdjointThermalFace mAdjointThermalFace2D2N;
+    const AdjointThermalFace mAdjointThermalFace3D3N;
 
     ///@}
     ///@name Private Operators

--- a/applications/ConvectionDiffusionApplication/custom_conditions/adjoint_thermal_face.cpp
+++ b/applications/ConvectionDiffusionApplication/custom_conditions/adjoint_thermal_face.cpp
@@ -10,7 +10,6 @@
 //
 
 #include "adjoint_thermal_face.h"
-#include "thermal_face.h"
 
 #include "convection_diffusion_application_variables.h"
 
@@ -22,53 +21,46 @@
 namespace Kratos
 {
 
-template<class PrimalCondition>
-AdjointThermalFace<PrimalCondition>::AdjointThermalFace(IndexType NewId, typename GeometryType::Pointer pGeometry):
-    PrimalCondition(NewId, pGeometry)
+AdjointThermalFace::AdjointThermalFace(IndexType NewId, typename GeometryType::Pointer pGeometry):
+    ThermalFace(NewId, pGeometry)
 {}
 
-template<class PrimalCondition>
-AdjointThermalFace<PrimalCondition>::AdjointThermalFace(
+AdjointThermalFace::AdjointThermalFace(
     IndexType NewId, typename GeometryType::Pointer pGeometry, Properties::Pointer pProperties):
-    PrimalCondition(NewId, pGeometry, pProperties)
+    ThermalFace(NewId, pGeometry, pProperties)
 {}
 
-template<class PrimalCondition>
-AdjointThermalFace<PrimalCondition>::~AdjointThermalFace() {}
+AdjointThermalFace::~AdjointThermalFace() {}
 
-template<class PrimalCondition>
-Condition::Pointer AdjointThermalFace<PrimalCondition>::Create(
+Condition::Pointer AdjointThermalFace::Create(
     IndexType NewId,
     NodesArrayType const& ThisNodes,
     Properties::Pointer pProperties) const
 {
-    return Kratos::make_intrusive<AdjointThermalFace<PrimalCondition>>(NewId, this->GetGeometry().Create(ThisNodes), pProperties);
+    return Kratos::make_intrusive<AdjointThermalFace>(NewId, this->GetGeometry().Create(ThisNodes), pProperties);
 }
 
-template<class PrimalCondition>
-Condition::Pointer AdjointThermalFace<PrimalCondition>::Create(
+Condition::Pointer AdjointThermalFace::Create(
     IndexType NewId,
     typename GeometryType::Pointer pGeometry,
     Properties::Pointer pProperties) const
 {
-    return Kratos::make_intrusive<AdjointThermalFace<PrimalCondition>>(NewId, pGeometry, pProperties);
+    return Kratos::make_intrusive<AdjointThermalFace>(NewId, pGeometry, pProperties);
 }
 
-template<class PrimalCondition>
-void AdjointThermalFace<PrimalCondition>::CalculateLocalSystem(
+void AdjointThermalFace::CalculateLocalSystem(
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
     ProcessInfo& rCurrentProcessInfo)
 {
     // Delegating LHS matrix to base class
-    PrimalCondition::CalculateLocalSystem(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo);
+    ThermalFace::CalculateLocalSystem(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo);
 
     // Setting the RHS vector to zero
     noalias(rRightHandSideVector) = ZeroVector(rLeftHandSideMatrix.size2());
 }
 
-template<class PrimalCondition>
-void AdjointThermalFace<PrimalCondition>::CalculateRightHandSide(
+void AdjointThermalFace::CalculateRightHandSide(
     VectorType& rRightHandSideVector,
     ProcessInfo& rCurrentProcessInfo)
 {
@@ -83,8 +75,7 @@ void AdjointThermalFace<PrimalCondition>::CalculateRightHandSide(
     noalias(rRightHandSideVector) = ZeroVector(num_nodes);
 }
 
-template<class PrimalCondition>
-void AdjointThermalFace<PrimalCondition>::GetValuesVector(Vector& rValues, int Step)
+void AdjointThermalFace::GetValuesVector(Vector& rValues, int Step)
 {
     const GeometryType& r_geom = this->GetGeometry();
     const unsigned int num_nodes = r_geom.PointsNumber();
@@ -100,8 +91,7 @@ void AdjointThermalFace<PrimalCondition>::GetValuesVector(Vector& rValues, int S
     }
 }
 
-template<class PrimalCondition>
-void AdjointThermalFace<PrimalCondition>::EquationIdVector(
+void AdjointThermalFace::EquationIdVector(
     EquationIdVectorType& rResult,
     ProcessInfo& rCurrentProcessInfo)
 {
@@ -119,8 +109,7 @@ void AdjointThermalFace<PrimalCondition>::EquationIdVector(
     }
 }
 
-template<class PrimalCondition>
-void AdjointThermalFace<PrimalCondition>::GetDofList(
+void AdjointThermalFace::GetDofList(
     DofsVectorType& rConditionDofList, ProcessInfo& rCurrentProcessInfo)
 {
     const GeometryType& r_geom = this->GetGeometry();
@@ -137,8 +126,7 @@ void AdjointThermalFace<PrimalCondition>::GetDofList(
     }
 }
 
-template<class PrimalCondition>
-int AdjointThermalFace<PrimalCondition>::Check(const ProcessInfo& rProcessInfo)
+int AdjointThermalFace::Check(const ProcessInfo& rProcessInfo)
 {
     KRATOS_TRY
     KRATOS_ERROR_IF_NOT(rProcessInfo.Has(CONVECTION_DIFFUSION_SETTINGS)) << "No CONVECTION_DIFFUSION_SETTINGS defined in ProcessInfo." << std::endl;
@@ -160,19 +148,17 @@ int AdjointThermalFace<PrimalCondition>::Check(const ProcessInfo& rProcessInfo)
     }
 
     KRATOS_CATCH("")
-    return PrimalCondition::Check(rProcessInfo);
+    return ThermalFace::Check(rProcessInfo);
 }
 
-template<class PrimalCondition>
-std::string AdjointThermalFace<PrimalCondition>::Info() const
+std::string AdjointThermalFace::Info() const
 {
     std::stringstream buffer;
     buffer << "AdjointThermalFace #" << this->Id();
     return buffer.str();
 }
 
-template<class PrimalCondition>
-void AdjointThermalFace<PrimalCondition>::PrintInfo(std::ostream& rOStream) const
+void AdjointThermalFace::PrintInfo(std::ostream& rOStream) const
 {
     const GeometryType& r_geom = this->GetGeometry();
     const unsigned int dimension = r_geom.WorkingSpaceDimension();
@@ -180,8 +166,7 @@ void AdjointThermalFace<PrimalCondition>::PrintInfo(std::ostream& rOStream) cons
     rOStream << "AdjointThermalFace" << dimension << "D" << num_nodes << "N";
 }
 
-template<class PrimalCondition>
-void AdjointThermalFace<PrimalCondition>::CalculateSensitivityMatrix(
+void AdjointThermalFace::CalculateSensitivityMatrix(
     const Variable<array_1d<double, 3>>& rDesignVariable,
     Matrix& rOutput,
     const ProcessInfo& rCurrentProcessInfo)
@@ -267,8 +252,7 @@ void AdjointThermalFace<PrimalCondition>::CalculateSensitivityMatrix(
     KRATOS_CATCH("")
 }
 
-template<class PrimalCondition>
-typename AdjointThermalFace<PrimalCondition>::MatrixType AdjointThermalFace<PrimalCondition>::GetJacobian(
+typename AdjointThermalFace::MatrixType AdjointThermalFace::GetJacobian(
     GeometryData::IntegrationMethod QuadratureOrder,
     unsigned int IntegrationPointIndex) const
 {
@@ -289,7 +273,5 @@ typename AdjointThermalFace<PrimalCondition>::MatrixType AdjointThermalFace<Prim
     noalias(jacobian) = prod(coordinates,rDN_De);
     return jacobian;
 }
-
-template class AdjointThermalFace<ThermalFace>;
 
 }

--- a/applications/ConvectionDiffusionApplication/custom_conditions/adjoint_thermal_face.cpp
+++ b/applications/ConvectionDiffusionApplication/custom_conditions/adjoint_thermal_face.cpp
@@ -221,6 +221,7 @@ void AdjointThermalFace<PrimalCondition>::CalculateSensitivityMatrix(
     const Properties& r_properties = this->GetProperties();
     const double ambient_temperature = r_properties.GetValue(AMBIENT_TEMPERATURE);
     const double convection_coefficient = r_properties.GetValue(CONVECTION_COEFFICIENT);
+    const double emissivity = r_properties.GetValue(EMISSIVITY);
 
     if (rDesignVariable == SHAPE_SENSITIVITY)
     {
@@ -239,6 +240,7 @@ void AdjointThermalFace<PrimalCondition>::CalculateSensitivityMatrix(
             double q_gauss = inner_prod(N,nodal_flux);
             double value_gauss = inner_prod(N, nodal_unknown);
             q_gauss -= convection_coefficient*(value_gauss - ambient_temperature); // add flux contribution from convection condition
+            q_gauss -= emissivity * StefanBoltzmann * (std::pow(value_gauss,4) - std::pow(ambient_temperature,4)); // flux contribution from radiation
 
             const double weight = integration_points[g].Weight();
 

--- a/applications/ConvectionDiffusionApplication/custom_conditions/adjoint_thermal_face.h
+++ b/applications/ConvectionDiffusionApplication/custom_conditions/adjoint_thermal_face.h
@@ -63,6 +63,8 @@ public:
     using EquationIdVectorType = typename PrimalCondition::EquationIdVectorType;
     using DofsVectorType = typename PrimalCondition::DofsVectorType;
 
+    constexpr static double StefanBoltzmann = PrimalCondition::StefanBoltzmann;
+
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/ConvectionDiffusionApplication/custom_conditions/adjoint_thermal_face.h
+++ b/applications/ConvectionDiffusionApplication/custom_conditions/adjoint_thermal_face.h
@@ -17,7 +17,7 @@
 // External includes
 
 // Project includes
-#include "includes/condition.h"
+#include "custom_conditions/thermal_face.h"
 
 namespace Kratos
 {
@@ -45,8 +45,7 @@ namespace Kratos
 ///@{
 
 /// Heat flux Neumann condition for the ajdoint thermal diffusion problem.
-template< class PrimalCondition >
-class AdjointThermalFace: public PrimalCondition
+class AdjointThermalFace: public ThermalFace
 {
 public:
     ///@name Type Definitions
@@ -55,15 +54,15 @@ public:
     /// Counted pointer of AdjointThermalFace
     KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(AdjointThermalFace);
 
-    using IndexType = typename PrimalCondition::IndexType;
-    using GeometryType = typename PrimalCondition::GeometryType;
-    using NodesArrayType = typename PrimalCondition::NodesArrayType;
-    using MatrixType = typename PrimalCondition::MatrixType;
-    using VectorType = typename PrimalCondition::VectorType;
-    using EquationIdVectorType = typename PrimalCondition::EquationIdVectorType;
-    using DofsVectorType = typename PrimalCondition::DofsVectorType;
+    using IndexType = typename ThermalFace::IndexType;
+    using GeometryType = typename ThermalFace::GeometryType;
+    using NodesArrayType = typename ThermalFace::NodesArrayType;
+    using MatrixType = typename ThermalFace::MatrixType;
+    using VectorType = typename ThermalFace::VectorType;
+    using EquationIdVectorType = typename ThermalFace::EquationIdVectorType;
+    using DofsVectorType = typename ThermalFace::DofsVectorType;
 
-    constexpr static double StefanBoltzmann = PrimalCondition::StefanBoltzmann;
+    constexpr static double StefanBoltzmann = ThermalFace::StefanBoltzmann;
 
     ///@}
     ///@name Life Cycle
@@ -171,19 +170,19 @@ private:
     friend class Serializer;
 
     // A private default constructor necessary for serialization
-    AdjointThermalFace() : PrimalCondition()
+    AdjointThermalFace() : ThermalFace()
     {
     }
 
     void save(Serializer& rSerializer) const override
     {
-        using BaseType = PrimalCondition;
+        using BaseType = ThermalFace;
         KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, BaseType);
     }
 
     void load(Serializer& rSerializer) override
     {
-        using BaseType = PrimalCondition;
+        using BaseType = ThermalFace;
         KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, BaseType);
     }
 
@@ -235,15 +234,13 @@ private:
 
 
 /// input stream function
-template< class PrimalCondition >
-inline std::istream& operator >> (std::istream& rIStream, AdjointThermalFace<PrimalCondition>& rThis)
+inline std::istream& operator >> (std::istream& rIStream, AdjointThermalFace& rThis)
 {
     return rIStream;
 }
 
 /// output stream function
-template< class PrimalCondition >
-inline std::ostream& operator << (std::ostream& rOStream, const AdjointThermalFace<PrimalCondition>& rThis)
+inline std::ostream& operator << (std::ostream& rOStream, const AdjointThermalFace& rThis)
 {
     rThis.PrintInfo(rOStream);
     rOStream << std::endl;

--- a/applications/ConvectionDiffusionApplication/custom_conditions/thermal_face.cpp
+++ b/applications/ConvectionDiffusionApplication/custom_conditions/thermal_face.cpp
@@ -312,10 +312,9 @@ void ThermalFace::AddIntegrationPointRHSContribution(
     VectorType& rRightHandSideVector,
     const ConditionDataStruct &rData)
 {
-    const double stefen_boltzmann = 5.67e-8;
     const double gauss_pt_unknown = rData.GaussPointUnknown();
     const double gauss_pt_flux = rData.GaussPointFaceHeatFlux();
-    const double aux_rad_rhs = rData.Emissivity * stefen_boltzmann * (std::pow(gauss_pt_unknown, 4) - pow(rData.AmbientTemperature, 4));
+    const double aux_rad_rhs = rData.Emissivity * StefanBoltzmann * (std::pow(gauss_pt_unknown, 4) - pow(rData.AmbientTemperature, 4));
     const double aux_conv_rhs = rData.ConvectionCoefficient * (gauss_pt_unknown - rData.AmbientTemperature);
     for (unsigned int i = 0; i < (this->GetGeometry()).PointsNumber(); ++i) {
         // Add external face heat flux contribution
@@ -331,9 +330,8 @@ void ThermalFace::AddIntegrationPointLHSContribution(
     MatrixType& rLeftHandSideMatrix,
     const ConditionDataStruct &rData)
 {
-    const double stefen_boltzmann = 5.67e-8;
     const unsigned int n_nodes = (this->GetGeometry()).PointsNumber();
-    const double aux_rad_lhs = rData.Emissivity * stefen_boltzmann * 4.0 * std::pow(rData.GaussPointUnknown(), 3);
+    const double aux_rad_lhs = rData.Emissivity * StefanBoltzmann * 4.0 * std::pow(rData.GaussPointUnknown(), 3);
     for (unsigned int i = 0; i < n_nodes; ++i) {
         for (unsigned int j = 0; j < n_nodes; ++j) {
             // Add ambient radiation contribution

--- a/applications/ConvectionDiffusionApplication/custom_conditions/thermal_face.h
+++ b/applications/ConvectionDiffusionApplication/custom_conditions/thermal_face.h
@@ -88,6 +88,9 @@ public:
     typedef Condition::MatrixType MatrixType;
     typedef Condition::VectorType VectorType;
 
+    /// Stefan Boltzmann constant for radiation in SI units: [W / (m^2 K^4)].
+    constexpr static double StefanBoltzmann = 5.67e-8;
+
     ///@}
     ///@name Life Cycle
     ///@{

--- a/applications/ConvectionDiffusionApplication/tests/adjoint_diffusion_test/ProjectParametersConvectionConditionPrimal.json
+++ b/applications/ConvectionDiffusionApplication/tests/adjoint_diffusion_test/ProjectParametersConvectionConditionPrimal.json
@@ -73,7 +73,7 @@
             "help"          : "This process writes postprocessing files for GiD",
             "Parameters"    : {
                 "model_part_name"        : "ThermalModelPart.thermal_computing_domain",
-                "output_name"            : "adjoint_test_convection_condition",
+                "output_name"            : "diffusion_test_primal",
                 "postprocess_parameters" : {
                     "result_file_configuration" : {
                         "gidpost_flags"       : {
@@ -96,27 +96,7 @@
                 }
             }
         }],
-        "vtk_output" : [{
-            "python_module" : "vtk_output_process",
-            "kratos_module" : "KratosMultiphysics",
-            "process_name"  : "VtkOutputProcess",
-            "help"          : "This process writes postprocessing files for Paraview",
-            "Parameters"    : {
-                "model_part_name"                    : "ThermalModelPart.thermal_computing_domain",
-                "output_control_type"                : "step",
-                "output_frequency"                   : 1,
-                "file_format"                        : "ascii",
-                "output_precision"                   : 7,
-                "output_sub_model_parts"             : false,
-                "folder_name"                        : "vtk_output",
-                "save_output_files_in_folder"        : true,
-                "nodal_solution_step_data_variables" : ["TEMPERATURE"],
-                "nodal_data_value_variables"         : [],
-                "element_data_value_variables"       : [],
-                "condition_data_value_variables"     : [],
-                "gauss_point_variables"              : []
-            }
-        }]
+        "vtk_output" : []
     },
     "restart_options"  : {
         "SaveRestart"      : false,

--- a/applications/ConvectionDiffusionApplication/tests/adjoint_diffusion_test/ProjectParametersRadiationAdjoint.json
+++ b/applications/ConvectionDiffusionApplication/tests/adjoint_diffusion_test/ProjectParametersRadiationAdjoint.json
@@ -1,0 +1,104 @@
+{
+    "problem_data"     : {
+        "problem_name"  : "adjoint_test",
+        "parallel_type" : "OpenMP",
+        "time_step"     : 1.0,
+        "start_time"    : 0.0,
+        "end_time"      : 0.99,
+        "echo_level"    : 0
+    },
+    "solver_settings": {
+        "solver_type": "adjoint_stationary",
+        "model_part_name": "AdjointModelPart",
+        "primal_model_part_name": "ThermalModelPart",
+        "domain_size": 2,
+        "response_function_settings": {
+            "response_type": "point_temperature",
+            "custom_settings": {
+                "model_part_name": "HeatFlux2D_right"
+            }
+        },
+        "sensitivity_settings": {
+            "sensitivity_model_part_name": "Parts_solid",
+            "nodal_solution_step_sensitivity_variables": [ "SHAPE_SENSITIVITY" ],
+            "build_mode": "static",
+            "nodal_solution_step_sensitivity_calculation_is_thread_safe": false
+        },
+        "model_import_settings": {
+            "input_type": "mdpa",
+            "input_filename": "adjoint_test"
+        },
+        "material_import_settings": {
+            "materials_filename": "ConvectionDiffusionMaterials.json"
+        },
+        "echo_level": 0,
+        "time_stepping": {
+            "time_step": 1.0
+        }
+    },
+    "processes"        : {
+        "initial_conditions_process_list" : [],
+        "constraints_process_list"        : [{
+            "python_module" : "assign_scalar_variable_process",
+            "kratos_module" : "KratosMultiphysics",
+            "Parameters"    : {
+                "model_part_name" : "AdjointModelPart.ImposedTemperature2D_left",
+                "variable_name"   : "ADJOINT_HEAT_TRANSFER",
+                "constrained"     : true,
+                "value"           : 0.0,
+                "interval"        : [0.0,"End"]
+            }
+        },{
+            "python_module" : "apply_thermal_face_process",
+            "kratos_module" : "KratosMultiphysics.ConvectionDiffusionApplication",
+            "Parameters"    : {
+                "model_part_name"        : "AdjointModelPart.HeatFlux2D_right",
+                "ambient_temperature"    : 150.0,
+                "add_ambient_radiation"  : true,
+                "emissivity"             : 0.9,
+                "add_ambient_convection" : false,
+                "convection_coefficient" : 0.0,
+                "interval"               : [0.0,"End"]
+            }
+        }],
+        "list_other_processes"            : []
+    },
+    "output_processes" : {
+        "gid_output" : [{
+            "python_module" : "gid_output_process",
+            "kratos_module" : "KratosMultiphysics",
+            "process_name"  : "GiDOutputProcess",
+            "help"          : "This process writes postprocessing files for GiD",
+            "Parameters"    : {
+                "model_part_name"        : "AdjointModelPart",
+                "output_name"            : "diffusion_test_adjoint",
+                "postprocess_parameters" : {
+                    "result_file_configuration" : {
+                        "gidpost_flags"       : {
+                            "GiDPostMode"           : "GiD_PostBinary",
+                            "WriteDeformedMeshFlag" : "WriteDeformed",
+                            "WriteConditionsFlag"   : "WriteConditions",
+                            "MultiFileFlag"         : "SingleFile"
+                        },
+                        "file_label"          : "time",
+                        "output_control_type" : "time",
+                        "output_frequency"    : 0.01,
+                        "body_output"         : true,
+                        "node_output"         : false,
+                        "skin_output"         : false,
+                        "plane_output"        : [],
+                        "nodal_results"       : ["TEMPERATURE","ADJOINT_HEAT_TRANSFER","SHAPE_SENSITIVITY","HEAT_FLUX","CONDUCTIVITY"],
+                        "gauss_point_results" : []
+                    },
+                    "point_data_configuration"  : []
+                }
+            }
+        }]
+    },
+    "restart_options"  : {
+        "SaveRestart"      : "False",
+        "RestartFrequency" : 0,
+        "LoadRestart"      : "False",
+        "Restart_Step"     : 0
+    }
+}

--- a/applications/ConvectionDiffusionApplication/tests/adjoint_diffusion_test/ProjectParametersRadiationPrimal.json
+++ b/applications/ConvectionDiffusionApplication/tests/adjoint_diffusion_test/ProjectParametersRadiationPrimal.json
@@ -1,0 +1,107 @@
+{
+    "problem_data"     : {
+        "problem_name"  : "adjoint_test",
+        "parallel_type" : "OpenMP",
+        "time_step"     : 1.0,
+        "start_time"    : 0.0,
+        "end_time"      : 0.99,
+        "echo_level"    : 0
+    },
+    "solver_settings"  : {
+        "solver_type"                        : "stationary",
+        "analysis_type"                      : "non_linear",
+        "model_part_name"                    : "ThermalModelPart",
+        "domain_size"                        : 2,
+        "model_import_settings"              : {
+            "input_type"     : "mdpa",
+            "input_filename" : "adjoint_test"
+        },
+        "material_import_settings"           : {
+            "materials_filename" : "ConvectionDiffusionMaterials.json"
+        },
+        "element_replace_settings"  :{
+            "element_name" : "LaplacianElement",
+            "condition_name" : "ThermalFace"
+        },
+        "line_search"                        : false,
+        "echo_level"                         : 0,
+        "compute_reactions"                  : false,
+        "max_iteration"                      : 10,
+        "convergence_criterion"              : "residual_criterion",
+        "solution_relative_tolerance"        : 1e-6,
+        "solution_absolute_tolerance"        : 1e-9,
+        "residual_relative_tolerance"        : 1e-6,
+        "residual_absolute_tolerance"        : 1e-9,
+        "problem_domain_sub_model_part_list" : ["Parts_solid"],
+        "processes_sub_model_part_list"      : ["HeatFlux2D_right","ImposedTemperature2D_left"],
+        "time_stepping"                      : {
+            "time_step" : 1.0
+        }
+    },
+    "processes"        : {
+        "initial_conditions_process_list" : [],
+        "constraints_process_list"        : [{
+            "python_module" : "assign_scalar_variable_process",
+            "kratos_module" : "KratosMultiphysics",
+            "Parameters"    : {
+                "model_part_name" : "ThermalModelPart.ImposedTemperature2D_left",
+                "variable_name"   : "TEMPERATURE",
+                "constrained"     : true,
+                "value"           : 300.0,
+                "interval"        : [0.0,"End"]
+            }
+        },{
+            "python_module" : "apply_thermal_face_process",
+            "kratos_module" : "KratosMultiphysics.ConvectionDiffusionApplication",
+            "Parameters"    : {
+                "model_part_name"        : "ThermalModelPart.HeatFlux2D_right",
+                "ambient_temperature"    : 150.0,
+                "add_ambient_radiation"  : true,
+                "emissivity"             : 0.9,
+                "add_ambient_convection" : false,
+                "convection_coefficient" : 0.0,
+                "interval"               : [0.0,"End"]
+            }
+        }],
+        "list_other_processes"            : []
+    },
+    "output_processes" : {
+        "gid_output" : [{
+            "python_module" : "gid_output_process",
+            "kratos_module" : "KratosMultiphysics",
+            "process_name"  : "GiDOutputProcess",
+            "help"          : "This process writes postprocessing files for GiD",
+            "Parameters"    : {
+                "model_part_name"        : "ThermalModelPart.thermal_computing_domain",
+                "output_name"            : "diffusion_test_primal",
+                "postprocess_parameters" : {
+                    "result_file_configuration" : {
+                        "gidpost_flags"       : {
+                            "GiDPostMode"           : "GiD_PostBinary",
+                            "WriteDeformedMeshFlag" : "WriteDeformed",
+                            "WriteConditionsFlag"   : "WriteConditions",
+                            "MultiFileFlag"         : "SingleFile"
+                        },
+                        "file_label"          : "time",
+                        "output_control_type" : "time",
+                        "output_frequency"    : 0.01,
+                        "body_output"         : true,
+                        "node_output"         : false,
+                        "skin_output"         : false,
+                        "plane_output"        : [],
+                        "nodal_results"       : ["TEMPERATURE"],
+                        "gauss_point_results" : []
+                    },
+                    "point_data_configuration"  : []
+                }
+            }
+        }],
+        "vtk_output" : []
+    },
+    "restart_options"  : {
+        "SaveRestart"      : false,
+        "RestartFrequency" : 0,
+        "LoadRestart"      : false,
+        "Restart_Step"     : 0
+    }
+}

--- a/applications/ConvectionDiffusionApplication/tests/adjoint_heat_diffusion_test.py
+++ b/applications/ConvectionDiffusionApplication/tests/adjoint_heat_diffusion_test.py
@@ -44,6 +44,11 @@ class AdjointHeatDiffusionTest(unittest.TestCase):
         self.adjoint_parameter_file_name = "ProjectParametersConvectionConditionAdjoint.json"
         self.directSensitivityCheck()
 
+    def testAdjointHeatDiffusionWithRadiation(self):
+        self.primal_parameter_file_name = "ProjectParametersRadiationPrimal.json"
+        self.adjoint_parameter_file_name = "ProjectParametersRadiationAdjoint.json"
+        self.directSensitivityCheck()
+
     def directSensitivityCheck(self):
         model = kratos.Model()
         settings = kratos.Parameters(r'''{}''')


### PR DESCRIPTION
This implements the required terms to compute the adjoint sensitivity (with respect to shape) for diffusion terms with radiation boundary conditions.

It also includes a test and removes the templated base class of the adjoint condition, since it is now quite tightly coupled to the details of the thermal face condition.