### PR TITLE
Dem/developing restart capabilities

### DIFF
--- a/applications/DEMApplication/custom_conditions/RigidEdge.cpp
+++ b/applications/DEMApplication/custom_conditions/RigidEdge.cpp
@@ -67,16 +67,16 @@ RigidEdge3D::~RigidEdge3D()
 * calculates only the RHS vector (certainly to be removed due to contact algorithm)
 */
 
-void RigidEdge3D::Initialize() {
+void RigidEdge3D::Initialize(const ProcessInfo& rCurrentProcessInfo) {
 
 //  mTgOfFrictionAngle = GetProperties()[FRICTION];
+    if (! rCurrentProcessInfo[IS_RESTARTED]){
+        this->GetGeometry()[0].FastGetSolutionStepValue(NON_DIMENSIONAL_VOLUME_WEAR) = 0.0;
+        this->GetGeometry()[1].FastGetSolutionStepValue(NON_DIMENSIONAL_VOLUME_WEAR) = 0.0;
 
-  this->GetGeometry()[0].FastGetSolutionStepValue(NON_DIMENSIONAL_VOLUME_WEAR) = 0.0;
-  this->GetGeometry()[1].FastGetSolutionStepValue(NON_DIMENSIONAL_VOLUME_WEAR) = 0.0;
-
-  this->GetGeometry()[0].FastGetSolutionStepValue(IMPACT_WEAR) = 0.0;
-  this->GetGeometry()[1].FastGetSolutionStepValue(IMPACT_WEAR) = 0.0;
-
+        this->GetGeometry()[0].FastGetSolutionStepValue(IMPACT_WEAR) = 0.0;
+        this->GetGeometry()[1].FastGetSolutionStepValue(IMPACT_WEAR) = 0.0;
+    }
 }
 
 

--- a/applications/DEMApplication/custom_conditions/RigidEdge.h
+++ b/applications/DEMApplication/custom_conditions/RigidEdge.h
@@ -59,7 +59,7 @@ public:
 
     Condition::Pointer Create( IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
 
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
     void CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& r_process_info) override;
     void CalculateElasticForces(VectorType& rElasticForces, ProcessInfo& r_process_info) override;
     void CalculateNormal(array_1d<double, 3>& rnormal) override;

--- a/applications/DEMApplication/custom_conditions/RigidFace.cpp
+++ b/applications/DEMApplication/custom_conditions/RigidFace.cpp
@@ -68,7 +68,7 @@ void RigidFace3D::Initialize(const ProcessInfo& rCurrentProcessInfo) {
 void RigidFace3D::CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& r_process_info) {
     const unsigned int number_of_nodes = GetGeometry().size();
     unsigned int MatSize = number_of_nodes * 3;
-    KRATOS_WATCH(MatSize)
+
     if (rRightHandSideVector.size() != MatSize) {
         rRightHandSideVector.resize(MatSize, false);
     }
@@ -101,10 +101,7 @@ void RigidFace3D::CalculateRightHandSide(VectorType& rRightHandSideVector, Proce
 
         //AddForcesDueToTorque(rRightHandSideVector, r_shape_functions_values, weights_vector, force, p_particle);
     }
-    KRATOS_WATCH(number_of_nodes)
-
     std::vector<SphericParticle*>& rNeighbours = this->mNeighbourSphericParticles;
-    KRATOS_WATCH(rNeighbours.size())
 
     for (unsigned int i=0; i<rNeighbours.size(); i++) {
         if(rNeighbours[i]->Is(BLOCKED)) continue; //Inlet Generator Spheres are ignored when integrating forces.
@@ -118,9 +115,6 @@ void RigidFace3D::CalculateRightHandSide(VectorType& rRightHandSideVector, Proce
             rRightHandSideVector[k * 3 + 2] += -force[2] * weights_vector[k];
         }
     }
-
-    KRATOS_WATCH(rNeighbours.size())
-
 }
 
 void RigidFace3D::AddForcesDueToTorque(VectorType& rRightHandSideVector, Vector& r_shape_functions_values, std::vector<double>& weights_vector, array_1d<double, 3>& force, SphericParticle* p_particle) {

--- a/applications/DEMApplication/custom_conditions/RigidFace.h
+++ b/applications/DEMApplication/custom_conditions/RigidFace.h
@@ -66,7 +66,7 @@ public:
 
     Condition::Pointer Create( IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties ) const override;
 
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
     void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& r_process_info ) override;
     void ComputeForceAndWeightsOfSphereOnThisFace(SphericParticle* p_particle, array_1d<double, 3>& force, std::vector<double>& weights_vector);
     void CalculateElasticForces(VectorType& rElasticForces, ProcessInfo& r_process_info) override;

--- a/applications/DEMApplication/custom_conditions/SolidFace.cpp
+++ b/applications/DEMApplication/custom_conditions/SolidFace.cpp
@@ -51,14 +51,15 @@ SolidFace3D::~SolidFace3D() {}
 //***********************************************************************************
 //***********************************************************************************
 
-void SolidFace3D::Initialize() {
+void SolidFace3D::Initialize(const ProcessInfo& rCurrentProcessInfo) {
+    if (! rCurrentProcessInfo[IS_RESTARTED]){
+        const unsigned int number_of_nodes = GetGeometry().size();
 
-    const unsigned int number_of_nodes = GetGeometry().size();
-
-    for (unsigned int i=0; i< number_of_nodes; i++)
-    {
-        this->GetGeometry()[i].FastGetSolutionStepValue(NON_DIMENSIONAL_VOLUME_WEAR) = 0.0;
-        this->GetGeometry()[i].FastGetSolutionStepValue(IMPACT_WEAR) = 0.0;
+        for (unsigned int i=0; i< number_of_nodes; i++)
+        {
+            this->GetGeometry()[i].FastGetSolutionStepValue(NON_DIMENSIONAL_VOLUME_WEAR) = 0.0;
+            this->GetGeometry()[i].FastGetSolutionStepValue(IMPACT_WEAR) = 0.0;
+        }
     }
 }
 

--- a/applications/DEMApplication/custom_conditions/SolidFace.h
+++ b/applications/DEMApplication/custom_conditions/SolidFace.h
@@ -48,7 +48,7 @@ public:
 
     Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties ) const override;
 
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
     void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& r_process_info ) override;
     void CalculateNormal(array_1d<double, 3>& rnormal) override;
     void FinalizeSolutionStep(ProcessInfo& r_process_info) override;

--- a/applications/DEMApplication/custom_conditions/dem_wall.cpp
+++ b/applications/DEMApplication/custom_conditions/dem_wall.cpp
@@ -57,7 +57,7 @@ DEMWall::~DEMWall()
 //***********************************************************************************
 //***********************************************************************************
 
-void DEMWall::Initialize()
+void DEMWall::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_THROW_ERROR(std::runtime_error, "This function (DEMWall::Initialize) shouldn't be accessed, use derived class instead", 0);
 }

--- a/applications/DEMApplication/custom_conditions/dem_wall.h
+++ b/applications/DEMApplication/custom_conditions/dem_wall.h
@@ -59,7 +59,7 @@ public:
         PropertiesType::Pointer pProperties ) const override;
 
 
-    virtual void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
     virtual void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& r_process_info ) override;
     virtual void CalculateElasticForces(VectorType& rRightHandSideVector, ProcessInfo& r_process_info );
     virtual void InitializeSolutionStep(ProcessInfo& r_process_info) override;
@@ -117,11 +117,10 @@ protected:
 private:
     ///@name Static Member Variables
     std::vector<SphericParticle*> mVectorOfGluedParticles;
-    /// privat variables
+    /// private variables
 
 
-    // privat name Operations
-
+    // private name Operations
 
 
     ///@}
@@ -133,11 +132,13 @@ private:
     virtual void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Condition );
+        //rSerializer.save("mRightHandSideVector", mRightHandSideVector);
     }
 
     virtual void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Condition );
+        //rSerializer.load("mRightHandSideVector", mRightHandSideVector);
     }
 
 

--- a/applications/DEMApplication/custom_conditions/mapping_condition.cpp
+++ b/applications/DEMApplication/custom_conditions/mapping_condition.cpp
@@ -57,7 +57,7 @@ MAPcond::~MAPcond()
 //***********************************************************************************
 //***********************************************************************************
 
-void MAPcond::Initialize()
+void MAPcond::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
 
 }
@@ -70,7 +70,7 @@ void MAPcond::CalculateRightHandSide(
     ProcessInfo& r_process_info)
 {
 
- }
+}
 
 
  void MAPcond::AddExplicitContribution(const VectorType& rRHS,

--- a/applications/DEMApplication/custom_conditions/mapping_condition.h
+++ b/applications/DEMApplication/custom_conditions/mapping_condition.h
@@ -58,7 +58,7 @@ public:
 
     virtual Condition::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties ) const override;
 
-    virtual void Initialize() override;
+    virtual void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
     virtual void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& r_process_info ) override;
     virtual void AddExplicitContribution(const VectorType& rRHS, const Variable<VectorType>& rRHSVariable, Variable<array_1d<double,3> >& rDestinationVariable, const ProcessInfo& r_process_info) override;
 

--- a/applications/DEMApplication/custom_elements/rigid_body_element.cpp
+++ b/applications/DEMApplication/custom_elements/rigid_body_element.cpp
@@ -79,81 +79,89 @@ namespace Kratos {
     }
 
     void RigidBodyElement3D::SetIntegrationScheme(DEMIntegrationScheme::Pointer& translational_integration_scheme, DEMIntegrationScheme::Pointer& rotational_integration_scheme){
+        KRATOS_WATCH("holaaa")
         mpTranslationalIntegrationScheme = translational_integration_scheme->CloneRaw();
         mpRotationalIntegrationScheme = rotational_integration_scheme->CloneRaw();
+
+        KRATOS_WATCH(GetTranslationalIntegrationScheme())
+        KRATOS_WATCH(mpRotationalIntegrationScheme)
     }
 
     void RigidBodyElement3D::CustomInitialize(ModelPart& rigid_body_element_sub_model_part) {
+        if (! rigid_body_element_sub_model_part[IS_RESTARTED]){
 
-        Node<3>& central_node = GetGeometry()[0]; //CENTRAL NODE OF THE RBE
+            Node<3>& central_node = GetGeometry()[0]; //CENTRAL NODE OF THE RBE
 
-        central_node.FastGetSolutionStepValue(ORIENTATION) = Quaternion<double>::Identity();
-        Quaternion<double>& Orientation = central_node.FastGetSolutionStepValue(ORIENTATION);
-        Orientation.normalize();
+            central_node.FastGetSolutionStepValue(ORIENTATION) = Quaternion<double>::Identity();
+            Quaternion<double>& Orientation = central_node.FastGetSolutionStepValue(ORIENTATION);
+            Orientation.normalize();
 
-        central_node.FastGetSolutionStepValue(NODAL_MASS) = 1.0;
+            central_node.FastGetSolutionStepValue(NODAL_MASS) = 1.0;
 
-        if (rigid_body_element_sub_model_part.Has(RIGID_BODY_MASS)) {
-            central_node.FastGetSolutionStepValue(NODAL_MASS) = rigid_body_element_sub_model_part[RIGID_BODY_MASS];
+            if (rigid_body_element_sub_model_part.Has(RIGID_BODY_MASS)) {
+                central_node.FastGetSolutionStepValue(NODAL_MASS) = rigid_body_element_sub_model_part[RIGID_BODY_MASS];
+            }
+
+            mInertias = ZeroVector(3);
+
+            if (rigid_body_element_sub_model_part.Has(RIGID_BODY_INERTIAS)) {
+                mInertias[0] = rigid_body_element_sub_model_part[RIGID_BODY_INERTIAS][0];
+                mInertias[1] = rigid_body_element_sub_model_part[RIGID_BODY_INERTIAS][1];
+                mInertias[2] = rigid_body_element_sub_model_part[RIGID_BODY_INERTIAS][2];
+            }
+
+            else {
+                mInertias[0] = 1.0;
+                mInertias[1] = 1.0;
+                mInertias[2] = 1.0;
+            }
+
+            const array_1d<double,3>& reference_inertias = mInertias;
+            central_node.FastGetSolutionStepValue(PRINCIPAL_MOMENTS_OF_INERTIA)[0] = reference_inertias[0];
+            central_node.FastGetSolutionStepValue(PRINCIPAL_MOMENTS_OF_INERTIA)[1] = reference_inertias[1];
+            central_node.FastGetSolutionStepValue(PRINCIPAL_MOMENTS_OF_INERTIA)[2] = reference_inertias[2];
+
+            array_1d<double, 3> base_principal_moments_of_inertia = central_node.FastGetSolutionStepValue(PRINCIPAL_MOMENTS_OF_INERTIA);
+
+            central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_FORCE) = ZeroVector(3);
+
+            if (rigid_body_element_sub_model_part.Has(EXTERNAL_APPLIED_FORCE)) {
+                central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_FORCE)[0] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_FORCE][0];
+                central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_FORCE)[1] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_FORCE][1];
+                central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_FORCE)[2] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_FORCE][2];
+            }
+
+            central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_MOMENT) = ZeroVector(3);
+
+            if (rigid_body_element_sub_model_part.Has(EXTERNAL_APPLIED_MOMENT)) {
+                central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_MOMENT)[0] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_MOMENT][0];
+                central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_MOMENT)[1] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_MOMENT][1];
+                central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_MOMENT)[2] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_MOMENT][2];
+            }
+
+            if (rigid_body_element_sub_model_part.Has(TABLE_NUMBER)) {
+                KRATOS_INFO("DEM") << "============================================================================" << std::endl;
+                KRATOS_INFO("DEM") << "** Warning ** in 1 January 2019 TABLE_NUMBER variable will disappear, the new" << std::endl;
+                KRATOS_INFO("DEM") << " variables are TABLE_NUMBER_VELOCITY, TABLE_NUMBER_ANGULAR_VELOCITY," << std::endl;
+                KRATOS_INFO("DEM") << " TABLE_NUMBER_FORCE and TABLE_NUMBER_MOMENT for defining each variable" << std::endl;
+                KRATOS_INFO("DEM") << "============================================================================" << std::endl;
+            }
+
+            array_1d<double, 3> angular_velocity = central_node.FastGetSolutionStepValue(ANGULAR_VELOCITY);
+            array_1d<double, 3> angular_momentum;
+            double LocalTensor[3][3];
+            double GlobalTensor[3][3];
+            GeometryFunctions::ConstructLocalTensor(base_principal_moments_of_inertia, LocalTensor);
+            GeometryFunctions::QuaternionTensorLocal2Global(Orientation, LocalTensor, GlobalTensor);
+            GeometryFunctions::ProductMatrix3X3Vector3X1(GlobalTensor, angular_velocity, angular_momentum);
+            noalias(this->GetGeometry()[0].FastGetSolutionStepValue(ANGULAR_MOMENTUM)) = angular_momentum;
+
+            array_1d<double, 3> local_angular_velocity;
+            GeometryFunctions::QuaternionVectorGlobal2Local(Orientation, angular_velocity, local_angular_velocity);
+            noalias(this->GetGeometry()[0].FastGetSolutionStepValue(LOCAL_ANGULAR_VELOCITY)) = local_angular_velocity;
         }
-
-        mInertias = ZeroVector(3);
-
-        if (rigid_body_element_sub_model_part.Has(RIGID_BODY_INERTIAS)) {
-            mInertias[0] = rigid_body_element_sub_model_part[RIGID_BODY_INERTIAS][0];
-            mInertias[1] = rigid_body_element_sub_model_part[RIGID_BODY_INERTIAS][1];
-            mInertias[2] = rigid_body_element_sub_model_part[RIGID_BODY_INERTIAS][2];
-        }
-
-        else {
-            mInertias[0] = 1.0;
-            mInertias[1] = 1.0;
-            mInertias[2] = 1.0;
-        }
-
-        const array_1d<double,3>& reference_inertias = mInertias;
-        central_node.FastGetSolutionStepValue(PRINCIPAL_MOMENTS_OF_INERTIA)[0] = reference_inertias[0];
-        central_node.FastGetSolutionStepValue(PRINCIPAL_MOMENTS_OF_INERTIA)[1] = reference_inertias[1];
-        central_node.FastGetSolutionStepValue(PRINCIPAL_MOMENTS_OF_INERTIA)[2] = reference_inertias[2];
-
-        array_1d<double, 3> base_principal_moments_of_inertia = central_node.FastGetSolutionStepValue(PRINCIPAL_MOMENTS_OF_INERTIA);
-
-        central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_FORCE) = ZeroVector(3);
-
-        if (rigid_body_element_sub_model_part.Has(EXTERNAL_APPLIED_FORCE)) {
-            central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_FORCE)[0] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_FORCE][0];
-            central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_FORCE)[1] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_FORCE][1];
-            central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_FORCE)[2] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_FORCE][2];
-        }
-
-        central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_MOMENT) = ZeroVector(3);
-
-        if (rigid_body_element_sub_model_part.Has(EXTERNAL_APPLIED_MOMENT)) {
-            central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_MOMENT)[0] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_MOMENT][0];
-            central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_MOMENT)[1] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_MOMENT][1];
-            central_node.FastGetSolutionStepValue(EXTERNAL_APPLIED_MOMENT)[2] = rigid_body_element_sub_model_part[EXTERNAL_APPLIED_MOMENT][2];
-        }
-
-        if (rigid_body_element_sub_model_part.Has(TABLE_NUMBER)) {
-            KRATOS_INFO("DEM") << "============================================================================" << std::endl;
-            KRATOS_INFO("DEM") << "** Warning ** in 1 January 2019 TABLE_NUMBER variable will disappear, the new" << std::endl;
-            KRATOS_INFO("DEM") << " variables are TABLE_NUMBER_VELOCITY, TABLE_NUMBER_ANGULAR_VELOCITY," << std::endl;
-            KRATOS_INFO("DEM") << " TABLE_NUMBER_FORCE and TABLE_NUMBER_MOMENT for defining each variable" << std::endl;
-            KRATOS_INFO("DEM") << "============================================================================" << std::endl;
-        }
-
-        array_1d<double, 3> angular_velocity = central_node.FastGetSolutionStepValue(ANGULAR_VELOCITY);
-        array_1d<double, 3> angular_momentum;
-        double LocalTensor[3][3];
-        double GlobalTensor[3][3];
-        GeometryFunctions::ConstructLocalTensor(base_principal_moments_of_inertia, LocalTensor);
-        GeometryFunctions::QuaternionTensorLocal2Global(Orientation, LocalTensor, GlobalTensor);
-        GeometryFunctions::ProductMatrix3X3Vector3X1(GlobalTensor, angular_velocity, angular_momentum);
-        noalias(this->GetGeometry()[0].FastGetSolutionStepValue(ANGULAR_MOMENTUM)) = angular_momentum;
-
-        array_1d<double, 3> local_angular_velocity;
-        GeometryFunctions::QuaternionVectorGlobal2Local(Orientation, angular_velocity, local_angular_velocity);
-        noalias(this->GetGeometry()[0].FastGetSolutionStepValue(LOCAL_ANGULAR_VELOCITY)) = local_angular_velocity;
+        KRATOS_WATCH("XXXX")
+        KRATOS_WATCH(GetTranslationalIntegrationScheme())
     }
 
     void RigidBodyElement3D::SetOrientation(const Quaternion<double> Orientation) {
@@ -273,10 +281,33 @@ namespace Kratos {
     double RigidBodyElement3D::GetMass() { return GetGeometry()[0].FastGetSolutionStepValue(NODAL_MASS); }
 
     void RigidBodyElement3D::Move(const double delta_t, const bool rotation_option, const double force_reduction_factor, const int StepFlag ) {
-
+        KRATOS_WATCH(GetTranslationalIntegrationScheme())
+        KRATOS_WATCH(delta_t)
         GetTranslationalIntegrationScheme().MoveRigidBodyElement(this, GetGeometry()[0], delta_t, force_reduction_factor, StepFlag);
+
+        KRATOS_WATCH(rotation_option)
+
         if (rotation_option) {
             GetRotationalIntegrationScheme().RotateRigidBodyElement(this, GetGeometry()[0], delta_t, force_reduction_factor, StepFlag);
         }
+        KRATOS_WATCH(force_reduction_factor)
+        KRATOS_WATCH(StepFlag)
     }
+
+    void RigidBodyElement3D::save(Serializer& rSerializer) const
+    {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
+        rSerializer.save("mListOfCoordinates", mListOfCoordinates);
+        rSerializer.save("mListOfNodes", mListOfNodes);
+        // rSerializer.save("mInertias", mInertias);
+    }
+
+    void RigidBodyElement3D::load(Serializer& rSerializer)
+    {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
+        rSerializer.load("mListOfCoordinates", mListOfCoordinates);
+        rSerializer.load("mListOfNodes", mListOfNodes);
+        // rSerializer.load("mInertias", mInertias);
+    }
+
 } // namespace Kratos

--- a/applications/DEMApplication/custom_elements/rigid_body_element.cpp
+++ b/applications/DEMApplication/custom_elements/rigid_body_element.cpp
@@ -79,12 +79,8 @@ namespace Kratos {
     }
 
     void RigidBodyElement3D::SetIntegrationScheme(DEMIntegrationScheme::Pointer& translational_integration_scheme, DEMIntegrationScheme::Pointer& rotational_integration_scheme){
-        KRATOS_WATCH("holaaa")
         mpTranslationalIntegrationScheme = translational_integration_scheme->CloneRaw();
         mpRotationalIntegrationScheme = rotational_integration_scheme->CloneRaw();
-
-        KRATOS_WATCH(GetTranslationalIntegrationScheme())
-        KRATOS_WATCH(mpRotationalIntegrationScheme)
     }
 
     void RigidBodyElement3D::CustomInitialize(ModelPart& rigid_body_element_sub_model_part) {
@@ -160,8 +156,6 @@ namespace Kratos {
             GeometryFunctions::QuaternionVectorGlobal2Local(Orientation, angular_velocity, local_angular_velocity);
             noalias(this->GetGeometry()[0].FastGetSolutionStepValue(LOCAL_ANGULAR_VELOCITY)) = local_angular_velocity;
         }
-        KRATOS_WATCH("XXXX")
-        KRATOS_WATCH(GetTranslationalIntegrationScheme())
     }
 
     void RigidBodyElement3D::SetOrientation(const Quaternion<double> Orientation) {
@@ -281,17 +275,11 @@ namespace Kratos {
     double RigidBodyElement3D::GetMass() { return GetGeometry()[0].FastGetSolutionStepValue(NODAL_MASS); }
 
     void RigidBodyElement3D::Move(const double delta_t, const bool rotation_option, const double force_reduction_factor, const int StepFlag ) {
-        KRATOS_WATCH(GetTranslationalIntegrationScheme())
-        KRATOS_WATCH(delta_t)
         GetTranslationalIntegrationScheme().MoveRigidBodyElement(this, GetGeometry()[0], delta_t, force_reduction_factor, StepFlag);
-
-        KRATOS_WATCH(rotation_option)
 
         if (rotation_option) {
             GetRotationalIntegrationScheme().RotateRigidBodyElement(this, GetGeometry()[0], delta_t, force_reduction_factor, StepFlag);
         }
-        KRATOS_WATCH(force_reduction_factor)
-        KRATOS_WATCH(StepFlag)
     }
 
     void RigidBodyElement3D::save(Serializer& rSerializer) const

--- a/applications/DEMApplication/custom_elements/rigid_body_element.h
+++ b/applications/DEMApplication/custom_elements/rigid_body_element.h
@@ -57,7 +57,7 @@ namespace Kratos {
         virtual void SetInitialConditionsToNodes(const array_1d<double,3>& velocity);
 
         virtual void Move(const double delta_t, const bool rotation_option, const double force_reduction_factor, const int StepFlag);
-        virtual DEMIntegrationScheme& GetTranslationalIntegrationScheme() { KRATOS_WATCH(mpTranslationalIntegrationScheme);return *mpTranslationalIntegrationScheme; }
+        virtual DEMIntegrationScheme& GetTranslationalIntegrationScheme() { return *mpTranslationalIntegrationScheme; }
         virtual DEMIntegrationScheme& GetRotationalIntegrationScheme() { return *mpRotationalIntegrationScheme; }
 
         virtual double GetMass();

--- a/applications/DEMApplication/custom_elements/rigid_body_element.h
+++ b/applications/DEMApplication/custom_elements/rigid_body_element.h
@@ -57,7 +57,7 @@ namespace Kratos {
         virtual void SetInitialConditionsToNodes(const array_1d<double,3>& velocity);
 
         virtual void Move(const double delta_t, const bool rotation_option, const double force_reduction_factor, const int StepFlag);
-        virtual DEMIntegrationScheme& GetTranslationalIntegrationScheme() { return *mpTranslationalIntegrationScheme; }
+        virtual DEMIntegrationScheme& GetTranslationalIntegrationScheme() { KRATOS_WATCH(mpTranslationalIntegrationScheme);return *mpTranslationalIntegrationScheme; }
         virtual DEMIntegrationScheme& GetRotationalIntegrationScheme() { return *mpRotationalIntegrationScheme; }
 
         virtual double GetMass();
@@ -97,15 +97,9 @@ namespace Kratos {
 
         friend class Serializer;
 
-        virtual void save(Serializer& rSerializer) const override
-        {
-            KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
-        }
+        virtual void save(Serializer& rSerializer) const override;
 
-        virtual void load(Serializer& rSerializer) override
-        {
-            KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
-        }
+        virtual void load(Serializer& rSerializer) override;
 
     }; // Class RigidBodyElement3D
 

--- a/applications/DEMApplication/custom_strategies/strategies/explicit_solver_strategy.cpp
+++ b/applications/DEMApplication/custom_strategies/strategies/explicit_solver_strategy.cpp
@@ -817,7 +817,6 @@ namespace Kratos {
                 #pragma omp parallel for
                 for (int i=0; i<(int)pTConditions.size(); i++) {
                     ConditionsArrayType::iterator it = pTConditions.ptr_begin() + i;
-                    auto pointer = dynamic_cast<RigidBodyElement3D*>(&*it);
                     (it)->Initialize(r_process_info);
                 }
 

--- a/applications/DEMApplication/python_scripts/DEM_restart_utility.py
+++ b/applications/DEMApplication/python_scripts/DEM_restart_utility.py
@@ -32,27 +32,35 @@ class DEMRestartUtility(RestartUtility):
 
         settings.ValidateAndAssignDefaults(default_settings)
         self.file_names = []
+        self.restart_utilities = dict()
+        self.model_parts = []
         for name in settings["input_filenames"]:
             self.file_names.append(name.GetString())
             settings_copy = settings.Clone()
             settings_copy.AddValue("input_filename", name)
             settings_copy.RemoveValue("input_filenames")
-            settings_copy.RemoveValue("input_filenames")
-            super(DEMRestartUtility, self).__init__(model.GetModelPart(name.GetString()), settings_copy)
+            model_part = model.GetModelPart(name.GetString())
+            self.restart_utilities[name.GetString()] = RestartUtility(model_part, settings_copy)
+            self.model_parts.append(model_part)
         self.restart_save_location = restart_save_location
+        super(DEMRestartUtility, self).__init__(self.model_parts[0], settings_copy)
         # print('yyyy'*50,self.restart_save_location)
         # self.restart_load_location = restart_load_location
 
     def SaveRestart(self):
         for name in self.file_names:
-            self.raw_path, self.raw_file_name = os.path.split(name)
+            restart_utility = self.restart_utilities[name]
+            restart_utility.raw_path, restart_utility.raw_file_name = os.path.split(name)
             #self.raw_path = os.path.join(os.getcwd(), self.raw_path)
-            self.raw_path = self.restart_save_location
-            super(DEMRestartUtility, self).SaveRestart()
+            restart_utility.raw_path = os.path.join(os.getcwd(), self.raw_path)
+
+            if restart_utility.IsRestartOutputStep():
+                restart_utility.SaveRestart()
 
     def LoadRestart(self,  restart_file_name=""):
         for name in self.file_names:
-            self.raw_path, self.raw_file_name = os.path.split(name)
-            self.raw_path = os.path.join(os.getcwd(), self.raw_path)
-            super(DEMRestartUtility, self).LoadRestart()
-            kratos_utilities.DeleteDirectoryIfExisting(self._RestartUtility__GetFolderPathLoad())
+            restart_utility = self.restart_utilities[name]
+            restart_utility.raw_path, restart_utility.raw_file_name = os.path.split(name)
+            restart_utility.raw_path = os.path.join(os.getcwd(), self.raw_path)
+            restart_utility.LoadRestart()
+            #kratos_utilities.DeleteDirectoryIfExisting(self._RestartUtility__GetFolderPathLoad())

--- a/applications/DEMApplication/python_scripts/DEM_restart_utility.py
+++ b/applications/DEMApplication/python_scripts/DEM_restart_utility.py
@@ -44,7 +44,6 @@ class DEMRestartUtility(RestartUtility):
             self.model_parts[name.GetString()] = model_part
         self.restart_save_location = restart_save_location
         super(DEMRestartUtility, self).__init__(list(self.model_parts.values())[0], settings_copy)
-        # print('yyyy'*50,self.restart_save_location)
         # self.restart_load_location = restart_load_location
 
     def SaveRestart(self):
@@ -56,7 +55,6 @@ class DEMRestartUtility(RestartUtility):
                 #self.raw_path = os.path.join(os.getcwd(), self.raw_path)
                 restart_utility.raw_path = os.path.join(os.getcwd(), self.raw_path)
                 restart_utility.SaveRestart()
-        caca
 
     def LoadRestart(self,  restart_file_name=""):
         for name in self.file_names:
@@ -66,4 +64,4 @@ class DEMRestartUtility(RestartUtility):
 
             restart_utility.LoadRestart()
 
-            #kratos_utilities.DeleteDirectoryIfExisting(self._RestartUtility__GetFolderPathLoad())
+            kratos_utilities.DeleteDirectoryIfExisting(restart_utility._RestartUtility__GetFolderPathLoad())

--- a/applications/DEMApplication/python_scripts/DEM_restart_utility.py
+++ b/applications/DEMApplication/python_scripts/DEM_restart_utility.py
@@ -33,7 +33,7 @@ class DEMRestartUtility(RestartUtility):
         settings.ValidateAndAssignDefaults(default_settings)
         self.file_names = []
         self.restart_utilities = dict()
-        self.model_parts = []
+        self.model_parts = dict()
         for name in settings["input_filenames"]:
             self.file_names.append(name.GetString())
             settings_copy = settings.Clone()
@@ -41,26 +41,29 @@ class DEMRestartUtility(RestartUtility):
             settings_copy.RemoveValue("input_filenames")
             model_part = model.GetModelPart(name.GetString())
             self.restart_utilities[name.GetString()] = RestartUtility(model_part, settings_copy)
-            self.model_parts.append(model_part)
+            self.model_parts[name.GetString()] = model_part
         self.restart_save_location = restart_save_location
-        super(DEMRestartUtility, self).__init__(self.model_parts[0], settings_copy)
+        super(DEMRestartUtility, self).__init__(list(self.model_parts.values())[0], settings_copy)
         # print('yyyy'*50,self.restart_save_location)
         # self.restart_load_location = restart_load_location
 
     def SaveRestart(self):
         for name in self.file_names:
             restart_utility = self.restart_utilities[name]
-            restart_utility.raw_path, restart_utility.raw_file_name = os.path.split(name)
-            #self.raw_path = os.path.join(os.getcwd(), self.raw_path)
-            restart_utility.raw_path = os.path.join(os.getcwd(), self.raw_path)
 
             if restart_utility.IsRestartOutputStep():
+                restart_utility.raw_path, restart_utility.raw_file_name = os.path.split(name)
+                #self.raw_path = os.path.join(os.getcwd(), self.raw_path)
+                restart_utility.raw_path = os.path.join(os.getcwd(), self.raw_path)
                 restart_utility.SaveRestart()
+        caca
 
     def LoadRestart(self,  restart_file_name=""):
         for name in self.file_names:
             restart_utility = self.restart_utilities[name]
             restart_utility.raw_path, restart_utility.raw_file_name = os.path.split(name)
             restart_utility.raw_path = os.path.join(os.getcwd(), self.raw_path)
+
             restart_utility.LoadRestart()
+
             #kratos_utilities.DeleteDirectoryIfExisting(self._RestartUtility__GetFolderPathLoad())

--- a/applications/DEMApplication/python_scripts/sphere_strategy.py
+++ b/applications/DEMApplication/python_scripts/sphere_strategy.py
@@ -61,7 +61,7 @@ class ExplicitStrategy(object):
 
         self.clean_init_indentation_option = DEM_parameters["CleanIndentationsOption"].GetBool()
 
-        if self.clean_init_indentation_option and self.solver_settings["model_import_settings"]["input_type"].GetString() == 'rest':
+        if self.clean_init_indentation_option and self._GetInputType() == 'rest':
             Logger.PrintWarning("DEM", '\nWARNING!: \'clean_indentations_option\' is set to true in a restarted simulation. The particles\' radii could be modified before the first time step.\n' * 50)
 
         self.contact_mesh_option           = 0
@@ -75,7 +75,12 @@ class ExplicitStrategy(object):
         self.search_increment_for_walls = 0.0
         self.coordination_number = 10.0
         self.case_option = 3
-        self.search_control = 1
+
+        if self._GetInputType() == 'rest':
+            self.search_control = 2
+
+        else:
+            self.search_control = 1
 
         if "LocalResolutionMethod" in DEM_parameters.keys():
             if (DEM_parameters["LocalResolutionMethod"].GetString() == "hierarchical"):
@@ -208,6 +213,8 @@ class ExplicitStrategy(object):
     def SetVariablesAndOptions(self):
 
         # Setting ProcessInfo variables
+        for name in self.all_model_parts.model_parts.keys():
+            self.all_model_parts.Get(name).ProcessInfo.SetValue(IS_RESTARTED, self._GetInputType() == 'rest')
 
         # SIMULATION FLAGS
         self.spheres_model_part.ProcessInfo.SetValue(VIRTUAL_MASS_OPTION, self.virtual_mass_option)
@@ -317,6 +324,9 @@ class ExplicitStrategy(object):
                                                              self.delta_option, self.creator_destructor, self.dem_fem_search,
                                                              self.search_strategy, self.solver_settings)
 
+    def _GetInputType(self):
+        return self.solver_settings["model_import_settings"]["input_type"].GetString()
+
     def AddVariables(self):
         pass
 
@@ -351,6 +361,8 @@ class ExplicitStrategy(object):
         """
         time += self.dt
         self._UpdateTimeInModelParts(time)
+        print(time)
+
         return time
 
     def _MoveAllMeshes(self, time, dt):
@@ -678,7 +690,8 @@ class ExplicitStrategy(object):
 
         if not properties.Has(ROLLING_FRICTION_WITH_WALLS):
             properties[ROLLING_FRICTION_WITH_WALLS] = properties[ROLLING_FRICTION]
-
+        print('88'*500)
+        print(properties)
     def ImportModelPart(self): #TODO: for the moment, provided for compatibility
         pass
 

--- a/applications/DEMApplication/python_scripts/sphere_strategy.py
+++ b/applications/DEMApplication/python_scripts/sphere_strategy.py
@@ -361,7 +361,6 @@ class ExplicitStrategy(object):
         """
         time += self.dt
         self._UpdateTimeInModelParts(time)
-        print(time)
 
         return time
 
@@ -690,8 +689,7 @@ class ExplicitStrategy(object):
 
         if not properties.Has(ROLLING_FRICTION_WITH_WALLS):
             properties[ROLLING_FRICTION_WITH_WALLS] = properties[ROLLING_FRICTION]
-        print('88'*500)
-        print(properties)
+
     def ImportModelPart(self): #TODO: for the moment, provided for compatibility
         pass
 

--- a/applications/DEMApplication/tests/restart_files/ball_and_wallDEM.mdpa
+++ b/applications/DEMApplication/tests/restart_files/ball_and_wallDEM.mdpa
@@ -1,0 +1,54 @@
+Begin ModelPartData
+//  VARIABLE_NAME value
+End ModelPartData
+
+Begin Properties 1
+    PARTICLE_DENSITY 2500.0
+    YOUNG_MODULUS 100000.0
+    POISSON_RATIO 0.20
+    FRICTION 1.0
+    COEFFICIENT_OF_RESTITUTION 0.2
+    PARTICLE_MATERIAL 1
+    ROLLING_FRICTION 0.01
+    ROLLING_FRICTION_WITH_WALLS 0.01
+    PARTICLE_SPHERICITY 1.0
+    DEM_DISCONTINUUM_CONSTITUTIVE_LAW_NAME DEM_D_Hertz_viscous_Coulomb
+    PARTICLE_COHESION 0.0
+    DEM_CONTINUUM_CONSTITUTIVE_LAW_NAME DEMContinuumConstitutiveLaw
+End Properties
+
+Begin Nodes
+    1        0.00000        0.00000        0.02000
+End Nodes
+
+
+Begin Nodes
+End Nodes
+
+
+Begin Nodes
+End Nodes
+
+
+Begin Nodes
+End Nodes
+
+
+Begin Elements SphericParticle3D// GUI group identifier: DEM
+        1          1          1 
+End Elements
+
+Begin NodalData RADIUS // GUI group identifier: DEM
+          1 0 0.00432601
+End NodalData
+
+Begin SubModelPart Parts_DEM // Group DEM // Subtree Parts
+    Begin SubModelPartNodes
+            1
+    End SubModelPartNodes
+    Begin SubModelPartElements
+            1
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart

--- a/applications/DEMApplication/tests/restart_files/ball_and_wallDEM.mdpa
+++ b/applications/DEMApplication/tests/restart_files/ball_and_wallDEM.mdpa
@@ -30,10 +30,6 @@ Begin Nodes
 End Nodes
 
 
-Begin Nodes
-End Nodes
-
-
 Begin Elements SphericParticle3D// GUI group identifier: DEM
         1          1          1 
 End Elements
@@ -41,14 +37,3 @@ End Elements
 Begin NodalData RADIUS // GUI group identifier: DEM
           1 0 0.00432601
 End NodalData
-
-Begin SubModelPart Parts_DEM // Group DEM // Subtree Parts
-    Begin SubModelPartNodes
-            1
-    End SubModelPartNodes
-    Begin SubModelPartElements
-            1
-    End SubModelPartElements
-    Begin SubModelPartConditions
-    End SubModelPartConditions
-End SubModelPart

--- a/applications/DEMApplication/tests/restart_files/ball_and_wallDEM_FEM_boundary.mdpa
+++ b/applications/DEMApplication/tests/restart_files/ball_and_wallDEM_FEM_boundary.mdpa
@@ -1,0 +1,57 @@
+Begin ModelPartData
+//  VARIABLE_NAME value
+End ModelPartData
+
+Begin Properties 2
+  FRICTION 30.0
+  WALL_COHESION 0.0
+  COMPUTE_WEAR 0
+  SEVERITY_OF_WEAR 0.001
+  IMPACT_WEAR_SEVERITY 0.001
+  BRINELL_HARDNESS 200.0
+  YOUNG_MODULUS 1e+20
+  POISSON_RATIO 0.25
+End Properties
+
+Begin Nodes
+    6        0.01000        0.01000        0.00000
+    7       -0.01000        0.01000        0.00000
+    8        0.01000       -0.01000        0.00000
+    9       -0.01000       -0.01000        0.00000
+End Nodes
+
+
+Begin Nodes
+End Nodes
+
+
+Begin Nodes
+End Nodes
+
+
+Begin Conditions RigidFace3D3N // GUI DEM-FEM-Wall group identifier: wall
+    2          2          9          8          6 
+    3          2          9          6          7 
+End Conditions
+
+Begin SubModelPart 1 // GUI DEM-FEM-Wall - DEM-FEM-Wall - group identifier: wall
+  Begin SubModelPartData // DEM-FEM-Wall. Group name: wall
+    IS_GHOST false
+    IDENTIFIER wall
+    TOP 0
+    BOTTOM 0
+    FORCE_INTEGRATION_GROUP 0
+  End SubModelPartData
+  Begin SubModelPartNodes
+         6
+         7
+         8
+         9
+  End SubModelPartNodes
+Begin SubModelPartConditions
+         2
+         3
+End SubModelPartConditions
+
+End SubModelPart
+

--- a/applications/DEMApplication/tests/restart_files/ball_and_wallDEM_Inlet.mdpa
+++ b/applications/DEMApplication/tests/restart_files/ball_and_wallDEM_Inlet.mdpa
@@ -1,0 +1,8 @@
+Begin ModelPartData
+//  VARIABLE_NAME value
+End ModelPartData
+
+Begin Nodes
+End Nodes
+
+

--- a/applications/DEMApplication/tests/restart_files/ball_and_wallProjectParametersDEM.json
+++ b/applications/DEMApplication/tests/restart_files/ball_and_wallProjectParametersDEM.json
@@ -60,7 +60,7 @@
     "PostParticleMoment"             : false,
     "PostEulerAngles"                : false,
     "PostRollingResistanceMoment"    : false,
-    "do_print_results_option"        : true,
+    "do_print_results_option"        : false,
     "problem_name"                   : "ball_and_wall",
 
     "output_processes" : {

--- a/applications/DEMApplication/tests/restart_files/ball_and_wallProjectParametersDEM.json
+++ b/applications/DEMApplication/tests/restart_files/ball_and_wallProjectParametersDEM.json
@@ -1,0 +1,82 @@
+{
+    "Dimension"                      : 3,
+    "PeriodicDomainOption"           : false,
+    "BoundingBoxOption"              : false,
+    "AutomaticBoundingBoxOption"     : false,
+    "BoundingBoxEnlargementFactor"   : 1.1,
+    "BoundingBoxStartTime"           : 0.0,
+    "BoundingBoxStopTime"            : 1000.0,
+    "BoundingBoxMaxX"                : 10,
+    "BoundingBoxMaxY"                : 10,
+    "BoundingBoxMaxZ"                : 10,
+    "BoundingBoxMinX"                : -10,
+    "BoundingBoxMinY"                : -10,
+    "BoundingBoxMinZ"                : -10,
+    "dem_inlet_option"               : false,
+    "GravityX"                       : 0.0,
+    "GravityY"                       : 0.0,
+    "GravityZ"                       : -9.81,
+    "RotationOption"                 : true,
+    "CleanIndentationsOption"        : false,
+    "solver_settings"                : {
+        "RemoveBallsInitiallyTouchingWalls" : false,
+        "strategy"                          : "sphere_strategy",
+        "model_import_settings"           : {
+            "input_type"     : "mdpa",
+            "serializer_trace"             : "no_trace",
+            "input_filenames" : ["SpheresPart","RigidFacePart"],
+            "restart_load_file_label" : "0.03001"
+        }
+    },
+    "VirtualMassCoefficient"         : 1.0,
+    "RollingFrictionOption"          : false,
+    "GlobalDamping"                  : 0.0,
+    "ContactMeshOption"              : false,
+    "OutputFileType"                 : "Binary",
+    "Multifile"                      : "multiple_files",
+    "ElementType"                    : "SphericPartDEMElement3D",
+    "TranslationalIntegrationScheme" : "Symplectic_Euler",
+    "RotationalIntegrationScheme"    : "Direct_Integration",
+    "MaxTimeStep"                    : 1e-5,
+    "FinalTime"                      : 0.03005,
+    "GraphExportFreq"                : 0.001,
+    "VelTrapGraphExportFreq"         : 0.001,
+    "OutputTimeStep"                 : 0.01,
+    "PostBoundingBox"                : false,
+    "PostLocalContactForce"          : false,
+    "PostDisplacement"               : true,
+    "PostRadius"                     : true,
+    "PostVelocity"                   : true,
+    "PostAngularVelocity"            : false,
+    "PostElasticForces"              : true,
+    "PostContactForces"              : true,
+    "PostRigidElementForces"         : false,
+    "PostStressStrainOption"         : false,
+    "PostTangentialElasticForces"    : false,
+    "PostTotalForces"                : true,
+    "PostPressure"                   : false,
+    "PostShearStress"                : false,
+    "PostNonDimensionalVolumeWear"   : false,
+    "PostParticleMoment"             : false,
+    "PostEulerAngles"                : false,
+    "PostRollingResistanceMoment"    : false,
+    "do_print_results_option"        : true,
+    "problem_name"                   : "ball_and_wall",
+
+    "output_processes" : {
+        "restart_processes" : [
+            {
+            "python_module"   : "DEMApplication.DEM_save_restart_process",
+            "kratos_module"   : "KratosMultiphysics",
+            "process_name"    : "DEMSaveRestartProcess",
+            "Parameters"            : {
+                "model_part_names" : ["SpheresPart","RigidFacePart"],
+                "echo_level"                   : 0,
+                "serializer_trace"             : "no_trace",
+                "restart_save_frequency"       : 0.01,
+                "restart_control_type"         : "time",
+                "save_restart_files_in_folder" : true
+            }
+        }]
+    }
+}

--- a/applications/DEMApplication/tests/test_restart.py
+++ b/applications/DEMApplication/tests/test_restart.py
@@ -47,15 +47,15 @@ class DEMRestartTestFactory():
                 for d1, d2 in zip(displacement_save, displacement_load):
                     self.assertAlmostEqual(d1, d2)
 
-# class TestRestartOneBall(DEMRestartTestFactory, KratosUnittest.TestCase):
-#     case_name = "one_ball"
-#     def setUp(self):
-#         super().setUp(TestRestartOneBall.case_name)
+class TestRestartOneBall(DEMRestartTestFactory, KratosUnittest.TestCase):
+    case_name = "one_ball"
+    def setUp(self):
+        super().setUp(TestRestartOneBall.case_name)
 
-# class TestRestartTwoBalls(DEMRestartTestFactory, KratosUnittest.TestCase):
-#     case_name = "two_balls"
-#     def setUp(self):
-#         super().setUp(TestRestartTwoBalls.case_name)
+class TestRestartTwoBalls(DEMRestartTestFactory, KratosUnittest.TestCase):
+    case_name = "two_balls"
+    def setUp(self):
+        super().setUp(TestRestartTwoBalls.case_name)
 
 class TestRestartBallAndWall(DEMRestartTestFactory, KratosUnittest.TestCase):
     case_name = "ball_and_wall"

--- a/applications/DEMApplication/tests/test_restart.py
+++ b/applications/DEMApplication/tests/test_restart.py
@@ -70,7 +70,8 @@ if __name__ == '__main__':
     smallSuite = suites['small'] # These tests are executed by the continuous integration tool
     test_list = [
         TestRestartOneBall,
-        TestRestartTwoBalls
+        TestRestartTwoBalls,
+        TestRestartBallAndWall
     ]
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases(test_list))
     allSuite = suites['all']

--- a/applications/DEMApplication/tests/test_restart.py
+++ b/applications/DEMApplication/tests/test_restart.py
@@ -47,15 +47,20 @@ class DEMRestartTestFactory():
                 for d1, d2 in zip(displacement_save, displacement_load):
                     self.assertAlmostEqual(d1, d2)
 
-class TestRestartOneBall(DEMRestartTestFactory, KratosUnittest.TestCase):
-    case_name = "one_ball"
-    def setUp(self):
-        super().setUp(TestRestartOneBall.case_name)
+# class TestRestartOneBall(DEMRestartTestFactory, KratosUnittest.TestCase):
+#     case_name = "one_ball"
+#     def setUp(self):
+#         super().setUp(TestRestartOneBall.case_name)
 
-class TestRestartTwoBalls(DEMRestartTestFactory, KratosUnittest.TestCase):
-    case_name = "two_balls"
+# class TestRestartTwoBalls(DEMRestartTestFactory, KratosUnittest.TestCase):
+#     case_name = "two_balls"
+#     def setUp(self):
+#         super().setUp(TestRestartTwoBalls.case_name)
+
+class TestRestartBallAndWall(DEMRestartTestFactory, KratosUnittest.TestCase):
+    case_name = "ball_and_wall"
     def setUp(self):
-        super().setUp(TestRestartTwoBalls.case_name)
+        super().setUp(TestRestartBallAndWall.case_name)
 
 if __name__ == '__main__':
     Kratos.Logger.GetDefaultOutput().SetSeverity(Kratos.Logger.Severity.WARNING)


### PR DESCRIPTION
I have added a third test to the collection (1 and 2-ball tests) that consists in a ball that falls on a rigid surface and rebounds of it. The test is significant in that it introduces a second model part, which requires the use of the generalised adaptations that DEMApplication requires for its restart utility.

There where two bugs that were causing the example to fail: first, the Initialise functions from the RigidBodyModelPart were not being called, as this is a special model part that is build after reading the other model parts, by creating the elements and adding them one by one. This was addressed by distinguishing between the two cases in the DEM strategy.

The second bug had to do with the initialization of two variables (DEM_PRESSURE and SHEAR_FORCE) that were using a (sometimes) null area in the denominator of their definition. The bug has not been addressed at its core, but now at least it is checked that the area should always be positive. **This issue thus requires taking care of** in the future.

My next goal is to create a factory that transforms any given test into a restart test, so that we can generate multitude of restart tests automatically without the need for new examples.