### PR TITLE
[StructuralMechanicsApplication] Fix solidshell damping matrix size

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/solid_shell_element_sprism_3D6N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/solid_shell_element_sprism_3D6N.cpp
@@ -510,7 +510,7 @@ void SolidShellElementSprism3D6N::CalculateDampingMatrix(
     )
 {
     const WeakPointerVectorNodesType& p_neighbour_nodes = this->GetValue(NEIGHBOUR_NODES);
-    const IndexType mat_size = GetGeometry().size() + NumberOfActiveNeighbours(p_neighbour_nodes) * 3;
+    const IndexType mat_size = ( GetGeometry().size() + NumberOfActiveNeighbours(p_neighbour_nodes) ) * 3;
 
     StructuralMechanicsElementUtilities::CalculateRayleighDampingMatrix(
         *this,


### PR DESCRIPTION
The damping matrix size computation was missing parentheses (c.f. lines 537 and 540).