### PR TITLE
[PotentialFlow] Avoid error if no far field modelpart is defined

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
@@ -23,8 +23,8 @@ class ComputeLiftProcess(KratosMultiphysics.Process):
 
         default_parameters = KratosMultiphysics.Parameters(r'''{
             "model_part_name": "please specify the model part that contains the surface nodes",
-            "far_field_model_part_name": "please specify the model part that contains the surface nodes",
             "moment_reference_point" : [0.0,0.0,0.0],
+            "far_field_model_part_name": "",
             "trailing_edge_model_part_name": "",
             "is_infinite_wing": false
         }''')
@@ -33,6 +33,7 @@ class ComputeLiftProcess(KratosMultiphysics.Process):
 
         self.body_model_part = Model[settings["model_part_name"].GetString()]
         far_field_model_part_name = settings["far_field_model_part_name"].GetString()
+        self.compute_far_field_forces = False
         if far_field_model_part_name != "":
             self.far_field_model_part = Model[far_field_model_part_name]
             self.compute_far_field_forces = True

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
@@ -33,15 +33,13 @@ class ComputeLiftProcess(KratosMultiphysics.Process):
 
         self.body_model_part = Model[settings["model_part_name"].GetString()]
         far_field_model_part_name = settings["far_field_model_part_name"].GetString()
-        self.compute_far_field_forces = False
-        if far_field_model_part_name != "":
+        self.compute_far_field_forces = far_field_model_part_name != ""
+        if self.compute_far_field_forces :
             self.far_field_model_part = Model[far_field_model_part_name]
-            self.compute_far_field_forces = True
-        self.compute_lift_from_jump_3d = False
         trailing_edge_model_part_name = settings["trailing_edge_model_part_name"].GetString()
-        if(trailing_edge_model_part_name != ""):
+        self.compute_lift_from_jump_3d = trailing_edge_model_part_name != ""
+        if self.compute_lift_from_jump_3d:
             self.trailing_edge_model_part = Model[trailing_edge_model_part_name]
-            self.compute_lift_from_jump_3d = True
         self.fluid_model_part = self.body_model_part.GetRootModelPart()
         self.reference_area =  self.fluid_model_part.ProcessInfo.GetValue(CPFApp.REFERENCE_CHORD)
         self.moment_reference_point = settings["moment_reference_point"].GetVector()


### PR DESCRIPTION
Right now, if no model_part name is defined for the far field, the process fails because it tries to retrieve the default one `"please specify the model part that contains the surface nodes"`.

Now the default one is an empty string so it wouldn't fail if the far field model part is not specified in the parameters. 

Do you agree on leaving both the far-field and potential jump methods to compute the lift as optional and to keep the pressure distribution as the default one @inigolcanalejo ?
