### PR TITLE
[PotentialFlow] Adding implementation to compute far-field and jump lift for embedded bodies

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.cpp
@@ -125,7 +125,7 @@ void DefineEmbeddedWakeProcess::ComputeTrailingEdgeNode(){
 
 void DefineEmbeddedWakeProcess::MarkKuttaWakeElements(){
 
-    // Find elements that touch the furthes deactivated element and that are part of the wake.
+    // Find elements that touch the furthest deactivated element and that are part of the wake.
     for (std::size_t i = 0; i < mKuttaWakeElementCandidates.size(); i++)
     {
         auto& r_geometry = mKuttaWakeElementCandidates[i].GetGeometry();

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.cpp
@@ -126,18 +126,26 @@ void DefineEmbeddedWakeProcess::ComputeTrailingEdgeNode(){
 void DefineEmbeddedWakeProcess::MarkKuttaWakeElements(){
 
     // Find elements that touch the furthest deactivated element and that are part of the wake.
+    std::vector<std::size_t> trailing_edge_node_list;
     for (std::size_t i = 0; i < mKuttaWakeElementCandidates.size(); i++)
     {
         auto& r_geometry = mKuttaWakeElementCandidates[i].GetGeometry();
         if (mKuttaWakeElementCandidates[i].GetValue(WAKE) && mKuttaWakeElementCandidates[i].Is(ACTIVE)) {
             for (std::size_t i_node= 0; i_node < r_geometry.size(); i_node++) {
                 if(r_geometry[i_node].GetValue(TRAILING_EDGE)){
-                    mKuttaWakeElementCandidates[i].Set(STRUCTURE);
-                    break;
+                    trailing_edge_node_list.push_back(r_geometry[i_node].Id());
+                    mKuttaWakeElementCandidates[i].Set(STRUCTURE);                    // break;
                 }
             }
         }
 
     }
+
+    mrModelPart.CreateSubModelPart("trailing_edge_sub_model_part");
+
+    std::sort(trailing_edge_node_list.begin(),
+              trailing_edge_node_list.end());
+    mrModelPart.GetSubModelPart("trailing_edge_sub_model_part").AddNodes(trailing_edge_node_list);
+
 }
 }// Namespace Kratos

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.cpp
@@ -141,6 +141,9 @@ void DefineEmbeddedWakeProcess::MarkKuttaWakeElements(){
 
     }
 
+    if (mrModelPart.HasSubModelPart("trailing_edge_sub_model_part")){
+        mrModelPart.RemoveSubModelPart("trailing_edge_sub_model_part");
+    }
     mrModelPart.CreateSubModelPart("trailing_edge_sub_model_part");
 
     std::sort(trailing_edge_node_list.begin(),

--- a/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/define_embedded_wake_process.cpp
@@ -134,7 +134,7 @@ void DefineEmbeddedWakeProcess::MarkKuttaWakeElements(){
             for (std::size_t i_node= 0; i_node < r_geometry.size(); i_node++) {
                 if(r_geometry[i_node].GetValue(TRAILING_EDGE)){
                     trailing_edge_node_list.push_back(r_geometry[i_node].Id());
-                    mKuttaWakeElementCandidates[i].Set(STRUCTURE);                    // break;
+                    mKuttaWakeElementCandidates[i].Set(STRUCTURE);
                 }
             }
         }

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_embedded_lift_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_embedded_lift_process.py
@@ -12,7 +12,11 @@ class ComputeEmbeddedLiftProcess(ComputeLiftProcess):
     def __init__(self, Model, settings ):
         KratosMultiphysics.Process.__init__(self)
         default_parameters = KratosMultiphysics.Parameters(r'''{
-            "model_part_name": "please specify the model part that contains the surface nodes"
+            "model_part_name": "please specify the model part that contains the surface nodes",
+            "moment_reference_point" : [0.0,0.0,0.0],
+            "far_field_model_part_name": "",
+            "trailing_edge_model_part_name": "",
+            "is_infinite_wing": false
         }''')
 
         settings.ValidateAndAssignDefaults(default_parameters)
@@ -20,10 +24,23 @@ class ComputeEmbeddedLiftProcess(ComputeLiftProcess):
         self.reference_area =  self.fluid_model_part.ProcessInfo.GetValue(CPFApp.REFERENCE_CHORD)
         self.resultant_force=KratosMultiphysics.Vector(3)
 
+
+        far_field_model_part_name = settings["far_field_model_part_name"].GetString()
+        self.compute_far_field_forces = far_field_model_part_name != ""
+        if self.compute_far_field_forces :
+            self.far_field_model_part = Model[far_field_model_part_name]
+        trailing_edge_model_part_name = settings["trailing_edge_model_part_name"].GetString()
+        self.compute_lift_from_jump_3d = trailing_edge_model_part_name != ""
+        if self.compute_lift_from_jump_3d:
+            self.trailing_edge_model_part = Model[trailing_edge_model_part_name]
+        self.reference_area =  self.fluid_model_part.ProcessInfo.GetValue(CPFApp.REFERENCE_CHORD)
+        self.moment_reference_point = settings["moment_reference_point"].GetVector()
+        self.is_infinite_wing = settings["is_infinite_wing"].GetBool()
+
         if not self.reference_area > 0.0:
             raise Exception('The reference area should be larger than 0.')
 
-    def ExecuteFinalizeSolutionStep(self):
+    def _ComputeLiftFromPressure(self):
         if (self.fluid_model_part.ProcessInfo.GetValue(KratosMultiphysics.DOMAIN_SIZE)==2):
             CPFApp.ComputeEmbeddedLiftProcess2D(self.fluid_model_part,self.resultant_force).Execute()
         elif (self.fluid_model_part.ProcessInfo.GetValue(KratosMultiphysics.DOMAIN_SIZE)==3):
@@ -42,3 +59,13 @@ class ComputeEmbeddedLiftProcess(ComputeLiftProcess):
         self.fluid_model_part.ProcessInfo.SetValue(CPFApp.DRAG_COEFFICIENT, self.drag_coefficient)
 
         # TODO Add call to ComputeLiftProcess PotentialJumpLift and FarFieldLift
+
+    def _ComputeMomentFromPressure(self):
+        # TODO Add implementation for embedded bodies
+        pass
+
+    def _GetTrailingEdgeNode(self):
+        for node in self.fluid_model_part.GetSubModelPart("trailing_edge_sub_model_part").Nodes:
+            self.te = node
+            break
+

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_embedded_lift_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_embedded_lift_process.py
@@ -15,7 +15,6 @@ class ComputeEmbeddedLiftProcess(ComputeLiftProcess):
             "model_part_name": "please specify the model part that contains the surface nodes",
             "moment_reference_point" : [0.0,0.0,0.0],
             "far_field_model_part_name": "",
-            "trailing_edge_model_part_name": "",
             "is_infinite_wing": false
         }''')
 
@@ -29,10 +28,7 @@ class ComputeEmbeddedLiftProcess(ComputeLiftProcess):
         self.compute_far_field_forces = far_field_model_part_name != ""
         if self.compute_far_field_forces :
             self.far_field_model_part = Model[far_field_model_part_name]
-        trailing_edge_model_part_name = settings["trailing_edge_model_part_name"].GetString()
-        self.compute_lift_from_jump_3d = trailing_edge_model_part_name != ""
-        if self.compute_lift_from_jump_3d:
-            self.trailing_edge_model_part = Model[trailing_edge_model_part_name]
+
         self.reference_area =  self.fluid_model_part.ProcessInfo.GetValue(CPFApp.REFERENCE_CHORD)
         self.moment_reference_point = settings["moment_reference_point"].GetVector()
         self.is_infinite_wing = settings["is_infinite_wing"].GetBool()
@@ -57,8 +53,6 @@ class ComputeEmbeddedLiftProcess(ComputeLiftProcess):
 
         self.fluid_model_part.ProcessInfo.SetValue(CPFApp.LIFT_COEFFICIENT, self.lift_coefficient)
         self.fluid_model_part.ProcessInfo.SetValue(CPFApp.DRAG_COEFFICIENT, self.drag_coefficient)
-
-        # TODO Add call to ComputeLiftProcess PotentialJumpLift and FarFieldLift
 
     def _ComputeMomentFromPressure(self):
         # TODO Add implementation for embedded bodies

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/compute_lift_process.py
@@ -119,7 +119,7 @@ class ComputeLiftProcess(KratosMultiphysics.Process):
         self.fluid_model_part.ProcessInfo.SetValue(CPFApp.MOMENT_COEFFICIENT, self.moment_coefficient[2])
 
     def _ComputeLiftFromJumpCondition(self):
-        self.__GetTrailingEdgeNode()
+        self._GetTrailingEdgeNode()
         free_stream_velocity = self.fluid_model_part.ProcessInfo.GetValue(CPFApp.FREE_STREAM_VELOCITY)
         u_inf = free_stream_velocity.norm_2()
 
@@ -149,7 +149,7 @@ class ComputeLiftProcess(KratosMultiphysics.Process):
         KratosMultiphysics.Logger.PrintInfo('ComputeLiftProcess',' Cl = ', self.lift_coefficient_jump, 'Potential Jump')
         self.fluid_model_part.ProcessInfo.SetValue(CPFApp.LIFT_COEFFICIENT_JUMP, self.lift_coefficient_jump)
 
-    def __GetTrailingEdgeNode(self):
+    def _GetTrailingEdgeNode(self):
         # Find the Trailing Edge node
         for node in self.body_model_part.Nodes:
             if node.GetValue(CPFApp.TRAILING_EDGE):

--- a/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_parameters.json
@@ -67,7 +67,8 @@
                 "python_module" : "compute_embedded_lift_process",
                 "kratos_module" : "KratosMultiphysics.CompressiblePotentialFlowApplication",
                 "Parameters"    : {
-                    "model_part_name" : "MainModelPart.Parts_Parts_Auto1"
+                    "model_part_name" : "MainModelPart.Parts_Parts_Auto1",
+                    "far_field_model_part_name" : "MainModelPart.PotentialWallCondition2D_Far_field_Auto1"
                 }
             }],
         "list_other_processes" :[{

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -97,6 +97,8 @@ class PotentialFlowTests(UnitTest.TestCase):
         with WorkFolderScope(work_folder):
             self._runTest(settings_file_name)
             self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT], -0.08769331821378197, 0.0, 1e-9)
+            self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_JUMP], -0.5405047994795951, 0.0, 1e-9)
+            self._check_results(self.main_model_part.ProcessInfo[CPFApp.LIFT_COEFFICIENT_FAR_FIELD], -0.04198874676923284, 0.0, 1e-9)
             self._runTest(settings_adjoint_file_name)
 
             for file_name in os.listdir(os.getcwd()):


### PR DESCRIPTION
Adding implementation to compute the far-field and jump lift in embedded geometries and adding these to the corresponding test.  

The far-field lift works out of the box just providing the FarField model part.

The potential jump lift requires to add an implementation to return the trailing edge node. 