### PR TITLE
[ContactStructuralMechanicsApplication] Removing PAIRED_NORMAL.…

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application.cpp
+++ b/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application.cpp
@@ -123,7 +123,6 @@ void KratosContactStructuralMechanicsApplication::Register()
     KRATOS_REGISTER_VARIABLE( DISTANCE_THRESHOLD )                                    // The distance threshold considered
     KRATOS_REGISTER_VARIABLE( ZERO_TOLERANCE_FACTOR )                                 // The epsilon factor considered
     KRATOS_REGISTER_VARIABLE( ACTIVE_CHECK_FACTOR )                                   // The factor employed to serach an active/inactive node
-    KRATOS_REGISTER_VARIABLE( PAIRED_NORMAL )                                         // The normal of the paired geometry
     KRATOS_REGISTER_3D_VARIABLE_WITH_COMPONENTS( AUXILIAR_COORDINATES )               // Auxiliar coordinates used to map
     KRATOS_REGISTER_3D_VARIABLE_WITH_COMPONENTS( DELTA_COORDINATES )                  // Delta coordinates used to map
 

--- a/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application_variables.cpp
+++ b/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application_variables.cpp
@@ -18,7 +18,6 @@
 
 namespace Kratos
 {
-typedef array_1d<double,3> Vector3;
 typedef Geometry<Node<3>> GeometryType;
 
 // VARIABLES
@@ -28,7 +27,6 @@ KRATOS_CREATE_VARIABLE( int , INTEGRATION_ORDER_CONTACT )                       
 KRATOS_CREATE_VARIABLE( double, DISTANCE_THRESHOLD )                              // The distance threshold considered
 KRATOS_CREATE_VARIABLE( double, ZERO_TOLERANCE_FACTOR )                           // The epsilon factor considered
 KRATOS_CREATE_VARIABLE( double, ACTIVE_CHECK_FACTOR )                             // The factor employed to search an active/inactive node
-KRATOS_CREATE_VARIABLE( Vector3, PAIRED_NORMAL )                                  // The normal of the paired geometry
 KRATOS_CREATE_3D_VARIABLE_WITH_COMPONENTS( AUXILIAR_COORDINATES )                 // Auxiliar coordinates used to map
 KRATOS_CREATE_3D_VARIABLE_WITH_COMPONENTS( DELTA_COORDINATES )                    // Delta coordinates used to map
 KRATOS_CREATE_VARIABLE( double, NORMAL_GAP )                                      // The normal gap employed in contact formulation

--- a/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application_variables.h
+++ b/applications/ContactStructuralMechanicsApplication/contact_structural_mechanics_application_variables.h
@@ -33,7 +33,6 @@ namespace Kratos
 ///@name Type Definitions
 ///@{
 
-    typedef array_1d<double,3> Vector3;
     typedef Geometry<Node<3>> GeometryType;
 
 ///@}
@@ -61,7 +60,6 @@ KRATOS_DEFINE_APPLICATION_VARIABLE( CONTACT_STRUCTURAL_MECHANICS_APPLICATION, in
 KRATOS_DEFINE_APPLICATION_VARIABLE( CONTACT_STRUCTURAL_MECHANICS_APPLICATION, double, DISTANCE_THRESHOLD )                             // The distance threshold considered
 KRATOS_DEFINE_APPLICATION_VARIABLE( CONTACT_STRUCTURAL_MECHANICS_APPLICATION, double, ZERO_TOLERANCE_FACTOR )                          // The epsilon factor considered
 KRATOS_DEFINE_APPLICATION_VARIABLE( CONTACT_STRUCTURAL_MECHANICS_APPLICATION, double, ACTIVE_CHECK_FACTOR )                            // The factor employed to search an active/inactive node
-KRATOS_DEFINE_APPLICATION_VARIABLE( CONTACT_STRUCTURAL_MECHANICS_APPLICATION, Vector3, PAIRED_NORMAL )                                 // The normal of the paired geometry
 KRATOS_DEFINE_3D_APPLICATION_VARIABLE_WITH_COMPONENTS(CONTACT_STRUCTURAL_MECHANICS_APPLICATION, AUXILIAR_COORDINATES )                 // Auxiliar coordinates used to map
 KRATOS_DEFINE_3D_APPLICATION_VARIABLE_WITH_COMPONENTS(CONTACT_STRUCTURAL_MECHANICS_APPLICATION, DELTA_COORDINATES )                    // Delta coordinates used to map
 KRATOS_DEFINE_APPLICATION_VARIABLE( CONTACT_STRUCTURAL_MECHANICS_APPLICATION, double, NORMAL_GAP )                                     // The normal gap employed in contact formulation

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
@@ -100,9 +100,8 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 
     // The master geometry
     GeometryType& r_master_geometry = this->GetPairedGeometry();
-    GeometryType::CoordinatesArrayType aux_coords;
-    r_master_geometry.PointLocalCoordinates(aux_coords, r_master_geometry.Center());
-    const array_1d<double, 3>& r_normal_master = r_master_geometry.UnitNormal(aux_coords);
+    const array_1d<double, 3>& r_normal_master = this->GetPairedNormal();
+
     // Initialize general variables for the current master element
     rVariables.Initialize();
 
@@ -178,7 +177,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 {
     KRATOS_TRY;
 
-    // NOTE: Add things if necessary
+    BaseType::InitializeSolutionStep(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }
@@ -191,7 +190,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 {
     KRATOS_TRY;
 
-    // NOTE: Add things if necessary
+    BaseType::InitializeNonLinearIteration(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }
@@ -204,7 +203,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Finalize
 {
     KRATOS_TRY;
 
-    // NOTE: Add things if necessary
+    BaseType::FinalizeSolutionStep(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }
@@ -217,7 +216,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Finalize
 {
     KRATOS_TRY;
 
-    // TODO: Add things if necessary
+    BaseType::FinalizeNonLinearIteration(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mesh_tying_mortar_condition.cpp
@@ -100,7 +100,9 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 
     // The master geometry
     GeometryType& r_master_geometry = this->GetPairedGeometry();
-    const array_1d<double, 3>& r_normal_master = this->GetValue(PAIRED_NORMAL);
+    GeometryType::CoordinatesArrayType aux_coords;
+    r_master_geometry.PointLocalCoordinates(aux_coords, r_master_geometry.Center());
+    const array_1d<double, 3>& r_normal_master = r_master_geometry.UnitNormal(aux_coords);
     // Initialize general variables for the current master element
     rVariables.Initialize();
 

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/mortar_contact_condition.cpp
@@ -104,7 +104,7 @@ void MortarContactCondition<TDim,TNumNodes,TFrictional, TNormalVariation,TNumNod
 {
     KRATOS_TRY;
 
-    // NOTE: Add things if necessary
+    BaseType::InitializeSolutionStep(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }
@@ -117,6 +117,8 @@ void MortarContactCondition<TDim,TNumNodes,TFrictional, TNormalVariation,TNumNod
 {
     KRATOS_TRY;
 
+    BaseType::InitializeNonLinearIteration(rCurrentProcessInfo);
+
     KRATOS_CATCH( "" );
 }
 
@@ -128,7 +130,7 @@ void MortarContactCondition<TDim,TNumNodes,TFrictional, TNormalVariation,TNumNod
 {
     KRATOS_TRY;
 
-    // NOTE: Add things if necessary
+    BaseType::FinalizeSolutionStep(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }
@@ -140,6 +142,8 @@ template< SizeType TDim, SizeType TNumNodes, FrictionalCase TFrictional, bool TN
 void MortarContactCondition<TDim,TNumNodes,TFrictional, TNormalVariation,TNumNodesMaster>::FinalizeNonLinearIteration( ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY;
+
+    BaseType::FinalizeNonLinearIteration(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }
@@ -320,7 +324,7 @@ void MortarContactCondition<TDim, TNumNodes, TFrictional, TNormalVariation, TNum
 
     // The master geometry
     const GeometryType& r_master_geometry = this->GetPairedGeometry();
-    const array_1d<double, 3>& r_normal_master = this->GetValue(PAIRED_NORMAL);
+    const array_1d<double, 3>& r_normal_master = this->GetPairedNormal();
 
     // Reading integration points
     ConditionArrayListType conditions_points_slave;
@@ -491,7 +495,7 @@ bool MortarContactCondition<TDim,TNumNodes,TFrictional, TNormalVariation,TNumNod
 //
 //     // We define the normals
 //     const array_1d<double, 3> normal_slave = this->GetValue(NORMAL);
-//     const array_1d<double, 3>& normal_master = this->GetValue(PAIRED_NORMAL);
+//     const array_1d<double, 3>& r_normal_master = this->GetPairedNormal();
 //
 //     const double angle_slave = MathUtils<double>::VectorsAngle(delta_disp_vect_slave, normal_slave);
 //     const double angle_master = MathUtils<double>::VectorsAngle(delta_disp_vect_master, normal_master);

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.cpp
@@ -86,7 +86,7 @@ void PairedCondition::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 
-    BaseType::InitializeSolutionStep();
+    BaseType::InitializeSolutionStep(rCurrentProcessInfo);
 
     // The normal of the paired condition
     const auto& r_paired_geometry = GetPairedGeometry();
@@ -104,7 +104,7 @@ void PairedCondition::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 
-    BaseType::InitializeNonLinearIteration();
+    BaseType::InitializeNonLinearIteration(rCurrentProcessInfo);
 
     // We update the normals if necessary
     const auto normal_variation = rCurrentProcessInfo.Has(CONSIDER_NORMAL_VARIATION) ? static_cast<NormalDerivativesComputation>(rCurrentProcessInfo.GetValue(CONSIDER_NORMAL_VARIATION)) : NO_DERIVATIVES_COMPUTATION;

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.cpp
@@ -100,7 +100,7 @@ void PairedCondition::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
 /***********************************************************************************/
 /***********************************************************************************/
 
-void PairedCondition::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void PairedCondition::InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.cpp
@@ -70,6 +70,51 @@ void PairedCondition::Initialize( )
 
     BaseType::Initialize();
 
+    // The normal of the paired condition
+    const auto& r_paired_geometry = GetPairedGeometry();
+    GeometryType::CoordinatesArrayType aux_coords;
+    r_paired_geometry.PointLocalCoordinates(aux_coords, r_paired_geometry.Center());
+    mPairedNormal = r_paired_geometry.UnitNormal(aux_coords);
+
+    KRATOS_CATCH( "" );
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void PairedCondition::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY;
+
+    BaseType::InitializeSolutionStep();
+
+    // The normal of the paired condition
+    const auto& r_paired_geometry = GetPairedGeometry();
+    GeometryType::CoordinatesArrayType aux_coords;
+    r_paired_geometry.PointLocalCoordinates(aux_coords, r_paired_geometry.Center());
+    mPairedNormal = r_paired_geometry.UnitNormal(aux_coords);
+
+    KRATOS_CATCH( "" );
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+void PairedCondition::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY;
+
+    BaseType::InitializeNonLinearIteration();
+
+    // We update the normals if necessary
+    const auto normal_variation = rCurrentProcessInfo.Has(CONSIDER_NORMAL_VARIATION) ? static_cast<NormalDerivativesComputation>(rCurrentProcessInfo.GetValue(CONSIDER_NORMAL_VARIATION)) : NO_DERIVATIVES_COMPUTATION;
+    if (normal_variation != NO_DERIVATIVES_COMPUTATION) {
+        const auto& r_paired_geometry = GetPairedGeometry();
+        GeometryType::CoordinatesArrayType aux_coords;
+        r_paired_geometry.PointLocalCoordinates(aux_coords, r_paired_geometry.Center());
+        mPairedNormal = r_paired_geometry.UnitNormal(aux_coords);
+    }
+
     KRATOS_CATCH( "" );
 }
 

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.h
@@ -139,6 +139,18 @@ public:
      */
     void Initialize() override;
 
+   /**
+    * @brief Called at the beginning of each solution step
+    * @param rCurrentProcessInfo the current process info instance
+    */
+    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+
+   /**
+    * @brief Called at the beginning of each iteration
+    * @param rCurrentProcessInfo the current process info instance
+    */
+    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+
     /**
      * @brief Creates a new element pointer from an arry of nodes
      * @param NewId the ID of the new element
@@ -220,6 +232,24 @@ public:
         return this->GetGeometry().GetGeometryPart(CouplingGeometryType::Slave);
     }
 
+    /**
+     * @brief This method sets the paired normal
+     * @param rPairedNormal The master geometry normal
+     */
+    void SetPairedNormal(const array_1d<double, 3>& rPairedNormal)
+    {
+        return mPairedNormal = rPairedNormal;
+    }
+
+    /**
+     * @brief This method returns the paired normal
+     * @return The master geometry normal
+     */
+    array_1d<double, 3> const& GetPairedNormal() const
+    {
+        return mPairedNormal;
+    }
+
     ///@}
     ///@name Inquiry
     ///@{
@@ -293,6 +323,8 @@ private:
     ///@name Member Variables
     ///@{
 
+    array_1d<double, 3> mPairedNormal = ZeroVector(3);
+
     ///@}
     ///@name Private Operators
     ///@{
@@ -320,11 +352,13 @@ private:
     void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Condition );
+        rSerializer.save("PairedNormal", mPairedNormal);
     }
 
     void load(Serializer& rSerializer) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Condition );
+        rSerializer.load("PairedNormal", mPairedNormal);
     }
 
     ///@}

--- a/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_conditions/paired_condition.h
@@ -238,7 +238,7 @@ public:
      */
     void SetPairedNormal(const array_1d<double, 3>& rPairedNormal)
     {
-        return mPairedNormal = rPairedNormal;
+        noalias(mPairedNormal) = rPairedNormal;
     }
 
     /**

--- a/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_processes/base_contact_search_process.cpp
@@ -861,7 +861,6 @@ Condition::Pointer BaseContactSearchProcess<TDim, TNumNodes, TNumNodesMaster>::A
         rComputingModelPart.AddCondition(p_auxiliar_condition);
         pIndexesPairs->SetNewEntityId(pObjectMaster->Id(), rConditionId);
         p_auxiliar_condition->SetValue(NORMAL, rSlaveNormal);
-        p_auxiliar_condition->SetValue(PAIRED_NORMAL, rMasterNormal);
         // We activate the condition and initialize it
         p_auxiliar_condition->Set(ACTIVE, true);
         p_auxiliar_condition->Initialize();

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/base_mortar_criteria.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/base_mortar_criteria.h
@@ -465,11 +465,6 @@ private:
             GeometryType& r_parent_geometry = it_cond->GetGeometry().GetGeometryPart(0);
             aux_coords = r_parent_geometry.PointLocalCoordinates(aux_coords, r_parent_geometry.Center());
             it_cond->SetValue(NORMAL, r_parent_geometry.UnitNormal(aux_coords));
-
-            // We update the paired normal
-            auto& r_paired_geometry = it_cond->GetGeometry().GetGeometryPart(1);
-            aux_coords = r_paired_geometry.PointLocalCoordinates(aux_coords, r_paired_geometry.Center());
-            it_cond->SetValue(PAIRED_NORMAL, r_paired_geometry.UnitNormal(aux_coords));
         }
     }
 

--- a/applications/ContactStructuralMechanicsApplication/custom_utilities/mortar_explicit_contribution_utilities.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_utilities/mortar_explicit_contribution_utilities.cpp
@@ -53,7 +53,7 @@ typename MortarExplicitContributionUtilities<TDim,TNumNodes,TFrictional, TNormal
     GeometryType& r_master_geometry = pCondition->GetPairedGeometry();
 
     // The normal of the master condition
-    const array_1d<double, 3>& r_normal_master = pCondition->GetValue(PAIRED_NORMAL);
+    const array_1d<double, 3>& r_normal_master = pCondition->GetPairedNormal();
 
     // Reading integration points
     ConditionArrayListType conditions_points_slave;
@@ -199,7 +199,7 @@ typename MortarExplicitContributionUtilities<TDim,TNumNodes,TFrictional, TNormal
     GeometryType& r_master_geometry = pCondition->GetPairedGeometry();
 
     // The normal of the master condition
-    const array_1d<double, 3>& r_normal_master = pCondition->GetValue(PAIRED_NORMAL);
+    const array_1d<double, 3>& r_normal_master = pCondition->GetPairedNormal();
 
     // Reading integration points
     ConditionArrayListType conditions_points_slave;
@@ -392,7 +392,7 @@ bool MortarExplicitContributionUtilities<TDim,TNumNodes,TFrictional, TNormalVari
     GeometryType& r_master_geometry = pCondition->GetPairedGeometry();
 
     // The normal of the master condition
-    const array_1d<double, 3>& r_normal_master = pCondition->GetValue(PAIRED_NORMAL);
+    const array_1d<double, 3>& r_normal_master = pCondition->GetPairedNormal();
 
     // Reading integration points
     ConditionArrayListType conditions_points_slave;

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition_template.cpp
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition_template.cpp
@@ -100,9 +100,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 
     // The master geometry
     GeometryType& r_master_geometry = this->GetPairedGeometry();
-    GeometryType::CoordinatesArrayType aux_coords;
-    r_master_geometry.PointLocalCoordinates(aux_coords, r_master_geometry.Center());
-    const array_1d<double, 3>& r_normal_master = r_master_geometry.UnitNormal(aux_coords);
+    const array_1d<double, 3>& r_normal_master = this->GetPairedNormal();
 
     // Initialize general variables for the current master element
     rVariables.Initialize();
@@ -179,7 +177,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 {
     KRATOS_TRY;
 
-    // NOTE: Add things if necessary
+    BaseType::InitializeSolutionStep(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }
@@ -192,7 +190,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 {
     KRATOS_TRY;
 
-    // NOTE: Add things if necessary
+    BaseType::InitializeNonLinearIteration(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }
@@ -205,7 +203,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Finalize
 {
     KRATOS_TRY;
 
-    // NOTE: Add things if necessary
+    BaseType::FinalizeSolutionStep(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }
@@ -218,7 +216,7 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Finalize
 {
     KRATOS_TRY;
 
-    // TODO: Add things if necessary
+    BaseType::FinalizeNonLinearIteration(rCurrentProcessInfo);
 
     KRATOS_CATCH( "" );
 }

--- a/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition_template.cpp
+++ b/applications/ContactStructuralMechanicsApplication/symbolic_generation/mesh_tying_mortar_condition/mesh_tying_mortar_condition_template.cpp
@@ -100,7 +100,10 @@ void MeshTyingMortarCondition<TDim,TNumNodesElem, TNumNodesElemMaster>::Initiali
 
     // The master geometry
     GeometryType& r_master_geometry = this->GetPairedGeometry();
-    const array_1d<double, 3>& r_normal_master = this->GetValue(PAIRED_NORMAL);
+    GeometryType::CoordinatesArrayType aux_coords;
+    r_master_geometry.PointLocalCoordinates(aux_coords, r_master_geometry.Center());
+    const array_1d<double, 3>& r_normal_master = r_master_geometry.UnitNormal(aux_coords);
+
     // Initialize general variables for the current master element
     rVariables.Initialize();
 

--- a/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_weighted_gap.cpp
+++ b/applications/ContactStructuralMechanicsApplication/tests/cpp_tests/test_weighted_gap.cpp
@@ -146,7 +146,6 @@ namespace Kratos
                     // We set the geometrical values
                     r_computing_contact_model_part.AddCondition(p_auxiliar_condition);
                     p_auxiliar_condition->SetValue(NORMAL, p_slave_cond->GetValue(NORMAL));
-                    p_auxiliar_condition->SetValue(PAIRED_NORMAL, p_master_cond->GetValue(NORMAL));
                     // We activate the condition and initialize it
                     p_auxiliar_condition->Set(ACTIVE, true);
                     p_auxiliar_condition->Set(SLAVE, true);
@@ -302,7 +301,6 @@ namespace Kratos
                     // We set the geometrical values
                     r_computing_contact_model_part.AddCondition(p_auxiliar_condition);
                     p_auxiliar_condition->SetValue(NORMAL, p_slave_cond->GetValue(NORMAL));
-                    p_auxiliar_condition->SetValue(PAIRED_NORMAL, p_master_cond->GetValue(NORMAL));
                     // We activate the condition and initialize it
                     p_auxiliar_condition->Set(ACTIVE, true);
                     p_auxiliar_condition->Set(SLAVE, true);
@@ -526,7 +524,6 @@ namespace Kratos
                     // We set the geometrical values
                     r_computing_contact_model_part.AddCondition(p_auxiliar_condition);
                     p_auxiliar_condition->SetValue(NORMAL, p_slave_cond->GetValue(NORMAL));
-                    p_auxiliar_condition->SetValue(PAIRED_NORMAL, p_master_cond->GetValue(NORMAL));
                     // We activate the condition and initialize it
                     p_auxiliar_condition->Set(ACTIVE, true);
                     p_auxiliar_condition->Set(SLAVE, true);
@@ -717,7 +714,6 @@ namespace Kratos
                     // We set the geometrical values
                     r_computing_contact_model_part.AddCondition(p_auxiliar_condition);
                     p_auxiliar_condition->SetValue(NORMAL, p_slave_cond->GetValue(NORMAL));
-                    p_auxiliar_condition->SetValue(PAIRED_NORMAL, p_master_cond->GetValue(NORMAL));
                     // We activate the condition and initialize it
                     p_auxiliar_condition->Set(SLAVE, true);
                     p_auxiliar_condition->Set(ACTIVE, true);


### PR DESCRIPTION
This is required in order to adapt to #5624 

The reason why the normal cannot be computed on the fly is that in case we compute considering that the normal is the same during all the time step we need a way to compute it only once each time step

(When #5624 is merged I can just access to the NORMAL computed in the paired geometry)