### PR TITLE
[CoSim] silence prints from EmpireAPI in tests

### DIFF
--- a/applications/CoSimulationApplication/custom_python/add_custom_io_to_python.cpp
+++ b/applications/CoSimulationApplication/custom_python/add_custom_io_to_python.cpp
@@ -342,6 +342,16 @@ void recvMesh_DefaultName(ModelPart& rModelPart, const bool UseConditions, const
     recvMesh(rModelPart, rModelPart.Name().c_str(), UseConditions, UseRawPointers);
 }
 
+void SetEchoLevel(const int EchoLevel)
+{
+    EMPIRE_API_helpers::EchoLevel = EchoLevel;
+}
+
+void SetPrintTiming(const bool PrintTiming)
+{
+    EMPIRE_API_helpers::PrintTiming = PrintTiming;
+}
+
 } // helpers namespace
 
 void  AddCustomIOToPython(pybind11::module& m)
@@ -384,6 +394,9 @@ void  AddCustomIOToPython(pybind11::module& m)
 
     mEMPIREAPI.def("EMPIRE_API_recvConvergenceSignal", EMPIRE_API_recvConvergenceSignal, py::arg("file_name_extension")="default");
     mEMPIREAPI.def("EMPIRE_API_sendConvergenceSignal", EMPIRE_API_sendConvergenceSignal, py::arg("signal"), py::arg("file_name_extension")="default");
+
+    mEMPIREAPI.def("EMPIRE_API_SetEchoLevel", EMPIRE_API_Wrappers::SetEchoLevel);
+    mEMPIREAPI.def("EMPIRE_API_PrintTiming",  EMPIRE_API_Wrappers::SetPrintTiming);
 }
 
 }  // namespace Python.

--- a/applications/CoSimulationApplication/python_scripts/helpers/dummy_flower_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/helpers/dummy_flower_solver.py
@@ -24,7 +24,6 @@ class DummyFLOWerSolver(object):
             "coupling_interfaces"         : [],
             "receive_meshes"              : [],
             "mdpa_file_name"              : "UNSPECIFIED",
-            "api_configuration_file_name" : "UNSPECIFIED",
             "debugging_settings" : { }
         }""")
 
@@ -36,10 +35,11 @@ class DummyFLOWerSolver(object):
         self.name = self.settings["name"].GetString()
 
         debugging_settings_defaults = KM.Parameters("""{
-            "echo_level"   : 0,
-            "dry_run"      : true,
-            "solving_time" : 0.0,
-            "print_colors" : false
+            "echo_level"         : 0,
+            "api_print_timing"   : false,
+            "dry_run"            : true,
+            "solving_time"       : 0.0,
+            "print_colors"       : false
         }""")
 
         self.settings["debugging_settings"].ValidateAndAssignDefaults(debugging_settings_defaults)
@@ -62,7 +62,9 @@ class DummyFLOWerSolver(object):
         model_part_io.ReadModelPart(self.model_part)
         KM.Logger.GetDefaultOutput().SetSeverity(severity)
 
-        KratosCoSim.EMPIRE_API.EMPIRE_API_Connect(self.settings["api_configuration_file_name"].GetString())
+        # Note: calling "EMPIRE_API_Connect" is NOT necessary, it is replaced by the next two lines
+        KratosCoSim.EMPIRE_API.EMPIRE_API_SetEchoLevel(self.echo_level)
+        KratosCoSim.EMPIRE_API.EMPIRE_API_PrintTiming(debugging_settings["api_print_timing"].GetBool())
 
     def Run(self):
         num_coupling_interfaces = self.settings["coupling_interfaces"].size()

--- a/applications/CoSimulationApplication/python_scripts/helpers/dummy_flower_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/helpers/dummy_flower_solver.py
@@ -96,7 +96,7 @@ class DummyFLOWerSolver(object):
         # time loop
         self.__CustomPrint(1, "Starting Solution Loop")
         for i in range(self.settings["num_steps"].GetInt()):
-            print() # newline
+            if self.echo_level > 0: print() # newline
             self.__CustomPrint(1, colors.bold('Step: {}/{}'.format(i+1, self.settings["num_steps"].GetInt())))
             self.SolveSolutionStep()
         self.__CustomPrint(1, "Finished")
@@ -126,11 +126,11 @@ class DummyFLOWerSolver(object):
 
         self.__CustomPrint(1, colors.green("Finished import") + " of CouplingInterfaceData")
 
-        print() # newline
+        if self.echo_level > 0: print() # newline
         self.__CustomPrint(1, colors.blue("Solving ..."))
         time.sleep(self.solving_time)
         self.__CustomPrint(2, "Solving took {} [sec]".format(self.solving_time))
-        print() # newline
+        if self.echo_level > 0: print() # newline
         # TODO implement random values ... ?
 
         self.__CustomPrint(1, colors.cyan("Starting export") + " of CouplingInterfaceData ...")

--- a/applications/CoSimulationApplication/python_scripts/solver_wrappers/empire_io.py
+++ b/applications/CoSimulationApplication/python_scripts/solver_wrappers/empire_io.py
@@ -24,7 +24,9 @@ class EmpireIO(CoSimulationIO):
     """
     def __init__(self, settings, model, solver_name):
         super(EmpireIO, self).__init__(settings, model, solver_name)
-        KratosCoSim.EMPIRE_API.EMPIRE_API_Connect(self.settings["api_configuration_file_name"].GetString())
+        # Note: calling "EMPIRE_API_Connect" is NOT necessary, it is replaced by the next two lines
+        KratosCoSim.EMPIRE_API.EMPIRE_API_SetEchoLevel(self.echo_level)
+        KratosCoSim.EMPIRE_API.EMPIRE_API_PrintTiming(self.settings["api_print_timing"].GetBool())
 
         # delete and recreate communication folder to avoid leftover files
         kratos_utilities.DeleteDirectoryIfExisting(communication_folder)
@@ -83,7 +85,7 @@ class EmpireIO(CoSimulationIO):
     @classmethod
     def _GetDefaultSettings(cls):
         this_defaults = KM.Parameters("""{
-            "api_configuration_file_name" : "UNSPECIFIED"
+            "api_print_timing" : false
         }""")
         this_defaults.AddMissingParameters(super(EmpireIO, cls)._GetDefaultSettings())
 

--- a/applications/CoSimulationApplication/tests/EMPIRE_API.conf
+++ b/applications/CoSimulationApplication/tests/EMPIRE_API.conf
@@ -1,2 +1,0 @@
-EchoLevel 0
-PrintTiming 0

--- a/applications/CoSimulationApplication/tests/EMPIRE_API.conf
+++ b/applications/CoSimulationApplication/tests/EMPIRE_API.conf
@@ -1,0 +1,2 @@
+EchoLevel 0
+PrintTiming 0

--- a/applications/CoSimulationApplication/tests/FLOWer_coupling/cosim_parameters.json
+++ b/applications/CoSimulationApplication/tests/FLOWer_coupling/cosim_parameters.json
@@ -10,7 +10,7 @@
     "solver_settings" :
     {
         "type" : "coupled_solvers.gauss_seidel_weak",
-        "echo_level" : 3,
+        "echo_level" : 0,
         "coupling_sequence":
         [
             {
@@ -62,7 +62,7 @@
             "external_solver":
             {
                 "type" : "solver_wrappers.external.flower_wrapper",
-                "echo_level" : 3,
+                "echo_level" : 0,
                 "solver_wrapper_settings" : {
                     "model_parts_read" : {
                         "Fluid_copy" : "generic_mdpa_files/Mok_CFD"
@@ -76,8 +76,7 @@
                     }
                 },
                 "io_settings" : {
-                    "type" : "empire_io",
-                    "api_configuration_file_name" : "EMPIRE_API.conf"
+                    "type" : "empire_io"
                 },
                 "data" : {
                     "Interface_1_disp" : {

--- a/applications/CoSimulationApplication/tests/FLOWer_coupling/cosim_parameters.json
+++ b/applications/CoSimulationApplication/tests/FLOWer_coupling/cosim_parameters.json
@@ -76,7 +76,8 @@
                     }
                 },
                 "io_settings" : {
-                    "type" : "empire_io"
+                    "type" : "empire_io",
+                    "api_configuration_file_name" : "EMPIRE_API.conf"
                 },
                 "data" : {
                     "Interface_1_disp" : {

--- a/applications/CoSimulationApplication/tests/FLOWer_coupling/dummy_flower_solver_parameters.json
+++ b/applications/CoSimulationApplication/tests/FLOWer_coupling/dummy_flower_solver_parameters.json
@@ -33,6 +33,7 @@
         }
     ],
     "mdpa_file_name"      : "generic_mdpa_files/Mok_CFD",
+    "api_configuration_file_name" : "EMPIRE_API.conf",
     "debugging_settings" : {
         "dry_run"      : false,
         "print_colors" : true,

--- a/applications/CoSimulationApplication/tests/FLOWer_coupling/dummy_flower_solver_parameters.json
+++ b/applications/CoSimulationApplication/tests/FLOWer_coupling/dummy_flower_solver_parameters.json
@@ -33,11 +33,11 @@
         }
     ],
     "mdpa_file_name"      : "generic_mdpa_files/Mok_CFD",
-    "api_configuration_file_name" : "EMPIRE_API.conf",
     "debugging_settings" : {
-        "dry_run"      : false,
-        "print_colors" : true,
-        "echo_level"   : 0,
-        "solving_time" : 0.0
+        "dry_run"            : false,
+        "print_colors"       : true,
+        "echo_level"         : 0,
+        "api_print_timing"   : false,
+        "solving_time"       : 0.0
     }
 }

--- a/applications/CoSimulationApplication/tests/test_cosim_EMPIRE_API.py
+++ b/applications/CoSimulationApplication/tests/test_cosim_EMPIRE_API.py
@@ -21,7 +21,8 @@ class TestCoSim_EMPIRE_API(KratosUnittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # to silence prints
-        KratosCoSim.EMPIRE_API.EMPIRE_API_Connect("EMPIRE_API.conf")
+        KratosCoSim.EMPIRE_API.EMPIRE_API_SetEchoLevel(0)
+        KratosCoSim.EMPIRE_API.EMPIRE_API_PrintTiming(False)
 
     def setUp(self):
         # delete and recreate communication folder to avoid leftover files

--- a/applications/CoSimulationApplication/tests/test_cosim_EMPIRE_API.py
+++ b/applications/CoSimulationApplication/tests/test_cosim_EMPIRE_API.py
@@ -18,6 +18,11 @@ conv_signal_file_name = os.path.join(communication_folder, "EMPIRE_convergence_s
 
 class TestCoSim_EMPIRE_API(KratosUnittest.TestCase):
 
+    @classmethod
+    def setUpClass(cls):
+        # to silence prints
+        KratosCoSim.EMPIRE_API.EMPIRE_API_Connect("EMPIRE_API.conf")
+
     def setUp(self):
         # delete and recreate communication folder to avoid leftover files
         kratos_utils.DeleteDirectoryIfExisting(communication_folder)
@@ -28,6 +33,7 @@ class TestCoSim_EMPIRE_API(KratosUnittest.TestCase):
 
 
     def test_unused_fcts(self):
+        # to make sure theses fcts still exist in case a solver still calls them
         KratosCoSim.EMPIRE_API.EMPIRE_API_Connect("dummy.xml")
         KratosCoSim.EMPIRE_API.EMPIRE_API_Disconnect()
         KratosCoSim.EMPIRE_API.EMPIRE_API_getUserDefinedText("dummy_element")

--- a/applications/CoSimulationApplication/tests/test_flower_coupling.py
+++ b/applications/CoSimulationApplication/tests/test_flower_coupling.py
@@ -15,7 +15,7 @@ class TestFLOWerCoupling(KratosUnittest.TestCase):
     '''TODO add description
     '''
 
-    def test_dummy_external_solver(self):
+    def test_dummy_flower_solver(self):
         self._createTest("FLOWer_coupling", "cosim", "dummy_flower_solver")
         self._runTest()
 


### PR DESCRIPTION
By default the cosim_EmpireAPI prints some things that make the output of the tests harder to read.
Now is silenced