### PR TITLE
[PotentialFlow] Avoiding deprecation modelpart warning (II)

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_adjoint_analytical_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_adjoint_analytical_parameters.json
@@ -71,7 +71,7 @@
             "Parameters"            : {
                 "check_variables" : ["SHAPE_SENSITIVITY","ADJOINT_VELOCITY_POTENTIAL","ADJOINT_AUXILIARY_VELOCITY_POTENTIAL"],
                 "input_file_name" : "adjoint_analytical_incompressible_test_results.json",
-                "model_part_name"  : "Parts_Parts_Auto1",
+                "model_part_name"  : "MainModelPart.Parts_Parts_Auto1",
                 "time_frequency"   : -2
             }
         }],
@@ -86,7 +86,7 @@
         "Parameters"            : {
             "output_variables" : ["SHAPE_SENSITIVITY","ADJOINT_VELOCITY_POTENTIAL","ADJOINT_AUXILIARY_VELOCITY_POTENTIAL"],
             "output_file_name" : "adjoint_analytical_incompressible_test_results.json",
-            "model_part_name"  : "Parts_Parts_Auto1",
+            "model_part_name"  : "MainModelPart.Parts_Parts_Auto1",
             "time_frequency"   : -2
         }
     }


### PR DESCRIPTION
I missed one test in #5632. Now all tests call the submodelparts as intended. 