### PR TITLE
[Potentialflow] Removing check wake condition from compressible element

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.cpp
@@ -150,7 +150,6 @@ void CompressiblePotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(Proce
 
     if (wake != 0 && active == true)
     {
-        CheckWakeCondition();
         ComputePotentialJump(rCurrentProcessInfo);
     }
     ComputeElementInternalEnergy();
@@ -630,20 +629,6 @@ void CompressiblePotentialFlowElement<Dim, NumNodes>::AssignLocalSystemWakeNode(
     else if (data.distances[row] > 0.0)
         for (unsigned int column = 0; column < NumNodes; ++column)
             rLeftHandSideMatrix(row + NumNodes, column) = -lhs_total(row, column); // Side 2
-}
-
-template <int Dim, int NumNodes>
-void CompressiblePotentialFlowElement<Dim, NumNodes>::CheckWakeCondition() const
-{
-    array_1d<double, Dim> upper_wake_velocity;
-    ComputeVelocityUpperWakeElement(upper_wake_velocity);
-    const double vupnorm = inner_prod(upper_wake_velocity, upper_wake_velocity);
-
-    array_1d<double, Dim> lower_wake_velocity;
-    ComputeVelocityLowerWakeElement(lower_wake_velocity);
-    const double vlownorm = inner_prod(lower_wake_velocity, lower_wake_velocity);
-
-    KRATOS_WARNING_IF("CompressibleElement", std::abs(vupnorm - vlownorm) > 0.1) << "WAKE CONDITION NOT FULFILLED IN ELEMENT # " << this->Id() << std::endl;
 }
 
 template <int Dim, int NumNodes>

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
@@ -259,8 +259,6 @@ private:
                                    const ElementalData<NumNodes, Dim>& data,
                                    unsigned int& row) const;
 
-    void CheckWakeCondition() const;
-
     void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
 
     void ComputeElementInternalEnergy();


### PR DESCRIPTION
After #5490, the "wake check" was moved to a utility and exposed to python. The compressible element still had the function in the element. 