### PR TITLE
[PotentialFlow] Setting material name as null (fast pr to avoid test errors)

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -78,7 +78,7 @@ class PotentialFlowSolver(FluidSolver):
                 "input_filename": "unknown_name"
             },
             "material_import_settings": {
-                "materials_filename": "unknown_materials.json"
+                "materials_filename": ""
             },
             "formulation": {
                 "element_type": "incompressible"
@@ -120,6 +120,7 @@ class PotentialFlowSolver(FluidSolver):
         self.domain_size = custom_settings["domain_size"].GetInt()
         self.reference_chord = custom_settings["reference_chord"].GetDouble()
         self.main_model_part.ProcessInfo.SetValue(KCPFApp.REFERENCE_CHORD,self.reference_chord)
+        self.element_has_nodal_properties = False
 
         #construct the linear solvers
         import KratosMultiphysics.python_linear_solver_factory as linear_solver_factory


### PR DESCRIPTION
Hi,

After #5364, the potential flow tests are failing since the default "unknown_materials.json" file does not exist.

Currently there are no properties being used in the potential flow, everything is controlled using the ProcessInfo, since all variables are global and seen for all elements and conditions (free stream conditions):

https://github.com/KratosMultiphysics/Kratos/blob/3e03c57eaaef24d9a7509f322fd4533785c666fb/applications/CompressiblePotentialFlowApplication/python_scripts/apply_far_field_process.py#L53-L57

We used to use properties for this, but at some point it was suggested to use the ProcessInfo https://github.com/KratosMultiphysics/Kratos/pull/4642#discussion_r274870170.

In this PR I simply add by default an empty string to avoid an error, which throws the warning. 

`Material properties have not been imported. Check 'material_import_settings' in your ProjectParameters.json.`

I assume this is not the preferred option but it is a fast one to avoid current test errors. Other things we can do is:

1) Start using the properties again for these variables and the corresponding material.json
2) Override the following method in the potential_flow_solver
https://github.com/KratosMultiphysics/Kratos/blob/3e03c57eaaef24d9a7509f322fd4533785c666fb/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py#L223-L239
to always output = True




