### PR TITLE
Core/feature report skipped tests

### DIFF
--- a/kratos/testing/test_case.cpp
+++ b/kratos/testing/test_case.cpp
@@ -21,6 +21,7 @@
 
 // Project includes
 #include "testing/test_case.h"
+#include "testing/test_skipped_exception.h"
 #include "includes/exception.h"
 
 
@@ -54,6 +55,10 @@ namespace Kratos
 				TestFunction();
 				TearDown();
 				mResult.SetToSucceed();
+			}
+			catch (TestSkippedException& e) {
+				mResult.SetToSkipped();
+				mResult.SetErrorMessage(e.what());
 			}
 			catch (Exception& e) {
 				mResult.SetToFailed();
@@ -89,6 +94,10 @@ namespace Kratos
 				mResult.SetRunElapsedTime(run_elapsed.count());
 				mResult.SetTearDownElapsedTime(tear_down_elapsed.count());
 				mResult.SetElapsedTime(elapsed.count());
+			}
+			catch (TestSkippedException& e) {
+				mResult.SetToSkipped();
+				mResult.SetErrorMessage(e.what());
 			}
 			catch (Exception& e) {
 				mResult.SetToFailed();

--- a/kratos/testing/test_case_result.cpp
+++ b/kratos/testing/test_case_result.cpp
@@ -26,11 +26,11 @@ namespace Kratos
 {
 	namespace Testing
 	{
-		TestCaseResult::TestCaseResult() : mSucceed(true), mOutput(""), mErrorMessage("")
+		TestCaseResult::TestCaseResult() : mStatus(Result::NotRun), mOutput(""), mErrorMessage("")
 			, mSetupElapsedTime(0.00), mRunElapsedTime(0.00), mTearDownElapsedTime(0.00), mElapsedTime(0.00) {}
 
 		TestCaseResult::TestCaseResult(TestCaseResult const& rOther)
-			: mSucceed(rOther.mSucceed), mOutput(rOther.mOutput), mErrorMessage(rOther.mErrorMessage)
+			: mStatus(rOther.mStatus), mOutput(rOther.mOutput), mErrorMessage(rOther.mErrorMessage)
 			, mSetupElapsedTime(rOther.mSetupElapsedTime), mRunElapsedTime(rOther.mRunElapsedTime)
 			, mTearDownElapsedTime(rOther.mTearDownElapsedTime), mElapsedTime(rOther.mElapsedTime) {}
 
@@ -38,7 +38,7 @@ namespace Kratos
 
 		TestCaseResult& TestCaseResult::operator=(TestCaseResult const& rOther)
 		{
-			mSucceed = rOther.mSucceed;
+			mStatus = rOther.mStatus;
 			mOutput = rOther.mOutput;
 			mErrorMessage = rOther.mErrorMessage;
 			mSetupElapsedTime = rOther.mSetupElapsedTime;
@@ -51,7 +51,7 @@ namespace Kratos
 
 		void TestCaseResult::Reset()
 		{
-			mSucceed = true;
+			mStatus = Result::NotRun;
 			mOutput = "";
 			mErrorMessage = "";
 			mSetupElapsedTime = 0.00;
@@ -61,11 +61,11 @@ namespace Kratos
 		}
 
 		void TestCaseResult::SetToSucceed()	{
-			mSucceed = true;
+			mStatus = Result::Passed;
 		}
 
 		void TestCaseResult::SetToFailed() {
-			mSucceed = false;
+			mStatus = Result::Failed;
 		}
 
 		void TestCaseResult::SetOutput(const std::string& TheOutput) {
@@ -127,19 +127,34 @@ namespace Kratos
 
 		bool TestCaseResult::IsSucceed() const
 		{
-			return mSucceed;
+			return mStatus == Result::Passed;
 		}
 
 		bool TestCaseResult::IsFailed() const
 		{
-			return !mSucceed;
+			return mStatus == Result::Failed;
 		}
 
 		std::string TestCaseResult::Info() const
 		{
-			if(mSucceed)
-				return "Test case succeed";
-			return "Test case failed";
+			if (mStatus == Result::NotRun)
+			{
+				return "Test case not run";
+			}
+			else if (mStatus == Result::Passed)
+			{
+				return "Test case successful";
+			}
+			else if (mStatus == Result::Failed)
+			{
+				return "Test case failed";
+			}
+			else if (mStatus == Result::Skipped)
+			{
+				return "Test case skipped";
+			}
+
+			return "Unknown test case state";
 		}
 
 		/// Print information about this object.

--- a/kratos/testing/test_case_result.cpp
+++ b/kratos/testing/test_case_result.cpp
@@ -68,6 +68,10 @@ namespace Kratos
 			mStatus = Result::Failed;
 		}
 
+		void TestCaseResult::SetToSkipped() {
+			mStatus = Result::Skipped;
+		}
+
 		void TestCaseResult::SetOutput(const std::string& TheOutput) {
 			mOutput = TheOutput;
 		}
@@ -133,6 +137,16 @@ namespace Kratos
 		bool TestCaseResult::IsFailed() const
 		{
 			return mStatus == Result::Failed;
+		}
+
+		bool TestCaseResult::IsSkipped() const
+		{
+			return mStatus == Result::Skipped;
+		}
+
+		bool TestCaseResult::IsRun() const
+		{
+			return mStatus != Result::NotRun;
 		}
 
 		std::string TestCaseResult::Info() const

--- a/kratos/testing/test_case_result.cpp
+++ b/kratos/testing/test_case_result.cpp
@@ -26,7 +26,7 @@ namespace Kratos
 {
 	namespace Testing
 	{
-		TestCaseResult::TestCaseResult() : mStatus(Result::NotRun), mOutput(""), mErrorMessage("")
+		TestCaseResult::TestCaseResult() : mStatus(Result::DidNotRun), mOutput(""), mErrorMessage("")
 			, mSetupElapsedTime(0.00), mRunElapsedTime(0.00), mTearDownElapsedTime(0.00), mElapsedTime(0.00) {}
 
 		TestCaseResult::TestCaseResult(TestCaseResult const& rOther)
@@ -51,7 +51,7 @@ namespace Kratos
 
 		void TestCaseResult::Reset()
 		{
-			mStatus = Result::NotRun;
+			mStatus = Result::DidNotRun;
 			mOutput = "";
 			mErrorMessage = "";
 			mSetupElapsedTime = 0.00;
@@ -146,12 +146,12 @@ namespace Kratos
 
 		bool TestCaseResult::IsRun() const
 		{
-			return mStatus != Result::NotRun;
+			return mStatus != Result::DidNotRun;
 		}
 
 		std::string TestCaseResult::Info() const
 		{
-			if (mStatus == Result::NotRun)
+			if (mStatus == Result::DidNotRun)
 			{
 				return "Test case not run";
 			}

--- a/kratos/testing/test_case_result.h
+++ b/kratos/testing/test_case_result.h
@@ -95,7 +95,7 @@ namespace Kratos
 			void SetTearDownElapsedTime(double ElapsedTime);
 
 			double GetTearDownElapsedTime() const;
-			
+
 			void SetElapsedTime(double ElapsedTime);
 
 			double GetElapsedTime() const;
@@ -133,6 +133,18 @@ namespace Kratos
 
 
 		private:
+
+			///@name Type definitions
+			///@{
+
+			enum class Result {
+				NotRun,
+				Passed,
+				Failed,
+				Skipped
+			};
+
+			///@}
 			///@name Static Member Variables
 			///@{
 
@@ -141,7 +153,7 @@ namespace Kratos
 			///@name Member Variables
 			///@{
 
-			bool mSucceed;
+			Result mStatus;
 			std::string mOutput;
 			std::string mErrorMessage;
 			double mSetupElapsedTime;

--- a/kratos/testing/test_case_result.h
+++ b/kratos/testing/test_case_result.h
@@ -76,6 +76,8 @@ namespace Kratos
 
 			void SetToFailed();
 
+			void SetToSkipped();
+
 			void SetOutput(const std::string& TheOutput);
 
 			const std::string& GetOutput() const;
@@ -109,6 +111,10 @@ namespace Kratos
 			bool IsSucceed() const;
 
 			bool IsFailed() const;
+
+			bool IsSkipped() const;
+
+			bool IsRun() const;
 
 			///@}
 			///@name Input and output

--- a/kratos/testing/test_case_result.h
+++ b/kratos/testing/test_case_result.h
@@ -144,7 +144,7 @@ namespace Kratos
 			///@{
 
 			enum class Result {
-				NotRun,
+				DidNotRun,
 				Passed,
 				Failed,
 				Skipped

--- a/kratos/testing/test_skipped_exception.cpp
+++ b/kratos/testing/test_skipped_exception.cpp
@@ -54,4 +54,21 @@ void TestSkippedException::PrintData(std::ostream &rOStream) const
     rOStream << "   in: " << where();
 }
 
+/// input stream function
+std::istream& operator >> (std::istream& rIStream,
+    TestSkippedException& rThis)
+{
+    return rIStream;
+}
+
+/// output stream function
+std::ostream& operator << (std::ostream& rOStream, const TestSkippedException& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
 } // namespace Kratos.

--- a/kratos/testing/test_skipped_exception.cpp
+++ b/kratos/testing/test_skipped_exception.cpp
@@ -1,0 +1,57 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:   Pooyan Dadvand
+//
+//
+
+#include <sstream>
+
+#include "testing/test_skipped_exception.h"
+
+namespace Kratos
+{
+
+TestSkippedException::TestSkippedException():
+    Exception()
+{}
+
+TestSkippedException::TestSkippedException(const std::string &rWhat):
+    Exception(rWhat)
+{}
+
+TestSkippedException::TestSkippedException(const std::string &rWhat, const CodeLocation &Location):
+    Exception(rWhat, Location)
+{}
+
+TestSkippedException::TestSkippedException(const TestSkippedException &Other):
+    Exception(Other)
+{}
+
+TestSkippedException::~TestSkippedException() throw()
+{}
+
+std::string TestSkippedException::Info() const
+{
+    return "TestSkippedException";
+}
+
+/// Print information about this object.
+void TestSkippedException::PrintInfo(std::ostream &rOStream) const
+{
+    rOStream << Info();
+}
+/// Print object's data.
+void TestSkippedException::PrintData(std::ostream &rOStream) const
+{
+    rOStream << "Test Skipped: " << message() << std::endl;
+    rOStream << "   in: " << where();
+}
+
+} // namespace Kratos.

--- a/kratos/testing/test_skipped_exception.cpp
+++ b/kratos/testing/test_skipped_exception.cpp
@@ -37,6 +37,24 @@ TestSkippedException::TestSkippedException(const TestSkippedException &Other):
 TestSkippedException::~TestSkippedException() throw()
 {}
 
+TestSkippedException& TestSkippedException::operator << (CodeLocation const& TheLocation)
+{
+    Exception::operator<<(TheLocation);
+    return *this;
+}
+
+TestSkippedException& TestSkippedException::operator << (std::ostream& (*pf)(std::ostream&))
+{
+    Exception::operator<<(pf);
+    return *this;
+}
+
+TestSkippedException& TestSkippedException::operator << (const char * rString)
+{
+    Exception::operator<<(rString);
+    return *this;
+}
+
 std::string TestSkippedException::Info() const
 {
     return "TestSkippedException";

--- a/kratos/testing/test_skipped_exception.h
+++ b/kratos/testing/test_skipped_exception.h
@@ -59,19 +59,22 @@ public:
     ///@name Operators
     ///@{
 
+    /// CodeLocation stream function
+    TestSkippedException& operator << (CodeLocation const& TheLocation);
+
     /// string stream function
-    template<class ValueType>
-    TestSkippedException& operator << (ValueType Value)
+    template<class StreamValueType>
+    TestSkippedException& operator << (StreamValueType const& rValue)
     {
-        Exception::operator << (Value);
+        Exception::operator << (rValue);
         return *this;
     }
 
-    TestSkippedException& operator << (std::ostream& (*pf)(std::ostream&))
-    {
-        Exception::operator<<(pf);
-        return *this;
-    }
+    /// Manipulator stream function
+    TestSkippedException& operator << (std::ostream& (*pf)(std::ostream&));
+
+    /// char stream function
+    TestSkippedException& operator << (const char * rString);
 
     ///@}
     ///@name Input and output

--- a/kratos/testing/test_skipped_exception.h
+++ b/kratos/testing/test_skipped_exception.h
@@ -56,6 +56,24 @@ public:
     ~TestSkippedException() noexcept override;
 
     ///@}
+    ///@name Operators
+    ///@{
+
+    /// string stream function
+    template<class ValueType>
+    TestSkippedException& operator << (ValueType Value)
+    {
+        Exception::operator << (Value);
+        return *this;
+    }
+
+    TestSkippedException& operator << (std::ostream& (*pf)(std::ostream&))
+    {
+        Exception::operator<<(pf);
+        return *this;
+    }
+
+    ///@}
     ///@name Input and output
     ///@{
 

--- a/kratos/testing/test_skipped_exception.h
+++ b/kratos/testing/test_skipped_exception.h
@@ -1,0 +1,108 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+//
+
+#ifndef KRATOS_TEST_SKIPPED_EXCEPTION_H_INCLUDED
+#define KRATOS_TEST_SKIPPED_EXCEPTION_H_INCLUDED
+
+#include <stdexcept>
+#include <string>
+#include <iostream>
+#include <sstream>
+#include <vector>
+
+// Project includes
+#include "includes/exception.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/// Exception type used to signal that a test should be skipped.
+class KRATOS_API(KRATOS_CORE) TestSkippedException : public Exception
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    TestSkippedException();
+
+    explicit TestSkippedException(const std::string &rWhat);
+
+    TestSkippedException(const std::string &rWhat, const CodeLocation &Location);
+
+    /// Copy constructor.
+    TestSkippedException(TestSkippedException const &Other);
+
+    /// Destructor.
+    ~TestSkippedException() noexcept override;
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override;
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream &rOStream) const override;
+
+    /// Print object's data.
+    void PrintData(std::ostream &rOStream) const override;
+
+    ///@}
+
+}; // Class TestSkippedException
+
+///@}
+
+///@name Kratos Macros
+///@{
+
+#define KRATOS_SKIP_TEST throw TestSkippedException("Test Skipped: ", KRATOS_CODE_LOCATION)
+
+#define KRATOS_SKIP_TEST_IF(conditional) \
+    if (conditional)                 \
+    throw TestSkippedException("Test Skipped: ", KRATOS_CODE_LOCATION)
+
+#define KRATOS_SKIP_TEST_IF_NOT(conditional) \
+    if (!(conditional))                  \
+    throw TestSkippedException("Test Skipped: ", KRATOS_CODE_LOCATION)
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+std::istream &operator>>(std::istream &rIStream,
+                         TestSkippedException &rThis);
+
+/// output stream function
+KRATOS_API(KRATOS_CORE)
+std::ostream &operator<<(std::ostream &rOStream, const TestSkippedException &rThis);
+
+///@}
+
+///@} addtogroup block
+
+} // namespace Kratos.
+
+#endif // KRATOS_TEST_SKIPPED_EXCEPTION_H_INCLUDED  defined

--- a/kratos/testing/tester.cpp
+++ b/kratos/testing/tester.cpp
@@ -325,13 +325,14 @@ namespace Kratos
 		void Tester::EndShowProgress(std::size_t Current, std::size_t Total, const TestCase* const pTheTestCase)
 		{
 			constexpr std::size_t ok_culumn = 72;
-			if (GetInstance().mVerbosity == Verbosity::PROGRESS)
+			if (GetInstance().mVerbosity == Verbosity::PROGRESS) {
 				if (pTheTestCase->GetResult().IsSucceed())
 					std::cout << ".";
 				else if (pTheTestCase->GetResult().IsFailed())
 					std::cout << "F";
 				else if (pTheTestCase->GetResult().IsSkipped())
 					std::cout << "s";
+			}
 			else if (GetInstance().mVerbosity >= Verbosity::TESTS_LIST)
 			{
 				for (std::size_t i = pTheTestCase->Name().size(); i < ok_culumn; i++)

--- a/kratos/testing/tester.cpp
+++ b/kratos/testing/tester.cpp
@@ -328,8 +328,10 @@ namespace Kratos
 			if (GetInstance().mVerbosity == Verbosity::PROGRESS)
 				if (pTheTestCase->GetResult().IsSucceed())
 					std::cout << ".";
-				else
+				else if (pTheTestCase->GetResult().IsFailed())
 					std::cout << "F";
+				else if (pTheTestCase->GetResult().IsSkipped())
+					std::cout << "s";
 			else if (GetInstance().mVerbosity >= Verbosity::TESTS_LIST)
 			{
 				for (std::size_t i = pTheTestCase->Name().size(); i < ok_culumn; i++)
@@ -341,10 +343,16 @@ namespace Kratos
 					if (GetInstance().mVerbosity == Verbosity::TESTS_OUTPUTS)
 						std::cout << pTheTestCase->GetResult().GetOutput() << std::endl;
 				}
-				else
+				else if (pTheTestCase->GetResult().IsFailed())
 				{
 					std::cout << " FAILED!" << std::endl;
 					if (GetInstance().mVerbosity >= Verbosity::FAILED_TESTS_OUTPUTS)
+						std::cout << pTheTestCase->GetResult().GetOutput() << std::endl;
+				}
+				else if (pTheTestCase->GetResult().IsSkipped())
+				{
+					std::cout << " SKIPPED." << std::endl;
+					if (GetInstance().mVerbosity == Verbosity::TESTS_OUTPUTS)
 						std::cout << pTheTestCase->GetResult().GetOutput() << std::endl;
 				}
 			}

--- a/kratos/testing/tester.cpp
+++ b/kratos/testing/tester.cpp
@@ -105,6 +105,20 @@ namespace Kratos
 			return result;
 		}
 
+		std::size_t Tester::NumberOfSkippedTestCases()
+		{
+			std::size_t result = 0;
+			for (auto i_test = GetInstance().mTestCases.begin();
+			i_test != GetInstance().mTestCases.end(); i_test++)
+			{
+				TestCaseResult const& test_case_result = i_test->second->GetResult();
+				if (test_case_result.IsSkipped())
+					result++;
+			}
+
+			return result;
+		}
+
 		void Tester::AddTestCase(TestCase* pHeapAllocatedTestCase)
 		{
 			KRATOS_ERROR_IF(HasTestCase(pHeapAllocatedTestCase->Name())) << "A duplicated test case found! The test case \"" << pHeapAllocatedTestCase->Name() << "\" is already added." << std::endl;
@@ -354,7 +368,7 @@ namespace Kratos
 				{
 					std::cout << " SKIPPED." << std::endl;
 					if (GetInstance().mVerbosity == Verbosity::TESTS_OUTPUTS)
-						std::cout << pTheTestCase->GetResult().GetOutput() << std::endl;
+						std::cout << pTheTestCase->GetResult().GetErrorMessage() << std::endl;
 				}
 			}
 		}
@@ -367,18 +381,25 @@ namespace Kratos
 				rOStream << std::endl;
 
 			auto number_of_failed_tests = NumberOfFailedTestCases();
+			auto number_of_skipped_tests = NumberOfSkippedTestCases();
 
 			std::string total_test_cases = " test case";
 			auto total_test_cases_size = GetInstance().mTestCases.size();
 			if (total_test_cases_size > 1)
 				total_test_cases += "s";
 
-			if (number_of_failed_tests == 0)
-				rOStream << "Ran " << NumberOfRunTests << " of " << total_test_cases_size << total_test_cases << " in " << ElapsedTime << "s. OK." << std::endl;
+			rOStream << "Ran " << NumberOfRunTests << " of " << total_test_cases_size << total_test_cases << " in " << ElapsedTime << "s";
+			if (number_of_skipped_tests > 0) {
+				rOStream << " (" << number_of_skipped_tests << " skipped)";
+			}
+
+			if (number_of_failed_tests == 0) {
+				rOStream << ". OK" << std::endl;
+			}
 			else
 			{
-				rOStream << "Ran " << NumberOfRunTests << " of " << total_test_cases_size << total_test_cases << " in " << ElapsedTime << "s. " << number_of_failed_tests << " failed:" << std::endl;
-                ReportFailures(rOStream);
+				rOStream << ". " << number_of_failed_tests << " failed:" << std::endl;
+				ReportFailures(rOStream);
                 exit_code = 1;
 			}
 

--- a/kratos/testing/tester.h
+++ b/kratos/testing/tester.h
@@ -104,6 +104,8 @@ namespace Kratos
 
 			static std::size_t NumberOfFailedTestCases();
 
+			static std::size_t NumberOfSkippedTestCases();
+
 			/// This method assumes that the given test case is allocated
 			/// via new. So it will delete it at the end of the program
 			static void AddTestCase(TestCase* pHeapAllocatedTestCase);

--- a/kratos/testing/testing.h
+++ b/kratos/testing/testing.h
@@ -8,7 +8,7 @@
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Pooyan Dadvand
-//                   
+//
 //
 
 #if !defined(KRATOS_TESTING_H_INCLUDED )
@@ -16,5 +16,6 @@
 
 #include "testing/test_suite.h" // This includes the test_case.h which includes tester.h
 #include "includes/checks.h"  // It is almost always necessary. includes the exception
+#include "testing/test_skipped_exception.h" // Macros and exception class used to skip tests.
 
 #endif // KRATOS_TEST_SUITE_H_INCLUDED  defined


### PR DESCRIPTION
Adding the possibility to skip C++ tests if some condition is not met. My motivation for this is MPI tests: right now tests with "the wrong number of threads" are being bypassed and reported as successes, but I would like to know if something is "working" because the test passed or because I am just running with the wrong number of processes.

Example of usage:
```C++
KRATOS_TEST_CASE_IN_SUITE(SuccessfulTest, KratosCoreTestTestingSuite) {
    KRATOS_CHECK(true);
}

KRATOS_TEST_CASE_IN_SUITE(FailedTest, KratosCoreTestTestingSuite) {
    KRATOS_CHECK(false);
}

KRATOS_TEST_CASE_IN_SUITE(SkippedTest, KratosCoreTestTestingSuite) {
    KRATOS_SKIP_TEST << "Skipping this test to test test skipping." << std::endl;
    KRATOS_CHECK(true);
}
```

output (verbosity level `TESTS_OUTPUTS`):
```
 |  /           |
 ' /   __| _` | __|  _ \   __|
 . \  |   (   | |   (   |\__ \
_|\_\_|  \__,_|\__|\___/ ____/
           Multi-Physics 7.0.0-fb91195595-FullDebug
Compiled with OpenMP and MPI support.
Maximum OpenMP threads: 16.
Running without MPI.
TestFailedTest                                                           FAILED!

TestSkippedTest                                                          SKIPPED.
Test Skipped: Skipping this test to test test skipping.

in kratos/tests/cpp_tests/testing/test_testing.cpp:44:virtual void Testing::TestSkippedTest::TestFunction()

TestSuccessfulTest                                                       OK.

Ran 3 of 647 test cases in 0.000292779s (1 skipped). 1 failed:
    TestFailedTest Failed with message: 
        Error: Check failed because false is not true
in kratos/tests/cpp_tests/testing/test_testing.cpp:40:virtual void Testing::TestFailedTest::TestFunction()
```

output (verbosity level `PROGRESS`)
```
 |  /           |
 ' /   __| _` | __|  _ \   __|
 . \  |   (   | |   (   |\__ \
_|\_\_|  \__,_|\__|\___/ ____/
           Multi-Physics 7.0.0-fb91195595-FullDebug
Compiled with OpenMP and MPI support.
Maximum OpenMP threads: 16.
Running without MPI.
Fs.
Ran 3 of 647 test cases in 0.000254407s (1 skipped). 1 failed:
    TestFailedTest Failed with message: 
        Error: Check failed because false is not true
in kratos/tests/cpp_tests/testing/test_testing.cpp:40:virtual void Testing::TestFailedTest::TestFunction()
```

The PR also introduces macros for conditional skipping (`KRATOS_SKIP_TEST_IF(condition)` and `KRATOS_SKIP_TEST_IF_FALSE(condition)`)
