### PR TITLE
[DEM] Remove functions disturbing results

### DIFF
--- a/applications/DEMApplication/custom_strategies/strategies/velocity_verlet_solver_strategy.h
+++ b/applications/DEMApplication/custom_strategies/strategies/velocity_verlet_solver_strategy.h
@@ -64,8 +64,6 @@ namespace Kratos
           VariablesList r_modelpart_nodal_variables_list = r_model_part.GetNodalSolutionStepVariablesList();
           if(r_modelpart_nodal_variables_list.Has(PARTITION_INDEX) )  has_mpi = true;
 
-          this->InitializeSolutionStep();
-
           this->PerformTimeIntegrationOfMotion(1);
 
           this->SearchDEMOperations(r_model_part, has_mpi);
@@ -73,8 +71,6 @@ namespace Kratos
           this->ForceOperations(r_model_part);
 
           this->PerformTimeIntegrationOfMotion(2);
-
-          this->FinalizeSolutionStep();
 
           KRATOS_CATCH("")
 


### PR DESCRIPTION
Remove Initialize and FinalizeSolutionStep from SolveSolutionStep in the Verlet Velocity Continuum strategy, as it was made in #5162 in the explicit_solver_continuum strategy.