### PR TITLE
test(RANS): added system matrix tests for low and high reynolds k-epsilon

### DIFF
--- a/applications/RANSModellingApplication/CMakeLists.txt
+++ b/applications/RANSModellingApplication/CMakeLists.txt
@@ -9,14 +9,9 @@ include_directories( ${CMAKE_SOURCE_DIR}/kratos )
 include_directories( ${CMAKE_SOURCE_DIR}/applications/FluidDynamicsApplication )
 
 # generate variables with the sources
-set( KRATOS_RANS_MODELLING_APPLICATION_SOURCES
+set( KRATOS_RANS_MODELLING_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/rans_modelling_application.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/rans_modelling_application_variables.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/rans_modelling_python_application.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_utilities_to_python.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_strategies_to_python.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_strategies_to_python.cpp
-    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_processes_to_python.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/rans_calculation_utilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/evm_k_epsilon/evm_k_epsilon_utilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/evm_k_epsilon/evm_k_element.cpp
@@ -25,15 +20,34 @@ set( KRATOS_RANS_MODELLING_APPLICATION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/evm_k_epsilon/evm_low_re_epsilon_element.cpp
 )
 
-# define library Kratos which defines the basic python interface
-pybind11_add_module(KratosRANSModellingApplication MODULE THIN_LTO ${KRATOS_RANS_MODELLING_APPLICATION_SOURCES})
-target_link_libraries(KratosRANSModellingApplication PRIVATE KratosCore KratosFluidDynamicsCore )
+set( KRATOS_RANS_MODELLING_APPLICATION_PYTHON_INTERFACE
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/rans_modelling_python_application.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_utilities_to_python.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_strategies_to_python.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_strategies_to_python.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_python/add_custom_processes_to_python.cpp
+)
+
+if(${KRATOS_BUILD_TESTING} MATCHES ON)
+  file(GLOB_RECURSE
+    KRATOS_RANS_MODELLING_APPLICATION_TESTING
+    ${CMAKE_CURRENT_SOURCE_DIR}/tests/cpp/*.cpp
+  )
+endif(${KRATOS_BUILD_TESTING} MATCHES ON)
+
+add_library(KratosRANSModellingCore SHARED ${KRATOS_RANS_MODELLING_APPLICATION_CORE} ${KRATOS_RANS_MODELLING_APPLICATION_TESTING})
+target_link_libraries(KratosRANSModellingCore PUBLIC KratosCore KratosFluidDynamicsCore)
+set_target_properties(KratosRANSModellingCore PROPERTIES COMPILE_DEFINITIONS "RANS_MODELLING_APPLICATION=EXPORT,API")
+
+pybind11_add_module(KratosRANSModellingApplication MODULE THIN_LTO ${KRATOS_RANS_MODELLING_APPLICATION_PYTHON_INTERFACE})
+target_link_libraries(KratosRANSModellingApplication PUBLIC KratosRANSModellingCore)
 set_target_properties(KratosRANSModellingApplication PROPERTIES PREFIX "")
 
 if(USE_COTIRE MATCHES ON)
     cotire(KratosRANSModellingApplication)
 endif(USE_COTIRE MATCHES ON)
 
+install(TARGETS KratosRANSModellingCore DESTINATION libs )
 install(TARGETS KratosRANSModellingApplication DESTINATION libs )
 
 # changing the .dll suffix to .pyd (Windows)

--- a/applications/RANSModellingApplication/custom_conditions/evm_k_epsilon/evm_epsilon_wall_condition.h
+++ b/applications/RANSModellingApplication/custom_conditions/evm_k_epsilon/evm_epsilon_wall_condition.h
@@ -105,7 +105,7 @@ public:
     /** Admits an Id as a parameter.
       @param NewId Index for the new condition
       */
-    EvmEpsilonWallCondition(IndexType NewId = 0) : Condition(NewId)
+    explicit EvmEpsilonWallCondition(IndexType NewId = 0) : Condition(NewId)
     {
     }
 

--- a/applications/RANSModellingApplication/custom_conditions/evm_k_epsilon/evm_vms_monolithic_wall_condition.h
+++ b/applications/RANSModellingApplication/custom_conditions/evm_k_epsilon/evm_vms_monolithic_wall_condition.h
@@ -107,7 +107,7 @@ public:
     /** Admits an Id as a parameter.
       @param NewId Index for the new condition
       */
-    EVMVMSMonolithicWallCondition(IndexType NewId = 0) : BaseType(NewId)
+    explicit EVMVMSMonolithicWallCondition(IndexType NewId = 0) : BaseType(NewId)
     {
     }
 

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_epsilon_element.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_epsilon_element.cpp
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    , KratosAppGenerator
+//  Main authors:    Suneth Warnakulasuriya (https://github.com/sunethwarna)
 //
 
 // System includes

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_epsilon_element.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_epsilon_element.cpp
@@ -396,18 +396,18 @@ void EvmEpsilonElement<TDim, TNumNodes>::CalculateConvectionDiffusionReactionDat
     const ProcessInfo& rCurrentProcessInfo,
     const int Step) const
 {
-    const double& c1 = rCurrentProcessInfo[TURBULENCE_RANS_C1];
-    const double& c2 = rCurrentProcessInfo[TURBULENCE_RANS_C2];
-    const double& c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
-    const double& epsilon_sigma =
+    const double c1 = rCurrentProcessInfo[TURBULENCE_RANS_C1];
+    const double c2 = rCurrentProcessInfo[TURBULENCE_RANS_C2];
+    const double c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
+    const double epsilon_sigma =
         rCurrentProcessInfo[TURBULENT_ENERGY_DISSIPATION_RATE_SIGMA];
 
-    const double& nu = this->EvaluateInPoint(KINEMATIC_VISCOSITY, rShapeFunctions);
-    const double& nu_t = this->EvaluateInPoint(TURBULENT_VISCOSITY, rShapeFunctions);
-    const double& tke = this->EvaluateInPoint(TURBULENT_KINETIC_ENERGY, rShapeFunctions);
-    // const double& epsilon =
+    const double nu = this->EvaluateInPoint(KINEMATIC_VISCOSITY, rShapeFunctions);
+    const double nu_t = this->EvaluateInPoint(TURBULENT_VISCOSITY, rShapeFunctions);
+    const double tke = this->EvaluateInPoint(TURBULENT_KINETIC_ENERGY, rShapeFunctions);
+    // const double epsilon =
     //     this->EvaluateInPoint(TURBULENT_ENERGY_DISSIPATION_RATE, rShapeFunctions);
-    const double& gamma = EvmKepsilonModelUtilities::CalculateGamma(c_mu, 1.0, tke, nu_t);
+    const double gamma = EvmKepsilonModelUtilities::CalculateGamma(c_mu, 1.0, tke, nu_t);
     // const double gamma = tke / (epsilon + std::numeric_limits<double>::epsilon());
     // const double wall_distance = this->EvaluateInPoint(DISTANCE, rShapeFunctions);
     // const double y_plus = this->EvaluateInPoint(RANS_Y_PLUS, rShapeFunctions);

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_epsilon_element.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_epsilon_element.cpp
@@ -274,8 +274,8 @@ int EvmEpsilonElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcess
     KRATOS_CHECK_VARIABLE_KEY(TURBULENT_KINETIC_ENERGY);
     KRATOS_CHECK_VARIABLE_KEY(TURBULENT_ENERGY_DISSIPATION_RATE);
     KRATOS_CHECK_VARIABLE_KEY(TURBULENT_ENERGY_DISSIPATION_RATE_2);
-    KRATOS_CHECK_VARIABLE_KEY(RANS_Y_PLUS);
-    KRATOS_CHECK_VARIABLE_KEY(DISTANCE);
+    // KRATOS_CHECK_VARIABLE_KEY(RANS_Y_PLUS);
+    // KRATOS_CHECK_VARIABLE_KEY(DISTANCE);
     KRATOS_CHECK_VARIABLE_KEY(RANS_AUXILIARY_VARIABLE_2);
 
     for (IndexType iNode = 0; iNode < this->GetGeometry().size(); ++iNode)
@@ -287,9 +287,9 @@ int EvmEpsilonElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcess
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_KINETIC_ENERGY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_ENERGY_DISSIPATION_RATE, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_ENERGY_DISSIPATION_RATE_2, r_node);
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(RANS_Y_PLUS, r_node);
+        // KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(RANS_Y_PLUS, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(RANS_AUXILIARY_VARIABLE_2, r_node);
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISTANCE, r_node);
+        // KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISTANCE, r_node);
 
         KRATOS_CHECK_DOF_IN_NODE(TURBULENT_ENERGY_DISSIPATION_RATE, r_node);
     }
@@ -405,26 +405,25 @@ void EvmEpsilonElement<TDim, TNumNodes>::CalculateConvectionDiffusionReactionDat
     const double& nu = this->EvaluateInPoint(KINEMATIC_VISCOSITY, rShapeFunctions);
     const double& nu_t = this->EvaluateInPoint(TURBULENT_VISCOSITY, rShapeFunctions);
     const double& tke = this->EvaluateInPoint(TURBULENT_KINETIC_ENERGY, rShapeFunctions);
-    const double& epsilon =
-        this->EvaluateInPoint(TURBULENT_ENERGY_DISSIPATION_RATE, rShapeFunctions);
+    // const double& epsilon =
+    //     this->EvaluateInPoint(TURBULENT_ENERGY_DISSIPATION_RATE, rShapeFunctions);
     const double& gamma = EvmKepsilonModelUtilities::CalculateGamma(c_mu, 1.0, tke, nu_t);
     // const double gamma = tke / (epsilon + std::numeric_limits<double>::epsilon());
-    const double wall_distance = this->EvaluateInPoint(DISTANCE, rShapeFunctions);
-    const double y_plus = this->EvaluateInPoint(RANS_Y_PLUS, rShapeFunctions);
+    // const double wall_distance = this->EvaluateInPoint(DISTANCE, rShapeFunctions);
+    // const double y_plus = this->EvaluateInPoint(RANS_Y_PLUS, rShapeFunctions);
 
     rData.C1 = c1;
     rData.C2 = c2;
     rData.Gamma = gamma;
-    rData.KinematicViscosity = nu;
     rData.ShapeFunctionDerivatives = rShapeFunctionDerivatives;
     rData.TurbulentKinematicViscosity = nu_t;
     rData.TurbulentKineticEnergy = tke;
-    rData.WallDistance = wall_distance;
-    rData.WallNormal = this->EvaluateInPoint(NORMAL, rShapeFunctions);
+    // rData.WallDistance = wall_distance;
+    // rData.WallNormal = this->EvaluateInPoint(NORMAL, rShapeFunctions);
     rData.VelocityDivergence =
         this->GetDivergenceOperator(VELOCITY, rShapeFunctionDerivatives);
-    rData.YPlus = y_plus;
-    rData.WallVelocity = norm_2(this->EvaluateInPoint(VELOCITY, rShapeFunctions));
+    // rData.YPlus = y_plus;
+    // rData.WallVelocity = norm_2(this->EvaluateInPoint(VELOCITY, rShapeFunctions));
 
     rEffectiveKinematicViscosity = nu + nu_t / epsilon_sigma;
 }
@@ -466,9 +465,9 @@ double EvmEpsilonElement<TDim, TNumNodes>::CalculateSourceTerm(const EvmEpsilonE
                                                                const int Step) const
 {
     double production = 0.0;
-    const double c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
-    const double von_karman = rCurrentProcessInfo[WALL_VON_KARMAN];
-    const double beta = rCurrentProcessInfo[WALL_SMOOTHNESS_BETA];
+    // const double c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
+    // const double von_karman = rCurrentProcessInfo[WALL_VON_KARMAN];
+    // const double beta = rCurrentProcessInfo[WALL_SMOOTHNESS_BETA];
     BoundedMatrix<double, TDim, TDim> velocity_gradient_matrix;
     this->CalculateGradient(velocity_gradient_matrix, VELOCITY, rData.ShapeFunctionDerivatives);
 

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_epsilon_element.h
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_epsilon_element.h
@@ -126,7 +126,7 @@ public:
     /**
      * Constructor.
      */
-    EvmEpsilonElement(IndexType NewId = 0);
+    explicit EvmEpsilonElement(IndexType NewId = 0);
 
     /**
      * Constructor using an array of nodes

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_epsilon_element.h
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_epsilon_element.h
@@ -53,16 +53,15 @@ struct EvmEpsilonElementData
     double C1;
     double C2;
     double Gamma;
-    double KinematicViscosity;
     double TurbulentKineticEnergy;
     double TurbulentKinematicViscosity;
-    double WallDistance;
+    // double WallDistance;
 
     Matrix ShapeFunctionDerivatives;
-    array_1d<double, 3> WallNormal;
+    // array_1d<double, 3> WallNormal;
     double VelocityDivergence;
-    double WallVelocity;
-    double YPlus;
+    // double WallVelocity;
+    // double YPlus;
 };
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_element.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_element.cpp
@@ -394,15 +394,15 @@ void EvmKElement<TDim, TNumNodes>::CalculateConvectionDiffusionReactionData(
 
     rData.ShapeFunctionDerivatives = rShapeFunctionDerivatives;
 
-    const double& c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
-    const double& tke_sigma = rCurrentProcessInfo[TURBULENT_KINETIC_ENERGY_SIGMA];
+    const double c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
+    const double tke_sigma = rCurrentProcessInfo[TURBULENT_KINETIC_ENERGY_SIGMA];
 
-    const double& nu_t = this->EvaluateInPoint(TURBULENT_VISCOSITY, rShapeFunctions);
-    const double& tke = this->EvaluateInPoint(TURBULENT_KINETIC_ENERGY, rShapeFunctions);
-    const double& nu = this->EvaluateInPoint(KINEMATIC_VISCOSITY, rShapeFunctions);
-    // const double& epsilon =
+    const double nu_t = this->EvaluateInPoint(TURBULENT_VISCOSITY, rShapeFunctions);
+    const double tke = this->EvaluateInPoint(TURBULENT_KINETIC_ENERGY, rShapeFunctions);
+    const double nu = this->EvaluateInPoint(KINEMATIC_VISCOSITY, rShapeFunctions);
+    // const double epsilon =
     //     this->EvaluateInPoint(TURBULENT_ENERGY_DISSIPATION_RATE, rShapeFunctions);
-    const double& gamma = EvmKepsilonModelUtilities::CalculateGamma(c_mu, 1.0, tke, nu_t);
+    const double gamma = EvmKepsilonModelUtilities::CalculateGamma(c_mu, 1.0, tke, nu_t);
     // const double gamma = tke / (epsilon + std::numeric_limits<double>::epsilon());
     // const double wall_distance = this->EvaluateInPoint(DISTANCE, rShapeFunctions);
     // const double y_plus = this->EvaluateInPoint(RANS_Y_PLUS, rShapeFunctions);
@@ -452,7 +452,7 @@ double EvmKElement<TDim, TNumNodes>::CalculateReactionTerm(const EvmKElementData
     // if (this->Is(STRUCTURE))
     //     return 2.0 * rData.VelocityDivergence / 3.0;
     // else
-    return rData.Gamma + 2 * rData.VelocityDivergence / 3.0;
+    return rData.Gamma + (2.0 / 3.0) * rData.VelocityDivergence;
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_element.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_element.cpp
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    , KratosAppGenerator
+//  Main authors:    Suneth Warnakulasuriya (https://github.com/sunethwarna)
 //
 
 // System includes

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_element.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_element.cpp
@@ -270,8 +270,8 @@ int EvmKElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcessInfo)
     KRATOS_CHECK_VARIABLE_KEY(KINEMATIC_VISCOSITY);
     KRATOS_CHECK_VARIABLE_KEY(TURBULENT_KINETIC_ENERGY);
     KRATOS_CHECK_VARIABLE_KEY(TURBULENT_KINETIC_ENERGY_RATE);
-    KRATOS_CHECK_VARIABLE_KEY(DISTANCE);
-    KRATOS_CHECK_VARIABLE_KEY(RANS_Y_PLUS);
+    // KRATOS_CHECK_VARIABLE_KEY(DISTANCE);
+    // KRATOS_CHECK_VARIABLE_KEY(RANS_Y_PLUS);
     KRATOS_CHECK_VARIABLE_KEY(RANS_AUXILIARY_VARIABLE_1);
 
     for (IndexType iNode = 0; iNode < this->GetGeometry().size(); ++iNode)
@@ -281,8 +281,8 @@ int EvmKElement<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentProcessInfo)
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(KINEMATIC_VISCOSITY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_KINETIC_ENERGY, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(TURBULENT_KINETIC_ENERGY_RATE, r_node);
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISTANCE, r_node);
-        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(RANS_Y_PLUS, r_node);
+        // KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(DISTANCE, r_node);
+        // KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(RANS_Y_PLUS, r_node);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(RANS_AUXILIARY_VARIABLE_1, r_node);
 
         KRATOS_CHECK_DOF_IN_NODE(TURBULENT_KINETIC_ENERGY, r_node);
@@ -400,27 +400,23 @@ void EvmKElement<TDim, TNumNodes>::CalculateConvectionDiffusionReactionData(
     const double& nu_t = this->EvaluateInPoint(TURBULENT_VISCOSITY, rShapeFunctions);
     const double& tke = this->EvaluateInPoint(TURBULENT_KINETIC_ENERGY, rShapeFunctions);
     const double& nu = this->EvaluateInPoint(KINEMATIC_VISCOSITY, rShapeFunctions);
-    const double& epsilon =
-        this->EvaluateInPoint(TURBULENT_ENERGY_DISSIPATION_RATE, rShapeFunctions);
+    // const double& epsilon =
+    //     this->EvaluateInPoint(TURBULENT_ENERGY_DISSIPATION_RATE, rShapeFunctions);
     const double& gamma = EvmKepsilonModelUtilities::CalculateGamma(c_mu, 1.0, tke, nu_t);
     // const double gamma = tke / (epsilon + std::numeric_limits<double>::epsilon());
-    const double wall_distance = this->EvaluateInPoint(DISTANCE, rShapeFunctions);
-    const double y_plus = this->EvaluateInPoint(RANS_Y_PLUS, rShapeFunctions);
-    rData.WallNormal = this->EvaluateInPoint(NORMAL, rShapeFunctions);
-    rData.TurbulentEnergyDissipationRate =
-        this->EvaluateInPoint(TURBULENT_ENERGY_DISSIPATION_RATE, rShapeFunctions);
+    // const double wall_distance = this->EvaluateInPoint(DISTANCE, rShapeFunctions);
+    // const double y_plus = this->EvaluateInPoint(RANS_Y_PLUS, rShapeFunctions);
 
     rData.TurbulentKinematicViscosity = nu_t;
     rData.TurbulentKineticEnergy = tke;
-    rData.KinematicViscosity = nu;
     rData.Gamma = gamma;
-    rData.WallDistance = wall_distance;
+    // rData.WallDistance = wall_distance;
     rData.VelocityDivergence =
         this->GetDivergenceOperator(VELOCITY, rShapeFunctionDerivatives);
     rEffectiveKinematicViscosity = nu + nu_t / tke_sigma;
 
-    rData.YPlus = y_plus;
-    rData.WallVelocity = norm_2(this->EvaluateInPoint(VELOCITY, rShapeFunctions));
+    // rData.YPlus = y_plus;
+    // rData.WallVelocity = norm_2(this->EvaluateInPoint(VELOCITY, rShapeFunctions));
 
     KRATOS_CATCH("");
 }
@@ -465,9 +461,9 @@ double EvmKElement<TDim, TNumNodes>::CalculateSourceTerm(const EvmKElementData& 
                                                          const int Step) const
 {
     double production = 0.0;
-    const double c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
-    const double von_karman = rCurrentProcessInfo[WALL_VON_KARMAN];
-    const double beta = rCurrentProcessInfo[WALL_SMOOTHNESS_BETA];
+    // const double c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
+    // const double von_karman = rCurrentProcessInfo[WALL_VON_KARMAN];
+    // const double beta = rCurrentProcessInfo[WALL_SMOOTHNESS_BETA];
     BoundedMatrix<double, TDim, TDim> velocity_gradient_matrix;
     this->CalculateGradient(velocity_gradient_matrix, VELOCITY, rData.ShapeFunctionDerivatives);
 

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_element.h
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_element.h
@@ -50,19 +50,16 @@ namespace Kratos
 
 struct EvmKElementData
 {
-    double KinematicViscosity;
     double Gamma;
 
     double TurbulentKineticEnergy;
-    double TurbulentEnergyDissipationRate;
     double TurbulentKinematicViscosity;
-    double WallDistance;
+    //double WallDistance;
     double VelocityDivergence;
 
     Matrix ShapeFunctionDerivatives;
-    array_1d<double, 3> WallNormal;
-    double WallVelocity;
-    double YPlus;
+    // double WallVelocity;
+    // double YPlus;
 };
 
 template <unsigned int TDim, unsigned int TNumNodes>

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_element.h
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_element.h
@@ -124,7 +124,7 @@ public:
     /**
      * Constructor.
      */
-    EvmKElement(IndexType NewId = 0);
+    explicit EvmKElement(IndexType NewId = 0);
 
     /**
      * Constructor using an array of nodes

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_epsilon_utilities.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_k_epsilon_utilities.cpp
@@ -45,7 +45,7 @@ double CalculateF2(const double turbulent_kinetic_energy,
     {
         const double Re_t = std::pow(turbulent_kinetic_energy, 2) /
                             (kinematic_viscosity * turbulent_energy_dissipation_rate);
-        const double f2 = 1.0 - 0.22 * std::exp(-1.0 * std::pow(Re_t / 6.0, 2));
+        const double f2 = 1.0 - 0.22 * std::exp(-1.0 * std::pow(Re_t * (1.0 / 6.0), 2));
 
         return f2;
     }

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_epsilon_element.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_epsilon_element.cpp
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    , KratosAppGenerator
+//  Main authors:    Suneth Warnakulasuriya (https://github.com/sunethwarna)
 //
 
 // System includes

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_epsilon_element.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_epsilon_element.cpp
@@ -397,22 +397,22 @@ void EvmLowReEpsilonElement<TDim, TNumNodes>::CalculateConvectionDiffusionReacti
     const ProcessInfo& rCurrentProcessInfo,
     const int Step) const
 {
-    const double& c1 = rCurrentProcessInfo[TURBULENCE_RANS_C1];
-    const double& c2 = rCurrentProcessInfo[TURBULENCE_RANS_C2];
-    const double& c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
-    const double& epsilon_sigma =
+    const double c1 = rCurrentProcessInfo[TURBULENCE_RANS_C1];
+    const double c2 = rCurrentProcessInfo[TURBULENCE_RANS_C2];
+    const double c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
+    const double epsilon_sigma =
         rCurrentProcessInfo[TURBULENT_ENERGY_DISSIPATION_RATE_SIGMA];
 
-    const double& nu = this->EvaluateInPoint(KINEMATIC_VISCOSITY, rShapeFunctions);
-    const double& nu_t = this->EvaluateInPoint(TURBULENT_VISCOSITY, rShapeFunctions);
-    const double& tke = this->EvaluateInPoint(TURBULENT_KINETIC_ENERGY, rShapeFunctions);
-    const double& epsilon =
+    const double nu = this->EvaluateInPoint(KINEMATIC_VISCOSITY, rShapeFunctions);
+    const double nu_t = this->EvaluateInPoint(TURBULENT_VISCOSITY, rShapeFunctions);
+    const double tke = this->EvaluateInPoint(TURBULENT_KINETIC_ENERGY, rShapeFunctions);
+    const double epsilon =
         this->EvaluateInPoint(TURBULENT_ENERGY_DISSIPATION_RATE, rShapeFunctions);
-    const double& y_plus = this->EvaluateInPoint(RANS_Y_PLUS, rShapeFunctions);
-    const double& f_mu = EvmKepsilonModelUtilities::CalculateFmu(y_plus);
-    const double& gamma = EvmKepsilonModelUtilities::CalculateGamma(c_mu, f_mu, tke, nu_t);
-    const double& f2 = EvmKepsilonModelUtilities::CalculateF2(tke, nu, epsilon);
-    const double& wall_distance = this->EvaluateInPoint(DISTANCE, rShapeFunctions);
+    const double y_plus = this->EvaluateInPoint(RANS_Y_PLUS, rShapeFunctions);
+    const double f_mu = EvmKepsilonModelUtilities::CalculateFmu(y_plus);
+    const double gamma = EvmKepsilonModelUtilities::CalculateGamma(c_mu, f_mu, tke, nu_t);
+    const double f2 = EvmKepsilonModelUtilities::CalculateF2(tke, nu, epsilon);
+    const double wall_distance = this->EvaluateInPoint(DISTANCE, rShapeFunctions);
 
     rData.C1 = c1;
     rData.C2 = c2;

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_epsilon_element.h
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_epsilon_element.h
@@ -125,7 +125,7 @@ public:
     /**
      * Constructor.
      */
-    EvmLowReEpsilonElement(IndexType NewId = 0);
+    explicit EvmLowReEpsilonElement(IndexType NewId = 0);
 
     /**
      * Constructor using an array of nodes

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_k_element.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_k_element.cpp
@@ -7,7 +7,7 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    , KratosAppGenerator
+//  Main authors:    Suneth Warnakulasuriya (https://github.com/sunethwarna)
 //
 
 // System includes

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_k_element.cpp
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_k_element.cpp
@@ -391,16 +391,16 @@ void EvmLowReKElement<TDim, TNumNodes>::CalculateConvectionDiffusionReactionData
 {
     rData.ShapeFunctionDerivatives = rShapeFunctionDerivatives;
 
-    const double& c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
-    const double& tke_sigma = rCurrentProcessInfo[TURBULENT_KINETIC_ENERGY_SIGMA];
+    const double c_mu = rCurrentProcessInfo[TURBULENCE_RANS_C_MU];
+    const double tke_sigma = rCurrentProcessInfo[TURBULENT_KINETIC_ENERGY_SIGMA];
 
-    const double& nu_t = this->EvaluateInPoint(TURBULENT_VISCOSITY, rShapeFunctions);
-    const double& tke = this->EvaluateInPoint(TURBULENT_KINETIC_ENERGY, rShapeFunctions);
-    const double& nu = this->EvaluateInPoint(KINEMATIC_VISCOSITY, rShapeFunctions);
-    const double& wall_distance = this->EvaluateInPoint(DISTANCE, rShapeFunctions);
-    const double& y_plus = this->EvaluateInPoint(RANS_Y_PLUS, rShapeFunctions);
-    const double& f_mu = EvmKepsilonModelUtilities::CalculateFmu(y_plus);
-    const double& gamma = EvmKepsilonModelUtilities::CalculateGamma(c_mu, f_mu, tke, nu_t);
+    const double nu_t = this->EvaluateInPoint(TURBULENT_VISCOSITY, rShapeFunctions);
+    const double tke = this->EvaluateInPoint(TURBULENT_KINETIC_ENERGY, rShapeFunctions);
+    const double nu = this->EvaluateInPoint(KINEMATIC_VISCOSITY, rShapeFunctions);
+    const double wall_distance = this->EvaluateInPoint(DISTANCE, rShapeFunctions);
+    const double y_plus = this->EvaluateInPoint(RANS_Y_PLUS, rShapeFunctions);
+    const double f_mu = EvmKepsilonModelUtilities::CalculateFmu(y_plus);
+    const double gamma = EvmKepsilonModelUtilities::CalculateGamma(c_mu, f_mu, tke, nu_t);
 
     rData.TurbulentKinematicViscosity = nu_t;
     rData.TurbulentKineticEnergy = tke;

--- a/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_k_element.h
+++ b/applications/RANSModellingApplication/custom_elements/evm_k_epsilon/evm_low_re_k_element.h
@@ -122,7 +122,7 @@ public:
     /**
      * Constructor.
      */
-    EvmLowReKElement(IndexType NewId = 0);
+    explicit EvmLowReKElement(IndexType NewId = 0);
 
     /**
      * Constructor using an array of nodes

--- a/applications/RANSModellingApplication/custom_elements/stabilized_convection_diffusion_reaction_element.h
+++ b/applications/RANSModellingApplication/custom_elements/stabilized_convection_diffusion_reaction_element.h
@@ -335,7 +335,7 @@ public:
         for (unsigned int g = 0; g < num_gauss_points; g++)
         {
             const Matrix& r_shape_derivatives = shape_derivatives[g];
-            const Vector& gauss_shape_functions = row(shape_functions, g);
+            const Vector gauss_shape_functions = row(shape_functions, g);
 
             const Matrix& r_parameter_derivatives_g = r_parameter_derivatives[g];
             Matrix contravariant_metric_tensor(r_parameter_derivatives_g.size1(),
@@ -530,7 +530,7 @@ public:
         for (unsigned int g = 0; g < num_gauss_points; g++)
         {
             const Matrix& r_shape_derivatives = shape_derivatives[g];
-            const Vector& gauss_shape_functions = row(shape_functions, g);
+            const Vector gauss_shape_functions = row(shape_functions, g);
 
             const Matrix& r_parameter_derivatives_g = r_parameter_derivatives[g];
             Matrix contravariant_metric_tensor(r_parameter_derivatives_g.size1(),
@@ -538,7 +538,7 @@ public:
             noalias(contravariant_metric_tensor) =
                 prod(trans(r_parameter_derivatives_g), r_parameter_derivatives_g);
 
-            const double mass = gauss_weights[g] / TNumNodes;
+            const double mass = gauss_weights[g] * (1.0 / TNumNodes);
             this->AddLumpedMassMatrix(rMassMatrix, mass);
 
             const array_1d<double, 3>& velocity =
@@ -607,7 +607,7 @@ public:
         for (unsigned int g = 0; g < num_gauss_points; g++)
         {
             const Matrix& r_shape_derivatives = shape_derivatives[g];
-            const Vector& gauss_shape_functions = row(shape_functions, g);
+            const Vector gauss_shape_functions = row(shape_functions, g);
 
             const Matrix& r_parameter_derivatives_g = r_parameter_derivatives[g];
             Matrix contravariant_metric_tensor(r_parameter_derivatives_g.size1(),
@@ -663,8 +663,8 @@ public:
                     chi, k1, k2, velocity_magnitude, tau, effective_kinematic_viscosity,
                     reaction, bossak_alpha, bossak_gamma, delta_time, element_length, dynamic_tau);
 
-                stream_line_diffusion = residual * chi * k1 / velocity_magnitude_square;
-                cross_wind_diffusion = residual * chi * k2 / velocity_magnitude_square;
+                stream_line_diffusion = residual * chi * k1 * (1.0 / velocity_magnitude_square);
+                cross_wind_diffusion = residual * chi * k2 * (1.0 / velocity_magnitude_square);
             }
 
             const double s = std::abs(reaction);

--- a/applications/RANSModellingApplication/custom_elements/stabilized_convection_diffusion_reaction_element.h
+++ b/applications/RANSModellingApplication/custom_elements/stabilized_convection_diffusion_reaction_element.h
@@ -106,7 +106,7 @@ public:
     /**
      * Constructor.
      */
-    StabilizedConvectionDiffusionReactionElement(IndexType NewId = 0)
+    explicit StabilizedConvectionDiffusionReactionElement(IndexType NewId = 0)
         : Element(NewId)
     {
     }

--- a/applications/RANSModellingApplication/custom_elements/stabilized_convection_diffusion_reaction_element.h
+++ b/applications/RANSModellingApplication/custom_elements/stabilized_convection_diffusion_reaction_element.h
@@ -92,6 +92,8 @@ public:
     /// Type for an array of shape function gradient matrices
     typedef GeometryType::ShapeFunctionsGradientsType ShapeFunctionDerivativesArrayType;
 
+    typedef TConvectionDiffusionReactionData ConvectionDiffusionReactionDataType;
+
     ///@}
     ///@name Pointer Definitions
     /// Pointer definition of StabilizedConvectionDiffusionReactionElement
@@ -778,6 +780,111 @@ public:
         KRATOS_CATCH("");
     }
 
+    double EvaluateInPoint(const Variable<double>& rVariable,
+                           const Vector& rShapeFunction,
+                           const int Step = 0) const
+    {
+        return RansCalculationUtilities().EvaluateInPoint(
+            this->GetGeometry(), rVariable, rShapeFunction, Step);
+    }
+
+    array_1d<double, 3> EvaluateInPoint(const Variable<array_1d<double, 3>>& rVariable,
+                                        const Vector& rShapeFunction,
+                                        const int Step = 0) const
+    {
+        return RansCalculationUtilities().EvaluateInPoint(
+            this->GetGeometry(), rVariable, rShapeFunction, Step);
+    }
+
+    double GetDivergenceOperator(const Variable<array_1d<double, 3>>& rVariable,
+                                 const Matrix& rShapeDerivatives,
+                                 const int Step = 0) const
+    {
+        double value = 0.0;
+        const GeometryType& r_geometry = this->GetGeometry();
+
+        for (unsigned int i = 0; i < TNumNodes; ++i)
+        {
+            const array_1d<double, 3>& r_value =
+                r_geometry[i].FastGetSolutionStepValue(rVariable, Step);
+            for (unsigned int j = 0; j < TDim; ++j)
+            {
+                value += r_value[j] * rShapeDerivatives(i, j);
+            }
+        }
+
+        return value;
+    }
+
+    virtual void CalculateConvectionDiffusionReactionData(
+        TConvectionDiffusionReactionData& rData,
+        double& rEffectiveKinematicViscosity,
+        const Vector& rShapeFunctions,
+        const Matrix& rShapeFunctionDerivatives,
+        const ProcessInfo& rCurrentProcessInfo,
+        const int Step = 0) const
+    {
+        KRATOS_TRY;
+        KRATOS_ERROR << "Attempting to call base "
+                        "StabilizedConvectionDiffusionReactionElement "
+                        "CalculateConvectionDiffusionReactionData method. "
+                        "Please implement it in the derrived class."
+                     << std::endl;
+        KRATOS_CATCH("");
+    }
+
+    virtual void CalculateConvectionDiffusionReactionData(
+        TConvectionDiffusionReactionData& rData,
+        double& rEffectiveKinematicViscosity,
+        double& rVariableGradientNorm,
+        double& rVariableRelaxedAcceleration,
+        const Vector& rShapeFunctions,
+        const Matrix& rShapeFunctionDerivatives,
+        const ProcessInfo& rCurrentProcessInfo,
+        const int Step = 0) const
+    {
+        KRATOS_TRY;
+        KRATOS_ERROR << "Attempting to call base "
+                        "StabilizedConvectionDiffusionReactionElement "
+                        "CalculateConvectionDiffusionReactionData method. "
+                        "Please implement it in the derrived class."
+                     << std::endl;
+        KRATOS_CATCH("");
+    }
+
+    ShapeFunctionDerivativesArrayType GetGeometryParameterDerivatives() const
+    {
+        const GeometryType& r_geometry = this->GetGeometry();
+        return RansCalculationUtilities().CalculateGeometryParameterDerivatives(
+            r_geometry, this->GetIntegrationMethod());
+    }
+
+    virtual double CalculateReactionTerm(const TConvectionDiffusionReactionData& rData,
+                                         const ProcessInfo& rCurrentProcessInfo,
+                                         const int Step = 0) const
+    {
+        KRATOS_TRY;
+        KRATOS_ERROR << "Attempting to call base "
+                        "StabilizedConvectionDiffusionReactionElement "
+                        "CalculateReactionTerm method. Please implement it in "
+                        "the derrived class."
+                     << std::endl;
+        KRATOS_CATCH("");
+    }
+
+    virtual double CalculateSourceTerm(const TConvectionDiffusionReactionData& rData,
+                                       const ProcessInfo& rCurrentProcessInfo,
+                                       const int Step = 0) const
+    {
+        KRATOS_TRY;
+        KRATOS_ERROR << "Attempting to call base "
+                        "StabilizedConvectionDiffusionReactionElement "
+                        "CalculateSourceTerm method. Please implement it in "
+                        "the derrived class."
+                     << std::endl;
+        KRATOS_CATCH("");
+    }
+
     ///@}
     ///@name Access
     ///@{
@@ -825,68 +932,6 @@ protected:
     ///@name Protected Operations
     ///@{
 
-    virtual void CalculateConvectionDiffusionReactionData(
-        TConvectionDiffusionReactionData& rData,
-        double& rEffectiveKinematicViscosity,
-        const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives,
-        const ProcessInfo& rCurrentProcessInfo,
-        const int Step = 0) const
-    {
-        KRATOS_TRY;
-        KRATOS_ERROR << "Attempting to call base "
-                        "StabilizedConvectionDiffusionReactionElement "
-                        "CalculateConvectionDiffusionReactionData method. "
-                        "Please implement it in the derrived class."
-                     << std::endl;
-        KRATOS_CATCH("");
-    }
-
-    virtual void CalculateConvectionDiffusionReactionData(
-        TConvectionDiffusionReactionData& rData,
-        double& rEffectiveKinematicViscosity,
-        double& rVariableGradientNorm,
-        double& rVariableRelaxedAcceleration,
-        const Vector& rShapeFunctions,
-        const Matrix& rShapeFunctionDerivatives,
-        const ProcessInfo& rCurrentProcessInfo,
-        const int Step = 0) const
-    {
-        KRATOS_TRY;
-        KRATOS_ERROR << "Attempting to call base "
-                        "StabilizedConvectionDiffusionReactionElement "
-                        "CalculateConvectionDiffusionReactionData method. "
-                        "Please implement it in the derrived class."
-                     << std::endl;
-        KRATOS_CATCH("");
-    }
-
-    virtual double CalculateSourceTerm(const TConvectionDiffusionReactionData& rData,
-                                       const ProcessInfo& rCurrentProcessInfo,
-                                       const int Step = 0) const
-    {
-        KRATOS_TRY;
-        KRATOS_ERROR << "Attempting to call base "
-                        "StabilizedConvectionDiffusionReactionElement "
-                        "CalculateSourceTerm method. Please implement it in "
-                        "the derrived class."
-                     << std::endl;
-        KRATOS_CATCH("");
-    }
-
-    virtual double CalculateReactionTerm(const TConvectionDiffusionReactionData& rData,
-                                         const ProcessInfo& rCurrentProcessInfo,
-                                         const int Step = 0) const
-    {
-        KRATOS_TRY;
-        KRATOS_ERROR << "Attempting to call base "
-                        "StabilizedConvectionDiffusionReactionElement "
-                        "CalculateReactionTerm method. Please implement it in "
-                        "the derrived class."
-                     << std::endl;
-        KRATOS_CATCH("");
-    }
-
     /// Determine integration point weights and shape funcition derivatives from the element's geometry.
     virtual void CalculateGeometryData(Vector& rGaussWeights,
                                        Matrix& rNContainer,
@@ -896,29 +941,6 @@ protected:
 
         RansCalculationUtilities().CalculateGeometryData(
             r_geometry, this->GetIntegrationMethod(), rGaussWeights, rNContainer, rDN_DX);
-    }
-
-    ShapeFunctionDerivativesArrayType GetGeometryParameterDerivatives() const
-    {
-        const GeometryType& r_geometry = this->GetGeometry();
-        return RansCalculationUtilities().CalculateGeometryParameterDerivatives(
-            r_geometry, this->GetIntegrationMethod());
-    }
-
-    double EvaluateInPoint(const Variable<double>& rVariable,
-                           const Vector& rShapeFunction,
-                           const int Step = 0) const
-    {
-        return RansCalculationUtilities().EvaluateInPoint(
-            this->GetGeometry(), rVariable, rShapeFunction, Step);
-    }
-
-    array_1d<double, 3> EvaluateInPoint(const Variable<array_1d<double, 3>>& rVariable,
-                                        const Vector& rShapeFunction,
-                                        const int Step = 0) const
-    {
-        return RansCalculationUtilities().EvaluateInPoint(
-            this->GetGeometry(), rVariable, rShapeFunction, Step);
     }
 
     void GetConvectionOperator(BoundedVector<double, TNumNodes>& rOutput,
@@ -931,26 +953,6 @@ protected:
             {
                 rOutput[i] += rVector[j] * rShapeDerivatives(i, j);
             }
-    }
-
-    double GetDivergenceOperator(const Variable<array_1d<double, 3>>& rVariable,
-                                 const Matrix& rShapeDerivatives,
-                                 const int Step = 0) const
-    {
-        double value = 0.0;
-        const GeometryType& r_geometry = this->GetGeometry();
-
-        for (unsigned int i = 0; i < TNumNodes; ++i)
-        {
-            const array_1d<double, 3>& r_value =
-                r_geometry[i].FastGetSolutionStepValue(rVariable, Step);
-            for (unsigned int j = 0; j < TDim; ++j)
-            {
-                value += r_value[j] * rShapeDerivatives(i, j);
-            }
-        }
-
-        return value;
     }
 
     void CalculateGradient(BoundedMatrix<double, TDim, TDim>& rOutput,

--- a/applications/RANSModellingApplication/custom_elements/stabilized_convection_diffusion_reaction_utilities.h
+++ b/applications/RANSModellingApplication/custom_elements/stabilized_convection_diffusion_reaction_utilities.h
@@ -50,7 +50,7 @@ inline double CalculatePsiOne(const double VelocityNorm, const double Tau, const
 inline double CalculatePsiTwo(const double DynamicReaction, const double Tau, const double ElementLength)
 {
     return (DynamicReaction + Tau * DynamicReaction * std::abs(DynamicReaction)) *
-           std::pow(ElementLength, 2) / 6.0;
+           std::pow(ElementLength, 2) * (1.0 / 6.0);
 }
 
 inline void CalculateStabilizationTau(double& rTau,
@@ -65,7 +65,7 @@ inline void CalculateStabilizationTau(double& rTau,
                                       const double DynamicTau)
 {
     unsigned int dim = rContravariantMetricTensor.size2();
-    const Vector& velocity = RansCalculationUtilities().GetVector(rVelocity, dim);
+    const Vector velocity = RansCalculationUtilities().GetVector(rVelocity, dim);
     Vector temp(dim);
     noalias(temp) = prod(rContravariantMetricTensor, velocity);
     const double velocity_norm = norm_2(rVelocity);

--- a/applications/RANSModellingApplication/custom_elements/stabilized_convection_diffusion_reaction_utilities.h
+++ b/applications/RANSModellingApplication/custom_elements/stabilized_convection_diffusion_reaction_utilities.h
@@ -114,9 +114,7 @@ inline void CalculateCrossWindDiffusionParameters(double& rChi,
     const double psi_one = CalculatePsiOne(VelocityMagnitude, Tau, reaction_dynamics);
     const double psi_two = CalculatePsiTwo(reaction_dynamics, Tau, ElementLength);
 
-    double value = 0.0;
-
-    value = 0.5 * std::abs(psi_one - Tau * VelocityMagnitude * reaction_dynamics) * ElementLength;
+    double value = 0.5 * std::abs(psi_one - Tau * VelocityMagnitude * reaction_dynamics) * ElementLength;
     value -= (EffectiveKinematicViscosity + Tau * std::pow(VelocityMagnitude, 2));
     value += psi_two;
 

--- a/applications/RANSModellingApplication/custom_utilities/rans_calculation_utilities.cpp
+++ b/applications/RANSModellingApplication/custom_utilities/rans_calculation_utilities.cpp
@@ -236,6 +236,7 @@ double RansCalculationUtilities::CalculateLogarithmicYPlusLimit(const double Kap
         << "Logarithmic y_plus limit reached max iterations with dx > "
            "Tolerance [ "
         << dx << " > " << Tolerance << ", MaxIterations = " << MaxIterations << " ].\n";
+    return y_plus;
 }
 
 // template instantiations

--- a/applications/RANSModellingApplication/tests/cpp/test_evm_k_element.cpp
+++ b/applications/RANSModellingApplication/tests/cpp/test_evm_k_element.cpp
@@ -192,11 +192,11 @@ void CalculateStreamlineAndCrossWindDiffusionParameters(double& rChi,
 
 void EvmKElement2D3N_SetUp(ModelPart& rModelPart)
 {
-    rModelPart.AddNodalSolutionStepVariable(DISTANCE);
+    // rModelPart.AddNodalSolutionStepVariable(DISTANCE);
     rModelPart.AddNodalSolutionStepVariable(KINEMATIC_VISCOSITY);
     rModelPart.AddNodalSolutionStepVariable(RANS_AUXILIARY_VARIABLE_1); // relaxed turb kin energy rate
-    rModelPart.AddNodalSolutionStepVariable(RANS_Y_PLUS);
-    rModelPart.AddNodalSolutionStepVariable(TURBULENT_ENERGY_DISSIPATION_RATE);
+    // rModelPart.AddNodalSolutionStepVariable(RANS_Y_PLUS);
+    // rModelPart.AddNodalSolutionStepVariable(TURBULENT_ENERGY_DISSIPATION_RATE);
     rModelPart.AddNodalSolutionStepVariable(TURBULENT_KINETIC_ENERGY);
     rModelPart.AddNodalSolutionStepVariable(TURBULENT_KINETIC_ENERGY_RATE);
     rModelPart.AddNodalSolutionStepVariable(TURBULENT_VISCOSITY);
@@ -206,11 +206,11 @@ void EvmKElement2D3N_SetUp(ModelPart& rModelPart)
 
 void EvmEpsilonElement2D3N_SetUp(ModelPart& rModelPart)
 {
-    rModelPart.AddNodalSolutionStepVariable(DISTANCE);
+    // rModelPart.AddNodalSolutionStepVariable(DISTANCE);
     rModelPart.AddNodalSolutionStepVariable(KINEMATIC_VISCOSITY);
-    rModelPart.AddNodalSolutionStepVariable(NORMAL);
+    // rModelPart.AddNodalSolutionStepVariable(NORMAL);
     rModelPart.AddNodalSolutionStepVariable(RANS_AUXILIARY_VARIABLE_2); // relaxed turb kin energy diss. rate 2
-    rModelPart.AddNodalSolutionStepVariable(RANS_Y_PLUS);
+    // rModelPart.AddNodalSolutionStepVariable(RANS_Y_PLUS);
     rModelPart.AddNodalSolutionStepVariable(TURBULENT_ENERGY_DISSIPATION_RATE);
     rModelPart.AddNodalSolutionStepVariable(TURBULENT_ENERGY_DISSIPATION_RATE_2);
     rModelPart.AddNodalSolutionStepVariable(TURBULENT_KINETIC_ENERGY);

--- a/applications/RANSModellingApplication/tests/cpp/test_evm_k_element.cpp
+++ b/applications/RANSModellingApplication/tests/cpp/test_evm_k_element.cpp
@@ -1,0 +1,978 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:
+//
+
+// System includes
+#include <string>
+#include <vector>
+
+// External includes
+
+// Project includes
+#include "containers/model.h"
+#include "includes/kratos_components.h"
+#include "includes/variables.h"
+#include "testing/testing.h"
+
+// Application includes
+#include "custom_elements/evm_k_epsilon/evm_epsilon_element.h"
+#include "custom_elements/evm_k_epsilon/evm_k_element.h"
+#include "custom_elements/evm_k_epsilon/evm_low_re_epsilon_element.h"
+#include "custom_elements/evm_k_epsilon/evm_low_re_k_element.h"
+#include "custom_elements/stabilized_convection_diffusion_reaction_utilities.h"
+#include "rans_modelling_application_variables.h"
+
+namespace Kratos
+{
+namespace Testing
+{
+namespace
+{
+void CreateEvmUnitTestModelPart(const std::string& rElementName,
+                                const Variable<double>& rDofVariable,
+                                ModelPart& rModelPart)
+{
+    const auto& r_proto = KratosComponents<Element>::Get(rElementName);
+    auto node_ids = std::vector<ModelPart::IndexType>{};
+    Matrix coords;
+    r_proto.GetGeometry().PointsLocalCoordinates(coords);
+    if (coords.size2() == 2)
+    {
+        for (std::size_t i = 0; i < coords.size1(); ++i)
+            rModelPart.CreateNewNode(i + 1, coords(i, 0), coords(i, 1), 0.0);
+    }
+    else
+    {
+        for (std::size_t i = 0; i < coords.size1(); ++i)
+            rModelPart.CreateNewNode(i + 1, coords(i, 0), coords(i, 1), coords(i, 2));
+    }
+    for (auto& r_node : rModelPart.Nodes())
+    {
+        r_node.AddDof(rDofVariable).SetEquationId(r_node.Id());
+        node_ids.push_back(r_node.Id());
+    }
+    auto p_prop = rModelPart.CreateNewProperties(1);
+    auto p_element = rModelPart.CreateNewElement(rElementName, 1, node_ids, p_prop);
+    rModelPart.SetBufferSize(1);
+}
+
+template <typename EvmElement>
+double EffectiveKinematicViscosity(const Element& rElement, const ProcessInfo& rProcessInfo)
+{
+    auto& r_geom = rElement.GetGeometry();
+    const Vector N = row(r_geom.ShapeFunctionsValues(GeometryData::GI_GAUSS_1), 0);
+    typename Element::GeometryType::ShapeFunctionsGradientsType DN_DX;
+    r_geom.ShapeFunctionsIntegrationPointsGradients(DN_DX, GeometryData::GI_GAUSS_1);
+    typename EvmElement::BaseType::ConvectionDiffusionReactionDataType data;
+    double effective_kinematic_viscosity{};
+    auto& rRANSElement = dynamic_cast<const typename EvmElement::BaseType&>(rElement);
+    rRANSElement.CalculateConvectionDiffusionReactionData(
+        data, effective_kinematic_viscosity, N, DN_DX[0], rProcessInfo);
+    return effective_kinematic_viscosity;
+}
+
+template <typename EvmElement>
+typename EvmElement::BaseType::ConvectionDiffusionReactionDataType ConvectionReactionDiffusionData(
+    const Element& rElement, const ProcessInfo& rProcessInfo)
+{
+    auto& r_geom = rElement.GetGeometry();
+    const Vector N = row(r_geom.ShapeFunctionsValues(GeometryData::GI_GAUSS_1), 0);
+    typename Element::GeometryType::ShapeFunctionsGradientsType DN_DX;
+    r_geom.ShapeFunctionsIntegrationPointsGradients(DN_DX, GeometryData::GI_GAUSS_1);
+    typename EvmElement::BaseType::ConvectionDiffusionReactionDataType data;
+    double effective_kinematic_viscosity{};
+    auto& rRANSElement = dynamic_cast<const typename EvmElement::BaseType&>(rElement);
+    rRANSElement.CalculateConvectionDiffusionReactionData(
+        data, effective_kinematic_viscosity, N, DN_DX[0], rProcessInfo);
+    return data;
+}
+
+template <typename EvmElement>
+double ReactionTerm(const Element& rElement, const ProcessInfo& rProcessInfo)
+{
+    const auto data = ConvectionReactionDiffusionData<EvmElement>(rElement, rProcessInfo);
+    auto& rRANSElement = dynamic_cast<const typename EvmElement::BaseType&>(rElement);
+    return rRANSElement.CalculateReactionTerm(data, rProcessInfo);
+}
+
+template <typename EvmElement>
+double DynamicReactionTerm(const Element& rElement, const ProcessInfo& rProcessInfo)
+{
+    const auto data = ConvectionReactionDiffusionData<EvmElement>(rElement, rProcessInfo);
+    auto& rRANSElement = dynamic_cast<const typename EvmElement::BaseType&>(rElement);
+    const double reaction = rRANSElement.CalculateReactionTerm(data, rProcessInfo);
+    const double delta_time = rProcessInfo[DELTA_TIME];
+    const double dynamic_tau = rProcessInfo[DYNAMIC_TAU];
+    const double bossak_alpha = rProcessInfo[BOSSAK_ALPHA];
+    const double bossak_gamma =
+        TimeDiscretization::Bossak(bossak_alpha, 0.25, 0.5).GetGamma();
+
+    return reaction + dynamic_tau * (1. - bossak_alpha) / (bossak_gamma * delta_time);
+}
+
+template <typename EvmElement>
+double SourceTerm(const Element& rElement, const ProcessInfo& rProcessInfo)
+{
+    auto data = ConvectionReactionDiffusionData<EvmElement>(rElement, rProcessInfo);
+    auto& rRANSElement = dynamic_cast<const typename EvmElement::BaseType&>(rElement);
+    return rRANSElement.CalculateSourceTerm(data, rProcessInfo);
+}
+
+template <typename EvmElement>
+double VelocityNorm(const Element& rElement)
+{
+    auto& r_geom = rElement.GetGeometry();
+    const Vector N = row(r_geom.ShapeFunctionsValues(GeometryData::GI_GAUSS_1), 0);
+    auto& rRANSElement = dynamic_cast<const typename EvmElement::BaseType&>(rElement);
+    const array_1d<double, 3> velocity = rRANSElement.EvaluateInPoint(VELOCITY, N);
+    return norm_2(velocity);
+}
+
+template <typename EvmElement>
+double DivVel(const Element& rElement)
+{
+    auto& r_geom = rElement.GetGeometry();
+    typename Element::GeometryType::ShapeFunctionsGradientsType DN_DX;
+    r_geom.ShapeFunctionsIntegrationPointsGradients(DN_DX, GeometryData::GI_GAUSS_1);
+    auto& rRANSElement = dynamic_cast<const typename EvmElement::BaseType&>(rElement);
+    const double div = rRANSElement.GetDivergenceOperator(VELOCITY, DN_DX[0]);
+    return div;
+}
+
+template <typename EvmElement>
+void CalculateStreamlineAndCrossWindDiffusionParameters(double& rChi,
+                                                        double& rSD,
+                                                        double& rCD,
+                                                        const Element& rElement,
+                                                        const ProcessInfo& rProcessInfo)
+{
+    // This code was extracted from StabilizedConvectionDiffusionReactionElement::CalculateDampingMatrix.
+    // We needed to add the tests before changing code, but this should be cleaned during refactoring.
+    auto& r_geom = rElement.GetGeometry();
+    const Vector N = row(r_geom.ShapeFunctionsValues(GeometryData::GI_GAUSS_1), 0);
+    typename Element::GeometryType::ShapeFunctionsGradientsType DN_DX;
+    r_geom.ShapeFunctionsIntegrationPointsGradients(DN_DX, GeometryData::GI_GAUSS_1);
+    typename EvmElement::BaseType::ConvectionDiffusionReactionDataType data;
+    double effective_kinematic_viscosity{}, variable_gradient_norm{},
+        relaxed_variable_acceleration{};
+    auto& rRANSElement = dynamic_cast<const typename EvmElement::BaseType&>(rElement);
+    rRANSElement.CalculateConvectionDiffusionReactionData(
+        data, effective_kinematic_viscosity, variable_gradient_norm,
+        relaxed_variable_acceleration, N, DN_DX[0], rProcessInfo);
+    const array_1d<double, 3> velocity = rRANSElement.EvaluateInPoint(VELOCITY, N);
+    const double velocity_magnitude = norm_2(velocity);
+    const Matrix r_parameter_derivatives_g =
+        rRANSElement.GetGeometryParameterDerivatives()[0];
+    Matrix contravariant_metric_tensor(r_parameter_derivatives_g.size1(),
+                                       r_parameter_derivatives_g.size2());
+    noalias(contravariant_metric_tensor) =
+        prod(trans(r_parameter_derivatives_g), r_parameter_derivatives_g);
+    const double reaction = rRANSElement.CalculateReactionTerm(data, rProcessInfo);
+    const double delta_time = rProcessInfo[DELTA_TIME];
+    const double bossak_alpha = rProcessInfo[BOSSAK_ALPHA];
+    const double bossak_gamma =
+        TimeDiscretization::Bossak(bossak_alpha, 0.25, 0.5).GetGamma();
+    const double dynamic_tau = rProcessInfo[DYNAMIC_TAU];
+    double tau, element_length;
+    StabilizedConvectionDiffusionReactionUtilities::CalculateStabilizationTau(
+        tau, element_length, velocity, contravariant_metric_tensor, reaction,
+        effective_kinematic_viscosity, bossak_alpha, bossak_gamma, delta_time, dynamic_tau);
+    StabilizedConvectionDiffusionReactionUtilities::CalculateCrossWindDiffusionParameters(
+        rChi, rSD, rCD, velocity_magnitude, tau, effective_kinematic_viscosity, reaction,
+        bossak_alpha, bossak_gamma, delta_time, element_length, dynamic_tau);
+}
+
+void EvmKElement2D3N_SetUp(ModelPart& rModelPart)
+{
+    rModelPart.AddNodalSolutionStepVariable(DISTANCE);
+    rModelPart.AddNodalSolutionStepVariable(KINEMATIC_VISCOSITY);
+    rModelPart.AddNodalSolutionStepVariable(RANS_AUXILIARY_VARIABLE_1); // relaxed turb kin energy rate
+    rModelPart.AddNodalSolutionStepVariable(RANS_Y_PLUS);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_ENERGY_DISSIPATION_RATE);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_KINETIC_ENERGY);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_KINETIC_ENERGY_RATE);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_VISCOSITY);
+    rModelPart.AddNodalSolutionStepVariable(VELOCITY);
+    CreateEvmUnitTestModelPart("RANSEVMK2D3N", TURBULENT_KINETIC_ENERGY, rModelPart);
+}
+
+void EvmEpsilonElement2D3N_SetUp(ModelPart& rModelPart)
+{
+    rModelPart.AddNodalSolutionStepVariable(DISTANCE);
+    rModelPart.AddNodalSolutionStepVariable(KINEMATIC_VISCOSITY);
+    rModelPart.AddNodalSolutionStepVariable(NORMAL);
+    rModelPart.AddNodalSolutionStepVariable(RANS_AUXILIARY_VARIABLE_2); // relaxed turb kin energy diss. rate 2
+    rModelPart.AddNodalSolutionStepVariable(RANS_Y_PLUS);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_ENERGY_DISSIPATION_RATE);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_ENERGY_DISSIPATION_RATE_2);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_KINETIC_ENERGY);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_VISCOSITY);
+    rModelPart.AddNodalSolutionStepVariable(VELOCITY);
+    CreateEvmUnitTestModelPart("RANSEVMEpsilon2D3N",
+                               TURBULENT_ENERGY_DISSIPATION_RATE, rModelPart);
+}
+
+void EvmLowReKElement2D3N_SetUp(ModelPart& rModelPart)
+{
+    rModelPart.AddNodalSolutionStepVariable(DISTANCE);
+    rModelPart.AddNodalSolutionStepVariable(KINEMATIC_VISCOSITY);
+    rModelPart.AddNodalSolutionStepVariable(RANS_AUXILIARY_VARIABLE_1); // relaxed turb kin energy rate
+    rModelPart.AddNodalSolutionStepVariable(RANS_Y_PLUS);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_KINETIC_ENERGY);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_KINETIC_ENERGY_RATE);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_VISCOSITY);
+    rModelPart.AddNodalSolutionStepVariable(VELOCITY);
+    CreateEvmUnitTestModelPart("RANSEVMLowReK2D3N", TURBULENT_KINETIC_ENERGY, rModelPart);
+}
+
+void EvmLowReEpsilonElement2D3N_SetUp(ModelPart& rModelPart)
+{
+    rModelPart.AddNodalSolutionStepVariable(DISTANCE);
+    rModelPart.AddNodalSolutionStepVariable(KINEMATIC_VISCOSITY);
+    rModelPart.AddNodalSolutionStepVariable(RANS_AUXILIARY_VARIABLE_2); // relaxed turb kin energy diss. rate 2
+    rModelPart.AddNodalSolutionStepVariable(RANS_Y_PLUS);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_ENERGY_DISSIPATION_RATE);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_ENERGY_DISSIPATION_RATE_2);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_KINETIC_ENERGY);
+    rModelPart.AddNodalSolutionStepVariable(TURBULENT_VISCOSITY);
+    rModelPart.AddNodalSolutionStepVariable(VELOCITY);
+    CreateEvmUnitTestModelPart("RANSEVMLowReEpsilon2D3N",
+                               TURBULENT_ENERGY_DISSIPATION_RATE, rModelPart);
+}
+
+template <typename EvmElement>
+void CheckEvmElementTestData(const Element& rElement, const ProcessInfo& rProcessInfo)
+{
+    // Ensure several contributions have comparable magnitudes:
+    const double effective_kinematic_viscosity =
+        EffectiveKinematicViscosity<EvmElement>(rElement, rProcessInfo);
+    KRATOS_CHECK(effective_kinematic_viscosity > 0.1 && effective_kinematic_viscosity < 100.0);
+    const double reaction = ReactionTerm<EvmElement>(rElement, rProcessInfo);
+    KRATOS_CHECK(reaction > 0.1 && reaction < 100.0);
+    const double dynamic_reaction = DynamicReactionTerm<EvmElement>(rElement, rProcessInfo);
+    KRATOS_CHECK(dynamic_reaction > 0.1 && dynamic_reaction < 100.0);
+    const double source = SourceTerm<EvmElement>(rElement, rProcessInfo);
+    KRATOS_CHECK(source > 0.1 && source < 100.0);
+    const double vel_norm = VelocityNorm<EvmElement>(rElement);
+    KRATOS_CHECK(vel_norm > 0.1 && vel_norm < 100.0);
+    const double div_vel = DivVel<EvmElement>(rElement);
+    KRATOS_CHECK(div_vel > 0.1 && div_vel < 10.0);
+    double chi{}, streamline_diffusion{}, crosswind_diffusion{};
+    CalculateStreamlineAndCrossWindDiffusionParameters<EvmElement>(
+        chi, streamline_diffusion, crosswind_diffusion, rElement, rProcessInfo);
+    KRATOS_CHECK(chi > 0.1 && chi < 100.0);
+    KRATOS_CHECK(streamline_diffusion > 0.1 && streamline_diffusion < 100.0);
+    KRATOS_CHECK(crosswind_diffusion > 0.1 && crosswind_diffusion < 100.0);
+}
+
+void EvmKElement2D3N_AssignTestData(ModelPart& rModelPart)
+{
+    rModelPart.GetProcessInfo()[BOSSAK_ALPHA] = -0.3;
+    rModelPart.GetProcessInfo()[DELTA_TIME] = 1.1;
+    rModelPart.GetProcessInfo()[DYNAMIC_TAU] = 0.1;
+    rModelPart.GetProcessInfo()[TURBULENCE_RANS_C_MU] = 0.09;
+    rModelPart.GetProcessInfo()[TURBULENT_KINETIC_ENERGY_SIGMA] = 0.98;
+    auto& node1 = rModelPart.GetNode(1);
+    node1.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.24;
+    node1.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_1) = 0.21;
+    node1.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 25.90;
+    node1.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 1.29;
+    node1.FastGetSolutionStepValue(VELOCITY_X) = -1.85;
+    node1.FastGetSolutionStepValue(VELOCITY_Y) = -2.15;
+    auto& node2 = rModelPart.GetNode(2);
+    node2.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.28;
+    node2.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_1) = 0.14;
+    node2.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 5.00;
+    node2.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 1.04;
+    node2.FastGetSolutionStepValue(VELOCITY_X) = -0.78;
+    node2.FastGetSolutionStepValue(VELOCITY_Y) = -0.06;
+    auto& node3 = rModelPart.GetNode(3);
+    node3.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.28;
+    node3.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_1) = 0.63;
+    node3.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 5.70;
+    node3.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 1.11;
+    node3.FastGetSolutionStepValue(VELOCITY_X) = 0.01;
+    node3.FastGetSolutionStepValue(VELOCITY_Y) = -0.65;
+    CheckEvmElementTestData<EvmKElement<2, 3>>(rModelPart.Elements().front(),
+                                               rModelPart.GetProcessInfo());
+}
+
+void EvmEpsilonElement2D3N_AssignTestData(ModelPart& rModelPart)
+{
+    rModelPart.GetProcessInfo()[BOSSAK_ALPHA] = -0.3;
+    rModelPart.GetProcessInfo()[DELTA_TIME] = 1.1;
+    rModelPart.GetProcessInfo()[DYNAMIC_TAU] = 0.1;
+    rModelPart.GetProcessInfo()[TURBULENCE_RANS_C1] = 1.44;
+    rModelPart.GetProcessInfo()[TURBULENCE_RANS_C2] = 1.92;
+    rModelPart.GetProcessInfo()[TURBULENCE_RANS_C_MU] = 0.09;
+    rModelPart.GetProcessInfo()[TURBULENT_ENERGY_DISSIPATION_RATE_SIGMA] = 1.3;
+    auto& node1 = rModelPart.GetNode(1);
+    node1.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.24;
+    node1.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_2) = 0.21;
+    node1.FastGetSolutionStepValue(TURBULENT_ENERGY_DISSIPATION_RATE) = 25.90;
+    node1.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 25.90;
+    node1.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 1.29;
+    node1.FastGetSolutionStepValue(VELOCITY_X) = -1.85;
+    node1.FastGetSolutionStepValue(VELOCITY_Y) = -2.15;
+    auto& node2 = rModelPart.GetNode(2);
+    node2.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.28;
+    node2.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_2) = 0.14;
+    node2.FastGetSolutionStepValue(TURBULENT_ENERGY_DISSIPATION_RATE) = 5.00;
+    node2.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 5.00;
+    node2.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 1.04;
+    node2.FastGetSolutionStepValue(VELOCITY_X) = -0.78;
+    node2.FastGetSolutionStepValue(VELOCITY_Y) = -0.06;
+    auto& node3 = rModelPart.GetNode(3);
+    node3.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.28;
+    node3.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_2) = 0.63;
+    node3.FastGetSolutionStepValue(TURBULENT_ENERGY_DISSIPATION_RATE) = 5.70;
+    node3.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 5.70;
+    node3.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 0.90;
+    node3.FastGetSolutionStepValue(VELOCITY_X) = 0.01;
+    node3.FastGetSolutionStepValue(VELOCITY_Y) = -0.65;
+    CheckEvmElementTestData<EvmEpsilonElement<2, 3>>(
+        rModelPart.Elements().front(), rModelPart.GetProcessInfo());
+}
+
+void EvmLowReKElement2D3N_AssignTestData(ModelPart& rModelPart)
+{
+    rModelPart.GetProcessInfo()[BOSSAK_ALPHA] = -0.3;
+    rModelPart.GetProcessInfo()[DELTA_TIME] = 1.1;
+    rModelPart.GetProcessInfo()[DYNAMIC_TAU] = 0.1;
+    rModelPart.GetProcessInfo()[TURBULENCE_RANS_C_MU] = 0.09;
+    rModelPart.GetProcessInfo()[TURBULENT_KINETIC_ENERGY_SIGMA] = 0.98;
+    auto& node1 = rModelPart.GetNode(1);
+    node1.FastGetSolutionStepValue(DISTANCE) = 0.78;
+    node1.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.24;
+    node1.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_1) = 0.21;
+    node1.FastGetSolutionStepValue(RANS_Y_PLUS) = 217.;
+    node1.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 25.90;
+    node1.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 1.29;
+    node1.FastGetSolutionStepValue(VELOCITY_X) = -1.85;
+    node1.FastGetSolutionStepValue(VELOCITY_Y) = -2.15;
+    auto& node2 = rModelPart.GetNode(2);
+    node2.FastGetSolutionStepValue(DISTANCE) = 0.64;
+    node2.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.28;
+    node2.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_1) = 0.14;
+    node2.FastGetSolutionStepValue(RANS_Y_PLUS) = 265.;
+    node2.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 5.00;
+    node2.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 1.04;
+    node2.FastGetSolutionStepValue(VELOCITY_X) = -0.78;
+    node2.FastGetSolutionStepValue(VELOCITY_Y) = -0.06;
+    auto& node3 = rModelPart.GetNode(3);
+    node3.FastGetSolutionStepValue(DISTANCE) = 0.81;
+    node3.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.28;
+    node3.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_1) = 0.63;
+    node3.FastGetSolutionStepValue(RANS_Y_PLUS) = 233.;
+    node3.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 5.70;
+    node3.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 1.11;
+    node3.FastGetSolutionStepValue(VELOCITY_X) = 0.01;
+    node3.FastGetSolutionStepValue(VELOCITY_Y) = -0.65;
+    CheckEvmElementTestData<EvmLowReKElement<2, 3>>(
+        rModelPart.Elements().front(), rModelPart.GetProcessInfo());
+}
+
+void EvmLowReEpsilonElement2D3N_AssignTestData(ModelPart& rModelPart)
+{
+    rModelPart.GetProcessInfo()[BOSSAK_ALPHA] = -0.3;
+    rModelPart.GetProcessInfo()[DELTA_TIME] = 1.1;
+    rModelPart.GetProcessInfo()[DYNAMIC_TAU] = 0.1;
+    rModelPart.GetProcessInfo()[TURBULENCE_RANS_C1] = 1.44;
+    rModelPart.GetProcessInfo()[TURBULENCE_RANS_C2] = 1.92;
+    rModelPart.GetProcessInfo()[TURBULENCE_RANS_C_MU] = 0.09;
+    rModelPart.GetProcessInfo()[TURBULENT_ENERGY_DISSIPATION_RATE_SIGMA] = 1.3;
+    auto& node1 = rModelPart.GetNode(1);
+    node1.FastGetSolutionStepValue(DISTANCE) = 0.78;
+    node1.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.24;
+    node1.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_2) = 0.21;
+    node1.FastGetSolutionStepValue(RANS_Y_PLUS) = 217.;
+    node1.FastGetSolutionStepValue(TURBULENT_ENERGY_DISSIPATION_RATE) = 25.90;
+    node1.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 25.90;
+    node1.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 1.29;
+    node1.FastGetSolutionStepValue(VELOCITY_X) = -1.85;
+    node1.FastGetSolutionStepValue(VELOCITY_Y) = -2.15;
+    auto& node2 = rModelPart.GetNode(2);
+    node2.FastGetSolutionStepValue(DISTANCE) = 0.64;
+    node2.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.28;
+    node2.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_2) = 0.14;
+    node2.FastGetSolutionStepValue(RANS_Y_PLUS) = 265.;
+    node2.FastGetSolutionStepValue(TURBULENT_ENERGY_DISSIPATION_RATE) = 5.00;
+    node2.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 5.00;
+    node2.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 1.04;
+    node2.FastGetSolutionStepValue(VELOCITY_X) = -0.78;
+    node2.FastGetSolutionStepValue(VELOCITY_Y) = -0.06;
+    auto& node3 = rModelPart.GetNode(3);
+    node3.FastGetSolutionStepValue(DISTANCE) = 0.81;
+    node3.FastGetSolutionStepValue(KINEMATIC_VISCOSITY) = 0.28;
+    node3.FastGetSolutionStepValue(RANS_AUXILIARY_VARIABLE_2) = 0.63;
+    node3.FastGetSolutionStepValue(RANS_Y_PLUS) = 233.;
+    node3.FastGetSolutionStepValue(TURBULENT_ENERGY_DISSIPATION_RATE) = 5.70;
+    node3.FastGetSolutionStepValue(TURBULENT_KINETIC_ENERGY) = 5.70;
+    node3.FastGetSolutionStepValue(TURBULENT_VISCOSITY) = 0.90;
+    node3.FastGetSolutionStepValue(VELOCITY_X) = 0.01;
+    node3.FastGetSolutionStepValue(VELOCITY_Y) = -0.65;
+    CheckEvmElementTestData<EvmLowReEpsilonElement<2, 3>>(
+        rModelPart.Elements().front(), rModelPart.GetProcessInfo());
+}
+
+} // namespace
+
+KRATOS_TEST_CASE_IN_SUITE(EvmKElement2D3N_EquationIdVector, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmKElement2D3N_SetUp(model_part);
+    // Test:
+    auto& r_element = model_part.Elements().front();
+    auto eqn_ids = std::vector<std::size_t>{};
+    r_element.EquationIdVector(eqn_ids, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(eqn_ids.size(), r_element.GetGeometry().PointsNumber());
+    for (std::size_t i = 0; i < eqn_ids.size(); ++i)
+    {
+        KRATOS_CHECK_EQUAL(eqn_ids[i], i + 1);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmKElement2D3N_GetDofList, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmKElement2D3N_SetUp(model_part);
+    // Test:
+    auto& r_element = model_part.Elements().front();
+    auto dofs = Element::DofsVectorType{};
+    r_element.GetDofList(dofs, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(dofs.size(), r_element.GetGeometry().PointsNumber());
+    for (std::size_t i = 0; i < dofs.size(); ++i)
+    {
+        KRATOS_CHECK_EQUAL(dofs[i]->GetVariable(), TURBULENT_KINETIC_ENERGY);
+        KRATOS_CHECK_EQUAL(dofs[i]->EquationId(), i + 1);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmKElement2D3N_CalculateLocalSystem, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmKElement2D3N_SetUp(model_part);
+    EvmKElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix LHS;
+    Vector RHS;
+    r_element.CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(RHS.size(), 3);
+    KRATOS_CHECK_NEAR(RHS(0), 8.931069870805642, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(1), 3.338665106995264, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(2), 3.24946053021652, 1e-12);
+    KRATOS_CHECK_EQUAL(LHS.size1(), 3);
+    KRATOS_CHECK_EQUAL(LHS.size2(), 3);
+    for (std::size_t i = 0; i < LHS.size1(); ++i)
+        for (std::size_t j = 0; j < LHS.size1(); ++j)
+            KRATOS_CHECK_EQUAL(LHS(i, j), 0.0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmKElement2D3N_CalculateRightHandSide, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmKElement2D3N_SetUp(model_part);
+    EvmKElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Vector RHS;
+    r_element.CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(RHS.size(), 3);
+    KRATOS_CHECK_NEAR(RHS(0), 8.931069870805642, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(1), 3.338665106995264, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(2), 3.24946053021652, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmKElement2D3N_CalculateLocalVelocityContribution, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmKElement2D3N_SetUp(model_part);
+    EvmKElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Vector residual = ZeroVector(3);
+    Matrix D;
+    r_element.CalculateLocalVelocityContribution(D, residual, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(D.size1(), 3);
+    KRATOS_CHECK_EQUAL(D.size2(), 3);
+    KRATOS_CHECK_NEAR(D(0, 2), -1.432057866188581, 1e-12);
+    KRATOS_CHECK_NEAR(D(1, 2), -0.1205221881980917, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 0), -0.9683078661885811, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 1), -0.107605521531425, 1e-12);
+    KRATOS_CHECK_EQUAL(residual.size(), 3);
+    KRATOS_CHECK_NEAR(residual(0), -89.3402313479333, 1e-12);
+    KRATOS_CHECK_NEAR(residual(1), 17.94985325293971, 1e-12);
+    KRATOS_CHECK_NEAR(residual(2), 17.26466653284805, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmKElement2D3N_CalculateMassMatrix, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmKElement2D3N_SetUp(model_part);
+    EvmKElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix M;
+    r_element.CalculateMassMatrix(M, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(M.size1(), 3);
+    KRATOS_CHECK_EQUAL(M.size2(), 3);
+    KRATOS_CHECK_NEAR(M(0, 2), 0.06992709666295463, 1e-12);
+    KRATOS_CHECK_NEAR(M(1, 2), -0.0001535393757536118, 1e-12);
+    KRATOS_CHECK_NEAR(M(2, 0), -0.0156530410619832, 1e-12);
+    KRATOS_CHECK_NEAR(M(2, 1), -0.002696120305636151, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmKElement2D3N_CalculateDampingMatrix, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmKElement2D3N_SetUp(model_part);
+    EvmKElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix D;
+    r_element.CalculateDampingMatrix(D, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(D.size1(), 3);
+    KRATOS_CHECK_EQUAL(D.size2(), 3);
+    KRATOS_CHECK_NEAR(D(0, 2), -1.432057866188581, 1e-12);
+    KRATOS_CHECK_NEAR(D(1, 2), -0.1205221881980917, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 0), -0.9683078661885811, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 1), -0.107605521531425, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmEpsilonElement2D3N_EquationIdVector, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmEpsilonElement2D3N_SetUp(model_part);
+    // Test:
+    auto& r_element = model_part.Elements().front();
+    auto eqn_ids = std::vector<std::size_t>{};
+    r_element.EquationIdVector(eqn_ids, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(eqn_ids.size(), r_element.GetGeometry().PointsNumber());
+    for (std::size_t i = 0; i < eqn_ids.size(); ++i)
+    {
+        KRATOS_CHECK_EQUAL(eqn_ids[i], i + 1);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmEpsilonElement2D3N_GetDofList, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmEpsilonElement2D3N_SetUp(model_part);
+    // Test:
+    auto& r_element = model_part.Elements().front();
+    auto dofs = Element::DofsVectorType{};
+    r_element.GetDofList(dofs, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(dofs.size(), r_element.GetGeometry().PointsNumber());
+    for (std::size_t i = 0; i < dofs.size(); ++i)
+    {
+        KRATOS_CHECK_EQUAL(dofs[i]->GetVariable(), TURBULENT_ENERGY_DISSIPATION_RATE);
+        KRATOS_CHECK_EQUAL(dofs[i]->EquationId(), i + 1);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmEpsilonElement2D3N_CalculateLocalSystem, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmEpsilonElement2D3N_SetUp(model_part);
+    EvmEpsilonElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix LHS;
+    Vector RHS;
+    r_element.CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(RHS.size(), 3);
+    KRATOS_CHECK_NEAR(RHS(0), 15.78947633440115, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(1), 4.796390099035942, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(2), 4.712758721178501, 1e-12);
+    KRATOS_CHECK_EQUAL(LHS.size1(), 3);
+    KRATOS_CHECK_EQUAL(LHS.size2(), 3);
+    for (std::size_t i = 0; i < LHS.size1(); ++i)
+        for (std::size_t j = 0; j < LHS.size1(); ++j)
+            KRATOS_CHECK_EQUAL(LHS(i, j), 0.0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmEpsilonElement2D3N_CalculateRightHandSide, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmEpsilonElement2D3N_SetUp(model_part);
+    EvmEpsilonElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Vector RHS;
+    r_element.CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(RHS.size(), 3);
+    KRATOS_CHECK_NEAR(RHS(0), 15.78947633440115, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(1), 4.796390099035942, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(2), 4.712758721178501, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmEpsilonElement2D3N_CalculateLocalVelocityContribution, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmEpsilonElement2D3N_SetUp(model_part);
+    EvmEpsilonElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Vector residual = ZeroVector(3);
+    Matrix D;
+    r_element.CalculateLocalVelocityContribution(D, residual, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(D.size1(), 3);
+    KRATOS_CHECK_EQUAL(D.size2(), 3);
+    KRATOS_CHECK_NEAR(D(0, 2), -1.575168090032179, 1e-12);
+    KRATOS_CHECK_NEAR(D(1, 2), -0.05948928036177866, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 0), -1.111418090032179, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 1), -0.046572613695112, 1e-12);
+    KRATOS_CHECK_EQUAL(residual.size(), 3);
+    KRATOS_CHECK_NEAR(residual(0), -119.7645351753402, 1e-12);
+    KRATOS_CHECK_NEAR(residual(1), 18.70077056906936, 1e-12);
+    KRATOS_CHECK_NEAR(residual(2), 17.43249290638806, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmEpsilonElement2D3N_CalculateMassMatrix, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmEpsilonElement2D3N_SetUp(model_part);
+    EvmEpsilonElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix M;
+    r_element.CalculateMassMatrix(M, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(M.size1(), 3);
+    KRATOS_CHECK_EQUAL(M.size2(), 3);
+    KRATOS_CHECK_NEAR(M(0, 2), 0.07845874453020782, 1e-12);
+    KRATOS_CHECK_NEAR(M(1, 2), 0.01257718139417343, 1e-12);
+    KRATOS_CHECK_NEAR(M(2, 0), -0.000451866090935742, 1e-12);
+    KRATOS_CHECK_NEAR(M(2, 1), 0.01028818435474877, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmEpsilonElement2D3N_CalculateDampingMatrix, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmEpsilonElement2D3N_SetUp(model_part);
+    EvmEpsilonElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix D;
+    r_element.CalculateDampingMatrix(D, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(D.size1(), 3);
+    KRATOS_CHECK_EQUAL(D.size2(), 3);
+    KRATOS_CHECK_NEAR(D(0, 2), -1.575168090032179, 1e-12);
+    KRATOS_CHECK_NEAR(D(1, 2), -0.05948928036177866, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 0), -1.111418090032179, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 1), -0.046572613695112, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReKElement2D3N_EquationIdVector, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReKElement2D3N_SetUp(model_part);
+    // Test:
+    auto& r_element = model_part.Elements().front();
+    auto eqn_ids = std::vector<std::size_t>{};
+    r_element.EquationIdVector(eqn_ids, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(eqn_ids.size(), r_element.GetGeometry().PointsNumber());
+    for (std::size_t i = 0; i < eqn_ids.size(); ++i)
+    {
+        KRATOS_CHECK_EQUAL(eqn_ids[i], i + 1);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReKElement2D3N_GetDofList, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReKElement2D3N_SetUp(model_part);
+    // Test:
+    auto& r_element = model_part.Elements().front();
+    auto dofs = Element::DofsVectorType{};
+    r_element.GetDofList(dofs, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(dofs.size(), r_element.GetGeometry().PointsNumber());
+    for (std::size_t i = 0; i < dofs.size(); ++i)
+    {
+        KRATOS_CHECK_EQUAL(dofs[i]->GetVariable(), TURBULENT_KINETIC_ENERGY);
+        KRATOS_CHECK_EQUAL(dofs[i]->EquationId(), i + 1);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReKElement2D3N_CalculateLocalSystem, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReKElement2D3N_SetUp(model_part);
+    EvmLowReKElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix LHS;
+    Vector RHS;
+    r_element.CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(RHS.size(), 3);
+    KRATOS_CHECK_NEAR(RHS(0), 8.738920812983658, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(1), 2.827896338059268, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(2), 2.641938862593186, 1e-12);
+    KRATOS_CHECK_EQUAL(LHS.size1(), 3);
+    KRATOS_CHECK_EQUAL(LHS.size2(), 3);
+    for (std::size_t i = 0; i < LHS.size1(); ++i)
+        for (std::size_t j = 0; j < LHS.size1(); ++j)
+            KRATOS_CHECK_EQUAL(LHS(i, j), 0.0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReKElement2D3N_CalculateRightHandSide, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReKElement2D3N_SetUp(model_part);
+    EvmLowReKElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Vector RHS;
+    r_element.CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(RHS.size(), 3);
+    KRATOS_CHECK_NEAR(RHS(0), 8.738920812983658, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(1), 2.827896338059268, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(2), 2.641938862593186, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReKElement2D3N_CalculateLocalVelocityContribution, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReKElement2D3N_SetUp(model_part);
+    EvmLowReKElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Vector residual = ZeroVector(3);
+    Matrix D;
+    r_element.CalculateLocalVelocityContribution(D, residual, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(D.size1(), 3);
+    KRATOS_CHECK_EQUAL(D.size2(), 3);
+    KRATOS_CHECK_NEAR(D(0, 2), -1.303513193561065, 1e-12);
+    KRATOS_CHECK_NEAR(D(1, 2), -0.1248471552079134, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 0), -0.8397631935610654, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 1), -0.1119304885412467, 1e-12);
+    KRATOS_CHECK_EQUAL(residual.size(), 3);
+    KRATOS_CHECK_NEAR(residual(0), -73.94106369404125, 1e-12);
+    KRATOS_CHECK_NEAR(residual(1), 15.79852924684175, 1e-12);
+    KRATOS_CHECK_NEAR(residual(2), 15.70892686764402, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReKElement2D3N_CalculateMassMatrix, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReKElement2D3N_SetUp(model_part);
+    EvmLowReKElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix M;
+    r_element.CalculateMassMatrix(M, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(M.size1(), 3);
+    KRATOS_CHECK_EQUAL(M.size2(), 3);
+    KRATOS_CHECK_NEAR(M(0, 2), 0.06797702378211926, 1e-12);
+    KRATOS_CHECK_NEAR(M(1, 2), -0.006912979516536945, 1e-12);
+    KRATOS_CHECK_NEAR(M(2, 0), -0.02419682698818793, 1e-12);
+    KRATOS_CHECK_NEAR(M(2, 1), -0.009531438219569609, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReKElement2D3N_CalculateDampingMatrix, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReKElement2D3N_SetUp(model_part);
+    EvmLowReKElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix D;
+    r_element.CalculateDampingMatrix(D, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(D.size1(), 3);
+    KRATOS_CHECK_EQUAL(D.size2(), 3);
+    KRATOS_CHECK_NEAR(D(0, 2), -1.303513193561065, 1e-12);
+    KRATOS_CHECK_NEAR(D(1, 2), -0.1248471552079134, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 0), -0.8397631935610654, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 1), -0.1119304885412467, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReEpsilonElement2D3N_EquationIdVector, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmEpsilonElement2D3N_SetUp(model_part);
+    // Test:
+    auto& r_element = model_part.Elements().front();
+    auto eqn_ids = std::vector<std::size_t>{};
+    r_element.EquationIdVector(eqn_ids, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(eqn_ids.size(), r_element.GetGeometry().PointsNumber());
+    for (std::size_t i = 0; i < eqn_ids.size(); ++i)
+    {
+        KRATOS_CHECK_EQUAL(eqn_ids[i], i + 1);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReEpsilonElement2D3N_GetDofList, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReEpsilonElement2D3N_SetUp(model_part);
+    // Test:
+    auto& r_element = model_part.Elements().front();
+    auto dofs = Element::DofsVectorType{};
+    r_element.GetDofList(dofs, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(dofs.size(), r_element.GetGeometry().PointsNumber());
+    for (std::size_t i = 0; i < dofs.size(); ++i)
+    {
+        KRATOS_CHECK_EQUAL(dofs[i]->GetVariable(), TURBULENT_ENERGY_DISSIPATION_RATE);
+        KRATOS_CHECK_EQUAL(dofs[i]->EquationId(), i + 1);
+    }
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReEpsilonElement2D3N_CalculateLocalSystem, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReEpsilonElement2D3N_SetUp(model_part);
+    EvmLowReEpsilonElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix LHS;
+    Vector RHS;
+    r_element.CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(RHS.size(), 3);
+    KRATOS_CHECK_NEAR(RHS(0), 14.9463327382447, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(1), 2.336970141491049, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(2), 2.143795867326259, 1e-12);
+    KRATOS_CHECK_EQUAL(LHS.size1(), 3);
+    KRATOS_CHECK_EQUAL(LHS.size2(), 3);
+    for (std::size_t i = 0; i < LHS.size1(); ++i)
+        for (std::size_t j = 0; j < LHS.size1(); ++j)
+            KRATOS_CHECK_EQUAL(LHS(i, j), 0.0);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReEpsilonElement2D3N_CalculateRightHandSide, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReEpsilonElement2D3N_SetUp(model_part);
+    EvmLowReEpsilonElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Vector RHS;
+    r_element.CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(RHS.size(), 3);
+    KRATOS_CHECK_NEAR(RHS(0), 14.9463327382447, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(1), 2.336970141491049, 1e-12);
+    KRATOS_CHECK_NEAR(RHS(2), 2.143795867326259, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReEpsilonElement2D3N_CalculateLocalVelocityContribution,
+                          KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReEpsilonElement2D3N_SetUp(model_part);
+    EvmLowReEpsilonElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Vector residual = ZeroVector(3);
+    Matrix D;
+    r_element.CalculateLocalVelocityContribution(D, residual, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(D.size1(), 3);
+    KRATOS_CHECK_EQUAL(D.size2(), 3);
+    KRATOS_CHECK_NEAR(D(0, 2), -1.190174138289223, 1e-12);
+    KRATOS_CHECK_NEAR(D(1, 2), -0.1327141888471861, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 0), -0.7264241382892225, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 1), -0.1197975221805195, 1e-12);
+    KRATOS_CHECK_EQUAL(residual.size(), 3);
+    KRATOS_CHECK_NEAR(residual(0), -73.56101662819738, 1e-12);
+    KRATOS_CHECK_NEAR(residual(1), 14.17125569125546, 1e-12);
+    KRATOS_CHECK_NEAR(residual(2), 13.64919472880242, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReEpsilonElement2D3N_CalculateMassMatrix, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReEpsilonElement2D3N_SetUp(model_part);
+    EvmLowReEpsilonElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix M;
+    r_element.CalculateMassMatrix(M, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(M.size1(), 3);
+    KRATOS_CHECK_EQUAL(M.size2(), 3);
+    KRATOS_CHECK_NEAR(M(0, 2), 0.08480160861988212, 1e-12);
+    KRATOS_CHECK_NEAR(M(1, 2), -0.01083695752111572, 1e-12);
+    KRATOS_CHECK_NEAR(M(2, 0), -0.02674653001144693, 1e-12);
+    KRATOS_CHECK_NEAR(M(2, 1), -0.01381400849385327, 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(EvmLowReEpsilonElement2D3N_CalculateDampingMatrix, KratosRANSTestSuite)
+{
+    // Setup:
+    Model model;
+    auto& model_part = model.CreateModelPart("test");
+    EvmLowReEpsilonElement2D3N_SetUp(model_part);
+    EvmLowReEpsilonElement2D3N_AssignTestData(model_part);
+    auto& r_element = model_part.Elements().front();
+    // Test:
+    Matrix D;
+    r_element.CalculateDampingMatrix(D, model_part.GetProcessInfo());
+    KRATOS_CHECK_EQUAL(D.size1(), 3);
+    KRATOS_CHECK_EQUAL(D.size2(), 3);
+    KRATOS_CHECK_NEAR(D(0, 2), -1.190174138289223, 1e-12);
+    KRATOS_CHECK_NEAR(D(1, 2), -0.1327141888471861, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 0), -0.7264241382892225, 1e-12);
+    KRATOS_CHECK_NEAR(D(2, 1), -0.1197975221805195, 1e-12);
+}
+
+} // namespace Testing
+} // namespace Kratos.

--- a/applications/RANSModellingApplication/tests/run_cpp_unit_tests.py
+++ b/applications/RANSModellingApplication/tests/run_cpp_unit_tests.py
@@ -1,0 +1,9 @@
+from KratosMultiphysics import *
+from KratosMultiphysics.RANSModellingApplication import *
+
+def run():
+    Tester.SetVerbosity(Tester.Verbosity.TESTS_OUTPUTS)
+    Tester.RunTestSuite("KratosRANSTestSuite")
+
+if __name__ == '__main__':
+    run()

--- a/applications/RANSModellingApplication/tests/test_RANSModellingApplication.py
+++ b/applications/RANSModellingApplication/tests/test_RANSModellingApplication.py
@@ -11,6 +11,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 # Import the tests o test_classes to create the suites
 from evm_k_epsilon_tests import EvmKEpsilonTest
 from custom_process_tests import CustomProcessTest
+import run_cpp_unit_tests
 
 def AssembleTestSuites():
     ''' Populates the test suites to run.
@@ -59,6 +60,7 @@ def AssembleTestSuites():
 if __name__ == '__main__':
     KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
     KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning cpp unit tests ...")
+    run_cpp_unit_tests.run()
     KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished running cpp unit tests!")
 
     KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning mpi python tests ...")


### PR DESCRIPTION
The elements were implemented and validated by @sunethwarna. These system
matrix tests are added as a set of fast tests to detect errors when changing
internal implementation. Only the pubic interface of the derived elements is
tested. This allows implementation, including the base class, to change
provided the results are the same.

Some basic cleanup was done after adding the tests.