### PR TITLE
[Fluid] Modify distance in Initialize()

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -373,6 +373,7 @@ class NavierStokesEmbeddedMonolithicSolver(FluidSolver):
 
         # Set the distance modification process
         self.__GetDistanceModificationProcess().ExecuteInitialize()
+        self.__GetDistanceModificationProcess().ExecuteInitializeSolutionStep()
 
         # For the primitive Ausas formulation, set the find nodal neighbours process
         # Recall that the Ausas condition requires the nodal neighbours.

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -373,7 +373,7 @@ class NavierStokesEmbeddedMonolithicSolver(FluidSolver):
 
         # Set the distance modification process
         self.__GetDistanceModificationProcess().ExecuteInitialize()
-        self.__GetDistanceModificationProcess().ExecuteInitializeSolutionStep()
+        self.__GetDistanceModificationProcess().ExecuteBeforeSolutionLoop()
 
         # For the primitive Ausas formulation, set the find nodal neighbours process
         # Recall that the Ausas condition requires the nodal neighbours.


### PR DESCRIPTION
This calls the modify distance process to correct the level set in the Initialize() method of the solver. This prevents ill-conditioned cuts if there is any splitting before the Solve() call (e.g. ExecuteBeforeSolutionLoop()).
