### PR TITLE
[Core][test-runner] running script in directory

### DIFF
--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -119,7 +119,7 @@ class Commander(object):
                         script,
                         '-l'+level,
                         '-v'+str(verbose)
-                    ], stdout=subprocess.PIPE)
+                    ], stdout=subprocess.PIPE, cwd=os.path.dirname(os.path.abspath(script)))
                 except OSError:
                     # Command does not exist
                     print('[Error]: Unable to execute {}'.format(command), file=sys.stderr)


### PR DESCRIPTION
using this we will no longer have to worry abt the paths of files => what we usually fix with `GetFilePath`
The solution is to run the scripts directly in the `tests` folder