### PR TITLE
Fluid fs strategy virtual methods

### DIFF
--- a/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
+++ b/applications/FluidDynamicsApplication/custom_strategies/strategies/fs_strategy.h
@@ -467,6 +467,43 @@ protected:
     ///@name Protected member Variables
     ///@{
 
+    double mVelocityTolerance;
+
+    double mPressureTolerance;
+
+    unsigned int mMaxVelocityIter;
+
+    unsigned int mMaxPressureIter;
+
+    unsigned int mDomainSize;
+
+    unsigned int mTimeOrder;
+
+    bool mPredictorCorrector;
+
+    bool mUseSlipConditions;
+
+    bool mReformDofSet;
+
+    // Fractional step index.
+    /*  1 : Momentum step (calculate fractional step velocity)
+      * 2-3 : Unused (reserved for componentwise calculation of frac step velocity)
+      * 4 : Pressure step
+      * 5 : Computation of projections
+      * 6 : End of step velocity
+      */
+//    unsigned int mStepId;
+
+    /// Scheme for the solution of the momentum equation
+    StrategyPointerType mpMomentumStrategy;
+
+    /// Scheme for the solution of the mass equation
+    StrategyPointerType mpPressureStrategy;
+
+    std::vector< Process::Pointer > mExtraIterationSteps;
+
+    const Kratos::Variable<int>& mrPeriodicIdVar;
+
 
     ///@}
     ///@name Protected Operators
@@ -517,7 +554,7 @@ protected:
         KRATOS_CATCH("");
     }
 
-    double SolveStep()
+    virtual double SolveStep()
     {
         ModelPart& rModelPart = BaseType::GetModelPart();
 
@@ -599,6 +636,7 @@ protected:
         rModelPart.GetProcessInfo().SetValue(FRACTIONAL_STEP,6);
 
         this->CalculateEndOfStepVelocity();
+
         /*
         mpPressureStrategy->Clear();
         double NormDu = mpPressureStrategy->Solve();
@@ -642,13 +680,14 @@ protected:
 
         double Ratio = NormDv / NormV;
 
-        if ( BaseType::GetEchoLevel() > 0 && rModelPart.GetCommunicator().MyPID() == 0)
-            std::cout << "Fractional velocity relative error: " << Ratio << std::endl;
+        KRATOS_INFO_IF("Fractional Step Strategy : ", BaseType::GetEchoLevel() > 0) << "CONVERGENCE CHECK:" << std::endl;
+        KRATOS_INFO_IF("Fractional Step Strategy : ", BaseType::GetEchoLevel() > 0) <<  std::scientific << std::setprecision(8)
+                                                                                    << "FRAC VEL.: ratio = "
+                                                                                    << Ratio <<"; exp.ratio = " << mVelocityTolerance
+                                                                                    << " abs = " << NormDv << std::endl;
 
         if (Ratio < mVelocityTolerance)
-        {
             return true;
-        }
         else
             return false;
     }
@@ -691,7 +730,7 @@ protected:
     }
 
 
-    void ComputeSplitOssProjections(ModelPart& rModelPart)
+    virtual void ComputeSplitOssProjections(ModelPart& rModelPart)
     {
         array_1d<double,3> Out = ZeroVector(3);
 
@@ -746,7 +785,7 @@ protected:
         }
     }
 
-    void CalculateEndOfStepVelocity()
+    virtual void CalculateEndOfStepVelocity()
     {
         ModelPart& rModelPart = BaseType::GetModelPart();
 
@@ -1034,43 +1073,6 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
-
-    double mVelocityTolerance;
-
-    double mPressureTolerance;
-
-    unsigned int mMaxVelocityIter;
-
-    unsigned int mMaxPressureIter;
-
-    unsigned int mDomainSize;
-
-    unsigned int mTimeOrder;
-
-    bool mPredictorCorrector;
-
-    bool mUseSlipConditions;
-
-    bool mReformDofSet;
-
-    // Fractional step index.
-    /*  1 : Momentum step (calculate fractional step velocity)
-      * 2-3 : Unused (reserved for componentwise calculation of frac step velocity)
-      * 4 : Pressure step
-      * 5 : Computation of projections
-      * 6 : End of step velocity
-      */
-//    unsigned int mStepId;
-
-    /// Scheme for the solution of the momentum equation
-    StrategyPointerType mpMomentumStrategy;
-
-    /// Scheme for the solution of the mass equation
-    StrategyPointerType mpPressureStrategy;
-
-    std::vector< Process::Pointer > mExtraIterationSteps;
-
-    const Kratos::Variable<int>& mrPeriodicIdVar;
 
     ///@}
     ///@name Private Operators

--- a/applications/FluidDynamicsApplication/custom_utilities/solver_settings.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/solver_settings.h
@@ -61,6 +61,7 @@ public:
     typedef SolvingStrategy<TSparseSpace,TDenseSpace,TLinearSolver> StrategyType;
     typedef typename StrategyType::Pointer StrategyPointerType;
     typedef typename Process::Pointer ProcessPointerType;
+    typedef BuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver> TBuilderAndSolverType;
 
     enum StrategyLabel { Velocity, Pressure, /*EddyViscosity,*/ NumLabels };
 
@@ -118,12 +119,18 @@ public:
     virtual void SetStrategy(StrategyLabel const& rStrategyLabel,
                              typename TLinearSolver::Pointer pLinearSolver,
                              const double Tolerance,
-                             const unsigned int MaxIter) = 0;
+                             const unsigned int MaxIter) {}
+
+    virtual void SetStrategy(StrategyLabel const& rStrategyLabel,
+                             typename TLinearSolver::Pointer pLinearSolver,
+                             const double Tolerance,
+                             const std::size_t MaxIter,
+                             typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver){}
 
     virtual void SetTurbulenceModel(TurbulenceModelLabel const& rTurbulenceModel,
                                     typename TLinearSolver::Pointer pLinearSolver,
                                     const double Tolerance,
-                                    const unsigned int MaxIter) = 0;
+                                    const unsigned int MaxIter) {}
 
     virtual void SetTurbulenceModel(ProcessPointerType pTurbulenceModel)
     {
@@ -169,11 +176,19 @@ public:
 
         if ( itStrategy != mStrategies.end() )
         {
-            pThisStrategy.swap(itStrategy->second);
-            return true;
+            if(itStrategy->second != nullptr)
+            {
+                pThisStrategy.swap(itStrategy->second);
+                return true;
+            } else {
+                KRATOS_INFO("SolverSettingsFSStrategy")<<"Strategy for :: "<<rStrategyLabel<<" not found."<<std::endl;
+                return false;
+            }
         }
-        else
+        else {
+            KRATOS_INFO("SolverSettingsFSStrategy")<<"Strategy for :: "<<rStrategyLabel<<" not found."<<std::endl;
             return false;
+        }
     }
 
     virtual bool FindTolerance(StrategyLabel const& rStrategyLabel,

--- a/applications/FluidDynamicsApplication/custom_utilities/solver_settings.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/solver_settings.h
@@ -119,13 +119,7 @@ public:
     virtual void SetStrategy(StrategyLabel const& rStrategyLabel,
                              typename TLinearSolver::Pointer pLinearSolver,
                              const double Tolerance,
-                             const unsigned int MaxIter) {}
-
-    virtual void SetStrategy(StrategyLabel const& rStrategyLabel,
-                             typename TLinearSolver::Pointer pLinearSolver,
-                             const double Tolerance,
-                             const std::size_t MaxIter,
-                             typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver){}
+                             const unsigned int MaxIter) = 0;
 
     virtual void SetTurbulenceModel(TurbulenceModelLabel const& rTurbulenceModel,
                                     typename TLinearSolver::Pointer pLinearSolver,


### PR DESCRIPTION
After discussing with @jcotela  : 

- This PR makes methods of the fs strategy virtual so specific fs strategies can be realized. (fs_strategy.h)
- Checks if the pointers are null and does return false or true accordingly (solver_settings.h)
- Adds a new overload of function SetStrategy to also include the builder and solver in (solver_settings.h)