### PR TITLE
[HDF5] Adding possibility to visualize conditions only hdf5 outputs

### DIFF
--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -227,11 +227,14 @@ def TimeLabel(file_path):
 
     Returns empty string if not found.
     """
-    timepat = re.compile(r"\d+(\.\d+)?\Z((e|E)(\+|-)\d+)?")
-    file_path = ".".join(file_path.split(".")[:-1]) # Strip any suffixes.
-    m = timepat.search(file_path)
-    if m:
-        return m.string[m.start():m.end()]
+    temp_file_path = file_path.replace("E-", "E*")
+    temp_file_path = temp_file_path.replace("e-", "e*")
+    dash_split = temp_file_path[:temp_file_path.rfind(".")].split("-")
+    float_regex = re.compile(r'^[-+]?([0-9]+|[0-9]*\.[0-9]+)([eE][-+]?[0-9]+)?$')
+    dash_split[-1] = dash_split[-1].replace("E*", "E-")
+    dash_split[-1] = dash_split[-1].replace("e*", "e-")
+    if (float_regex.match(dash_split[-1])):
+        return dash_split[-1]
     else:
         return ""
 

--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -121,7 +121,16 @@ def CreateXdmfSpatialGrid(h5_model_part):
     sgrid = SpatialGrid()
     geom = Geometry(HDF5UniformDataItem(
         h5_model_part["Nodes/Local/Coordinates"]))
-    for name, value in h5_model_part["Xdmf/Elements"].items():
+    if ("Xdmf/Elements" in h5_model_part and "Xdmf/Conditions" in h5_model_part):
+        KratosMultiphysics.Logger.PrintInfo("CreateXdmfSpatialGrid", "Element and Condition blocks found. Spacial grid is made from Elements block only.")
+        spatial_grid_block_name = "Xdmf/Elements"
+    elif "Xdmf/Elements" in h5_model_part:
+        KratosMultiphysics.Logger.PrintInfo("CreateXdmfSpatialGrid","Spacial grid is made from Elements.")
+        spatial_grid_block_name = "Xdmf/Elements"
+    elif "Xdmf/Conditions" in h5_model_part:
+        KratosMultiphysics.Logger.PrintInfo("CreateXdmfSpatialGrid","Spacial grid is made from Conditions.")
+        spatial_grid_block_name = "Xdmf/Conditions"
+    for name, value in h5_model_part[spatial_grid_block_name].items():
         cell_type = TopologyCellType(
             value.attrs["Dimension"], value.attrs["NumberOfNodes"])
         connectivities = HDF5UniformDataItem(value["Connectivities"])
@@ -218,7 +227,7 @@ def TimeLabel(file_path):
 
     Returns empty string if not found.
     """
-    timepat = re.compile(r"\d+(\.\d+)?((e|E)(\+|-)\d+)?")
+    timepat = re.compile(r"\d+(\.\d+)?\Z((e|E)(\+|-)\d+)?")
     file_path = ".".join(file_path.split(".")[:-1]) # Strip any suffixes.
     m = timepat.search(file_path)
     if m:

--- a/applications/HDF5Application/python_scripts/xdmf_utils.py
+++ b/applications/HDF5Application/python_scripts/xdmf_utils.py
@@ -227,12 +227,15 @@ def TimeLabel(file_path):
 
     Returns empty string if not found.
     """
+    # Is there a better way to do this?
     temp_file_path = file_path.replace("E-", "E*")
     temp_file_path = temp_file_path.replace("e-", "e*")
+
     dash_split = temp_file_path[:temp_file_path.rfind(".")].split("-")
-    float_regex = re.compile(r'^[-+]?([0-9]+|[0-9]*\.[0-9]+)([eE][-+]?[0-9]+)?$')
     dash_split[-1] = dash_split[-1].replace("E*", "E-")
     dash_split[-1] = dash_split[-1].replace("e*", "e-")
+
+    float_regex = re.compile(r'^[-+]?([0-9]+|[0-9]*\.[0-9]+)([eE][-+]?[0-9]+)?$')
     if (float_regex.match(dash_split[-1])):
         return dash_split[-1]
     else:

--- a/applications/HDF5Application/tests/test_hdf5_xdmf.py
+++ b/applications/HDF5Application/tests/test_hdf5_xdmf.py
@@ -153,6 +153,10 @@ class TestTimeLabel(KratosUnittest.TestCase):
         self.assertEqual(TimeLabel("kratos-1.2.h5"), "1.2")
         self.assertEqual(TimeLabel("kratos-1.2e+00.h5"), "1.2e+00")
         self.assertEqual(TimeLabel("kratos-1.2E+00.h5"), "1.2E+00")
+        self.assertEqual(TimeLabel("kratos-1.2E-01.h5"), "1.2E-01")
+        self.assertEqual(TimeLabel("kratos-kratos-1.2E-01.h5"), "1.2E-01")
+        self.assertEqual(TimeLabel("kratos1-kratos-1.2E-01.h5"), "1.2E-01")
+        self.assertEqual(TimeLabel("kratos1-kratos-1.2E+01.h5"), "1.2E+01")
 
 
 class TestFindMatchingFiles(KratosUnittest.TestCase):


### PR DESCRIPTION
Hi,

This adds possibility to use hdf5 output to visualize conditions only model parts in paraview. I found a small bug in the time label method also. If the model_part name has a numeric character, then it is identified as the label, therfore i changed the way time label is computed. Is there a better way to do this? I added some tests strings for testing as well.