### PR TITLE
[Core] Removing warnings nurbs utilities

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -91,6 +91,7 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/exact_mortar_segmentation_utility.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/timer.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/geometrical_transformation_utilities.cpp;
+    ${CMAKE_CURRENT_SOURCE_DIR}/geometries/nurbs_shape_function_utilities/nurbs_utilities.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/tetrahedra_ball.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/tetrahedra_edge_shell.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modified_shape_functions/modified_shape_functions.cpp;

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.cpp
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.cpp
@@ -1,0 +1,111 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Thomas Oberbichler
+//
+//  Ported from the ANurbs library (https://github.com/oberbichler/ANurbs)
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "geometries/nurbs_shape_function_utilities/nurbs_utilities.h"
+
+namespace Kratos {
+
+namespace NurbsUtilities
+{
+
+std::size_t GetUpperSpan(
+    const std::size_t PolynomialDegree,
+    const Vector& rKnots,
+    const double ParameterT
+    )
+{
+    const auto span = std::upper_bound(std::begin(rKnots) + PolynomialDegree,
+        std::end(rKnots) - PolynomialDegree, ParameterT) - std::begin(rKnots) - 1;
+    return span;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t GetLowerSpan(
+    const std::size_t PolynomialDegree,
+    const Vector& rKnots,
+    const double ParameterT
+    )
+{
+    const auto span = std::lower_bound(std::begin(rKnots) + PolynomialDegree,
+        std::end(rKnots) - PolynomialDegree, ParameterT) - std::begin(rKnots) - 1;
+    return span;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t GetPolynomialDegree(
+    const std::size_t NumberOfKnots, 
+    const std::size_t NumberOfControlPoints
+    )
+{
+    return NumberOfKnots - NumberOfControlPoints + 1;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t GetNumberOfKnots(
+    const std::size_t PolynomialDegree, 
+    const std::size_t NumberOfControlPoints
+    )
+{
+    return NumberOfControlPoints + PolynomialDegree - 1;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t GetNumberOfControlPoints(
+    const std::size_t PolynomialDegree, 
+    const std::size_t NumberOfKnots
+    )
+{
+    return NumberOfKnots - PolynomialDegree + 1;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::size_t GetNumberOfSpans(
+    const std::size_t PolynomialDegree, 
+    const std::size_t NumberOfKnots
+    )
+{
+    return NumberOfKnots - 2 * PolynomialDegree + 1;
+}
+
+/***********************************************************************************/
+/***********************************************************************************/
+
+std::pair<std::size_t, std::size_t> GetMatrixIndicesFromVectorIndex(
+    const std::size_t NumberPerRow,
+    const std::size_t NumberPerColumn,
+    const std::size_t Index
+    ) noexcept
+{
+    const IndexType row = Index % NumberPerRow;
+    const IndexType col = Index / NumberPerRow;
+
+    return std::make_pair(row, col);
+}
+}; // class NurbsUtility
+} // namespace Kratos

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h
@@ -26,18 +26,20 @@ namespace Kratos {
 ///@name Kratos Classes
 ///@{
 
-/// Utility functions for NURBS computation
-/*
-* Provides universal geometrical utiltity functions for the computation of
-* curve and surface NURBS/ B-Spline shape functions.
+/**
+ * @namespace NurbsUtilities
+ * @ingroup KratosCore
+ * @brief Utility functions for NURBS computation
+ * @details Provides universal geometrical utiltity functions for the computation of curve and surface NURBS/ B-Spline shape functions.
+ * @author Thomas Oberbichler
  */
 namespace NurbsUtilities
 {
     ///@name Type Definitions
     ///@{
 
-    typedef typename std::size_t IndexType;
-    typedef typename std::size_t SizeType;
+    typedef std::size_t IndexType;
+    typedef std::size_t SizeType;
 
     ///@}
     ///@name Static Operations

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h
@@ -16,10 +16,15 @@
 #define  KRATOS_NURBS_UTILITY_H_INCLUDED
 
 // System includes
+#include <utility>
+#include <algorithm>
+#include <iterator>
 
 // External includes
 
 // Project includes
+#include "includes/define.h"
+#include "spaces/ublas_space.h"
 
 namespace Kratos {
 
@@ -47,76 +52,71 @@ namespace NurbsUtilities
     
     /**
      * @brief the index of the upper limit of the span in which the ParameterT lays.
-     * From Piegl and Tiller, The NURBS Book, Algorithm A2.1
+     * @note From Piegl and Tiller, The NURBS Book, Algorithm A2.1
      */
-    static IndexType GetUpperSpan(
+    IndexType KRATOS_API(KRATOS_CORE) GetUpperSpan(
         const SizeType PolynomialDegree,
         const Vector& rKnots,
-        const double ParameterT)
-    {
-        const auto span = std::upper_bound(std::begin(rKnots) + PolynomialDegree,
-            std::end(rKnots) - PolynomialDegree, ParameterT) - std::begin(rKnots) - 1;
-        return span;
-    }
+        const double ParameterT
+        );
 
     /**
      * @brief the index of the lower limit of the span in which the ParameterT lays.
-     * From Piegl and Tiller, The NURBS Book, Algorithm A2.1
+     * @note From Piegl and Tiller, The NURBS Book, Algorithm A2.1
      */
-    static IndexType GetLowerSpan(
+    IndexType KRATOS_API(KRATOS_CORE) GetLowerSpan(
         const SizeType PolynomialDegree,
         const Vector& rKnots,
-        const double ParameterT)
-    {
-        const auto span = std::lower_bound(std::begin(rKnots) + PolynomialDegree,
-            std::end(rKnots) - PolynomialDegree, ParameterT) - std::begin(rKnots) - 1;
-        return span;
-    }
+        const double ParameterT
+        );
 
     /**
      * @brief Computes the degree of a nurbs/ b-spline shape by:
      * @param NumberOfKnots and
      * @param NumberOfControlPoints
      */
-    static SizeType GetPolynomialDegree(const SizeType NumberOfKnots, const SizeType NumberOfControlPoints)
-    {
-        return NumberOfKnots - NumberOfControlPoints + 1;
-    }
-
+    SizeType KRATOS_API(KRATOS_CORE) GetPolynomialDegree(
+        const SizeType NumberOfKnots, 
+        const SizeType NumberOfControlPoints
+        );
+    
     /**
      * @brief Computes the number of knots of a nurbs/ b-spline shape by:
      * @param PolynomialDegree and
      * @param NumberOfControlPoints
      */
-    static SizeType GetNumberOfKnots(const SizeType PolynomialDegree, const SizeType NumberOfControlPoints)
-    {
-        return NumberOfControlPoints + PolynomialDegree - 1;
-    }
+    SizeType KRATOS_API(KRATOS_CORE) GetNumberOfKnots(
+        const SizeType PolynomialDegree, 
+        const SizeType NumberOfControlPoints
+        );
 
     /**
      * @brief Computes the number of control points of a nurbs/ b-spline shape by:
      * @param PolynomialDegree and
      * @param NumberOfKnots
      */
-    static SizeType GetNumberOfControlPoints(const SizeType PolynomialDegree, const SizeType NumberOfKnots)
-    {
-        return NumberOfKnots - PolynomialDegree + 1;
-    }
+    SizeType KRATOS_API(KRATOS_CORE) GetNumberOfControlPoints(
+        const SizeType PolynomialDegree, 
+        const SizeType NumberOfKnots
+        );
 
     /**
      * @brief Computes the number of spans of a nurbs/ b-spline shape by:
      * @param PolynomialDegree and
      * @param NumberOfKnots
      */
-    SizeType GetNumberOfSpans(const SizeType PolynomialDegree, const SizeType NumberOfKnots)
-    {
-        return NumberOfKnots - 2 * PolynomialDegree + 1;
-    }
+    SizeType KRATOS_API(KRATOS_CORE) GetNumberOfSpans(
+        const SizeType PolynomialDegree, 
+        const SizeType NumberOfKnots
+        );
 
-    /*
-    * @brief Computes the binomial coefficient for (N || K).
-    */
-    static constexpr inline SizeType GetBinomCoefficient(const SizeType N, const SizeType K) noexcept
+    /**
+     * @brief Computes the binomial coefficient for (N || K).
+     */
+    constexpr inline SizeType GetBinomCoefficient(
+        const SizeType N, 
+        const SizeType K
+        ) noexcept
     {
         // clang-format off
         return
@@ -129,32 +129,31 @@ namespace NurbsUtilities
         // clang-format on
     }
 
-
     /**
      * @brief Computes a vector index from two matrix indicies.
      * @return index within vector
      */
-    static constexpr inline IndexType GetVectorIndexFromMatrixIndices(
-        const SizeType NumberPerRow, const SizeType NumberPerColumn,
-        const IndexType RowIndex, const IndexType ColumnIndex) noexcept
+    constexpr inline IndexType GetVectorIndexFromMatrixIndices(
+        const SizeType NumberPerRow, 
+        const SizeType NumberPerColumn,
+        const IndexType RowIndex, 
+        const IndexType ColumnIndex
+        ) noexcept
     {
         return ColumnIndex * NumberPerRow + RowIndex;
     }
+
 
     /**
      * @brief Computes two matrix indices from vector index.
      * @return indices within Matrix
      */
-    static inline std::pair<IndexType, IndexType> GetMatrixIndicesFromVectorIndex(
+    inline std::pair<IndexType, IndexType> KRATOS_API(KRATOS_CORE) GetMatrixIndicesFromVectorIndex(
         const SizeType NumberPerRow,
         const SizeType NumberPerColumn,
-        const IndexType Index) noexcept
-    {
-        const IndexType row = Index % NumberPerRow;
-        const IndexType col = Index / NumberPerRow;
-
-        return std::make_pair(row, col);
-    }
+        const IndexType Index
+        ) noexcept;
+        
     ///@}
 }; // class NurbsUtility
 ///@}

--- a/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h
+++ b/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h
@@ -44,10 +44,11 @@ namespace NurbsUtilities
     ///@}
     ///@name Static Operations
     ///@{
-    /*
-    * @brief the index of the upper limit of the span in which the ParameterT lays.
-    * From Piegl and Tiller, The NURBS Book, Algorithm A2.1
-    */
+    
+    /**
+     * @brief the index of the upper limit of the span in which the ParameterT lays.
+     * From Piegl and Tiller, The NURBS Book, Algorithm A2.1
+     */
     static IndexType GetUpperSpan(
         const SizeType PolynomialDegree,
         const Vector& rKnots,
@@ -58,10 +59,10 @@ namespace NurbsUtilities
         return span;
     }
 
-    /*
-    * @brief the index of the lower limit of the span in which the ParameterT lays.
-    * From Piegl and Tiller, The NURBS Book, Algorithm A2.1
-    */
+    /**
+     * @brief the index of the lower limit of the span in which the ParameterT lays.
+     * From Piegl and Tiller, The NURBS Book, Algorithm A2.1
+     */
     static IndexType GetLowerSpan(
         const SizeType PolynomialDegree,
         const Vector& rKnots,
@@ -72,42 +73,42 @@ namespace NurbsUtilities
         return span;
     }
 
-    /*
-    * @brief Computes the degree of a nurbs/ b-spline shape by:
-    * @param NumberOfKnots and
-    * @param NumberOfControlPoints
-    */
+    /**
+     * @brief Computes the degree of a nurbs/ b-spline shape by:
+     * @param NumberOfKnots and
+     * @param NumberOfControlPoints
+     */
     static SizeType GetPolynomialDegree(const SizeType NumberOfKnots, const SizeType NumberOfControlPoints)
     {
         return NumberOfKnots - NumberOfControlPoints + 1;
     }
 
-    /*
-    * @brief Computes the number of knots of a nurbs/ b-spline shape by:
-    * @param PolynomialDegree and
-    * @param NumberOfControlPoints
-    */
+    /**
+     * @brief Computes the number of knots of a nurbs/ b-spline shape by:
+     * @param PolynomialDegree and
+     * @param NumberOfControlPoints
+     */
     static SizeType GetNumberOfKnots(const SizeType PolynomialDegree, const SizeType NumberOfControlPoints)
     {
         return NumberOfControlPoints + PolynomialDegree - 1;
     }
 
-    /*
-    * @brief Computes the number of control points of a nurbs/ b-spline shape by:
-    * @param PolynomialDegree and
-    * @param NumberOfKnots
-    */
+    /**
+     * @brief Computes the number of control points of a nurbs/ b-spline shape by:
+     * @param PolynomialDegree and
+     * @param NumberOfKnots
+     */
     static SizeType GetNumberOfControlPoints(const SizeType PolynomialDegree, const SizeType NumberOfKnots)
     {
         return NumberOfKnots - PolynomialDegree + 1;
     }
 
-    /*
-    * @brief Computes the number of spans of a nurbs/ b-spline shape by:
-    * @param PolynomialDegree and
-    * @param NumberOfKnots
-    */
-    static SizeType GetNumberOfSpans(const SizeType PolynomialDegree, const SizeType NumberOfKnots)
+    /**
+     * @brief Computes the number of spans of a nurbs/ b-spline shape by:
+     * @param PolynomialDegree and
+     * @param NumberOfKnots
+     */
+    SizeType GetNumberOfSpans(const SizeType PolynomialDegree, const SizeType NumberOfKnots)
     {
         return NumberOfKnots - 2 * PolynomialDegree + 1;
     }
@@ -129,10 +130,10 @@ namespace NurbsUtilities
     }
 
 
-    /*
-    * @brief Computes a vector index from two matrix indicies.
-    * @return index within vector
-    */
+    /**
+     * @brief Computes a vector index from two matrix indicies.
+     * @return index within vector
+     */
     static constexpr inline IndexType GetVectorIndexFromMatrixIndices(
         const SizeType NumberPerRow, const SizeType NumberPerColumn,
         const IndexType RowIndex, const IndexType ColumnIndex) noexcept
@@ -140,10 +141,10 @@ namespace NurbsUtilities
         return ColumnIndex * NumberPerRow + RowIndex;
     }
 
-    /*
-    * @brief Computes two matrix indices from vector index.
-    * @return indices within Matrix
-    */
+    /**
+     * @brief Computes two matrix indices from vector index.
+     * @return indices within Matrix
+     */
     static inline std::pair<IndexType, IndexType> GetMatrixIndicesFromVectorIndex(
         const SizeType NumberPerRow,
         const SizeType NumberPerColumn,


### PR DESCRIPTION
~~~sh
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:63:22: warning: ‘Kratos::NurbsUtilities::IndexType Kratos::NurbsUtilities::GetLowerSpan(Kratos::NurbsUtilities::SizeType, const Vector&, double)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:78:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetPolynomialDegree(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:98:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfControlPoints(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:108:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfSpans(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:78:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetPolynomialDegree(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:88:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfKnots(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:108:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfSpans(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:78:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetPolynomialDegree(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:108:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfSpans(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:78:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetPolynomialDegree(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:88:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfKnots(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:98:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfControlPoints(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:108:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfSpans(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:78:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetPolynomialDegree(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:88:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfKnots(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:108:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfSpans(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:78:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetPolynomialDegree(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:108:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfSpans(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:63:22: warning: ‘Kratos::NurbsUtilities::IndexType Kratos::NurbsUtilities::GetLowerSpan(Kratos::NurbsUtilities::SizeType, const Vector&, double)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:78:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetPolynomialDegree(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:98:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfControlPoints(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
/home/ubuntu/Kratos/kratos/geometries/nurbs_shape_function_utilities/nurbs_utilities.h:108:21: warning: ‘Kratos::NurbsUtilities::SizeType Kratos::NurbsUtilities::GetNumberOfSpans(Kratos::NurbsUtilities::SizeType, Kratos::NurbsUtilities::SizeType)’ defined but not used [-Wunused-function]
~~~