### PR TITLE
[ShapeOpt] Using scientific notation for rel. and abs. tolerances in trust region

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/value_logger_trust_region.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/value_logger_trust_region.py
@@ -79,8 +79,8 @@ class ValueLoggerTrustRegion( ValueLogger ):
 
             objective_id = self.objectives[0]["identifier"].GetString()
             row.append(" {:> .5E}".format(self.history["response_value"][objective_id][self.current_index]))
-            row.append("{:>12f}".format(self.history["abs_change_objective"][self.current_index]))
-            row.append("{:>12f}".format(self.history["rel_change_objective"][self.current_index]))
+            row.append(" {:> .5E}".format(self.history["abs_change_objective"][self.current_index]))
+            row.append(" {:> .5E}".format(self.history["rel_change_objective"][self.current_index]))
 
             for itr in range(self.constraints.size()):
                 constraint_id = self.constraints[itr]["identifier"].GetString()


### PR DESCRIPTION
Hi, 

In the value_logger of the trust region algorithm, the absolute and relative tolerances are written as floats. For the rest of algorithms these are written using scientific notation.

In this PR I switch to scientific notation in the trust region algorithm as well, which in my opinion is also easier to read when tolerance values approach to 0.

Before
![image](https://user-images.githubusercontent.com/32136457/68405812-0b498d00-0181-11ea-9942-4fd818eb9866.png)

After
![image](https://user-images.githubusercontent.com/32136457/68405858-1f8d8a00-0181-11ea-93d3-eda111c5e7f4.png)
