### PR TITLE
fix(HDF5): fixes can't open file error in subprocess

### DIFF
--- a/applications/HDF5Application/tests/test_HDF5Application.py
+++ b/applications/HDF5Application/tests/test_HDF5Application.py
@@ -1,4 +1,5 @@
 import subprocess
+from os.path import dirname
 
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
@@ -46,7 +47,11 @@ def run_cpp_unit_tests():
     This runs a subprocess because the HDF5 used by h5py clashed with the HDF5
     linked to the c++ unit tests on some systems. h5py is used by some XDMF tests.
     """
-    return subprocess.check_output(['python3', 'run_cpp_unit_tests.py']).decode('utf-8')
+    # We set cwd in case the script is run from another directory. This is needed
+    # when testing from the core.
+    out_bytes = subprocess.check_output(
+        ['python3', 'run_cpp_unit_tests.py'], cwd=dirname(__file__))
+    return out_bytes.decode('utf-8')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The error occured when test_HDF5Application.py was run from a non-local
directory. This happens when running test from the core. The chosen
solution modifies the call to subprocess.check_output() by setting the
current working directory to HDF5Application/tests via dirname(__file__).
