### PR TITLE
[Fluid] Fix steady cylinder adjoint test

### DIFF
--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_adjoint_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_adjoint_parameters.json
@@ -74,7 +74,7 @@
             "input_filename" : "AdjointVMSSensitivity2DTest/steady_cylinder_test"
         },
         "material_import_settings": {
-            "materials_filename": "AdjointVMSSensitivity2DTest/cylinder_test_materials.json"
+            "materials_filename": "AdjointVMSSensitivity2DTest/steady_cylinder_test_materials.json"
         },
         "time_stepping"               : {
             "automatic_time_step" : false,

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_materials.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_materials.json
@@ -1,0 +1,14 @@
+{
+    "properties" : [{
+        "model_part_name" : "MainModelPart.Parts_Fluid",
+        "properties_id"   : 1,
+        "Material"        : {
+            "Variables"        : {
+                "DENSITY" : 1.0E+00,
+                "VISCOSITY" : 1.0E-03,
+                "DYNAMIC_VISCOSITY" : 1.0E-03
+            },
+            "Tables"           : {}
+        }
+    }]
+}

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_parameters.json
@@ -51,7 +51,7 @@
             "input_filename" : "AdjointVMSSensitivity2DTest/steady_cylinder_test"
         },
         "material_import_settings": {
-            "materials_filename": "AdjointVMSSensitivity2DTest/cylinder_test_materials.json"
+            "materials_filename": "AdjointVMSSensitivity2DTest/steady_cylinder_test_materials.json"
         },
         "model_part_name"              : "MainModelPart",
         "maximum_iterations"           : 1000,

--- a/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/AdjointVMSSensitivity2DTest/steady_cylinder_test_parameters.json
@@ -60,9 +60,9 @@
         "compute_reactions"            : true,
         "reform_dofs_at_each_step"     : false,
         "relative_velocity_tolerance"  : 1e-5,
-        "absolute_velocity_tolerance"  : 1e-7,
+        "absolute_velocity_tolerance"  : 1e-9,
         "relative_pressure_tolerance"  : 1e-5,
-        "absolute_pressure_tolerance"  : 1e-7,
+        "absolute_pressure_tolerance"  : 1e-9,
         "linear_solver_settings"       : {
             "solver_type"         : "amgcl",
             "max_iteration"       : 200,


### PR DESCRIPTION
Looks like we changed the settings for one of the validation tests inadvertently when introducing materials.json. I also reduced the tolerance, since for some reason the obtained results are less accurate than in release 7.0 (I guess a default setting has changed somewhere? Or maybe the bugfixes in convergence criteria?).