### PR TITLE
cps/normalizing vectors and updating distances

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
@@ -109,7 +109,7 @@ class DefineWakeProcess3D(KratosMultiphysics.Process):
             # The surface normal points outisde the domain
             surface_normal = cond.GetGeometry().Normal()
             norm = math.sqrt(surface_normal[0]**2 + surface_normal[1]**2 + surface_normal[2]**2)
-            if not abs(norm) > 0.0:
+            if abs(norm) < self.epsilon:
                 raise Exception('The norm of the condition ', cond.Id , ' should be larger than 0.')
             # Normalizing normal vector
             surface_normal /= norm

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
@@ -109,6 +109,8 @@ class DefineWakeProcess3D(KratosMultiphysics.Process):
             # The surface normal points outisde the domain
             surface_normal = cond.GetGeometry().Normal()
             norm = math.sqrt(surface_normal[0]**2 + surface_normal[1]**2 + surface_normal[2]**2)
+            if not abs(norm) > 0.0:
+                raise Exception('The norm of the condition ', cond.Id , ' should be larger than 0.')
             # Normalizing normal vector
             surface_normal /= norm
             projection = DotProduct(surface_normal, self.wake_normal)

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/define_wake_process_3d.py
@@ -108,11 +108,18 @@ class DefineWakeProcess3D(KratosMultiphysics.Process):
         for cond in self.body_model_part.Conditions:
             # The surface normal points outisde the domain
             surface_normal = cond.GetGeometry().Normal()
+            norm = math.sqrt(surface_normal[0]**2 + surface_normal[1]**2 + surface_normal[2]**2)
+            # Normalizing normal vector
+            surface_normal /= norm
             projection = DotProduct(surface_normal, self.wake_normal)
             # The surface normal in the same direction as the wake normal belongs to the lower_surface
             if(projection > 0.0):
                 for node in cond.GetNodes():
                     node.SetValue(KratosMultiphysics.NORMAL,surface_normal)
+                    node.SetValue(CPFApp.LOWER_SURFACE, True)
+            else:
+                for node in cond.GetNodes():
+                    node.SetValue(CPFApp.UPPER_SURFACE, True)
 
     # This function imports the stl file containing the wake and creates the wake model part out of it.
     # TODO: implement an automatic generation of the wake
@@ -242,8 +249,12 @@ class DefineWakeProcess3D(KratosMultiphysics.Process):
                 # Compute the distance in the free stream direction
                 free_stream_direction_distance = DotProduct(distance_vector, self.wake_direction)
 
+                if(elnode.GetValue(CPFApp.UPPER_SURFACE)):
+                    distance = self.epsilon
+                elif(elnode.GetValue(CPFApp.LOWER_SURFACE)):
+                    distance = -self.epsilon
                 # Node laying either above or below the lower surface
-                if(free_stream_direction_distance < 0.0):
+                elif(free_stream_direction_distance < 0.0):
                     # Compute the distance in the lower surface normal direction
                     distance = DotProduct(distance_vector, trailing_edge_node.GetValue(KratosMultiphysics.NORMAL))
                 # Node laying either above or below the wake
@@ -275,6 +286,26 @@ class DefineWakeProcess3D(KratosMultiphysics.Process):
             # Wake elements touching the trailing edge are marked as structure
             # TODO: change STRUCTURE to a more meaningful variable name
             elem.Set(KratosMultiphysics.STRUCTURE)
+            # Updating distance values
+            if(elem.GetValue(CPFApp.WAKE)):
+                wake_elemental_distances = elem.GetValue(CPFApp.WAKE_ELEMENTAL_DISTANCES)
+            else:
+                KratosMultiphysics.Logger.PrintInfo('...Setting non cut element to structure...', elem.Id)
+                elem.SetValue(CPFApp.WAKE, True)
+                wake_elemental_distances = KratosMultiphysics.Vector(4)
+            counter = 0
+            counter2 = 0
+            for elnode in elem.GetNodes():
+                if elnode.GetValue(CPFApp.TRAILING_EDGE):
+                    # Setting the distance at the trailing edge to positive
+                    elnode.SetValue(CPFApp.WAKE_DISTANCE,self.epsilon)
+                    wake_elemental_distances[counter] = self.epsilon
+                else:
+                    elnode.SetValue(CPFApp.WAKE_DISTANCE,nodal_distances[counter2])
+                    wake_elemental_distances[counter] = nodal_distances[counter2]
+                    counter2 +=1
+                counter +=1
+            elem.SetValue(CPFApp.WAKE_ELEMENTAL_DISTANCES,wake_elemental_distances)
             pass
         # Elements with all non trailing edge nodes above the wake and the lower surface are normal
         elif(number_of_nodes_with_positive_distance > number_of_non_te_nodes - 1):


### PR DESCRIPTION
This is a small PR to correct some mistakes I found in the wake process while validating larger cases.

The four changes are:
- Trailing edge nodes need to have a positive distance according to the current implementation of the element.
- The normals need to be normalized because otherwise for very small elements we run into problems with the tolerances.
- Nodes belonging to the upper and lower surface are assigned a positive and negative distance to the wake respectively. 
- The wake distances need to be updated for the kutta_wake elementes (STRUCTURE).

With this changes I have obtained satisfactory results for naca0012 wing at AOA 5 and spans larger than 0.1 meters. I have only tried until spans of 5 meters (meshes in 3d are very heavy).

For example I show the results for the following model with 5 meter span:
![cp_wing_AR5](https://user-images.githubusercontent.com/28628414/63953025-d0d8bb00-ca80-11e9-8018-b0851d5f681b.png)

The mesh:
![cp_wing_AR5_mesh](https://user-images.githubusercontent.com/28628414/63953090-f5cd2e00-ca80-11e9-8f92-f747bf9e5bee.png)

The whole domain:
![cp_wing_AR5_domain](https://user-images.githubusercontent.com/28628414/63953153-139a9300-ca81-11e9-8ca5-9e3b5ba4cc87.png)

Pressure distribution on one of the sides:
![cp_3d](https://user-images.githubusercontent.com/28628414/63953174-1f865500-ca81-11e9-913e-3a9b1518ec53.png)

Expected pressure distribution from the same airfoil in 2d:
![cp_2d](https://user-images.githubusercontent.com/28628414/63953370-7e4bce80-ca81-11e9-9305-4521c5b7ca8f.png)

Here is a table that shows the resulting lift and drag coefficients computed using the pressure distribution and the far field values for different spans:

[results_3d_p.txt](https://github.com/KratosMultiphysics/Kratos/files/3556346/results_3d_p.txt)




