### PR TITLE
[Core] option to enable colored (yellow) warning logger messages 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,9 +212,9 @@ include(install_function)
 include(KratosDependencies)
 
 # Logger configuration
-if(KRATOS_COLORED_LOGGING MATCHES ON)
-  add_definitions(-DKRATOS_COLORED_LOGGING)
-endif(KRATOS_COLORED_LOGGING MATCHES ON)
+if(KRATOS_COLORED_OUTPUT MATCHES ON)
+  add_definitions(-DKRATOS_COLORED_OUTPUT)
+endif(KRATOS_COLORED_OUTPUT MATCHES ON)
 
 ################### PYBIND11
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -211,6 +211,11 @@ SET(INSTALL_PYTHON_FILES ON)        # To be removed when all applications are po
 include(install_function)
 include(KratosDependencies)
 
+# Logger configuration
+if(KRATOS_COLORED_LOGGING MATCHES ON)
+  add_definitions(-DKRATOS_COLORED_LOGGING)
+endif(KRATOS_COLORED_LOGGING MATCHES ON)
+
 ################### PYBIND11
 
 # Try to use python executable from env variable

--- a/kratos/input_output/logger_output.cpp
+++ b/kratos/input_output/logger_output.cpp
@@ -21,6 +21,9 @@
 #include "input_output/logger_output.h"
 #include "includes/kratos_version.h"
 
+#if defined(KRATOS_COLORED_LOGGING)
+#include "utilities/color_utilities.h"
+#endif
 
 namespace Kratos
 {
@@ -53,7 +56,12 @@ namespace Kratos
             switch (message_severity)
             {
             case LoggerMessage::Severity::WARNING:
-                if (mOptions.Is(WARNING_PREFIX)) mrStream << "[WARNING] ";
+                if (mOptions.Is(WARNING_PREFIX)) {
+                    #if defined(KRATOS_COLORED_LOGGING)
+                    mrStream << KYEL;
+                    #endif
+                    mrStream << "[WARNING] ";
+                }
                 break;
             case LoggerMessage::Severity::INFO:
                 if (mOptions.Is(INFO_PREFIX)) mrStream << "[INFO] ";
@@ -78,6 +86,10 @@ namespace Kratos
                 mrStream << TheMessage.GetLabel() << ": " << TheMessage.GetMessage();
             else
                 mrStream << TheMessage.GetMessage();
+
+            #if defined(KRATOS_COLORED_LOGGING)
+            mrStream << RST;
+            #endif
         }
     }
 

--- a/kratos/input_output/logger_output.cpp
+++ b/kratos/input_output/logger_output.cpp
@@ -53,15 +53,14 @@ namespace Kratos
         auto message_severity = TheMessage.GetSeverity();
         if (TheMessage.WriteInThisRank() && message_severity <= mSeverity)
         {
+            #if defined(KRATOS_COLORED_LOGGING)
+            if (message_severity == LoggerMessage::Severity::WARNING) mrStream << KYEL;
+            #endif
+            
             switch (message_severity)
             {
             case LoggerMessage::Severity::WARNING:
-                if (mOptions.Is(WARNING_PREFIX)) {
-                    #if defined(KRATOS_COLORED_LOGGING)
-                    mrStream << KYEL;
-                    #endif
-                    mrStream << "[WARNING] ";
-                }
+                if (mOptions.Is(WARNING_PREFIX)) mrStream << "[WARNING] ";
                 break;
             case LoggerMessage::Severity::INFO:
                 if (mOptions.Is(INFO_PREFIX)) mrStream << "[INFO] ";

--- a/kratos/input_output/logger_output.cpp
+++ b/kratos/input_output/logger_output.cpp
@@ -21,7 +21,7 @@
 #include "input_output/logger_output.h"
 #include "includes/kratos_version.h"
 
-#if defined(KRATOS_COLORED_LOGGING)
+#if defined(KRATOS_COLORED_OUTPUT)
 #include "utilities/color_utilities.h"
 #endif
 
@@ -53,10 +53,8 @@ namespace Kratos
         auto message_severity = TheMessage.GetSeverity();
         if (TheMessage.WriteInThisRank() && message_severity <= mSeverity)
         {
-            #if defined(KRATOS_COLORED_LOGGING)
-            if (message_severity == LoggerMessage::Severity::WARNING) mrStream << KYEL;
-            #endif
-            
+            SetMessageColor(message_severity);
+
             switch (message_severity)
             {
             case LoggerMessage::Severity::WARNING:
@@ -86,9 +84,7 @@ namespace Kratos
             else
                 mrStream << TheMessage.GetMessage();
 
-            #if defined(KRATOS_COLORED_LOGGING)
-            mrStream << RST;
-            #endif
+            ResetMessageColor(message_severity);
         }
     }
 
@@ -127,6 +123,19 @@ namespace Kratos
         return *this;
     }
 
+    void LoggerOutput::SetMessageColor(LoggerMessage::Severity MessageSeverity)
+    {
+        #if defined(KRATOS_COLORED_OUTPUT)
+        if (MessageSeverity == LoggerMessage::Severity::WARNING) mrStream << KYEL;
+        #endif
+    }
+
+    void LoggerOutput::ResetMessageColor(LoggerMessage::Severity MessageSeverity)
+    {
+        #if defined(KRATOS_COLORED_OUTPUT)
+        mrStream << RST;
+        #endif
+    }
 
     /// output stream function
     std::ostream& operator << (std::ostream& rOStream,

--- a/kratos/input_output/logger_output.h
+++ b/kratos/input_output/logger_output.h
@@ -183,6 +183,9 @@ protected:
 
   std::ostream& GetStream() {return mrStream;}
 
+  virtual void SetMessageColor(LoggerMessage::Severity MessageSeverity);
+  virtual void ResetMessageColor(LoggerMessage::Severity MessageSeverity);
+
 private:
   ///@name Life Cycle
   ///@{


### PR DESCRIPTION
Option to enable colored (yellow) warning logger messages.
By default colored logging is NOT used, but it can be activated with a compiler flag.

Following the suggestions of @KratosMultiphysics/technical-committee from #5643

![image](https://user-images.githubusercontent.com/25903585/71096115-0f1ff480-21ae-11ea-8e40-4493ea8b7707.png)

closes #5643