### PR TITLE
[amgcl] Fixing rigid body modes construction for elasticity problems

### DIFF
--- a/applications/TrilinosApplication/external_includes/amgcl_mpi_schur_complement_solver.h
+++ b/applications/TrilinosApplication/external_includes/amgcl_mpi_schur_complement_solver.h
@@ -37,7 +37,7 @@
 
 #include <amgcl/mpi/make_solver.hpp>
 #include <amgcl/mpi/schur_pressure_correction.hpp>
-#include <amgcl/solver/runtime.hpp>
+#include <amgcl/mpi/solver/runtime.hpp>
 #include <amgcl/mpi/block_preconditioner.hpp>
 #include <amgcl/relaxation/as_preconditioner.hpp>
 #include <amgcl/relaxation/runtime.hpp>
@@ -214,7 +214,7 @@ public:
                     amgcl::mpi::block_preconditioner<
                         amgcl::relaxation::as_preconditioner<Backend, amgcl::runtime::relaxation::wrapper>
                         >,
-                    amgcl::runtime::solver::wrapper
+                    amgcl::runtime::mpi::solver::wrapper<Backend>
                     >,
                 amgcl::mpi::make_solver<
                     amgcl::mpi::amg<
@@ -224,10 +224,10 @@ public:
                         amgcl::runtime::mpi::direct::solver<double>,
                         amgcl::runtime::mpi::partition::wrapper<Backend>
                         >,
-                    amgcl::runtime::solver::wrapper
+                    amgcl::runtime::mpi::solver::wrapper<Backend>
                     >
                 >,
-            amgcl::runtime::solver::wrapper
+            amgcl::runtime::mpi::solver::wrapper<Backend>
             > Solver;
 
         mprm.put("precond.pmask", static_cast<void*>(&mPressureMask[0]));

--- a/applications/TrilinosApplication/external_includes/amgcl_mpi_solver_impl.cpp
+++ b/applications/TrilinosApplication/external_includes/amgcl_mpi_solver_impl.cpp
@@ -8,11 +8,11 @@
 #include <amgcl/adapter/block_matrix.hpp>
 #include <amgcl/backend/builtin.hpp>
 #include <amgcl/value_type/static_matrix.hpp>
-#include <amgcl/solver/runtime.hpp>
 
 #include <amgcl/mpi/util.hpp>
 #include <amgcl/mpi/make_solver.hpp>
 #include <amgcl/mpi/preconditioner.hpp>
+#include <amgcl/mpi/solver/runtime.hpp>
 
 #ifdef AMGCL_GPGPU
 #  include <amgcl/backend/vexcl.hpp>
@@ -54,7 +54,7 @@ void AMGCLScalarSolve(
         typedef
             amgcl::mpi::make_solver<
                 amgcl::runtime::mpi::preconditioner<Backend>,
-                amgcl::runtime::solver::wrapper
+                amgcl::runtime::mpi::solver::wrapper<Backend>
                 >
             Solver;
 
@@ -79,7 +79,7 @@ void AMGCLScalarSolve(
         typedef
             amgcl::mpi::make_solver<
                 amgcl::runtime::mpi::preconditioner<Backend>,
-                amgcl::runtime::solver::wrapper
+                amgcl::runtime::mpi::solver::wrapper<Backend>
                 >
             Solver;
 
@@ -128,7 +128,7 @@ void AMGCLBlockSolve(
         typedef
             amgcl::mpi::make_solver<
                 amgcl::runtime::mpi::preconditioner<Backend>,
-                amgcl::runtime::solver::wrapper
+                amgcl::runtime::mpi::solver::wrapper<Backend>
                 >
             Solver;
 
@@ -158,7 +158,7 @@ void AMGCLBlockSolve(
         typedef
             amgcl::mpi::make_solver<
                 amgcl::runtime::mpi::preconditioner<Backend>,
-                amgcl::runtime::solver::wrapper
+                amgcl::runtime::mpi::solver::wrapper<Backend>
                 >
             Solver;
 

--- a/external_libraries/amgcl/amg.hpp
+++ b/external_libraries/amgcl/amg.hpp
@@ -351,10 +351,11 @@ class amg {
             {
                 AMGCL_TIC("transfer operators");
                 std::shared_ptr<build_matrix> P, R;
-                std::tie(P, R) = C.transfer_operators(*A);
 
-                if(backend::cols(*P) == 0) {
-                    // Zero-sized coarse level in amgcl (diagonal matrix?)
+                try {
+                    std::tie(P, R) = C.transfer_operators(*A);
+                } catch(error::empty_level) {
+                    AMGCL_TOC("transfer operators");
                     return std::shared_ptr<build_matrix>();
                 }
 

--- a/external_libraries/amgcl/backend/blaze.hpp
+++ b/external_libraries/amgcl/backend/blaze.hpp
@@ -54,7 +54,7 @@ struct blaze {
     typedef real      value_type;
     typedef ptrdiff_t index_type;
 
-    struct provides_row_iterator : std::false_type {};
+    struct provides_row_iterator : std::true_type {};
 
     typedef ::blaze::CompressedMatrix<real> matrix;
     typedef ::blaze::DynamicVector<real>    vector;
@@ -130,8 +130,8 @@ struct blaze {
 //---------------------------------------------------------------------------
 // Backend interface implementation
 //---------------------------------------------------------------------------
-template < typename V >
-struct value_type < ::blaze::CompressedMatrix<V> > {
+template < typename V, bool O >
+struct value_type < ::blaze::CompressedMatrix<V, O> > {
     typedef V type;
 };
 
@@ -140,31 +140,66 @@ struct value_type < ::blaze::DynamicVector<V> > {
     typedef V type;
 };
 
-template < typename V >
-struct cols_impl< ::blaze::CompressedMatrix<V> > {
-    typedef ::blaze::CompressedMatrix<V> matrix;
+template < typename V, bool O >
+struct cols_impl< ::blaze::CompressedMatrix<V, O> > {
+    typedef ::blaze::CompressedMatrix<V, O> matrix;
 
     static size_t get(const matrix &A) {
         return A.columns();
     }
 };
 
-template < typename V >
-struct nonzeros_impl< ::blaze::CompressedMatrix<V> > {
-    typedef ::blaze::CompressedMatrix<V> matrix;
+template < typename V, bool O >
+struct nonzeros_impl< ::blaze::CompressedMatrix<V, O> > {
+    typedef ::blaze::CompressedMatrix<V, O> matrix;
 
     static size_t get(const matrix &A) {
         return A.nonZeros();
     }
 };
 
-template < class A, class B, typename V >
+template < typename V, bool O >
+struct row_iterator< ::blaze::CompressedMatrix<V, O> >
+{
+    struct type {
+        typedef typename ::blaze::CompressedMatrix<V, O>::ConstIterator Base;
+        Base base;
+        Base end;
+
+        operator bool() const {
+            return base != end;
+        }
+
+        type operator++() {
+            ++base;
+            return *this;
+        }
+
+        size_t col() const {
+            return base->index();
+        }
+
+        V value() const {
+            return base->value();
+        }
+    };
+};
+
+template < typename V, bool O >
+struct row_begin_impl< ::blaze::CompressedMatrix<V, O> > {
+    typedef typename row_iterator< ::blaze::CompressedMatrix<V, O> >::type iterator;
+    static iterator get(const ::blaze::CompressedMatrix<V, O> &A, size_t row) {
+        return iterator{A.cbegin(row), A.cend(row)};
+    }
+};
+
+template < class A, class B, typename V, bool O >
 struct spmv_impl<
-    A, ::blaze::CompressedMatrix<V>, ::blaze::DynamicVector<V>,
+    A, ::blaze::CompressedMatrix<V, O>, ::blaze::DynamicVector<V>,
     B, ::blaze::DynamicVector<V>
     >
 {
-    typedef ::blaze::CompressedMatrix<V> matrix;
+    typedef ::blaze::CompressedMatrix<V, O> matrix;
     typedef ::blaze::DynamicVector<V>    vector;
 
     static void apply(A alpha, const matrix &K, const vector &x, B beta, vector &y)
@@ -176,15 +211,15 @@ struct spmv_impl<
     }
 };
 
-template < typename V >
+template < typename V, bool O >
 struct residual_impl<
-    ::blaze::CompressedMatrix<V>,
+    ::blaze::CompressedMatrix<V, O>,
     ::blaze::DynamicVector<V>,
     ::blaze::DynamicVector<V>,
     ::blaze::DynamicVector<V>
     >
 {
-    typedef ::blaze::CompressedMatrix<V> matrix;
+    typedef ::blaze::CompressedMatrix<V, O> matrix;
     typedef ::blaze::DynamicVector<V>    vector;
 
     static void apply(const vector &rhs, const matrix &A, const vector &x,

--- a/external_libraries/amgcl/backend/builtin.hpp
+++ b/external_libraries/amgcl/backend/builtin.hpp
@@ -665,7 +665,11 @@ std::shared_ptr< numa_vector<V> > diagonal(const crs<V, C, P> &A, bool invert = 
     for(ptrdiff_t i = 0; i < static_cast<ptrdiff_t>(n); ++i) {
         for(auto a = A.row_begin(i); a; ++a) {
             if (a.col() == i) {
-                (*dia)[i] = invert ? math::inverse(a.value()) : a.value();
+                V d = a.value();
+                if (invert) {
+                    d = math::is_zero(d) ? math::identity<V>() : math::inverse(d);
+                }
+                (*dia)[i] = d;
                 break;
             }
         }

--- a/external_libraries/amgcl/backend/vexcl_static_matrix.hpp
+++ b/external_libraries/amgcl/backend/vexcl_static_matrix.hpp
@@ -61,10 +61,10 @@ struct rhs_of< amgcl::static_matrix<T, N, N> > {
     typedef amgcl::static_matrix<T, N, 1> type;
 };
 
-template <typename T, int N>
-struct spmv_ops_impl<amgcl::static_matrix<T,N,N>, amgcl::static_matrix<T,N,1>> {
-    typedef amgcl::static_matrix<T,N,N> matrix_value;
-    typedef amgcl::static_matrix<T,N,1> vector_value;
+template <typename TA, typename TX, int N>
+struct spmv_ops_impl<amgcl::static_matrix<TA,N,N>, amgcl::static_matrix<TX,N,1>> {
+    typedef amgcl::static_matrix<TA,N,N> matrix_value;
+    typedef amgcl::static_matrix<TX,N,1> vector_value;
 
     static void decl_accum_var(backend::source_generator &src, const std::string &name)
     {
@@ -650,22 +650,49 @@ struct vex_scale {
     } const apply;
 };
 
-template <typename T, int N>
-struct vex_add {
-    typedef static_matrix<T,N,1> vector;
+template <typename TS, typename TD, int N>
+struct vex_convert {
+    typedef static_matrix<TS,N,1> src_vector;
+    typedef static_matrix<TD,N,1> dst_vector;
 
-    struct apply_type : vex::UserFunction<apply_type, vector(vector, vector)> {
+    struct apply_type : vex::UserFunction<apply_type, dst_vector(src_vector)> {
         apply_type() {}
 
         static std::string name() {
-            return "add_" + vex::type_name<vector>();
+            return "convert_" + vex::type_name<src_vector>() + "_" + vex::type_name<dst_vector>();
         }
 
         static void define(vex::backend::source_generator &src, const std::string &fname = name()) {
-            src.begin_function<vector>(fname);
+            src.begin_function<dst_vector>(fname);
             src.begin_function_parameters();
-            src.parameter<vector>("a");
-            src.parameter<vector>("b");
+            src.parameter<src_vector>("s");
+            src.end_function_parameters();
+            src.new_line() << vex::type_name<dst_vector>() << " d;";
+            for(int i = 0; i < N; ++i)
+                src.new_line() << "d.data[" << i << "][0] = s.data[" << i << "][0];";
+            src.new_line() << "return d;";
+            src.end_function();
+        }
+    } const apply;
+};
+
+template <typename TA, typename TB, int N>
+struct vex_add {
+    typedef static_matrix<TA,N,1> vectorA;
+    typedef static_matrix<TB,N,1> vectorB;
+
+    struct apply_type : vex::UserFunction<apply_type, vectorA(vectorA, vectorB)> {
+        apply_type() {}
+
+        static std::string name() {
+            return "add_" + vex::type_name<vectorA>() + "_" + vex::type_name<vectorB>();
+        }
+
+        static void define(vex::backend::source_generator &src, const std::string &fname = name()) {
+            src.begin_function<vectorA>(fname);
+            src.begin_function_parameters();
+            src.parameter<vectorA>("a");
+            src.parameter<vectorB>("b");
             src.end_function_parameters();
             for(int i = 0; i < N; ++i)
                 src.new_line() << "a.data[" << i << "][0] += "
@@ -676,22 +703,23 @@ struct vex_add {
     } const apply;
 };
 
-template <typename T, int N>
+template <typename TA, typename TB, int N>
 struct vex_sub {
-    typedef static_matrix<T,N,1> vector;
+    typedef static_matrix<TA,N,1> vectorA;
+    typedef static_matrix<TB,N,1> vectorB;
 
-    struct apply_type : vex::UserFunction<apply_type, vector(vector, vector)> {
+    struct apply_type : vex::UserFunction<apply_type, vectorA(vectorA, vectorB)> {
         apply_type() {}
 
         static std::string name() {
-            return "sub_" + vex::type_name<vector>();
+            return "sub_" + vex::type_name<vectorA>() + "_" + vex::type_name<vectorB>();
         }
 
         static void define(vex::backend::source_generator &src, const std::string &fname = name()) {
-            src.begin_function<vector>(fname);
+            src.begin_function<vectorA>(fname);
             src.begin_function_parameters();
-            src.parameter<vector>("a");
-            src.parameter<vector>("b");
+            src.parameter<vectorA>("a");
+            src.parameter<vectorB>("b");
             src.end_function_parameters();
             for(int i = 0; i < N; ++i)
                 src.new_line() << "a.data[" << i << "][0] -= "
@@ -702,25 +730,26 @@ struct vex_sub {
     } const apply;
 };
 
-template <typename T, int N>
+template <typename TA, typename TX, int N>
 struct vex_mul {
-    typedef static_matrix<T,N,N> matrix;
-    typedef static_matrix<T,N,1> vector;
+    typedef static_matrix<TA,N,N> matrix;
+    typedef static_matrix<TX,N,1> vectorX;
+    typedef static_matrix<TA,N,1> vectorY;
 
-    struct apply_type : vex::UserFunction<apply_type, vector(matrix, vector)> {
+    struct apply_type : vex::UserFunction<apply_type, vectorY(matrix, vectorX)> {
         apply_type() {}
 
         static std::string name() {
-            return "mul_" + vex::type_name<matrix>();
+            return "mul_" + vex::type_name<matrix>() + "_" + vex::type_name<vectorX>();
         }
 
         static void define(vex::backend::source_generator &src, const std::string &fname = name()) {
-            src.begin_function<vector>(fname);
+            src.begin_function<vectorY>(fname);
             src.begin_function_parameters();
             src.parameter<matrix>("a");
-            src.parameter<vector>("b");
+            src.parameter<vectorX>("b");
             src.end_function_parameters();
-            src.new_line() << vex::type_name<vector>() << " c;";
+            src.new_line() << vex::type_name<vectorY>() << " c;";
             for(int i = 0; i < N; ++i) {
                 src.new_line() << "c.data[" << i << "][0] = ";
                 for(int j = 0; j < N; ++j) {
@@ -735,20 +764,21 @@ struct vex_mul {
     } const apply;
 };
 
-template <typename Alpha, typename Beta, typename T, int B>
+template <typename Alpha, typename Beta, typename TA, typename TX, typename TY, int B>
 struct spmv_impl<Alpha,
-    vex::sparse::distributed<vex::sparse::matrix<static_matrix<T,B,B>, ptrdiff_t, ptrdiff_t>>,
-    vex::vector<static_matrix<T,B,1>>, Beta, vex::vector<static_matrix<T,B,1>>>
+    vex::sparse::distributed<vex::sparse::matrix<static_matrix<TA,B,B>, ptrdiff_t, ptrdiff_t>>,
+    vex::vector<static_matrix<TX,B,1>>, Beta, vex::vector<static_matrix<TY,B,1>>>
 {
-    typedef vex::sparse::distributed<vex::sparse::matrix<static_matrix<T,B,B>, ptrdiff_t, ptrdiff_t>> matrix;
-    typedef vex::vector<static_matrix<T,B,1>> vector;
+    typedef vex::sparse::distributed<vex::sparse::matrix<static_matrix<TA,B,B>, ptrdiff_t, ptrdiff_t>> matrix;
+    typedef vex::vector<static_matrix<TX,B,1>> vectorX;
+    typedef vex::vector<static_matrix<TY,B,1>> vectorY;
 
-    static void apply(Alpha alpha, const matrix &A, const vector &x, Beta beta, vector &y)
+    static void apply(Alpha alpha, const matrix &A, const vectorX &x, Beta beta, vectorY &y)
     {
         if (beta)
-            y = vex_add<T,B>().apply(vex_scale<T,B>().apply(alpha, A * x), vex_scale<T,B>().apply(beta, y));
+            y = vex_add<TY,TA,B>().apply(vex_scale<TY,B>().apply(beta, y), vex_scale<TA,B>().apply(alpha, A * x));
         else
-            y = vex_scale<T,B>().apply(alpha, A * x);
+            y = vex_convert<TA,TY,B>().apply(vex_scale<TA,B>().apply(alpha, A * x));
     }
 };
 
@@ -799,39 +829,42 @@ struct spmv_impl<Alpha,
     }
 };
 
-template <typename T, int B>
+template <typename TB, typename TA, typename TX, typename TR, int B>
 struct residual_impl<
-    vex::sparse::distributed<vex::sparse::matrix<static_matrix<T,B,B>, ptrdiff_t, ptrdiff_t>>,
-    vex::vector<static_matrix<T,B,1>>,
-    vex::vector<static_matrix<T,B,1>>,
-    vex::vector<static_matrix<T,B,1>>
+    vex::sparse::distributed<vex::sparse::matrix<static_matrix<TA,B,B>, ptrdiff_t, ptrdiff_t>>,
+    vex::vector<static_matrix<TB,B,1>>,
+    vex::vector<static_matrix<TX,B,1>>,
+    vex::vector<static_matrix<TR,B,1>>
     >
 {
-    typedef vex::sparse::distributed<vex::sparse::matrix<static_matrix<T,B,B>, ptrdiff_t, ptrdiff_t>> matrix;
-    typedef vex::vector<static_matrix<T,B,1>> vector;
+    typedef vex::sparse::distributed<vex::sparse::matrix<static_matrix<TA,B,B>, ptrdiff_t, ptrdiff_t>> matrix;
+    typedef vex::vector<static_matrix<TB,B,1>> vectorB;
+    typedef vex::vector<static_matrix<TX,B,1>> vectorX;
+    typedef vex::vector<static_matrix<TR,B,1>> vectorR;
 
-    static void apply(const vector &rhs, const matrix &A, const vector &x, vector &r)
+    static void apply(const vectorB &rhs, const matrix &A, const vectorX &x, vectorR &r)
     {
-        r = vex_sub<T,B>().apply(rhs, A * x);
+        r = vex_convert<TB,TR,B>().apply(vex_sub<TB, TA, B>().apply(rhs, A * x));
     }
 };
 
-template < typename Alpha, typename Beta, typename T, int B >
+template < typename Alpha, typename Beta, typename TX, typename TY, typename TZ, int B >
 struct vmul_impl<
-    Alpha, vex::vector< static_matrix<T,B,B> >,
-    vex::vector< static_matrix<T,B,1> >,
-    Beta, vex::vector< static_matrix<T,B,1> >
+    Alpha, vex::vector< static_matrix<TX,B,B> >,
+    vex::vector< static_matrix<TY,B,1> >,
+    Beta, vex::vector< static_matrix<TZ,B,1> >
     >
 {
-    typedef vex::vector< static_matrix<T,B,B> > matrix;
-    typedef vex::vector< static_matrix<T,B,1> > vector;
+    typedef vex::vector< static_matrix<TX,B,B> > matrix;
+    typedef vex::vector< static_matrix<TY,B,1> > vectorY;
+    typedef vex::vector< static_matrix<TZ,B,1> > vectorZ;
 
-    static void apply(Alpha a, const matrix &x, const vector &y, Beta b, vector &z)
+    static void apply(Alpha a, const matrix &x, const vectorY &y, Beta b, vectorZ &z)
     {
         if (b)
-            z = vex_add<T,B>().apply(vex_scale<T,B>().apply(a, vex_mul<T,B>().apply(x, y)), vex_scale<T,B>().apply(b, z));
+            z = vex_add<TZ,TX,B>().apply(vex_scale<TZ,B>().apply(b, z), vex_scale<TX,B>().apply(a, vex_mul<TX,TY,B>().apply(x, y)));
         else
-            z = vex_scale<T,B>().apply(a, vex_mul<T,B>().apply(x, y));
+            z = vex_convert<TX,TZ,B>().apply(vex_scale<TX,B>().apply(a, vex_mul<TX,TY,B>().apply(x, y)));
     }
 };
 
@@ -861,44 +894,47 @@ struct copy_impl<
     }
 };
 
-template < typename A, typename B, typename T, int N >
+template < typename A, typename B, typename TX, typename TY, int N >
 struct axpby_impl<
-    A, vex::vector< static_matrix<T, N, 1> >,
-    B, vex::vector< static_matrix<T, N, 1> >
+    A, vex::vector< static_matrix<TX, N, 1> >,
+    B, vex::vector< static_matrix<TY, N, 1> >
     >
 {
-    typedef vex::vector< static_matrix<T,N,1> > vector;
+    typedef vex::vector< static_matrix<TX,N,1> > vectorX;
+    typedef vex::vector< static_matrix<TY,N,1> > vectorY;
 
-    static void apply(A a, const vector &x, B b, vector &y) {
+    static void apply(A a, const vectorX &x, B b, vectorY &y) {
         if (b)
-            y.template reinterpret<T>() =
-                a * x.template reinterpret<T>() +
-                b * y.template reinterpret<T>();
+            y.template reinterpret<TY>() =
+                a * x.template reinterpret<TX>() +
+                b * y.template reinterpret<TY>();
         else
-            y.template reinterpret<T>() =
-                a * x.template reinterpret<T>();
+            y.template reinterpret<TY>() =
+                a * x.template reinterpret<TX>();
     }
 };
 
-template < typename A, typename B, typename C, typename T, int N >
+template < typename A, typename B, typename C, typename TX, typename TY, typename TZ, int N >
 struct axpbypcz_impl<
-    A, vex::vector< static_matrix<T, N, 1> >,
-    B, vex::vector< static_matrix<T, N, 1> >,
-    C, vex::vector< static_matrix<T, N, 1> >
+    A, vex::vector< static_matrix<TX, N, 1> >,
+    B, vex::vector< static_matrix<TY, N, 1> >,
+    C, vex::vector< static_matrix<TZ, N, 1> >
     >
 {
-    typedef vex::vector< static_matrix<T,N,1> > vector;
+    typedef vex::vector< static_matrix<TX,N,1> > vectorX;
+    typedef vex::vector< static_matrix<TY,N,1> > vectorY;
+    typedef vex::vector< static_matrix<TZ,N,1> > vectorZ;
 
-    static void apply(A a, const vector &x, B b, const vector &y, C c, vector &z) {
+    static void apply(A a, const vectorX &x, B b, const vectorY &y, C c, vectorZ &z) {
         if (c)
-            z.template reinterpret<T>() =
-                a * x.template reinterpret<T>() +
-                b * y.template reinterpret<T>() +
-                c * z.template reinterpret<T>();
+            z.template reinterpret<TZ>() =
+                a * x.template reinterpret<TX>() +
+                b * y.template reinterpret<TY>() +
+                c * z.template reinterpret<TZ>();
         else
-            z.template reinterpret<T>() =
-                a * x.template reinterpret<T>() +
-                b * y.template reinterpret<T>();
+            z.template reinterpret<TZ>() =
+                a * x.template reinterpret<TX>() +
+                b * y.template reinterpret<TY>();
     }
 };
 

--- a/external_libraries/amgcl/backend/vexcl_static_matrix.hpp
+++ b/external_libraries/amgcl/backend/vexcl_static_matrix.hpp
@@ -155,7 +155,7 @@ class ell<amgcl::static_matrix<T, N, N>, Col, Ptr> {
             if (ell_width == 0) {
                 assert(csr_nnz == nnz);
 
-                csr_ptr = backend::device_vector<Col>(q[0], n + 1,   &ptr[0]);
+                csr_ptr = backend::device_vector<Ptr>(q[0], n + 1,   &ptr[0]);
                 csr_col = backend::device_vector<Col>(q[0], csr_nnz, &col[0]);
                 csr_val = create_device_vector       (q[0], csr_nnz, &val[0], false);
 

--- a/external_libraries/amgcl/coarsening/plain_aggregates.hpp
+++ b/external_libraries/amgcl/coarsening/plain_aggregates.hpp
@@ -189,7 +189,7 @@ struct plain_aggregates {
             }
         }
 
-        precondition(count > 0, "Zero aggregates found.");
+        if (!count) throw error::empty_level();
 
         // Some of the aggregates could potentially vanish during expansion
         // step (*) above. We need to exclude those and renumber the rest.

--- a/external_libraries/amgcl/coarsening/rigid_body_modes.hpp
+++ b/external_libraries/amgcl/coarsening/rigid_body_modes.hpp
@@ -1,0 +1,129 @@
+#ifndef AMGCL_COARSENING_RIGID_BODY_MODES_HPP
+#define AMGCL_COARSENING_RIGID_BODY_MODES_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/coarsening/rigid_body_modes.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  Create rigid body modes from coordinates.
+ */
+
+#include <amgcl/util.hpp>
+
+namespace amgcl {
+namespace coarsening {
+
+// Create rigid body modes from coordinate vector.
+// To be used as near-nullspace vectors with aggregation coarsening
+// for 2D or 3D elasticity problems.
+template <class Vector>
+int rigid_body_modes(int ndim, const Vector &coo, std::vector<double> &B) {
+    precondition(ndim == 2 || ndim == 3, "Only 2D or 3D problems are supported");
+    precondition(coo.size() % ndim == 0, "Coordinate vector size should be divisible by ndim");
+
+    size_t n = coo.size();
+    int nmodes = (ndim == 2 ? 3 : 6);
+    B.resize(n * nmodes, 0.0);
+
+    double sn = 1 / sqrt(n);
+
+    if (ndim == 2) {
+        for(size_t i = 0; i < n; ++i) {
+            size_t nod = i / ndim;
+            size_t dim = i % ndim;
+
+            double x = coo[nod * 2 + 0];
+            double y = coo[nod * 2 + 1];
+
+            // Translation
+            B[i * nmodes + dim] = sn;
+
+            // Rotation
+            switch(dim) {
+                case 0:
+                    B[i * nmodes + 2] = -y;
+                    break;
+                case 1:
+                    B[i * nmodes + 2] = x;
+                    break;
+            }
+        }
+    } else if (ndim == 3) {
+        for(size_t i = 0; i < n; ++i) {
+            size_t nod = i / ndim;
+            size_t dim = i % ndim;
+
+            double x = coo[nod * 3 + 0];
+            double y = coo[nod * 3 + 1];
+            double z = coo[nod * 3 + 2];
+
+            // Translation
+            B[i * nmodes + dim] = sn;
+
+            // Rotation
+            switch(dim) {
+                case 0:
+                    B[i * nmodes + 3] = y;
+                    B[i * nmodes + 5] = z;
+                    break;
+                case 1:
+                    B[i * nmodes + 3] = -x;
+                    B[i * nmodes + 4] = -z;
+                    break;
+                case 2:
+                    B[i * nmodes + 4] =  y;
+                    B[i * nmodes + 5] = -x;
+                    break;
+            }
+        }
+    }
+
+    // Orthonormalization
+    std::array<double, 6> dot;
+    for(int i = ndim; i < nmodes; ++i) {
+        std::fill(dot.begin(), dot.end(), 0.0);
+        for(size_t j = 0; j < n; ++j) {
+            for(int k = 0; k < i; ++k)
+                dot[k] += B[j * nmodes + k] * B[j * nmodes + i];
+        }
+        double s = 0.0;
+        for(size_t j = 0; j < n; ++j) {
+            for(int k = 0; k < i; ++k)
+                B[j * nmodes + i] -= dot[k] * B[j * nmodes + k];
+            s += B[j * nmodes + i] * B[j * nmodes + i];
+        }
+        s = sqrt(s);
+        for(size_t j = 0; j < n; ++j)
+            B[j * nmodes + i] /= s;
+    }
+
+    return nmodes;
+}
+
+} // namespace coarsening
+} // namespace amgcl
+
+#endif

--- a/external_libraries/amgcl/coarsening/ruge_stuben.hpp
+++ b/external_libraries/amgcl/coarsening/ruge_stuben.hpp
@@ -127,6 +127,8 @@ struct ruge_stuben {
         for(size_t i = 0; i < n; ++i)
             if (cf[i] == 'C') cidx[i] = static_cast<ptrdiff_t>(nc++);
 
+        if (!nc) throw error::empty_level();
+
         auto P = std::make_shared<Matrix>();
         P->set_size(n, nc, true);
 

--- a/external_libraries/amgcl/coarsening/tentative_prolongation.hpp
+++ b/external_libraries/amgcl/coarsening/tentative_prolongation.hpp
@@ -133,7 +133,7 @@ std::shared_ptr<Matrix> tentative_prolongation(
     if (nullspace.cols > 0) {
         // Sort fine points by aggregate number.
         // Put points not belonging to any aggregate to the end of the list.
-        std::vector<ptrdiff_t> order(0);
+        std::vector<ptrdiff_t> order(n);
         for(size_t i = 0; i < n; ++i) order[i] = i;
         std::stable_sort(order.begin(), order.end(), detail::skip_negative(aggr, block_size));
 

--- a/external_libraries/amgcl/mpi/distributed_matrix.hpp
+++ b/external_libraries/amgcl/mpi/distributed_matrix.hpp
@@ -452,7 +452,7 @@ class distributed_matrix {
                 A_loc = Backend::copy_matrix(a_loc, bprm);
             }
 
-            if (!A_rem) {
+            if (!A_rem && a_rem && a_rem->nnz > 0) {
                 C->renumber(a_rem->nnz, a_rem->col);
                 A_rem = Backend::copy_matrix(a_rem, bprm);
             }
@@ -1071,6 +1071,13 @@ struct residual_impl<mpi::distributed_matrix<Backend>, Vec1, Vec2, Vec3>
         A.residual(rhs, x, r);
     }
 };
+
+// Diagonal of the matrix
+template <class Backend>
+std::shared_ptr< numa_vector<typename Backend::value_type> >
+diagonal(const mpi::distributed_matrix<Backend> &A, bool invert = false) {
+    return diagonal(*A.local(), invert);
+}
 
 // Estimate spectral radius of the matrix.
 template <bool scale, class Backend>

--- a/external_libraries/amgcl/mpi/make_solver.hpp
+++ b/external_libraries/amgcl/mpi/make_solver.hpp
@@ -40,29 +40,34 @@ THE SOFTWARE.
 
 #include <amgcl/util.hpp>
 #include <amgcl/mpi/inner_product.hpp>
+#include <amgcl/mpi/distributed_matrix.hpp>
 
 namespace amgcl {
 namespace mpi {
 
 template <
     class Precond,
-    template <class, class> class IterativeSolver
+    class IterativeSolver
     >
 class make_solver : public amgcl::detail::non_copyable {
+    static_assert(
+            backend::backends_compatible<
+                typename IterativeSolver::backend_type,
+                typename Precond::backend_type
+            >::value,
+            "Backends for preconditioner and iterative solver should be compatible"
+            );
     public:
-        typedef typename Precond::backend_type backend_type;
-        typedef typename Precond::matrix matrix;
+        typedef typename IterativeSolver::backend_type backend_type;
+        typedef amgcl::mpi::distributed_matrix<backend_type> matrix;
         typedef typename backend_type::value_type value_type;
         typedef typename backend_type::params backend_params;
         typedef typename backend::builtin<value_type>::matrix build_matrix;
         typedef typename math::scalar_of<value_type>::type scalar_type;
 
-        typedef IterativeSolver<backend_type, mpi::inner_product> Solver;
-
-
         struct params {
             typename Precond::params precond; ///< Preconditioner parameters.
-            typename Solver::params  solver;  ///< Iterative solver parameters.
+            typename IterativeSolver::params  solver;  ///< Iterative solver parameters.
 
             params() {}
 
@@ -136,7 +141,7 @@ class make_solver : public amgcl::detail::non_copyable {
             return P;
         }
 
-        const Solver& solver() const {
+        const IterativeSolver& solver() const {
             return S;
         }
 
@@ -165,7 +170,7 @@ class make_solver : public amgcl::detail::non_copyable {
         size_t n;
 
         Precond P;
-        Solver  S;
+        IterativeSolver  S;
 };
 
 } // namespace mpi

--- a/external_libraries/amgcl/mpi/solver/bicgstab.hpp
+++ b/external_libraries/amgcl/mpi/solver/bicgstab.hpp
@@ -1,0 +1,52 @@
+#ifndef AMGCL_MPI_SOLVER_BICGSTAB_HPP
+#define AMGCL_MPI_SOLVER_BICGSTAB_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/mpi/solver/bicgstab.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  MPI wrapper for BiCGStab iterative method.
+ */
+
+#include <amgcl/solver/bicgstab.hpp>
+#include <amgcl/mpi/inner_product.hpp>
+
+namespace amgcl {
+namespace mpi {
+namespace solver {
+
+template <class Backend, class InnerProduct = mpi::inner_product>
+class bicgstab : public amgcl::solver::bicgstab<Backend, InnerProduct> {
+    typedef amgcl::solver::bicgstab<Backend, InnerProduct> Base;
+    public:
+        using Base::Base;
+};
+
+} // namespace solver
+} // namespace mpi
+} // namespace amgcl
+
+#endif

--- a/external_libraries/amgcl/mpi/solver/bicgstabl.hpp
+++ b/external_libraries/amgcl/mpi/solver/bicgstabl.hpp
@@ -1,0 +1,53 @@
+#ifndef AMGCL_MPI_SOLVER_BICGSTABL_HPP
+#define AMGCL_MPI_SOLVER_BICGSTABL_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/mpi/solver/bicgstabl.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  MPI wrapper for BiCGStab(L) iterative method.
+ */
+
+#include <amgcl/solver/bicgstabl.hpp>
+#include <amgcl/mpi/inner_product.hpp>
+
+namespace amgcl {
+namespace mpi {
+namespace solver {
+
+template <class Backend, class InnerProduct = mpi::inner_product>
+class bicgstabl : public amgcl::solver::bicgstabl<Backend, InnerProduct> {
+    typedef amgcl::solver::bicgstabl<Backend, InnerProduct> Base;
+    public:
+        using Base::Base;
+};
+
+} // namespace solver
+} // namespace mpi
+} // namespace amgcl
+
+
+#endif

--- a/external_libraries/amgcl/mpi/solver/cg.hpp
+++ b/external_libraries/amgcl/mpi/solver/cg.hpp
@@ -1,0 +1,53 @@
+#ifndef AMGCL_MPI_SOLVER_CG_HPP
+#define AMGCL_MPI_SOLVER_CG_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/mpi/solver/cg.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  MPI wrapper for CG iterative method.
+ */
+
+#include <amgcl/solver/cg.hpp>
+#include <amgcl/mpi/inner_product.hpp>
+
+namespace amgcl {
+namespace mpi {
+namespace solver {
+
+template <class Backend, class InnerProduct = mpi::inner_product>
+class cg : public amgcl::solver::cg<Backend, InnerProduct> {
+    typedef amgcl::solver::cg<Backend, InnerProduct> Base;
+    public:
+        using Base::Base;
+};
+
+} // namespace solver
+} // namespace mpi
+} // namespace amgcl
+
+
+#endif

--- a/external_libraries/amgcl/mpi/solver/fgmres.hpp
+++ b/external_libraries/amgcl/mpi/solver/fgmres.hpp
@@ -1,0 +1,53 @@
+#ifndef AMGCL_MPI_SOLVER_FGMRES_HPP
+#define AMGCL_MPI_SOLVER_FGMRES_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/mpi/solver/fgmres.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  MPI wrapper for FGMRES iterative method.
+ */
+
+#include <amgcl/solver/fgmres.hpp>
+#include <amgcl/mpi/inner_product.hpp>
+
+namespace amgcl {
+namespace mpi {
+namespace solver {
+
+template <class Backend, class InnerProduct = mpi::inner_product>
+class fgmres : public amgcl::solver::fgmres<Backend, InnerProduct> {
+    typedef amgcl::solver::fgmres<Backend, InnerProduct> Base;
+    public:
+        using Base::Base;
+};
+
+} // namespace solver
+} // namespace mpi
+} // namespace amgcl
+
+
+#endif

--- a/external_libraries/amgcl/mpi/solver/gmres.hpp
+++ b/external_libraries/amgcl/mpi/solver/gmres.hpp
@@ -1,0 +1,53 @@
+#ifndef AMGCL_MPI_SOLVER_GMRES_HPP
+#define AMGCL_MPI_SOLVER_GMRES_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/mpi/solver/gmres.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  MPI wrapper for GMRES iterative method.
+ */
+
+#include <amgcl/solver/gmres.hpp>
+#include <amgcl/mpi/inner_product.hpp>
+
+namespace amgcl {
+namespace mpi {
+namespace solver {
+
+template <class Backend, class InnerProduct = mpi::inner_product>
+class gmres : public amgcl::solver::gmres<Backend, InnerProduct> {
+    typedef amgcl::solver::gmres<Backend, InnerProduct> Base;
+    public:
+        using Base::Base;
+};
+
+} // namespace solver
+} // namespace mpi
+} // namespace amgcl
+
+
+#endif

--- a/external_libraries/amgcl/mpi/solver/idrs.hpp
+++ b/external_libraries/amgcl/mpi/solver/idrs.hpp
@@ -1,0 +1,53 @@
+#ifndef AMGCL_MPI_SOLVER_IDRS_HPP
+#define AMGCL_MPI_SOLVER_IDRS_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/mpi/solver/idrs.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  MPI wrapper for IDR(s) iterative method.
+ */
+
+#include <amgcl/solver/idrs.hpp>
+#include <amgcl/mpi/inner_product.hpp>
+
+namespace amgcl {
+namespace mpi {
+namespace solver {
+
+template <class Backend, class InnerProduct = mpi::inner_product>
+class idrs : public amgcl::solver::idrs<Backend, InnerProduct> {
+    typedef amgcl::solver::idrs<Backend, InnerProduct> Base;
+    public:
+        using Base::Base;
+};
+
+} // namespace solver
+} // namespace mpi
+} // namespace amgcl
+
+
+#endif

--- a/external_libraries/amgcl/mpi/solver/lgmres.hpp
+++ b/external_libraries/amgcl/mpi/solver/lgmres.hpp
@@ -1,0 +1,53 @@
+#ifndef AMGCL_MPI_SOLVER_LGMRES_HPP
+#define AMGCL_MPI_SOLVER_LGMRES_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/mpi/solver/lgmres.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  MPI wrapper for LGMRES iterative method.
+ */
+
+#include <amgcl/solver/lgmres.hpp>
+#include <amgcl/mpi/inner_product.hpp>
+
+namespace amgcl {
+namespace mpi {
+namespace solver {
+
+template <class Backend, class InnerProduct = mpi::inner_product>
+class lgmres : public amgcl::solver::lgmres<Backend, InnerProduct> {
+    typedef amgcl::solver::lgmres<Backend, InnerProduct> Base;
+    public:
+        using Base::Base;
+};
+
+} // namespace solver
+} // namespace mpi
+} // namespace amgcl
+
+
+#endif

--- a/external_libraries/amgcl/mpi/solver/runtime.hpp
+++ b/external_libraries/amgcl/mpi/solver/runtime.hpp
@@ -1,0 +1,53 @@
+#ifndef AMGCL_MPI_SOLVER_RUNTIME_HPP
+#define AMGCL_MPI_SOLVER_RUNTIME_HPP
+
+/*
+The MIT License
+
+Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+
+/**
+ * \file   amgcl/mpi/solver/runtime.hpp
+ * \author Denis Demidov <dennis.demidov@gmail.com>
+ * \brief  Runtime-configurable MPI wrapper around amgcl iterative solvers.
+ */
+
+#include <amgcl/solver/runtime.hpp>
+#include <amgcl/mpi/inner_product.hpp>
+
+namespace amgcl {
+namespace runtime { 
+namespace mpi {
+namespace solver {
+
+template <class Backend, class InnerProduct = amgcl::mpi::inner_product>
+struct wrapper : public amgcl::runtime::solver::wrapper<Backend, InnerProduct> {
+    typedef amgcl::runtime::solver::wrapper<Backend, InnerProduct> Base;
+    using Base::Base;
+};
+
+} // namespace solver
+} // namespace mpi
+} // namespace runtime
+} // namespace amgcl
+
+#endif

--- a/external_libraries/amgcl/mpi/subdomain_deflation.hpp
+++ b/external_libraries/amgcl/mpi/subdomain_deflation.hpp
@@ -107,18 +107,17 @@ sdd_projected_matrix<SDD, Matrix> make_sdd_projected_matrix(const SDD &S, const 
  */
 template <
     class LocalPrecond,
-    template <class, class> class IterativeSolver,
+    class IterativeSolver,
     class DirectSolver = mpi::direct::skyline_lu<typename LocalPrecond::backend_type::value_type>
     >
 class subdomain_deflation {
     public:
         typedef typename LocalPrecond::backend_type backend_type;
         typedef typename backend_type::params backend_params;
-        typedef IterativeSolver<backend_type, mpi::inner_product> ISolver;
 
         struct params {
             typename LocalPrecond::params local;
-            typename ISolver::params      isolver;
+            typename IterativeSolver::params isolver;
             typename DirectSolver::params dsolver;
 
             // Number of deflation vectors.
@@ -535,7 +534,7 @@ class subdomain_deflation {
         std::shared_ptr<vector> q;
         std::shared_ptr<vector> dd;
 
-        ISolver S;
+        IterativeSolver S;
 
         void coarse_solve(std::vector<value_type> &f, std::vector<value_type> &x) const
         {

--- a/external_libraries/amgcl/relaxation/chebyshev.hpp
+++ b/external_libraries/amgcl/relaxation/chebyshev.hpp
@@ -5,6 +5,7 @@
 The MIT License
 
 Copyright (c) 2012-2019 Denis Demidov <dennis.demidov@gmail.com>
+Copyright (c) 2019 Peter Gamnitzer, UIBK (University of Innsbruck)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -29,6 +30,11 @@ THE SOFTWARE.
  * \file   amgcl/relaxation/chebyshev.hpp
  * \author Denis Demidov <dennis.demidov@gmail.com>
  * \brief  Chebyshev polynomial smoother.
+ *
+ * Implements Algorithm 1 from
+ * P. Ghysels, P. Kłosiewicz, and W. Vanroose.
+ * "Improving the arithmetic intensity of multigrid with the help of polynomial smoothers".
+ * Numer. Linear Algebra Appl. 2012;19:253-267. DOI: 10.1002/nla.1808
  */
 
 #include <vector>
@@ -58,6 +64,14 @@ class chebyshev {
             /// Chebyshev polynomial degree.
             unsigned degree;
 
+            /// highest eigen value safety upscaling.
+            // use boosting factor for a more conservative upper bound estimate
+            // See: Adams, Brezina, Hu, Tuminaro,
+            //      PARALLEL MULTIGRID SMOOTHING: POLYNOMIAL VERSUS
+            //      GAUSS-SEIDEL, J. Comp. Phys. 188 (2003) 593-610.
+            //
+            float higher;
+
             /// Lowest-to-highest eigen value ratio.
             float lower;
 
@@ -66,21 +80,31 @@ class chebyshev {
             // spectral radius.
             int power_iters;
 
-            params() : degree(5), lower(1.0f / 30), power_iters(0) {}
+            // Scale the system matrix
+            bool scale;
+
+            params()
+                : degree(5), higher(1.0f), lower(1.0f / 30), power_iters(0),
+                  scale(false)
+            {}
 
 #ifndef AMGCL_NO_BOOST
             params(const boost::property_tree::ptree &p)
                 : AMGCL_PARAMS_IMPORT_VALUE(p, degree),
+                  AMGCL_PARAMS_IMPORT_VALUE(p, higher),
                   AMGCL_PARAMS_IMPORT_VALUE(p, lower),
-                  AMGCL_PARAMS_IMPORT_VALUE(p, power_iters)
+                  AMGCL_PARAMS_IMPORT_VALUE(p, power_iters),
+                  AMGCL_PARAMS_IMPORT_VALUE(p, scale)
             {
-                check_params(p, {"degree", "lower", "power_iters"});
+                check_params(p, {"degree", "higher", "lower", "power_iters", "scale"});
             }
 
             void get(boost::property_tree::ptree &p, const std::string &path) const {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, degree);
+                AMGCL_PARAMS_EXPORT_VALUE(p, path, higher);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, lower);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, power_iters);
+                AMGCL_PARAMS_EXPORT_VALUE(p, path, scale);
             }
 #endif
         } prm;
@@ -90,109 +114,90 @@ class chebyshev {
         chebyshev(
                 const Matrix &A, const params &prm,
                 const typename Backend::params &backend_prm
-            ) : C( prm.degree ),
+            ) : prm(prm),
                 p( Backend::create_vector(rows(A), backend_prm) ),
-                q( Backend::create_vector(rows(A), backend_prm) )
+                r( Backend::create_vector(rows(A), backend_prm) )
         {
-            scalar_type hi = backend::spectral_radius</*scale=*/false>(A, prm.power_iters);
-            scalar_type lo = hi * prm.lower;
+            scalar_type hi, lo;
 
-            // Chebyshev polynomial roots on the interval [lo, hi].
-            std::vector<scalar_type> roots(prm.degree);
-            for(unsigned i = 0; i < prm.degree; ++i) {
-                scalar_type pi   = static_cast<scalar_type>(3.14159265358979323846);
-                scalar_type half = static_cast<scalar_type>(0.5);
-
-                roots[i] = lo + half * (hi - lo) * (1 + cos( pi * ( i + half ) / prm.degree));
+            if (prm.scale) {
+                M  = Backend::copy_vector( diagonal(A, /*invert*/true), backend_prm );
+                hi = backend::spectral_radius<true>(A, prm.power_iters);
+            } else {
+                hi = backend::spectral_radius<false>(A, prm.power_iters);
             }
 
-            // Construct linear system to determine Chebyshev coefficients.
-            multi_array<scalar_type, 2> S(prm.degree, prm.degree);
-            std::vector<scalar_type> buf(prm.degree * prm.degree);
+            lo = hi * prm.lower;
+            hi *= prm.higher;
 
-            std::vector<scalar_type> rhs(prm.degree);
-            for(unsigned i = 0; i < prm.degree; ++i) {
-                scalar_type x = roots[i];
-                scalar_type x_to_j = 1;
-                for(unsigned j = 0; j < prm.degree; ++j) {
-                    S(i,j) = x_to_j;
-                    x_to_j *= x;
-                }
-                rhs[i] = -x_to_j;
-            }
+            // Centre of ellipse containing the eigenvalues of A:
+            d = 0.5 * (hi + lo);
 
-            // Invert S, compute coefficients.
-            amgcl::detail::inverse(prm.degree, S.data(), buf.data());
-
-            scalar_type const_c = 1;
-            for(unsigned i = 0; i < prm.degree; ++i) {
-                scalar_type c = 0;
-                for(unsigned j = 0; j < prm.degree; ++j)
-                    c += S(i,j) * rhs[j];
-                if (i == 0)
-                    const_c = c;
-                else
-                    C[prm.degree - i] = -c / const_c;
-            }
-            C[0] = -1 / const_c;
+            // Semi-major axis of ellipse containing the eigenvalues of A:
+            c = 0.5 * (hi - lo);
         }
 
-        /// \copydoc amgcl::relaxation::damped_jacobi::apply_pre
         template <class Matrix, class VectorRHS, class VectorX, class VectorTMP>
         void apply_pre(
-                const Matrix &A, const VectorRHS &rhs, VectorX &x, VectorTMP &tmp
+                const Matrix &A, const VectorRHS &rhs, VectorX &x, VectorTMP&
                 ) const
-        {
-            static const scalar_type one  = math::identity<scalar_type>();
-
-            backend::residual(rhs, A, x, tmp);
-            solve(A, tmp, *p);
-            backend::axpby(one, *p, one, x);
-        }
-
-        /// \copydoc amgcl::relaxation::damped_jacobi::apply_post
-        template <class Matrix, class VectorRHS, class VectorX, class VectorTMP>
-        void apply_post(
-                const Matrix &A, const VectorRHS &rhs, VectorX &x, VectorTMP &tmp
-                ) const
-        {
-            static const scalar_type one  = math::identity<scalar_type>();
-
-            backend::residual(rhs, A, x, tmp);
-            solve(A, tmp, *p);
-            backend::axpby(one, *p, one, x);
-        }
-
-        /// \copydoc amgcl::relaxation::damped_jacobi::apply_post
-        template <class Matrix, class VectorRHS, class VectorX>
-        void apply(const Matrix &A, const VectorRHS &rhs, VectorX &x) const
         {
             solve(A, rhs, x);
         }
 
+        template <class Matrix, class VectorRHS, class VectorX, class VectorTMP>
+        void apply_post(
+                const Matrix &A, const VectorRHS &rhs, VectorX &x, VectorTMP&
+                ) const
+        {
+            solve(A, rhs, x);
+        }
+
+        template <class Matrix, class VectorRHS, class VectorX>
+        void apply(const Matrix &A, const VectorRHS &rhs, VectorX &x) const
+        {
+            backend::clear(x);
+            solve(A, rhs, x);
+        }
+
         size_t bytes() const {
-            return
-                backend::bytes(C) +
-                backend::bytes(*p) +
-                backend::bytes(*q);
+            size_t b = backend::bytes(*p) + backend::bytes(*r);
+            if (prm.scale) b += backend::bytes(*M);
+            return b;
         }
 
     private:
-        std::vector<scalar_type> C;
-        mutable std::shared_ptr<vector> p, q;
+        std::shared_ptr<typename Backend::matrix_diagonal> M;
+        mutable std::shared_ptr<vector> p, r;
 
-        template <class Matrix, class VectorRHS, class VectorX>
-        void solve(const Matrix &A, const VectorRHS &rhs, VectorX &x) const
+        scalar_type c, d;
+
+        template <class Matrix, class VectorB, class VectorX>
+        void solve(const Matrix &A, const VectorB &b, VectorX &x) const
         {
             static const scalar_type one  = math::identity<scalar_type>();
             static const scalar_type zero = math::zero<scalar_type>();
 
-            backend::axpby(C[0], rhs, zero, x);
+            scalar_type alpha, beta;
 
-            for(auto c = C.begin() + 1; c != C.end(); ++c)
-            {
-                backend::spmv(one, A, x, zero, *q);
-                backend::axpbypcz(*c, rhs, one, *q, zero, x);
+            for (unsigned k = 0; k < prm.degree; ++k) {
+                backend::residual(b, A, x, *r);
+
+                if (prm.scale) backend::vmul(one, *M, *r, zero, *r);
+
+                if (k == 0) {
+                    alpha = math::inverse(d);
+                    beta  = zero;
+                } else if (k == 1) {
+                    alpha = 2 * d * math::inverse(2 * d * d - c * c);
+                    beta  = alpha * d - one;
+                } else {
+                    alpha = math::inverse(d - 0.25 * alpha * c * c);
+                    beta  = alpha * d - one;
+                }
+
+                backend::axpby(alpha, *r, beta, *p);
+                backend::axpby(one, *p, one, x);
             }
         }
 };

--- a/external_libraries/amgcl/relaxation/gauss_seidel.hpp
+++ b/external_libraries/amgcl/relaxation/gauss_seidel.hpp
@@ -164,8 +164,9 @@ struct gauss_seidel {
             const ptrdiff_t inc = forward ? 1 : -1;
 
             for(ptrdiff_t i = beg; i != end; i += inc) {
-                rhs_type X = rhs[i];
                 val_type D = math::identity<val_type>();
+                rhs_type X;
+                X = rhs[i];
 
                 for (auto a = backend::row_begin(A, i); a; ++a) {
                     ptrdiff_t c = a.col();
@@ -329,8 +330,9 @@ struct gauss_seidel {
                             ptrdiff_t beg = ptr[tid][r];
                             ptrdiff_t end = ptr[tid][r+1];
 
-                            rhs_type   X = rhs[i];
                             value_type D = math::identity<value_type>();
+                            rhs_type X;
+                            X = rhs[i];
 
                             for(ptrdiff_t j = beg; j < end; ++j) {
                                 ptrdiff_t  c = col[tid][j];

--- a/external_libraries/amgcl/solver/bicgstab.hpp
+++ b/external_libraries/amgcl/solver/bicgstab.hpp
@@ -150,7 +150,7 @@ class bicgstab {
             static const coef_type zero = math::zero<coef_type>();
 
             scalar_type norm_rhs = norm(rhs);
-            if (norm_rhs < amgcl::detail::eps<scalar_type>(n)) {
+            if (norm_rhs < amgcl::detail::eps<scalar_type>(1)) {
                 backend::clear(x);
                 return std::make_tuple(0, norm_rhs);
             }

--- a/external_libraries/amgcl/solver/bicgstab.hpp
+++ b/external_libraries/amgcl/solver/bicgstab.hpp
@@ -80,9 +80,13 @@ class bicgstab {
             /// Target absolute residual error.
             scalar_type abstol;
 
+            /// Always do at least one iteration.
+            bool check_after;
+
             params()
                 : pside(preconditioner::side::right), maxiter(100), tol(1e-8),
-                  abstol(std::numeric_limits<scalar_type>::min())
+                  abstol(std::numeric_limits<scalar_type>::min()),
+                  check_after(false)
             {}
 
 #ifndef AMGCL_NO_BOOST
@@ -90,9 +94,10 @@ class bicgstab {
                 : AMGCL_PARAMS_IMPORT_VALUE(p, pside),
                   AMGCL_PARAMS_IMPORT_VALUE(p, maxiter),
                   AMGCL_PARAMS_IMPORT_VALUE(p, tol),
-                  AMGCL_PARAMS_IMPORT_VALUE(p, abstol)
+                  AMGCL_PARAMS_IMPORT_VALUE(p, abstol),
+                  AMGCL_PARAMS_IMPORT_VALUE(p, check_after)
             {
-                check_params(p, {"pside", "maxiter", "tol", "abstol"});
+                check_params(p, {"pside", "maxiter", "tol", "abstol", "check_after"});
             }
 
             void get(boost::property_tree::ptree &p, const std::string &path) const {
@@ -100,6 +105,7 @@ class bicgstab {
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, maxiter);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, tol);
                 AMGCL_PARAMS_EXPORT_VALUE(p, path, abstol);
+                AMGCL_PARAMS_EXPORT_VALUE(p, path, check_after);
             }
 #endif
         };
@@ -157,8 +163,8 @@ class bicgstab {
             }
             backend::copy(*r, *rh);
 
-            scalar_type res = norm(*r);
             scalar_type eps = std::max(norm_rhs * prm.tol, prm.abstol);
+            scalar_type res = prm.check_after ? 2 * eps : norm(*r);
 
             coef_type rho1  = zero;
             coef_type rho2  = zero;

--- a/external_libraries/amgcl/solver/bicgstabl.hpp
+++ b/external_libraries/amgcl/solver/bicgstabl.hpp
@@ -208,7 +208,7 @@ class bicgstabl {
             scalar_type norm_rhs = norm(rhs);
 
             // Check if there is a trivial solution
-            if (norm_rhs < amgcl::detail::eps<scalar_type>(n)) {
+            if (norm_rhs < amgcl::detail::eps<scalar_type>(1)) {
                 backend::clear(x);
                 return std::make_tuple(0, norm_rhs);
             }

--- a/external_libraries/amgcl/solver/cg.hpp
+++ b/external_libraries/amgcl/solver/cg.hpp
@@ -144,7 +144,7 @@ class cg {
 
             backend::residual(rhs, A, x, *r);
             scalar_type norm_rhs = norm(rhs);
-            if (norm_rhs < amgcl::detail::eps<scalar_type>(n)) {
+            if (norm_rhs < amgcl::detail::eps<scalar_type>(1)) {
                 backend::clear(x);
                 return std::make_tuple(0, norm_rhs);
             }

--- a/external_libraries/amgcl/solver/fgmres.hpp
+++ b/external_libraries/amgcl/solver/fgmres.hpp
@@ -146,7 +146,7 @@ class fgmres {
                 ) const
         {
             scalar_type norm_rhs = norm(rhs);
-            if (norm_rhs < amgcl::detail::eps<scalar_type>(n)) {
+            if (norm_rhs < amgcl::detail::eps<scalar_type>(1)) {
                 backend::clear(x);
                 return std::make_tuple(0, norm_rhs);
             }

--- a/external_libraries/amgcl/solver/gmres.hpp
+++ b/external_libraries/amgcl/solver/gmres.hpp
@@ -155,7 +155,7 @@ class gmres {
             static const scalar_type one  = math::identity<scalar_type>();
 
             scalar_type norm_rhs = norm(rhs);
-            if (norm_rhs < amgcl::detail::eps<scalar_type>(n)) {
+            if (norm_rhs < amgcl::detail::eps<scalar_type>(1)) {
                 backend::clear(x);
                 return std::make_tuple(0, norm_rhs);
             }

--- a/external_libraries/amgcl/solver/idrs.hpp
+++ b/external_libraries/amgcl/solver/idrs.hpp
@@ -249,7 +249,7 @@ class idrs {
             static const scalar_type zero = math::zero<scalar_type>();
 
             scalar_type norm_rhs = norm(rhs);
-            if (norm_rhs < amgcl::detail::eps<scalar_type>(n)) {
+            if (norm_rhs < amgcl::detail::eps<scalar_type>(1)) {
                 backend::clear(x);
                 return std::make_tuple(0, norm_rhs);
             }

--- a/external_libraries/amgcl/solver/lgmres.hpp
+++ b/external_libraries/amgcl/solver/lgmres.hpp
@@ -222,7 +222,7 @@ class lgmres {
             }
 
             scalar_type norm_rhs = norm(rhs);
-            if (norm_rhs < amgcl::detail::eps<scalar_type>(n)) {
+            if (norm_rhs < amgcl::detail::eps<scalar_type>(1)) {
                 backend::clear(x);
                 return std::make_tuple(0, norm_rhs);
             }

--- a/external_libraries/amgcl/solver/skyline_lu.hpp
+++ b/external_libraries/amgcl/solver/skyline_lu.hpp
@@ -182,7 +182,8 @@ class skyline_lu {
             // x = invperm[y];
 
             for(int i = 0; i < n; ++i) {
-                rhs_type sum = rhs[perm[i]];
+                rhs_type sum;
+                sum = rhs[perm[i]];
                 for(int k = ptr[i], j = i - ptr[i+1] + k; k < ptr[i+1]; ++k, ++j)
                     sum -= L[k] * y[j];
 

--- a/external_libraries/amgcl/util.hpp
+++ b/external_libraries/amgcl/util.hpp
@@ -375,6 +375,11 @@ class non_copyable {
 
 } // namespace detail
 
+namespace error {
+
+struct empty_level {};
+
+} // namespace error
 } // namespace amgcl
 
 namespace std {

--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -37,6 +37,8 @@
 #include "includes/ublas_interface.h"
 #include "spaces/ublas_space.h"
 
+#include <amgcl/coarsening/rigid_body_modes.hpp>
+
 namespace Kratos
 {
 ///@name Kratos Globals
@@ -381,78 +383,17 @@ public:
         if(mUseAMGPreconditioning)
             mAMGCLParameters.put("precond.coarse_enough",mCoarseEnough/mBlockSize);
 
-        Matrix B;
         if(mUseAMGPreconditioning && mProvideCoordinates && (mBlockSize == 2 || mBlockSize == 3)) {
-            double sn = 1 / sqrt(TSparseSpaceType::Size1(rA));
+            std::vector<double> B;
+            int nmodes = amgcl::coarsening::rigid_body_modes(mBlockSize,
+                    boost::make_iterator_range(
+                        &mCoordinates[0][0],
+                        &mCoordinates[0][0] + TSparseSpaceType::Size1(rA)),
+                    B);
 
-            if (mBlockSize == 2) {
-                B = ZeroMatrix(  TSparseSpaceType::Size1(rA), 3);
-                for(IndexType i = 0; i<TSparseSpaceType::Size1(rA); ++i) {
-                    IndexType inode = i / mBlockSize;
-                    IndexType coord = i % mBlockSize;
-
-                    // Translation
-                    B(i,coord) = sn;
-
-                    // Rotation
-                    switch(coord) {
-                        case 0:
-                            B(i,2) = -mCoordinates[inode][1];
-                            break;
-                        case 1:
-                            B(i,2) = mCoordinates[inode][0];
-                            break;
-                    }
-                }
-            } else if (mBlockSize == 3) {
-                B = ZeroMatrix(  TSparseSpaceType::Size1(rA), 6);
-                for(IndexType i = 0; i<TSparseSpaceType::Size1(rA); ++i) {
-                    IndexType inode = i / mBlockSize;
-                    IndexType coord = i % mBlockSize;
-
-                    // Translation
-                    B(i,coord) = sn;
-
-                    // Rotation
-                    switch(coord) {
-                        case 0:
-                            B(i,3) = mCoordinates[inode][1];
-                            B(i,5) = mCoordinates[inode][2];
-                            break;
-                        case 1:
-                            B(i,3) = -mCoordinates[inode][0];
-                            B(i,4) = -mCoordinates[inode][2];
-                            break;
-                        case 2:
-                            B(i,4) = mCoordinates[inode][1];
-                            B(i,5) = -mCoordinates[inode][0];
-                            break;
-                    }
-                }
-            }
-
-            // Orthonormalization
-            std::vector<double> dot(B.size2());
-            for(IndexType i = mBlockSize; i < B.size2(); ++i) {
-                std::fill(dot.begin(), dot.end(), 0.0);
-                for(IndexType j = 0; j < TSparseSpaceType::Size1(rA); ++j) {
-                    for(IndexType k = 0; k < i; ++k)
-                        dot[k] += B(j,k) * B(j,i);
-                }
-                double nrm = 0.0;
-                for(IndexType j = 0; j < TSparseSpaceType::Size1(rA); ++j) {
-                    for(IndexType k = 0; k < i; ++k)
-                        B(j,i) -= dot[k] * B(j,k);
-                    nrm += B(j,i) * B(j,i);
-                }
-                nrm = sqrt(nrm);
-                for(IndexType j = 0; j < TSparseSpaceType::Size1(rA); ++j)
-                    B(j,i) /= nrm;
-            }
-
-            mAMGCLParameters.put("precond.coarsening.nullspace.cols", B.size2());
-            mAMGCLParameters.put("precond.coarsening.nullspace.rows", B.size1());
-            mAMGCLParameters.put("precond.coarsening.nullspace.B",    &(B.data()[0]));
+            mAMGCLParameters.put("precond.coarsening.nullspace.cols", nmodes);
+            mAMGCLParameters.put("precond.coarsening.nullspace.rows", TSparseSpaceType::Size1(rA));
+            mAMGCLParameters.put("precond.coarsening.nullspace.B",    &B[0]);
         }
 
         if(mVerbosity > 1)


### PR DESCRIPTION
This is a two-part PR:

1. Brings bug fixes from upstream, mostly for this issue: https://github.com/ddemidov/amgcl/issues/135
2. It seems the construction of near-null-space vectors (rigid body modes) in Kratos wrapper code was wrong (probably brought over from subdomain deflation code):

https://github.com/KratosMultiphysics/Kratos/blob/b176b910ff4f562932cf4bb1cb57f2300bf958b8/kratos/linear_solvers/amgcl_solver.h#L385-L397

It is shown in https://github.com/ddemidov/amgcl/issues/135 that using the correct rigid body modes with elasticity problems may reduce the number of iterations by a factor of two (compared with block-wise coarsening).

The changes here will only work for pure elasticity problems (without the pressure) in 2D or 3D. This requires some testing (I don't know how to do this myself) to see if it does actually improves convergence.