### PR TITLE
fix(HDF5): fixes parallel model part output in processes and subprocess call in tests

### DIFF
--- a/applications/HDF5Application/python_scripts/multiple_mesh_temporal_output_process.py
+++ b/applications/HDF5Application/python_scripts/multiple_mesh_temporal_output_process.py
@@ -107,11 +107,13 @@ def CreateCoreSettings(user_settings):
         for key in user_settings["file_settings"]:
             core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
         if IsDistributed():
+            model_part_output_type = "partitioned_model_part_output"
             core_settings[i]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
         else:
+            model_part_output_type = "model_part_output"
             core_settings[i]["io_settings"]["io_type"] = "serial_hdf5_file_io"
         core_settings[i]["list_of_operations"] = [
-            CreateOperationSettings("model_part_output",
+            CreateOperationSettings(model_part_output_type,
                                     user_settings["model_part_output_settings"]),
             CreateOperationSettings("nodal_solution_step_data_output",
                                     user_settings["nodal_solution_step_data_settings"]),

--- a/applications/HDF5Application/python_scripts/single_mesh_primal_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_primal_output_process.py
@@ -108,13 +108,15 @@ def CreateCoreSettings(user_settings):
         for key in user_settings["file_settings"]:
             core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
     if IsDistributed():
+        model_part_output_type = "partitioned_model_part_output"
         core_settings[0]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
         core_settings[1]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
     else:
+        model_part_output_type = "model_part_output"
         core_settings[0]["io_settings"]["io_type"] = "serial_hdf5_file_io"
         core_settings[1]["io_settings"]["io_type"] = "serial_hdf5_file_io"
     core_settings[0]["list_of_operations"] = [
-        CreateOperationSettings("model_part_output", user_settings["model_part_output_settings"]),
+        CreateOperationSettings(model_part_output_type, user_settings["model_part_output_settings"]),
         CreateOperationSettings("primal_bossak_output", user_settings["nodal_solution_step_data_settings"]),
         CreateOperationSettings("nodal_data_value_output", user_settings["nodal_data_value_settings"]),
         CreateOperationSettings("element_data_value_output", user_settings["element_data_value_settings"])

--- a/applications/HDF5Application/python_scripts/single_mesh_temporal_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_temporal_output_process.py
@@ -105,11 +105,13 @@ def CreateCoreSettings(user_settings):
         for key in user_settings["file_settings"]:
             core_settings[i]["io_settings"][key] = user_settings["file_settings"][key]
         if IsDistributed():
+            model_part_output_type = "partitioned_model_part_output"
             core_settings[i]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
         else:
+            model_part_output_type = "model_part_output"
             core_settings[i]["io_settings"]["io_type"] = "serial_hdf5_file_io"
     core_settings[0]["list_of_operations"] = [
-        CreateOperationSettings("model_part_output",
+        CreateOperationSettings(model_part_output_type,
                                 user_settings["model_part_output_settings"]),
         CreateOperationSettings("nodal_solution_step_data_output",
                                 user_settings["nodal_solution_step_data_settings"]),

--- a/applications/HDF5Application/python_scripts/single_mesh_xdmf_output_process.py
+++ b/applications/HDF5Application/python_scripts/single_mesh_xdmf_output_process.py
@@ -139,13 +139,15 @@ def CreateCoreSettings(user_settings):
     core_settings[0]["io_settings"]["io_type"] = "mock_hdf5_file_io"
     core_settings[3]["io_settings"]["io_type"] = "mock_hdf5_file_io"
     if IsDistributed():
+        model_part_output_type = "partitioned_model_part_output"
         core_settings[1]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
         core_settings[2]["io_settings"]["io_type"] = "parallel_hdf5_file_io"
     else:
+        model_part_output_type = "model_part_output"
         core_settings[1]["io_settings"]["io_type"] = "serial_hdf5_file_io"
         core_settings[2]["io_settings"]["io_type"] = "serial_hdf5_file_io"
     core_settings[1]["list_of_operations"] = [
-        CreateOperationSettings("model_part_output",
+        CreateOperationSettings(model_part_output_type,
                                 user_settings["model_part_output_settings"]),
         CreateOperationSettings("nodal_solution_step_data_output",
                                 user_settings["nodal_solution_step_data_settings"]),

--- a/applications/HDF5Application/tests/test_HDF5Application.py
+++ b/applications/HDF5Application/tests/test_HDF5Application.py
@@ -1,5 +1,6 @@
 import subprocess
 from os.path import dirname
+from os.path import abspath
 
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
@@ -50,7 +51,7 @@ def run_cpp_unit_tests():
     # We set cwd in case the script is run from another directory. This is needed
     # when testing from the core.
     out_bytes = subprocess.check_output(
-        ['python3', 'run_cpp_unit_tests.py'], cwd=dirname(__file__))
+        ['python3', 'run_cpp_unit_tests.py'], cwd=abspath(dirname(__file__)))
     return out_bytes.decode('utf-8')
 
 


### PR DESCRIPTION
Calling `test_HDF5Application.py` from the same directory as `run_cpp_unit_test.py`
failed because `dirname(__file__)` returns the empty string. This caused
`subprocess.check_output(..., cwd=dirname(__file__))` to fail. The solution was
to convert the string to an absolute path.

When kratos detects a distributed simulation, the parallel hdf5 file is
automatically selected by the process, but the parallel model part output
was not being selected. The solution was to select parallel model part
output when `IsDistributed()` is true.