### PR TITLE
[Core] Encapsulation of the prints showing the progress of the analysis

### DIFF
--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -128,6 +128,9 @@ class AnalysisStage(object):
         self.ChangeMaterialProperties() #this is normally empty
         self._GetSolver().InitializeSolutionStep()
 
+        self.PrintAnalysisStageProgressInformation()
+
+    def PrintAnalysisStageProgressInformation(self):
         KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "STEP: ", self._GetSolver().GetComputingModelPart().ProcessInfo[KratosMultiphysics.STEP])
         KratosMultiphysics.Logger.PrintInfo(self._GetSimulationName(), "TIME: ", self.time)
 


### PR DESCRIPTION
For applications where the time step is very small, this print is very annoying. For example we do not print every time step in DEM, but one out of many.
I am proposing this encapsulation in a method, such that it can be overriden by the derived classes and customized.