### PR TITLE
[Core] Adding a missing line

### DIFF
--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -602,7 +602,10 @@ class ResidualBasedNewtonRaphsonStrategy
         TSystemVectorType& rb = *mpb;
 
         if (mpConvergenceCriteria->GetActualizeRHSflag() == true)
+        {
+            TSparseSpace::SetToZero(rb);
             GetBuilderAndSolver()->BuildRHS(GetScheme(), BaseType::GetModelPart(), rb);
+        }
 
         return mpConvergenceCriteria->PostCriteria(BaseType::GetModelPart(), GetBuilderAndSolver()->GetDofSet(), rA, rDx, rb);
 


### PR DESCRIPTION
Hi,

In the SolvesolutionStep of the residualbased_newton_raphson_strategy.h calculates convergence as given below.
https://github.com/KratosMultiphysics/Kratos/blob/a1c013527dbf1908af424d11009ae85a3b2b3e2c/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h#L789-L795

But in the IsConverged method of the same class calculates IsConverged status as given below,
https://github.com/KratosMultiphysics/Kratos/blob/a1c013527dbf1908af424d11009ae85a3b2b3e2c/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h#L604-L607

Calculation of IsConverged status in IsConverged method is missing "TSparseSpace::SetToZero(rb);" due to this it gives me different behaviours. This difference in behavior occurs since I'm calling IsConvereged method from the schemes to ensure that my rest of the solving process needs to be continued or not. With current implementation, when my scheme calls IsConverged through
https://github.com/KratosMultiphysics/Kratos/blob/a1c013527dbf1908af424d11009ae85a3b2b3e2c/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h#L785
this line, it returns false, therefore my solving processes exits without calculating and updating. But when it executes the later check for "is_converged", it returns true hence assuming a converged solution (because my other solving processes were not executed, therefore varibles were not updated) and exits the solution procedure leaving with an unconverged soltuion.

Is this done perposely?, or can we go ahead with the proposed change? I'm not sure whether I will be breaking anyones code if this change is added to the core.
