### PR TITLE
[StructuralMechanicsApplication] Extending structural solver wrapper to work with contact solvers

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
@@ -18,10 +18,7 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
     else:
         time_integration_method = "implicit" # defaulting to implicit time-integration
 
-    if solver_settings.Has("contact_settings"):
-        contact_problem = True
-    else:
-        contact_problem = False
+    contact_problem = solver_settings.Has("contact_settings")
 
     # Solvers for OpenMP parallelism
     if parallelism == "OpenMP":
@@ -86,19 +83,12 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
         err_msg += "Available options are: \"OpenMP\", \"MPI\""
         raise Exception(err_msg)
 
-    if not "contact_" in solver_module_name:
-        if not kratos_utilities.CheckIfApplicationsAvailable("StructuralMechanicsApplication"):
-            err_msg =  "The KratosMultiphysics.StructuralMechanicsApplication must be imported in your main script in order to call this solver:\n"
-            err_msg += solver_module_name
-            raise Exception(err_msg)
-        module_full = 'KratosMultiphysics.StructuralMechanicsApplication.' + solver_module_name
+    if contact_problem:
+        kratos_module = "KratosMultiphysics.ContactStructuralMechanicsApplication"
     else:
-        if not kratos_utilities.CheckIfApplicationsAvailable("ContactStructuralMechanicsApplication"):
-            err_msg =  "The KratosMultiphysics.ContactStructuralMechanicsApplication must be imported in your main script in order to call this solver:\n"
-            err_msg += solver_module_name
-            raise Exception(err_msg)
-        module_full = 'KratosMultiphysics.ContactStructuralMechanicsApplication.' + solver_module_name
-    solver = import_module(module_full).CreateSolver(model, solver_settings)
+        kratos_module = "KratosMultiphysics.StructuralMechanicsApplication"
+
+    solver = import_module(kratos_module + "." + solver_module_name).CreateSolver(model, solver_settings)
 
     return solver
 

--- a/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
@@ -15,31 +15,20 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
     else:
         time_integration_method = "implicit" # defaulting to implicit time-integration
 
-    contact_problem = solver_settings.Has("contact_settings")
-
     # Solvers for OpenMP parallelism
     if parallelism == "OpenMP":
         if solver_type == "dynamic" or solver_type == "Dynamic":
             if time_integration_method == "implicit":
-                if not contact_problem:
-                    solver_module_name = "structural_mechanics_implicit_dynamic_solver"
-                else:
-                    solver_module_name = "contact_structural_mechanics_implicit_dynamic_solver"
+                solver_module_name = "structural_mechanics_implicit_dynamic_solver"
             elif time_integration_method == "explicit":
-                if not contact_problem:
-                    solver_module_name = "structural_mechanics_explicit_dynamic_solver"
-                else:
-                    solver_module_name = "contact_structural_mechanics_explicit_dynamic_solver"
+                solver_module_name = "structural_mechanics_explicit_dynamic_solver"
             else:
                 err_msg =  "The requested time integration method \"" + time_integration_method + "\" is not in the python solvers wrapper\n"
                 err_msg += "Available options are: \"implicit\", \"explicit\""
                 raise Exception(err_msg)
 
         elif solver_type == "static" or solver_type == "Static":
-            if not contact_problem:
-                solver_module_name = "structural_mechanics_static_solver"
-            else:
-                solver_module_name = "contact_structural_mechanics_static_solver"
+            solver_module_name = "structural_mechanics_static_solver"
 
         elif solver_type == "eigen_value":
             solver_module_name = "structural_mechanics_eigensolver"
@@ -80,8 +69,9 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
         err_msg += "Available options are: \"OpenMP\", \"MPI\""
         raise Exception(err_msg)
 
-    if contact_problem:
+    if solver_settings.Has("contact_settings"): # this is a contact problem
         kratos_module = "KratosMultiphysics.ContactStructuralMechanicsApplication"
+        solver_module_name = "contact_" + solver_module_name
     else:
         kratos_module = "KratosMultiphysics.StructuralMechanicsApplication"
 

--- a/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
@@ -1,6 +1,12 @@
 from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 
+# Importing Kratos
 import KratosMultiphysics
+
+# Importing Kratos utilities
+import KratosMultiphysics.kratos_utilities as kratos_utilities
+
+# Other imports
 from importlib import import_module
 
 def CreateSolverByParameters(model, solver_settings, parallelism):
@@ -13,30 +19,30 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
         time_integration_method = "implicit" # defaulting to implicit time-integration
 
     # Solvers for OpenMP parallelism
-    if (parallelism == "OpenMP"):
-        if (solver_type == "dynamic" or solver_type == "Dynamic"):
-            if (time_integration_method == "implicit"):
+    if parallelism == "OpenMP":
+        if solver_type == "dynamic" or solver_type == "Dynamic":
+            if time_integration_method == "implicit":
                 solver_module_name = "structural_mechanics_implicit_dynamic_solver"
-            elif ( time_integration_method == "explicit"):
+            elif time_integration_method == "explicit":
                 solver_module_name = "structural_mechanics_explicit_dynamic_solver"
             else:
                 err_msg =  "The requested time integration method \"" + time_integration_method + "\" is not in the python solvers wrapper\n"
                 err_msg += "Available options are: \"implicit\", \"explicit\""
                 raise Exception(err_msg)
 
-        elif (solver_type == "static" or solver_type == "Static"):
+        elif solver_type == "static" or solver_type == "Static":
             solver_module_name = "structural_mechanics_static_solver"
 
-        elif (solver_type == "eigen_value"):
+        elif solver_type == "eigen_value":
             solver_module_name = "structural_mechanics_eigensolver"
 
-        elif (solver_type == "harmonic_analysis"):
+        elif solver_type == "harmonic_analysis":
             solver_module_name = "structural_mechanics_harmonic_analysis_solver"
 
-        elif (solver_type == "formfinding"):
+        elif solver_type == "formfinding":
             solver_module_name = "structural_mechanics_formfinding_solver"
 
-        elif (solver_type == "adjoint_static"):
+        elif solver_type == "adjoint_static":
             solver_module_name = "structural_mechanics_adjoint_static_solver"
 
         else:
@@ -45,16 +51,16 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
             raise Exception(err_msg)
 
     # Solvers for MPI parallelism
-    elif (parallelism == "MPI"):
-        if (solver_type == "dynamic" or solver_type == "Dynamic"):
-            if (time_integration_method == "implicit"):
+    elif parallelism == "MPI":
+        if solver_type == "dynamic" or solver_type == "Dynamic":
+            if time_integration_method == "implicit":
                 solver_module_name = "trilinos_structural_mechanics_implicit_dynamic_solver"
             else:
                 err_msg =  "The requested time integration method \"" + time_integration_method + "\" is not in the python solvers wrapper\n"
                 err_msg += "Available options are: \"implicit\""
                 raise Exception(err_msg)
 
-        elif (solver_type == "static" or solver_type == "Static"):
+        elif solver_type == "static" or solver_type == "Static":
             solver_module_name = "trilinos_structural_mechanics_static_solver"
 
         else:
@@ -66,6 +72,10 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
         err_msg += "Available options are: \"OpenMP\", \"MPI\""
         raise Exception(err_msg)
 
+    if not kratos_utilities.CheckIfApplicationsAvailable("StructuralMechanicsApplication"):
+        err_msg =  "The KratosMultiphysics.StructuralMechanicsApplication must be imported in your main script in order to call this solver:\n"
+        err_msg += solver_module_name
+        raise Exception(err_msg)
     module_full = 'KratosMultiphysics.StructuralMechanicsApplication.' + solver_module_name
     solver = import_module(module_full).CreateSolver(model, solver_settings)
 
@@ -74,10 +84,10 @@ def CreateSolverByParameters(model, solver_settings, parallelism):
 
 def CreateSolver(model, custom_settings):
 
-    if (type(model) != KratosMultiphysics.Model):
+    if not isinstance(model, KratosMultiphysics.Model):
         raise Exception("input is expected to be provided as a Kratos Model object")#
 
-    if (type(custom_settings) != KratosMultiphysics.Parameters):
+    if not isinstance(custom_settings, KratosMultiphysics.Parameters):
         raise Exception("input is expected to be provided as a Kratos Parameters object")
 
     solver_settings = custom_settings["solver_settings"]

--- a/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
@@ -3,9 +3,6 @@ from __future__ import print_function, absolute_import, division #makes KratosMu
 # Importing Kratos
 import KratosMultiphysics
 
-# Importing Kratos utilities
-import KratosMultiphysics.kratos_utilities as kratos_utilities
-
 # Other imports
 from importlib import import_module
 


### PR DESCRIPTION
This is a transition PR, the tests are not updated and the duplicated files are not removed yet. It allows to use the structural analysis with contact problems. The only thing needed is to add the import of the ContactStructuralMechanicsApplication to the main script (so it can import the modules). With this I will be able to remove the duplicated wrappers and analysis in the contact app