### PR TITLE
[Core] Remove debug errors for pGetProperties in element and condition

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -1268,19 +1268,19 @@ public:
     ///@name Access
     ///@{
 
+    /**
+    * @brief returns the pointer to the property of the condition.
+    *        Does not throw an error, to allow copying of
+    *        conditions which don't have any property assigned.
+    * @return property pointer
+    */
     PropertiesType::Pointer pGetProperties()
     {
-        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
-            << "Tryining to get the properties of " << Info()
-            << ", which are uninitialized." << std::endl;
         return mpProperties;
     }
 
     const PropertiesType::Pointer pGetProperties() const
     {
-        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
-            << "Tryining to get the properties of " << Info()
-            << ", which are uninitialized." << std::endl;
         return mpProperties;
     }
 

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -1302,19 +1302,19 @@ public:
     ///@name Access
     ///@{
 
+    /**
+    * @brief returns the pointer to the property of the element.
+    *        Does not throw an error, to allow copying of
+    *        elements which don't have any property assigned.
+    * @return property pointer
+    */
     PropertiesType::Pointer pGetProperties()
     {
-        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
-            << "Tryining to get the properties of " << Info()
-            << ", which are uninitialized." << std::endl;
         return mpProperties;
     }
 
     const PropertiesType::Pointer pGetProperties() const
     {
-        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
-            << "Tryining to get the properties of " << Info()
-            << ", which are uninitialized." << std::endl;
         return mpProperties;
     }
 


### PR DESCRIPTION
Hi all,

as adressed in #4517 I am removing here the debug errors if nullptr is adressed within condition and element. This allows to copy also elements/conditions which don't have any property assigned.

It is not smart to remove the debug warning for the GetProperty access to the source as this is not a possible operation.

Thanks!
closes #4517 