### PR TITLE
Fix for unittest in python 2.7

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/test_cr_beam_adjoint_element_3d2n.py
+++ b/applications/StructuralMechanicsApplication/tests/test_cr_beam_adjoint_element_3d2n.py
@@ -142,13 +142,6 @@ class TestCrBeamAdjointElement(KratosUnittest.TestCase):
         l = math.sqrt(dx*dx + dy*dy + dz*dz)
         return l
 
-    def _assert_matrix_almost_equal(self, matrix1, matrix2, prec=4):
-        self.assertEqual(matrix1.Size1(), matrix2.Size1())
-        self.assertEqual(matrix1.Size2(), matrix2.Size2())
-        for i in range(matrix1.Size1()):
-            for j in range(matrix1.Size2()):
-                self.assertAlmostEqual(matrix1[i,j], matrix2[i,j], prec)
-
     def test_CalculateSensitivityMatrix_Shape(self):
         # unperturbed residual
         LHSUnperturbed = KratosMultiphysics.Matrix(12,12)
@@ -183,7 +176,7 @@ class TestCrBeamAdjointElement(KratosUnittest.TestCase):
         PseudoLoadMatrix = KratosMultiphysics.Matrix(6,12)
         self.model_part.ProcessInfo[StructuralMechanicsApplication.PERTURBATION_SIZE] = h
         self.adjoint_beam_element.CalculateSensitivityMatrix(KratosMultiphysics.SHAPE_SENSITIVITY,PseudoLoadMatrix,self.model_part.ProcessInfo)
-        self._assert_matrix_almost_equal(FDPseudoLoadMatrix, PseudoLoadMatrix, 4)
+        self.assertMatrixAlmostEqual(FDPseudoLoadMatrix, PseudoLoadMatrix, 4)
 
     def test_CalculateSensitivityMatrix_Property(self):
         # unperturbed residual
@@ -217,7 +210,7 @@ class TestCrBeamAdjointElement(KratosUnittest.TestCase):
         PseudoLoadMatrix = KratosMultiphysics.Matrix(1,12)
         self.model_part.ProcessInfo[StructuralMechanicsApplication.PERTURBATION_SIZE] = h
         self.adjoint_beam_element.CalculateSensitivityMatrix(StructuralMechanicsApplication.I22, PseudoLoadMatrix, self.model_part.ProcessInfo)
-        self._assert_matrix_almost_equal(FDPseudoLoadMatrix, PseudoLoadMatrix, 4)
+        self.assertMatrixAlmostEqual(FDPseudoLoadMatrix, PseudoLoadMatrix, 4)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/StructuralMechanicsApplication/tests/test_linear_thin_shell_adjoint_element_3d3n.py
+++ b/applications/StructuralMechanicsApplication/tests/test_linear_thin_shell_adjoint_element_3d3n.py
@@ -177,13 +177,6 @@ class TestShellThinAdjointElement3D3N(KratosUnittest.TestCase):
         l = l/3
         return l
 
-    def _assert_matrix_almost_equal(self, matrix1, matrix2, prec=4):
-        self.assertEqual(matrix1.Size1(), matrix2.Size1())
-        self.assertEqual(matrix1.Size2(), matrix2.Size2())
-        for i in range(matrix1.Size1()):
-            for j in range(matrix1.Size2()):
-                self.assertAlmostEqual(matrix1[i,j], matrix2[i,j], prec)
-
     def test_CalculateSensitivityMatrix_Shape(self):
         # unperturbed residual
         dummy_LHS = KratosMultiphysics.Matrix(18,18)
@@ -213,7 +206,7 @@ class TestShellThinAdjointElement3D3N(KratosUnittest.TestCase):
         self.model_part.ProcessInfo[StructuralMechanicsApplication.ADAPT_PERTURBATION_SIZE] = True
         self.model_part.ProcessInfo[StructuralMechanicsApplication.PERTURBATION_SIZE] = h
         self.adjoint_shell_element.CalculateSensitivityMatrix(KratosMultiphysics.SHAPE_SENSITIVITY,PseudoLoadMatrix,self.model_part.ProcessInfo)
-        self._assert_matrix_almost_equal(FDPseudoLoadMatrix, PseudoLoadMatrix, 4)
+        self.assertMatrixAlmostEqual(FDPseudoLoadMatrix, PseudoLoadMatrix, 4)
 
     def test_CalculateSensitivityMatrix_Property(self):
         # unperturbed residual
@@ -241,7 +234,7 @@ class TestShellThinAdjointElement3D3N(KratosUnittest.TestCase):
         self.model_part.ProcessInfo[StructuralMechanicsApplication.ADAPT_PERTURBATION_SIZE] = True
         self.model_part.ProcessInfo[StructuralMechanicsApplication.PERTURBATION_SIZE] = h
         self.adjoint_shell_element.CalculateSensitivityMatrix(KratosMultiphysics.THICKNESS, PseudoLoadMatrix, self.model_part.ProcessInfo)
-        self._assert_matrix_almost_equal(FDPseudoLoadMatrix, PseudoLoadMatrix, 4)
+        self.assertMatrixAlmostEqual(FDPseudoLoadMatrix, PseudoLoadMatrix, 4)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/StructuralMechanicsApplication/tests/test_loading_conditions_line.py
+++ b/applications/StructuralMechanicsApplication/tests/test_loading_conditions_line.py
@@ -40,7 +40,7 @@ class TestLoadingConditionsLine(KratosUnittest.TestCase):
         rhs = KratosMultiphysics.Vector(0)
 
         #first we apply a constant LINE_LOAD to theh condition
-        Line_Load_i = 10000.00/math.sqrt(2) #apply a 45° load
+        Line_Load_i = 10000.00/math.sqrt(2) #apply a 45 degrees load
 
         load_on_cond = KratosMultiphysics.Vector(3)
         load_on_cond[0] = 0.00

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_membrane.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_membrane.py
@@ -237,16 +237,6 @@ class BasePatchTestMembrane(KratosUnittest.TestCase):
         strategy.Check()
         strategy.Solve()
 
-    def _create_dynamic_explicit_strategy(mp,scheme_name):
-        if (scheme_name=='central_differences'):
-            scheme = StructuralMechanicsApplication.ExplicitCentralDifferencesScheme(0.00,0.00,0.00)
-        elif scheme_name=='multi_stage':
-            scheme = StructuralMechanicsApplication.ExplicitMultiStageKimScheme(0.33333333333333333)
-
-        strategy = StructuralMechanicsApplication.MechanicalExplicitStrategy(mp,scheme,0,0,1)
-        strategy.SetEchoLevel(0)
-        return strategy
-
     def _check_static_results(self,node,displacement_results):
         #check that the results are exact on the node
         displacement = node.GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT)
@@ -457,7 +447,7 @@ class DynamicPatchTestMembrane(BasePatchTestMembrane):
         step = 0
 
         self._set_and_fill_buffer(mp,3,dt)
-        strategy_expl = BasePatchTestMembrane._create_dynamic_explicit_strategy(mp,'central_differences')
+        strategy_expl = _create_dynamic_explicit_strategy(mp,'central_differences')
         while(time <= end_time):
             time = time + dt
             step = step + 1
@@ -465,7 +455,15 @@ class DynamicPatchTestMembrane(BasePatchTestMembrane):
             strategy_expl.Solve()
             self._check_dynamic_results(mp.Nodes[10],step-1,displacement_results)
 
+def _create_dynamic_explicit_strategy(mp,scheme_name):
+    if (scheme_name=='central_differences'):
+        scheme = StructuralMechanicsApplication.ExplicitCentralDifferencesScheme(0.00,0.00,0.00)
+    elif scheme_name=='multi_stage':
+        scheme = StructuralMechanicsApplication.ExplicitMultiStageKimScheme(0.33333333333333333)
 
+    strategy = StructuralMechanicsApplication.MechanicalExplicitStrategy(mp,scheme,0,0,1)
+    strategy.SetEchoLevel(0)
+    return strategy
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/StructuralMechanicsApplication/tests/test_truss_adjoint_element_3d2n.py
+++ b/applications/StructuralMechanicsApplication/tests/test_truss_adjoint_element_3d2n.py
@@ -117,13 +117,6 @@ def FD_calculate_sensitivity_matrix(primal_element, primal_model_part, perturbed
 
     return FDPseudoLoadMatrix
 
-def assert_matrix_almost_equal(matrix1, matrix2, prec=7):
-    KratosUnittest.TestCase().assertEqual(matrix1.Size1(), matrix2.Size1())
-    KratosUnittest.TestCase().assertEqual(matrix1.Size2(), matrix2.Size2())
-    for i in range(matrix1.Size1()):
-        for j in range(matrix1.Size2()):
-            KratosUnittest.TestCase().assertAlmostEqual(matrix1[i,j], matrix2[i,j], prec)
-
 class TestTrussLinearAdjointElement(KratosUnittest.TestCase):
 
     def setUp(self):
@@ -173,7 +166,7 @@ class TestTrussLinearAdjointElement(KratosUnittest.TestCase):
         self.model_part.ProcessInfo[StructuralMechanicsApplication.ADAPT_PERTURBATION_SIZE] = True
         self.model_part.ProcessInfo[StructuralMechanicsApplication.PERTURBATION_SIZE] = h
         self.adjoint_truss_element.CalculateSensitivityMatrix(StructuralMechanicsApplication.CROSS_AREA, PseudoLoadMatrix, self.model_part.ProcessInfo)
-        assert_matrix_almost_equal(FDPseudoLoadMatrix, PseudoLoadMatrix, 5)
+        self.assertMatrixAlmostEqual(FDPseudoLoadMatrix, PseudoLoadMatrix, 5)
 
 
     def test_CalculateSensitivityMatrix_Shape(self):
@@ -193,7 +186,7 @@ class TestTrussLinearAdjointElement(KratosUnittest.TestCase):
 
         self.model_part.ProcessInfo[StructuralMechanicsApplication.PERTURBATION_SIZE] = h
         self.adjoint_truss_element.CalculateSensitivityMatrix(KratosMultiphysics.SHAPE_SENSITIVITY, PseudoLoadMatrix,self.model_part.ProcessInfo)
-        assert_matrix_almost_equal(FDPseudoLoadMatrix, PseudoLoadMatrix, 5)
+        self.assertMatrixAlmostEqual(FDPseudoLoadMatrix, PseudoLoadMatrix, 5)
 
 
 class TestTrussAdjointElement(KratosUnittest.TestCase):
@@ -246,7 +239,7 @@ class TestTrussAdjointElement(KratosUnittest.TestCase):
 
         self.model_part.ProcessInfo[StructuralMechanicsApplication.PERTURBATION_SIZE] = h
         self.adjoint_truss_element.CalculateSensitivityMatrix(StructuralMechanicsApplication.CROSS_AREA, PseudoLoadMatrix, self.model_part.ProcessInfo)
-        assert_matrix_almost_equal(FDPseudoLoadMatrix, PseudoLoadMatrix, 5)
+        self.assertMatrixAlmostEqual(FDPseudoLoadMatrix, PseudoLoadMatrix, 5)
 
 
     def test_CalculateSensitivityMatrix_Shape(self):
@@ -267,7 +260,7 @@ class TestTrussAdjointElement(KratosUnittest.TestCase):
 
         self.model_part.ProcessInfo[StructuralMechanicsApplication.PERTURBATION_SIZE] = h
         self.adjoint_truss_element.CalculateSensitivityMatrix(KratosMultiphysics.SHAPE_SENSITIVITY, PseudoLoadMatrix,self.model_part.ProcessInfo)
-        assert_matrix_almost_equal(FDPseudoLoadMatrix, PseudoLoadMatrix, 5)
+        self.assertMatrixAlmostEqual(FDPseudoLoadMatrix, PseudoLoadMatrix, 5)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -66,8 +66,22 @@ class TestCase(TestCase):
         msg = self._formatMessage(msg, standardMsg)
         raise self.failureException(msg)
 
+    def failUnlessVectorEqualWithTolerance(vector1, vector2, prec=7):
+        self.assertEqual(matrix1.Size1(), matrix2.Size1())
+        for i in range(matrix1.Size1()):
+            self.assertAlmostEqual(vector1[i], vector2[i], prec)
+
+    def failUnlessMatrixEqualWithTolerance(matrix1, matrix2, prec=7):
+        self.assertEqual(matrix1.Size1(), matrix2.Size1())
+        self.assertEqual(matrix1.Size2(), matrix2.Size2())
+        for i in range(matrix1.Size1()):
+            for j in range(matrix1.Size2()):
+                self.assertAlmostEqual(matrix1[i,j], matrix2[i,j], prec)
+
 
     assertEqualTolerance = failUnlessEqualWithTolerance
+    assertVectorAlmostEqual = failUnlessVectorEqualWithTolerance
+    assertMatrixAlmostEqual = failUnlessMatrixEqualWithTolerance
 
 @contextmanager
 def SupressConsoleOutput():

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -35,19 +35,19 @@ class TestCase(TestCase):
         super(TestCase,self).run(result)
 
     def failUnlessEqualWithTolerance(self, first, second, tolerance, msg=None):
-        ''' fails if first and second have a difference greater than
+        ''' Fails if first and second have a difference greater than
         tolerance '''
 
         if first < (second - tolerance) or first > (second + tolerance):
             raise self.failureException(msg or '%r != %r within %r places' % (first, second, tolerance))
 
     def failUnlessAbsAndRelDifference(self, first, second, rel_tol=None, abs_tol=None, msg=None):
-        """Fail if the two objects are unequal as determined by their
-           absolute and relative difference
+        ''' Fails if the two objects are unequal as determined by their
+        absolute and relative difference
 
-           If the two objects compare equal then they will automatically
-           compare relative almost equal.
-        """
+        If the two objects compare equal then they will automatically
+        compare relative almost equal. ''' 
+
         if first == second:
             # shortcut
             return
@@ -210,10 +210,9 @@ KratosSuites = {
 
 
 def isclose(a, b, rel_tol=1e-09, abs_tol=0.0):
-    '''Same implementation as math.isclose
+    ''' Same implementation as math.isclose
     self-implemented bcs math.isclose was only introduced in python3.5
-    see https://www.python.org/dev/peps/pep-0485/
-    '''
+    see https://www.python.org/dev/peps/pep-0485/ '''
     return abs(a - b) <= max(rel_tol * max(abs(a), abs(b)), abs_tol)
 
 

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -41,7 +41,7 @@ class TestCase(TestCase):
         if first < (second - tolerance) or first > (second + tolerance):
             raise self.failureException(msg or '%r != %r within %r places' % (first, second, tolerance))
 
-    def assertIsClose(self, first, second, rel_tol=None, abs_tol=None, msg=None):
+    def failUnlessAbsAndRelDifference(self, first, second, rel_tol=None, abs_tol=None, msg=None):
         """Fail if the two objects are unequal as determined by their
            absolute and relative difference
 
@@ -78,8 +78,8 @@ class TestCase(TestCase):
             for j in range(matrix1.Size2()):
                 self.assertAlmostEqual(matrix1[i,j], matrix2[i,j], prec)
 
-
     assertEqualTolerance = failUnlessEqualWithTolerance
+    assertIsClose = failUnlessAbsAndRelDifference
     assertVectorAlmostEqual = failUnlessVectorEqualWithTolerance
     assertMatrixAlmostEqual = failUnlessMatrixEqualWithTolerance
 

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -34,14 +34,14 @@ class TestCase(TestCase):
     def run(self, result=None):
         super(TestCase,self).run(result)
 
-    def failUnlessEqualWithTolerance(self, first, second, tolerance, msg=None):
+    def assertEqualTolerance(self, first, second, tolerance, msg=None):
         ''' Fails if first and second have a difference greater than
         tolerance '''
 
         if first < (second - tolerance) or first > (second + tolerance):
             raise self.failureException(msg or '%r != %r within %r places' % (first, second, tolerance))
 
-    def failUnlessAbsAndRelDifference(self, first, second, rel_tol=None, abs_tol=None, msg=None):
+    def assertIsClose(self, first, second, rel_tol=None, abs_tol=None, msg=None):
         ''' Fails if the two objects are unequal as determined by their
         absolute and relative difference
 
@@ -66,22 +66,17 @@ class TestCase(TestCase):
         msg = self._formatMessage(msg, standardMsg)
         raise self.failureException(msg)
 
-    def failUnlessVectorEqualWithTolerance(self, vector1, vector2, prec=7):
+    def assertVectorAlmostEqual(self, vector1, vector2, prec=7):
         self.assertEqual(matrix1.Size1(), matrix2.Size1())
         for i in range(matrix1.Size1()):
             self.assertAlmostEqual(vector1[i], vector2[i], prec)
 
-    def failUnlessMatrixEqualWithTolerance(self, matrix1, matrix2, prec=7):
+    def assertMatrixAlmostEqual(self, matrix1, matrix2, prec=7):
         self.assertEqual(matrix1.Size1(), matrix2.Size1())
         self.assertEqual(matrix1.Size2(), matrix2.Size2())
         for i in range(matrix1.Size1()):
             for j in range(matrix1.Size2()):
                 self.assertAlmostEqual(matrix1[i,j], matrix2[i,j], prec)
-
-    assertEqualTolerance = failUnlessEqualWithTolerance
-    assertIsClose = failUnlessAbsAndRelDifference
-    assertVectorAlmostEqual = failUnlessVectorEqualWithTolerance
-    assertMatrixAlmostEqual = failUnlessMatrixEqualWithTolerance
 
 @contextmanager
 def SupressConsoleOutput():

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -66,12 +66,12 @@ class TestCase(TestCase):
         msg = self._formatMessage(msg, standardMsg)
         raise self.failureException(msg)
 
-    def failUnlessVectorEqualWithTolerance(vector1, vector2, prec=7):
+    def failUnlessVectorEqualWithTolerance(self, vector1, vector2, prec=7):
         self.assertEqual(matrix1.Size1(), matrix2.Size1())
         for i in range(matrix1.Size1()):
             self.assertAlmostEqual(vector1[i], vector2[i], prec)
 
-    def failUnlessMatrixEqualWithTolerance(matrix1, matrix2, prec=7):
+    def failUnlessMatrixEqualWithTolerance(self, matrix1, matrix2, prec=7):
         self.assertEqual(matrix1.Size1(), matrix2.Size1())
         self.assertEqual(matrix1.Size2(), matrix2.Size2())
         for i in range(matrix1.Size1()):


### PR DESCRIPTION
This fixes several problems in the structural mechanics application while running with python 2.7

Also, I made some extensions to the `KratosUnittest` class to include the `AssertMatrixAlmostEqual` (and its vector version) and also clean up a little the interface extension.

Tests were updated to use the new internal version and avoid duplications. Also I move a couple of methods that were inside classes to be independent on the class as otherwise it can give problems in Python 2.7.

Finally, I removed a `º`. Please don't use those on python, as we still need to give support to 2.7 and that version does not allow non-ascii chars in the code, even in the comments.

Also, it seems that compiling with mpi causes the serial script to run a test in mpi. Not sure which one but we should look into that.