### PR TITLE
[Core][ModelpartIO] improve error message for hanging nodes

### DIFF
--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -576,7 +576,7 @@ std::size_t ModelPartIO::ReadNodalGraph(ConnectivitiesContainerType& rAuxConnect
     for (const auto& r_conn : rAuxConnectivities) {
         n++;
         KRATOS_ERROR_IF(r_conn.size() == 0) << "Node #" << n << " caused an error during the construction of the nodal graph. Possible reasons are:\n"
-            << "The node is a hanging node node, not connected to any element or condition\n"
+            << "The node is a hanging node, not connected to any element or condition\n"
             << "The nodes are not consecutively numbered. This can be avoided by using the \"ReorderConsecutiveModelPartIO\"" << std::endl;
     }
 

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -573,7 +573,7 @@ std::size_t ModelPartIO::ReadNodalGraph(ConnectivitiesContainerType& rAuxConnect
 
     // Check for hanging nodes
     SizeType n=0;
-    for (const auto r_conn : rAuxConnectivities) {
+    for (const auto& r_conn : rAuxConnectivities) {
         n++;
         KRATOS_ERROR_IF(r_conn.size() == 0) << "Node #" << n << " is a hanging node, not connected to any element or condition. Hence it is not possible to create the nodal graph, please check your input" << std::endl;
     }

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -571,11 +571,13 @@ std::size_t ModelPartIO::ReadNodalGraph(ConnectivitiesContainerType& rAuxConnect
         }
     }
 
-    // Check for hanging nodes
+    // Checking the connectivities
     SizeType n=0;
     for (const auto& r_conn : rAuxConnectivities) {
         n++;
-        KRATOS_ERROR_IF(r_conn.size() == 0) << "Node #" << n << " is a hanging node, not connected to any element or condition. Hence it is not possible to create the nodal graph, please check your input" << std::endl;
+        KRATOS_ERROR_IF(r_conn.size() == 0) << "Node #" << n << " caused an error during the construction of the nodal graph. Possible reasons are:\n"
+            << "The node is a hanging node node, not connected to any element or condition\n"
+            << "The nodes are not consecutively numbered. This can be avoided by using the \"ReorderConsecutiveModelPartIO\"" << std::endl;
     }
 
     // 3. Sort each entry in the auxiliary connectivities vector, remove duplicates

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -571,17 +571,11 @@ std::size_t ModelPartIO::ReadNodalGraph(ConnectivitiesContainerType& rAuxConnect
         }
     }
 
-    // Check that node indices are consecutive
-    unsigned int n = 0;
-    for (ConnectivitiesContainerType::iterator inode = rAuxConnectivities.begin(); inode != rAuxConnectivities.end(); inode++)
-    {
+    // Check for hanging nodes
+    SizeType n=0;
+    for (const auto r_conn : rAuxConnectivities) {
         n++;
-        if (inode->size() == 0)
-        {
-            std::stringstream msg;
-            msg << "Nodes are not consecutively numbered. Node " << n << " was not found in mdpa file." << std::endl;
-            KRATOS_ERROR << msg.str() << std::endl;
-        }
+        KRATOS_ERROR_IF(r_conn.size() == 0) << "Node #" << n << " is a hanging node, not connected to any element or condition. Hence it is not possible to create the nodal graph, please check your input" << std::endl;
     }
 
     // 3. Sort each entry in the auxiliary connectivities vector, remove duplicates


### PR DESCRIPTION
After speaking to @jcotela we realized that the error message is misleading, it is actually checking for hanging nodes, which is a no-go for the creation of the nodal graph.

Maybe we should add an option to skip the hanging nodes (separate discussion)

FYI @AndreasWinterstein 