### PR TITLE
[core] Add Swimming DEM to Travis

### DIFF
--- a/scripts/build/travis/configure_travis_bionic.sh
+++ b/scripts/build/travis/configure_travis_bionic.sh
@@ -31,7 +31,6 @@ add_app ${KRATOS_APP_DIR}/DEMApplication;
 add_app ${KRATOS_APP_DIR}/CSharpWrapperApplication;
 add_app ${KRATOS_APP_DIR}/MetisApplication;
 add_app ${KRATOS_APP_DIR}/TrilinosApplication;
-add_app ${KRATOS_APP_DIR}/PfemApplication;
 add_app ${KRATOS_APP_DIR}/PfemFluidDynamicsApplication;
 add_app ${KRATOS_APP_DIR}/SwimmingDEMApplication;
 

--- a/scripts/build/travis/configure_travis_bionic.sh
+++ b/scripts/build/travis/configure_travis_bionic.sh
@@ -33,7 +33,7 @@ add_app ${KRATOS_APP_DIR}/MetisApplication;
 add_app ${KRATOS_APP_DIR}/TrilinosApplication;
 add_app ${KRATOS_APP_DIR}/PfemApplication;
 add_app ${KRATOS_APP_DIR}/PfemFluidDynamicsApplication;
-add_app ${KRATOS_APP_DIR}/TrilinosApplication;
+add_app ${KRATOS_APP_DIR}/SwimmingDEMApplication;
 
 # Clean
 clear
@@ -60,4 +60,3 @@ cmake -H"${KRATOS_SOURCE}" -B"${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" \
 # Buid
 cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target all_unity    -- -j1
 cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install/fast -- -j1
-

--- a/scripts/build/travis/configure_travis_bionic.sh
+++ b/scripts/build/travis/configure_travis_bionic.sh
@@ -31,6 +31,9 @@ add_app ${KRATOS_APP_DIR}/DEMApplication;
 add_app ${KRATOS_APP_DIR}/CSharpWrapperApplication;
 add_app ${KRATOS_APP_DIR}/MetisApplication;
 add_app ${KRATOS_APP_DIR}/TrilinosApplication;
+add_app ${KRATOS_APP_DIR}/PfemApplication;
+add_app ${KRATOS_APP_DIR}/PfemFluidDynamicsApplication;
+add_app ${KRATOS_APP_DIR}/TrilinosApplication;
 
 # Clean
 clear


### PR DESCRIPTION
The idea is to add the Swimming DEM to Travis (or actions), but it will require activating PFEMFluid, as the Swimming DEM also couples DEM with PFEM.
I will close this PR if it takes too much compilation time.

Added later from comments below and further thoughts: 

- Swimming DEM uses Python modules which are non-standard
- PFEM Fluid uses Triangle/Tetgen