### PR TITLE
[Structural] copy-paste bugfix in ConvCrit

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_and_other_dof_criteria.h
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_convergencecriterias/displacement_and_other_dof_criteria.h
@@ -420,7 +420,7 @@ private:
                 }
                 else
                 {
-                    mReferenceOtherDoFNorm += AuxValue*AuxValue;
+                    DeltaOtherDoFNorm += AuxValue*AuxValue;
                 }
             }
         }


### PR DESCRIPTION
Fixing a copy-paste error that leads to NEGLECTING the "other" Dof. For Structural Cases this means that it ALWAYS neglects how the rotations converge / convergence of rotations is not being checked!!!

This is the second time I fixed a MAYOR error in this criteria.
I have not checked the tests yet, no time right now

Since this is anyway 100% the same as the VelPr Criteria in the FluidDynamics I will refactor this and put it to the Core (and also make it compatible with Trilinos) FYI @sunethwarna @jcotela 

@KratosMultiphysics/structural-mechanics please check your cases with this

Edit after my findings I would say this should also solve #4479 (closes #4479)