### PR TITLE
[PotentialFlow] Correct defintion of Kratos API in ComputeNodalVelocity process for windows compilation

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_nodal_potential_flow_velocity_process.h
@@ -45,7 +45,7 @@ namespace Kratos
 ///@{
 
 
-class KRATOS_API(CompressiblePotentialFlowApplication) ComputeNodalPotentialFlowVelocityProcess
+class KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) ComputeNodalPotentialFlowVelocityProcess
     : public Process
 {
 public:


### PR DESCRIPTION
Fixing windows compilation to close #5681, thank you @roigcarlo!