### PR TITLE
[External] Compilation fix in triangle.c without cotire 

### DIFF
--- a/external_libraries/triangle/triangle.c
+++ b/external_libraries/triangle/triangle.c
@@ -343,6 +343,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stddef.h>
 #include <math.h>
 #ifndef NO_TIMER
 #include <sys/time.h>


### PR DESCRIPTION
Just that, a  missing include