### PR TITLE
[Kratos] using imported module name consistently

### DIFF
--- a/kratos/python_scripts/process_factory.py
+++ b/kratos/python_scripts/process_factory.py
@@ -16,7 +16,7 @@ class KratosProcessFactory(object):
         for i in range(0,process_list.size()):
             item = process_list[i]
             if not item.Has("python_module"):
-                KratosMultiphysics.Logger.PrintWarning("Your list of processes: ", process_list)
+                KM.Logger.PrintWarning("Your list of processes: ", process_list)
                 raise NameError('"python_module" must be defined in your parameters. Check all your processes')
 
             # python-script that contains the process


### PR DESCRIPTION
Using shortened name to match the import for the module. The error only occurred if the input was wrong.
FYI @sunethwarna 