### PR TITLE
[CoSim][CouplingOperation] adding error-msg

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
@@ -35,7 +35,7 @@ class CoSimulationCouplingOperation(object):
 
 
     def Execute(self):
-        pass
+        raise NotImplementedError('"Execute" is not implemented for {}!'.format(self._ClassName))
 
 
     def PrintInfo(self):


### PR DESCRIPTION
using this method is optional, hence we need a way to tell the user that using it then is nonsense