### PR TITLE
[Core][ResiduaCriteria] restrictions for MPI

### DIFF
--- a/kratos/solving_strategies/convergencecriterias/residual_criteria.h
+++ b/kratos/solving_strategies/convergencecriterias/residual_criteria.h
@@ -200,6 +200,7 @@ public:
     void Initialize(ModelPart& rModelPart) override
     {
         BaseType::Initialize(rModelPart);
+        KRATOS_ERROR_IF(rModelPart.IsDistributed() && rModelPart.NumberOfMasterSlaveConstraints() > 0) << "This Criteria does not yet support constraints in MPI!" << std::endl;
     }
 
     /**
@@ -221,7 +222,9 @@ public:
         BaseType::InitializeSolutionStep(rModelPart, rDofSet, rA, rDx, rb);
 
         // Filling mActiveDofs when MPC exist
-        ConstraintUtilities::ComputeActiveDofs(rModelPart, mActiveDofs, rDofSet);
+        if (rModelPart.NumberOfMasterSlaveConstraints() > 0) {
+            ConstraintUtilities::ComputeActiveDofs(rModelPart, mActiveDofs, rDofSet);
+        }
 
         SizeType size_residual;
         CalculateResidualNorm(rModelPart, mInitialResidualNorm, size_residual, rDofSet, rb);


### PR DESCRIPTION
this fixes the usage of the ResidualCriteria in MPI
Basically when the Active dofs are computed we try to access the vector based on the eq-ID, which on most ranks won't start from 0 and hence the access in the vector fails

Also an error is added in case this criteria is used in MPI when constraints are present, since the problem is not fully fixed and reuqires a larger update