### PR TITLE
[MeshingApplication][MMG] Fixing test remesh sphere failure in debug compilation.

### DIFF
--- a/applications/MeshingApplication/tests/test_remesh_sphere.py
+++ b/applications/MeshingApplication/tests/test_remesh_sphere.py
@@ -308,6 +308,7 @@ class TestRemeshMMG3D(KratosUnittest.TestCase):
 
         for node in main_model_part.Nodes:
             node.SetSolutionStepValue(KratosMultiphysics.DISTANCE, abs(node.X))
+            node.SetValue(MeshingApplication.METRIC_SCALAR, 0.0)
 
         # We calculate the gradient of the distance variable
         KratosMultiphysics.VariableUtils().SetNonHistoricalVariable(KratosMultiphysics.NODAL_H, 0.0, main_model_part.Nodes)


### PR DESCRIPTION
Test `test_remesh_sphere_skin_prisms` in `test_remesh_sphere.py` fails due to segfault while trying to produce the error message in 
https://github.com/KratosMultiphysics/Kratos/blob/650306f51ea411de5218217418dc82ec5c61afc7/applications/MeshingApplication/custom_processes/mmg_process.cpp#L299

This seems to fix it, although I do not know if it is the correct fix. BTW, the test produces some warning text, is it normal?
```
.  ## WARNING: WRONG SOLUTION NUMBER. IGNORED
Geometry: Computation of local coordinates failed at iteration 0
```
