### PR TITLE
[Core] add clone method to python interface of properties

### DIFF
--- a/kratos/python/add_properties_to_python.cpp
+++ b/kratos/python/add_properties_to_python.cpp
@@ -106,6 +106,12 @@ typename Properties::TableType& GetTableHelperFunction1( TContainerType& el,
     return el.GetTable(XVar, YVar);
 }
 
+Properties::Pointer CloneProperties(const Properties& rReference){
+    Properties::Pointer p_new_properties = Kratos::make_shared<Properties>(rReference.Id());
+    *p_new_properties = rReference;
+    return p_new_properties;
+}
+
 void  AddPropertiesToPython(pybind11::module& m)
 {
     py::class_<Properties, Properties::Pointer, Properties::BaseType >(m,"Properties")
@@ -178,6 +184,8 @@ void  AddPropertiesToPython(pybind11::module& m)
     .def("HasTables", &Properties::HasTables)
     .def("IsEmpty", &Properties::IsEmpty)
     .def("__str__", PrintObject<Properties>)
+
+    .def("Clone", [](const Properties& rSelf){ return CloneProperties(rSelf); })
     ;
 
     PointerVectorSetPythonInterface<MeshType::PropertiesContainerType>().CreateInterface(m,"PropertiesArray");

--- a/kratos/python/add_properties_to_python.cpp
+++ b/kratos/python/add_properties_to_python.cpp
@@ -111,6 +111,7 @@ void  AddPropertiesToPython(pybind11::module& m)
 {
     py::class_<Properties, Properties::Pointer, Properties::BaseType >(m,"Properties")
     .def(py::init<Kratos::Properties::IndexType>())
+    .def(py::init<const Properties&>())
     .def("__setitem__", SetValueHelperFunction1< Properties, Variable< array_1d<double, 6> > >)
     .def("__getitem__", GetValueHelperFunction1< Properties, Variable< array_1d<double, 6> > >)
     .def("Has", HasHelperFunction_Element< Properties, Variable< array_1d<double, 6> > >)
@@ -179,8 +180,6 @@ void  AddPropertiesToPython(pybind11::module& m)
     .def("HasTables", &Properties::HasTables)
     .def("IsEmpty", &Properties::IsEmpty)
     .def("__str__", PrintObject<Properties>)
-
-    .def("Clone", [](Properties::Pointer pSelf){ return Kratos::make_shared<Properties>(*pSelf); })
     ;
 
     PointerVectorSetPythonInterface<MeshType::PropertiesContainerType>().CreateInterface(m,"PropertiesArray");

--- a/kratos/python/add_properties_to_python.cpp
+++ b/kratos/python/add_properties_to_python.cpp
@@ -106,11 +106,6 @@ typename Properties::TableType& GetTableHelperFunction1( TContainerType& el,
     return el.GetTable(XVar, YVar);
 }
 
-Properties::Pointer CloneProperties(const Properties& rReference){
-    Properties::Pointer p_new_properties = Kratos::make_shared<Properties>(rReference.Id());
-    *p_new_properties = rReference;
-    return p_new_properties;
-}
 
 void  AddPropertiesToPython(pybind11::module& m)
 {
@@ -185,7 +180,7 @@ void  AddPropertiesToPython(pybind11::module& m)
     .def("IsEmpty", &Properties::IsEmpty)
     .def("__str__", PrintObject<Properties>)
 
-    .def("Clone", [](const Properties& rSelf){ return CloneProperties(rSelf); })
+    .def("Clone", [](Properties::Pointer pSelf){ return Kratos::make_shared<Properties>(*pSelf); })
     ;
 
     PointerVectorSetPythonInterface<MeshType::PropertiesContainerType>().CreateInterface(m,"PropertiesArray");

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -18,6 +18,7 @@ import test_linear_solvers
 import test_eigen_solvers
 import test_condition_number
 import test_processes
+import test_properties
 import test_importing
 import test_connectivity_preserve_modeler
 import test_model
@@ -75,6 +76,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_eigen_solvers.TestEigenSolvers]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_condition_number.TestConditionNumber]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_processes.TestProcesses]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_properties.TestProperties]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_importing.TestImporting]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_connectivity_preserve_modeler.TestConnectivityPreserveModeler]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_model.TestModel]))

--- a/kratos/tests/test_properties.py
+++ b/kratos/tests/test_properties.py
@@ -3,7 +3,7 @@ import KratosMultiphysics as KM
 
 class TestProperties(KratosUnittest.TestCase):
 
-    def test_clone_properties(self):
+    def test_copy_properties(self):
         current_model = KM.Model()
 
         model_part= current_model.CreateModelPart("Main")
@@ -14,13 +14,12 @@ class TestProperties(KratosUnittest.TestCase):
         properties.SetValue(KM.YOUNG_MODULUS, 1.0)
         self.assertEqual(properties.GetValue(KM.YOUNG_MODULUS), 1.0)
 
-        cloned_properties = properties.Clone()
+        cloned_properties = KM.Properties(properties) #copy constructor
         self.assertEqual(cloned_properties.GetValue(KM.YOUNG_MODULUS), 1.0)
 
         cloned_properties.SetValue(KM.YOUNG_MODULUS, 10.0)
         self.assertEqual(properties.GetValue(KM.YOUNG_MODULUS), 1.0)
         self.assertEqual(cloned_properties.GetValue(KM.YOUNG_MODULUS), 10.0)
-
 
 
 if __name__ == '__main__':

--- a/kratos/tests/test_properties.py
+++ b/kratos/tests/test_properties.py
@@ -1,0 +1,27 @@
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+import KratosMultiphysics as KM
+
+class TestProperties(KratosUnittest.TestCase):
+
+    def test_clone_properties(self):
+        current_model = KM.Model()
+
+        model_part= current_model.CreateModelPart("Main")
+
+        model_part.CreateNewProperties(1)
+        properties = model_part.GetProperties()[1]
+
+        properties.SetValue(KM.YOUNG_MODULUS, 1.0)
+        self.assertEqual(properties.GetValue(KM.YOUNG_MODULUS), 1.0)
+
+        cloned_properties = properties.Clone()
+        self.assertEqual(cloned_properties.GetValue(KM.YOUNG_MODULUS), 1.0)
+
+        cloned_properties.SetValue(KM.YOUNG_MODULUS, 10.0)
+        self.assertEqual(properties.GetValue(KM.YOUNG_MODULUS), 1.0)
+        self.assertEqual(cloned_properties.GetValue(KM.YOUNG_MODULUS), 10.0)
+
+
+
+if __name__ == '__main__':
+    KratosUnittest.main()


### PR DESCRIPTION
@KratosMultiphysics/interface-committee 

I have added a clone function to the python interface of a property. Like this one can create a copy of a property at python level.