### PR TITLE
[Nightly] disabling ThermoMechApp

### DIFF
--- a/scripts/build/nightly/configure_clang.sh
+++ b/scripts/build/nightly/configure_clang.sh
@@ -49,7 +49,7 @@ cmake .. \
 -DIGA_APPLICATION=ON                                                                            \
 -DANURBS_ROOT="${HOME}/ANurbs"                                                                  \
 -DSWIMMING_DEM_APPLICATION=OFF                                                                  \
--DTHERMO_MECHANICAL_APPLICATION=ON                                                              \
+-DTHERMO_MECHANICAL_APPLICATION=OFF                                                              \
 -DCONTACT_STRUCTURAL_MECHANICS_APPLICATION=ON                                                   \
 -DMAPPING_APPLICATION=ON                                                                        \
 -DMETIS_APPLICATION=OFF                                                                         \

--- a/scripts/build/nightly/configure_gcc.sh
+++ b/scripts/build/nightly/configure_gcc.sh
@@ -49,7 +49,7 @@ cmake .. \
 -DIGA_APPLICATION=ON                                                                            \
 -DANURBS_ROOT="${HOME}/ANurbs"                                                                  \
 -DSWIMMING_DEM_APPLICATION=OFF                                                                  \
--DTHERMO_MECHANICAL_APPLICATION=ON                                                              \
+-DTHERMO_MECHANICAL_APPLICATION=OFF                                                              \
 -DCONTACT_STRUCTURAL_MECHANICS_APPLICATION=ON                                                   \
 -DMAPPING_APPLICATION=ON                                                                        \
 -DMETIS_APPLICATION=OFF                                                                         \


### PR DESCRIPTION
this app does not compile and hence the entire nightly build fails
Afaik this is anyway legacy, so I propose to disable it, at least until it is fixed (or I had time for #4881)