### PR TITLE
[core] amgcl upstream updates and ilu0 robustness on GPUs

### DIFF
--- a/applications/TrilinosApplication/amgcl_mpi_solver_impl.cpp
+++ b/applications/TrilinosApplication/amgcl_mpi_solver_impl.cpp
@@ -187,7 +187,7 @@ void AMGCLSolve(
     TrilinosSpace<Epetra_FECrsMatrix, Epetra_FEVector>::VectorType& rB,
     TrilinosSpace<Epetra_FECrsMatrix, Epetra_FEVector>::IndexType& rIterationNumber,
     double& rResidual,
-    const boost::property_tree::ptree &amgclParams,
+    boost::property_tree::ptree amgclParams,
     int verbosity_level,
     bool use_gpgpu
     )

--- a/external_libraries/amgcl/adapter/crs_tuple.hpp
+++ b/external_libraries/amgcl/adapter/crs_tuple.hpp
@@ -46,9 +46,9 @@ int    *col;
 double *val;
 
 AMG amg(std::make_tuple(n,
-                          boost::make_iterator_range(ptr, ptr + n + 1),
-                          boost::make_iterator_range(col, col + ptr[n]),
-                          boost::make_iterator_range(val, val + ptr[n])
+                          amgcl::make_iterator_range(ptr, ptr + n + 1),
+                          amgcl::make_iterator_range(col, col + ptr[n]),
+                          amgcl::make_iterator_range(val, val + ptr[n])
                           ) );
 \endcode
 */

--- a/external_libraries/amgcl/adapter/ublas.hpp
+++ b/external_libraries/amgcl/adapter/ublas.hpp
@@ -33,7 +33,6 @@ THE SOFTWARE.
 \ingroup adapters
 */
 
-#include <boost/range/iterator_range.hpp>
 #include <boost/numeric/ublas/vector.hpp>
 #include <boost/numeric/ublas/matrix_sparse.hpp>
 #include <amgcl/backend/builtin.hpp>
@@ -51,20 +50,20 @@ struct is_builtin_vector< boost::numeric::ublas::vector<T> >
 template <typename T>
 std::tuple<
     size_t,
-    boost::iterator_range<const size_t*>,
-    boost::iterator_range<const size_t*>,
-    boost::iterator_range<const T*>
+    iterator_range<const size_t*>,
+    iterator_range<const size_t*>,
+    iterator_range<const T*>
     >
 map(const boost::numeric::ublas::compressed_matrix<T, boost::numeric::ublas::row_major> &A) {
     return std::make_tuple(
             A.size1(),
-            boost::make_iterator_range(
+            make_iterator_range(
                 A.index1_data().begin(), A.index1_data().end()
                 ),
-            boost::make_iterator_range(
+            make_iterator_range(
                 A.index2_data().begin(), A.index2_data().end()
                 ),
-            boost::make_iterator_range(
+            make_iterator_range(
                 A.value_data().begin(), A.value_data().end()
                 )
             );

--- a/external_libraries/amgcl/backend/builtin.hpp
+++ b/external_libraries/amgcl/backend/builtin.hpp
@@ -1198,6 +1198,9 @@ namespace amgcl {
 namespace backend {
 
 template <class Iterator>
+struct is_builtin_vector< amgcl::iterator_range<Iterator> > : std::true_type {};
+
+template <class Iterator>
 struct is_builtin_vector< boost::iterator_range<Iterator> > : std::true_type {};
 
 } // namespace backend

--- a/external_libraries/amgcl/backend/detail/matrix_ops.hpp
+++ b/external_libraries/amgcl/backend/detail/matrix_ops.hpp
@@ -86,7 +86,10 @@ template <class Matrix, class Vector1, class Vector2, class Vector3>
 struct residual_impl<
     Matrix, Vector1, Vector2, Vector3,
     typename std::enable_if<
-        detail::use_builtin_matrix_ops<Matrix>::value
+        detail::use_builtin_matrix_ops<Matrix>::value &&
+        math::static_rows<typename value_type<Matrix>::type>::value == math::static_rows<typename value_type<Vector1>::type>::value &&
+        math::static_rows<typename value_type<Matrix>::type>::value == math::static_rows<typename value_type<Vector2>::type>::value &&
+        math::static_rows<typename value_type<Matrix>::type>::value == math::static_rows<typename value_type<Vector3>::type>::value
         >::type
     >
 {
@@ -108,6 +111,81 @@ struct residual_impl<
                 sum += a.value() * x[ a.col() ];
             res[i] = rhs[i] - sum;
         }
+    }
+};
+
+/* Allows to do matrix-vector products with mixed scalar/nonscalar types.
+ * Reinterprets pointers to the vectors data into appropriate types.
+ */
+template <class Alpha, class Matrix, class Vector1, class Beta, class Vector2>
+struct spmv_impl<
+    Alpha, Matrix, Vector1, Beta, Vector2,
+    typename std::enable_if<
+            detail::use_builtin_matrix_ops<Matrix>::value && (
+            math::static_rows<typename value_type<Matrix>::type>::value != math::static_rows<typename value_type<Vector1>::type>::value ||
+            math::static_rows<typename value_type<Matrix>::type>::value != math::static_rows<typename value_type<Vector2>::type>::value)
+        >::type
+    >
+{
+    static void apply(
+            Alpha alpha, const Matrix &A, const Vector1 &x, Beta beta, Vector2 &y
+            )
+    {
+        typedef typename value_type<Matrix>::type     val_type;
+        typedef typename math::rhs_of<val_type>::type rhs_type;
+        typedef typename math::replace_scalar<rhs_type, typename math::scalar_of<typename value_type<Vector1>::type>::type>::type x_type;
+        typedef typename math::replace_scalar<rhs_type, typename math::scalar_of<typename value_type<Vector2>::type>::type>::type y_type;
+
+        const size_t n = backend::rows(A);
+        const size_t m = backend::cols(A);
+
+        x_type const * xptr = reinterpret_cast<x_type const *>(&x[0]);
+        y_type       * yptr = reinterpret_cast<y_type       *>(&y[0]);
+
+        iterator_range<x_type const *> xrng(xptr, xptr + m);
+        iterator_range<y_type       *> yrng(yptr, yptr + n);
+
+        spmv(alpha, A, xrng, beta, yrng);
+    }
+};
+
+template <class Matrix, class Vector1, class Vector2, class Vector3>
+struct residual_impl<
+    Matrix, Vector1, Vector2, Vector3,
+    typename std::enable_if<
+            detail::use_builtin_matrix_ops<Matrix>::value && (
+            math::static_rows<typename value_type<Matrix>::type>::value != math::static_rows<typename value_type<Vector1>::type>::value ||
+            math::static_rows<typename value_type<Matrix>::type>::value != math::static_rows<typename value_type<Vector2>::type>::value ||
+            math::static_rows<typename value_type<Matrix>::type>::value != math::static_rows<typename value_type<Vector3>::type>::value)
+        >::type
+    >
+{
+    static void apply(
+            Vector1 const &f,
+            Matrix  const &A,
+            Vector2 const &x,
+            Vector3       &r
+            )
+    {
+        typedef typename value_type<Matrix>::type     val_type;
+        typedef typename math::rhs_of<val_type>::type rhs_type;
+
+        typedef typename math::replace_scalar<rhs_type, typename math::scalar_of<typename value_type<Vector1>::type>::type>::type f_type;
+        typedef typename math::replace_scalar<rhs_type, typename math::scalar_of<typename value_type<Vector2>::type>::type>::type x_type;
+        typedef typename math::replace_scalar<rhs_type, typename math::scalar_of<typename value_type<Vector3>::type>::type>::type r_type;
+
+        const size_t n = backend::rows(A);
+        const size_t m = backend::cols(A);
+
+        x_type const * xptr = reinterpret_cast<x_type const *>(&x[0]);
+        f_type const * fptr = reinterpret_cast<f_type const *>(&f[0]);
+        r_type       * rptr = reinterpret_cast<r_type       *>(&r[0]);
+
+        iterator_range<x_type const *> xrng(xptr, xptr + m);
+        iterator_range<f_type const *> frng(fptr, fptr + n);
+        iterator_range<r_type       *> rrng(rptr, rptr + n);
+
+        residual(frng, A, xrng, rrng);
     }
 };
 

--- a/external_libraries/amgcl/make_block_solver.hpp
+++ b/external_libraries/amgcl/make_block_solver.hpp
@@ -5,43 +5,11 @@
 #include <amgcl/adapter/block_matrix.hpp>
 #include <amgcl/value_type/static_matrix.hpp>
 #include <amgcl/make_solver.hpp>
+#include <amgcl/util.hpp>
 
 namespace amgcl {
 
 namespace backend {
-
-/* Allows to do matrix-vector products with mixed scalar/nonscalar types.
- * Reinterprets pointers to the vectors data into appropriate types.
- */
-template <class Alpha, class Matrix, class Vector1, class Beta, class Vector2>
-struct spmv_impl<
-    Alpha, Matrix, Vector1, Beta, Vector2,
-    typename std::enable_if<
-            detail::use_builtin_matrix_ops<Matrix>::value && (
-            math::static_rows<typename value_type<Matrix>::type>::value != math::static_rows<typename value_type<Vector1>::type>::value ||
-            math::static_rows<typename value_type<Matrix>::type>::value != math::static_rows<typename value_type<Vector2>::type>::value)
-        >::type
-    >
-{
-    static void apply(
-            Alpha alpha, const Matrix &A, const Vector1 &x, Beta beta, Vector2 &y
-            )
-    {
-        typedef typename value_type<Matrix>::type     val_type;
-        typedef typename math::rhs_of<val_type>::type rhs_type;
-
-        const size_t n = backend::rows(A);
-        const size_t m = backend::cols(A);
-
-        rhs_type const * xptr = reinterpret_cast<rhs_type const *>(&x[0]);
-        rhs_type       * yptr = reinterpret_cast<rhs_type       *>(&y[0]);
-
-        boost::iterator_range<rhs_type const *> xrng(xptr, xptr + m);
-        boost::iterator_range<rhs_type       *> yrng(yptr, yptr + n);
-
-        spmv(alpha, A, xrng, beta, yrng);
-    }
-};
 
 } // namespace backend
 
@@ -79,8 +47,8 @@ class make_block_solver {
             rhs_type const * fptr = reinterpret_cast<rhs_type const *>(&rhs[0]);
             rhs_type       * xptr = reinterpret_cast<rhs_type       *>(&x[0]);
 
-            boost::iterator_range<rhs_type const *> frng(fptr, fptr + n);
-            boost::iterator_range<rhs_type       *> xrng(xptr, xptr + n);
+            iterator_range<rhs_type const *> frng(fptr, fptr + n);
+            iterator_range<rhs_type       *> xrng(xptr, xptr + n);
 
             return (*S)(A, frng, xrng);
         }
@@ -93,8 +61,8 @@ class make_block_solver {
             rhs_type const * fptr = reinterpret_cast<rhs_type const *>(&rhs[0]);
             rhs_type       * xptr = reinterpret_cast<rhs_type       *>(&x[0]);
 
-            boost::iterator_range<rhs_type const *> frng(fptr, fptr + n);
-            boost::iterator_range<rhs_type       *> xrng(xptr, xptr + n);
+            iterator_range<rhs_type const *> frng(fptr, fptr + n);
+            iterator_range<rhs_type       *> xrng(xptr, xptr + n);
 
             return (*S)(frng, xrng);
         }

--- a/external_libraries/amgcl/make_solver.hpp
+++ b/external_libraries/amgcl/make_solver.hpp
@@ -177,6 +177,11 @@ class make_solver : public amgcl::detail::non_copyable {
             return P;
         }
 
+        /// Returns reference to the constructed preconditioner.
+        Precond& precond() {
+            return P;
+        }
+
         /// Returns reference to the constructed iterative solver.
         const IterativeSolver& solver() const {
             return S;

--- a/external_libraries/amgcl/preconditioner/cpr.hpp
+++ b/external_libraries/amgcl/preconditioner/cpr.hpp
@@ -43,21 +43,35 @@ namespace preconditioner {
 template <class PPrecond, class SPrecond>
 class cpr {
     static_assert(
-            std::is_same<
+            math::static_rows<typename PPrecond::backend_type::value_type>::value == 1,
+            "Pressure backend should have scalar value type!"
+            );
+
+    static_assert(
+            backend::backends_compatible<
                 typename PPrecond::backend_type,
                 typename SPrecond::backend_type
                 >::value,
-            "Backends for pressure and flow preconditioners should coinside!"
+            "Backends for pressure and flow preconditioners should coincide!"
             );
+
     public:
-        typedef typename PPrecond::backend_type backend_type;
+        typedef typename SPrecond::backend_type backend_type;
+        typedef typename PPrecond::backend_type backend_type_p;
 
-        typedef typename backend_type::value_type value_type;
-        typedef typename backend_type::matrix     matrix;
-        typedef typename backend_type::vector     vector;
-        typedef typename backend_type::params     backend_params;
+        typedef typename backend_type::value_type   value_type;
+        typedef typename backend_type::matrix       matrix;
+        typedef typename backend_type::vector       vector;
+        typedef typename backend_type_p::value_type value_type_p;
+        typedef typename backend_type_p::matrix     matrix_p;
+        typedef typename backend_type_p::vector     vector_p;
 
-        typedef typename backend::builtin<value_type>::matrix build_matrix;
+        typedef typename backend_type::params       backend_params;
+
+        typedef typename backend::builtin<value_type>::matrix   build_matrix;
+        typedef typename backend::builtin<value_type_p>::matrix build_matrix_p;
+
+        typedef typename math::scalar_of<value_type>::type scalar_type;
 
         struct params {
             typedef typename PPrecond::params pprecond_params;
@@ -69,7 +83,9 @@ class cpr {
             int    block_size;
             size_t active_rows;
 
-            params() : block_size(2), active_rows(0) {}
+            params()
+                : block_size(math::static_rows<value_type>::value == 1 ? 2 : math::static_rows<value_type>::value),
+                  active_rows(0) {}
 
 #ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
@@ -98,25 +114,31 @@ class cpr {
                 const backend_params &bprm = backend_params()
            ) : prm(prm), n(backend::rows(K))
         {
-            init(std::make_shared<build_matrix>(K), bprm);
+            init(std::make_shared<build_matrix>(K), bprm,
+                    std::integral_constant<bool, math::static_rows<value_type>::value == 1>());
         }
 
         cpr(
                 std::shared_ptr<build_matrix> K,
                 const params &prm = params(),
-                const backend_params bprm = backend_params()
+                const backend_params &bprm = backend_params()
            ) : prm(prm), n(backend::rows(*K))
         {
-            init(K, bprm);
+            init(K, bprm,
+                    std::integral_constant<bool, math::static_rows<value_type>::value == 1>());
         }
 
         template <class Vec1, class Vec2>
         void apply(const Vec1 &rhs, Vec2 &&x) const {
+            AMGCL_TIC("sprecond");
             S->apply(rhs, x);
+            AMGCL_TOC("sprecond");
             backend::residual(rhs, S->system_matrix(), x, *rs);
 
             backend::spmv(1, *Fpp, *rs, 0, *rp);
+            AMGCL_TIC("pprecond");
             P->apply(*rp, *xp);
+            AMGCL_TOC("pprecond");
 
             backend::spmv(1, *Scatter, *xp, 1, x);
         }
@@ -129,37 +151,64 @@ class cpr {
             return S->system_matrix();
         }
 
+        template <class Matrix>
+        void partial_update(
+                const Matrix &K,
+                bool update_transfer_ops = true,
+                const backend_params &bprm = backend_params()
+              )
+        {
+            auto K_ptr = std::make_shared<build_matrix>(K);
+            // Update global preconditioner
+            S = std::make_shared<SPrecond>(K_ptr, prm.sprecond, bprm);
+            if(update_transfer_ops){
+              // Update transfer operator Fpp
+              update_transfer(
+                  K_ptr,
+                  bprm,
+                  std::integral_constant<bool, math::static_rows<value_type>::value == 1>()
+                );
+            }
+        }
+
     private:
         size_t n, np;
 
         std::shared_ptr<PPrecond> P;
         std::shared_ptr<SPrecond> S;
 
-        std::shared_ptr<matrix> Fpp, Scatter;
-        std::shared_ptr<vector> rp, xp, rs;
+        std::shared_ptr<matrix_p> Fpp, Scatter;
+        std::shared_ptr<vector>   rs;
+        std::shared_ptr<vector_p> rp, xp;
 
-        void init(std::shared_ptr<build_matrix> K, const backend_params bprm)
-        {
+        // Returns pressure transfer operator fpp and (optionally)
+        // partially constructed pressure system matrix App.
+        std::tuple<std::shared_ptr<build_matrix_p>, std::shared_ptr<build_matrix_p>>
+        first_scalar_pass(std::shared_ptr<build_matrix> K, bool get_app = true) {
             typedef typename backend::row_iterator<build_matrix>::type row_iterator;
             const int       B = prm.block_size;
             const ptrdiff_t N = (prm.active_rows ? prm.active_rows : n);
 
             np = N / B;
 
-            auto fpp = std::make_shared<build_matrix>();
-            fpp->set_size(np, n);
-            fpp->set_nonzeros(n);
+            auto fpp = std::make_shared<build_matrix_p>();
+            fpp->set_size(np, N);
+            fpp->set_nonzeros(N);
             fpp->ptr[0] = 0;
 
-            auto App = std::make_shared<build_matrix>();
-            App->set_size(np, np, true);
+            std::shared_ptr<build_matrix_p> App;
+
+            if (get_app) {
+                App = std::make_shared<build_matrix>();
+                App->set_size(np, np, true);
+            }
 
             // Get the pressure matrix nonzero pattern,
             // extract and invert block diagonals.
 #pragma omp parallel
             {
                 std::vector<row_iterator> k; k.reserve(B);
-                multi_array<value_type, 2> v(B, B);
+                multi_array<scalar_type, 2> v(B, B);
 
 #pragma omp for
                 for(ptrdiff_t ip = 0; ip < static_cast<ptrdiff_t>(np); ++ip) {
@@ -186,7 +235,7 @@ class cpr {
                     fpp->ptr[ip+1] = ik + B;
 
                     while (!done) {
-                        ++App->ptr[ip+1];
+                        if (get_app) ++App->ptr[ip+1];
 
                         ptrdiff_t end = (cur_col + 1) * B;
 
@@ -201,7 +250,9 @@ class cpr {
                                 for(; k[i] && k[i].col() < end; ++k[i])
                                     v(k[i].col() % B, i) = k[i].value();
 
-                            invert(v, &fpp->val[ik]);
+                            invert(v.data(), &fpp->val[ik]);
+
+                            if (!get_app) break;
                         } else {
                             // This is off-diagonal block.
                             // Just skip it.
@@ -226,9 +277,25 @@ class cpr {
                 }
             }
 
-            App->set_nonzeros(App->scan_row_sizes());
+            if (get_app)
+                App->set_nonzeros(App->scan_row_sizes());
 
-            auto scatter = std::make_shared<build_matrix>();
+            return std::make_tuple(fpp, App);
+        }
+
+        // The system matrix has scalar values
+        void init(std::shared_ptr<build_matrix> K, const backend_params bprm, std::true_type)
+        {
+            typedef typename backend::row_iterator<build_matrix>::type row_iterator;
+            const int       B = prm.block_size;
+            const ptrdiff_t N = (prm.active_rows ? prm.active_rows : n);
+
+            np = N / B;
+
+            std::shared_ptr<build_matrix_p> fpp, App;
+            std::tie(fpp, App) = first_scalar_pass(K);
+
+            auto scatter = std::make_shared<build_matrix_p>();
             scatter->set_size(n, np);
             scatter->set_nonzeros(np);
             scatter->ptr[0] = 0;
@@ -244,7 +311,7 @@ class cpr {
                     bool      done = true;
                     ptrdiff_t cur_col;
 
-                    value_type *d = &fpp->val[ik];
+                    value_type_p *d = &fpp->val[ik];
 
                     k.clear();
                     for(int i = 0; i < B; ++i) {
@@ -262,8 +329,8 @@ class cpr {
                     }
 
                     while (!done) {
-                        ptrdiff_t  end = (cur_col + 1) * B;
-                        value_type app = 0;
+                        ptrdiff_t    end = (cur_col + 1) * B;
+                        value_type_p app = 0;
 
                         for(int i = 0; i < B; ++i) {
                             for(; k[i] && k[i].col() < end; ++k[i]) {
@@ -293,7 +360,7 @@ class cpr {
                     }
 
                     scatter->col[ip] = ip;
-                    scatter->val[ip] = math::identity<value_type>();
+                    scatter->val[ip] = math::identity<value_type_p>();
 
                     ptrdiff_t nnz = ip;
                     for(int i = 0; i < B; ++i) {
@@ -306,48 +373,170 @@ class cpr {
             for(size_t i = N; i < n; ++i)
                 scatter->ptr[i+1] = scatter->ptr[i];
 
+            AMGCL_TIC("pprecond");
             P = std::make_shared<PPrecond>(App, prm.pprecond, bprm);
+            AMGCL_TOC("pprecond");
+            AMGCL_TIC("sprecond");
             S = std::make_shared<SPrecond>(K,   prm.sprecond, bprm);
+            AMGCL_TOC("sprecond");
 
-            Fpp     = backend_type::copy_matrix(fpp, bprm);
-            Scatter = backend_type::copy_matrix(scatter, bprm);
+            Fpp     = backend_type_p::copy_matrix(fpp, bprm);
+            Scatter = backend_type_p::copy_matrix(scatter, bprm);
 
-            rp = backend_type::create_vector(np, bprm);
-            xp = backend_type::create_vector(np, bprm);
+            rp = backend_type_p::create_vector(np, bprm);
+            xp = backend_type_p::create_vector(np, bprm);
             rs = backend_type::create_vector(n, bprm);
+        }
+
+        void update_transfer(std::shared_ptr<build_matrix> K, const backend_params bprm, std::true_type)
+        {
+            auto fpp = std::get<0>(first_scalar_pass(K, /*get_app*/false));
+            Fpp = backend_type_p::copy_matrix(fpp, bprm);
+        }
+
+        // The system matrix has block values
+        void init(std::shared_ptr<build_matrix> K, const backend_params bprm, std::false_type)
+        {
+            const int       B = math::static_rows<value_type>::value;
+            const ptrdiff_t N = (prm.active_rows ? prm.active_rows : n);
+
+            np = N;
+
+            auto fpp = std::make_shared<build_matrix_p>();
+            fpp->set_size(np, np * B);
+            fpp->set_nonzeros(np * B);
+            fpp->ptr[0] = 0;
+
+            auto scatter = std::make_shared<build_matrix_p>();
+            scatter->set_size(np * B, np);
+            scatter->set_nonzeros(np);
+            scatter->ptr[0] = 0;
+
+            auto App = std::make_shared<build_matrix_p>();
+            App->set_size(np, np, true);
+            App->set_nonzeros(K->nnz);
+            App->ptr[0] = 0;
+
+#pragma omp parallel for
+            for (ptrdiff_t i = 0; i < static_cast<ptrdiff_t>(np); ++i) {
+                ptrdiff_t ik = i * B;
+                for(int k = 0; k < B; ++k, ++ik) {
+                    fpp->col[ik] = ik;
+                    scatter->ptr[ik + 1] = i + 1;
+                }
+
+                fpp->ptr[i + 1] = ik;
+                scatter->col[i] = i;
+                scatter->val[i] = math::identity<value_type_p>();
+
+                ptrdiff_t row_beg = K->ptr[i];
+                ptrdiff_t row_end = K->ptr[i + 1];
+                App->ptr[i+1] = row_end;
+
+                // Extract and invert block diagonals
+                value_type_p *d = &fpp->val[i * B];
+                for(ptrdiff_t j = row_beg; j < row_end; ++j) {
+                    if (K->col[j] == i) {
+                        value_type v = math::adjoint(K->val[j]);
+                        invert(v.data(), d);
+                        break;
+                    }
+                }
+
+                for(ptrdiff_t j = row_beg; j < row_end; ++j) {
+                    value_type_p app = 0;
+                    for(int k = 0; k < B; ++k)
+                        app += d[k] * K->val[j](k,0);
+
+                    App->col[j] = K->col[j];
+                    App->val[j] = app;
+                }
+            }
+
+            AMGCL_TIC("pprecond");
+            P = std::make_shared<PPrecond>(App, prm.pprecond, bprm);
+            AMGCL_TOC("pprecond");
+            AMGCL_TIC("sprecond");
+            S = std::make_shared<SPrecond>(K,   prm.sprecond, bprm);
+            AMGCL_TOC("sprecond");
+
+
+            Fpp     = backend_type_p::copy_matrix(fpp, bprm);
+            Scatter = backend_type_p::copy_matrix(scatter, bprm);
+
+            rp = backend_type_p::create_vector(np, bprm);
+            xp = backend_type_p::create_vector(np, bprm);
+            rs = backend_type::create_vector(n, bprm);
+        }
+
+        void update_transfer(std::shared_ptr<build_matrix> K, const backend_params bprm, std::false_type)
+        {
+            const int       B = math::static_rows<value_type>::value;
+            const ptrdiff_t N = (prm.active_rows ? prm.active_rows : n);
+
+            np = N;
+
+            auto fpp = std::make_shared<build_matrix_p>();
+            fpp->set_size(np, np * B);
+            fpp->set_nonzeros(np * B);
+            fpp->ptr[0] = 0;
+
+#pragma omp parallel for
+            for (ptrdiff_t i = 0; i < static_cast<ptrdiff_t>(np); ++i) {
+                ptrdiff_t ik = i * B;
+                for(int k = 0; k < B; ++k, ++ik) {
+                    fpp->col[ik] = ik;
+                }
+
+                fpp->ptr[i + 1] = ik;
+
+                ptrdiff_t row_beg = K->ptr[i];
+                ptrdiff_t row_end = K->ptr[i + 1];
+
+                // Extract and invert block diagonals
+                value_type_p *d = &fpp->val[i * B];
+                for(ptrdiff_t j = row_beg; j < row_end; ++j) {
+                    if (K->col[j] == i) {
+                        value_type v = math::adjoint(K->val[j]);
+                        invert(v.data(), d);
+                        break;
+                    }
+                }
+            }
+            Fpp = backend_type_p::copy_matrix(fpp, bprm);
         }
 
         // Inverts dense matrix A;
         // Returns the first column of the inverted matrix.
-        void invert(multi_array<value_type, 2> &A, value_type *y)
+        void invert(scalar_type *A, value_type_p *y)
         {
-            const int B = prm.block_size;
+            const int B = math::static_rows<value_type>::value == 1 ? prm.block_size : math::static_rows<value_type>::value;
 
             // Perform LU-factorization of A in-place
             for(int k = 0; k < B; ++k) {
-                value_type d = A(k,k);
+                scalar_type d = A[k*B+k];
                 assert(!math::is_zero(d));
                 for(int i = k+1; i < B; ++i) {
-                    A(i,k) /= d;
+                    A[i*B+k] /= d;
                     for(int j = k+1; j < B; ++j)
-                        A(i,j) -= A(i,k) * A(k,j);
+                        A[i*B+j] -= A[i*B+k] * A[k*B+j];
                 }
             }
 
             // Invert unit vector in-place.
             // Lower triangular solve:
             for(int i = 0; i < B; ++i) {
-                value_type b = static_cast<value_type>(i == 0);
+                value_type_p b = static_cast<value_type_p>(i == 0);
                 for(int j = 0; j < i; ++j)
-                    b -= A(i,j) * y[j];
+                    b -= A[i*B+j] * y[j];
                 y[i] = b;
             }
 
             // Upper triangular solve:
             for(int i = B; i --> 0; ) {
                 for(int j = i+1; j < B; ++j)
-                    y[i] -= A(i,j) * y[j];
-                y[i] /= A(i,i);
+                    y[i] -= A[i*B+j] * y[j];
+                y[i] /= A[i*B+i];
             }
         }
 

--- a/external_libraries/amgcl/preconditioner/cpr_drs.hpp
+++ b/external_libraries/amgcl/preconditioner/cpr_drs.hpp
@@ -45,21 +45,32 @@ namespace preconditioner {
 template <class PPrecond, class SPrecond>
 class cpr_drs {
     static_assert(
-            std::is_same<
+            math::static_rows<typename PPrecond::backend_type::value_type>::value == 1,
+            "Pressure backend should have scalar value type!"
+            );
+
+    static_assert(
+            backend::backends_compatible<
                 typename PPrecond::backend_type,
                 typename SPrecond::backend_type
                 >::value,
-            "Backends for pressure and flow preconditioners should coinside!"
+            "Backends for pressure and flow preconditioners should coincide!"
             );
     public:
-        typedef typename PPrecond::backend_type backend_type;
+        typedef typename SPrecond::backend_type backend_type;
+        typedef typename PPrecond::backend_type backend_type_p;
 
-        typedef typename backend_type::value_type value_type;
-        typedef typename backend_type::matrix     matrix;
-        typedef typename backend_type::vector     vector;
-        typedef typename backend_type::params     backend_params;
+        typedef typename backend_type::value_type   value_type;
+        typedef typename backend_type::matrix       matrix;
+        typedef typename backend_type::vector       vector;
+        typedef typename backend_type_p::value_type value_type_p;
+        typedef typename backend_type_p::matrix     matrix_p;
+        typedef typename backend_type_p::vector     vector_p;
 
-        typedef typename backend::builtin<value_type>::matrix build_matrix;
+        typedef typename backend_type::params       backend_params;
+
+        typedef typename backend::builtin<value_type>::matrix   build_matrix;
+        typedef typename backend::builtin<value_type_p>::matrix build_matrix_p;
 
         struct params {
             typedef typename PPrecond::params pprecond_params;
@@ -75,7 +86,9 @@ class cpr_drs {
 
             std::vector<double> weights;
 
-            params() : block_size(2), active_rows(0), eps_dd(0.2), eps_ps(0.02) {}
+            params()
+                : block_size(math::static_rows<value_type>::value == 1 ? 2 : math::static_rows<value_type>::value),
+                  active_rows(0), eps_dd(0.2), eps_ps(0.02) {}
 
 #ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
@@ -125,25 +138,31 @@ class cpr_drs {
                 const backend_params &bprm = backend_params()
                ) : prm(prm), n(backend::rows(K))
         {
-            init(std::make_shared<build_matrix>(K), bprm);
+            init(std::make_shared<build_matrix>(K), bprm,
+                    std::integral_constant<bool, math::static_rows<value_type>::value == 1>());
         }
 
         cpr_drs(
                 std::shared_ptr<build_matrix> K,
                 const params &prm = params(),
-                const backend_params bprm = backend_params()
+                const backend_params &bprm = backend_params()
                ) : prm(prm), n(backend::rows(*K))
         {
-            init(K, bprm);
+            init(K, bprm,
+                    std::integral_constant<bool, math::static_rows<value_type>::value == 1>());
         }
 
         template <class Vec1, class Vec2>
         void apply(const Vec1 &rhs, Vec2 &&x) const {
+            AMGCL_TIC("sprecond");
             S->apply(rhs, x);
+            AMGCL_TOC("sprecond");
             backend::residual(rhs, S->system_matrix(), x, *rs);
 
             backend::spmv(1, *Fpp, *rs, 0, *rp);
+            AMGCL_TIC("pprecond");
             P->apply(*rp, *xp);
+            AMGCL_TOC("pprecond");
 
             backend::spmv(1, *Scatter, *xp, 1, x);
         }
@@ -156,34 +175,60 @@ class cpr_drs {
             return S->system_matrix();
         }
 
+        /* Perform a partial update of the CPR preconditioner. This function
+         * leaves the AMG hierarchy intact, but updates the global preconditioner
+         * SPrecond and optionally also the transfer operator Fpp.
+         */
+        template <class Matrix>
+        void partial_update(
+                const Matrix &K,
+                bool update_transfer_ops = true,
+                const backend_params &bprm = backend_params()
+              )
+        {
+            auto K_ptr = std::make_shared<build_matrix>(K);
+            // Update global preconditioner
+            S = std::make_shared<SPrecond>(K_ptr, prm.sprecond, bprm);
+            if(update_transfer_ops){
+              // Update transfer operator Fpp
+              update_transfer(
+                  K_ptr,
+                  bprm,
+                  std::integral_constant<bool, math::static_rows<value_type>::value == 1>()
+                );
+            }
+        }
+
     private:
         size_t n, np;
 
         std::shared_ptr<PPrecond> P;
         std::shared_ptr<SPrecond> S;
 
-        std::shared_ptr<matrix> Fpp, Scatter;
-        std::shared_ptr<vector> rp, xp, rs;
+        std::shared_ptr<matrix_p> Fpp, Scatter;
+        std::shared_ptr<vector>   rs;
+        std::shared_ptr<vector_p> rp, xp;
 
-        void init(std::shared_ptr<build_matrix> K, const backend_params bprm)
-        {
+        // Returns pressure transfer operator fpp and (optionally)
+        // partially constructed pressure system matrix App.
+        std::tuple<std::shared_ptr<build_matrix_p>, std::shared_ptr<build_matrix_p>>
+        first_scalar_pass(std::shared_ptr<build_matrix> K, bool get_app = true) {
             typedef typename backend::row_iterator<build_matrix>::type row_iterator;
             const int       B = prm.block_size;
             const ptrdiff_t N = (prm.active_rows ? prm.active_rows : n);
 
-            precondition(
-                    prm.weights.empty() || prm.weights.size() == static_cast<size_t>(N),
-                    "CPR: weights size is not equal to number of active rows.");
-
             np = N / B;
 
-            auto fpp = std::make_shared<build_matrix>();
+            auto fpp = std::make_shared<build_matrix_p>();
             fpp->set_size(np, n);
             fpp->set_nonzeros(n);
             fpp->ptr[0] = 0;
 
-            auto App = std::make_shared<build_matrix>();
-            App->set_size(np, np, true);
+            std::shared_ptr<build_matrix_p> App;
+            if (get_app) {
+                App = std::make_shared<build_matrix_p>();
+                App->set_size(np, np, true);
+            }
 
 #pragma omp parallel
             {
@@ -216,7 +261,7 @@ class cpr_drs {
                     }
 
                     while (!done) {
-                        ++App->ptr[ip+1];
+                        if (get_app) ++App->ptr[ip+1];
 
                         ptrdiff_t end = (cur_col + 1) * B;
 
@@ -278,7 +323,25 @@ class cpr_drs {
 
             App->set_nonzeros(App->scan_row_sizes());
 
-            auto scatter = std::make_shared<build_matrix>();
+            return std::make_tuple(fpp, App);
+        }
+
+        void init(std::shared_ptr<build_matrix> K, const backend_params bprm, std::true_type)
+        {
+            typedef typename backend::row_iterator<build_matrix>::type row_iterator;
+            const int       B = prm.block_size;
+            const ptrdiff_t N = (prm.active_rows ? prm.active_rows : n);
+
+            precondition(
+                    prm.weights.empty() || prm.weights.size() == static_cast<size_t>(N),
+                    "CPR: weights size is not equal to number of active rows.");
+
+            np = N / B;
+
+            std::shared_ptr<build_matrix_p> fpp, App;
+            std::tie(fpp, App) = first_scalar_pass(K);
+
+            auto scatter = std::make_shared<build_matrix_p>();
             scatter->set_size(n, np);
             scatter->set_nonzeros(np);
             scatter->ptr[0] = 0;
@@ -294,7 +357,7 @@ class cpr_drs {
                     bool      done = true;
                     ptrdiff_t cur_col = 0;
 
-                    value_type *d = &fpp->val[ik];
+                    value_type_p *d = &fpp->val[ik];
 
                     k.clear();
                     for(int i = 0; i < B; ++i) {
@@ -313,7 +376,7 @@ class cpr_drs {
 
                     while (!done) {
                         ptrdiff_t  end = (cur_col + 1) * B;
-                        value_type app = 0;
+                        value_type_p app = 0;
 
                         for(int i = 0; i < B; ++i) {
                             for(; k[i] && k[i].col() < end; ++k[i]) {
@@ -356,16 +419,190 @@ class cpr_drs {
             for(size_t i = N; i < n; ++i)
                 scatter->ptr[i+1] = scatter->ptr[i];
 
+            AMGCL_TIC("pprecond");
             P = std::make_shared<PPrecond>(App, prm.pprecond, bprm);
+            AMGCL_TOC("pprecond");
+            AMGCL_TIC("sprecond");
             S = std::make_shared<SPrecond>(K,   prm.sprecond, bprm);
+            AMGCL_TOC("sprecond");
 
-            Fpp     = backend_type::copy_matrix(fpp, bprm);
-            Scatter = backend_type::copy_matrix(scatter, bprm);
+            Fpp     = backend_type_p::copy_matrix(fpp, bprm);
+            Scatter = backend_type_p::copy_matrix(scatter, bprm);
 
-            rp = backend_type::create_vector(np, bprm);
-            xp = backend_type::create_vector(np, bprm);
+            rp = backend_type_p::create_vector(np, bprm);
+            xp = backend_type_p::create_vector(np, bprm);
             rs = backend_type::create_vector(n, bprm);
         }
+
+        void update_transfer(std::shared_ptr<build_matrix> K, const backend_params bprm, std::true_type)
+        {
+            auto fpp = std::get<0>(first_scalar_pass(K, /*get_app*/false));
+            Fpp = backend_type_p::copy_matrix(fpp, bprm);
+        }
+
+        void init(std::shared_ptr<build_matrix> K, const backend_params bprm, std::false_type)
+        {
+            const int       B = math::static_rows<value_type>::value;
+            const ptrdiff_t N = (prm.active_rows ? prm.active_rows : n);
+
+            precondition(
+                    prm.weights.empty() || prm.weights.size() == static_cast<size_t>(N * B),
+                    "CPR: weights size is not equal to number of active rows.");
+
+            np = N;
+
+            auto fpp = std::make_shared<build_matrix_p>();
+            fpp->set_size(np, np * B);
+            fpp->set_nonzeros(np * B);
+            fpp->ptr[0] = 0;
+
+            auto scatter = std::make_shared<build_matrix_p>();
+            scatter->set_size(np * B, np);
+            scatter->set_nonzeros(np);
+            scatter->ptr[0] = 0;
+
+            auto App = std::make_shared<build_matrix_p>();
+            App->set_size(np, np, true);
+            App->set_nonzeros(K->nnz);
+            App->ptr[0] = 0;
+
+#pragma omp parallel for
+            for (ptrdiff_t i = 0; i < static_cast<ptrdiff_t>(np); ++i) {
+                ptrdiff_t ik = i * B;
+                for(int k = 0; k < B; ++k, ++ik) {
+                    fpp->col[ik] = ik;
+                    scatter->ptr[ik + 1] = i + 1;
+                }
+                fpp->ptr[i + 1] = ik;
+                scatter->col[i] = i;
+                scatter->val[i] = math::identity<value_type_p>();
+
+                ptrdiff_t row_beg = K->ptr[i];
+                ptrdiff_t row_end = K->ptr[i + 1];
+                App->ptr[i+1] = row_end;
+
+                value_type_p *d = &fpp->val[i * B];
+                const double *w = prm.weights.empty() ? nullptr : &prm.weights[i * B];
+
+                std::array<value_type_p, B> a_dia{};
+                std::array<value_type_p, B> a_off{};
+                std::array<value_type_p, B> a_top{};
+
+                for(ptrdiff_t j = row_beg; j < row_end; ++j) {
+                    ptrdiff_t  c = K->col[j];
+                    value_type v = K->val[j];
+
+                    for(int k = 0; k < B; ++k) {
+                        a_top[k] += std::abs(v(0,k));
+                        if (c == i) {
+                            a_dia[k] = v(k,0);
+                        } else {
+                            a_off[k] += std::abs(v(k,0));
+                        }
+                    }
+                }
+
+                for(int k = 0; k < B; ++k) {
+                    if (k > 0 &&
+                            (a_dia[k] < prm.eps_dd * a_off[k] ||
+                             a_top[k] < prm.eps_ps * std::abs(a_dia[0])
+                            ))
+                    {
+                        d[k] = 0;
+                    } else {
+                        d[k] = w ? w[k] : 1.0;
+                    }
+                }
+
+                for(ptrdiff_t j = row_beg; j < row_end; ++j) {
+                    App->col[j] = K->col[j];
+
+                    value_type_p app = 0;
+                    for(int k = 0; k < B; ++k)
+                        app += d[k] * K->val[j](k,0);
+
+                    App->val[j] = app;
+                }
+            }
+
+            AMGCL_TIC("pprecond");
+            P = std::make_shared<PPrecond>(App, prm.pprecond, bprm);
+            AMGCL_TOC("pprecond");
+            AMGCL_TIC("sprecond");
+            S = std::make_shared<SPrecond>(K,   prm.sprecond, bprm);
+            AMGCL_TOC("sprecond");
+
+            Fpp     = backend_type_p::copy_matrix(fpp, bprm);
+            Scatter = backend_type_p::copy_matrix(scatter, bprm);
+
+            rp = backend_type_p::create_vector(np, bprm);
+            xp = backend_type_p::create_vector(np, bprm);
+            rs = backend_type::create_vector(n, bprm);
+        }
+
+        void update_transfer(std::shared_ptr<build_matrix> K, const backend_params bprm, std::false_type)
+        {
+            const int       B = math::static_rows<value_type>::value;
+            const ptrdiff_t N = (prm.active_rows ? prm.active_rows : n);
+
+            precondition(
+                    prm.weights.empty() || prm.weights.size() == static_cast<size_t>(N * B),
+                    "CPR: weights size is not equal to number of active rows.");
+
+            np = N;
+
+            auto fpp = std::make_shared<build_matrix_p>();
+            fpp->set_size(np, np * B);
+            fpp->set_nonzeros(np * B);
+            fpp->ptr[0] = 0;
+
+#pragma omp parallel for
+            for (ptrdiff_t i = 0; i < static_cast<ptrdiff_t>(np); ++i) {
+                ptrdiff_t ik = i * B;
+                for(int k = 0; k < B; ++k, ++ik) {
+                    fpp->col[ik] = ik;
+                }
+                fpp->ptr[i + 1] = ik;
+
+                ptrdiff_t row_beg = K->ptr[i];
+                ptrdiff_t row_end = K->ptr[i + 1];
+
+                value_type_p *d = &fpp->val[i * B];
+                const double *w = prm.weights.empty() ? nullptr : &prm.weights[i * B];
+
+                std::array<value_type_p, B> a_dia{};
+                std::array<value_type_p, B> a_off{};
+                std::array<value_type_p, B> a_top{};
+
+                for(ptrdiff_t j = row_beg; j < row_end; ++j) {
+                    ptrdiff_t  c = K->col[j];
+                    value_type v = K->val[j];
+
+                    for(int k = 0; k < B; ++k) {
+                        a_top[k] += std::abs(v(0,k));
+                        if (c == i) {
+                            a_dia[k] = v(k,0);
+                        } else {
+                            a_off[k] += std::abs(v(k,0));
+                        }
+                    }
+                }
+
+                for(int k = 0; k < B; ++k) {
+                    if (k > 0 &&
+                            (a_dia[k] < prm.eps_dd * a_off[k] ||
+                             a_top[k] < prm.eps_ps * std::abs(a_dia[0])
+                            ))
+                    {
+                        d[k] = 0;
+                    } else {
+                        d[k] = w ? w[k] : 1.0;
+                    }
+                }
+            }
+            Fpp     = backend_type_p::copy_matrix(fpp, bprm);
+        }
+
 
         friend std::ostream& operator<<(std::ostream &os, const cpr_drs &p) {
             os << "CPR_DRS (two-stage preconditioner)\n"

--- a/external_libraries/amgcl/preconditioner/schur_pressure_correction.hpp
+++ b/external_libraries/amgcl/preconditioner/schur_pressure_correction.hpp
@@ -44,17 +44,6 @@ namespace preconditioner {
 
 namespace detail {
 
-// Same backends are always compatible
-template <class B1, class B2>
-struct compatible_backends
-    : std::is_same<B1, B2>::type {};
-
-// Builtin backend allows mixing backends of different value types,
-// so that scalar and non-scalar backends may coexist.
-template <class V1, class V2>
-struct compatible_backends< backend::builtin<V1>, backend::builtin<V2> >
-    : std::true_type {};
-
 // Backend for schur complement preconditioner is selected as the one with
 // lower dimensionality of its value_type.
 
@@ -84,7 +73,7 @@ struct common_backend< backend::builtin<V1>, backend::builtin<V2>,
 template <class USolver, class PSolver>
 class schur_pressure_correction {
     static_assert(
-            detail::compatible_backends<
+            backend::backends_compatible<
                 typename USolver::backend_type,
                 typename PSolver::backend_type
                 >::value,

--- a/external_libraries/amgcl/util.hpp
+++ b/external_libraries/amgcl/util.hpp
@@ -33,6 +33,7 @@ THE SOFTWARE.
 
 #include <iostream>
 #include <iomanip>
+#include <iterator>
 #include <vector>
 #include <array>
 #include <string>
@@ -194,6 +195,44 @@ struct empty_params {
 
 } // namespace detail
 
+// Iterator range
+template <class Iterator>
+class iterator_range {
+    public:
+        typedef Iterator iterator;
+        typedef Iterator const_iterator;
+        typedef typename std::iterator_traits<Iterator>::value_type value_type;
+
+        iterator_range(Iterator b, Iterator e)
+            : b(b), e(e) {}
+
+        ptrdiff_t size() const {
+            return std::distance(b, e);
+        }
+
+        Iterator begin() const {
+            return b;
+        }
+
+        Iterator end() const {
+            return e;
+        }
+
+        const value_type& operator[](size_t i) const {
+            return b[i];
+        }
+
+        value_type& operator[](size_t i) {
+            return b[i];
+        }
+    private:
+        Iterator b, e;
+};
+
+template <class Iterator>
+iterator_range<Iterator> make_iterator_range(Iterator b, Iterator e) {
+    return iterator_range<Iterator>(b, e);
+}
 
 // N-dimensional dense matrix
 template <class T, int N>

--- a/external_libraries/amgcl/value_type/complex.hpp
+++ b/external_libraries/amgcl/value_type/complex.hpp
@@ -51,6 +51,12 @@ struct scalar_of< std::complex<T> > {
     typedef T type;
 };
 
+/// Replace scalar type in the complex type.
+template <class T, class S>
+struct replace_scalar<std::complex<T>, S> {
+    typedef std::complex<S> type;
+};
+
 /// Specialization of conjugate transpose for scalar complex arguments.
 template <typename T>
 struct adjoint_impl< std::complex<T> >

--- a/external_libraries/amgcl/value_type/eigen.hpp
+++ b/external_libraries/amgcl/value_type/eigen.hpp
@@ -53,6 +53,12 @@ struct scalar_of< Eigen::Matrix<T, N, M> > {
     typedef typename math::scalar_of<T>::type type;
 };
 
+/// Replace scalar type in the static matrix
+template <class T, int N, int M, class S>
+struct replace_scalar< Eigen::Matrix<T, N, M>, S> {
+    typedef Eigen::Matrix<S, N, M> type;
+};
+
 /// RHS type corresponding to a non-scalar type.
 template <class T, int N>
 struct rhs_of< Eigen::Matrix<T, N, N> > {

--- a/external_libraries/amgcl/value_type/interface.hpp
+++ b/external_libraries/amgcl/value_type/interface.hpp
@@ -48,6 +48,12 @@ struct rhs_of {
     typedef T type;
 };
 
+/// Replace scalar type in the static matrix
+template<class T, class S, class Enable = void>
+struct replace_scalar {
+    typedef S type;
+};
+
 /// Whether the value type is a statically sized matrix.
 template <class T, class Enable = void>
 struct is_static_matrix : std::false_type {};

--- a/external_libraries/amgcl/value_type/static_matrix.hpp
+++ b/external_libraries/amgcl/value_type/static_matrix.hpp
@@ -185,6 +185,12 @@ struct scalar_of< static_matrix<T, N, M> > {
     typedef typename scalar_of<T>::type type;
 };
 
+/// Replace scalar type in the static matrix.
+template <class T, int N, int M, class S>
+struct replace_scalar<static_matrix<T, N, M>, S> {
+    typedef static_matrix<S, N, M> type;
+};
+
 /// RHS type corresponding to a non-scalar type.
 template <class T, int N>
 struct rhs_of< static_matrix<T, N, N> > {

--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -84,7 +84,7 @@ void KRATOS_API(KRATOS_CORE) AMGCLSolve(
     TUblasSparseSpace<double>::VectorType& rB,
     TUblasSparseSpace<double>::IndexType& rIterationNumber,
     double& rResidual,
-    const boost::property_tree::ptree &amgclParams,
+    boost::property_tree::ptree amgclParams,
     int verbosity_level,
     bool use_gpgpu
     );


### PR DESCRIPTION
8e97b80 brings changes from upstream amgcl (mostly for the fix of https://github.com/ddemidov/amgcl/issues/119).

The ILU0 in AMGCL has approximate iterative implementation for GPU backends.  08bedfa increases the number of iterations to 9 for the sake of robustness. @RiccardoRossi has a problem example where this is relevant.