### PR TITLE
[PotentialFlow] Adding hessian refinement script and process to compute nodal velocities

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/CMakeLists.txt
+++ b/applications/CompressiblePotentialFlowApplication/CMakeLists.txt
@@ -28,6 +28,7 @@ set( KRATOS_COMPRESSIBLE_POTENTIAL_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/embedded_incompressible_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/incompressible_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/apply_far_field_process.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/define_2d_wake_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/move_model_part_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_response_functions/adjoint_potential_response_function.cpp

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Marc Nunez, based on R.Rossi and V.Mataix work
 //

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
@@ -18,7 +18,6 @@
 
 /* Project includes */
 #include "utilities/variable_utils.h"
-#include "utilities/geometry_utilities.h"
 #include "compute_nodal_potential_flow_velocity_process.h"
 #include "compressible_potential_flow_application_variables.h"
 #include "custom_utilities/potential_flow_utilities.h"
@@ -43,8 +42,6 @@ void ComputeNodalPotentialFlowVelocityProcess::Execute()
 
     // Current domain size
     const std::size_t dimension = mrModelPart.GetProcessInfo()[DOMAIN_SIZE];
-
-    const array_1d<double, 3> free_stream_velocity = mrModelPart.GetProcessInfo()[FREE_STREAM_VELOCITY];
 
     // Iterate over the elements
     #pragma omp parallel for firstprivate(N)

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
@@ -19,14 +19,14 @@
 /* Project includes */
 #include "utilities/variable_utils.h"
 #include "utilities/geometry_utilities.h"
-#include "compute_custom_nodal_gradient_process.h"
+#include "compute_nodal_potential_flow_velocity_process.h"
 #include "compressible_potential_flow_application_variables.h"
 
 
 namespace Kratos
 {
 template<bool THistorical>
-void ComputeCustomNodalGradient<THistorical>::Execute()
+void ComputeNodalPotentialFlowVelocityProcess<THistorical>::Execute()
 {
     KRATOS_TRY;
 
@@ -148,7 +148,7 @@ void ComputeCustomNodalGradient<THistorical>::Execute()
 /***********************************************************************************/
 
 template<>
-ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalVariable>::ComputeCustomNodalGradient(
+ComputeNodalPotentialFlowVelocityProcess<ComputeNodalPotentialFlowVelocityProcessSettings::SaveAsHistoricalVariable>::ComputeNodalPotentialFlowVelocityProcess(
     ModelPart& rModelPart,
     Variable<array_1d<double,3> >& rGradientVariable,
     Variable<double>& rAreaVariable)
@@ -172,7 +172,7 @@ ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalV
 /***********************************************************************************/
 
 template<>
-ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoricalVariable>::ComputeCustomNodalGradient(
+ComputeNodalPotentialFlowVelocityProcess<ComputeNodalPotentialFlowVelocityProcessSettings::SaveAsNonHistoricalVariable>::ComputeNodalPotentialFlowVelocityProcess(
     ModelPart& rModelPart,
     Variable<array_1d<double,3> >& rGradientVariable,
     Variable<double>& rAreaVariable)
@@ -199,7 +199,7 @@ ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoric
 /***********************************************************************************/
 
 template<>
-void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalVariable>::ClearGradient()
+void ComputeNodalPotentialFlowVelocityProcess<ComputeNodalPotentialFlowVelocityProcessSettings::SaveAsHistoricalVariable>::ClearGradient()
 {
     #pragma omp parallel for
     for(int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); ++i) {
@@ -213,7 +213,7 @@ void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistor
 /***********************************************************************************/
 
 template <>
-void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoricalVariable>::ClearGradient()
+void ComputeNodalPotentialFlowVelocityProcess<ComputeNodalPotentialFlowVelocityProcessSettings::SaveAsNonHistoricalVariable>::ClearGradient()
 {
     const array_1d<double, 3> aux_zero_vector = ZeroVector(3);
 
@@ -229,7 +229,7 @@ void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHis
 /***********************************************************************************/
 
 template <>
-array_1d<double, 3>& ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalVariable>::GetGradient(
+array_1d<double, 3>& ComputeNodalPotentialFlowVelocityProcess<ComputeNodalPotentialFlowVelocityProcessSettings::SaveAsHistoricalVariable>::GetGradient(
     Element::GeometryType& rThisGeometry,
     unsigned int i
     )
@@ -242,7 +242,7 @@ array_1d<double, 3>& ComputeCustomNodalGradient<ComputeCustomNodalGradientSettin
 /***********************************************************************************/
 
 template <>
-array_1d<double, 3>& ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoricalVariable>::GetGradient(
+array_1d<double, 3>& ComputeNodalPotentialFlowVelocityProcess<ComputeNodalPotentialFlowVelocityProcessSettings::SaveAsNonHistoricalVariable>::GetGradient(
     Element::GeometryType& rThisGeometry,
     unsigned int i
     )
@@ -255,7 +255,7 @@ array_1d<double, 3>& ComputeCustomNodalGradient<ComputeCustomNodalGradientSettin
 /***********************************************************************************/
 
 template <>
-void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalVariable>::PonderateGradient()
+void ComputeNodalPotentialFlowVelocityProcess<ComputeNodalPotentialFlowVelocityProcessSettings::SaveAsHistoricalVariable>::PonderateGradient()
 {
     #pragma omp parallel for
     for(int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); ++i) {
@@ -268,7 +268,7 @@ void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistor
 /***********************************************************************************/
 
 template <>
-void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoricalVariable>::PonderateGradient()
+void ComputeNodalPotentialFlowVelocityProcess<ComputeNodalPotentialFlowVelocityProcessSettings::SaveAsNonHistoricalVariable>::PonderateGradient()
 {
     #pragma omp parallel for
     for(int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); ++i)
@@ -280,7 +280,7 @@ void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHis
 /***********************************************************************************/
 /***********************************************************************************/
 
-template class ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalVariable>;
-template class ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoricalVariable>;
+template class ComputeNodalPotentialFlowVelocityProcess<ComputeNodalPotentialFlowVelocityProcessSettings::SaveAsHistoricalVariable>;
+template class ComputeNodalPotentialFlowVelocityProcess<ComputeNodalPotentialFlowVelocityProcessSettings::SaveAsNonHistoricalVariable>;
 
 } /* namespace Kratos.*/

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
@@ -42,6 +42,7 @@ void ComputeNodalPotentialFlowVelocityProcess::Execute()
 
     // Current domain size
     const std::size_t dimension = mrModelPart.GetProcessInfo()[DOMAIN_SIZE];
+    KRATOS_ERROR_IF(dimension != 2 && dimension !=3) << "Dimension has to be either 2 or 3! Current dimension: " << dimension << std::endl;
 
     // Iterate over the elements
     #pragma omp parallel for firstprivate(N)

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.cpp
@@ -1,0 +1,286 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Riccardo Rossi
+//                   Vicente Mataix Ferrandiz
+//
+//
+
+/* System includes */
+
+/* External includes */
+
+/* Project includes */
+#include "utilities/variable_utils.h"
+#include "utilities/geometry_utilities.h"
+#include "compute_custom_nodal_gradient_process.h"
+#include "compressible_potential_flow_application_variables.h"
+
+
+namespace Kratos
+{
+template<bool THistorical>
+void ComputeCustomNodalGradient<THistorical>::Execute()
+{
+    KRATOS_TRY;
+
+    // Set to zero
+    ClearGradient();
+
+    // Auxiliar containers
+    Matrix DN_DX, J0;
+    Vector N;
+
+    // First element iterator
+    const auto it_element_begin = mrModelPart.ElementsBegin();
+
+    // Current domain size
+    const std::size_t dimension = mrModelPart.GetProcessInfo()[DOMAIN_SIZE];
+
+    const array_1d<double, 3> free_stream_velocity = mrModelPart.GetProcessInfo()[FREE_STREAM_VELOCITY];
+    const double free_stream_velocity_norm = inner_prod(free_stream_velocity, free_stream_velocity);
+
+
+
+
+    // Iterate over the elements
+    #pragma omp parallel for firstprivate(DN_DX,  N, J0)
+    for(int i_elem=0; i_elem<static_cast<int>(mrModelPart.Elements().size()); ++i_elem) {
+        auto it_elem = it_element_begin + i_elem;
+        auto& r_geometry = it_elem->GetGeometry();
+
+        // Current geometry information
+        const std::size_t local_space_dimension = r_geometry.LocalSpaceDimension();
+        const std::size_t number_of_nodes = r_geometry.PointsNumber();
+
+        // Resize if needed
+        if (DN_DX.size1() != number_of_nodes || DN_DX.size2() != dimension)
+            DN_DX.resize(number_of_nodes, dimension);
+        if (N.size() != number_of_nodes)
+            N.resize(number_of_nodes);
+        if (J0.size1() != dimension || J0.size2() != local_space_dimension)
+            J0.resize(dimension, local_space_dimension);
+
+        // The integration points
+        const auto& r_integration_method = r_geometry.GetDefaultIntegrationMethod();
+        const auto& r_integration_points = r_geometry.IntegrationPoints(r_integration_method);
+        const std::size_t number_of_integration_points = r_integration_points.size();
+
+        Vector values(number_of_nodes);
+        if (it_elem->GetValue(WAKE)){
+            for(std::size_t i_node=0; i_node<number_of_nodes; ++i_node){
+                double distance = r_geometry[i_node].GetValue(WAKE_DISTANCE);
+                if (distance>0)
+                    values[i_node] = r_geometry[i_node].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
+                else
+                    values[i_node] = r_geometry[i_node].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
+            }
+        }else{
+            if (it_elem->GetValue(KUTTA)){
+                for(std::size_t i_node=0; i_node<number_of_nodes; ++i_node){
+                    if (r_geometry[i_node].GetValue(TRAILING_EDGE))
+                        values[i_node] = r_geometry[i_node].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
+                    else
+                        values[i_node] = r_geometry[i_node].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
+                }
+            }else{
+                for(std::size_t i_node=0; i_node<number_of_nodes; ++i_node)
+                    values[i_node] = r_geometry[i_node].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
+            }
+        }
+
+        // The containers of the shape functions and the local gradients
+        const Matrix& rNcontainer = r_geometry.ShapeFunctionsValues(r_integration_method);
+        const auto& rDN_DeContainer = r_geometry.ShapeFunctionsLocalGradients(r_integration_method);
+
+        for ( IndexType point_number = 0; point_number < number_of_integration_points; ++point_number ) {
+            // Getting the shape functions
+            noalias(N) = row(rNcontainer, point_number);
+
+            // Getting the jacobians and local gradients
+            GeometryUtils::JacobianOnInitialConfiguration(r_geometry, r_integration_points[point_number], J0);
+            double detJ0;
+            Matrix InvJ0;
+            MathUtils<double>::GeneralizedInvertMatrix(J0, InvJ0, detJ0);
+            const Matrix& rDN_De = rDN_DeContainer[point_number];
+            GeometryUtils::ShapeFunctionsGradients(rDN_De, InvJ0, DN_DX);
+
+            const Vector grad = prod(trans(DN_DX), values);
+            const double gauss_point_volume = r_integration_points[point_number].Weight() * detJ0;
+
+            for(std::size_t i_node=0; i_node<number_of_nodes; ++i_node) {
+                array_1d<double, 3>& r_gradient = GetGradient(r_geometry, i_node);
+                for(std::size_t k=0; k<dimension; ++k) {
+                    #pragma omp atomic
+                    r_gradient[k] += N[i_node] * gauss_point_volume*grad[k];
+                }
+
+                double& vol = r_geometry[i_node].GetValue(mrAreaVariable);
+
+                #pragma omp atomic
+                vol += N[i_node] * gauss_point_volume;
+            }
+        }
+    }
+
+    PonderateGradient();
+
+    for(int i_node=0; i_node<static_cast<int>(mrModelPart.Nodes().size()); ++i_node) {
+        auto it_node=mrModelPart.NodesBegin()+i_node;
+        auto nodal_velocity = it_node->FastGetSolutionStepValue(mrGradientVariable);
+
+        double pressure_coefficient = (free_stream_velocity_norm - inner_prod(nodal_velocity, nodal_velocity)) /
+                free_stream_velocity_norm; // 0.5*(norm_2(free_stream_velocity) - norm_2(v));
+        it_node->GetValue(PRESSURE_COEFFICIENT) = pressure_coefficient;
+    }
+
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<>
+ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalVariable>::ComputeCustomNodalGradient(
+    ModelPart& rModelPart,
+    Variable<array_1d<double,3> >& rGradientVariable,
+    Variable<double>& rAreaVariable)
+    :mrModelPart(rModelPart), mrGradientVariable(rGradientVariable), mrAreaVariable(rAreaVariable)
+{
+    KRATOS_TRY
+
+    // We push the list of double variables
+
+    VariableUtils().CheckVariableExists(rGradientVariable, mrModelPart.Nodes());
+    // In case the area or gradient variable is not initialized we initialize it
+    auto& r_nodes = rModelPart.Nodes();
+    if (!r_nodes.begin()->Has( rAreaVariable )) {
+        VariableUtils().SetNonHistoricalVariable(rAreaVariable, 0.0, r_nodes);
+    }
+
+    KRATOS_CATCH("")
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<>
+ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoricalVariable>::ComputeCustomNodalGradient(
+    ModelPart& rModelPart,
+    Variable<array_1d<double,3> >& rGradientVariable,
+    Variable<double>& rAreaVariable)
+    :mrModelPart(rModelPart), mrGradientVariable(rGradientVariable), mrAreaVariable(rAreaVariable)
+{
+    KRATOS_TRY
+
+
+    // In case the area or gradient variable is not initialized we initialize it
+    auto& r_nodes = rModelPart.Nodes();
+    if (!r_nodes.begin()->Has( rGradientVariable )) {
+        const array_1d<double,3> zero_vector = ZeroVector(3);
+        VariableUtils().SetNonHistoricalVariable(rGradientVariable, zero_vector, r_nodes);
+    }
+    if (!r_nodes.begin()->Has( rAreaVariable )) {
+        VariableUtils().SetNonHistoricalVariable(rAreaVariable, 0.0, r_nodes);
+    }
+
+    KRATOS_CATCH("")
+}
+
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template<>
+void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalVariable>::ClearGradient()
+{
+    #pragma omp parallel for
+    for(int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); ++i) {
+        auto it_node=mrModelPart.NodesBegin()+i;
+        it_node->SetValue(mrAreaVariable, 0.0);
+        it_node->FastGetSolutionStepValue(mrGradientVariable).clear();
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template <>
+void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoricalVariable>::ClearGradient()
+{
+    const array_1d<double, 3> aux_zero_vector = ZeroVector(3);
+
+    #pragma omp parallel for
+    for(int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); ++i) {
+        auto it_node=mrModelPart.NodesBegin()+i;
+        it_node->SetValue(mrAreaVariable, 0.0);
+        it_node->SetValue(mrGradientVariable, aux_zero_vector);
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template <>
+array_1d<double, 3>& ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalVariable>::GetGradient(
+    Element::GeometryType& rThisGeometry,
+    unsigned int i
+    )
+{
+    array_1d<double, 3>& val = rThisGeometry[i].FastGetSolutionStepValue(mrGradientVariable);
+    return val;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template <>
+array_1d<double, 3>& ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoricalVariable>::GetGradient(
+    Element::GeometryType& rThisGeometry,
+    unsigned int i
+    )
+{
+    array_1d<double, 3>& val = rThisGeometry[i].GetValue(mrGradientVariable);
+    return val;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template <>
+void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalVariable>::PonderateGradient()
+{
+    #pragma omp parallel for
+    for(int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); ++i) {
+        auto it_node = mrModelPart.NodesBegin()+i;
+        it_node->FastGetSolutionStepValue(mrGradientVariable) /= it_node->GetValue(mrAreaVariable);
+    }
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+template <>
+void ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoricalVariable>::PonderateGradient()
+{
+    #pragma omp parallel for
+    for(int i = 0; i < static_cast<int>(mrModelPart.Nodes().size()); ++i)
+    {
+        auto it_node=mrModelPart.NodesBegin()+i;
+        it_node->GetValue(mrGradientVariable) /= it_node->GetValue(mrAreaVariable);
+    }
+}
+/***********************************************************************************/
+/***********************************************************************************/
+
+template class ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsHistoricalVariable>;
+template class ComputeCustomNodalGradient<ComputeCustomNodalGradientSettings::SaveAsNonHistoricalVariable>;
+
+} /* namespace Kratos.*/

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.h
@@ -1,0 +1,294 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Riccardo Rossi
+//                   Vicente Mataix Ferrandiz
+//
+
+#if !defined(KRATOS_COMPUTE_GRADIENT_PROCESS_INCLUDED )
+#define  KRATOS_COMPUTE_GRADIENT_PROCESS_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+#include "processes/process.h"
+#include "includes/model_part.h"
+
+namespace Kratos
+{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+    typedef VariableComponent< VectorComponentAdaptor<array_1d<double, 3> > > ComponentType;
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/**
+ * @brief This struct is used in order to identify when using the hitorical and non historical variables
+ */
+struct ComputeCustomNodalGradientSettings
+{
+    // Defining clearer options
+    constexpr static bool SaveAsHistoricalVariable = true;
+    constexpr static bool SaveAsNonHistoricalVariable = false;
+};
+
+/**
+ * @class ComputeCustomNodalGradient
+ * @ingroup KratosCore
+ * @brief Compute Nodal Gradient process
+ * @details This process computes the gradient of a certain variable stored in the nodes
+ * @author Riccardo Rossi
+ * @author Vicente Mataix Ferrandiz
+ * @tparam THistorical If the variable is historical or not
+*/
+template<bool THistorical>
+class KRATOS_API(KRATOS_CORE) ComputeCustomNodalGradient
+    : public Process
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of ComputeCustomNodalGradient
+    KRATOS_CLASS_POINTER_DEFINITION(ComputeCustomNodalGradient);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor. (double)
+    ComputeCustomNodalGradient(
+        ModelPart& rModelPart,
+        Variable<array_1d<double,3> >& rGradientVariable,
+        Variable<double>& rAreaVariable = NODAL_AREA
+        );
+
+    /// Destructor.
+    ~ComputeCustomNodalGradient() override
+    {
+    }
+
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// This operator is provided to call the process as a function and simply calls the Execute method.
+    void operator()()
+    {
+        Execute();
+    }
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * Execute method is used to execute the Process algorithms.
+     * In this process the gradient of a scalar variable will be computed
+     */
+    void Execute() override;
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        return "ComputeCustomNodalGradient";
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << "ComputeCustomNodalGradient";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override
+    {
+    }
+
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+    ModelPart& mrModelPart;                                      /// The main model part
+    std::vector<Variable<double>*> mrOriginVariableDoubleList;   /// The scalar variable list to compute
+    std::vector<ComponentType*> mrOriginVariableComponentsList;  /// The scalar variable list to compute (components)
+    Variable<array_1d<double,3> >& mrGradientVariable;           /// The resultant gradient variable
+    Variable<double>& mrAreaVariable;                            /// The auxiliar area variable
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    // TODO: Try to use enable_if!!!
+
+    /**
+     * This clears the gradient
+     */
+    void ClearGradient();
+
+    /**
+     * This gets the gradient value
+     * @param rThisGeometry The geometry of the element
+     * @param i The node index
+     */
+    array_1d<double, 3>& GetGradient(
+        Element::GeometryType& rThisGeometry,
+        unsigned int i
+        );
+
+    /**
+     * This divides the gradient value by the nodal area
+     */
+    void PonderateGradient();
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    ComputeCustomNodalGradient& operator=(ComputeCustomNodalGradient const& rOther);
+
+    /// Copy constructor.
+    //ComputeCustomNodalGradient(ComputeCustomNodalGradient const& rOther);
+
+
+    ///@}
+
+}; // Class ComputeCustomNodalGradient
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+// inline std::istream& operator >> (std::istream& rIStream,
+//                                   ComputeCustomNodalGradient& rThis);
+//
+// /// output stream function
+// inline std::ostream& operator << (std::ostream& rOStream,
+//                                   const ComputeCustomNodalGradient& rThis)
+// {
+//     rThis.PrintInfo(rOStream);
+//     rOStream << std::endl;
+//     rThis.PrintData(rOStream);
+//
+//     return rOStream;
+// }
+///@}
+
+}  // namespace Kratos.
+
+#endif // KRATOS_COMPUTE_GRADIENT_PROCESS_INCLUDED  defined
+
+

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.h
@@ -50,7 +50,7 @@ namespace Kratos
 /**
  * @brief This struct is used in order to identify when using the hitorical and non historical variables
  */
-struct ComputeCustomNodalGradientSettings
+struct ComputeNodalPotentialFlowVelocityProcessSettings
 {
     // Defining clearer options
     constexpr static bool SaveAsHistoricalVariable = true;
@@ -58,7 +58,7 @@ struct ComputeCustomNodalGradientSettings
 };
 
 /**
- * @class ComputeCustomNodalGradient
+ * @class ComputeNodalPotentialFlowVelocityProcess
  * @ingroup KratosCore
  * @brief Compute Nodal Gradient process
  * @details This process computes the gradient of a certain variable stored in the nodes
@@ -67,29 +67,29 @@ struct ComputeCustomNodalGradientSettings
  * @tparam THistorical If the variable is historical or not
 */
 template<bool THistorical>
-class KRATOS_API(KRATOS_CORE) ComputeCustomNodalGradient
+class KRATOS_API(KRATOS_CORE) ComputeNodalPotentialFlowVelocityProcess
     : public Process
 {
 public:
     ///@name Type Definitions
     ///@{
 
-    /// Pointer definition of ComputeCustomNodalGradient
-    KRATOS_CLASS_POINTER_DEFINITION(ComputeCustomNodalGradient);
+    /// Pointer definition of ComputeNodalPotentialFlowVelocityProcess
+    KRATOS_CLASS_POINTER_DEFINITION(ComputeNodalPotentialFlowVelocityProcess);
 
     ///@}
     ///@name Life Cycle
     ///@{
 
     /// Default constructor. (double)
-    ComputeCustomNodalGradient(
+    ComputeNodalPotentialFlowVelocityProcess(
         ModelPart& rModelPart,
         Variable<array_1d<double,3> >& rGradientVariable,
         Variable<double>& rAreaVariable = NODAL_AREA
         );
 
     /// Destructor.
-    ~ComputeCustomNodalGradient() override
+    ~ComputeNodalPotentialFlowVelocityProcess() override
     {
     }
 
@@ -132,13 +132,13 @@ public:
     /// Turn back information as a string.
     std::string Info() const override
     {
-        return "ComputeCustomNodalGradient";
+        return "ComputeNodalPotentialFlowVelocityProcess";
     }
 
     /// Print information about this object.
     void PrintInfo(std::ostream& rOStream) const override
     {
-        rOStream << "ComputeCustomNodalGradient";
+        rOStream << "ComputeNodalPotentialFlowVelocityProcess";
     }
 
     /// Print object's data.
@@ -251,15 +251,15 @@ private:
     ///@{
 
     /// Assignment operator.
-    ComputeCustomNodalGradient& operator=(ComputeCustomNodalGradient const& rOther);
+    ComputeNodalPotentialFlowVelocityProcess& operator=(ComputeNodalPotentialFlowVelocityProcess const& rOther);
 
     /// Copy constructor.
-    //ComputeCustomNodalGradient(ComputeCustomNodalGradient const& rOther);
+    //ComputeNodalPotentialFlowVelocityProcess(ComputeNodalPotentialFlowVelocityProcess const& rOther);
 
 
     ///@}
 
-}; // Class ComputeCustomNodalGradient
+}; // Class ComputeNodalPotentialFlowVelocityProcess
 
 ///@}
 
@@ -273,11 +273,11 @@ private:
 
 /// input stream function
 // inline std::istream& operator >> (std::istream& rIStream,
-//                                   ComputeCustomNodalGradient& rThis);
+//                                   ComputeNodalPotentialFlowVelocityProcess& rThis);
 //
 // /// output stream function
 // inline std::ostream& operator << (std::ostream& rOStream,
-//                                   const ComputeCustomNodalGradient& rThis)
+//                                   const ComputeNodalPotentialFlowVelocityProcess& rThis)
 // {
 //     rThis.PrintInfo(rOStream);
 //     rOStream << std::endl;

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.h
@@ -1,11 +1,11 @@
 //    |  /           |
 //    ' /   __| _` | __|  _ \   __|
-//    . \  |   (   | |   (   |\__ \.
+//    . \  |   (   | |   (   |\__ `
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Marc Nunez, based on R.Rossi and V.Mataix work
 //

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.h
@@ -7,12 +7,12 @@
 //  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
-//  Main authors:    Riccardo Rossi
-//                   Vicente Mataix Ferrandiz
+//  Main authors:    Marc Nunez, based on R.Rossi and V.Mataix work
+//
 //
 
-#if !defined(KRATOS_COMPUTE_GRADIENT_PROCESS_INCLUDED )
-#define  KRATOS_COMPUTE_GRADIENT_PROCESS_INCLUDED
+#if !defined(KRATOS_COMPUTE_NODAL_POTENTIAL_FLOW_VELOCITY_PROCESS_INCLUDED )
+#define  KRATOS_COMPUTE_NODAL_POTENTIAL_FLOW_VELOCITY_INCLUDED
 
 // System includes
 
@@ -32,9 +32,6 @@ namespace Kratos
 ///@}
 ///@name Type Definitions
 ///@{
-
-    typedef VariableComponent< VectorComponentAdaptor<array_1d<double, 3> > > ComponentType;
-
 ///@}
 ///@name  Enum's
 ///@{
@@ -47,27 +44,8 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
-/**
- * @brief This struct is used in order to identify when using the hitorical and non historical variables
- */
-struct ComputeNodalPotentialFlowVelocityProcessSettings
-{
-    // Defining clearer options
-    constexpr static bool SaveAsHistoricalVariable = true;
-    constexpr static bool SaveAsNonHistoricalVariable = false;
-};
 
-/**
- * @class ComputeNodalPotentialFlowVelocityProcess
- * @ingroup KratosCore
- * @brief Compute Nodal Gradient process
- * @details This process computes the gradient of a certain variable stored in the nodes
- * @author Riccardo Rossi
- * @author Vicente Mataix Ferrandiz
- * @tparam THistorical If the variable is historical or not
-*/
-template<bool THistorical>
-class KRATOS_API(KRATOS_CORE) ComputeNodalPotentialFlowVelocityProcess
+class KRATOS_API(CompressiblePotentialFlowApplication) ComputeNodalPotentialFlowVelocityProcess
     : public Process
 {
 public:
@@ -83,9 +61,7 @@ public:
 
     /// Default constructor. (double)
     ComputeNodalPotentialFlowVelocityProcess(
-        ModelPart& rModelPart,
-        Variable<array_1d<double,3> >& rGradientVariable,
-        Variable<double>& rAreaVariable = NODAL_AREA
+        ModelPart& rModelPart
         );
 
     /// Destructor.
@@ -201,10 +177,6 @@ private:
     ///@{
 
     ModelPart& mrModelPart;                                      /// The main model part
-    std::vector<Variable<double>*> mrOriginVariableDoubleList;   /// The scalar variable list to compute
-    std::vector<ComponentType*> mrOriginVariableComponentsList;  /// The scalar variable list to compute (components)
-    Variable<array_1d<double,3> >& mrGradientVariable;           /// The resultant gradient variable
-    Variable<double>& mrAreaVariable;                            /// The auxiliar area variable
 
     ///@}
     ///@name Private Operators
@@ -271,20 +243,6 @@ private:
 ///@name Input and output
 ///@{
 
-/// input stream function
-// inline std::istream& operator >> (std::istream& rIStream,
-//                                   ComputeNodalPotentialFlowVelocityProcess& rThis);
-//
-// /// output stream function
-// inline std::ostream& operator << (std::ostream& rOStream,
-//                                   const ComputeNodalPotentialFlowVelocityProcess& rThis)
-// {
-//     rThis.PrintInfo(rOStream);
-//     rOStream << std::endl;
-//     rThis.PrintData(rOStream);
-//
-//     return rOStream;
-// }
 ///@}
 
 }  // namespace Kratos.

--- a/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_processes_to_python.cpp
@@ -22,6 +22,7 @@
 #include "custom_processes/move_model_part_process.h"
 #include "custom_processes/define_2d_wake_process.h"
 #include "custom_processes/apply_far_field_process.h"
+#include "custom_processes/compute_nodal_potential_flow_velocity_process.h"
 
 namespace Kratos {
 namespace Python {
@@ -43,6 +44,11 @@ void  AddCustomProcessesToPython(pybind11::module& m)
     py::class_<Define2DWakeProcess, Define2DWakeProcess::Pointer, Process >
         (m, "Define2DWakeProcess")
         .def(py::init<ModelPart&, const double>())
+        ;
+
+    py::class_<ApplyFarFieldProcess, ApplyFarFieldProcess::Pointer, Process >
+        (m, "ApplyFarFieldProcess")
+        .def(py::init<ModelPart&, const double, const bool>())
         ;
 
     py::class_<ApplyFarFieldProcess, ApplyFarFieldProcess::Pointer, Process >

--- a/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_processes_to_python.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_python/add_custom_processes_to_python.cpp
@@ -51,10 +51,10 @@ void  AddCustomProcessesToPython(pybind11::module& m)
         .def(py::init<ModelPart&, const double, const bool>())
         ;
 
-    py::class_<ApplyFarFieldProcess, ApplyFarFieldProcess::Pointer, Process >
-        (m, "ApplyFarFieldProcess")
-        .def(py::init<ModelPart&, const double, const bool>())
-        ;
+    py::class_<ComputeNodalPotentialFlowVelocityProcess, ComputeNodalPotentialFlowVelocityProcess::Pointer, Process>
+        (m,"ComputeNodalPotentialFlowVelocityProcess")
+        .def(py::init<ModelPart&>())
+    ;
 }
 
 }  // namespace Python.

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/apply_potential_flow_hessian_remeshing_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/apply_potential_flow_hessian_remeshing_process.py
@@ -64,7 +64,7 @@ class ApplyPotentialFlowHessianRemeshingProcess(KratosMultiphysics.Process):
 
     def __ComputeNodalVelocity(self):
 
-        nodal_velocity_process = KratosMultiphysics.CompressiblePotentialFlowApplication.ComputeNodalPotentialFlowVelocityProcess(self.main_model_part)
+        nodal_velocity_process = CPFApp.ComputeNodalPotentialFlowVelocityProcess(self.main_model_part)
         nodal_velocity_process.Execute()
 
     def __ComputeHessianMetric(self):
@@ -72,13 +72,13 @@ class ApplyPotentialFlowHessianRemeshingProcess(KratosMultiphysics.Process):
         find_nodal_h = KratosMultiphysics.FindNodalHNonHistoricalProcess(self.main_model_part)
         find_nodal_h.Execute()
 
-        metric_x = KratosMultiphysics.MeshingApplication.ComputeHessianSolMetricProcess(self.main_model_part, KratosMultiphysics.VELOCITY_X, self.metric_parameters)
+        metric_x = KratosMeshing.ComputeHessianSolMetricProcess(self.main_model_part, KratosMultiphysics.VELOCITY_X, self.metric_parameters)
         metric_x.Execute()
-        metric_y = KratosMultiphysics.MeshingApplication.ComputeHessianSolMetricProcess(self.main_model_part, KratosMultiphysics.VELOCITY_Y, self.metric_parameters)
+        metric_y = KratosMeshing.ComputeHessianSolMetricProcess(self.main_model_part, KratosMultiphysics.VELOCITY_Y, self.metric_parameters)
         metric_y.Execute()
 
         if (self.domain_size == 3):
-            metric_z = KratosMultiphysics.MeshingApplication.ComputeHessianSolMetricProcess(self.main_model_part, KratosMultiphysics.VELOCITY_Z, self.metric_parameters)
+            metric_z = KratosMeshing.ComputeHessianSolMetricProcess(self.main_model_part, KratosMultiphysics.VELOCITY_Z, self.metric_parameters)
             metric_z.Execute()
 
     def __RemoveSubModelParts(self):

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/apply_potential_flow_hessian_remeshing_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/apply_potential_flow_hessian_remeshing_process.py
@@ -1,0 +1,100 @@
+import KratosMultiphysics
+import KratosMultiphysics.CompressiblePotentialFlowApplication as CPFApp
+import KratosMultiphysics.MeshingApplication as KratosMeshing
+
+
+def Factory(settings, Model):
+    if( not isinstance(settings,KratosMultiphysics.Parameters) ):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    return ApplyPotentialFlowHessianRemeshingProcess(Model, settings["Parameters"])
+
+## All the processes python should be derived from "Process"
+class ApplyPotentialFlowHessianRemeshingProcess(KratosMultiphysics.Process):
+    def __init__(self, Model, settings ):
+        KratosMultiphysics.Process.__init__(self)
+
+        default_parameters = KratosMultiphysics.Parameters( """
+            {
+                "model_part_name"   :"",
+                "metric_parameters" : {
+                    "minimal_size"                        : 0.001,
+                    "maximal_size"                        : 10.0,
+                    "enforce_current"                     : false,
+                    "hessian_strategy_parameters":
+                    {
+                        "non_historical_metric_variable"  : true,
+                        "estimate_interpolation_error"    : false,
+                        "interpolation_error"             : 1e-2
+                    },
+                    "anisotropy_remeshing"                : false
+                },
+                "mmg_parameters"  :{
+                    "discretization_type"              : "STANDARD",
+                    "save_external_files"              : false,
+                    "initialize_entities"              : false,
+                    "echo_level"                       : 0
+                }
+            }  """ )
+        settings.ValidateAndAssignDefaults(default_parameters)
+
+        self.main_model_part = Model[settings["model_part_name"].GetString()]
+        self.domain_size = self.main_model_part.ProcessInfo.GetValue(KratosMultiphysics.DOMAIN_SIZE)
+        if not self.domain_size == 2 and not self.domain_size == 3:
+            raise(Exception("Domain size is different than 2 and different than 3. Please set the domain size correclty"))
+
+        self.metric_parameters = settings["metric_parameters"]
+        self.mmg_parameters = settings["mmg_parameters"]
+
+        if self.metric_parameters["hessian_strategy_parameters"].Has("non_historical_metric_variable"):
+            if not self.metric_parameters["hessian_strategy_parameters"]["non_historical_metric_variable"].GetBool():
+               raise(Exception("Potential Flow remeshing process uses non historical"))
+        else:
+            self.metric_parameters["hessian_strategy_parameters"].AddEmptyValue("non_historical_metric_variable")
+            self.metric_parameters["hessian_strategy_parameters"]["non_historical_metric_variable"].SetBool(True)
+
+    def ExecuteFinalize(self):
+
+        self.__ComputeNodalVelocity()
+
+        self.__ComputeHessianMetric()
+
+        self.__RemoveSubModelParts()
+
+        self.__ExecuteRefinement()
+
+    def __ComputeNodalVelocity(self):
+
+        nodal_velocity_process = KratosMultiphysics.CompressiblePotentialFlowApplication.ComputeNonNodalPotentialFlowVelocityProcess(self.main_model_part, KratosMultiphysics.VELOCITY, KratosMultiphysics.NODAL_AREA)
+        nodal_velocity_process.Execute()
+
+    def __ComputeHessianMetric(self):
+
+        find_nodal_h = KratosMultiphysics.FindNodalHNonHistoricalProcess(self.main_model_part)
+        find_nodal_h.Execute()
+
+        metric_x = KratosMultiphysics.MeshingApplication.ComputeHessianSolMetricProcess(self.main_model_part, KratosMultiphysics.VELOCITY_X, self.metric_parameters)
+        metric_x.Execute()
+        metric_y = KratosMultiphysics.MeshingApplication.ComputeHessianSolMetricProcess(self.main_model_part, KratosMultiphysics.VELOCITY_Y, self.metric_parameters)
+        metric_y.Execute()
+
+        if (self.domain_size == 3):
+            metric_z = KratosMultiphysics.MeshingApplication.ComputeHessianSolMetricProcess(self.main_model_part, KratosMultiphysics.VELOCITY_Z, self.metric_parameters)
+            metric_z.Execute()
+
+    def __RemoveSubModelParts(self):
+
+        self.main_model_part.RemoveSubModelPart('wake_sub_model_part')
+        self.main_model_part.RemoveSubModelPart('trailing_edge_sub_model_part')
+        self.main_model_part.RemoveSubModelPart('fluid_computational_model_part')
+
+    def __ExecuteRefinement(self):
+
+        if (self.domain_size == 2):
+            MmgProcess = KratosMeshing.MmgProcess2D(self.main_model_part, self.mmg_parameters)
+            MmgProcess.Execute()
+        elif (self.domain_size == 3):
+            MmgProcess = KratosMeshing.MmgProcess3D(self.main_model_part, self.mmg_parameters)
+            MmgProcess.Execute()
+
+
+

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/apply_potential_flow_hessian_remeshing_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/apply_potential_flow_hessian_remeshing_process.py
@@ -47,7 +47,7 @@ class ApplyPotentialFlowHessianRemeshingProcess(KratosMultiphysics.Process):
 
         if self.metric_parameters["hessian_strategy_parameters"].Has("non_historical_metric_variable"):
             if not self.metric_parameters["hessian_strategy_parameters"]["non_historical_metric_variable"].GetBool():
-               raise(Exception("Potential Flow remeshing process uses non historical"))
+               raise(Exception("Potential Flow remeshing process uses non historical velocity variable!"))
         else:
             self.metric_parameters["hessian_strategy_parameters"].AddEmptyValue("non_historical_metric_variable")
             self.metric_parameters["hessian_strategy_parameters"]["non_historical_metric_variable"].SetBool(True)

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/apply_potential_flow_hessian_remeshing_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/apply_potential_flow_hessian_remeshing_process.py
@@ -64,7 +64,7 @@ class ApplyPotentialFlowHessianRemeshingProcess(KratosMultiphysics.Process):
 
     def __ComputeNodalVelocity(self):
 
-        nodal_velocity_process = KratosMultiphysics.CompressiblePotentialFlowApplication.ComputeNonNodalPotentialFlowVelocityProcess(self.main_model_part, KratosMultiphysics.VELOCITY, KratosMultiphysics.NODAL_AREA)
+        nodal_velocity_process = KratosMultiphysics.CompressiblePotentialFlowApplication.ComputeNodalPotentialFlowVelocityProcess(self.main_model_part)
         nodal_velocity_process.Execute()
 
     def __ComputeHessianMetric(self):


### PR DESCRIPTION
Hi,

In this PR Im adding a python script to perform adaptive refinement using the hessian process:

![image](https://user-images.githubusercontent.com/32136457/65307882-23d9f580-db89-11e9-9a24-c93d22a0933a.png)


![image](https://user-images.githubusercontent.com/32136457/65307848-0f95f880-db89-11e9-8a16-1805b99c1986.png)


The nodal velocity process that is added is a reduced version of the compute_nodal_gradient_process, only to compute the non-historical velocity (aimed to be used for the refinement). **The reason to use a custom one is that we have to take into account the wake elements** when computing the gradient of the potential (i.e the velocity), so I can't directly use the process in the core. 

