### PR TITLE
Adding python interface for DenseVector<int>.

### DIFF
--- a/kratos/python/add_vector_to_python.cpp
+++ b/kratos/python/add_vector_to_python.cpp
@@ -216,6 +216,18 @@ namespace Python
         py::implicitly_convertible<py::list, Vector>();
         py::implicitly_convertible<array_1d<double,3>, Vector>();
 
+        auto int_vector_binder = CreateVectorInterface<DenseVector<int>>(m, "DenseVectorInt");
+        int_vector_binder.def(py::init<typename DenseVector<int>::size_type>());
+        int_vector_binder.def(py::init<typename DenseVector<int>::size_type, int>());
+        int_vector_binder.def(py::init<DenseVector<int>>());
+        int_vector_binder.def(py::init( [](const py::list& input){
+                                DenseVector<int> tmp(input.size());
+                                for(unsigned int i=0; i<tmp.size(); ++i)
+                                    tmp[i] = py::cast<int>(input[i]);
+                                return tmp;
+                                }));
+        py::implicitly_convertible<py::list, DenseVector<int>>();
+
         CreateArray1DInterface< 3 >(m,"Array3");
         CreateArray1DInterface< 4 >(m,"Array4");
         CreateArray1DInterface< 6 >(m,"Array6");


### PR DESCRIPTION
Required (for example) to retrieve the neighbor indices from the ModelPart Communicator, as reported by @marcnunezc in #5654 

@marcnunezc please give it a try, I would guess we lost the vector interface for ints when moving to Pybind11.