### PR TITLE
[Core][Proposal] Support for ARMx32 (RPi and similar embedded systems). Update dof

### DIFF
--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -25,7 +25,7 @@
 #include "includes/shared_pointers.h"
 #include "includes/exception.h"
 
-
+// Defining the OS
 #if defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
     #define KRATOS_COMPILED_IN_LINUX
 
@@ -36,6 +36,21 @@
     #define KRATOS_COMPILED_IN_WINDOWS
 #endif
 
+// Defining the architecture (see https://sourceforge.net/p/predef/wiki/Architectures/)
+// Check Windows
+#if defined(_WIN32) || defined(_WIN64)
+   #if defined(_WIN64)
+     #define ENV64BIT
+   #else
+     #define ENV32BIT
+  #endif
+#else // It is POSIX (Linux, MacOSX, BSD...)
+  #if defined(__x86_64__) || defined(__ppc64__) || defined(__aarch64__)
+    #define ENV64BIT
+  #else // This includes __arm__ and __x86__
+    #define ENV32BIT
+  #endif
+#endif
 
 //-----------------------------------------------------------------
 //

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -477,7 +477,7 @@ private:
     int mIndex : 6;
 
     /** Equation identificator of the degree of freedom */
-#if defined (__arm__)
+#if defined (__arm__) // Required to avoid overflow on ARM systems (32 bit)
     EquationIdType mEquationId : 32;
 #else
     EquationIdType mEquationId : 48;

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -477,7 +477,7 @@ private:
     int mIndex : 6;
 
     /** Equation identificator of the degree of freedom */
-#if defined (__arm__) // Required to avoid overflow on ARM systems (32 bit)
+#if ENV32BIT // Required to avoid overflow on 32 bit systems
     EquationIdType mEquationId : 32;
 #else
     EquationIdType mEquationId : 48;

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -478,7 +478,7 @@ private:
 
     /** Equation identificator of the degree of freedom */
 #if defined (__arm__)
-    EquationIdType mEquationId : 16;
+    EquationIdType mEquationId : 32;
 #else
     EquationIdType mEquationId : 48;
 #endif

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -477,7 +477,7 @@ private:
     int mIndex : 6;
 
     /** Equation identificator of the degree of freedom */
-#if ENV32BIT // Required to avoid overflow on 32 bit systems
+#ifdef ENV32BIT // Required to avoid overflow on 32 bit systems
     EquationIdType mEquationId : 32;
 #else
     EquationIdType mEquationId : 48;

--- a/kratos/includes/dof.h
+++ b/kratos/includes/dof.h
@@ -477,7 +477,11 @@ private:
     int mIndex : 6;
 
     /** Equation identificator of the degree of freedom */
+#if defined (__arm__)
+    EquationIdType mEquationId : 16;
+#else
     EquationIdType mEquationId : 48;
+#endif
 
     /** A pointer to nodal data stored in node which is corresponded to this dof */
     NodalData* mpNodalData;


### PR DESCRIPTION
Fixes #5576. This PR reduces the size of the EquationId from 48 to 16 bits (to complete the 32 bits). It is only activated when ARMx32 bits is used. If I understood we no longer support x86 (32 bits on PC).