### PR TITLE
[Core] Adding normal computation in Triangle2D3

### DIFF
--- a/kratos/geometries/triangle_2d_3.h
+++ b/kratos/geometries/triangle_2d_3.h
@@ -691,6 +691,22 @@ public:
     }
 
     /**
+     * @brief It returns a vector that is normal to its corresponding geometry in the given local point
+     * @param rPointLocalCoordinates Reference to the local coordinates of the point in where the normal is to be computed
+     * @return The normal in the given point
+     */
+    array_1d<double, 3> Normal(const CoordinatesArrayType& rPointLocalCoordinates) const override
+    {
+        const array_1d<double, 3> tangent_xi  = this->GetPoint(1) - this->GetPoint(0);
+        const array_1d<double, 3> tangent_eta = this->GetPoint(2) - this->GetPoint(0);
+
+        array_1d<double, 3> normal;
+        MathUtils<double>::CrossProduct(normal, tangent_xi, tangent_eta);
+
+        return 0.5 * normal;
+    }
+
+    /**
      * Returns whether given arbitrary point is inside the Geometry and the respective
      * local point for the given global point
      * @param rPoint The point to be checked if is inside o note in global coordinates

--- a/kratos/tests/cpp_tests/geometries/test_triangle_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_triangle_2d_3.cpp
@@ -574,5 +574,38 @@ namespace Testing {
       TestAllShapeFunctionsLocalGradients(*geom);
     }
 
+    KRATOS_TEST_CASE_IN_SUITE(Triangle2D3Normal, KratosCoreGeometriesFastSuite) {
+
+        auto geom = GeneratePointsRightTriangle2D3();
+        Point::CoordinatesArrayType LocalCoord;
+        LocalCoord.clear();
+        auto normal = geom->Normal(LocalCoord);
+        KRATOS_WATCH(geom)
+        array_1d<double, 3> cross_norm(3, 0.0);
+        cross_norm[2] = 1.0;
+        array_1d<double, 3> cross(3, 0.0);
+        MathUtils<double>::CrossProduct(cross, cross_norm, normal);
+
+        KRATOS_WATCH(cross)
+
+        KRATOS_WATCH(normal)
+
+        KRATOS_CHECK_NEAR(cross[0], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(cross[1], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(cross[2], 0.0, TOLERANCE);
+
+        normal /= norm_2(normal);
+
+        auto unit_normal = geom->UnitNormal(LocalCoord);
+
+        KRATOS_CHECK_NEAR(unit_normal[0], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(unit_normal[1], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(unit_normal[2], 1.0, TOLERANCE);
+
+        KRATOS_CHECK_NEAR(unit_normal[0], normal[0], TOLERANCE);
+        KRATOS_CHECK_NEAR(unit_normal[1], normal[1], TOLERANCE);
+        KRATOS_CHECK_NEAR(unit_normal[2], normal[2], TOLERANCE);
+    }
+
 } // namespace Testing.
 } // namespace Kratos.

--- a/kratos/tests/cpp_tests/geometries/test_triangle_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_triangle_2d_3.cpp
@@ -580,15 +580,15 @@ namespace Testing {
         Point::CoordinatesArrayType LocalCoord;
         LocalCoord.clear();
         auto normal = geom->Normal(LocalCoord);
-        KRATOS_WATCH(geom)
+
+        KRATOS_CHECK_NEAR(normal[0], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(normal[1], 0.0, TOLERANCE);
+        KRATOS_CHECK_NEAR(normal[2], 0.5, TOLERANCE);
+
         array_1d<double, 3> cross_norm(3, 0.0);
         cross_norm[2] = 1.0;
         array_1d<double, 3> cross(3, 0.0);
         MathUtils<double>::CrossProduct(cross, cross_norm, normal);
-
-        KRATOS_WATCH(cross)
-
-        KRATOS_WATCH(normal)
 
         KRATOS_CHECK_NEAR(cross[0], 0.0, TOLERANCE);
         KRATOS_CHECK_NEAR(cross[1], 0.0, TOLERANCE);

--- a/kratos/tests/cpp_tests/geometries/test_triangle_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_triangle_2d_3.cpp
@@ -585,9 +585,11 @@ namespace Testing {
         KRATOS_CHECK_NEAR(normal[1], 0.0, TOLERANCE);
         KRATOS_CHECK_NEAR(normal[2], 0.5, TOLERANCE);
 
-        array_1d<double, 3> cross_norm(3, 0.0);
+        array_1d<double, 3> cross_norm;
+        cross_norm[0] = 0.0;
+        cross_norm[1] = 0.0;
         cross_norm[2] = 1.0;
-        array_1d<double, 3> cross(3, 0.0);
+        array_1d<double, 3> cross;
         MathUtils<double>::CrossProduct(cross, cross_norm, normal);
 
         KRATOS_CHECK_NEAR(cross[0], 0.0, TOLERANCE);

--- a/kratos/tests/cpp_tests/geometries/test_triangle_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_triangle_3d_3.cpp
@@ -722,9 +722,11 @@ namespace Testing
         );
         auto normal = geom.Normal(0);
 
-        array_1d<double, 3> cross_norm(3, 0.0);
+        array_1d<double, 3> cross_norm;
+        cross_norm[0] = 0.0;
+        cross_norm[1] = 0.0;
         cross_norm[2] = 1.0;
-        array_1d<double, 3> cross(3, 0.0);
+        array_1d<double, 3> cross;
         MathUtils<double>::CrossProduct(cross, cross_norm, normal);
 
         KRATOS_CHECK_NEAR(cross[0], 0.0, TOLERANCE);

--- a/kratos/tests/cpp_tests/geometries/test_triangle_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_triangle_3d_3.cpp
@@ -727,12 +727,9 @@ namespace Testing
         array_1d<double, 3> cross(3, 0.0);
         MathUtils<double>::CrossProduct(cross, cross_norm, normal);
 
-        KRATOS_WATCH(normal)
         KRATOS_CHECK_NEAR(cross[0], 0.0, TOLERANCE);
         KRATOS_CHECK_NEAR(cross[1], 0.0, TOLERANCE);
         KRATOS_CHECK_NEAR(cross[2], 0.0, TOLERANCE);
-
-        KRATOS_WATCH(cross)
 
         normal /= norm_2(normal);
 
@@ -742,7 +739,6 @@ namespace Testing
         KRATOS_CHECK_NEAR(unit_normal[1], 0.0, TOLERANCE);
         KRATOS_CHECK_NEAR(unit_normal[2], -1.0, TOLERANCE);
 
-        KRATOS_WATCH(unit_normal)
         KRATOS_CHECK_NEAR(unit_normal[0], normal[0], TOLERANCE);
         KRATOS_CHECK_NEAR(unit_normal[1], normal[1], TOLERANCE);
         KRATOS_CHECK_NEAR(unit_normal[2], normal[2], TOLERANCE);


### PR DESCRIPTION
Adding the computation of the triangle 2d3 normal (same implementation as triangle3d3) and a test. This addresses #5945

closes #5945 