### PR TITLE
[Core] fix data value container - merge

### DIFF
--- a/kratos/containers/data_value_container.cpp
+++ b/kratos/containers/data_value_container.cpp
@@ -40,6 +40,7 @@ namespace Kratos
                 for (iterator j = mData.begin(); j != mData.end(); ++j) {
                     if (i->first == j->first) {
                         variable_already_exist = true;
+                        j->first->Delete(j->second);
                         j->second = i->first->Clone(i->second);
                     }
                 }

--- a/kratos/tests/cpp_tests/containers/test_data_value_container.cpp
+++ b/kratos/tests/cpp_tests/containers/test_data_value_container.cpp
@@ -62,14 +62,25 @@ KRATOS_TEST_CASE_IN_SUITE(DataValueContainerMerge, KratosCoreFastSuite) {
     container_origin.SetValue(VISCOSITY, viscosity_1);
     container_target.SetValue(VISCOSITY, viscosity_2);
     Flags options;
-    //First case: do not overwrite old values
     options.Set(DataValueContainer::OVERWRITE_OLD_VALUES, false);
     container_target.Merge(container_origin, options);
 
     KRATOS_CHECK_EQUAL(container_target.GetValue(DENSITY), density);
     KRATOS_CHECK_EQUAL(container_target.GetValue(VISCOSITY), viscosity_2);
+}
 
-    //Second case: do overwrite old values
+KRATOS_TEST_CASE_IN_SUITE(DataValueContainerMergeOverride, KratosCoreFastSuite) {
+    DataValueContainer container_origin;
+    DataValueContainer container_target;
+
+    const double density = 1000.0;
+    const double viscosity_1 = 1e-3;
+    const double viscosity_2 = 2e-3;
+
+    container_origin.SetValue(DENSITY, density);
+    container_origin.SetValue(VISCOSITY, viscosity_1);
+    container_target.SetValue(VISCOSITY, viscosity_2);
+    Flags options;
     options.Set(DataValueContainer::OVERWRITE_OLD_VALUES, true);
     container_target.Merge(container_origin, options);
     KRATOS_CHECK_EQUAL(container_target.GetValue(DENSITY), density);


### PR DESCRIPTION
valgrind was giving an error in merge method from data value container. 
![image](https://user-images.githubusercontent.com/25667299/65042141-8a2c0180-d958-11e9-9b44-6f212a229c17.png)
pointer was being modified but original object was not removed. Please @pooyan-dadvand check this is correct now.