### PR TITLE
[dem] Disabling copy of useless files when installing after compilation

### DIFF
--- a/applications/DEMApplication/CMakeLists.txt
+++ b/applications/DEMApplication/CMakeLists.txt
@@ -152,6 +152,11 @@ if(${INSTALL_TESTING_FILES} MATCHES ON )
         PATTERN "*.h" EXCLUDE
         PATTERN "*.cpp" EXCLUDE
         PATTERN "*.hpp" EXCLUDE
+        PATTERN "*.vtk" EXCLUDE
+        PATTERN "*.lst" EXCLUDE
+        PATTERN "*.pyc" EXCLUDE
+        PATTERN "*.bin" EXCLUDE
+        PATTERN "*.time" EXCLUDE
   )
 endif(${INSTALL_TESTING_FILES} MATCHES ON)
 


### PR DESCRIPTION
Some files, probably coming from the old compilation system and som local runs, were being copied to the destination folder.
Nothing that everyone should need, but helpful temporarily.