### PR TITLE
[Structure]Parsing error in "volumetric_strain_dofs"

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -144,7 +144,7 @@ class MechanicalSolver(PythonSolver):
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ROTATION)
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION_MOMENT)
             self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_MOMENT)
-        if self.settings["volumetric_strain_dofs"]:
+        if self.settings["volumetric_strain_dofs"].GetBool():
             # Add specific variables for the problem (rotation dofs).
             self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VOLUMETRIC_STRAIN)
             self.main_model_part.AddNodalSolutionStepVariable(StructuralMechanicsApplication.REACTION_STRAIN)


### PR DESCRIPTION
I suggest changing line 149 to: 
>> if self.settings["volumetric_strain_dofs"].GetBool():
Otherwise, the VOLUMETRIC_STRAIN is always added as a variable, which provokes error because the module 'KratosMultiphysics' has no attribute 'VOLUMETRIC_STRAIN' in the up-to-date version @