### PR TITLE
GiD_Prism element GiD_fWriteGaussPoint3D #5947

### DIFF
--- a/kratos/includes/gid_gauss_point_container.h
+++ b/kratos/includes/gid_gauss_point_container.h
@@ -560,13 +560,13 @@ public:
             {
                 GiD_fBeginGaussPoint( MeshFile, mGPTitle, GiD_Prism, NULL, 6, 0, 0 );
 
-                GiD_fWriteGaussPoint3D( MeshFile, 1.00 / 3.00 , 2.00 / 3.00, 0.5 * (1.0 - std::sqrt(1.00 / 3.00)));
-                GiD_fWriteGaussPoint3D( MeshFile, 2.00 / 3.00 , 1.00 / 3.00, 0.5 * (1.0 - std::sqrt(1.00 / 3.00)));
-                GiD_fWriteGaussPoint3D( MeshFile, 2.00 / 3.00 , 2.00 / 3.00, 0.5 * (1.0 - std::sqrt(1.00 / 3.00)));
+				GiD_fWriteGaussPoint3D(MeshFile, 2.00 / 3.00, 1.00 / 6.00, 0.5 * (1.0 - std::sqrt(1.00 / 3.00)));
+				GiD_fWriteGaussPoint3D(MeshFile, 1.00 / 6.00, 2.00 / 3.00, 0.5 * (1.0 - std::sqrt(1.00 / 3.00)));
+				GiD_fWriteGaussPoint3D(MeshFile, 1.00 / 6.00, 1.00 / 6.00, 0.5 * (1.0 - std::sqrt(1.00 / 3.00)));
 
-                GiD_fWriteGaussPoint3D( MeshFile, 1.00 / 3.00 , 2.00 / 3.00, 0.5 * (1.0 + std::sqrt(1.00 / 3.00)));
-                GiD_fWriteGaussPoint3D( MeshFile, 2.00 / 3.00 , 1.00 / 3.00, 0.5 * (1.0 + std::sqrt(1.00 / 3.00)));
-                GiD_fWriteGaussPoint3D( MeshFile, 2.00 / 3.00 , 2.00 / 3.00, 0.5 * (1.0 + std::sqrt(1.00 / 3.00)));
+				GiD_fWriteGaussPoint3D(MeshFile, 2.00 / 3.00, 1.00 / 6.00, 0.5 * (1.0 + std::sqrt(1.00 / 3.00)));
+				GiD_fWriteGaussPoint3D(MeshFile, 1.00 / 6.00, 2.00 / 3.00, 0.5 * (1.0 + std::sqrt(1.00 / 3.00)));
+				GiD_fWriteGaussPoint3D(MeshFile, 1.00 / 6.00, 1.00 / 6.00, 0.5 * (1.0 + std::sqrt(1.00 / 3.00)));
 
                 GiD_fEndGaussPoint(MeshFile);
             }

--- a/kratos/includes/gid_gauss_point_container.h
+++ b/kratos/includes/gid_gauss_point_container.h
@@ -560,13 +560,13 @@ public:
             {
                 GiD_fBeginGaussPoint( MeshFile, mGPTitle, GiD_Prism, NULL, 6, 0, 0 );
 
+				GiD_fWriteGaussPoint3D(MeshFile, 1.00 / 6.00, 1.00 / 6.00, 0.5 * (1.0 - std::sqrt(1.00 / 3.00)));
 				GiD_fWriteGaussPoint3D(MeshFile, 2.00 / 3.00, 1.00 / 6.00, 0.5 * (1.0 - std::sqrt(1.00 / 3.00)));
 				GiD_fWriteGaussPoint3D(MeshFile, 1.00 / 6.00, 2.00 / 3.00, 0.5 * (1.0 - std::sqrt(1.00 / 3.00)));
-				GiD_fWriteGaussPoint3D(MeshFile, 1.00 / 6.00, 1.00 / 6.00, 0.5 * (1.0 - std::sqrt(1.00 / 3.00)));
 
+				GiD_fWriteGaussPoint3D(MeshFile, 1.00 / 6.00, 1.00 / 6.00, 0.5 * (1.0 + std::sqrt(1.00 / 3.00)));
 				GiD_fWriteGaussPoint3D(MeshFile, 2.00 / 3.00, 1.00 / 6.00, 0.5 * (1.0 + std::sqrt(1.00 / 3.00)));
 				GiD_fWriteGaussPoint3D(MeshFile, 1.00 / 6.00, 2.00 / 3.00, 0.5 * (1.0 + std::sqrt(1.00 / 3.00)));
-				GiD_fWriteGaussPoint3D(MeshFile, 1.00 / 6.00, 1.00 / 6.00, 0.5 * (1.0 + std::sqrt(1.00 / 3.00)));
 
                 GiD_fEndGaussPoint(MeshFile);
             }


### PR DESCRIPTION
Fixes #5947 by @vgudzulic but with a modification in the order of the gauss points (see image below)


As you can see in the pic, the order of the gauss points are now following the node order in the connectivities
![image](https://user-images.githubusercontent.com/5918085/69648257-39790900-106b-11ea-8cee-2a669de01752.png)

Anyway:
Calls to GiD_fWriteGaussPoint3D are not mandatory since GiD calculates the position of the  gauss points following the rules defined here: https://www.gidhome.com/documents/customizationmanual/POSTPROCESS%20DATA%20FILES/Results%20format:%20ModelName.post.res/Gauss%20Points
In order to use the internal gauss point definition, the  last parameter of `GiD_fBeginGaussPoint `should be 1:
``` C
else if ( mGidElementFamily == GiD_Prism  && mSize > 1)
{
    GiD_fBeginGaussPoint( MeshFile, mGPTitle, GiD_Prism, NULL, 6, 0, 1 );
    // removed lines GiD_fWriteGaussPoint3D
    GiD_fEndGaussPoint(MeshFile);
}
```

I don't know how to test it, if anyone has a test with this kind of prisms, please answer this PR @loumalouomega 