### PR TITLE
[Structural] Allow incompressible limit in CLAW Poission ratio checks

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_advanced_constitutive/elastic_isotropic_plane_stress_uncoupled_shear.cpp
+++ b/applications/StructuralMechanicsApplication/custom_advanced_constitutive/elastic_isotropic_plane_stress_uncoupled_shear.cpp
@@ -63,15 +63,18 @@ int ElasticIsotropicPlaneStressUncoupledShear::Check(
 )
 {
     KRATOS_CHECK_VARIABLE_KEY(YOUNG_MODULUS);
-    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] < 0.0) << "YOUNG_MODULUS is invalid value " << std::endl;
+    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] <= 0.0) << "YOUNG_MODULUS is null or negative." << std::endl;
 
     KRATOS_CHECK_VARIABLE_KEY(POISSON_RATIO);
-    const double& nu = rMaterialProperties[POISSON_RATIO];
-    const bool check = static_cast<bool>((nu >0.499 && nu<0.501) || (nu < -0.999 && nu > -1.01));
-    KRATOS_ERROR_IF(check) << "POISSON_RATIO is invalid value " << std::endl;;
+    const double tolerance = 1.0e-12;
+    const double nu_upper_bound = 0.5;
+    const double nu_lower_bound = -1.0;
+    const double nu = rMaterialProperties[POISSON_RATIO];
+    KRATOS_ERROR_IF((nu_upper_bound - nu) < tolerance) << "POISSON_RATIO is above the upper bound 0.5." << std::endl;
+    KRATOS_ERROR_IF((nu - nu_lower_bound) < tolerance) << "POISSON_RATIO is below the lower bound -1.0." << std::endl;
 
     KRATOS_CHECK_VARIABLE_KEY(DENSITY);
-    KRATOS_ERROR_IF(rMaterialProperties[DENSITY] < 0.0) << "DENSITY is invalid value " << std::endl;
+    KRATOS_ERROR_IF(rMaterialProperties[DENSITY] < 0.0) << "DENSITY is negative." << std::endl;
 
     KRATOS_CHECK_VARIABLE_KEY(SHEAR_MODULUS);
     KRATOS_ERROR_IF(rMaterialProperties[SHEAR_MODULUS] <= 0.0) << "SHEAR_MODULUS is invalid value " << std::endl;

--- a/applications/StructuralMechanicsApplication/custom_advanced_constitutive/hyper_elastic_isotropic_kirchhoff_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_advanced_constitutive/hyper_elastic_isotropic_kirchhoff_3d.cpp
@@ -444,15 +444,18 @@ int HyperElasticIsotropicKirchhoff3D::Check(
     )
 {
     KRATOS_CHECK_VARIABLE_KEY(YOUNG_MODULUS);
-    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] <= 0.0) << "YOUNG_MODULUS is invalid value " << std::endl;
+    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] <= 0.0) << "YOUNG_MODULUS is null or negative." << std::endl;
 
     KRATOS_CHECK_VARIABLE_KEY(POISSON_RATIO);
+    const double tolerance = 1.0e-12;
+    const double nu_upper_bound = 0.5;
+    const double nu_lower_bound = -1.0;
     const double nu = rMaterialProperties[POISSON_RATIO];
-    const bool check = static_cast<bool>((nu >0.499 && nu<0.501) || (nu < -0.999 && nu > -1.01));
-    KRATOS_ERROR_IF(check) << "POISSON_RATIO is invalid value " << std::endl;
+    KRATOS_ERROR_IF((nu_upper_bound - nu) < tolerance) << "POISSON_RATIO is above the upper bound 0.5." << std::endl;
+    KRATOS_ERROR_IF((nu - nu_lower_bound) < tolerance) << "POISSON_RATIO is below the lower bound -1.0." << std::endl;
 
     KRATOS_CHECK_VARIABLE_KEY(DENSITY);
-    KRATOS_ERROR_IF(rMaterialProperties[DENSITY] < 0.0) << "DENSITY is invalid value " << std::endl;
+    KRATOS_ERROR_IF(rMaterialProperties[DENSITY] < 0.0) << "DENSITY is negative." << std::endl;
 
     return 0;
 }

--- a/applications/StructuralMechanicsApplication/custom_advanced_constitutive/hyper_elastic_isotropic_neo_hookean_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_advanced_constitutive/hyper_elastic_isotropic_neo_hookean_3d.cpp
@@ -464,15 +464,18 @@ int HyperElasticIsotropicNeoHookean3D::Check(
     )
 {
     KRATOS_CHECK_VARIABLE_KEY(YOUNG_MODULUS);
-    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] <= 0.0) << "YOUNG_MODULUS is invalid value " << std::endl;
+    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] <= 0.0) << "YOUNG_MODULUS is null or negative." << std::endl;
 
     KRATOS_CHECK_VARIABLE_KEY(POISSON_RATIO);
+    const double tolerance = 1.0e-12;
+    const double nu_upper_bound = 0.5;
+    const double nu_lower_bound = -1.0;
     const double nu = rMaterialProperties[POISSON_RATIO];
-    const bool check = static_cast<bool>((nu >0.499 && nu<0.501) || (nu < -0.999 && nu > -1.01));
-    KRATOS_ERROR_IF(check) << "POISSON_RATIO is invalid value " << std::endl;
+    KRATOS_ERROR_IF((nu_upper_bound - nu) < tolerance) << "POISSON_RATIO is above the upper bound 0.5." << std::endl;
+    KRATOS_ERROR_IF((nu - nu_lower_bound) < tolerance) << "POISSON_RATIO is below the lower bound -1.0." << std::endl;
 
     KRATOS_CHECK_VARIABLE_KEY(DENSITY);
-    KRATOS_ERROR_IF(rMaterialProperties[DENSITY] < 0.0) << "DENSITY is invalid value " << std::endl;
+    KRATOS_ERROR_IF(rMaterialProperties[DENSITY] < 0.0) << "DENSITY is negative." << std::endl;
 
     return 0;
 }

--- a/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.cpp
@@ -72,12 +72,12 @@ void  ElasticIsotropic3D::CalculateMaterialResponsePK2(ConstitutiveLaw::Paramete
         Vector& r_stress_vector = rValues.GetStressVector();
         CalculatePK2Stress( r_strain_vector, r_stress_vector, rValues);
     }
-    
+
     if( r_constitutive_law_options.Is( ConstitutiveLaw::COMPUTE_CONSTITUTIVE_TENSOR )) {
         Matrix& r_constitutive_matrix = rValues.GetConstitutiveMatrix();
         CalculateElasticMatrix( r_constitutive_matrix, rValues);
     }
-    
+
     KRATOS_CATCH("");
 }
 
@@ -283,15 +283,18 @@ int ElasticIsotropic3D::Check(
     )
 {
     KRATOS_CHECK_VARIABLE_KEY(YOUNG_MODULUS);
-    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] <= 0.0) << "YOUNG_MODULUS is invalid value " << std::endl;
+    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] <= 0.0) << "YOUNG_MODULUS is null or negative." << std::endl;
 
     KRATOS_CHECK_VARIABLE_KEY(POISSON_RATIO);
-    const double& nu = rMaterialProperties[POISSON_RATIO];
-    const bool check = static_cast<bool>((nu >0.499 && nu<0.501) || (nu < -0.999 && nu > -1.01));
-    KRATOS_ERROR_IF(check) << "POISSON_RATIO is invalid value " << std::endl;
+    const double tolerance = 1.0e-12;
+    const double nu_upper_bound = 0.5;
+    const double nu_lower_bound = -1.0;
+    const double nu = rMaterialProperties[POISSON_RATIO];
+    KRATOS_ERROR_IF((nu_upper_bound - nu) < tolerance) << "POISSON_RATIO is above the upper bound 0.5." << std::endl;
+    KRATOS_ERROR_IF((nu - nu_lower_bound) < tolerance) << "POISSON_RATIO is below the lower bound -1.0." << std::endl;
 
     KRATOS_CHECK_VARIABLE_KEY(DENSITY);
-    KRATOS_ERROR_IF(rMaterialProperties[DENSITY] < 0.0) << "DENSITY is invalid value " << std::endl;
+    KRATOS_ERROR_IF(rMaterialProperties[DENSITY] < 0.0) << "DENSITY is negative." << std::endl;
 
     return 0;
 }


### PR DESCRIPTION
Right now the `POISSION_RATIO` check  in some of the constitutive laws in the StructuralMechanicsApplication throws an error when approaching (but not reaching) the incompressible limit. Besides, the previous check didn't throw an error for non-physical values.

I took the chance to throw more descriptive error messages.