### PR TITLE
[MeshMoving] fix param name

### DIFF
--- a/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
+++ b/applications/MeshMovingApplication/python_scripts/mesh_solver_base.py
@@ -63,7 +63,7 @@ class MeshSolverBase(PythonSolver):
                 "input_type"     : "mdpa",
                 "input_filename" : "unknown_name"
             },
-            "mesh_motion_linear_solver_settings" : {
+            "linear_solver_settings" : {
                 "solver_type" : "amgcl",
                 "smoother_type":"ilu0",
                 "krylov_type": "gmres",
@@ -174,7 +174,7 @@ class MeshSolverBase(PythonSolver):
 
     def _create_linear_solver(self):
         from KratosMultiphysics.python_linear_solver_factory import ConstructSolver
-        return ConstructSolver(self.settings["mesh_motion_linear_solver_settings"])
+        return ConstructSolver(self.settings["linear_solver_settings"])
 
     def _create_mesh_motion_solving_strategy(self):
         """Create the mesh motion solving strategy.

--- a/applications/MeshMovingApplication/python_scripts/trilinos_mesh_solver_base.py
+++ b/applications/MeshMovingApplication/python_scripts/trilinos_mesh_solver_base.py
@@ -74,7 +74,7 @@ class TrilinosMeshSolverBase(MeshSolverBase):
     #### Private functions ####
 
     def _create_linear_solver(self):
-        return trilinos_linear_solver_factory.ConstructSolver(self.settings["mesh_motion_linear_solver_settings"])
+        return trilinos_linear_solver_factory.ConstructSolver(self.settings["linear_solver_settings"])
 
     def _create_mesh_motion_solving_strategy(self):
         raise Exception("Mesh motion solver must be created by the derived class.")

--- a/applications/MeshMovingApplication/tests/test_example/ProjectParameters.json
+++ b/applications/MeshMovingApplication/tests/test_example/ProjectParameters.json
@@ -40,7 +40,7 @@
             "input_type"     : "mdpa",
             "input_filename" : "01_Mesh_Test_2D3N"
         },
-        "mesh_motion_linear_solver_settings"        : {
+        "linear_solver_settings"        : {
         "solver_type" : "SuperLUSolver"
         },
         "computing_model_part_name"       : "Parts_Fluid",

--- a/applications/ShapeOptimizationApplication/python_scripts/mesh_controller_with_solver.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/mesh_controller_with_solver.py
@@ -38,7 +38,7 @@ class MeshControllerWithSolver(MeshController) :
                 "time_stepping" : {
                     "time_step"       : 1.0
                 },
-                "mesh_motion_linear_solver_settings" : {
+                "linear_solver_settings" : {
                     "solver_type" : "amgcl",
                     "smoother_type":"ilu0",
                     "krylov_type": "gmres",
@@ -58,8 +58,8 @@ class MeshControllerWithSolver(MeshController) :
         self.MeshSolverSettings["solver_settings"].ValidateAndAssignDefaults(default_settings["solver_settings"])
         self.MeshSolverSettings["processes"].ValidateAndAssignDefaults(default_settings["processes"])
 
-        if not self.MeshSolverSettings["solver_settings"].Has("mesh_motion_linear_solver_settings"):
-            MeshSolverSettings.AddValue("mesh_motion_linear_solver_settings", default_settings["solver_settings"]["mesh_motion_linear_solver_settings"])
+        if not self.MeshSolverSettings["solver_settings"].Has("linear_solver_settings"):
+            MeshSolverSettings.AddValue("linear_solver_settings", default_settings["solver_settings"]["linear_solver_settings"])
             KM.Logger.PrintInfo("ShapeOpt", "::[MeshControllerWithSolver]:: using default linear solver for mesh motion.")
 
         if not MeshSolverSettings.Has("problem_data"):

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
@@ -23,7 +23,7 @@
                     "time_stepping" : {
                         "time_step"       : 1.0
                     },
-                    "mesh_motion_linear_solver_settings"  : {
+                    "linear_solver_settings"  : {
                         "solver_type"         : "amgcl",
                         "max_iteration"       : 500,
                         "tolerance"           : 1e-7,


### PR DESCRIPTION
This was inconsistent (with the Trilinos version)

I replaced all occurences in the code, should I add a backwards-compatibility option?