### PR TITLE
[Core][Strategies] using global num constraints to skip Apply for constraints

### DIFF
--- a/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
@@ -359,9 +359,9 @@ public:
 
         this->GetScheme()->Predict(BaseType::GetModelPart(), r_dof_set, rA, rDx, rb);
         auto& r_constraints_array = BaseType::GetModelPart().MasterSlaveConstraints();
-        const std::size_t local_number_of_constraints = r_constraints_array.size();
+        const int local_number_of_constraints = r_constraints_array.size();
         const int global_number_of_constraints = r_comm.SumAll(local_number_of_constraints);
-        if(global_number_of_constraints != 0) {        
+        if(global_number_of_constraints != 0) {
             const auto& rProcessInfo = BaseType::GetModelPart().GetProcessInfo();
 
             auto it_begin = BaseType::GetModelPart().MasterSlaveConstraints().begin();
@@ -373,7 +373,7 @@ public:
             #pragma omp parallel for firstprivate(it_begin)
             for(int i=0; i<static_cast<int>(local_number_of_constraints); ++i)
                  (it_begin+i)->Apply(rProcessInfo);
-            
+
             //the following is needed since we need to eventually compute time derivatives after applying 
             //Master slave relations
             TSparseSpace::SetToZero(rDx);

--- a/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
@@ -341,6 +341,7 @@ public:
     void Predict() override
     {
         KRATOS_TRY
+        const DataCommunicator &r_comm = BaseType::GetModelPart().GetCommunicator().GetDataCommunicator();
         //OPERATIONS THAT SHOULD BE DONE ONCE - internal check to avoid repetitions
         //if the operations needed were already performed this does nothing
         if(mInitializeWasPerformed == false)
@@ -357,19 +358,20 @@ public:
         DofsArrayType& r_dof_set = GetBuilderAndSolver()->GetDofSet();
 
         this->GetScheme()->Predict(BaseType::GetModelPart(), r_dof_set, rA, rDx, rb);
-
-        if(BaseType::GetModelPart().MasterSlaveConstraints().size() != 0)
-        {
+        auto& r_constraints_array = BaseType::GetModelPart().MasterSlaveConstraints();
+        const std::size_t local_number_of_constraints = r_constraints_array.size();
+        const int global_number_of_constraints = r_comm.SumAll(local_number_of_constraints);
+        if(global_number_of_constraints != 0) {        
             const auto& rProcessInfo = BaseType::GetModelPart().GetProcessInfo();
 
             auto it_begin = BaseType::GetModelPart().MasterSlaveConstraints().begin();
 
             #pragma omp parallel for firstprivate(it_begin)
-            for(int i=0; i<static_cast<int>(BaseType::GetModelPart().MasterSlaveConstraints().size()); ++i)
+            for(int i=0; i<local_number_of_constraints; ++i)
                 (it_begin+i)->ResetSlaveDofs(rProcessInfo);
 
             #pragma omp parallel for firstprivate(it_begin)
-            for(int i=0; i<static_cast<int>(BaseType::GetModelPart().MasterSlaveConstraints().size()); ++i)
+            for(int i=0; i<local_number_of_constraints; ++i)
                  (it_begin+i)->Apply(rProcessInfo);
             
             //the following is needed since we need to eventually compute time derivatives after applying 

--- a/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
@@ -367,11 +367,11 @@ public:
             auto it_begin = BaseType::GetModelPart().MasterSlaveConstraints().begin();
 
             #pragma omp parallel for firstprivate(it_begin)
-            for(int i=0; i<local_number_of_constraints; ++i)
+            for(int i=0; i<static_cast<int>(local_number_of_constraints); ++i)
                 (it_begin+i)->ResetSlaveDofs(rProcessInfo);
 
             #pragma omp parallel for firstprivate(it_begin)
-            for(int i=0; i<local_number_of_constraints; ++i)
+            for(int i=0; i<static_cast<int>(local_number_of_constraints); ++i)
                  (it_begin+i)->Apply(rProcessInfo);
             
             //the following is needed since we need to eventually compute time derivatives after applying 

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -480,6 +480,7 @@ class ResidualBasedNewtonRaphsonStrategy
     void Predict() override
     {
         KRATOS_TRY
+        const DataCommunicator &r_comm = BaseType::GetModelPart().GetCommunicator().GetDataCommunicator();
         //OPERATIONS THAT SHOULD BE DONE ONCE - internal check to avoid repetitions
         //if the operations needed were already performed this does nothing
         if (mInitializeWasPerformed == false)
@@ -499,18 +500,19 @@ class ResidualBasedNewtonRaphsonStrategy
 
         // Applying constraints if needed
         auto& r_constraints_array = BaseType::GetModelPart().MasterSlaveConstraints();
-        const std::size_t number_of_constraints = r_constraints_array.size();
-        if(number_of_constraints != 0) {
+        const std::size_t local_number_of_constraints = r_constraints_array.size();
+        const int global_number_of_constraints = r_comm.SumAll(local_number_of_constraints);
+        if(global_number_of_constraints != 0) {
             const auto& r_process_info = BaseType::GetModelPart().GetProcessInfo();
 
             const auto it_const_begin = r_constraints_array.begin();
 
             #pragma omp parallel for
-            for(int i=0; i<static_cast<int>(number_of_constraints); ++i)
+            for(int i=0; i<static_cast<int>(local_number_of_constraints); ++i)
                 (it_const_begin + i)->ResetSlaveDofs(r_process_info);
 
             #pragma omp parallel for
-            for(int i=0; i<static_cast<int>(number_of_constraints); ++i)
+            for(int i=0; i<static_cast<int>(local_number_of_constraints); ++i)
                  (it_const_begin + i)->Apply(r_process_info);
 
             // The following is needed since we need to eventually compute time derivatives after applying

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -500,7 +500,7 @@ class ResidualBasedNewtonRaphsonStrategy
 
         // Applying constraints if needed
         auto& r_constraints_array = BaseType::GetModelPart().MasterSlaveConstraints();
-        const std::size_t local_number_of_constraints = r_constraints_array.size();
+        const int local_number_of_constraints = r_constraints_array.size();
         const int global_number_of_constraints = r_comm.SumAll(local_number_of_constraints);
         if(global_number_of_constraints != 0) {
             const auto& r_process_info = BaseType::GetModelPart().GetProcessInfo();


### PR DESCRIPTION
The changes stem from my implementations in a different branch. 

Currently the `Apply` and `ResetSlaveDofs` function calls of the MS constraints and the `TSparseSpace::SetToZero(rDx);`  in the Predict of Newton-Raphson strategy are guarded by an if statement which checks if there are any constraints on the modelpart. 

In MPI checking if the constraints exist locally is not sufficient as `TSparseSpace::SetToZero(rDx);`  would require a all to all communication in the comm. 

https://github.com/KratosMultiphysics/Kratos/blob/bb911f5415e24c0304e4af22cc2729ec771dbf6a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h#L518

This pr changes the check to use the global_number_of_constraints. 

In serial the r_comm.SumAll() will have no effect. 
