### PR TITLE
[ShapeOpt] Adding stopping criteria in trust region algorith by relative tolerance

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_penalized_projection.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_penalized_projection.py
@@ -205,8 +205,8 @@ class AlgorithmPenalizedProjection(OptimizationAlgorithm):
                 return True
 
             # Check for relative tolerance
-            relativeChangeOfObjectiveValue = self.data_logger.GetValues("rel_change_objective")[self.optimization_iteration]
-            if abs(relativeChangeOfObjectiveValue) < self.relative_tolerance:
+            relative_change_of_objective_value = self.data_logger.GetValues("rel_change_objective")[self.optimization_iteration]
+            if abs(relative_change_of_objective_value) < self.relative_tolerance:
                 KM.Logger.Print("")
                 KM.Logger.PrintInfo("ShapeOpt", "Optimization problem converged within a relative objective tolerance of ",self.relative_tolerance,"%.")
                 return True

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_steepest_descent.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_steepest_descent.py
@@ -239,8 +239,8 @@ class AlgorithmSteepestDescent(OptimizationAlgorithm):
                     return True
 
             # Check for relative tolerance
-            relativeChangeOfObjectiveValue = self.data_logger.GetValues("rel_change_objective")[self.optimization_iteration]
-            if abs(relativeChangeOfObjectiveValue) < self.relative_tolerance:
+            relative_change_of_objective_value = self.data_logger.GetValues("rel_change_objective")[self.optimization_iteration]
+            if abs(relative_change_of_objective_value) < self.relative_tolerance:
                 KM.Logger.Print("")
                 KM.Logger.PrintInfo("ShapeOpt", "Optimization problem converged within a relative objective tolerance of ",self.relative_tolerance,"%.")
                 return True

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
@@ -138,6 +138,7 @@ class AlgorithmTrustRegion(OptimizationAlgorithm):
         self.analyzer.FinalizeAfterOptimizationLoop()
         self.data_logger.FinalizeDataLogging()
 
+    # --------------------------------------------------------------------------
     def __isAlgorithmConverged(self):
 
         if self.opt_iteration > 1 :

--- a/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/algorithm_trust_region.py
@@ -149,8 +149,8 @@ class AlgorithmTrustRegion(OptimizationAlgorithm):
                 return True
 
             # Check for relative tolerance
-            relativeChangeOfObjectiveValue = self.data_logger.GetValues("rel_change_objective")[self.opt_iteration]
-            if abs(relativeChangeOfObjectiveValue) < self.algorithm_settings["relative_tolerance"].GetDouble():
+            relative_change_of_objective_value = self.data_logger.GetValues("rel_change_objective")[self.opt_iteration]
+            if abs(relative_change_of_objective_value) < self.algorithm_settings["relative_tolerance"].GetDouble():
                 KM.Logger.Print("")
                 KM.Logger.PrintInfo("ShapeOpt", "Optimization problem converged within a relative objective tolerance of ",self.algorithm_settings["relative_tolerance"].GetDouble(),"%.")
                 return True


### PR DESCRIPTION
Hi!

Current trust region algorithm does not have an stopping criteria (apart from the maximum iterations limit). Is there an specific reason for this related to the algorithm or is it something that was simply not done yet?

In this PR I'm adding an stopping criteria with the relative tolerance, using the same function as the steepest descent algorithm to check if the algorithm is converged.

