### PR TITLE
[core] Printing the ModelPart variables (ModelPartData) when a ModelPart is printed

### DIFF
--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -1623,6 +1623,8 @@ void ModelPart::PrintInfo(std::ostream& rOStream) const
 
 void ModelPart::PrintData(std::ostream& rOStream) const
 {
+    DataValueContainer::PrintData(rOStream);
+
     if (!IsSubModelPart()) {
         rOStream  << "    Buffer Size : " << mBufferSize << std::endl;
     }

--- a/kratos/tests/test_object_printing.py
+++ b/kratos/tests/test_object_printing.py
@@ -15,6 +15,7 @@ prop_str = '''Properties
 This properties contains 0 tables'''
 
 model_part_str = '''-Main- model part
+    AMBIENT_TEMPERATURE : 250
     Buffer Size : 1
     Number of tables : 1
     Number of sub model parts : 2


### PR DESCRIPTION
I think this was missing, as the ModelPart derives from DataValueContainer, it should print what its base class prints, too.