### PR TITLE
[Core] - prefix warning level output

### DIFF
--- a/kratos/input_output/logger_output.cpp
+++ b/kratos/input_output/logger_output.cpp
@@ -43,6 +43,9 @@ namespace Kratos
         auto message_severity = TheMessage.GetSeverity();
         if (TheMessage.WriteInThisRank() && message_severity <= mSeverity)
         {
+            if (message_severity == LoggerMessage::Severity::WARNING)
+                mrStream << "[WARNING] ";
+
             if(TheMessage.IsDistributed())
                 mrStream << "Rank " << TheMessage.GetSourceRank() << ": ";
 

--- a/kratos/input_output/logger_output.cpp
+++ b/kratos/input_output/logger_output.cpp
@@ -24,6 +24,13 @@
 
 namespace Kratos
 {
+
+    KRATOS_CREATE_LOCAL_FLAG( LoggerOutput, WARNING_PREFIX,  0 );
+    KRATOS_CREATE_LOCAL_FLAG( LoggerOutput, INFO_PREFIX,     1 );
+    KRATOS_CREATE_LOCAL_FLAG( LoggerOutput, DETAIL_PREFIX,   2 );
+    KRATOS_CREATE_LOCAL_FLAG( LoggerOutput, DEBUG_PREFIX,    3 );
+    KRATOS_CREATE_LOCAL_FLAG( LoggerOutput, TRACE_PREFIX,    4 );
+
     std::string LoggerOutput::Info() const
     {
         return "LoggerOutput";
@@ -45,20 +52,20 @@ namespace Kratos
         {
             switch (message_severity)
             {
-            case LoggerMessage::Severity::INFO:
-                if (mInfoPrefix) mrStream << "[INFO] ";
-                break;
             case LoggerMessage::Severity::WARNING:
-                if (mWarningPrefix) mrStream << "[WARNING] ";
+                if (mOptions.Is(WARNING_PREFIX)) mrStream << "[WARNING] ";
+                break;
+            case LoggerMessage::Severity::INFO:
+                if (mOptions.Is(INFO_PREFIX)) mrStream << "[INFO] ";
                 break;
             case LoggerMessage::Severity::DETAIL:
-                if (mDetailPrefix) mrStream << "[DETAIL] ";
+                if (mOptions.Is(DETAIL_PREFIX)) mrStream << "[DETAIL] ";
                 break;
             case LoggerMessage::Severity::DEBUG:
-                if (mDebugPrefix) mrStream << "[DEBUG] ";
+                if (mOptions.Is(DEBUG_PREFIX)) mrStream << "[DEBUG] ";
                 break;
             case LoggerMessage::Severity::TRACE:
-                if (mTracePrefix) mrStream << "[TRACE] ";
+                if (mOptions.Is(TRACE_PREFIX)) mrStream << "[TRACE] ";
                 break;
             default:
                 break;

--- a/kratos/input_output/logger_output.cpp
+++ b/kratos/input_output/logger_output.cpp
@@ -43,8 +43,26 @@ namespace Kratos
         auto message_severity = TheMessage.GetSeverity();
         if (TheMessage.WriteInThisRank() && message_severity <= mSeverity)
         {
-            if (message_severity == LoggerMessage::Severity::WARNING)
-                mrStream << "[WARNING] ";
+            switch (message_severity)
+            {
+            case LoggerMessage::Severity::INFO:
+                if (mInfoPrefix) mrStream << "[INFO] ";
+                break;
+            case LoggerMessage::Severity::WARNING:
+                if (mWarningPrefix) mrStream << "[WARNING] ";
+                break;
+            case LoggerMessage::Severity::DETAIL:
+                if (mDetailPrefix) mrStream << "[DETAIL] ";
+                break;
+            case LoggerMessage::Severity::DEBUG:
+                if (mDebugPrefix) mrStream << "[DEBUG] ";
+                break;
+            case LoggerMessage::Severity::TRACE:
+                if (mTracePrefix) mrStream << "[TRACE] ";
+                break;
+            default:
+                break;
+            }
 
             if(TheMessage.IsDistributed())
                 mrStream << "Rank " << TheMessage.GetSourceRank() << ": ";

--- a/kratos/input_output/logger_output.h
+++ b/kratos/input_output/logger_output.h
@@ -29,6 +29,7 @@
 // Project includes
 #include "includes/define.h"
 #include "input_output/logger_message.h"
+#include "containers/flags.h"
 
 namespace Kratos
 {
@@ -49,6 +50,11 @@ public:
   ///@name Type Definitions
   ///@{
 
+  KRATOS_DEFINE_LOCAL_FLAG(WARNING_PREFIX);
+  KRATOS_DEFINE_LOCAL_FLAG(INFO_PREFIX);
+  KRATOS_DEFINE_LOCAL_FLAG(DETAIL_PREFIX);
+  KRATOS_DEFINE_LOCAL_FLAG(DEBUG_PREFIX);
+  KRATOS_DEFINE_LOCAL_FLAG(TRACE_PREFIX);
 
   /// Pointer definition of LoggerOutput
   KRATOS_CLASS_POINTER_DEFINITION(LoggerOutput);
@@ -62,7 +68,17 @@ public:
   ///@{
 
   explicit LoggerOutput(std::ostream& rOutputStream)
-    : mrStream(rOutputStream), mMaxLevel(1), mSeverity(LoggerMessage::Severity::INFO), mCategory(LoggerMessage::Category::STATUS) {}
+    : mrStream(rOutputStream),
+      mMaxLevel(1),
+      mSeverity(LoggerMessage::Severity::INFO),
+      mCategory(LoggerMessage::Category::STATUS)
+  {
+    mOptions.Set(WARNING_PREFIX, true);
+    mOptions.Set(INFO_PREFIX, false);
+    mOptions.Set(DETAIL_PREFIX, false);
+    mOptions.Set(DEBUG_PREFIX, false);
+    mOptions.Set(TRACE_PREFIX, false);
+  }
 
   LoggerOutput(LoggerOutput const& Other)
     : mrStream(Other.mrStream), mMaxLevel(Other.mMaxLevel), mSeverity(Other.mSeverity), mCategory(Other.mCategory) {}
@@ -116,44 +132,12 @@ public:
     return mCategory;
   }
 
-  void SetWarningPrefix(bool Flag) {
-    mWarningPrefix = Flag;
+  void SetOption(Kratos::Flags ThisFlag, bool Value) {
+    mOptions.Set(ThisFlag, Value);
   }
 
-  bool GetWarningPrefix() const {
-    return mWarningPrefix;
-  }
-
-  void SetInfoPrefix(bool Flag) {
-    mInfoPrefix = Flag;
-  }
-
-  bool GetInfoPrefix() const {
-    return mInfoPrefix;
-  }
-
-  void SetDetailPrefix(bool Flag) {
-    mDetailPrefix = Flag;
-  }
-
-  bool GetDetailPrefix() const {
-    return mDetailPrefix;
-  }
-
-  void SetDebugPrefix(bool Flag) {
-    mDebugPrefix = Flag;
-  }
-
-  bool GetDebugPrefix() const {
-    return mDebugPrefix;
-  }
-
-  void SetTracePrefix(bool Flag) {
-    mTracePrefix = Flag;
-  }
-
-  bool GetTracePrefix() const {
-    return mTracePrefix;
+  bool GetOption(Kratos::Flags ThisFlag) {
+    return mOptions.Is(ThisFlag);
   }
 
   ///@}
@@ -211,11 +195,7 @@ private:
   std::size_t mMaxLevel;
   LoggerMessage::Severity mSeverity;
   LoggerMessage::Category mCategory;
-  bool mWarningPrefix = true;
-  bool mInfoPrefix = false;
-  bool mDetailPrefix = false;
-  bool mDebugPrefix = false;
-  bool mTracePrefix = false;
+  Kratos::Flags mOptions;
 
   ///@}
 }; // Class LoggerOutput

--- a/kratos/input_output/logger_output.h
+++ b/kratos/input_output/logger_output.h
@@ -116,6 +116,46 @@ public:
     return mCategory;
   }
 
+  void SetWarningPrefix(bool Flag) {
+    mWarningPrefix = Flag;
+  }
+
+  bool GetWarningPrefix() const {
+    return mWarningPrefix;
+  }
+
+  void SetInfoPrefix(bool Flag) {
+    mInfoPrefix = Flag;
+  }
+
+  bool GetInfoPrefix() const {
+    return mInfoPrefix;
+  }
+
+  void SetDetailPrefix(bool Flag) {
+    mDetailPrefix = Flag;
+  }
+
+  bool GetDetailPrefix() const {
+    return mDetailPrefix;
+  }
+
+  void SetDebugPrefix(bool Flag) {
+    mDebugPrefix = Flag;
+  }
+
+  bool GetDebugPrefix() const {
+    return mDebugPrefix;
+  }
+
+  void SetTracePrefix(bool Flag) {
+    mTracePrefix = Flag;
+  }
+
+  bool GetTracePrefix() const {
+    return mTracePrefix;
+  }
+
   ///@}
   ///@name Inquiry
   ///@{
@@ -171,6 +211,11 @@ private:
   std::size_t mMaxLevel;
   LoggerMessage::Severity mSeverity;
   LoggerMessage::Category mCategory;
+  bool mWarningPrefix = true;
+  bool mInfoPrefix = false;
+  bool mDetailPrefix = false;
+  bool mDebugPrefix = false;
+  bool mTracePrefix = false;
 
   ///@}
 }; // Class LoggerOutput

--- a/kratos/python/add_logger_to_python.cpp
+++ b/kratos/python/add_logger_to_python.cpp
@@ -158,6 +158,16 @@ void  AddLoggerToPython(pybind11::module& m) {
     .def("GetSeverity", &LoggerOutput::GetSeverity)
     .def("SetCategory", &LoggerOutput::SetCategory)
     .def("GetCategory", &LoggerOutput::GetCategory)
+    .def("SetWarningPrefix", &LoggerOutput::SetWarningPrefix)
+    .def("GetWarningPrefix", &LoggerOutput::GetWarningPrefix)
+    .def("SetInfoPrefix", &LoggerOutput::SetInfoPrefix)
+    .def("GetInfoPrefix", &LoggerOutput::GetInfoPrefix)
+    .def("SetDetailPrefix", &LoggerOutput::SetDetailPrefix)
+    .def("GetDetailPrefix", &LoggerOutput::GetDetailPrefix)
+    .def("SetDebugPrefix", &LoggerOutput::SetDebugPrefix)
+    .def("GetDebugPrefix", &LoggerOutput::GetDebugPrefix)
+    .def("SetTracePrefix", &LoggerOutput::SetTracePrefix)
+    .def("GetTracePrefix", &LoggerOutput::GetTracePrefix)
     ;
 
     py::class_<Logger, Kratos::shared_ptr<Logger>> logger_scope(m,"Logger");

--- a/kratos/python/add_logger_to_python.cpp
+++ b/kratos/python/add_logger_to_python.cpp
@@ -151,24 +151,21 @@ void printWarningOnAllRanks(pybind11::args args, pybind11::kwargs kwargs) {
 
 void  AddLoggerToPython(pybind11::module& m) {
 
-    py::class_<LoggerOutput, Kratos::shared_ptr<LoggerOutput>>(m,"LoggerOutput")
+    auto logger_output = py::class_<LoggerOutput, Kratos::shared_ptr<LoggerOutput>>(m,"LoggerOutput")
     .def("SetMaxLevel", &LoggerOutput::SetMaxLevel)
     .def("GetMaxLevel", &LoggerOutput::GetMaxLevel)
     .def("SetSeverity", &LoggerOutput::SetSeverity)
     .def("GetSeverity", &LoggerOutput::GetSeverity)
     .def("SetCategory", &LoggerOutput::SetCategory)
     .def("GetCategory", &LoggerOutput::GetCategory)
-    .def("SetWarningPrefix", &LoggerOutput::SetWarningPrefix)
-    .def("GetWarningPrefix", &LoggerOutput::GetWarningPrefix)
-    .def("SetInfoPrefix", &LoggerOutput::SetInfoPrefix)
-    .def("GetInfoPrefix", &LoggerOutput::GetInfoPrefix)
-    .def("SetDetailPrefix", &LoggerOutput::SetDetailPrefix)
-    .def("GetDetailPrefix", &LoggerOutput::GetDetailPrefix)
-    .def("SetDebugPrefix", &LoggerOutput::SetDebugPrefix)
-    .def("GetDebugPrefix", &LoggerOutput::GetDebugPrefix)
-    .def("SetTracePrefix", &LoggerOutput::SetTracePrefix)
-    .def("GetTracePrefix", &LoggerOutput::GetTracePrefix)
+    .def("SetOption", &LoggerOutput::SetOption)
+    .def("GetOption", &LoggerOutput::GetOption)
     ;
+    logger_output.attr("WARNING_PREFIX") = LoggerOutput::WARNING_PREFIX;
+    logger_output.attr("INFO_PREFIX") = LoggerOutput::INFO_PREFIX;
+    logger_output.attr("DETAIL_PREFIX") = LoggerOutput::DETAIL_PREFIX;
+    logger_output.attr("DEBUG_PREFIX") = LoggerOutput::DEBUG_PREFIX;
+    logger_output.attr("TRACE_PREFIX") = LoggerOutput::TRACE_PREFIX;
 
     py::class_<Logger, Kratos::shared_ptr<Logger>> logger_scope(m,"Logger");
     logger_scope.def(py::init<std::string const &>());

--- a/kratos/tests/cpp_tests/input_output/test_logger.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_logger.cpp
@@ -155,7 +155,7 @@ namespace Kratos {
 
             KRATOS_WARNING("TestWarning") << "Test warning message";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestWarning: Test warning message" : "";
+            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: Test warning message" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -168,7 +168,7 @@ namespace Kratos {
             KRATOS_WARNING_IF("TestWarning", true) << "Test warning message";
             KRATOS_WARNING_IF("TestWarning", false) << "This should not appear";
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestWarning: Test warning message" : "";
+            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: Test warning message" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -182,7 +182,7 @@ namespace Kratos {
                 KRATOS_WARNING_ONCE("TestWarning") << "Test warning message - " << i;
             }
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestWarning: Test warning message - 0" : "";
+            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: Test warning message - 0" : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -196,7 +196,7 @@ namespace Kratos {
                 KRATOS_WARNING_FIRST_N("TestWarning", 4) << ".";
             }
 
-            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestWarning: .TestWarning: .TestWarning: .TestWarning: ." : "";
+            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: .[WARNING] TestWarning: .[WARNING] TestWarning: .[WARNING] TestWarning: ." : "";
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 

--- a/kratos/tests/cpp_tests/input_output/test_logger.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_logger.cpp
@@ -446,6 +446,47 @@ namespace Kratos {
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), out.str().c_str());
         }
 
+        KRATOS_TEST_CASE_IN_SUITE(LoggerNoPrefix, KratosCoreFastSuite)
+        {
+            static std::stringstream buffer;
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
+            p_output->SetWarningPrefix(false);
+            p_output->SetInfoPrefix(false);
+            p_output->SetDetailPrefix(false);
+            p_output->SetDebugPrefix(false);
+            p_output->SetTracePrefix(false);
+            Logger::AddOutput(p_output);
+
+            KRATOS_WARNING("TestWarning") << "Test message\n";
+            KRATOS_INFO("TestInfo") << "Test message\n";
+            KRATOS_DETAIL("TestDetail") << "Test message\n";
+
+            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestWarning: Test message\nTestInfo: Test message\nTestDetail: Test message\n" : "";
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
+        }
+
+
+        KRATOS_TEST_CASE_IN_SUITE(LoggerPrefix, KratosCoreFastSuite)
+        {
+            static std::stringstream buffer;
+            LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
+            p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
+            p_output->SetWarningPrefix(true);
+            p_output->SetInfoPrefix(true);
+            p_output->SetDetailPrefix(true);
+            p_output->SetDebugPrefix(true);
+            p_output->SetTracePrefix(true);
+            Logger::AddOutput(p_output);
+
+            KRATOS_WARNING("TestWarning") << "Test message\n";
+            KRATOS_INFO("TestInfo") << "Test message\n";
+            KRATOS_DETAIL("TestDetail") << "Test message\n";
+
+            std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: Test message\n[INFO] TestInfo: Test message\n[DETAIL] TestDetail: Test message\n" : "";
+            KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
+        }
+
     }   // namespace Testing
 }  // namespace Kratos.
 

--- a/kratos/tests/cpp_tests/input_output/test_logger.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_logger.cpp
@@ -451,11 +451,11 @@ namespace Kratos {
             static std::stringstream buffer;
             LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
             p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
-            p_output->SetWarningPrefix(false);
-            p_output->SetInfoPrefix(false);
-            p_output->SetDetailPrefix(false);
-            p_output->SetDebugPrefix(false);
-            p_output->SetTracePrefix(false);
+            p_output->SetOption(LoggerOutput::WARNING_PREFIX, false);
+            p_output->SetOption(LoggerOutput::INFO_PREFIX, false);
+            p_output->SetOption(LoggerOutput::DETAIL_PREFIX, false);
+            p_output->SetOption(LoggerOutput::DEBUG_PREFIX, false);
+            p_output->SetOption(LoggerOutput::TRACE_PREFIX, false);
             Logger::AddOutput(p_output);
 
             KRATOS_WARNING("TestWarning") << "Test message\n";
@@ -472,11 +472,11 @@ namespace Kratos {
             static std::stringstream buffer;
             LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
             p_output->SetSeverity(LoggerMessage::Severity::DETAIL);
-            p_output->SetWarningPrefix(true);
-            p_output->SetInfoPrefix(true);
-            p_output->SetDetailPrefix(true);
-            p_output->SetDebugPrefix(true);
-            p_output->SetTracePrefix(true);
+            p_output->SetOption(LoggerOutput::WARNING_PREFIX, true);
+            p_output->SetOption(LoggerOutput::INFO_PREFIX, true);
+            p_output->SetOption(LoggerOutput::DETAIL_PREFIX, true);
+            p_output->SetOption(LoggerOutput::DEBUG_PREFIX, true);
+            p_output->SetOption(LoggerOutput::TRACE_PREFIX, true);
             Logger::AddOutput(p_output);
 
             KRATOS_WARNING("TestWarning") << "Test message\n";


### PR DESCRIPTION
@KratosMultiphysics/interface-committee 

Currently warning messages look the same as messages in other severity levels. This makes it very hard to filter them among many other logging lines. In order to make them more visible this PR adds highlights them with a prefix.

Like this it is easier to see them in the terminal output, and search them in a log file using a unique search key.

Warning messages are modified to:
```
[WARNING] label: message
```

```
ShapeOpt: Starting to update the mesh...
::[Mesh Moving Simulation]:: : STEP:  1 
::[Mesh Moving Simulation]:: : TIME:  1.0 
[WARNING] ResidualBasedBlockBuilderAndSolver: ATTENTION! setting the RHS to zero!
ShapeOpt: Time needed for updating the mesh =  0.16 s
```

This is a simplified version of #5643 