### PR TITLE
Tests return & improving integration of C-Tests

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/run_cpp_unit_tests.py
+++ b/applications/StructuralMechanicsApplication/tests/run_cpp_unit_tests.py
@@ -3,7 +3,7 @@ from KratosMultiphysics.StructuralMechanicsApplication import *
 
 def run():
     Tester.SetVerbosity(Tester.Verbosity.PROGRESS) # TESTS_OUTPUTS
-    Tester.RunTestSuite("KratosStructuralMechanicsFastSuite")
+    return Tester.RunTestSuite("KratosStructuralMechanicsFastSuite")
 
 if __name__ == '__main__':
     run()

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -468,8 +468,9 @@ def AssembleTestSuites():
 
 
 if __name__ == '__main__':
+    tests_successful = True
     KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning cpp unit tests ...")
-    run_cpp_unit_tests.run()
+    tests_successful &= run_cpp_unit_tests.run()
     KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished running cpp unit tests!")
 
     if kratos_utilities.IsMPIAvailable() and kratos_utilities.CheckIfApplicationsAvailable("MetisApplication", "TrilinosApplication"):
@@ -479,10 +480,12 @@ if __name__ == '__main__':
             stdout=subprocess.PIPE,
             cwd=os.path.dirname(os.path.abspath(__file__)))
         p.wait()
+        tests_successful &= p.exit_code
         KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished mpi python tests!")
     else:
         KratosMultiphysics.Logger.PrintInfo("Unittests", "\nSkipping mpi python tests due to missing dependencies")
 
     KratosMultiphysics.Logger.PrintInfo("Unittests", "\nRunning python tests ...")
-    KratosUnittest.runTests(AssembleTestSuites())
+    tests_successful &= KratosUnittest.runTests(AssembleTestSuites())
     KratosMultiphysics.Logger.PrintInfo("Unittests", "Finished python tests!")
+    sys.exit(tests_successful)

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication_mpi.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication_mpi.py
@@ -44,5 +44,6 @@ def AssembleTestSuites():
 
 
 if __name__ == '__main__':
+    tests_successful = 0
     tests_successful = max(tests_successful, int(KratosUnittest.runTests(AssembleTestSuites())))
     sys.exit(tests_successful)

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication_mpi.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication_mpi.py
@@ -2,6 +2,8 @@
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 
+import sys
+
 # Import Kratos "wrapper" for unittests
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication_mpi.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication_mpi.py
@@ -44,4 +44,5 @@ def AssembleTestSuites():
 
 
 if __name__ == '__main__':
-    KratosUnittest.runTests(AssembleTestSuites())
+    tests_successful = max(tests_successful, int(KratosUnittest.runTests(AssembleTestSuites())))
+    sys.exit(tests_successful)

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -46,7 +46,7 @@ class TestCase(TestCase):
         absolute and relative difference
 
         If the two objects compare equal then they will automatically
-        compare relative almost equal. ''' 
+        compare relative almost equal. '''
 
         if first == second:
             # shortcut
@@ -188,8 +188,7 @@ def runTests(tests):
             '[Warning]: "{}" test suite is empty'.format(level),
             file=sys.stderr)
     else:
-        result = not TextTestRunner(verbosity=verbosity, buffer=True).run(tests[level]).wasSuccessful()
-        sys.exit(result)
+        return not TextTestRunner(verbosity=verbosity, buffer=True).run(tests[level]).wasSuccessful()
 
 
 KratosSuites = {

--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -154,16 +154,11 @@ class Commander(object):
                         file=sys.stderr)
                     sys.stderr.flush()
 
-    def RunCppTests(self, applications):
+    def RunCppTests(self):
         ''' Calls the cpp tests directly
         '''
 
         self.exitCode = 0
-
-        # # importing the apps such that they get registered for the cpp-tests
-        # this one fails if incompatible apps are being imported!
-        # for application in applications:
-        #     import_module("KratosMultiphysics." + application)
 
         try:
             KtsMp.Tester.SetVerbosity(KtsMp.Tester.Verbosity.PROGRESS)
@@ -307,7 +302,7 @@ def main():
     # Run the cpp tests (does the same as run_cpp_tests.py)
     print('Running cpp tests', file=sys.stderr)
     with KtsUt.SupressConsoleOutput():
-        commander.RunCppTests(applications)
+        commander.RunCppTests()
 
     exit_code = max(exit_code, commander.exitCode)
 

--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -160,9 +160,10 @@ class Commander(object):
 
         self.exitCode = 0
 
-        # importing the apps such that they get registered for the cpp-tests
-        for application in applications:
-            import_module("KratosMultiphysics." + application)
+        # # importing the apps such that they get registered for the cpp-tests
+        # this one fails if incompatible apps are being imported!
+        # for application in applications:
+        #     import_module("KratosMultiphysics." + application)
 
         try:
             KtsMp.Tester.SetVerbosity(KtsMp.Tester.Verbosity.PROGRESS)

--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -266,7 +266,7 @@ def main():
     commander = Commander()
 
     # KratosCore must always be runned
-    print('Running tests for KratosCore', file=sys.stderr)
+    print('\nRunning tests for KratosCore', file=sys.stderr)
 
     with KtsUt.SupressConsoleOutput():
         commander.RunTestSuitInTime(
@@ -283,7 +283,7 @@ def main():
 
     # Run the tests for the rest of the Applications
     for application in applications:
-        print('Running tests for {}'.format(application), file=sys.stderr)
+        print('\nRunning tests for {}'.format(application), file=sys.stderr)
         sys.stderr.flush()
 
         with KtsUt.SupressConsoleOutput():


### PR DESCRIPTION

Current situation:
We have `test_AppName.py` in most apps, which by default runs the py-tests. However the cpp-tests are not included by default and are awkwardly added by hand (e.g, Fluid & Structure). Same for the mpi-tests (if existent).
Now `test_AppName.py` is usually the script that is used to run the tests of an app, and I think it should remain the only one => makes it easier for the CI and for ppl not familiar with the app

In order to improve this I am proposing to change how the tests are being executed in terms of how the result of the test is being handled. Right now the `runTests` fct that is used to run the py-tests exits and this is how the return code of the error if propagated to the executing script (e.g. `run_tests.py` which is used in the CI)
I changed this to only return the value and NOT exit. This way each app can INDIVIDUALLY define the tests that should be run (e.g. Cpp or MPI)

Another advantage of this is that it will be possible to avoid the failure that is happening with the cpp tests for a while already that if two apps are incompatible (e.g. due to naming clashes) then the cpp tests cannot be executed

This does NOT change the usage, one the apps in the CI are being affected and will be updated

what do you think @roigcarlo ?
If you agree then I will start updating other apps too