### PR TITLE
[Core] missing include in checks.h

### DIFF
--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -12,6 +12,7 @@
 //
 
 #include <cstring>
+#include <limits>
 #include "includes/exception.h"
 
 #if !defined(KRATOS_CHECKS_H_INCLUDED )


### PR DESCRIPTION
it did still compile bcs it somehow got the header from somewhere else but I would say it should be consistent.