### PR TITLE
Core/components remove

### DIFF
--- a/kratos/includes/kratos_components.h
+++ b/kratos/includes/kratos_components.h
@@ -87,6 +87,12 @@ public:
         msComponents.insert(ValueType(Name , &ThisComponent));
     }
 
+    static void Remove(std::string const& Name)
+    {
+        std::size_t num_erased = msComponents.erase(Name);
+        KRATOS_ERROR_IF(num_erased == 0) << "Trying to remove inexistent component \"" << Name << "\"." << std::endl;
+    }
+
     static TComponentType const& Get(std::string const& Name)
     {
         auto it_comp =  msComponents.find(Name);
@@ -285,6 +291,12 @@ public:
     static void Add(std::string const& Name, VariableData& ThisComponent)
     {
         msComponents.insert(ValueType(Name, &ThisComponent));
+    }
+
+    static void Remove(std::string const& Name)
+    {
+        std::size_t num_erased = msComponents.erase(Name);
+        KRATOS_ERROR_IF(num_erased == 0) << "Trying to remove inexistent component \"" << Name << "\"." << std::endl;
     }
 
     static std::size_t Size()

--- a/kratos/tests/cpp_tests/sources/test_kratos_components.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_components.cpp
@@ -68,5 +68,33 @@ KRATOS_TEST_CASE_IN_SUITE(KratosComponentsAddDifferentObjectsSameName, KratosCor
     KRATOS_CHECK_EXCEPTION_IS_THROWN(KratosComponents<Condition>::Add("dummy_1", dummy_2), "Error: An object of different type was already registered with name \"dummy_1\"");
 }
 
+KRATOS_TEST_CASE_IN_SUITE(KratosComponentsRemove, KratosCoreFastSuite)
+{
+    DummyCondition1 remove_dummy;
+    std::string registered_name("RemoveTestDummy");
+
+    // First we add the condition
+    KratosComponents<Condition>::Add(registered_name, remove_dummy);
+    KRATOS_CHECK(KratosComponents<Condition>::Has(registered_name));
+
+    // Then we remove it
+    KratosComponents<Condition>::Remove(registered_name);
+    KRATOS_CHECK_IS_FALSE(KratosComponents<Condition>::Has(registered_name));
+
+    // We can still register another object with the same name
+    DummyCondition1 another_dummy;
+    KratosComponents<Condition>::Add(registered_name, another_dummy);
+    KRATOS_CHECK(KratosComponents<Condition>::Has(registered_name));
+
+    // If we try to remove things that do not exist, we get an error
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        KratosComponents<Condition>::Remove("WrongName"),
+        "Error: Trying to remove inexistent component \"WrongName\"."
+    );
+
+    // Clean up after ourselves
+    KratosComponents<Condition>::Remove(registered_name);
+}
+
 }
 }  // namespace Kratos.

--- a/kratos/tests/cpp_tests/sources/test_kratos_components.cpp
+++ b/kratos/tests/cpp_tests/sources/test_kratos_components.cpp
@@ -66,6 +66,10 @@ KRATOS_TEST_CASE_IN_SUITE(KratosComponentsAddDifferentObjectsSameName, KratosCor
 
     // registering the a different object with the name - NOT OK, this is UNDEFINED BEHAVIOR, we don't know what we get when we query the name
     KRATOS_CHECK_EXCEPTION_IS_THROWN(KratosComponents<Condition>::Add("dummy_1", dummy_2), "Error: An object of different type was already registered with name \"dummy_1\"");
+
+    // Clean up after ourselves
+    KratosComponents<Condition>::Remove("dummy_1");
+    KratosComponents<Condition>::Remove("dummy_1111");
 }
 
 KRATOS_TEST_CASE_IN_SUITE(KratosComponentsRemove, KratosCoreFastSuite)


### PR DESCRIPTION
Adding the possibility to unregister objects from KratosComponents. I need it to be able to remove `DataCommunicator` objects from the MPICore once the underlying `MPI_Comm` object is freed.