### PR TITLE
[Core] another missing include in checks.h

### DIFF
--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -13,6 +13,7 @@
 
 #include <cstring>
 #include <limits>
+#include <cmath> // std::abs for double
 #include "includes/exception.h"
 
 #if !defined(KRATOS_CHECKS_H_INCLUDED )


### PR DESCRIPTION
I had problems with ambiguous calls to std::abs => basically we are not including the necessary header: https://stackoverflow.com/questions/1374037/ambiguous-overload-call-to-absdouble