### PR TITLE
[ShapeOpt] pass full model part to analyzer

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_bead_optimization.py
@@ -224,7 +224,7 @@ class AlgorithmBeadOptimization(OptimizationAlgorithm):
                 self.communicator.requestValueOf(self.objectives[0]["identifier"].GetString())
                 self.communicator.requestGradientOf(self.objectives[0]["identifier"].GetString())
 
-                self.analyzer.AnalyzeDesignAndReportToCommunicator(self.design_surface, total_iteration, self.communicator)
+                self.analyzer.AnalyzeDesignAndReportToCommunicator(self.optimization_model_part, total_iteration, self.communicator)
 
                 objective_value = self.communicator.getStandardizedValue(self.objectives[0]["identifier"].GetString())
                 objGradientDict = self.communicator.getStandardizedGradient(self.objectives[0]["identifier"].GetString())

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_penalized_projection.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_penalized_projection.py
@@ -137,7 +137,7 @@ class AlgorithmPenalizedProjection(OptimizationAlgorithm):
         self.communicator.requestValueOf(self.constraints[0]["identifier"].GetString())
         self.communicator.requestGradientOf(self.constraints[0]["identifier"].GetString())
 
-        self.analyzer.AnalyzeDesignAndReportToCommunicator(self.design_surface, self.optimization_iteration, self.communicator)
+        self.analyzer.AnalyzeDesignAndReportToCommunicator(self.optimization_model_part, self.optimization_iteration, self.communicator)
 
         objGradientDict = self.communicator.getStandardizedGradient(self.objectives[0]["identifier"].GetString())
         conGradientDict = self.communicator.getStandardizedGradient(self.constraints[0]["identifier"].GetString())

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_steepest_descent.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_steepest_descent.py
@@ -145,7 +145,7 @@ class AlgorithmSteepestDescent(OptimizationAlgorithm):
         self.communicator.requestValueOf(self.objectives[0]["identifier"].GetString())
         self.communicator.requestGradientOf(self.objectives[0]["identifier"].GetString())
 
-        self.analyzer.AnalyzeDesignAndReportToCommunicator(self.design_surface, self.optimization_iteration, self.communicator)
+        self.analyzer.AnalyzeDesignAndReportToCommunicator(self.optimization_model_part, self.optimization_iteration, self.communicator)
 
         objGradientDict = self.communicator.getStandardizedGradient(self.objectives[0]["identifier"].GetString())
         WriteDictionaryDataOnNodalVariable(objGradientDict, self.optimization_model_part, KSO.DF1DX)

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
@@ -151,7 +151,7 @@ class AlgorithmTrustRegion(OptimizationAlgorithm):
                 self.communicator.requestValueOf(con_id)
                 self.communicator.requestGradientOf(con_id)
 
-            self.analyzer.AnalyzeDesignAndReportToCommunicator(self.design_surface, self.opt_iteration, self.communicator)
+            self.analyzer.AnalyzeDesignAndReportToCommunicator(self.optimization_model_part, self.opt_iteration, self.communicator)
 
     # --------------------------------------------------------------------------
     def __PostProcessGradientsObtainedFromAnalysis(self):


### PR DESCRIPTION
If mesh motion is done inside Kratos, it is necessary to pass the full model part to the analyzer in order to allow him to consider the updated coordinates of the internal nodes