### PR TITLE
[FSI] Python solvers hotfixes

### DIFF
--- a/applications/FSIApplication/python_scripts/partitioned_embedded_fsi_base_solver.py
+++ b/applications/FSIApplication/python_scripts/partitioned_embedded_fsi_base_solver.py
@@ -117,6 +117,11 @@ class PartitionedEmbeddedFSIBaseSolver(PythonSolver):
         # Python fluid solver initialization
         self.fluid_solver.Initialize()
 
+        # Compute the fluid domain NODAL_AREA values
+        # Required by the parallel distance calculator if the distance has to be extended
+        if (self.level_set_type == "continuous"):
+            KratosMultiphysics.CalculateNodalAreaProcess(self.GetFluidComputingModelPart(), self.domain_size).Execute()
+
         # Initialize the Dirichlet-Neumann interface
         self.__InitializeFSIInterfaces()
 
@@ -126,9 +131,13 @@ class PartitionedEmbeddedFSIBaseSolver(PythonSolver):
         # Initialize the distance field
         update_distance_process = True
         self.__GetDistanceToSkinProcess(update_distance_process).Execute()
+        if (self.level_set_type == "continuous"):
+            self.__ExtendLevelSet()
 
         # Initialize the embedded skin utility
         self.__GetEmbeddedSkinUtility()
+
+        KratosMultiphysics.Logger.PrintInfo('PartitionedEmbeddedFSIBaseSolver', "Finished initialization.")
 
     def AdvanceInTime(self, current_time):
         fluid_new_time = self.fluid_solver.AdvanceInTime(current_time)
@@ -302,7 +311,7 @@ class PartitionedEmbeddedFSIBaseSolver(PythonSolver):
     def __CreateDistanceToSkinProcess(self):
         # Set the distance computation process
         if (self.level_set_type == "continuous"):
-            raycasting_relative_tolerance = 1.0e-8
+            raycasting_relative_tolerance = 1.0e-10
             if self.domain_size == 2:
                 return KratosMultiphysics.CalculateDistanceToSkinProcess2D(
                     self.GetFluidComputingModelPart(),
@@ -329,6 +338,19 @@ class PartitionedEmbeddedFSIBaseSolver(PythonSolver):
         else:
             err_msg = 'Level set type is: \'' + self.level_set_type + '\'. Expected \'continuous\' or \'discontinuous\'.'
             raise Exception(err_msg)
+
+    def __GetParallelDistanceCalculator(self):
+        if not hasattr(self, '_parallel_distance_calculator'):
+            self._parallel_distance_calculator = self.__CreateParallelDistanceCalculator()
+        return self._parallel_distance_calculator
+
+    def __CreateParallelDistanceCalculator(self):
+        if self.domain_size == 2:
+            return KratosMultiphysics.ParallelDistanceCalculator2D()
+        elif self.domain_size == 3:
+            return KratosMultiphysics.ParallelDistanceCalculator3D()
+        else:
+            raise Exception("Domain size expected to be 2 or 3. Got " + str(self.domain_size))
 
     def __GetEmbeddedSkinUtility(self):
         if not hasattr(self, '_embedded_skin_utility'):
@@ -392,6 +414,24 @@ class PartitionedEmbeddedFSIBaseSolver(PythonSolver):
     def __UpdateLevelSet(self):
         # Recompute the distance field with the obtained solution
         self.__GetDistanceToSkinProcess().Execute()
+
+        # Extend the level set to the first layer of non-intersected elements
+        # This is required in case the distance modification process moves the level set
+        # to a non-intersected element to prevent almost empty fluid elements.
+        # Note that non-intersected elements have a large default distance value, which might
+        # alter the zero isosurface when the distance modification avoids almost empty elements.
+        if (self.level_set_type == "continuous"):
+            self.__ExtendLevelSet()
+
+    def __ExtendLevelSet(self):
+        max_layers = 2
+        max_distance = 1.0e+12
+        self.__GetParallelDistanceCalculator().CalculateDistances(
+            self.GetFluidComputingModelPart(),
+            KratosMultiphysics.DISTANCE,
+            KratosMultiphysics.NODAL_AREA,
+            max_layers,
+            max_distance)
 
     def __SolveFluid(self):
         # Update the current iteration level-set position

--- a/applications/FSIApplication/python_scripts/partitioned_fsi_base_solver.py
+++ b/applications/FSIApplication/python_scripts/partitioned_fsi_base_solver.py
@@ -511,19 +511,19 @@ class PartitionedFSIBaseSolver(PythonSolver):
             keep_sign = False
             distribute_load = True
             self.interface_mapper.PositiveFluidToStructure_VectorMap(KratosMultiphysics.REACTION,
-                                                                     KratosFSI.POSITIVE_MAPPED_VECTOR_VARIABLE,
+                                                                     KratosMultiphysics.POSITIVE_MAPPED_VECTOR_VARIABLE,
                                                                      keep_sign,
                                                                      distribute_load)
             self.interface_mapper.NegativeFluidToStructure_VectorMap(KratosMultiphysics.REACTION,
-                                                                     KratosFSI.NEGATIVE_MAPPED_VECTOR_VARIABLE,
+                                                                     KratosMultiphysics.NEGATIVE_MAPPED_VECTOR_VARIABLE,
                                                                      keep_sign,
                                                                      distribute_load)
 
             # Add the two faces contributions to the POINT_LOAD variable
             # TODO: Add this to the variables utils
             for node in self._GetStructureInterfaceSubmodelPart().Nodes:
-                pos_face_force = node.GetSolutionStepValue(KratosFSI.POSITIVE_MAPPED_VECTOR_VARIABLE)
-                neg_face_force = node.GetSolutionStepValue(KratosFSI.NEGATIVE_MAPPED_VECTOR_VARIABLE)
+                pos_face_force = node.GetSolutionStepValue(KratosMultiphysics.POSITIVE_MAPPED_VECTOR_VARIABLE)
+                neg_face_force = node.GetSolutionStepValue(KratosMultiphysics.NEGATIVE_MAPPED_VECTOR_VARIABLE)
                 node.SetSolutionStepValue(KratosStructural.POINT_LOAD, 0, pos_face_force+neg_face_force)
 
             # Solve the current step structure problem with the previous step fluid interface nodal fluxes


### PR DESCRIPTION
This PR includes:
- body fitted solver: a hotfix to retrieve the mapping variables from the core module (this is a consequence of the migration of the fsi_variables.h)
- embedded solver: when dealing with volume bodies, we now extend the continuous level set two layers of elements to prevent isolated bubbles close to the isosurface after the distance correction.