### PR TITLE
fix(HDF5): fixed issues with tests

### DIFF
--- a/applications/HDF5Application/tests/test_HDF5Application.py
+++ b/applications/HDF5Application/tests/test_HDF5Application.py
@@ -1,5 +1,7 @@
-import KratosMultiphysics.KratosUnittest as KratosUnittest
+import subprocess
 
+
+import KratosMultiphysics.KratosUnittest as KratosUnittest
 from test_hdf5_core import TestFileIO as TestHDF5FileIO
 from test_hdf5_core import TestOperations as TestHDF5Operations
 from test_hdf5_core import TestControllers as TestHDF5Controllers
@@ -13,11 +15,10 @@ from test_hdf5_xdmf import TestXdmfResults
 from test_hdf5_xdmf import TestTimeLabel
 from test_hdf5_xdmf import TestFindMatchingFiles
 from test_hdf5_xdmf import TestCreateXdmfTemporalGridFromMultifile
-import run_cpp_unit_tests
+
 
 def AssembleTestSuites():
     suites = KratosUnittest.KratosSuites
-
     smallSuite = suites['small']
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestHDF5FileIO]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestHDF5Operations]))
@@ -32,19 +33,27 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestTimeLabel]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestFindMatchingFiles]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCreateXdmfTemporalGridFromMultifile]))
-
     nightSuite = suites['nightly']
     nightSuite.addTests(smallSuite)
-
     allSuite = suites['all']
     allSuite.addTests([nightSuite])
-
     return suites
 
+
+def run_cpp_unit_tests():
+    """Run the c++ unit tests.
+
+    This runs a subprocess because the HDF5 used by h5py clashed with the HDF5
+    linked to the c++ unit tests on some systems. h5py is used by some XDMF tests.
+    """
+    return subprocess.check_output(['python3', 'run_cpp_unit_tests.py']).decode('utf-8')
+
+
 if __name__ == '__main__':
-    print("Running cpp unit tests ...")
-    run_cpp_unit_tests.run()
+    print("\nRunning cpp unit tests ...")
+    cpp_test_text = run_cpp_unit_tests()
+    print(cpp_test_text)
     print("Finished running cpp unit tests!")
-    print("Running python tests ...")
+    print("\nRunning python tests ...")
     KratosUnittest.runTests(AssembleTestSuites())
     print("Finished python tests!")

--- a/applications/HDF5Application/tests/test_hdf5_xdmf.py
+++ b/applications/HDF5Application/tests/test_hdf5_xdmf.py
@@ -70,23 +70,27 @@ class TestCreateXdmfSpatialGrid(KratosUnittest.TestCase):
 class TestXdmfNodalResults(KratosUnittest.TestCase):
 
     @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
-    def test_XdmfNodalResults(self):
+    def test_XdmfNodalResults1(self):
         with h5py.File("kratos.h5", "a", "core", backing_store=False) as f:
             f.create_dataset(
                 "/Results/NodalSolutionStepData/VELOCITY", (15, 3), "float64")
-            f.create_dataset(
-                "/Results/NodalDataValues/DENSITY", (15,), "float64")
             results = XdmfNodalResults(f["/Results"])
         self.assertEqual(results[0].name, "VELOCITY")
         self.assertEqual(results[0].data.file_name, "kratos.h5")
         self.assertEqual(results[0].data.name, "/Results/NodalSolutionStepData/VELOCITY")
         self.assertEqual(results[0].data.dtype, "float64")
         self.assertEqual(results[0].attribute_type, "Vector")
-        self.assertEqual(results[1].name, "DENSITY")
-        self.assertEqual(results[1].data.file_name, "kratos.h5")
-        self.assertEqual(results[1].data.name, "/Results/NodalDataValues/DENSITY")
-        self.assertEqual(results[1].data.dtype, "float64")
-        self.assertEqual(results[1].attribute_type, "Scalar")
+
+    def test_XdmfNodalResults2(self):
+        with h5py.File("kratos.h5", "a", "core", backing_store=False) as f:
+            f.create_dataset(
+                "/Results/NodalDataValues/DENSITY", (15,), "float64")
+            results = XdmfNodalResults(f["/Results"])
+        self.assertEqual(results[0].name, "DENSITY")
+        self.assertEqual(results[0].data.file_name, "kratos.h5")
+        self.assertEqual(results[0].data.name, "/Results/NodalDataValues/DENSITY")
+        self.assertEqual(results[0].data.dtype, "float64")
+        self.assertEqual(results[0].attribute_type, "Scalar")
 
     @KratosUnittest.skipIf(h5py == None, "this test requires h5py")
     def test_XdmfNodalResults_RepeatedVariableException(self):


### PR DESCRIPTION
After #5437, failing test were reported on some systems. These appear to
be caused by a clash between the HDF5 linked to the c++ tests and the
HDF5 used by h5py. We resolve the problem here by running the c++ tests
in a subprocess.

A test was occasionally failing due to an invalid assumption that the
constructed list of XDMF nodal results is partially ordered by the type
of nodal container. This splits the test to eliminate the bug.
Alternatively an ordered dictionary may be used in the implementation of
XdmfNodalResults().