### PR TITLE
[PotentialFlow] Adding missing density in embedded element and updating test settings

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
@@ -96,10 +96,12 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateEmbedde
         positive_side_weights,
         GeometryData::GI_GAUSS_1);
 
+    const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
+
     BoundedMatrix<double,NumNodes,Dim> DN_DX;
     for (unsigned int i_gauss=0;i_gauss<positive_side_sh_func_gradients.size();i_gauss++){
         DN_DX=positive_side_sh_func_gradients(i_gauss);
-        noalias(rLeftHandSideMatrix) += prod(DN_DX,trans(DN_DX))*positive_side_weights(i_gauss);;
+        noalias(rLeftHandSideMatrix) += free_stream_density*prod(DN_DX,trans(DN_DX))*positive_side_weights(i_gauss);;
     }
 
     noalias(rRightHandSideVector) = -prod(rLeftHandSideMatrix, potential);

--- a/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_no_wake_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_no_wake_parameters.json
@@ -53,6 +53,7 @@
                 "angle_of_attack": 0.0,
                 "mach_infinity": 0.02941176471,
                 "inlet_potential": 1.0,
+                "free_stream_density": 1.225,
                 "initialize_flow_field": false
             }
         }],

--- a/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_primal_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_primal_parameters.json
@@ -37,7 +37,6 @@
                 "mach_infinity": 0.02941176471,
                 "free_stream_density": 1.225,
                 "inlet_potential"         : 1.0
-
             }
         },{
             "python_module" : "define_wake_process_2d",

--- a/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_primal_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_primal_parameters.json
@@ -35,7 +35,9 @@
                 "model_part_name"   : "MainModelPart.PotentialWallCondition2D_Far_field_Auto1",
                 "angle_of_attack": 0.0,
                 "mach_infinity": 0.02941176471,
+                "free_stream_density": 1.225,
                 "inlet_potential"         : 1.0
+
             }
         },{
             "python_module" : "define_wake_process_2d",


### PR DESCRIPTION
Small PR to add the density value that was missing in the incompressible embedded element.

Test were not failing because the default value of density is 1, so this was not spotted. I updated the test to a non-default value so that tests fail in the future if this is not set correctly.