### PR TITLE
[SDEM] Setting properly move_mesh in sdem. Pfem test fixed

### DIFF
--- a/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_solver.py
+++ b/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_solver.py
@@ -46,6 +46,7 @@ class SwimmingDEMSolver(PythonSolver):
         nodal_area_process_parameters = non_optional_solver_processes[non_optional_solver_processes.size() -1]["Parameters"]
         nodal_area_process_parameters["model_part_name"].SetString(self.fluid_solver.main_model_part.Name)
         nodal_area_process_parameters["domain_size"].SetInt(self.fluid_domain_dimension)
+        the_mesh_moves = False
         if self.fluid_solver.settings.Has('move_mesh_flag'):
             the_mesh_moves = self.fluid_solver.settings["move_mesh_flag"].GetBool()
             nodal_area_process_parameters["fixed_mesh"].SetBool(not the_mesh_moves)
@@ -55,7 +56,7 @@ class SwimmingDEMSolver(PythonSolver):
         elif self.fluid_solver.settings["solvers"][0]["Parameters"]["time_integration_settings"].Has('move_mesh_flag'):
             the_mesh_moves = self.fluid_solver.settings["solvers"][0]["Parameters"]["time_integration_settings"]["move_mesh_flag"].GetBool()
             nodal_area_process_parameters["fixed_mesh"].SetBool(not the_mesh_moves)
-        self.move_mesh_flag = self.GetTimeIntegrationMoveMeshFlag()
+        self.move_mesh_flag = the_mesh_moves
         return project_parameters
 
     def __init__(self, model, project_parameters, field_utility, fluid_solver, dem_solver, variables_manager):
@@ -305,9 +306,3 @@ class SwimmingDEMSolver(PythonSolver):
 
     def GetComputingModelPart(self):
         return self.dem_solver.spheres_model_part
-
-    def GetTimeIntegrationMoveMeshFlag(self):
-        move_mesh_flag = False
-        if self.fluid_solver.settings.Has('time_integration_settings'):
-            move_mesh_flag = self.fluid_solver.settings["time_integration_settings"]["move_mesh_flag"].GetBool()
-        return move_mesh_flag

--- a/applications/SwimmingDEMApplication/tests/PFEM-DEM_tests/ProjectParameters.json
+++ b/applications/SwimmingDEMApplication/tests/PFEM-DEM_tests/ProjectParameters.json
@@ -134,6 +134,7 @@
             "input_type" : "mdpa",
             "input_filename" : "PFEM-DEM_tests/sdem_pfem_coupling_one_way_test"
         },
+        "move_mesh_flag": false,
         "maximum_pressure_iterations" : 7,
         "velocity_tolerance" : 1e-5,
         "pressure_tolerance" : 1e-5,
@@ -351,7 +352,7 @@
     "do_search_neighbours" : true,
     "type_of_dem_inlet" : "VelocityImposed",
     "type_of_dem_inlet_comment" : "VelocityImposed or ForceImposed",
-    "translational_integration_scheme" : "Hybrid_Bashforth"
+    "translational_integration_scheme" : "Symplectic_Euler"
 },
 
 "dem_parameters" : {


### PR DESCRIPTION
- The move_mesh flag was not properly recovered from PFEMFluid ProjectParameters.json. This PR fixes that.

- Now all SDEM tests run ok in FullDebug mode.

@MZecchetto and @joaquinirazabal , bear in mind that the pfem-dem test included here has the move_mesh_flag set to false in order to speed up the test. Normally, in pfem-dem simulations, you should set this flag to **true**.