### PR TITLE
[KratosCore] Feature/submodelpart skin

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -57,6 +57,7 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/find_nodal_h_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/calculate_nodal_area_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/skin_detection_process.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/processes/sub_model_part_skin_detection_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/replace_elements_and_condition_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/entity_erase_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/processes/assign_scalar_variable_to_entities_process.cpp

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -192,7 +192,7 @@ void SkinDetectionProcess<TDim>::FillAuxiliaryModelPart(
     // The indexes of the nodes of the skin
     std::unordered_set<IndexType> nodes_in_the_skin;
 
-    this->CreateConditions(r_auxiliar_model_part, rInverseFaceMap, rPropertiesFaceMap, nodes_in_the_skin, base_name);
+    this->CreateConditions(mrModelPart, r_auxiliar_model_part, rInverseFaceMap, rPropertiesFaceMap, nodes_in_the_skin, base_name);
 
     // Adding to the auxiliar model part
     VectorIndexType indexes_skin;
@@ -214,14 +214,15 @@ void SkinDetectionProcess<TDim>::FillAuxiliaryModelPart(
 
 template<SizeType TDim>
 void SkinDetectionProcess<TDim>::CreateConditions(
-    ModelPart& rAuxiliaryModelPart,
+    ModelPart& rMainModelPart,
+    ModelPart& rSkinModelPart,
     HashMapVectorIntType& rInverseFaceMap,
     HashMapVectorIntIdsType& rPropertiesFaceMap,
     std::unordered_set<IndexType>& rNodesInTheSkin,
     const std::string& rConditionName) const
 {
 
-    IndexType condition_id = mrModelPart.GetRootModelPart().Conditions().size();
+    IndexType condition_id = rMainModelPart.GetRootModelPart().Conditions().size();
 
     // Create the auxiliar conditions
     for (auto& map : rInverseFaceMap) {
@@ -231,18 +232,19 @@ void SkinDetectionProcess<TDim>::CreateConditions(
 
         Properties::Pointer p_prop;
         const IndexType property_id = rPropertiesFaceMap[map.first];
-         if (mrModelPart.RecursivelyHasProperties(property_id)) {
-             p_prop = mrModelPart.pGetProperties(property_id);
+         if (rMainModelPart.RecursivelyHasProperties(property_id)) {
+             p_prop = rMainModelPart.pGetProperties(property_id);
          } else {
-             p_prop = mrModelPart.CreateNewProperties(property_id);
+             p_prop = rMainModelPart.CreateNewProperties(property_id);
          }
 
         for (auto& index : nodes_face)
             rNodesInTheSkin.insert(index);
 
         const std::string complete_name = rConditionName + std::to_string(TDim) + "D" + std::to_string(nodes_face.size()) + "N"; // If the condition doesn't follow this structure...sorry, we then need to modify this...
-        auto p_cond = mrModelPart.CreateNewCondition(complete_name, condition_id, nodes_face, p_prop);
-        rAuxiliaryModelPart.AddCondition(p_cond);
+        auto p_cond = rMainModelPart.CreateNewCondition(complete_name, condition_id, nodes_face, p_prop);
+        ModelPart& rMainModelPart,
+        rSkinModelPart.AddCondition(p_cond);
         p_cond->Set(INTERFACE, true);
         p_cond->Initialize();
     }

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -172,7 +172,7 @@ ModelPart& SkinDetectionProcess<TDim>::SetUpAuxiliaryModelPart()
 
 template<SizeType TDim>
 void SkinDetectionProcess<TDim>::FillAuxiliaryModelPart(
-    ModelPart& r_auxiliar_model_part,
+    ModelPart& rAuxiliaryModelPart,
     HashMapVectorIntType& rInverseFaceMap,
     HashMapVectorIntIdsType& rPropertiesFaceMap)
 {
@@ -192,18 +192,18 @@ void SkinDetectionProcess<TDim>::FillAuxiliaryModelPart(
     // The indexes of the nodes of the skin
     std::unordered_set<IndexType> nodes_in_the_skin;
 
-    this->CreateConditions(mrModelPart, r_auxiliar_model_part, rInverseFaceMap, rPropertiesFaceMap, nodes_in_the_skin, base_name);
+    this->CreateConditions(mrModelPart, rAuxiliaryModelPart, rInverseFaceMap, rPropertiesFaceMap, nodes_in_the_skin, base_name);
 
     // Adding to the auxiliar model part
     VectorIndexType indexes_skin;
     indexes_skin.insert(indexes_skin.end(), nodes_in_the_skin.begin(), nodes_in_the_skin.end());
-    r_auxiliar_model_part.AddNodes(indexes_skin);
+    rAuxiliaryModelPart.AddNodes(indexes_skin);
 
     const SizeType echo_level = mThisParameters["echo_level"].GetInt();
     KRATOS_INFO_IF("SkinDetectionProcess", echo_level > 0) << rInverseFaceMap.size() << " have been created" << std::endl;
 
     // Now we set the falg on the nodes. The list of nodes of the auxiliar model part
-    auto& nodes_array = r_auxiliar_model_part.Nodes();
+    auto& nodes_array = rAuxiliaryModelPart.Nodes();
 
     #pragma omp parallel for
     for(int i = 0; i < static_cast<int>(nodes_array.size()); ++i) {
@@ -251,7 +251,7 @@ void SkinDetectionProcess<TDim>::CreateConditions(
 }
 
 template<SizeType TDim>
-void SkinDetectionProcess<TDim>::SetUpAdditionalSubModelParts(const ModelPart& r_auxiliar_model_part)
+void SkinDetectionProcess<TDim>::SetUpAdditionalSubModelParts(const ModelPart& rAuxiliaryModelPart)
 {
     // We detect the conditions in the boundary model parts
     const SizeType n_model_parts = mThisParameters["list_model_parts_to_assign_conditions"].size();
@@ -260,7 +260,7 @@ void SkinDetectionProcess<TDim>::SetUpAdditionalSubModelParts(const ModelPart& r
         // We build a database of indexes
         std::unordered_map<IndexType, std::unordered_set<IndexType>> conditions_nodes_ids_map;
 
-        for (auto& cond : r_auxiliar_model_part.Conditions()) {
+        for (auto& cond : rAuxiliaryModelPart.Conditions()) {
             auto& geom = cond.GetGeometry();
 
             for (auto& node : geom) {

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -243,7 +243,6 @@ void SkinDetectionProcess<TDim>::CreateConditions(
 
         const std::string complete_name = rConditionName + std::to_string(TDim) + "D" + std::to_string(nodes_face.size()) + "N"; // If the condition doesn't follow this structure...sorry, we then need to modify this...
         auto p_cond = rMainModelPart.CreateNewCondition(complete_name, condition_id, nodes_face, p_prop);
-        ModelPart& rMainModelPart,
         rSkinModelPart.AddCondition(p_cond);
         p_cond->Set(INTERFACE, true);
         p_cond->Initialize();

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -202,7 +202,7 @@ void SkinDetectionProcess<TDim>::FillAuxiliaryModelPart(
     const SizeType echo_level = mThisParameters["echo_level"].GetInt();
     KRATOS_INFO_IF("SkinDetectionProcess", echo_level > 0) << rInverseFaceMap.size() << " have been created" << std::endl;
 
-    // Now we set the falg on the nodes. The list of nodes of the auxiliar model part
+    // Now we set the flag on the nodes. The list of nodes of the auxiliar model part
     auto& nodes_array = rAuxiliaryModelPart.Nodes();
 
     #pragma omp parallel for

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -179,8 +179,9 @@ void SkinDetectionProcess<TDim>::FillAuxiliaryModelPart(
     // The auxiliar name of the condition
     const std::string& name_condition = mThisParameters["name_auxiliar_condition"].GetString();
     std::string pre_name = "";
-    if (TDim == 3 && name_condition == "Condition")
+    if (TDim == 3 && name_condition == "Condition") {
         pre_name = "Surface";
+    }
     const std::string base_name = pre_name + name_condition;
 
     // The number of conditions

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -26,15 +26,7 @@ SkinDetectionProcess<TDim>::SkinDetectionProcess(
     ) : mrModelPart(rModelPart),
         mThisParameters(ThisParameters)
 {
-    Parameters default_parameters = Parameters(R"(
-    {
-        "name_auxiliar_model_part"              : "SkinModelPart",
-        "name_auxiliar_condition"               : "Condition",
-        "list_model_parts_to_assign_conditions" : [],
-        "echo_level"                            : 0
-    })" );
-
-    mThisParameters.ValidateAndAssignDefaults(default_parameters);
+    mThisParameters.ValidateAndAssignDefaults(this->GetDefaultSettings());
 }
 
 /***********************************************************************************/
@@ -288,6 +280,34 @@ void SkinDetectionProcess<TDim>::Execute()
     }
 
     KRATOS_CATCH("");
+}
+
+
+/***********************************************************************************/
+/***********************************************************************************/
+template<SizeType TDim>
+Parameters SkinDetectionProcess<TDim>::GetDefaultSettings() const
+{
+    Parameters default_parameters = Parameters(R"(
+    {
+        "name_auxiliar_model_part"              : "SkinModelPart",
+        "name_auxiliar_condition"               : "Condition",
+        "list_model_parts_to_assign_conditions" : [],
+        "echo_level"                            : 0
+    })" );
+    return default_parameters;
+}
+
+template<SizeType TDim>
+SkinDetectionProcess<TDim>::SkinDetectionProcess(
+    ModelPart& rModelPart,
+    Parameters Settings,
+    Parameters DefaultSettings)
+    : Process()
+    , mrModelPart(rModelPart)
+    , mThisParameters(Settings)
+{
+    mThisParameters.ValidateAndAssignDefaults(DefaultSettings);
 }
 
 /***********************************************************************************/

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -207,7 +207,7 @@ void SkinDetectionProcess<TDim>::FillAuxiliaryModelPart(
 
     #pragma omp parallel for
     for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
-        auto it_node = nodes_array.begin() + i;
+        auto it_node = r_nodes_array.begin() + i;
         it_node->Set(INTERFACE, true);
     }
 }

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -337,6 +337,24 @@ Parameters SkinDetectionProcess<TDim>::GetDefaultSettings() const
     return default_parameters;
 }
 
+/***********************************************************************************/
+/***********************************************************************************/
+template<SizeType TDim>
+ModelPart& SkinDetectionProcess<TDim>::GetModelPart() const
+{
+    return this->mrModelPart;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+template<SizeType TDim>
+Parameters SkinDetectionProcess<TDim>::GetSettings() const
+{
+    return this->mThisParameters;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
 template<SizeType TDim>
 SkinDetectionProcess<TDim>::SkinDetectionProcess(
     ModelPart& rModelPart,

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -206,7 +206,7 @@ void SkinDetectionProcess<TDim>::FillAuxiliaryModelPart(
     auto& r_nodes_array = rAuxiliaryModelPart.Nodes();
 
     #pragma omp parallel for
-    for(int i = 0; i < static_cast<int>(nodes_array.size()); ++i) {
+    for(int i = 0; i < static_cast<int>(r_nodes_array.size()); ++i) {
         auto it_node = nodes_array.begin() + i;
         it_node->Set(INTERFACE, true);
     }

--- a/kratos/processes/skin_detection_process.cpp
+++ b/kratos/processes/skin_detection_process.cpp
@@ -203,7 +203,7 @@ void SkinDetectionProcess<TDim>::FillAuxiliaryModelPart(
     KRATOS_INFO_IF("SkinDetectionProcess", echo_level > 0) << rInverseFaceMap.size() << " have been created" << std::endl;
 
     // Now we set the flag on the nodes. The list of nodes of the auxiliar model part
-    auto& nodes_array = rAuxiliaryModelPart.Nodes();
+    auto& r_nodes_array = rAuxiliaryModelPart.Nodes();
 
     #pragma omp parallel for
     for(int i = 0; i < static_cast<int>(nodes_array.size()); ++i) {

--- a/kratos/processes/skin_detection_process.h
+++ b/kratos/processes/skin_detection_process.h
@@ -205,6 +205,14 @@ protected:
     ///@name Protected Operations
     ///@{
 
+    void GenerateFaceMaps(
+        HashMapVectorIntType& rInverseFaceMap,
+        HashMapVectorIntIdsType& rPropertiesFaceMap) const;
+
+    void GenerateSkinConditions(
+        HashMapVectorIntType& rInverseFaceMap,
+        HashMapVectorIntIdsType& rPropertiesFaceMap);
+
     /// Auxiliar function to get default settings.
     /** It is defined as virtual so that it can be overriden by derived classes
      */

--- a/kratos/processes/skin_detection_process.h
+++ b/kratos/processes/skin_detection_process.h
@@ -217,7 +217,8 @@ protected:
         HashMapVectorIntIdsType& rPropertiesFaceMap);
 
     virtual void CreateConditions(
-        ModelPart& rAuxiliaryModelPart,
+        ModelPart& rMainModelPart,
+        ModelPart& rSkinModelPart,
         HashMapVectorIntType& rInverseFaceMap,
         HashMapVectorIntIdsType& rPropertiesFaceMap,
         std::unordered_set<IndexType>& rNodesInTheSkin,

--- a/kratos/processes/skin_detection_process.h
+++ b/kratos/processes/skin_detection_process.h
@@ -209,9 +209,21 @@ protected:
         HashMapVectorIntType& rInverseFaceMap,
         HashMapVectorIntIdsType& rPropertiesFaceMap) const;
 
-    void GenerateSkinConditions(
+    ModelPart& SetUpAuxiliaryModelPart();
+
+    void FillAuxiliaryModelPart(
+        ModelPart& rAuxiliaryModelPart,
         HashMapVectorIntType& rInverseFaceMap,
         HashMapVectorIntIdsType& rPropertiesFaceMap);
+
+    virtual void CreateConditions(
+        ModelPart& rAuxiliaryModelPart,
+        HashMapVectorIntType& rInverseFaceMap,
+        HashMapVectorIntIdsType& rPropertiesFaceMap,
+        std::unordered_set<IndexType>& rNodesInTheSkin,
+        const std::string& rConditionName) const;
+
+    void SetUpAdditionalSubModelParts(const ModelPart& rAuxiliaryModelPart);
 
     /// Auxiliar function to get default settings.
     /** It is defined as virtual so that it can be overriden by derived classes

--- a/kratos/processes/skin_detection_process.h
+++ b/kratos/processes/skin_detection_process.h
@@ -205,17 +205,37 @@ protected:
     ///@name Protected Operations
     ///@{
 
+    /** @brief Create auxiliary data structures identifying the element faces on the outer boundary.
+     *  @param[out] rInverseFaceMap describes the outer faces of the domain.
+     *  @param[out] rPropertiesFaceMap identifies the property of the element the face belongs to.
+     */
     void GenerateFaceMaps(
         HashMapVectorIntType& rInverseFaceMap,
         HashMapVectorIntIdsType& rPropertiesFaceMap) const;
 
+    /** @brief Create and prepare the SubModelPart containing the new face conditions.
+     *  @return A reference to the new SubModelPart.
+     */
     ModelPart& SetUpAuxiliaryModelPart();
 
+    /** @brief Assign new conditions to the target SubModelPart.
+     *  @param[out] rAuxiliaryModelPart Empty ModelPart to be filled with the new conditions.
+     *  @param[in] rInverseFaceMap auxiliary data structure describing the outer faces of the domain.
+     *  @param[in] rPropertiesFaceMap auxiliary data structure identifying the property of the element the face belongs to.
+     */
     void FillAuxiliaryModelPart(
         ModelPart& rAuxiliaryModelPart,
         HashMapVectorIntType& rInverseFaceMap,
         HashMapVectorIntIdsType& rPropertiesFaceMap);
 
+    /** @brief Create new Conditions based on the results of the face detection algorithm.
+     *  @param[in/out] rMainModelPart Complete ModelPart for the domain.
+     *  @param[in/out] rSkinModelPart Target ModelPart that will contain the new conditions.
+     *  @param[in] rInverseFaceMap auxiliary data structure describing the outer faces of the domain.
+     *  @param[in] rPropertiesFaceMap auxiliary data structure identifying the property of the element the face belongs to.
+     *  @param[out] rNodesInTheSkin list of all nodes belonging to the model skin.
+     *  @param[in] rConditionName base name for the conditions to be created (number of nodes and dimension will be added dynamically).
+     */
     virtual void CreateConditions(
         ModelPart& rMainModelPart,
         ModelPart& rSkinModelPart,
@@ -224,6 +244,9 @@ protected:
         std::unordered_set<IndexType>& rNodesInTheSkin,
         const std::string& rConditionName) const;
 
+    /** @brief Assing new conditions to additional ModelParts (if requested by user).
+     *  @param[in] rAuxiliaryModelPart ModelPart containing the new conditions.
+     */
     void SetUpAdditionalSubModelParts(const ModelPart& rAuxiliaryModelPart);
 
     /// Auxiliar function to get default settings.

--- a/kratos/processes/skin_detection_process.h
+++ b/kratos/processes/skin_detection_process.h
@@ -205,6 +205,11 @@ protected:
     ///@name Protected Operations
     ///@{
 
+    /// Auxiliar function to get default settings.
+    /** It is defined as virtual so that it can be overriden by derived classes
+     */
+    virtual Parameters GetDefaultSettings() const;
+
     ///@}
     ///@name Protected  Access
     ///@{
@@ -216,6 +221,9 @@ protected:
     ///@}
     ///@name Protected LifeCycle
     ///@{
+
+    /// Protected constructor with modified default settings to be defined by derived class.
+    SkinDetectionProcess(ModelPart& rModelPart, Parameters Settings, Parameters DefaultSettings);
 
     ///@}
 

--- a/kratos/processes/skin_detection_process.h
+++ b/kratos/processes/skin_detection_process.h
@@ -235,6 +235,10 @@ protected:
     ///@name Protected  Access
     ///@{
 
+    ModelPart& GetModelPart() const;
+
+    Parameters GetSettings() const;
+
     ///@}
     ///@name Protected Inquiry
     ///@{

--- a/kratos/processes/sub_model_part_skin_detection_process.cpp
+++ b/kratos/processes/sub_model_part_skin_detection_process.cpp
@@ -21,13 +21,25 @@ SubModelPartSkinDetectionProcess<TDim>::SubModelPartSkinDetectionProcess(
     ModelPart& rModelPart, Parameters Settings)
     : SkinDetectionProcess<TDim>(rModelPart, Settings, this->GetDefaultSettings())
 {
+    KRATOS_TRY;
+
     Parameters settings = this->GetSettings();
     if (settings["selection_criteria"].GetString() == "nodes_on_sub_model_part")
     {
+        KRATOS_ERROR_IF_NOT(settings["selection_settings"].Has("sub_model_part_name"))
+        << "When using \"selection_criteria\" == \"nodes_on_sub_model_part\","
+        << " SubModelPartSkinDetectionProcess requires the name of the target SubModelPart,"
+        << " given as the \"sub_model_part_name\" string argument." << std::endl;
         mpFaceSelector = Kratos::make_shared<SelectIfAllNodesOnSubModelPart>(
             settings["selection_settings"]["sub_model_part_name"].GetString()
         );
     }
+    else
+    {
+        KRATOS_ERROR << "Unsupported \"selection_criteria\" \"" << settings["selection_criteria"].GetString() << "\"." << std::endl;
+    }
+
+    KRATOS_CATCH("");
 }
 
 template<SizeType TDim>

--- a/kratos/processes/sub_model_part_skin_detection_process.cpp
+++ b/kratos/processes/sub_model_part_skin_detection_process.cpp
@@ -93,6 +93,10 @@ Parameters SubModelPartSkinDetectionProcess<TDim>::GetDefaultSettings() const
     return defaults;
 }
 
+// Here one should use the KRATOS_CREATE_LOCAL_FLAG, but it does not play nice with template parameters
+template<SizeType TDim>
+const Kratos::Flags SubModelPartSkinDetectionProcess<TDim>::NODE_SELECTED(Kratos::Flags::Create(0));
+
 
 template class SubModelPartSkinDetectionProcess<2>;
 template class SubModelPartSkinDetectionProcess<3>;

--- a/kratos/processes/sub_model_part_skin_detection_process.cpp
+++ b/kratos/processes/sub_model_part_skin_detection_process.cpp
@@ -16,8 +16,13 @@
 namespace Kratos
 {
 
+template<unsigned int TDim>
+SubModelPartSkinDetectionProcess<TDim>::SubModelPartSkinDetectionProcess(
+    ModelPart& rModelPart, Parameters Settings)
+    : SkinDetectionProcess<TDim>(rModelPart, Settings)
+{}
 
-
+template<> class SubModelPartSkinDetectionProcess<2>;
 template<> class SubModelPartSkinDetectionProcess<3>;
 
 }  // namespace Kratos.

--- a/kratos/processes/sub_model_part_skin_detection_process.cpp
+++ b/kratos/processes/sub_model_part_skin_detection_process.cpp
@@ -1,0 +1,25 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Jordi Cotela
+//
+
+// Project includes
+#include "sub_model_part_skin_detection_process.h"
+
+namespace Kratos
+{
+
+
+
+template<> class SubModelPartSkinDetectionProcess<3>;
+
+}  // namespace Kratos.
+
+

--- a/kratos/processes/sub_model_part_skin_detection_process.cpp
+++ b/kratos/processes/sub_model_part_skin_detection_process.cpp
@@ -16,14 +16,21 @@
 namespace Kratos
 {
 
-template<unsigned int TDim>
+template<SizeType TDim>
 SubModelPartSkinDetectionProcess<TDim>::SubModelPartSkinDetectionProcess(
     ModelPart& rModelPart, Parameters Settings)
-    : SkinDetectionProcess<TDim>(rModelPart, Settings)
+    : SkinDetectionProcess<TDim>(rModelPart, Settings, this->GetDefaultSettings())
 {}
 
-template<> class SubModelPartSkinDetectionProcess<2>;
-template<> class SubModelPartSkinDetectionProcess<3>;
+template<SizeType TDim>
+Parameters SubModelPartSkinDetectionProcess<TDim>::GetDefaultSettings() const
+{
+    return SkinDetectionProcess<TDim>::GetDefaultSettings();
+}
+
+
+template class SubModelPartSkinDetectionProcess<2>;
+template class SubModelPartSkinDetectionProcess<3>;
 
 }  // namespace Kratos.
 

--- a/kratos/processes/sub_model_part_skin_detection_process.h
+++ b/kratos/processes/sub_model_part_skin_detection_process.h
@@ -31,7 +31,7 @@ namespace Kratos
 /// Short class definition.
 /** Detail class definition.
 */
-template<SizeType TDim>
+template<unsigned int TDim>
 class SubModelPartSkinDetectionProcess: public SkinDetectionProcess<TDim>
 {
 public:
@@ -45,8 +45,11 @@ KRATOS_CLASS_POINTER_DEFINITION(SubModelPartSkinDetectionProcess);
 ///@name Life Cycle
 ///@{
 
-/// Default constructor.
-SubModelPartSkinDetectionProcess();
+/// Constructor
+SubModelPartSkinDetectionProcess(ModelPart& rModelPart, Parameters Settings);
+
+/// Deleted default constructor.
+SubModelPartSkinDetectionProcess() = delete;
 
 /// Deleted copy constructor.
 SubModelPartSkinDetectionProcess(SubModelPartSkinDetectionProcess const &rOther) = delete;

--- a/kratos/processes/sub_model_part_skin_detection_process.h
+++ b/kratos/processes/sub_model_part_skin_detection_process.h
@@ -34,6 +34,9 @@ namespace Kratos
 template<SizeType TDim>
 class SubModelPartSkinDetectionProcess: public SkinDetectionProcess<TDim>
 {
+
+KRATOS_DEFINE_LOCAL_FLAG( NODE_SELECTED );
+
 class FaceSelector
 {
 public:
@@ -57,7 +60,7 @@ void Prepare(ModelPart& rMainModelPart) const override
     #pragma omp parallel for
     for (int k = 0; k < num_nodes; k++)
     {
-        (node_begin+k)->Set(MPI_BOUNDARY);
+        (node_begin+k)->Set(SubModelPartSkinDetectionProcess::NODE_SELECTED);
     }
 }
 
@@ -66,7 +69,7 @@ bool IsSelected(const Geometry<Node<3>>::PointsArrayType& rNodes) const override
     bool select = true;
     for (auto i_node = rNodes.begin(); i_node != rNodes.end(); ++i_node)
     {
-        select &= i_node->Is(MPI_BOUNDARY);
+        select &= i_node->Is(SubModelPartSkinDetectionProcess::NODE_SELECTED);
     }
     return select;
 }

--- a/kratos/processes/sub_model_part_skin_detection_process.h
+++ b/kratos/processes/sub_model_part_skin_detection_process.h
@@ -28,8 +28,8 @@ namespace Kratos
 ///@name Kratos Classes
 ///@{
 
-/// Short class definition.
-/** Detail class definition.
+/// Create a SubModelPart covering a part of the outside skin of the computation domain where a condition is met.
+/** For example, create the outer skin for the part of the domain belonging to a given SubModelPart.
 */
 template<SizeType TDim>
 class SubModelPartSkinDetectionProcess: public SkinDetectionProcess<TDim>
@@ -37,6 +37,7 @@ class SubModelPartSkinDetectionProcess: public SkinDetectionProcess<TDim>
 
 KRATOS_DEFINE_LOCAL_FLAG( NODE_SELECTED );
 
+// Internal class used to select which faces to create.
 class FaceSelector
 {
 public:
@@ -45,6 +46,7 @@ virtual void Prepare(ModelPart& rMainModelPart) const = 0;
 virtual bool IsSelected(const Geometry<Node<3>>::PointsArrayType&) const = 0;
 };
 
+// Select faces where all nodes belong to given SubModelPart.
 class SelectIfAllNodesOnSubModelPart: public FaceSelector
 {
 std::string mName;
@@ -141,18 +143,7 @@ void PrintData(std::ostream& rOStream) const override
 ///@}
 
 protected:
-///@name Protected static Member Variables
-///@{
 
-///@}
-///@name Protected member Variables
-///@{
-
-///@}
-///@name Protected Operators
-///@{
-
-///@}
 ///@name Protected Operations
 ///@{
 
@@ -167,24 +158,9 @@ void CreateConditions(
 Parameters GetDefaultSettings() const override;
 
 ///@}
-///@name Protected  Access
-///@{
-
-///@}
-///@name Protected Inquiry
-///@{
-
-///@}
-///@name Protected LifeCycle
-///@{
-
-///@}
 
 private:
-///@name Static Member Variables
-///@{
 
-///@}
 ///@name Member Variables
 ///@{
 

--- a/kratos/processes/sub_model_part_skin_detection_process.h
+++ b/kratos/processes/sub_model_part_skin_detection_process.h
@@ -1,0 +1,164 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Jordi Cotela
+//
+
+#if !defined(KRATOS_SUB_MODEL_PART_SKIN_DETECTION_PROCESS_H_INCLUDED)
+#define KRATOS_SUB_MODEL_PART_SKIN_DETECTION_PROCESS_H_INCLUDED
+
+// System includes
+#include <string>
+#include <iostream>
+
+// Project includes
+#include "skin_detection_process.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/// Short class definition.
+/** Detail class definition.
+*/
+template<SizeType TDim>
+class SubModelPartSkinDetectionProcess: public SkinDetectionProcess<TDim>
+{
+public:
+///@name Type Definitions
+///@{
+
+/// Pointer definition of SubModelPartSkinDetectionProcess
+KRATOS_CLASS_POINTER_DEFINITION(SubModelPartSkinDetectionProcess);
+
+///@}
+///@name Life Cycle
+///@{
+
+/// Default constructor.
+SubModelPartSkinDetectionProcess();
+
+/// Deleted copy constructor.
+SubModelPartSkinDetectionProcess(SubModelPartSkinDetectionProcess const &rOther) = delete;
+
+/// Destructor.
+~SubModelPartSkinDetectionProcess() override = default;
+
+///@}
+///@name Operators
+///@{
+
+/// Deleted sssignment operator.
+SubModelPartSkinDetectionProcess &operator=(SubModelPartSkinDetectionProcess const &rOther) = delete;
+
+///@}
+///@name Operations
+///@{
+
+void Execute() override;
+
+///@}
+///@name Input and output
+///@{
+
+std::string Info() const override
+{
+    return "SkinDetectionProcess";
+}
+
+/// Print information about this object.
+void PrintInfo(std::ostream& rOStream) const override
+{
+    rOStream << "SkinDetectionProcess";
+}
+
+/// Print object's data.
+void PrintData(std::ostream& rOStream) const override
+{
+}
+
+///@}
+
+protected:
+///@name Protected static Member Variables
+///@{
+
+///@}
+///@name Protected member Variables
+///@{
+
+///@}
+///@name Protected Operators
+///@{
+
+///@}
+///@name Protected Operations
+///@{
+
+///@}
+///@name Protected  Access
+///@{
+
+///@}
+///@name Protected Inquiry
+///@{
+
+///@}
+///@name Protected LifeCycle
+///@{
+
+///@}
+
+private:
+///@name Static Member Variables
+///@{
+
+///@}
+///@name Member Variables
+///@{
+
+///@}
+///@name Private Operations
+///@{
+
+///@}
+
+}; // Class SubModelPartSkinDetectionProcess
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+template<SizeType TDim>
+inline std::istream &operator>>(std::istream &rIStream,
+                                SubModelPartSkinDetectionProcess<TDim> &rThis);
+
+/// output stream function
+template<SizeType TDim>
+inline std::ostream &operator<<(std::ostream &rOStream,
+                                const SubModelPartSkinDetectionProcess<TDim> &rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+///@}
+
+} // namespace Kratos.
+
+#endif // KRATOS_SUB_MODEL_PART_SKIN_DETECTION_PROCESS_H_INCLUDED  defined

--- a/kratos/processes/sub_model_part_skin_detection_process.h
+++ b/kratos/processes/sub_model_part_skin_detection_process.h
@@ -41,6 +41,12 @@ public:
 /// Pointer definition of SubModelPartSkinDetectionProcess
 KRATOS_CLASS_POINTER_DEFINITION(SubModelPartSkinDetectionProcess);
 
+using typename SkinDetectionProcess<TDim>::HashMapVectorIntType;
+using typename SkinDetectionProcess<TDim>::HashMapVectorIntIdsType;
+using typename SkinDetectionProcess<TDim>::VectorIndexType;
+
+using ConditionCheckType = bool(const Geometry<Node<3>>::PointsArrayType&);
+
 ///@}
 ///@name Life Cycle
 ///@{
@@ -108,6 +114,14 @@ protected:
 ///@name Protected Operations
 ///@{
 
+void CreateConditions(
+    ModelPart& rMainModelPart,
+    ModelPart& rSkinModelPart,
+    HashMapVectorIntType& rInverseFaceMap,
+    HashMapVectorIntIdsType& rPropertiesFaceMap,
+    std::unordered_set<IndexType>& rNodesInTheSkin,
+    const std::string& rConditionName) const override;
+
 Parameters GetDefaultSettings() const override;
 
 ///@}
@@ -132,9 +146,16 @@ private:
 ///@name Member Variables
 ///@{
 
+ConditionCheckType const* CreateThisFace;
+
 ///@}
 ///@name Private Operations
 ///@{
+
+static bool FaceIsNeeded(const Geometry<Node<3>>::PointsArrayType&)
+{
+    return true;
+}
 
 ///@}
 

--- a/kratos/processes/sub_model_part_skin_detection_process.h
+++ b/kratos/processes/sub_model_part_skin_detection_process.h
@@ -32,7 +32,7 @@ namespace Kratos
 /** For example, create the outer skin for the part of the domain belonging to a given SubModelPart.
 */
 template<SizeType TDim>
-class SubModelPartSkinDetectionProcess: public SkinDetectionProcess<TDim>
+class KRATOS_API(KRATOS_CORE) SubModelPartSkinDetectionProcess: public SkinDetectionProcess<TDim>
 {
 
 KRATOS_DEFINE_LOCAL_FLAG( NODE_SELECTED );

--- a/kratos/processes/sub_model_part_skin_detection_process.h
+++ b/kratos/processes/sub_model_part_skin_detection_process.h
@@ -31,7 +31,7 @@ namespace Kratos
 /// Short class definition.
 /** Detail class definition.
 */
-template<unsigned int TDim>
+template<SizeType TDim>
 class SubModelPartSkinDetectionProcess: public SkinDetectionProcess<TDim>
 {
 public:
@@ -68,7 +68,7 @@ SubModelPartSkinDetectionProcess &operator=(SubModelPartSkinDetectionProcess con
 ///@name Operations
 ///@{
 
-void Execute() override;
+//void Execute() override;
 
 ///@}
 ///@name Input and output
@@ -107,6 +107,8 @@ protected:
 ///@}
 ///@name Protected Operations
 ///@{
+
+Parameters GetDefaultSettings() const override;
 
 ///@}
 ///@name Protected  Access

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -56,6 +56,7 @@
 #include "processes/simple_mortar_mapper_process.h"
 #include "processes/simple_mortar_mapper_wrapper_process.h"
 #include "processes/skin_detection_process.h"
+#include "processes/sub_model_part_skin_detection_process.h"
 #include "processes/apply_periodic_boundary_condition_process.h"
 #include "processes/integration_values_extrapolation_to_nodes_process.h"
 #include "includes/node.h"
@@ -582,6 +583,16 @@ void  AddProcessesToPython(pybind11::module& m)
         .def(py::init<ModelPart&>())
         .def(py::init< ModelPart&, Parameters >())
         ;
+
+    py::class_<SubModelPartSkinDetectionProcess<2>, SubModelPartSkinDetectionProcess<2>::Pointer, SkinDetectionProcess<2>>
+    (m, "SubModelPartSkinDetectionProcess2D")
+    .def(py::init< ModelPart&, Parameters >())
+    ;
+
+    py::class_<SubModelPartSkinDetectionProcess<3>, SubModelPartSkinDetectionProcess<3>::Pointer, Process>
+    (m, "SubModelPartSkinDetectionProcess3D")
+    .def(py::init< ModelPart&, Parameters >())
+    ;
 
     py::class_<ApplyPeriodicConditionProcess, ApplyPeriodicConditionProcess::Pointer, Process>(m,"ApplyPeriodicConditionProcess")
             .def(py::init<ModelPart&,ModelPart&, Parameters>())

--- a/kratos/python/add_processes_to_python.cpp
+++ b/kratos/python/add_processes_to_python.cpp
@@ -589,7 +589,7 @@ void  AddProcessesToPython(pybind11::module& m)
     .def(py::init< ModelPart&, Parameters >())
     ;
 
-    py::class_<SubModelPartSkinDetectionProcess<3>, SubModelPartSkinDetectionProcess<3>::Pointer, Process>
+    py::class_<SubModelPartSkinDetectionProcess<3>, SubModelPartSkinDetectionProcess<3>::Pointer, SkinDetectionProcess<3>>
     (m, "SubModelPartSkinDetectionProcess3D")
     .def(py::init< ModelPart&, Parameters >())
     ;

--- a/kratos/python_scripts/sub_model_part_skin_detection_process.py
+++ b/kratos/python_scripts/sub_model_part_skin_detection_process.py
@@ -1,0 +1,18 @@
+from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
+
+# Importing the Kratos Library
+import KratosMultiphysics
+
+def Factory(settings, Model):
+    if(type(settings) != KratosMultiphysics.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+
+    main_model_part = Model.GetModelPart(
+        settings["Parameters"]["selection_settings"]["sub_model_part_name"].GetString()
+        ).GetRootModelPart()
+    domain_size = main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE]
+
+    if domain_size == 2:
+        return KratosMultiphysics.SubModelPartSkinDetectionProcess2D(main_model_part,settings["Parameters"])
+    else:
+        return KratosMultiphysics.SubModelPartSkinDetectionProcess3D(main_model_part,settings["Parameters"])

--- a/kratos/tests/auxiliar_files_for_python_unnitest/mdpa_files/coarse_sphere.mdpa
+++ b/kratos/tests/auxiliar_files_for_python_unnitest/mdpa_files/coarse_sphere.mdpa
@@ -423,3 +423,25 @@ Begin SubModelPart Skin_Part
     Begin SubModelPartConditions
     End SubModelPartConditions
 End SubModelPart
+
+Begin SubModelPart Partial_Skin_Part
+    Begin SubModelPartNodes
+            34
+            37
+            48
+            51
+            52
+            60
+            64
+            68
+            70
+            73
+            74
+            79
+            80
+    End SubModelPartNodes
+    Begin SubModelPartElements
+    End SubModelPartElements
+    Begin SubModelPartConditions
+    End SubModelPartConditions
+End SubModelPart

--- a/kratos/tests/test_skin_detection_process.py
+++ b/kratos/tests/test_skin_detection_process.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
+from KratosMultiphysics.gid_output_process import GiDOutputProcess
 import os
 
 def GetFilePath(fileName):
@@ -52,7 +53,6 @@ class TestSkinDetectionProcess(KratosUnittest.TestCase):
         self.assertEqual(model_part.GetSubModelPart("Skin_Part").NumberOfConditions(), model_part.NumberOfConditions())
 
     def _post_process(self, model_part):
-        from gid_output_process import GiDOutputProcess
         gid_output = GiDOutputProcess(model_part,
                                     "gid_output",
                                     KratosMultiphysics.Parameters("""
@@ -86,14 +86,21 @@ class TestSkinDetectionProcess(KratosUnittest.TestCase):
         model_part_io.ReadModelPart(model_part)
 
         # We set a flag in the already knon node in the skin
-        for node in model_part.GetSubModelPart("Skin_Part").Nodes:
+        for node in model_part.GetSubModelPart("Partial_Skin_Part").Nodes:
             node.Set(KratosMultiphysics.ACTIVE, True)
 
-        detect_skin = KratosMultiphysics.SubModelPartSkinDetectionProcess3D(model_part, KratosMultiphysics.Parameters(r'{}'))
+        detect_skin = KratosMultiphysics.SubModelPartSkinDetectionProcess3D(model_part, KratosMultiphysics.Parameters(r"""
+        {
+            "name_auxiliar_model_part": "SkinModelPart",
+            "selection_criteria": "nodes_on_sub_model_part",
+            "selection_settings": {
+                "sub_model_part_name" : "Partial_Skin_Part"
+            }
+        }"""))
         detect_skin.Execute()
 
         ## DEBUG
-        #self._post_process(model_part)
+        self._post_process(model_part)
 
         for node in model_part.Nodes:
             self.assertEqual(node.Is(KratosMultiphysics.INTERFACE), node.Is(KratosMultiphysics.ACTIVE))

--- a/kratos/tests/test_skin_detection_process.py
+++ b/kratos/tests/test_skin_detection_process.py
@@ -77,5 +77,26 @@ class TestSkinDetectionProcess(KratosUnittest.TestCase):
         gid_output.ExecuteFinalizeSolutionStep()
         gid_output.ExecuteFinalize()
 
+    def test_SubModelPartSkinDetectionProcess(self):
+        current_model = KratosMultiphysics.Model()
+
+        KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
+        model_part = current_model.CreateModelPart("Main")
+        model_part_io = KratosMultiphysics.ModelPartIO(GetFilePath("auxiliar_files_for_python_unnitest/mdpa_files/coarse_sphere"))
+        model_part_io.ReadModelPart(model_part)
+
+        # We set a flag in the already knon node in the skin
+        for node in model_part.GetSubModelPart("Skin_Part").Nodes:
+            node.Set(KratosMultiphysics.ACTIVE, True)
+
+        detect_skin = KratosMultiphysics.SubModelPartSkinDetectionProcess3D(model_part, KratosMultiphysics.Parameters(r'{}'))
+        detect_skin.Execute()
+
+        ## DEBUG
+        #self._post_process(model_part)
+
+        for node in model_part.Nodes:
+            self.assertEqual(node.Is(KratosMultiphysics.INTERFACE), node.Is(KratosMultiphysics.ACTIVE))
+
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/tests/test_skin_detection_process.py
+++ b/kratos/tests/test_skin_detection_process.py
@@ -100,7 +100,7 @@ class TestSkinDetectionProcess(KratosUnittest.TestCase):
         detect_skin.Execute()
 
         ## DEBUG
-        self._post_process(model_part)
+        #self._post_process(model_part)
 
         for node in model_part.Nodes:
             self.assertEqual(node.Is(KratosMultiphysics.INTERFACE), node.Is(KratosMultiphysics.ACTIVE))


### PR DESCRIPTION
I need to work with input files translated from Nastran input format for thermal flows, which unfortunately applies heat flux conditions nodally. In practice, this means that I have a list of nodes on the surface of my model (given as a node-only SubModelPart) and I need to generate a triangulation from it. Other conditions are already given as triangles, so I cannot just use the standard SkinDetectionProcess (I would end up with duplicate conditions in some parts).

I solved my problem by implementing a derived version of the SkinDetectionProcess that only creates the skin Condition if a certain requirement is met. In this case, the Condition is only created if all nodes belong to the SubModelPart, although it could be enhanced to support other conditions in the future.

This PR includes some refactoring of the base class to allow me to reimplement only the parts that behave differently. In this sense, the base class modifications should not change the existing logic at all.

A test has also been added.