### PR TITLE
Change iterator to signed int in omp parallel for

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_processes/compute_embedded_lift_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/compute_embedded_lift_process.cpp
@@ -42,7 +42,7 @@ void ComputeEmbeddedLiftProcess<Dim, NumNodes>::Execute()
     double fz = 0.0;
 
     #pragma omp parallel for reduction(+:fx,fy,fz)
-    for(std::size_t i = 0; i < mrModelPart.Elements().size(); ++i) {
+    for(int i = 0; i < mrModelPart.Elements().size(); ++i) {
         auto it_elem=mrModelPart.ElementsBegin()+i;
         auto r_geometry = it_elem->GetGeometry();
 

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/move_model_part_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/move_model_part_process.cpp
@@ -53,7 +53,7 @@ void MoveModelPartProcess::Execute()
     KRATOS_TRY;
 
     #pragma omp parallel for
-    for(std::size_t i = 0; i < mrModelPart.Nodes().size(); ++i) {
+    for(int i = 0; i < mrModelPart.Nodes().size(); ++i) {
         auto it_node=mrModelPart.NodesBegin()+i;
         auto &r_coordinates = it_node->Coordinates();
 


### PR DESCRIPTION
I've changed from std::size_t to int in order to compile in Windows

Check this https://stackoverflow.com/questions/14033280/openmp-index-variable-in-openmp-for-statement-must-have-signed-integral-type