### PR TITLE
Core/minimal scipy support

### DIFF
--- a/kratos/python/add_matrix_to_python.cpp
+++ b/kratos/python/add_matrix_to_python.cpp
@@ -95,6 +95,22 @@ namespace Python
         auto compressed_matrix_binder = CreateMatrixInterface< CompressedMatrix >(m,"CompressedMatrix");
         compressed_matrix_binder.def(py::init<const CompressedMatrix::size_type, const CompressedMatrix::size_type>());
         compressed_matrix_binder.def(py::init<const CompressedMatrix& >());
+        compressed_matrix_binder.def("value_data", [](const CompressedMatrix& rA) ->  std::vector<double> 
+                                                    {return std::vector<double>(
+                                                        rA.value_data().begin(),
+                                                        rA.value_data().end()
+                                                        ) ;});
+        compressed_matrix_binder.def("index1_data", [](const CompressedMatrix& rA) -> std::vector<std::size_t> 
+                                                    {return std::vector<std::size_t>(
+                                                        rA.index1_data().begin(),
+                                                        rA.index1_data().end()
+                                                        ) ;});
+        compressed_matrix_binder.def("index2_data", [](const CompressedMatrix& rA) -> std::vector<std::size_t> 
+                                                    {return std::vector<std::size_t>(
+                                                        rA.index2_data().begin(),
+                                                        rA.index2_data().end()
+                                                        ) ;});
+
     }
 
 }  // namespace Python.

--- a/kratos/python_scripts/scipy_conversion_tools.py
+++ b/kratos/python_scripts/scipy_conversion_tools.py
@@ -1,4 +1,9 @@
-from KratosMultiphysics import *
+from __future__ import print_function, absolute_import, division
+
+# Import Kratos
+import KratosMultiphysics
+
+# Import scipy
 import scipy
 import scipy.sparse
 

--- a/kratos/python_scripts/scipy_conversion_tools.py
+++ b/kratos/python_scripts/scipy_conversion_tools.py
@@ -1,0 +1,8 @@
+from KratosMultiphysics import *
+import scipy
+import scipy.sparse
+
+def to_csr(A):
+    Ascipy = scipy.sparse.csr_matrix((A.value_data(), A.index2_data(), A.index1_data()), shape=(A.Size1(), A.Size2()))
+    return Ascipy
+

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -46,6 +46,7 @@ import test_flags
 import test_time_discretization
 import test_python_generic_function_utility
 import test_serializer
+import test_scipy_conversion_tools
 
 
 def AssembleTestSuites():
@@ -109,6 +110,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_time_discretization.TestTimeDiscretization]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_python_generic_function_utility.TestPythonGenericFunctionUtility]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_serializer.TestSerializer]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_scipy_conversion_tools.TestScipyConversionTools]))
 
     # Create a test suite with the selected tests plus all small tests
     nightSuite = suites['nightly']

--- a/kratos/tests/test_scipy_conversion_tools.py
+++ b/kratos/tests/test_scipy_conversion_tools.py
@@ -1,0 +1,37 @@
+from __future__ import print_function, absolute_import, division
+
+import KratosMultiphysics
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+try:
+    import KratosMultiphysics.scipy_conversion_tools
+    import numpy as np
+    missing_scipy = False
+except ImportError as e:
+    missing_scipy = True
+
+class TestScipyConversionTools(KratosUnittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_scipy_conversion_tools(self):
+
+
+
+        if not missing_scipy:
+            # Create a kratos matrix
+            A = KratosMultiphysics.CompressedMatrix(3,3)
+            A[0,0] = 1.0
+            A[1,1] = 2.0
+            A[2,2] = 3.0
+            A[0,2] = 4.0
+
+            # Convert it to scipy. Note that Ascipy is A COPY of A
+            Ascipy = KratosMultiphysics.scipy_conversion_tools.to_csr(A)
+
+            for i, j in np.nditer(Ascipy.nonzero()):
+                self.assertAlmostEqual(A[int(i), int(j)], Ascipy[int(i), int(j)], 1e-12)
+
+if __name__ == '__main__':
+    KratosUnittest.main()

--- a/kratos/tests/test_scipy_conversion_tools.py
+++ b/kratos/tests/test_scipy_conversion_tools.py
@@ -12,23 +12,20 @@ except ImportError as e:
 
 class TestScipyConversionTools(KratosUnittest.TestCase):
 
-    def setUp(self):
-        pass
-
+    @KratosUnittest.skipIf(missing_scipy,"Missing python libraries (scipy)")
     def test_scipy_conversion_tools(self):
-        if not missing_scipy:
-            # Create a kratos matrix
-            A = KratosMultiphysics.CompressedMatrix(3,3)
-            A[0,0] = 1.0
-            A[1,1] = 2.0
-            A[2,2] = 3.0
-            A[0,2] = 4.0
+        # Create a kratos matrix
+        A = KratosMultiphysics.CompressedMatrix(3,3)
+        A[0,0] = 1.0
+        A[1,1] = 2.0
+        A[2,2] = 3.0
+        A[0,2] = 4.0
 
-            # Convert it to scipy. Note that Ascipy is A COPY of A
-            Ascipy = KratosMultiphysics.scipy_conversion_tools.to_csr(A)
+        # Convert it to scipy. Note that Ascipy is A COPY of A
+        Ascipy = KratosMultiphysics.scipy_conversion_tools.to_csr(A)
 
-            for i, j in np.nditer(Ascipy.nonzero()):
-                self.assertAlmostEqual(A[int(i), int(j)], Ascipy[int(i), int(j)], 1e-12)
+        for i, j in np.nditer(Ascipy.nonzero()):
+            self.assertAlmostEqual(A[int(i), int(j)], Ascipy[int(i), int(j)], 1e-12)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/tests/test_scipy_conversion_tools.py
+++ b/kratos/tests/test_scipy_conversion_tools.py
@@ -16,9 +16,6 @@ class TestScipyConversionTools(KratosUnittest.TestCase):
         pass
 
     def test_scipy_conversion_tools(self):
-
-
-
         if not missing_scipy:
             # Create a kratos matrix
             A = KratosMultiphysics.CompressedMatrix(3,3)

--- a/kratos/tests/test_sparse_multiplication.py
+++ b/kratos/tests/test_sparse_multiplication.py
@@ -20,8 +20,7 @@ class TestSparseMatrixSum(KratosUnittest.TestCase):
         except ImportError as e:
             missing_scipy = True
 
-        if (missing_scipy == False):
-
+        if not missing_scipy:
             # Read the matrices
             A = KratosMultiphysics.CompressedMatrix()
             B = KratosMultiphysics.CompressedMatrix()
@@ -111,9 +110,9 @@ class TestSparseMatrixMultiplication(KratosUnittest.TestCase):
             A2_python = np.dot(A_python, A_python)
 
             # Solve
-            if (problem == "saad"):
+            if problem == "saad":
                 KratosMultiphysics.SparseMatrixMultiplicationUtility.MatrixMultiplicationSaad(A, A, A2)
-            elif (problem == "rmerge"):
+            elif problem == "rmerge":
                 KratosMultiphysics.SparseMatrixMultiplicationUtility.MatrixMultiplicationRMerge(A, A, A2)
 
             for i, j in np.nditer(A2_python.nonzero()):

--- a/kratos/tests/test_sparse_multiplication.py
+++ b/kratos/tests/test_sparse_multiplication.py
@@ -1,134 +1,112 @@
 from __future__ import print_function, absolute_import, division
+
+# Import Kratos
 import KratosMultiphysics
 import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+# Additional imports
 import os
+
+try:
+    from scipy import sparse, io
+    import numpy as np
+    missing_scipy = False
+except ImportError as e:
+    missing_scipy = True
 
 def GetFilePath(fileName):
     return os.path.dirname(os.path.realpath(__file__)) + "/" + fileName
 
 class TestSparseMatrixSum(KratosUnittest.TestCase):
 
-    def setUp(self):
-        pass
-
     def __sparse_matrix_sum(self, file_name = "auxiliar_files_for_python_unittest/sparse_matrix_files/A.mm"):
+        # Read the matrices
+        A = KratosMultiphysics.CompressedMatrix()
+        B = KratosMultiphysics.CompressedMatrix()
+        KratosMultiphysics.ReadMatrixMarketMatrix(GetFilePath(file_name),A)
+        KratosMultiphysics.ReadMatrixMarketMatrix(GetFilePath(file_name),B)
 
-        try:
-            from scipy import sparse, io
-            import numpy as np
-            missing_scipy = False
-        except ImportError as e:
-            missing_scipy = True
+        A_python = io.mmread(GetFilePath(file_name))
+        A_python.toarray()
+        B_python = io.mmread(GetFilePath(file_name))
+        B_python.toarray()
 
-        if not missing_scipy:
-            # Read the matrices
-            A = KratosMultiphysics.CompressedMatrix()
-            B = KratosMultiphysics.CompressedMatrix()
-            KratosMultiphysics.ReadMatrixMarketMatrix(GetFilePath(file_name),A)
-            KratosMultiphysics.ReadMatrixMarketMatrix(GetFilePath(file_name),B)
+        A_python = A_python + B_python
 
-            A_python = io.mmread(GetFilePath(file_name))
-            A_python.toarray()
-            B_python = io.mmread(GetFilePath(file_name))
-            B_python.toarray()
+        # Solve
+        KratosMultiphysics.SparseMatrixMultiplicationUtility.MatrixAdd(A, B, 1.0)
 
-            A_python = A_python + B_python
+        for i, j in np.nditer(A_python.nonzero()):
+            self.assertAlmostEqual(A[int(i), int(j)], A_python[int(i), int(j)])
 
-            # Solve
-            KratosMultiphysics.SparseMatrixMultiplicationUtility.MatrixAdd(A, B, 1.0)
-
-            for i, j in np.nditer(A_python.nonzero()):
-                self.assertAlmostEqual(A[int(i), int(j)], A_python[int(i), int(j)])
-        else:
-            self.skipTest("Missing python libraries (scipy)")
-
+    @KratosUnittest.skipIf(missing_scipy,"Missing python libraries (scipy)")
     def test_sparse_matrix_sum_small(self):
         self.__sparse_matrix_sum("auxiliar_files_for_python_unittest/sparse_matrix_files/small_A.mm")
 
+    @KratosUnittest.skipIf(missing_scipy,"Missing python libraries (scipy)")
     def test_sparse_matrix_sum_full(self):
         self.__sparse_matrix_sum()
 
 class TestSparseMatrixTranspose(KratosUnittest.TestCase):
 
-    def setUp(self):
-        pass
-
     def __sparse_matrix_transpose(self, file_name = "auxiliar_files_for_python_unittest/sparse_matrix_files/A.mm"):
-        try:
-            from scipy import sparse, io
-            import numpy as np
-            missing_scipy = False
-        except ImportError as e:
-            missing_scipy = True
+        # Read the matrices
+        A = KratosMultiphysics.CompressedMatrix()
+        KratosMultiphysics.ReadMatrixMarketMatrix(GetFilePath(file_name),A)
+        B = KratosMultiphysics.CompressedMatrix()
 
-        if (missing_scipy == False):
-            # Read the matrices
-            A = KratosMultiphysics.CompressedMatrix()
-            KratosMultiphysics.ReadMatrixMarketMatrix(GetFilePath(file_name),A)
-            B = KratosMultiphysics.CompressedMatrix()
+        A_python = io.mmread(GetFilePath(file_name))
+        B_python = np.matrix.transpose(A_python.toarray())
 
-            A_python = io.mmread(GetFilePath(file_name))
-            B_python = np.matrix.transpose(A_python.toarray())
+        # Solve
+        KratosMultiphysics.SparseMatrixMultiplicationUtility.TransposeMatrix(B, A, 1.0)
 
-            # Solve
-            KratosMultiphysics.SparseMatrixMultiplicationUtility.TransposeMatrix(B, A, 1.0)
+        for i, j in np.nditer(B_python.nonzero()):
+            self.assertAlmostEqual(B[int(i), int(j)], A[int(j), int(i)])
 
-            for i, j in np.nditer(B_python.nonzero()):
-                self.assertAlmostEqual(B[int(i), int(j)], A[int(j), int(i)])
-        else:
-            self.skipTest("Missing python libraries (scipy)")
-
+    @KratosUnittest.skipIf(missing_scipy,"Missing python libraries (scipy)")
     def test_sparse_matrix_transpose_small(self):
         self.__sparse_matrix_transpose("auxiliar_files_for_python_unittest/sparse_matrix_files/small_A.mm")
 
+    @KratosUnittest.skipIf(missing_scipy,"Missing python libraries (scipy)")
     def test_sparse_matrix_transpose_full(self):
         self.__sparse_matrix_transpose()
 
 class TestSparseMatrixMultiplication(KratosUnittest.TestCase):
 
-    def setUp(self):
-        pass
-
     def __sparse_matrix_multiplication(self, problem = "saad", file_name = "auxiliar_files_for_python_unittest/sparse_matrix_files/A.mm"):
-        try:
-            from scipy import sparse, io
-            import numpy as np
-            missing_scipy = False
-        except ImportError as e:
-            missing_scipy = True
+        # Read the matrices
+        A = KratosMultiphysics.CompressedMatrix()
+        A2 = KratosMultiphysics.CompressedMatrix()
+        KratosMultiphysics.ReadMatrixMarketMatrix(GetFilePath(file_name),A)
 
-        if (missing_scipy == False):
+        A_python = io.mmread(GetFilePath(file_name))
+        A_python.toarray()
 
-            # Read the matrices
-            A = KratosMultiphysics.CompressedMatrix()
-            A2 = KratosMultiphysics.CompressedMatrix()
-            KratosMultiphysics.ReadMatrixMarketMatrix(GetFilePath(file_name),A)
+        A2_python = np.dot(A_python, A_python)
 
-            A_python = io.mmread(GetFilePath(file_name))
-            A_python.toarray()
+        # Solve
+        if problem == "saad":
+            KratosMultiphysics.SparseMatrixMultiplicationUtility.MatrixMultiplicationSaad(A, A, A2)
+        elif problem == "rmerge":
+            KratosMultiphysics.SparseMatrixMultiplicationUtility.MatrixMultiplicationRMerge(A, A, A2)
 
-            A2_python = np.dot(A_python, A_python)
+        for i, j in np.nditer(A2_python.nonzero()):
+            self.assertAlmostEqual(A2[int(i), int(j)], A2_python[int(i), int(j)], 1e-3)
 
-            # Solve
-            if problem == "saad":
-                KratosMultiphysics.SparseMatrixMultiplicationUtility.MatrixMultiplicationSaad(A, A, A2)
-            elif problem == "rmerge":
-                KratosMultiphysics.SparseMatrixMultiplicationUtility.MatrixMultiplicationRMerge(A, A, A2)
-
-            for i, j in np.nditer(A2_python.nonzero()):
-                self.assertAlmostEqual(A2[int(i), int(j)], A2_python[int(i), int(j)], 1e-3)
-        else:
-            self.skipTest("Missing python libraries (scipy)")
-
+    @KratosUnittest.skipIf(missing_scipy,"Missing python libraries (scipy)")
     def test_sparse_matrix_multiplication_saad_small(self):
         self.__sparse_matrix_multiplication("saad", "auxiliar_files_for_python_unittest/sparse_matrix_files/small_A.mm")
 
+    @KratosUnittest.skipIf(missing_scipy,"Missing python libraries (scipy)")
     def test_sparse_matrix_multiplication_rmerge_small(self):
         self.__sparse_matrix_multiplication("rmerge", "auxiliar_files_for_python_unittest/sparse_matrix_files/small_A.mm")
 
+    @KratosUnittest.skipIf(missing_scipy,"Missing python libraries (scipy)")
     def test_sparse_matrix_multiplication_saad_full(self):
         self.__sparse_matrix_multiplication("saad")
 
+    @KratosUnittest.skipIf(missing_scipy,"Missing python libraries (scipy)")
     def test_sparse_matrix_multiplication_rmerge_full(self):
         self.__sparse_matrix_multiplication("rmerge")
 


### PR DESCRIPTION
this is a minimal change to allow copying a kratos sparse matrix to a scipy sparse matrix, as suggested for example by @emiroglu 

for its very nature it requires scipy...so it cannot be included in tests. Nevertheless the change is minimal and the feature is useful so i would include it

usage is something like

~~~py
import KratosMultiphysics
import KratosMultiphysics.scipy_conversion_tools

#create a kratos matrix
A = KratosMultiphysics.CompressedMatrix(3,3)
A[0,0] = 1.0
A[1,1] = 2.0
A[2,2] = 3.0
A[0,2] = 4.0

#convert it to scipy. Note that Ascipy is A COPY of A
Ascipy = KratosMultiphysics.scipy_conversion_tools.to_csr(A)

~~~