### PR TITLE
[CORE] Bugfix ResidualBasedNewtonRaphsonStrategy

### DIFF
--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -138,7 +138,7 @@ class ResidualBasedNewtonRaphsonStrategy
         // Setting up the default builder and solver
         mpBuilderAndSolver = typename TBuilderAndSolverType::Pointer(
             new ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>(mpLinearSolver));
-        
+
         // Tells to the builder and solver if the reactions have to be Calculated or not
         GetBuilderAndSolver()->SetCalculateReactionsFlag(mCalculateReactionsFlag);
 
@@ -194,7 +194,7 @@ class ResidualBasedNewtonRaphsonStrategy
           mKeepSystemConstantDuringIterations(false)
     {
         KRATOS_TRY
-        
+
         // Tells to the builder and solver if the reactions have to be Calculated or not
         GetBuilderAndSolver()->SetCalculateReactionsFlag(mCalculateReactionsFlag);
 
@@ -247,7 +247,7 @@ class ResidualBasedNewtonRaphsonStrategy
         // Setting up the default builder and solver
         mpBuilderAndSolver = typename TBuilderAndSolverType::Pointer(
             new ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>(mpLinearSolver));
-        
+
         // Tells to the builder and solver if the reactions have to be Calculated or not
         GetBuilderAndSolver()->SetCalculateReactionsFlag(mCalculateReactionsFlag);
 
@@ -732,10 +732,6 @@ class ResidualBasedNewtonRaphsonStrategy
 
         if (mReformDofSetAtEachStep == true) //deallocate the systemvectors
         {
-            SparseSpaceType::Clear(mpA);
-            SparseSpaceType::Clear(mpDx);
-            SparseSpaceType::Clear(mpb);
-
             this->Clear();
         }
 
@@ -1054,7 +1050,7 @@ class ResidualBasedNewtonRaphsonStrategy
   protected:
     ///@name Static Member Variables
     ///@{
-        
+
     ///@}
     ///@name Member Variables
     ///@{
@@ -1162,7 +1158,7 @@ class ResidualBasedNewtonRaphsonStrategy
             << "ATTENTION: max iterations ( " << mMaxIterationNumber
             << " ) exceeded!" << std::endl;
     }
-    
+
     /**
      * @brief This method returns the default settings
      */
@@ -1175,7 +1171,7 @@ class ResidualBasedNewtonRaphsonStrategy
         })");
         return default_settings;
     }
-    
+
     /**
      * @brief This method assigns settings to member variables
      * @param Settings Parameters that are assigned to the member variables


### PR DESCRIPTION
Hi all,

This is a small bugfix for ResidualBasedNewtonRaphsonStrategy. Clearing and assigning new matrices before clearing the ML preconditoner gives runtime errors with memory deallocation inside trilinos ml. Therefore, clearing is removed from here, and it is already taken care in the Clear method of the startegy where matrices are cleared following the precondtioner.