### PR TITLE
[PotentialFlow] Adding embedded compressible element

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/CMakeLists.txt
+++ b/applications/CompressiblePotentialFlowApplication/CMakeLists.txt
@@ -25,6 +25,7 @@ set( KRATOS_COMPRESSIBLE_POTENTIAL_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/adjoint_base_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/adjoint_finite_difference_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/compressible_potential_flow_element.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/embedded_compressible_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/embedded_incompressible_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/incompressible_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/apply_far_field_process.cpp

--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.cpp
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.cpp
@@ -34,6 +34,7 @@ KratosCompressiblePotentialFlowApplication::KratosCompressiblePotentialFlowAppli
     mAdjointIncompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mAdjointCompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mEmbeddedIncompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+    mEmbeddedCompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mPotentialWallCondition2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
     mPotentialWallCondition3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mAdjointPotentialWallCondition2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2))))
@@ -113,6 +114,7 @@ void KratosCompressiblePotentialFlowApplication::Register()
   KRATOS_REGISTER_ELEMENT("AdjointIncompressiblePotentialFlowElement2D3N", mAdjointIncompressiblePotentialFlowElement2D3N);
   KRATOS_REGISTER_ELEMENT("AdjointCompressiblePotentialFlowElement2D3N", mAdjointCompressiblePotentialFlowElement2D3N);
   KRATOS_REGISTER_ELEMENT("EmbeddedIncompressiblePotentialFlowElement2D3N", mEmbeddedIncompressiblePotentialFlowElement2D3N);
+  KRATOS_REGISTER_ELEMENT("EmbeddedCompressiblePotentialFlowElement2D3N", mEmbeddedCompressiblePotentialFlowElement2D3N);
 
   //Register conditions
   KRATOS_REGISTER_CONDITION("PotentialWallCondition2D2N", mPotentialWallCondition2D2N);

--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
@@ -25,8 +25,8 @@
 #include "custom_elements/compressible_potential_flow_element.h"
 #include "custom_elements/incompressible_potential_flow_element.h"
 #include "custom_elements/embedded_incompressible_potential_flow_element.h"
+#include "custom_elements/embedded_compressible_potential_flow_element.h"
 #include "custom_conditions/potential_wall_condition.h"
-
 #include "custom_elements/adjoint_analytical_incompressible_potential_flow_element.h"
 #include "custom_elements/adjoint_finite_difference_potential_flow_element.h"
 #include "custom_conditions/adjoint_potential_wall_condition.h"
@@ -108,6 +108,7 @@ private:
     const AdjointFiniteDifferencePotentialFlowElement<IncompressiblePotentialFlowElement<2,3>> mAdjointIncompressiblePotentialFlowElement2D3N;
     const AdjointFiniteDifferencePotentialFlowElement<CompressiblePotentialFlowElement<2,3>> mAdjointCompressiblePotentialFlowElement2D3N;
     const EmbeddedIncompressiblePotentialFlowElement<2,3> mEmbeddedIncompressiblePotentialFlowElement2D3N;
+    const EmbeddedCompressiblePotentialFlowElement<2,3> mEmbeddedCompressiblePotentialFlowElement2D3N;
 
     const PotentialWallCondition<2,2> mPotentialWallCondition2D2N;
     const PotentialWallCondition<3,3> mPotentialWallCondition3D3N;

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
@@ -202,6 +202,12 @@ public:
     void PrintData(std::ostream& rOStream) const override;
 
     ///@}
+protected:
+
+    double ComputeDensity(const ProcessInfo& rCurrentProcessInfo) const;
+
+    double ComputeDensityDerivative(const double density,
+                                    const ProcessInfo& rCurrentProcessInfo) const;
 
 private:
     ///@name Private Operators
@@ -283,11 +289,6 @@ private:
     void ComputeVelocityLowerWakeElement(array_1d<double, Dim>& velocity) const;
 
     double ComputePressureCoefficient(const ProcessInfo& rCurrentProcessInfo) const;
-
-    double ComputeDensity(const ProcessInfo& rCurrentProcessInfo) const;
-
-    double ComputeDensityDerivative(const double density,
-                                    const ProcessInfo& rCurrentProcessInfo) const;
 
     ///@}
     ///@name Private Operations

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.cpp
@@ -7,9 +7,9 @@
 //  License:        BSD License
 //                  Kratos default license: kratos/license.txt
 //
-//  Main authors:    Marc Núñez, based on Iñigo Lopez and Riccardo Rossi work
+//  Main authors:    Marc Nunez, based on Inigo Lopez and Riccardo Rossi work
 //
-#include "embedded_incompressible_potential_flow_element.h"
+#include "embedded_compressible_potential_flow_element.h"
 #include "compressible_potential_flow_application_variables.h"
 #include "custom_utilities/potential_flow_utilities.h"
 
@@ -19,40 +19,40 @@ namespace Kratos
 // Public Operations
 
 template <int Dim, int NumNodes>
-Element::Pointer EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Create(
+Element::Pointer EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::Create(
     IndexType NewId, NodesArrayType const& ThisNodes, typename PropertiesType::Pointer pProperties) const
 {
     KRATOS_TRY
-    return Kratos::make_intrusive<EmbeddedIncompressiblePotentialFlowElement>(
+    return Kratos::make_intrusive<EmbeddedCompressiblePotentialFlowElement>(
         NewId, this->GetGeometry().Create(ThisNodes), pProperties);
     KRATOS_CATCH("");
 }
 
 template <int Dim, int NumNodes>
-Element::Pointer EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Create(
+Element::Pointer EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::Create(
     IndexType NewId, typename GeometryType::Pointer pGeom, typename PropertiesType::Pointer pProperties) const
 {
     KRATOS_TRY
-    return Kratos::make_intrusive<EmbeddedIncompressiblePotentialFlowElement>(
+    return Kratos::make_intrusive<EmbeddedCompressiblePotentialFlowElement>(
         NewId, pGeom, pProperties);
     KRATOS_CATCH("");
 }
 
 template <int Dim, int NumNodes>
-Element::Pointer EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Clone(
+Element::Pointer EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::Clone(
     IndexType NewId, NodesArrayType const& ThisNodes) const
 {
     KRATOS_TRY
-    return Kratos::make_intrusive<EmbeddedIncompressiblePotentialFlowElement>(
+    return Kratos::make_intrusive<EmbeddedCompressiblePotentialFlowElement>(
         NewId, this->GetGeometry().Create(ThisNodes), this->pGetProperties());
     KRATOS_CATCH("");
 }
 
 template <int Dim, int NumNodes>
-void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
+void EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
     MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
 {
-    const EmbeddedIncompressiblePotentialFlowElement& r_this = *this;
+    const EmbeddedCompressiblePotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
     const int kutta = r_this.GetValue(KUTTA);
 
@@ -70,7 +70,7 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSy
 }
 
 template <int Dim, int NumNodes>
-void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateEmbeddedLocalSystem(
+void EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::CalculateEmbeddedLocalSystem(
     MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
 {
     if (rLeftHandSideMatrix.size1() != NumNodes || rLeftHandSideMatrix.size2() != NumNodes)
@@ -108,7 +108,7 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateEmbedde
 }
 
 template <>
-ModifiedShapeFunctions::Pointer EmbeddedIncompressiblePotentialFlowElement<2,3>::pGetModifiedShapeFunctions(Vector& rDistances) {
+ModifiedShapeFunctions::Pointer EmbeddedCompressiblePotentialFlowElement<2,3>::pGetModifiedShapeFunctions(Vector& rDistances) {
     return Kratos::make_shared<Triangle2D3ModifiedShapeFunctions>(this->pGetGeometry(), rDistances);
 }
 
@@ -116,7 +116,7 @@ ModifiedShapeFunctions::Pointer EmbeddedIncompressiblePotentialFlowElement<2,3>:
 // Inquiry
 
 template <int Dim, int NumNodes>
-int EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Check(const ProcessInfo& rCurrentProcessInfo)
+int EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::Check(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -142,21 +142,21 @@ int EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Check(const Proce
 // Input and output
 
 template <int Dim, int NumNodes>
-std::string EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Info() const
+std::string EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::Info() const
 {
     std::stringstream buffer;
-    buffer << "EmbeddedIncompressiblePotentialFlowElement #" << this->Id();
+    buffer << "EmbeddedCompressiblePotentialFlowElement #" << this->Id();
     return buffer.str();
 }
 
 template <int Dim, int NumNodes>
-void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::PrintInfo(std::ostream& rOStream) const
+void EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::PrintInfo(std::ostream& rOStream) const
 {
-    rOStream << "EmbeddedIncompressiblePotentialFlowElement #" << this->Id();
+    rOStream << "EmbeddedCompressiblePotentialFlowElement #" << this->Id();
 }
 
 template <int Dim, int NumNodes>
-void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::PrintData(std::ostream& rOStream) const
+void EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::PrintData(std::ostream& rOStream) const
 {
     this->pGetGeometry()->PrintData(rOStream);
 }
@@ -168,13 +168,13 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::PrintData(std::o
 // serializer
 
 template <int Dim, int NumNodes>
-void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::save(Serializer& rSerializer) const
+void EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::save(Serializer& rSerializer) const
 {
     KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
 }
 
 template <int Dim, int NumNodes>
-void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::load(Serializer& rSerializer)
+void EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::load(Serializer& rSerializer)
 {
     KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
 }
@@ -182,6 +182,6 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::load(Serializer&
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Template class instantiation
 
-template class EmbeddedIncompressiblePotentialFlowElement<2, 3>;
+template class EmbeddedCompressiblePotentialFlowElement<2, 3>;
 
 } // namespace Kratos

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.cpp
@@ -1,0 +1,187 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:        BSD License
+//                  Kratos default license: kratos/license.txt
+//
+//  Main authors:    Marc Núñez, based on Iñigo Lopez and Riccardo Rossi work
+//
+#include "embedded_incompressible_potential_flow_element.h"
+#include "compressible_potential_flow_application_variables.h"
+#include "custom_utilities/potential_flow_utilities.h"
+
+namespace Kratos
+{
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Public Operations
+
+template <int Dim, int NumNodes>
+Element::Pointer EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Create(
+    IndexType NewId, NodesArrayType const& ThisNodes, typename PropertiesType::Pointer pProperties) const
+{
+    KRATOS_TRY
+    return Kratos::make_intrusive<EmbeddedIncompressiblePotentialFlowElement>(
+        NewId, this->GetGeometry().Create(ThisNodes), pProperties);
+    KRATOS_CATCH("");
+}
+
+template <int Dim, int NumNodes>
+Element::Pointer EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Create(
+    IndexType NewId, typename GeometryType::Pointer pGeom, typename PropertiesType::Pointer pProperties) const
+{
+    KRATOS_TRY
+    return Kratos::make_intrusive<EmbeddedIncompressiblePotentialFlowElement>(
+        NewId, pGeom, pProperties);
+    KRATOS_CATCH("");
+}
+
+template <int Dim, int NumNodes>
+Element::Pointer EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Clone(
+    IndexType NewId, NodesArrayType const& ThisNodes) const
+{
+    KRATOS_TRY
+    return Kratos::make_intrusive<EmbeddedIncompressiblePotentialFlowElement>(
+        NewId, this->GetGeometry().Create(ThisNodes), this->pGetProperties());
+    KRATOS_CATCH("");
+}
+
+template <int Dim, int NumNodes>
+void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+{
+    const EmbeddedIncompressiblePotentialFlowElement& r_this = *this;
+    const int wake = r_this.GetValue(WAKE);
+    const int kutta = r_this.GetValue(KUTTA);
+
+    BoundedVector<double,NumNodes> distances;
+    for(unsigned int i_node = 0; i_node<NumNodes; i_node++){
+        distances[i_node] = this->GetGeometry()[i_node].GetSolutionStepValue(GEOMETRY_DISTANCE);
+    }
+    const bool is_embedded = PotentialFlowUtilities::CheckIfElementIsCutByDistance<Dim,NumNodes>(distances);
+
+    if (is_embedded && wake == 0 && kutta == 0)
+        CalculateEmbeddedLocalSystem(rLeftHandSideMatrix,rRightHandSideVector,rCurrentProcessInfo);
+    else
+        BaseType::CalculateLocalSystem(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo);
+
+}
+
+template <int Dim, int NumNodes>
+void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateEmbeddedLocalSystem(
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+{
+    if (rLeftHandSideMatrix.size1() != NumNodes || rLeftHandSideMatrix.size2() != NumNodes)
+        rLeftHandSideMatrix.resize(NumNodes, NumNodes, false);
+    if (rRightHandSideVector.size() != NumNodes)
+        rRightHandSideVector.resize(NumNodes, false);
+    rLeftHandSideMatrix.clear();
+
+    array_1d<double, NumNodes> potential;
+    Vector distances(NumNodes);
+    for(unsigned int i_node = 0; i_node<NumNodes; i_node++)
+        distances(i_node) = this->GetGeometry()[i_node].GetSolutionStepValue(GEOMETRY_DISTANCE);
+
+    potential = PotentialFlowUtilities::GetPotentialOnNormalElement<2,3>(*this);
+
+    ModifiedShapeFunctions::Pointer pModifiedShFunc = this->pGetModifiedShapeFunctions(distances);
+    Matrix positive_side_sh_func;
+    ModifiedShapeFunctions::ShapeFunctionsGradientsType positive_side_sh_func_gradients;
+    Vector positive_side_weights;
+    pModifiedShFunc -> ComputePositiveSideShapeFunctionsAndGradientsValues(
+        positive_side_sh_func,
+        positive_side_sh_func_gradients,
+        positive_side_weights,
+        GeometryData::GI_GAUSS_1);
+
+    const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
+
+    BoundedMatrix<double,NumNodes,Dim> DN_DX;
+    for (unsigned int i_gauss=0;i_gauss<positive_side_sh_func_gradients.size();i_gauss++){
+        DN_DX=positive_side_sh_func_gradients(i_gauss);
+        noalias(rLeftHandSideMatrix) += free_stream_density*prod(DN_DX,trans(DN_DX))*positive_side_weights(i_gauss);;
+    }
+
+    noalias(rRightHandSideVector) = -prod(rLeftHandSideMatrix, potential);
+}
+
+template <>
+ModifiedShapeFunctions::Pointer EmbeddedIncompressiblePotentialFlowElement<2,3>::pGetModifiedShapeFunctions(Vector& rDistances) {
+    return Kratos::make_shared<Triangle2D3ModifiedShapeFunctions>(this->pGetGeometry(), rDistances);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Inquiry
+
+template <int Dim, int NumNodes>
+int EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Check(const ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    // Generic geometry check
+    int out = BaseType::Check(rCurrentProcessInfo);
+    if (out != 0)
+    {
+        return out;
+    }
+
+    for (unsigned int i = 0; i < this->GetGeometry().size(); i++)
+    {
+        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(GEOMETRY_DISTANCE,this->GetGeometry()[i]);
+    }
+
+    return out;
+
+    KRATOS_CATCH("");
+}
+
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Input and output
+
+template <int Dim, int NumNodes>
+std::string EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Info() const
+{
+    std::stringstream buffer;
+    buffer << "EmbeddedIncompressiblePotentialFlowElement #" << this->Id();
+    return buffer.str();
+}
+
+template <int Dim, int NumNodes>
+void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::PrintInfo(std::ostream& rOStream) const
+{
+    rOStream << "EmbeddedIncompressiblePotentialFlowElement #" << this->Id();
+}
+
+template <int Dim, int NumNodes>
+void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::PrintData(std::ostream& rOStream) const
+{
+    this->pGetGeometry()->PrintData(rOStream);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Private functions
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+// serializer
+
+template <int Dim, int NumNodes>
+void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::save(Serializer& rSerializer) const
+{
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
+}
+
+template <int Dim, int NumNodes>
+void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::load(Serializer& rSerializer)
+{
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Template class instantiation
+
+template class EmbeddedIncompressiblePotentialFlowElement<2, 3>;
+
+} // namespace Kratos

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.h
@@ -1,0 +1,147 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:        BSD License
+//                  Kratos default license: kratos/license.txt
+//
+//  Main authors:    Marc Núñez, based on Iñigo Lopez and Riccardo Rossi work
+//
+
+#if !defined(KRATOS_EMBEDDED_INCOMPRESSIBLE_POTENTIAL_FLOW_ELEMENT_H)
+#define KRATOS_EMBEDDED_INCOMPRESSIBLE_POTENTIAL_FLOW_ELEMENT_H
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "modified_shape_functions/triangle_2d_3_modified_shape_functions.h"
+#include "incompressible_potential_flow_element.h"
+
+namespace Kratos
+{
+template <int Dim, int NumNodes>
+class EmbeddedIncompressiblePotentialFlowElement : public IncompressiblePotentialFlowElement<Dim,NumNodes>
+{
+public:
+   ///@name Type Definitions
+    ///@{
+
+    typedef IncompressiblePotentialFlowElement<Dim,NumNodes> BaseType;
+
+    typedef typename BaseType::IndexType IndexType;
+    typedef typename BaseType::GeometryType GeometryType;
+    typedef typename BaseType::PropertiesType PropertiesType;
+    typedef typename BaseType::NodesArrayType NodesArrayType;
+    typedef typename BaseType::VectorType VectorType;
+    typedef typename BaseType::MatrixType MatrixType;
+
+    ///@name Pointer Definitions
+    /// Pointer definition of EmbeddedIncompressiblePotentialFlowElement
+    KRATOS_CLASS_POINTER_DEFINITION(EmbeddedIncompressiblePotentialFlowElement);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    // Constructors.
+
+    /// Default constuctor.
+    /**
+     * @param NewId Index number of the new element (optional)
+     */
+    explicit EmbeddedIncompressiblePotentialFlowElement(IndexType NewId = 0){}
+
+    /**
+     * Constructor using an array of nodes
+     */
+    EmbeddedIncompressiblePotentialFlowElement(IndexType NewId, const NodesArrayType& ThisNodes)
+        : IncompressiblePotentialFlowElement<Dim,NumNodes>(NewId, ThisNodes){}
+
+    /**
+     * Constructor using Geometry
+     */
+    EmbeddedIncompressiblePotentialFlowElement(IndexType NewId, typename GeometryType::Pointer pGeometry)
+        : IncompressiblePotentialFlowElement<Dim,NumNodes>(NewId, pGeometry){}
+
+    /**
+     * Constructor using Properties
+     */
+    EmbeddedIncompressiblePotentialFlowElement(IndexType NewId,
+                                       typename GeometryType::Pointer pGeometry,
+                                       typename PropertiesType::Pointer pProperties)
+        : IncompressiblePotentialFlowElement<Dim,NumNodes>(NewId, pGeometry, pProperties){}
+
+    /**
+     * Copy Constructor
+     */
+    EmbeddedIncompressiblePotentialFlowElement(EmbeddedIncompressiblePotentialFlowElement const& rOther) = delete;
+
+    /**
+     * Move Constructor
+     */
+    EmbeddedIncompressiblePotentialFlowElement(EmbeddedIncompressiblePotentialFlowElement&& rOther) = delete;
+
+    /**
+     * Destructor
+     */
+    ~EmbeddedIncompressiblePotentialFlowElement() override{}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Assignment operator.
+    EmbeddedIncompressiblePotentialFlowElement& operator=(EmbeddedIncompressiblePotentialFlowElement const& rOther) = delete;
+
+    /// Move operator.
+    EmbeddedIncompressiblePotentialFlowElement& operator=(EmbeddedIncompressiblePotentialFlowElement&& rOther) = delete;
+
+    Element::Pointer Create(IndexType NewId,
+                            NodesArrayType const& ThisNodes,
+                            typename PropertiesType::Pointer pProperties) const override;
+
+    Element::Pointer Create(IndexType NewId,
+                            typename GeometryType::Pointer pGeom,
+                            typename PropertiesType::Pointer pProperties) const override;
+
+    Element::Pointer Clone(IndexType NewId, NodesArrayType const& ThisNodes) const override;
+
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+                              VectorType& rRightHandSideVector,
+                              ProcessInfo& rCurrentProcessInfo) override;
+
+    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    /// Turn back information as a string.
+    std::string Info() const override;
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override;
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override;
+
+
+protected:
+
+    ModifiedShapeFunctions::Pointer pGetModifiedShapeFunctions(Vector& rDistances);
+
+private:
+
+    void CalculateEmbeddedLocalSystem(MatrixType& rLeftHandSideMatrix,
+                              VectorType& rRightHandSideVector,
+                              ProcessInfo& rCurrentProcessInfo);
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override;
+
+    void load(Serializer& rSerializer) override;
+
+}; // Class EmbeddedIncompressiblePotentialFlowElement
+
+} // namespace Kratos.
+
+#endif // KRATOS_EMBEDDED_INCOMPRESSIBLE_POTENTIAL_FLOW_ELEMENT_H  defined

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.h
@@ -7,11 +7,11 @@
 //  License:        BSD License
 //                  Kratos default license: kratos/license.txt
 //
-//  Main authors:    Marc Núñez, based on Iñigo Lopez and Riccardo Rossi work
+//  Main authors:    Marc Nunez, based on Inigo Lopez and Riccardo Rossi work
 //
 
-#if !defined(KRATOS_EMBEDDED_INCOMPRESSIBLE_POTENTIAL_FLOW_ELEMENT_H)
-#define KRATOS_EMBEDDED_INCOMPRESSIBLE_POTENTIAL_FLOW_ELEMENT_H
+#if !defined(KRATOS_EMBEDDED_COMPRESSIBLE_POTENTIAL_FLOW_ELEMENT_H)
+#define KRATOS_EMBEDDED_COMPRESSIBLE_POTENTIAL_FLOW_ELEMENT_H
 
 // System includes
 
@@ -19,18 +19,18 @@
 
 // Project includes
 #include "modified_shape_functions/triangle_2d_3_modified_shape_functions.h"
-#include "incompressible_potential_flow_element.h"
+#include "compressible_potential_flow_element.h"
 
 namespace Kratos
 {
 template <int Dim, int NumNodes>
-class EmbeddedIncompressiblePotentialFlowElement : public IncompressiblePotentialFlowElement<Dim,NumNodes>
+class EmbeddedCompressiblePotentialFlowElement : public CompressiblePotentialFlowElement<Dim,NumNodes>
 {
 public:
    ///@name Type Definitions
     ///@{
 
-    typedef IncompressiblePotentialFlowElement<Dim,NumNodes> BaseType;
+    typedef CompressiblePotentialFlowElement<Dim,NumNodes> BaseType;
 
     typedef typename BaseType::IndexType IndexType;
     typedef typename BaseType::GeometryType GeometryType;
@@ -40,8 +40,8 @@ public:
     typedef typename BaseType::MatrixType MatrixType;
 
     ///@name Pointer Definitions
-    /// Pointer definition of EmbeddedIncompressiblePotentialFlowElement
-    KRATOS_CLASS_POINTER_DEFINITION(EmbeddedIncompressiblePotentialFlowElement);
+    /// Pointer definition of EmbeddedCompressiblePotentialFlowElement
+    KRATOS_CLASS_POINTER_DEFINITION(EmbeddedCompressiblePotentialFlowElement);
 
     ///@}
     ///@name Life Cycle
@@ -53,52 +53,52 @@ public:
     /**
      * @param NewId Index number of the new element (optional)
      */
-    explicit EmbeddedIncompressiblePotentialFlowElement(IndexType NewId = 0){}
+    explicit EmbeddedCompressiblePotentialFlowElement(IndexType NewId = 0){}
 
     /**
      * Constructor using an array of nodes
      */
-    EmbeddedIncompressiblePotentialFlowElement(IndexType NewId, const NodesArrayType& ThisNodes)
-        : IncompressiblePotentialFlowElement<Dim,NumNodes>(NewId, ThisNodes){}
+    EmbeddedCompressiblePotentialFlowElement(IndexType NewId, const NodesArrayType& ThisNodes)
+        : CompressiblePotentialFlowElement<Dim,NumNodes>(NewId, ThisNodes){}
 
     /**
      * Constructor using Geometry
      */
-    EmbeddedIncompressiblePotentialFlowElement(IndexType NewId, typename GeometryType::Pointer pGeometry)
-        : IncompressiblePotentialFlowElement<Dim,NumNodes>(NewId, pGeometry){}
+    EmbeddedCompressiblePotentialFlowElement(IndexType NewId, typename GeometryType::Pointer pGeometry)
+        : CompressiblePotentialFlowElement<Dim,NumNodes>(NewId, pGeometry){}
 
     /**
      * Constructor using Properties
      */
-    EmbeddedIncompressiblePotentialFlowElement(IndexType NewId,
+    EmbeddedCompressiblePotentialFlowElement(IndexType NewId,
                                        typename GeometryType::Pointer pGeometry,
                                        typename PropertiesType::Pointer pProperties)
-        : IncompressiblePotentialFlowElement<Dim,NumNodes>(NewId, pGeometry, pProperties){}
+        : CompressiblePotentialFlowElement<Dim,NumNodes>(NewId, pGeometry, pProperties){}
 
     /**
      * Copy Constructor
      */
-    EmbeddedIncompressiblePotentialFlowElement(EmbeddedIncompressiblePotentialFlowElement const& rOther) = delete;
+    EmbeddedCompressiblePotentialFlowElement(EmbeddedCompressiblePotentialFlowElement const& rOther) = delete;
 
     /**
      * Move Constructor
      */
-    EmbeddedIncompressiblePotentialFlowElement(EmbeddedIncompressiblePotentialFlowElement&& rOther) = delete;
+    EmbeddedCompressiblePotentialFlowElement(EmbeddedCompressiblePotentialFlowElement&& rOther) = delete;
 
     /**
      * Destructor
      */
-    ~EmbeddedIncompressiblePotentialFlowElement() override{}
+    ~EmbeddedCompressiblePotentialFlowElement() override{}
 
     ///@}
     ///@name Operators
     ///@{
 
     /// Assignment operator.
-    EmbeddedIncompressiblePotentialFlowElement& operator=(EmbeddedIncompressiblePotentialFlowElement const& rOther) = delete;
+    EmbeddedCompressiblePotentialFlowElement& operator=(EmbeddedCompressiblePotentialFlowElement const& rOther) = delete;
 
     /// Move operator.
-    EmbeddedIncompressiblePotentialFlowElement& operator=(EmbeddedIncompressiblePotentialFlowElement&& rOther) = delete;
+    EmbeddedCompressiblePotentialFlowElement& operator=(EmbeddedCompressiblePotentialFlowElement&& rOther) = delete;
 
     Element::Pointer Create(IndexType NewId,
                             NodesArrayType const& ThisNodes,
@@ -140,7 +140,7 @@ private:
 
     void load(Serializer& rSerializer) override;
 
-}; // Class EmbeddedIncompressiblePotentialFlowElement
+}; // Class EmbeddedCompressiblePotentialFlowElement
 
 } // namespace Kratos.
 

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -20,6 +20,8 @@ class PotentialFlowFormulation(object):
                 self._SetUpCompressibleElement(formulation_settings)
             elif element_type == "embedded_incompressible":
                 self._SetUpEmbeddedIncompressibleElement(formulation_settings)
+            elif element_type == "embedded_compressible":
+                self._SetUpEmbeddedCompressibleElement(formulation_settings)
         else:
             raise RuntimeError("Argument \'element_type\' not found in formulation settings.")
 
@@ -48,6 +50,15 @@ class PotentialFlowFormulation(object):
         formulation_settings.ValidateAndAssignDefaults(default_settings)
 
         self.element_name = "EmbeddedIncompressiblePotentialFlowElement"
+        self.condition_name = "PotentialWallCondition"
+
+    def _SetUpEmbeddedCompressibleElement(self, formulation_settings):
+        default_settings = KratosMultiphysics.Parameters(r"""{
+            "element_type": "embedded_compressible"
+        }""")
+        formulation_settings.ValidateAndAssignDefaults(default_settings)
+
+        self.element_name = "EmbeddedCompressiblePotentialFlowElement"
         self.condition_name = "PotentialWallCondition"
 
 def CreateSolver(model, custom_settings):

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_potential_element.cpp
@@ -189,7 +189,7 @@ namespace Kratos {
       }
     }
 
-        KRATOS_TEST_CASE_IN_SUITE(EmbeddedCompressiblePotentialFlowElementCalculateLocalSystemLHS, CompressiblePotentialApplicationFastSuite)
+    KRATOS_TEST_CASE_IN_SUITE(EmbeddedCompressiblePotentialFlowElementCalculateLocalSystemLHS, CompressiblePotentialApplicationFastSuite)
     {
       Model this_model;
       ModelPart& model_part = this_model.CreateModelPart("Main", 3);

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_potential_element.cpp
@@ -157,23 +157,13 @@ namespace Kratos {
       Element::Pointer pElement = model_part.pGetElement(1);
 
       // Define the nodal values
-      std::array<double,3> potential;
-      potential[0] = 1.0;
-      potential[1] = 2.0;
-      potential[2] = 3.0;
+      std::array<double,3> potential({1.0, 2.0, 3.0});
+      // Define the distance values
+      std::array<double,3> level_set({1.0, -1.0, -1.0});
 
       for (unsigned int i = 0; i < 3; i++){
         pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) = potential[i];
-      }
-
-      // Define the distance values
-      Vector level_set(3);
-      level_set(0) = 1.0;
-      level_set(1) = -1.0;
-      level_set(2) = -1.0;
-
-      for (unsigned int i = 0; i < 3; i++){
-        pElement->GetGeometry()[i].FastGetSolutionStepValue(GEOMETRY_DISTANCE) = level_set(i);
+        pElement->GetGeometry()[i].FastGetSolutionStepValue(GEOMETRY_DISTANCE) = level_set[i];
       }
 
       // Compute RHS and LHS
@@ -182,11 +172,9 @@ namespace Kratos {
 
       pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
-      std::array<double, 3> reference({0.125625, 0.0, -0.125625});
+      std::vector<double> reference({0.125625, 0.0, -0.125625});
 
-      for (unsigned int i = 0; i < RHS.size(); i++) {
-        KRATOS_CHECK_NEAR(RHS(i), reference[i], 1e-6);
-      }
+      KRATOS_CHECK_VECTOR_NEAR(RHS, reference, 1e-6);
     }
 
     KRATOS_TEST_CASE_IN_SUITE(EmbeddedCompressiblePotentialFlowElementCalculateLocalSystemLHS, CompressiblePotentialApplicationFastSuite)
@@ -198,23 +186,12 @@ namespace Kratos {
       Element::Pointer pElement = model_part.pGetElement(1);
 
       // Define the nodal values
-      std::array<double,3> potential;
-      potential[0] = 1.0;
-      potential[1] = 2.0;
-      potential[2] = 3.0;
-
+      std::array<double,3> potential({1.0, 2.0, 3.0});
+      // Define the distance values
+      std::array<double,3> level_set({1.0, -1.0, -1.0});
       for (unsigned int i = 0; i < 3; i++){
         pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) = potential[i];
-      }
-
-      // Define the distance values
-      Vector level_set(3);
-      level_set(0) = 1.0;
-      level_set(1) = -1.0;
-      level_set(2) = -1.0;
-
-      for (unsigned int i = 0; i < 3; i++){
-        pElement->GetGeometry()[i].FastGetSolutionStepValue(GEOMETRY_DISTANCE) = level_set(i);
+        pElement->GetGeometry()[i].FastGetSolutionStepValue(GEOMETRY_DISTANCE) = level_set[i];
       }
 
       // Compute RHS and LHS
@@ -223,15 +200,16 @@ namespace Kratos {
 
       pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
-      std::array<double, 9> reference({0.251249, -0.25125, 1.08455e-06, -0.25125, 0.502499, -0.25125, 1.08455e-06, -0.25125, 0.251249});
-
-      KRATOS_WATCH(LHS)
-
-      for (unsigned int i = 0; i < LHS.size1(); i++) {
-        for (unsigned int j = 0; i < LHS.size2(); i++) {
-          KRATOS_CHECK_NEAR(LHS(i,j), reference[3*i+j], 1e-6);
+      std::array<double, 9> reference_array({0.251249, -0.25125, 1.08455e-06, -0.25125, 0.502499, -0.25125, 1.08455e-06, -0.25125, 0.251249});
+      // Copying to a 3x3 matrix to check against LHS
+      Matrix reference(3,3);
+      for (unsigned int i = 0; i < reference.size1(); i++) {
+        for (unsigned int j = 0; j < reference.size2(); j++) {
+          reference(i,j) =  reference_array[i*reference.size1()+j];
         }
       }
+
+      KRATOS_CHECK_MATRIX_NEAR(LHS, reference, 1e-6);
     }
 
     KRATOS_TEST_CASE_IN_SUITE(CompressiblePotentialFlowElementRHSWake, CompressiblePotentialApplicationFastSuite)


### PR DESCRIPTION
Hi, 

In this PR I am adding the compressible element to be used with embedded geometries. As in the incompressible version, the embedded element is a child of the body-fitted element.

I added cpp tests and will add a python test after #5261.

![embedded_compressible_background1_naca0012_5 0_REMESH_0 001](https://user-images.githubusercontent.com/32136457/65409654-8da40a80-dde8-11e9-94aa-4d2ef9cd0671.png)
![embedded_compressible_background1_naca0012_5 0_REMESH_0 001_COMPARISON](https://user-images.githubusercontent.com/32136457/65409657-90066480-dde8-11e9-8245-fe19f99937a0.png)
