### PR TITLE
[Core][Logger] Add option to output a time stamp at the beginning of each log line

### DIFF
--- a/kratos/input_output/logger_message.cpp
+++ b/kratos/input_output/logger_message.cpp
@@ -12,7 +12,9 @@
 //
 
 // System includes
-#include <ctime>
+#include <chrono>  // chrono::system_clock
+#include <ctime>   // localtime
+#include <iomanip> // put_time
 
 
 // External includes
@@ -36,13 +38,12 @@ namespace Kratos
 
   std::string LoggerMessage::GetTimeStamp() const
   {
-    time_t raw_time;
-    char buffer[10];
+    auto now = std::chrono::system_clock::now();
+    auto in_time_t = std::chrono::system_clock::to_time_t(now);
 
-    time (&raw_time);
-
-    strftime(buffer, sizeof(buffer), "%H:%M:%S", localtime(&raw_time));
-    return std::string(buffer);
+    std::stringstream ss;
+    ss << std::put_time(std::localtime(&in_time_t), "%X");
+    return ss.str();
   }
 
   /// Print information about this object.

--- a/kratos/input_output/logger_message.cpp
+++ b/kratos/input_output/logger_message.cpp
@@ -12,6 +12,7 @@
 //
 
 // System includes
+#include <ctime>
 
 
 // External includes
@@ -31,6 +32,17 @@ namespace Kratos
   std::string LoggerMessage::Info() const
   {
     return "LoggerMessage";
+  }
+
+  std::string LoggerMessage::GetTimeStamp() const
+  {
+    time_t raw_time;
+    char buffer[10];
+
+    time (&raw_time);
+
+    strftime(buffer, sizeof(buffer), "%H:%M:%S", localtime(&raw_time));
+    return std::string(buffer);
   }
 
   /// Print information about this object.

--- a/kratos/input_output/logger_message.h
+++ b/kratos/input_output/logger_message.h
@@ -242,6 +242,8 @@ public:
   return mTime;
   }
 
+  std::string GetTimeStamp() const;
+
   ///@}
   ///@name Inquiry
   ///@{

--- a/kratos/input_output/logger_output.cpp
+++ b/kratos/input_output/logger_output.cpp
@@ -43,6 +43,9 @@ namespace Kratos
         auto message_severity = TheMessage.GetSeverity();
         if (TheMessage.WriteInThisRank() && message_severity <= mSeverity)
         {
+            if(mWriteTimeStamp && TheMessage.GetLabel().size() && TheMessage.GetMessage().size())
+                mrStream << TheMessage.GetTimeStamp() << " - ";
+
             if(TheMessage.IsDistributed())
                 mrStream << "Rank " << TheMessage.GetSourceRank() << ": ";
 

--- a/kratos/input_output/logger_output.h
+++ b/kratos/input_output/logger_output.h
@@ -116,6 +116,15 @@ public:
     return mCategory;
   }
 
+
+  void SetTimeStampFlag(bool WriteTimeStamp) {
+    mWriteTimeStamp = WriteTimeStamp;
+  }
+
+  bool GetTimeStampFlag() const {
+    return mWriteTimeStamp;
+  }
+
   ///@}
   ///@name Inquiry
   ///@{
@@ -171,6 +180,7 @@ private:
   std::size_t mMaxLevel;
   LoggerMessage::Severity mSeverity;
   LoggerMessage::Category mCategory;
+  bool mWriteTimeStamp=false;
 
   ///@}
 }; // Class LoggerOutput

--- a/kratos/python/add_logger_to_python.cpp
+++ b/kratos/python/add_logger_to_python.cpp
@@ -158,6 +158,8 @@ void  AddLoggerToPython(pybind11::module& m) {
     .def("GetSeverity", &LoggerOutput::GetSeverity)
     .def("SetCategory", &LoggerOutput::SetCategory)
     .def("GetCategory", &LoggerOutput::GetCategory)
+    .def("SetTimeStampFlag", &LoggerOutput::SetTimeStampFlag)
+    .def("GetTimeStampFlag", &LoggerOutput::GetTimeStampFlag)
     ;
 
     py::class_<Logger, Kratos::shared_ptr<Logger>> logger_scope(m,"Logger");


### PR DESCRIPTION
Similar to the severity level, a flag for adding the time stamp at the beginning of each log line can be set to the Logger.
```
[time stamp] - [label]: [message]
```
e.g.
```
11:26:52 - ShapeOpt: Current value of objective =   1.11393E-07 
```

This can be activated by:
```python
KM.Logger.GetDefaultOutput().SetTimeStampFlag(True)
```

@KratosMultiphysics/technical-committee 
