### PR TITLE
[FluidDynamics] skip failing test in python 2.7

### DIFF
--- a/applications/FluidDynamicsApplication/tests/fluid_analysis_test.py
+++ b/applications/FluidDynamicsApplication/tests/fluid_analysis_test.py
@@ -1,3 +1,5 @@
+import sys
+
 import KratosMultiphysics as km
 import KratosMultiphysics.FluidDynamicsApplication as kfd
 
@@ -12,6 +14,7 @@ class FluidAnalysisTest(UnitTest.TestCase):
         # Set to true to get post-process files for the test
         self.print_output = False
 
+    @UnitTest.skipIf(sys.version_info < (3,0), "this test only runs in Python 3")
     def testFluidDynamicsAnalysis(self):
         work_folder = "CylinderTest"
         settings_file_name = "cylinder_fluid_parameters.json"


### PR DESCRIPTION
This test fails here in Python 2.7:
https://github.com/KratosMultiphysics/Kratos/blob/e84ebec42c695f5c4adcbd9ae40429f255e3a78d/applications/FluidDynamicsApplication/python_scripts/cfl_output_process.py#L8

as this module was not available before python3
