### PR TITLE
[Core] removing old check-fcts

### DIFF
--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -86,15 +86,5 @@ def _ImportApplicationAsModuleCustomFolder(application, application_name, applic
     # Add application to kernel
     Kernel.ImportApplication(application)
 
-def CheckForPreviousImport():
-    warn_msg  = '"CheckForPreviousImport" is not needed any more and can be safely removed\n'
-    warn_msg += 'It does nothing any more'
-    Logger.PrintWarning('DEPRECATION', warn_msg)
-
-def CheckRegisteredApplications(*applications):
-    warn_msg  = '"CheckRegisteredApplications" is not needed any more and can be safely removed\n'
-    warn_msg += 'It does nothing any more'
-    Logger.PrintWarning('DEPRECATION', warn_msg)
-
 def IsDistributedRun():
     return KratosGlobals.Kernel.IsDistributedRun()


### PR DESCRIPTION
Those were deprecated almost a year ago
Since then I think they were removed in most places

`CheckForPreviousImport` only appears in some files of very old applications
`CheckRegisteredApplications` is not used anywhere