### PR TITLE
[ShapeOpt] fix deprecated gid output and remove many warnings

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/mesh_controller_with_solver.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/mesh_controller_with_solver.py
@@ -47,8 +47,7 @@ class MeshControllerWithSolver(MeshController) :
                     "verbosity" : 0,
                     "tolerance": 1e-7
                 },
-                "compute_reactions"         : false,
-                "calculate_mesh_velocities" : false
+                "compute_reactions"         : false
             },
             "processes" : {
                 "boundary_conditions_process_list" : []

--- a/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/analysis_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/analysis_parameters.json
@@ -32,8 +32,6 @@
       "linear_solver_settings"             : {
           "solver_type" : "ExternalSolversApplication.super_lu"
       },
-      "problem_domain_sub_model_part_list" : ["structure"],
-      "processes_sub_model_part_list"      : ["corner_points","load_point"],
       "rotation_dofs"                      : true
   },
   "processes" : {

--- a/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/materials.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/materials.json
@@ -8,10 +8,10 @@
                             "name": "LinearElasticPlaneStress2DLaw"
                     },
                     "Variables": {
-                            "KratosMultiphysics.DENSITY": 7.85000E+03,
-                            "KratosMultiphysics.YOUNG_MODULUS": 2.06900E+11,
-                            "KratosMultiphysics.POISSON_RATIO": 2.90000E-01,
-                            "KratosMultiphysics.THICKNESS": 1.00000E+00
+                            "DENSITY": 7.85000E+03,
+                            "YOUNG_MODULUS": 2.06900E+11,
+                            "POISSON_RATIO": 2.90000E-01,
+                            "THICKNESS": 1.00000E+00
                     },
                     "Tables": {}
             }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/primal_parameters.json
@@ -26,10 +26,9 @@
             "number_of_eigenvalues": 2,
             "max_iteration": 1000,
             "tolerance": 1e-6,
-            "echo_level": 1
+            "echo_level": 1,
+            "normalize_eigenvectors" : true
         },
-        "problem_domain_sub_model_part_list" : ["Parts_structure"],
-        "processes_sub_model_part_list"      : ["DISPLACEMENT_support","PointLoad3D_load_point"],
         "rotation_dofs"                      : false
     },
     "processes": {

--- a/applications/ShapeOptimizationApplication/tests/opt_process_multiobjective_test/analysis_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_multiobjective_test/analysis_parameters.json
@@ -28,8 +28,6 @@
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
         "max_iteration"                      : 10,
-        "problem_domain_sub_model_part_list" : ["structure"],
-        "processes_sub_model_part_list"      : ["fix_support","roller_support","load_point"],
         "rotation_dofs"                      : true
     },
     "processes": {
@@ -37,7 +35,7 @@
             "python_module" : "assign_vector_variable_process",
             "kratos_module" : "KratosMultiphysics",
             "Parameters"    : {
-                "model_part_name" : "fix_support",
+                "model_part_name" : "structure.fix_support",
                 "variable_name"   : "DISPLACEMENT",
                 "constrained"     : [true,true,true],
                 "value"           : [0.0,0.0,0.0],
@@ -47,7 +45,7 @@
             "python_module" : "assign_vector_variable_process",
             "kratos_module" : "KratosMultiphysics",
             "Parameters"    : {
-                "model_part_name" : "roller_support",
+                "model_part_name" : "structure.roller_support",
                 "variable_name"   : "DISPLACEMENT",
                 "constrained"     : [false,true,true],
                 "value"           : [0.0,0.0,0.0],
@@ -59,7 +57,7 @@
             "kratos_module" : "KratosMultiphysics",
             "check"         : "DirectorVectorNonZero direction",
             "Parameters"    : {
-                "model_part_name" : "load_point",
+                "model_part_name" : "structure.load_point",
                 "variable_name"   : "POINT_LOAD",
                 "modulus"         : 1000.0,
                 "direction"       : [0.0,-1,0.0],
@@ -91,24 +89,29 @@
                 "time_frequency"   : 0.0
            }
     }],
-    "output_configuration"     : {
-        "result_file_configuration" : {
-            "gidpost_flags"       : {
-                "GiDPostMode"           : "GiD_PostBinary",
-                "WriteDeformedMeshFlag" : "WriteDeformed",
-                "WriteConditionsFlag"   : "WriteConditions",
-                "MultiFileFlag"         : "SingleFile"
-            },
-            "file_label"          : "step",
-            "output_control_type" : "step",
-            "output_frequency"    : 1,
-            "body_output"         : true,
-            "node_output"         : false,
-            "skin_output"         : false,
-            "plane_output"        : [],
-            "nodal_results"       : ["DISPLACEMENT","REACTION"],
-            "gauss_point_results" : ["VON_MISES_STRESS"]
-        },
-        "point_data_configuration"  : []
+    "_output_processes" : {
+        "gid_output" : [{
+            "python_module" : "gid_output_process",
+            "kratos_module" : "KratosMultiphysics",
+            "process_name"  : "GiDOutputProcess",
+            "help"          : "This process writes postprocessing files for GiD",
+            "Parameters"    : {
+                "model_part_name"        : "structure",
+                "output_name"            : "structure",
+                "postprocess_parameters" : {
+                    "result_file_configuration" : {
+                        "gidpost_flags"       : {
+                            "GiDPostMode"           : "GiD_PostBinary",
+                            "WriteDeformedMeshFlag" : "WriteDeformed",
+                            "WriteConditionsFlag"   : "WriteConditions",
+                            "MultiFileFlag"         : "SingleFile"
+                        },
+                        "nodal_results"       : ["DISPLACEMENT","REACTION"],
+                        "gauss_point_results" : ["VON_MISES_STRESS"]
+                    },
+                    "point_data_configuration"  : []
+                }
+            }
+        }]
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/primal_parameters.json
@@ -28,8 +28,6 @@
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
         "max_iteration"                      : 10,
-        "problem_domain_sub_model_part_list" : ["shell"],
-        "processes_sub_model_part_list"      : ["support","support","load_point"],
         "rotation_dofs"                      : true
     },
     "processes": {

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
@@ -24,7 +24,7 @@
                         "time_step"       : 1.0
                     },
                     "mesh_motion_linear_solver_settings"  : {
-                        "solver_type"         : "AMGCL",
+                        "solver_type"         : "amgcl",
                         "max_iteration"       : 500,
                         "tolerance"           : 1e-7,
                         "provide_coordinates" : false,

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/primal_parameters.json
@@ -28,8 +28,6 @@
         "residual_relative_tolerance"        : 0.0001,
         "residual_absolute_tolerance"        : 1e-9,
         "max_iteration"                      : 10,
-        "problem_domain_sub_model_part_list" : ["Parts_structure"],
-        "processes_sub_model_part_list"      : ["DISPLACEMENT_support","PointLoad3D_load_point", "structure"],
         "rotation_dofs"                      : false
     },
     "processes": {

--- a/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/primal_parameters.json
@@ -21,8 +21,6 @@
         "material_import_settings"           : {
             "materials_filename" : "material.json"
         },
-        "problem_domain_sub_model_part_list" : ["Parts_structure"],
-        "processes_sub_model_part_list"      : ["DISPLACEMENT_support","PointLoad3D_load_point", "Parts_structure"],
         "rotation_dofs"                      : false
     },
     "processes": {

--- a/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/tent.mdpa
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/tent.mdpa
@@ -1,8 +1,4 @@
 Begin Properties 1
- DENSITY 1
- YOUNG_MODULUS 1
- THICKNESS 1
- POISSON_RATIO 1
 End Properties
 
 Begin Nodes

--- a/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/primal_parameters.json
@@ -26,10 +26,9 @@
             "number_of_eigenvalues": 2,
             "max_iteration": 1000,
             "tolerance": 1e-6,
-            "echo_level": 1
+            "echo_level": 1,
+            "normalize_eigenvectors" : true
         },
-        "problem_domain_sub_model_part_list" : ["Parts_structure"],
-        "processes_sub_model_part_list"      : ["DISPLACEMENT_support","PointLoad3D_load_point"],
         "rotation_dofs"                      : false
     },
     "processes": {

--- a/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/primal_parameters.json
@@ -22,8 +22,6 @@
         "material_import_settings"           : {
             "materials_filename" : "material.json"
         },
-        "problem_domain_sub_model_part_list" : ["Parts_structure"],
-        "processes_sub_model_part_list"      : ["DISPLACEMENT_support","PointLoad3D_load_point"],
         "rotation_dofs"                      : false
     },
     "processes": {

--- a/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/run_semi_analytic_step_size_verification.py
+++ b/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/run_semi_analytic_step_size_verification.py
@@ -23,9 +23,9 @@ kratos_response_settings = KM.Parameters("""
     "adjoint_settings"  : "auto",
     "sensitivity_settings" : {
         "sensitivity_model_part_name"     : "Parts_structure",
-        "nodal_sensitivity_variables"     : ["SHAPE_SENSITIVITY"],
-        "element_sensitivity_variables"   : [],
-        "condition_sensitivity_variables" : [],
+        "nodal_solution_step_sensitivity_variables"     : ["SHAPE_SENSITIVITY"],
+        "element_data_value_sensitivity_variables"   : [],
+        "condition_data_value_sensitivity_variables" : [],
         "build_mode": "static"
     }
 }""")

--- a/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/run_sensitivity_verification_in_design_space.py
+++ b/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/run_sensitivity_verification_in_design_space.py
@@ -26,9 +26,9 @@ kratos_response_settings = KM.Parameters("""
     "adjoint_settings"  : "auto",
     "sensitivity_settings" : {
         "sensitivity_model_part_name"     : "Parts_structure",
-        "nodal_sensitivity_variables"     : ["SHAPE_SENSITIVITY"],
-        "element_sensitivity_variables"   : [],
-        "condition_sensitivity_variables" : [],
+        "nodal_solution_step_sensitivity_variables"     : ["SHAPE_SENSITIVITY"],
+        "element_data_value_sensitivity_variables"   : [],
+        "condition_data_value_sensitivity_variables" : [],
         "build_mode": "static"
     }
 }""")

--- a/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/run_sensitivity_verification_in_geometry_space.py
+++ b/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/run_sensitivity_verification_in_geometry_space.py
@@ -23,9 +23,9 @@ kratos_response_settings = KM.Parameters("""
     "adjoint_settings"  : "auto",
     "sensitivity_settings" : {
         "sensitivity_model_part_name"     : "Parts_structure",
-        "nodal_sensitivity_variables"     : ["SHAPE_SENSITIVITY"],
-        "element_sensitivity_variables"   : [],
-        "condition_sensitivity_variables" : [],
+        "nodal_solution_step_sensitivity_variables"     : ["SHAPE_SENSITIVITY"],
+        "element_data_value_sensitivity_variables"   : [],
+        "condition_data_value_sensitivity_variables" : [],
         "build_mode": "static"
     }
 }""")


### PR DESCRIPTION
One test was failing because of the deprecated GiD output.

Also many warnings have been removed with an update of the json settings.
There are still a few left because of assignment of properties. Btu that requires more work.