### PR TITLE
[Core] Removing one warning in nurbs_curve_geometry

### DIFF
--- a/kratos/geometries/nurbs_curve_geometry.h
+++ b/kratos/geometries/nurbs_curve_geometry.h
@@ -405,7 +405,7 @@ public:
     /// Turn back information as a string.
     std::string Info() const override
     {
-        return TWorkingSpaceDimension + " dimensional nurbs curve.";
+        return std::to_string(TWorkingSpaceDimension) + " dimensional nurbs curve.";
     }
 
     /// Print information about this object.


### PR DESCRIPTION
~~~
/home/vicente/src/Kratos/kratos/geometries/nurbs_curve_geometry.h:408:39: warning: adding 'int' to a string does not append to the string [-Wstring-plus-int]
        return TWorkingSpaceDimension + " dimensional nurbs curve.";
~~~