### PR TITLE
[Travis] disable mpi for testing DO NOT MERGE!!!

### DIFF
--- a/scripts/build/travis/configure_travis_bionic.sh
+++ b/scripts/build/travis/configure_travis_bionic.sh
@@ -134,7 +134,7 @@ CMAKE_APPLICATION=(
 
 CMAKE_BUILD=(
   # compiling the MPI-Core (required for e.g. TrilinosApp)
-  -DMPI_NEEDED=ON
+  -DMPI_NEEDED=OFF
 
    # CMake C compiler
   -DCMAKE_C_COMPILER=${C_COMPILER}
@@ -170,7 +170,7 @@ CMAKE_EXTRA=(
   -DINSTALL_EMBEDDED_PYTHON=ON
 
   # Metis
-  -DMETIS_APPLICATION=ON
+  -DMETIS_APPLICATION=OFF
 
   # Trillinos
   -DTRILINOS_APPLICATION=OFF


### PR DESCRIPTION
This is only for testing, to see if compiling the MPI-core triggers another (non-cotired) compilation of the core 
See #5769 