### PR TITLE
[Structural] adding error if bdf order is missing

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -112,9 +112,11 @@ class ImplicitMechanicalSolver(MechanicalSolver):
 
     def _bdf_integration_order(self):
         scheme_type = self.settings["scheme_type"].GetString()
-        if (scheme_type == "backward_euler"):
+        if scheme_type == "backward_euler":
             order = 1
         else:
+            if scheme_type == "bdf":
+                raise Exception('Wrong input for scheme type: "bdf"! Please append the order to the bdf-scheme, e.g. "bdf2"')
             # BDF schemes can be from 1 to 5 order, so in order to detect the integration order from the scheme_type we remove the "bdf" string, that is, if the user tells bdf3 only 3 will remain when we remove bdf which corresponds to the method of choice
             order = int(scheme_type.replace("bdf", ""))
 


### PR DESCRIPTION
this gives a better error in case the user sets `bdf` as input (without the order)
