### PR TITLE
[Core] Add geometrical object bins

### DIFF
--- a/kratos/geometries/bounding_box.h
+++ b/kratos/geometries/bounding_box.h
@@ -100,25 +100,29 @@ public:
     template<typename TIteratorType>
     void Set(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd){
         if (PointsBegin == PointsEnd) {
-            for (int i = 0; i < Dimension; i++)
-            {
+            for (int i = 0; i < Dimension; i++) {
                 mMinPoint[i] = 0.00;
                 mMaxPoint[i] = 0.00;
             }
             return;
         }
 
-        for (int i = 0; i < Dimension; i++)
-        {
+        for (int i = 0; i < Dimension; i++) {
             mMinPoint[i] = (*PointsBegin)[i];
             mMaxPoint[i] = (*PointsBegin)[i];
         }
 
-        for (TIteratorType Point = PointsBegin; Point != PointsEnd; Point++){
+        Extend(PointsBegin, PointsEnd);
+    }
+
+    template<typename TIteratorType>
+    void Extend(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd){
+
+        for (TIteratorType i_point = PointsBegin; i_point != PointsEnd; i_point++){
             for (int i = 0; i < Dimension; i++)
             {
-                if ((*Point)[i] < mMinPoint[i]) mMinPoint[i] = (*Point)[i];
-                if ((*Point)[i] > mMaxPoint[i]) mMaxPoint[i] = (*Point)[i];
+                if ((*i_point)[i] < mMinPoint[i]) mMinPoint[i] = (*i_point)[i];
+                if ((*i_point)[i] > mMaxPoint[i]) mMaxPoint[i] = (*i_point)[i];
             }
         }
     }

--- a/kratos/geometries/bounding_box.h
+++ b/kratos/geometries/bounding_box.h
@@ -1,0 +1,210 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//                  
+//
+
+#if !defined(KRATOS_BOUNDING_BOX_H_INCLUDED )
+#define  KRATOS_BOUNDING_BOX_H_INCLUDED
+
+
+// System includes
+#include <string>
+#include <iostream>
+
+
+// External includes
+
+
+// Project includes
+#include "includes/define.h"
+
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/// Representing a bounding box by storing the min and max points
+/** It stores the min and max points and have constructor for it construction with any container of points.
+ *  TPointType should provide access operator [] to its coordinate and deep copy operator=
+*/
+template <typename TPointType>
+class BoundingBox
+{
+	static constexpr int Dimension = 3;
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of BoundingBox
+    KRATOS_CLASS_POINTER_DEFINITION(BoundingBox);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor deleted.
+    BoundingBox() = delete;
+
+	BoundingBox(TPointType const& MinPoint, TPointType const& MaxPoint) :
+		mMinPoint(MinPoint), mMaxPoint(MaxPoint) {}
+
+    /// Copy constructor
+	BoundingBox( const BoundingBox &Other) :
+		mMinPoint( Other.mMinPoint), mMaxPoint( Other.mMaxPoint) {}
+
+
+    /// Construction with container of points.
+	template<typename TIteratorType>
+	BoundingBox(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd) {
+		if (PointsBegin == PointsEnd) {
+			for (int i = 0; i < Dimension; i++)
+			{
+				mMinPoint[i] = 0.00;
+				mMaxPoint[i] = 0.00;
+			}
+			return;
+		}
+
+		for (int i = 0; i < Dimension; i++)
+		{
+			mMinPoint[i] = (*PointsBegin)[i];
+			mMaxPoint[i] = (*PointsBegin)[i];
+		}
+
+		for (TIteratorType Point = PointsBegin; Point != PointsEnd; Point++)
+			for (int i = 0; i < Dimension; i++)
+			{
+				if ((*Point)[i] < mMinPoint[i]) mMinPoint[i] = (*Point)[i];
+				if ((*Point)[i] > mMaxPoint[i]) mMaxPoint[i] = (*Point)[i];
+			}
+	}
+
+    /// Destructor.
+    virtual ~BoundingBox(){}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+
+    /// Assignment operator.
+    BoundingBox& operator=(BoundingBox const& rOther){
+        mMinPoint = rOther.mMinPoint;
+        mMaxPoint = rOther.mMaxPoint;
+
+        return *this;
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+
+    ///@}
+    ///@name Access
+    ///@{
+
+	TPointType& GetMinPoint() { return mMinPoint; }
+	TPointType const& GetMinPoint() const { return mMinPoint; }
+
+	TPointType& GetMaxPoint() { return mMaxPoint; }
+	TPointType const& GetMaxPoint() const { return mMaxPoint; }
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    virtual std::string Info() const
+    {
+        std::stringstream buffer;
+        buffer << "BoundingBox" ;
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream& rOStream) const {rOStream << "BoundingBox";}
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const {}
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+    
+    TPointType mMinPoint;
+	TPointType mMaxPoint;
+
+
+    ///@}
+
+}; // Class BoundingBox
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+
+/// input stream function
+template <typename TPointType>
+inline std::istream& operator >> (std::istream& rIStream,
+                BoundingBox<TPointType>& rThis){
+                    return rIStream;
+                }
+
+/// output stream function
+template <typename TPointType>
+inline std::ostream& operator << (std::ostream& rOStream,
+                const BoundingBox<TPointType>& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_BOUNDING_BOX_H_INCLUDED  defined
+
+

--- a/kratos/geometries/bounding_box.h
+++ b/kratos/geometries/bounding_box.h
@@ -127,6 +127,14 @@ public:
         }
     }
 
+    void Extend(double Margin){
+        for (int i = 0; i < Dimension; i++){
+            mMinPoint[i] -= Margin;
+            mMaxPoint[i] += Margin;
+        }
+
+    }
+
 
     ///@}
     ///@name Access

--- a/kratos/geometries/bounding_box.h
+++ b/kratos/geometries/bounding_box.h
@@ -40,7 +40,7 @@ namespace Kratos
  *  TPointType should provide access operator [] to its coordinate and deep copy operator=
 */
 template <typename TPointType>
-class BoundingBox
+class BoundingBox 
 {
 	static constexpr int Dimension = 3;
 public:
@@ -58,17 +58,17 @@ public:
     BoundingBox(){
         for (int i = 0; i < Dimension; i++)
         {
-            mMinPoint[i] = 0.00;
-            mMaxPoint[i] = 0.00;
+            GetMinPoint()[i] = 0.00;
+            GetMaxPoint()[i] = 0.00;
         }
     };
 
 	BoundingBox(TPointType const& MinPoint, TPointType const& MaxPoint) :
-		mMinPoint(MinPoint), mMaxPoint(MaxPoint) {}
+		mMinMaxPoints{MinPoint,MaxPoint} {}
 
     /// Copy constructor
 	BoundingBox( const BoundingBox &Other) :
-		mMinPoint( Other.mMinPoint), mMaxPoint( Other.mMaxPoint) {}
+		mMinMaxPoints(Other.mMinMaxPoints) {}
 
 
     /// Construction with container of points.
@@ -87,8 +87,8 @@ public:
 
     /// Assignment operator.
     BoundingBox& operator=(BoundingBox const& rOther){
-        mMinPoint = rOther.mMinPoint;
-        mMaxPoint = rOther.mMaxPoint;
+        GetMinPoint() = rOther.GetMinPoint();
+        GetMaxPoint() = rOther.GetMaxPoint();
 
         return *this;
     }
@@ -101,15 +101,15 @@ public:
     void Set(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd){
         if (PointsBegin == PointsEnd) {
             for (int i = 0; i < Dimension; i++) {
-                mMinPoint[i] = 0.00;
-                mMaxPoint[i] = 0.00;
+                GetMinPoint()[i] = 0.00;
+                GetMaxPoint()[i] = 0.00;
             }
             return;
         }
 
         for (int i = 0; i < Dimension; i++) {
-            mMinPoint[i] = (*PointsBegin)[i];
-            mMaxPoint[i] = (*PointsBegin)[i];
+            GetMinPoint()[i] = (*PointsBegin)[i];
+            GetMaxPoint()[i] = (*PointsBegin)[i];
         }
 
         Extend(PointsBegin, PointsEnd);
@@ -121,16 +121,16 @@ public:
         for (TIteratorType i_point = PointsBegin; i_point != PointsEnd; i_point++){
             for (int i = 0; i < Dimension; i++)
             {
-                if ((*i_point)[i] < mMinPoint[i]) mMinPoint[i] = (*i_point)[i];
-                if ((*i_point)[i] > mMaxPoint[i]) mMaxPoint[i] = (*i_point)[i];
+                if ((*i_point)[i] < GetMinPoint()[i]) GetMinPoint()[i] = (*i_point)[i];
+                if ((*i_point)[i] > GetMaxPoint()[i]) GetMaxPoint()[i] = (*i_point)[i];
             }
         }
     }
 
     void Extend(double Margin){
         for (int i = 0; i < Dimension; i++){
-            mMinPoint[i] -= Margin;
-            mMaxPoint[i] += Margin;
+            GetMinPoint()[i] -= Margin;
+            GetMaxPoint()[i] += Margin;
         }
 
     }
@@ -140,11 +140,11 @@ public:
     ///@name Access
     ///@{
 
-	TPointType& GetMinPoint() { return mMinPoint; }
-	TPointType const& GetMinPoint() const { return mMinPoint; }
+	TPointType& GetMinPoint() { return mMinMaxPoints[0]; }
+	TPointType const& GetMinPoint() const { return mMinMaxPoints[0]; }
 
-	TPointType& GetMaxPoint() { return mMaxPoint; }
-	TPointType const& GetMaxPoint() const { return mMaxPoint; }
+	TPointType& GetMaxPoint() { return mMinMaxPoints[1]; }
+	TPointType const& GetMaxPoint() const { return mMinMaxPoints[1]; }
 
 
     ///@}
@@ -168,7 +168,10 @@ public:
     virtual void PrintInfo(std::ostream& rOStream) const {rOStream << "BoundingBox";}
 
     /// Print object's data.
-    virtual void PrintData(std::ostream& rOStream) const {}
+    virtual void PrintData(std::ostream& rOStream) const {
+        rOStream << "   MinPoint : [" << GetMinPoint()[0] << ","  << GetMinPoint()[1] << ","  << GetMinPoint()[2] << "]" << std::endl;
+        rOStream << "   MaxPoint : [" << GetMaxPoint()[0] << ","  << GetMaxPoint()[1] << ","  << GetMaxPoint()[2] << "]" << std::endl;
+    }
 
     ///@}
     ///@name Friends
@@ -185,10 +188,8 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
-    
-    TPointType mMinPoint;
-	TPointType mMaxPoint;
 
+        std::array<TPointType, 2> mMinMaxPoints;
 
     ///@}
 

--- a/kratos/geometries/bounding_box.h
+++ b/kratos/geometries/bounding_box.h
@@ -55,7 +55,13 @@ public:
     ///@{
 
     /// Default constructor deleted.
-    BoundingBox() = delete;
+    BoundingBox(){
+        for (int i = 0; i < Dimension; i++)
+        {
+            mMinPoint[i] = 0.00;
+            mMaxPoint[i] = 0.00;
+        }
+    };
 
 	BoundingBox(TPointType const& MinPoint, TPointType const& MaxPoint) :
 		mMinPoint(MinPoint), mMaxPoint(MaxPoint) {}
@@ -68,27 +74,7 @@ public:
     /// Construction with container of points.
 	template<typename TIteratorType>
 	BoundingBox(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd) {
-		if (PointsBegin == PointsEnd) {
-			for (int i = 0; i < Dimension; i++)
-			{
-				mMinPoint[i] = 0.00;
-				mMaxPoint[i] = 0.00;
-			}
-			return;
-		}
-
-		for (int i = 0; i < Dimension; i++)
-		{
-			mMinPoint[i] = (*PointsBegin)[i];
-			mMaxPoint[i] = (*PointsBegin)[i];
-		}
-
-		for (TIteratorType Point = PointsBegin; Point != PointsEnd; Point++)
-			for (int i = 0; i < Dimension; i++)
-			{
-				if ((*Point)[i] < mMinPoint[i]) mMinPoint[i] = (*Point)[i];
-				if ((*Point)[i] > mMaxPoint[i]) mMaxPoint[i] = (*Point)[i];
-			}
+        Set(PointsBegin, PointsEnd);
 	}
 
     /// Destructor.
@@ -110,6 +96,32 @@ public:
     ///@}
     ///@name Operations
     ///@{
+
+    template<typename TIteratorType>
+    void Set(TIteratorType const& PointsBegin, TIteratorType const& PointsEnd){
+        if (PointsBegin == PointsEnd) {
+            for (int i = 0; i < Dimension; i++)
+            {
+                mMinPoint[i] = 0.00;
+                mMaxPoint[i] = 0.00;
+            }
+            return;
+        }
+
+        for (int i = 0; i < Dimension; i++)
+        {
+            mMinPoint[i] = (*PointsBegin)[i];
+            mMaxPoint[i] = (*PointsBegin)[i];
+        }
+
+        for (TIteratorType Point = PointsBegin; Point != PointsEnd; Point++){
+            for (int i = 0; i < Dimension; i++)
+            {
+                if ((*Point)[i] < mMinPoint[i]) mMinPoint[i] = (*Point)[i];
+                if ((*Point)[i] > mMaxPoint[i]) mMaxPoint[i] = (*Point)[i];
+            }
+        }
+    }
 
 
     ///@}

--- a/kratos/spatial_containers/geometrical_objects_bins.h
+++ b/kratos/spatial_containers/geometrical_objects_bins.h
@@ -1,0 +1,432 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+
+
+#if !defined(KRATOS_GEOMETRICAL_OBJECTS_BINS_H_INCLUDED )
+#define  KRATOS_GEOMETRICAL_OBJECTS_BINS_H_INCLUDED
+
+
+// System includes
+#include <string>
+#include <iostream>
+#include <unordered_set>
+
+
+// External includes
+
+
+// Project includes
+#include "includes/define.h"
+#include "geometries/bounding_box.h"
+#include "geometries/point.h"
+#include "includes/geometrical_object.h"
+#include "includes/global_pointer.h"
+#include "utilities/geometry_utilities.h"
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+
+template <typename TObjectType>
+class SpatialSearchResult {
+	using TPointerType = GlobalPointer<TObjectType>;
+	TPointerType mpObject;
+	double mDistance2;
+	bool mIsObjectFound;
+	bool mIsDistanceCalculated;
+
+public:
+	SpatialSearchResult() : mpObject(nullptr), mDistance2(0.00), mIsObjectFound(false), mIsDistanceCalculated(false) {}
+	SpatialSearchResult(TObjectType* pObject) : mpObject(pObject), mDistance2(0.00), mIsObjectFound(false), mIsDistanceCalculated(false) {
+		if (mpObject.get() != nullptr)
+			mIsObjectFound = true;
+	}
+
+	SpatialSearchResult(SpatialSearchResult const& /* Other */) = default;
+
+	SpatialSearchResult(SpatialSearchResult&& /* Other */) = default;
+
+	TPointerType Get() { return mpObject; }
+	TPointerType const Get() const { return mpObject; }
+	void Set(TObjectType* pObject) {
+		mpObject = pObject;
+		mIsObjectFound = true;
+	}
+	bool IsObjectFound() const { return mIsObjectFound; }
+
+	double GetDistance2() const { return mDistance2; }
+	void SetDistance2(double TheDistance2) {
+		mDistance2 = TheDistance2;
+		mIsDistanceCalculated = true;
+	}
+	bool IsDistanceCalculated() const { return mIsDistanceCalculated; }
+
+	void Reset() {
+		mpObject = mpObject(nullptr);
+		mDistance2 = 0.00;
+		mIsObjectFound = false;
+		mIsDistanceCalculated = false;
+	}
+
+        SpatialSearchResult& operator=(SpatialSearchResult const& /*Other*/) = default;
+
+};
+
+/// A bins container for 3 dimensional geometries.
+/** Detail class definition.
+*/
+class GeometricalObjectsBins
+{
+    static constexpr int Dimension = 3;
+    static constexpr double Tolerance = 1e-12;
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of GeometricalObjectsBins
+    KRATOS_CLASS_POINTER_DEFINITION(GeometricalObjectsBins);
+
+    using CellType = std::vector<GeometricalObject*>;
+    using ResultType = SpatialSearchResult<GeometricalObject>;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor deleted.
+    GeometricalObjectsBins() = delete;
+
+    template<typename TIteratorType>
+	GeometricalObjectsBins(TIteratorType GeometricalObjectsBegin, TIteratorType GeometricalObjectsEnd) {
+        std::size_t number_of_objects = std::distance(GeometricalObjectsBegin, GeometricalObjectsEnd);
+        if(number_of_objects > 0){
+            mBoundingBox.Set(GeometricalObjectsBegin->GetGeometry().begin(), GeometricalObjectsBegin->GetGeometry().end());
+            for(TIteratorType i_object = GeometricalObjectsBegin ; i_object != GeometricalObjectsEnd ; i_object++){
+                mBoundingBox.Extend(i_object->GetGeometry().begin() , i_object->GetGeometry().end());
+            }
+	    }
+        mBoundingBox.Extend(Tolerance);
+		CalculateCellSize(number_of_objects);
+        mCells.resize(GetTotalNumberOfCells());
+        AddObjectsToCells(GeometricalObjectsBegin, GeometricalObjectsEnd);
+    }
+
+
+    /// Destructor.
+    virtual ~GeometricalObjectsBins(){}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    const BoundingBox<Point>& GetBoundingBox() const {
+        return mBoundingBox;
+    }
+
+    const array_1d<double, 3>& GetCellSizes(){
+        return mCellSizes;
+    }
+
+    const array_1d<std::size_t, 3>& GetNumberOfCells(){
+        return mNumberOfCells;
+    }
+
+    const std::size_t GetTotalNumberOfCells(){
+        return mNumberOfCells[0] * mNumberOfCells[1] * mNumberOfCells[2];
+    }
+
+    CellType& GetCell(std::size_t I, std::size_t J, std::size_t K){
+        const std::size_t index = I + J * mNumberOfCells[0] + K * mNumberOfCells[1] * mNumberOfCells[0];
+        return mCells[index];
+    }
+
+    BoundingBox<Point> GetCellBoundingBox(std::size_t I, std::size_t J, std::size_t K){
+        BoundingBox<Point> result;
+        
+        result.GetMinPoint()[0] = mBoundingBox.GetMinPoint()[0] + I * mCellSizes[0];
+        result.GetMinPoint()[1] = mBoundingBox.GetMinPoint()[1] + J * mCellSizes[1];
+        result.GetMinPoint()[2] = mBoundingBox.GetMinPoint()[2] + K * mCellSizes[2];
+         
+        result.GetMaxPoint()[0] = mBoundingBox.GetMinPoint()[0] + (I + 1) * mCellSizes[0];
+        result.GetMaxPoint()[1] = mBoundingBox.GetMinPoint()[1] + (J + 1) * mCellSizes[1];
+        result.GetMaxPoint()[2] = mBoundingBox.GetMinPoint()[2] + (K + 1) * mCellSizes[2];
+
+        return result;
+    }
+
+    template<typename TPointType>
+    void SearchInRadius(TPointType const& ThePoint, double Radius, std::vector<ResultType>& rResults) {
+        std::unordered_set<GeometricalObject*> results;
+
+        array_1d< std::size_t, 3 > min_position;
+        array_1d< std::size_t, 3 > max_position;
+
+        for(int i = 0; i < 3; i++ ) {
+            min_position[ i ] = CalculatePosition( ThePoint[i] - Radius, i );
+            max_position[ i ] = CalculatePosition( ThePoint[i] + Radius, i ) + 1;
+        }
+        for(std::size_t k = min_position[2] ; k < max_position[2] ; k++){
+            for(std::size_t j = min_position[1] ; j < max_position[1] ; j++){
+                for(std::size_t i = min_position[0] ; i < max_position[0] ; i++){
+                    auto& cell = GetCell(i,j,k);
+                    SearchInRadiusInCell(cell, ThePoint, Radius, results);
+                }
+            }
+        }
+
+        rResults.clear();
+        for(auto p_object : results){
+            rResults.push_back(ResultType(p_object));
+        }
+    }
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    virtual std::string Info() const
+    {
+        std::stringstream buffer;
+        buffer << "GeometricalObjectsBins" ;
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream& rOStream) const {rOStream << "GeometricalObjectsBins";}
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const {}
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+	
+    BoundingBox<Point> mBoundingBox;
+	array_1d<std::size_t, Dimension> mNumberOfCells;
+    array_1d<double, 3>  mCellSizes;
+	array_1d<double, 3>  mInverseOfCellSize;
+    std::vector<CellType> mCells;
+
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    void CalculateCellSize(std::size_t NumberOfPoints) {
+		std::size_t avarage_number_of_cells = static_cast<std::size_t>(std::pow(static_cast<double>(NumberOfPoints), 1.00 / Dimension));
+		std::array<double, 3> lengths;
+		double avarage_length = 0.00;
+		for (int i = 0; i < Dimension; i++) {
+			lengths[i] = mBoundingBox.GetMaxPoint()[i] - mBoundingBox.GetMinPoint()[i];
+			avarage_length += lengths[i];
+		}
+		avarage_length *= 1.00 / 3.00;
+
+		if (avarage_length < std::numeric_limits<double>::epsilon()) {
+			mNumberOfCells = ScalarVector(3, 1);
+			return;
+		}
+
+		for (int i = 0; i < Dimension; i++) {
+			mNumberOfCells[i] = static_cast<std::size_t>(lengths[i] / avarage_length * avarage_number_of_cells) + 1;
+			if (mNumberOfCells[i] > 1)
+				mCellSizes[i] = lengths[i] / mNumberOfCells[i];
+			else
+				mCellSizes[i] = avarage_length;
+
+			mInverseOfCellSize[i] = 1.00 / mCellSizes[i];
+		}
+
+	}
+
+
+    template<typename TIteratorType>
+	void AddObjectsToCells(TIteratorType GeometricalObjectsBegin, TIteratorType GeometricalObjectsEnd) {
+        for(auto i_geometrical_object = GeometricalObjectsBegin ; i_geometrical_object != GeometricalObjectsEnd ; i_geometrical_object++){
+            array_1d< std::size_t, 3 > min_position;
+            array_1d< std::size_t, 3 > max_position;
+            CalculateMinMaxPositions(i_geometrical_object->GetGeometry(), min_position, max_position);
+            for(std::size_t k = min_position[2] ; k < max_position[2] ; k++){
+                for(std::size_t j = min_position[1] ; j < max_position[1] ; j++){
+                    for(std::size_t i = min_position[0] ; i < max_position[0] ; i++){
+                        auto cell_bounding_box = GetCellBoundingBox(i,j,k);
+                        if(IsIntersected(i_geometrical_object->GetGeometry(), cell_bounding_box, Tolerance)){
+                            GetCell(i,j,k).push_back(&(*i_geometrical_object));
+                        }
+                    }
+                }
+            }
+        }        
+    }
+
+
+    template<typename TGeometryType>
+    void CalculateMinMaxPositions(TGeometryType const& TheGeometry, array_1d< std::size_t, 3 >& MinPosition, array_1d< std::size_t, 3 >& MaxPosition){
+        if(TheGeometry.empty())
+            return;
+
+        BoundingBox<Point> bounding_box(TheGeometry.begin(), TheGeometry.end());
+
+        for(int i = 0; i < 3; i++ ) {
+            MinPosition[ i ] = CalculatePosition( bounding_box.GetMinPoint()[i], i );
+            MaxPosition[ i ] = CalculatePosition( bounding_box.GetMaxPoint()[i], i ) + 1;
+        }
+    }
+
+
+    void CalculateMinMaxPositions(BoundingBox<Point> TheBox, array_1d< std::size_t, 3 >& MinPosition, array_1d< std::size_t, 3 >& MaxPosition){
+        for(int i = 0; i < 3; i++ ) {
+            MinPosition[ i ] = CalculatePosition( TheBox.GetMinPoint()[i], i );
+            MaxPosition[ i ] = CalculatePosition( TheBox.GetMaxPoint()[i], i ) + 1;
+        }
+    }
+
+    std::size_t CalculatePosition( double Coordinate, int ThisDimension ) const {
+        auto distance = Coordinate - mBoundingBox.GetMinPoint()[ ThisDimension ];
+        distance = ( distance < 0.00 ) ? 0.00 : distance;
+        std::size_t position =
+            static_cast< std::size_t >( distance * mInverseOfCellSize[ ThisDimension ] );
+        std::size_t result= ( position > mNumberOfCells[ ThisDimension ] - 1 )
+                                ? mNumberOfCells[ ThisDimension ] - 1
+                                : position;
+        return result;
+    }
+    
+    template<typename TGeometryType>
+    static inline bool IsIntersected(TGeometryType& TheGeometry, BoundingBox<Point> Box, const double tolerance)
+    {
+        Point rLowPointTolerance;
+        Point rHighPointTolerance;
+        
+        for(std::size_t i = 0; i<3; i++)
+        {
+            rLowPointTolerance[i]  =  Box.GetMinPoint()[i] - tolerance;
+            rHighPointTolerance[i] =  Box.GetMaxPoint()[i] + tolerance;
+        }
+        
+        return  TheGeometry.HasIntersection(rLowPointTolerance,rHighPointTolerance);
+    }
+
+    template<typename TPointType>
+    void SearchInRadiusInCell(CellType const& TheCell, TPointType const& ThePoint, double Radius, std::unordered_set<GeometricalObject*>& rResults) {
+        for(auto p_geometrical_object : TheCell){  
+            auto& geometry = p_geometrical_object->GetGeometry();
+            // TODO: Change this to new Distance method of the geometry to be more general
+            double distance = GeometryUtils::PointDistanceToTriangle3D(
+			geometry[0],
+			geometry[1],
+			geometry[2],
+			ThePoint);
+            if((Radius + Tolerance) > distance){
+                rResults.insert(p_geometrical_object);
+            }
+        }
+    }
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator deleted.
+    GeometricalObjectsBins& operator=(GeometricalObjectsBins const& rOther) = delete;
+
+    /// Copy constructor deleted.
+    GeometricalObjectsBins(GeometricalObjectsBins const& rOther) = delete;
+
+    ///@}
+
+}; // Class GeometricalObjectsBins
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+
+/// input stream function
+inline std::istream& operator >> (std::istream& rIStream,
+                GeometricalObjectsBins& rThis){
+                    return rIStream;
+                }
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                const GeometricalObjectsBins& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_GEOMETRICAL_OBJECTS_BINS_H_INCLUDED  defined
+
+

--- a/kratos/spatial_containers/geometrical_objects_bins.h
+++ b/kratos/spatial_containers/geometrical_objects_bins.h
@@ -31,6 +31,7 @@
 #include "includes/geometrical_object.h"
 #include "includes/global_pointer.h"
 #include "utilities/geometry_utilities.h"
+#include "spatial_containers/spatial_search_result.h"
 
 namespace Kratos
 {
@@ -39,52 +40,6 @@ namespace Kratos
 
 ///@name Kratos Classes
 ///@{
-
-
-template <typename TObjectType>
-class SpatialSearchResult {
-	using TPointerType = GlobalPointer<TObjectType>;
-	TPointerType mpObject;
-	double mDistance;
-	bool mIsObjectFound;
-	bool mIsDistanceCalculated;
-
-public:
-	SpatialSearchResult() : mpObject(nullptr), mDistance(0.00), mIsObjectFound(false), mIsDistanceCalculated(false) {}
-	SpatialSearchResult(TObjectType* pObject) : mpObject(pObject), mDistance(0.00), mIsObjectFound(false), mIsDistanceCalculated(false) {
-		if (mpObject.get() != nullptr)
-			mIsObjectFound = true;
-	}
-
-	SpatialSearchResult(SpatialSearchResult const& /* Other */) = default;
-
-	SpatialSearchResult(SpatialSearchResult&& /* Other */) = default;
-
-	TPointerType Get() { return mpObject; }
-	TPointerType const Get() const { return mpObject; }
-	void Set(TObjectType* pObject) {
-		mpObject = pObject;
-		mIsObjectFound = true;
-	}
-	bool IsObjectFound() const { return mIsObjectFound; }
-
-	double GetDistance() const { return mDistance; }
-	void SetDistance(double TheDistance) {
-		mDistance = TheDistance;
-		mIsDistanceCalculated = true;
-	}
-	bool IsDistanceCalculated() const { return mIsDistanceCalculated; }
-
-	void Reset() {
-		mpObject = mpObject(nullptr);
-		mDistance = 0.00;
-		mIsObjectFound = false;
-		mIsDistanceCalculated = false;
-	}
-
-        SpatialSearchResult& operator=(SpatialSearchResult const& /*Other*/) = default;
-
-};
 
 /// A bins container for 3 dimensional geometries.
 /** Detail class definition.

--- a/kratos/spatial_containers/geometrical_objects_bins.h
+++ b/kratos/spatial_containers/geometrical_objects_bins.h
@@ -185,7 +185,7 @@ public:
 
     /** This method takes a point and finds the nearest object to it in a given radius.
      * If there are more than one object in the same minimum distance only one is returned
-     * If there are no objects in that radius the 
+     * If there are no objects in that radius the result will be set to not found.
      * Result contains a flag is the object has been found or not. 
     */
      template<typename TPointType>
@@ -216,7 +216,7 @@ public:
             bool all_cells_are_covered = (min_position[0] == 0) && (min_position[1] == 0) && (min_position[2] == 0);
             all_cells_are_covered &= (max_position[0] == mNumberOfCells[0] - 1) && (max_position[1] == mNumberOfCells[1] - 1) && (max_position[2] == mNumberOfCells[2] - 1);
 
-            if(all_cells_are_covered){
+            if(all_cells_are_covered || current_result.IsObjectFound()){
                 break;
             }
         }

--- a/kratos/spatial_containers/geometrical_objects_bins.h
+++ b/kratos/spatial_containers/geometrical_objects_bins.h
@@ -121,7 +121,7 @@ public:
     }
 
     /// The total number of cells in the container
-    const std::size_t GetTotalNumberOfCells(){
+    std::size_t GetTotalNumberOfCells(){
         return mNumberOfCells[0] * mNumberOfCells[1] * mNumberOfCells[2];
     }
 

--- a/kratos/spatial_containers/spatial_search_result.h
+++ b/kratos/spatial_containers/spatial_search_result.h
@@ -1,0 +1,224 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+
+
+#if !defined(KRATOS_SPATIAL_SEARCH_RESULT_H_INCLUDED )
+#define  KRATOS_SPATIAL_SEARCH_RESULT_H_INCLUDED
+
+
+// System includes
+#include <string>
+#include <iostream>
+
+
+// External includes
+
+
+// Project includes
+#include "includes/define.h"
+
+
+namespace Kratos
+{
+///@addtogroup ApplicationNameApplication
+///@{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/// Short class definition.
+/** Detail class definition.
+*/
+template <typename TObjectType>
+class SpatialSearchResult
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of SpatialSearchResult
+    KRATOS_CLASS_POINTER_DEFINITION(SpatialSearchResult);
+	
+    using TPointerType = GlobalPointer<TObjectType>;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+   	SpatialSearchResult() : mpObject(nullptr), mDistance(0.00), mIsObjectFound(false), mIsDistanceCalculated(false) {}
+       
+	SpatialSearchResult(TObjectType* pObject) : mpObject(pObject), mDistance(0.00), mIsObjectFound(false), mIsDistanceCalculated(false) {
+		if (mpObject.get() != nullptr)
+			mIsObjectFound = true;
+	}
+
+	SpatialSearchResult(SpatialSearchResult const& /* Other */) = default;
+
+	SpatialSearchResult(SpatialSearchResult&& /* Other */) = default;
+
+    /// Destructor.
+    virtual ~SpatialSearchResult(){}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+        SpatialSearchResult& operator=(SpatialSearchResult const& /*Other*/) = default;
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+	void Reset() {
+		mpObject = mpObject(nullptr);
+		mDistance = 0.00;
+		mIsObjectFound = false;
+		mIsDistanceCalculated = false;
+	}
+
+    ///@}
+    ///@name Access
+    ///@{
+
+	TPointerType Get() { return mpObject; }
+	TPointerType const Get() const { return mpObject; }
+	void Set(TObjectType* pObject) {
+		mpObject = pObject;
+		mIsObjectFound = true;
+	}
+	double GetDistance() const { return mDistance; }
+	void SetDistance(double TheDistance) {
+		mDistance = TheDistance;
+		mIsDistanceCalculated = true;
+	}
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+	bool IsObjectFound() const { return mIsObjectFound; }
+
+	bool IsDistanceCalculated() const { return mIsDistanceCalculated; }
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    virtual std::string Info() const
+    {
+        std::stringstream buffer;
+            buffer << "SpatialSearchResult" ;
+            return buffer.str();
+    }
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream& rOStream) const {rOStream << "SpatialSearchResult";}
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const {}
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+	TPointerType mpObject;
+	double mDistance;
+	bool mIsObjectFound;
+	bool mIsDistanceCalculated;
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    ///@}
+
+}; // Class SpatialSearchResult
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+
+/// input stream function
+template <typename TObjectType>
+inline std::istream& operator >> (std::istream& rIStream,
+                SpatialSearchResult<TObjectType>& rThis){
+                    return rIStream;
+                }
+
+/// output stream function
+template <typename TObjectType>
+inline std::ostream& operator << (std::ostream& rOStream,
+                const SpatialSearchResult<TObjectType>& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_SPATIAL_SEARCH_RESULT_H_INCLUDED  defined
+
+

--- a/kratos/spatial_containers/spatial_search_result.h
+++ b/kratos/spatial_containers/spatial_search_result.h
@@ -32,27 +32,14 @@ namespace Kratos
 ///@addtogroup ApplicationNameApplication
 ///@{
 
-///@name Kratos Globals
-///@{
-
-///@}
-///@name Type Definitions
-///@{
-
-///@}
-///@name  Enum's
-///@{
-
-///@}
-///@name  Functions
-///@{
-
-///@}
 ///@name Kratos Classes
 ///@{
 
-/// Short class definition.
-/** Detail class definition.
+/// This class is the result of the spatial searches.
+/** It provides:
+ *  - A global pointer to the object found.
+ *  - Distance to the object if IsDistanceCalculated() is true
+ *  - IsObjectFound if for example search nearest fails or not
 */
 template <typename TObjectType>
 class SpatialSearchResult
@@ -72,7 +59,8 @@ public:
 
     /// Default constructor.
    	SpatialSearchResult() : mpObject(nullptr), mDistance(0.00), mIsObjectFound(false), mIsDistanceCalculated(false) {}
-       
+
+    /// Constructor with the resulted object   
 	SpatialSearchResult(TObjectType* pObject) : mpObject(pObject), mDistance(0.00), mIsObjectFound(false), mIsDistanceCalculated(false) {
 		if (mpObject.get() != nullptr)
 			mIsObjectFound = true;
@@ -107,13 +95,28 @@ public:
     ///@name Access
     ///@{
 
-	TPointerType Get() { return mpObject; }
-	TPointerType const Get() const { return mpObject; }
+    /// Returns the global pointer to the object
+	TPointerType Get() { 
+        return mpObject; 
+    }
+    
+    /// Returns a const global pointer to the object
+	TPointerType const Get() const { 
+        return mpObject; 
+    }
+
+    /// Set the object to be pointed
 	void Set(TObjectType* pObject) {
 		mpObject = pObject;
 		mIsObjectFound = true;
 	}
-	double GetDistance() const { return mDistance; }
+
+    /// Getting the result distance
+	double GetDistance() const { 
+        return mDistance; 
+    }
+
+    /// Setting the result distance
 	void SetDistance(double TheDistance) {
 		mDistance = TheDistance;
 		mIsDistanceCalculated = true;
@@ -123,9 +126,15 @@ public:
     ///@name Inquiry
     ///@{
 
-	bool IsObjectFound() const { return mIsObjectFound; }
+    /// Returns true if the object is set 
+	bool IsObjectFound() const { 
+        return mIsObjectFound; 
+    }
 
-	bool IsDistanceCalculated() const { return mIsDistanceCalculated; }
+    /// Returns true if the distance is set
+	bool IsDistanceCalculated() const { 
+        return mIsDistanceCalculated; 
+    }
 
     ///@}
     ///@name Input and output
@@ -157,28 +166,9 @@ private:
 	bool mIsDistanceCalculated;
 
     ///@}
-    ///@name Private Operators
-    ///@{
-
-
-    ///@}
     ///@name Private Operations
     ///@{
 
-
-    ///@}
-    ///@name Private  Access
-    ///@{
-
-
-    ///@}
-    ///@name Private Inquiry
-    ///@{
-
-
-    ///@}
-    ///@name Un accessible methods
-    ///@{
 
     ///@}
 

--- a/kratos/tests/cpp_tests/geometries/test_bounding_box.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_bounding_box.cpp
@@ -83,6 +83,54 @@ namespace Testing {
         KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[2], 0.30, tolerance);
     }
 
+    /** Checks BoundingBox set method
+    */
+    KRATOS_TEST_CASE_IN_SUITE(BoundingBoxSet, KratosCoreGeometriesFastSuite) {
+        constexpr double tolerance = 1e-12;
+
+        std::vector<Point> points;
+        points.push_back(Point{0.0, 0.4, -0.3});
+        points.push_back(Point{0.9, -0.3, 0.1});
+        points.push_back(Point{-0.2, 0.4, 0.3});
+        points.push_back(Point{0.0, 0.8, -0.5});
+
+
+        BoundingBox<Point> bounding_box;
+
+        bounding_box.Set(points.begin(), points.end());
+
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[0],-0.20, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[1],-0.30, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[2],-0.50, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[0], 0.90, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[1], 0.80, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[2], 0.30, tolerance);
+    }
+
+    /** Checks BoundingBox set method
+    */
+    KRATOS_TEST_CASE_IN_SUITE(BoundingSet, KratosCoreGeometriesFastSuite) {
+        constexpr double tolerance = 1e-12;
+
+        std::vector<Point> points;
+        points.push_back(Point{0.0, 0.4, -0.3});
+        points.push_back(Point{0.9, -0.3, 0.1});
+
+        BoundingBox<Point> bounding_box(points.begin(), points.end());
+
+        points[0] = Point{-0.2, 0.4, 0.3};
+        points[1] = Point{0.0, 0.8, -0.5};
+
+        bounding_box.Extend(points.begin(), points.end());
+
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[0],-0.20, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[1],-0.30, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[2],-0.50, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[0], 0.90, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[1], 0.80, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[2], 0.30, tolerance);
+    }
+
  
 } // namespace Testing.
 } // namespace Kratos.

--- a/kratos/tests/cpp_tests/geometries/test_bounding_box.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_bounding_box.cpp
@@ -1,0 +1,88 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Aditya Ghantasala
+//                   Vicente Mataix Ferrandiz
+//
+
+// System includes
+#include <limits>
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "geometries/bounding_box.h"
+#include "geometries/point.h"
+
+namespace Kratos {
+namespace Testing {
+
+
+    /** Checks BoundingBox creation with min max point
+    */
+    KRATOS_TEST_CASE_IN_SUITE(BoundingBoxMinMaxConstruction, KratosCoreGeometriesFastSuite) {
+        constexpr double tolerance = 1e-12;
+        BoundingBox<Point> bounding_box({0, .1, .3}, {2.1, 3.4, 5.6});
+
+
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[0], 0.00, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[1], 0.10, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[2], 0.30, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[0], 2.10, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[1], 3.40, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[2], 5.60, tolerance);
+    }
+
+
+    /** Checks BoundingBox copy and assingment
+    */
+    KRATOS_TEST_CASE_IN_SUITE(BoundingCopyAndAssignment, KratosCoreGeometriesFastSuite) {
+        constexpr double tolerance = 1e-12;
+        BoundingBox<Point> bounding_box({0, .1, .3}, {2.1, 3.4, 5.6});
+
+        BoundingBox<Point> copied_box(bounding_box);
+        BoundingBox<Point> assigned_box({0.0, 0.0, 0.0}, {0.0, 0.0, 0.0});
+
+        assigned_box = copied_box;
+
+
+        KRATOS_CHECK_NEAR(assigned_box.GetMinPoint()[0], 0.00, tolerance);
+        KRATOS_CHECK_NEAR(assigned_box.GetMinPoint()[1], 0.10, tolerance);
+        KRATOS_CHECK_NEAR(assigned_box.GetMinPoint()[2], 0.30, tolerance);
+        KRATOS_CHECK_NEAR(assigned_box.GetMaxPoint()[0], 2.10, tolerance);
+        KRATOS_CHECK_NEAR(assigned_box.GetMaxPoint()[1], 3.40, tolerance);
+        KRATOS_CHECK_NEAR(assigned_box.GetMaxPoint()[2], 5.60, tolerance);
+    }
+
+    /** Checks BoundingBox creation with iterator of points
+    */
+    KRATOS_TEST_CASE_IN_SUITE(BoundingPointsConstruction, KratosCoreGeometriesFastSuite) {
+        constexpr double tolerance = 1e-12;
+
+        std::vector<Point> points;
+        points.push_back(Point{0.0, 0.4, -0.3});
+        points.push_back(Point{0.9, -0.3, 0.1});
+        points.push_back(Point{-0.2, 0.4, 0.3});
+        points.push_back(Point{0.0, 0.8, -0.5});
+
+        BoundingBox<Point> bounding_box(points.begin(), points.end());
+
+
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[0],-0.20, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[1],-0.30, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[2],-0.50, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[0], 0.90, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[1], 0.80, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[2], 0.30, tolerance);
+    }
+
+ 
+} // namespace Testing.
+} // namespace Kratos.

--- a/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
@@ -25,29 +25,17 @@
 namespace Kratos {
 namespace Testing {
 
-
-    /** Checks bins bounding box
-    */
-    KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsBoundingBox, KratosFastSuite) {
-        constexpr double tolerance = 1e-12;
-
-        Model current_model;
-
-        const double cube_x = 0.6;
-        const double cube_y = 0.9;
-        const double cube_z = 0.3;
-
+    ModelPart& CreateCubeSkinModelPart(Model& CurrentModel, double HalfX, double HalfY, double HalfZ){
         // Generate the cube skin
-        ModelPart& skin_part = current_model.CreateModelPart("Skin");
-        skin_part.AddNodalSolutionStepVariable(VELOCITY);
-        skin_part.CreateNewNode(1, -cube_x, -cube_y, -cube_z);
-        skin_part.CreateNewNode(2,  cube_x, -cube_y, -cube_z);
-        skin_part.CreateNewNode(3,  cube_x,  cube_y, -cube_z);
-        skin_part.CreateNewNode(4, -cube_x,  cube_y, -cube_z);
-        skin_part.CreateNewNode(5, -cube_x, -cube_y,  cube_z);
-        skin_part.CreateNewNode(6,  cube_x, -cube_y,  cube_z);
-        skin_part.CreateNewNode(7,  cube_x,  cube_y,  cube_z);
-        skin_part.CreateNewNode(8, -cube_x,  cube_y,  cube_z);
+        ModelPart& skin_part = CurrentModel.CreateModelPart("Skin");
+        skin_part.CreateNewNode(1, -HalfX, -HalfY, -HalfZ);
+        skin_part.CreateNewNode(2,  HalfX, -HalfY, -HalfZ);
+        skin_part.CreateNewNode(3,  HalfX,  HalfY, -HalfZ);
+        skin_part.CreateNewNode(4, -HalfX,  HalfY, -HalfZ);
+        skin_part.CreateNewNode(5, -HalfX, -HalfY,  HalfZ);
+        skin_part.CreateNewNode(6,  HalfX, -HalfY,  HalfZ);
+        skin_part.CreateNewNode(7,  HalfX,  HalfY,  HalfZ);
+        skin_part.CreateNewNode(8, -HalfX,  HalfY,  HalfZ);
         Properties::Pointer p_properties(new Properties(0));
         skin_part.CreateNewElement("Element3D3N",  1, { 1,2,3 }, p_properties);
         skin_part.CreateNewElement("Element3D3N",  2, { 1,3,4 }, p_properties);
@@ -61,6 +49,23 @@ namespace Testing {
         skin_part.CreateNewElement("Element3D3N", 10, { 3,8,7 }, p_properties);
         skin_part.CreateNewElement("Element3D3N", 11, { 2,1,5 }, p_properties);
         skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
+
+        return skin_part;
+    }
+
+    /** Checks bins bounding box
+    */
+    KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsBoundingBox, KratosFastSuite) {
+        constexpr double tolerance = 1e-12;
+
+        Model current_model;
+
+        const double cube_x = 0.6;
+        const double cube_y = 0.9;
+        const double cube_z = 0.3;
+
+        // Generate the cube skin
+        ModelPart& skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
 
         GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
 
@@ -86,29 +91,7 @@ namespace Testing {
         const double cube_z = 0.3;
 
         // Generate the cube skin
-        ModelPart& skin_part = current_model.CreateModelPart("Skin");
-        skin_part.AddNodalSolutionStepVariable(VELOCITY);
-        skin_part.CreateNewNode(1, -cube_x, -cube_y, -cube_z);
-        skin_part.CreateNewNode(2,  cube_x, -cube_y, -cube_z);
-        skin_part.CreateNewNode(3,  cube_x,  cube_y, -cube_z);
-        skin_part.CreateNewNode(4, -cube_x,  cube_y, -cube_z);
-        skin_part.CreateNewNode(5, -cube_x, -cube_y,  cube_z);
-        skin_part.CreateNewNode(6,  cube_x, -cube_y,  cube_z);
-        skin_part.CreateNewNode(7,  cube_x,  cube_y,  cube_z);
-        skin_part.CreateNewNode(8, -cube_x,  cube_y,  cube_z);
-        Properties::Pointer p_properties(new Properties(0));
-        skin_part.CreateNewElement("Element3D3N",  1, { 1,2,3 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  2, { 1,3,4 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  3, { 5,6,7 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  4, { 5,7,8 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  5, { 3,6,2 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  6, { 3,7,6 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  7, { 4,5,1 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  8, { 4,8,5 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  9, { 3,4,8 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N", 10, { 3,8,7 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N", 11, { 2,1,5 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
+        ModelPart& skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
 
         GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
 
@@ -134,29 +117,7 @@ namespace Testing {
         const double cube_z = 0.3;
 
         // Generate the cube skin
-        ModelPart& skin_part = current_model.CreateModelPart("Skin");
-        skin_part.AddNodalSolutionStepVariable(VELOCITY);
-        skin_part.CreateNewNode(1, -cube_x, -cube_y, -cube_z);
-        skin_part.CreateNewNode(2,  cube_x, -cube_y, -cube_z);
-        skin_part.CreateNewNode(3,  cube_x,  cube_y, -cube_z);
-        skin_part.CreateNewNode(4, -cube_x,  cube_y, -cube_z);
-        skin_part.CreateNewNode(5, -cube_x, -cube_y,  cube_z);
-        skin_part.CreateNewNode(6,  cube_x, -cube_y,  cube_z);
-        skin_part.CreateNewNode(7,  cube_x,  cube_y,  cube_z);
-        skin_part.CreateNewNode(8, -cube_x,  cube_y,  cube_z);
-        Properties::Pointer p_properties(new Properties(0));
-        skin_part.CreateNewElement("Element3D3N",  1, { 1,2,3 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  2, { 1,3,4 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  3, { 5,6,7 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  4, { 5,7,8 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  5, { 3,6,2 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  6, { 3,7,6 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  7, { 4,5,1 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  8, { 4,8,5 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  9, { 3,4,8 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N", 10, { 3,8,7 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N", 11, { 2,1,5 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
+        ModelPart& skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
 
         GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
 
@@ -185,29 +146,7 @@ namespace Testing {
         const double cube_z = 0.3;
 
         // Generate the cube skin
-        ModelPart& skin_part = current_model.CreateModelPart("Skin");
-        skin_part.AddNodalSolutionStepVariable(VELOCITY);
-        skin_part.CreateNewNode(1, -cube_x, -cube_y, -cube_z);
-        skin_part.CreateNewNode(2,  cube_x, -cube_y, -cube_z);
-        skin_part.CreateNewNode(3,  cube_x,  cube_y, -cube_z);
-        skin_part.CreateNewNode(4, -cube_x,  cube_y, -cube_z);
-        skin_part.CreateNewNode(5, -cube_x, -cube_y,  cube_z);
-        skin_part.CreateNewNode(6,  cube_x, -cube_y,  cube_z);
-        skin_part.CreateNewNode(7,  cube_x,  cube_y,  cube_z);
-        skin_part.CreateNewNode(8, -cube_x,  cube_y,  cube_z);
-        Properties::Pointer p_properties(new Properties(0));
-        skin_part.CreateNewElement("Element3D3N",  1, { 1,2,3 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  2, { 1,3,4 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  3, { 5,6,7 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  4, { 5,7,8 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  5, { 3,6,2 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  6, { 3,7,6 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  7, { 4,5,1 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  8, { 4,8,5 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N",  9, { 3,4,8 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N", 10, { 3,8,7 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N", 11, { 2,1,5 }, p_properties);
-        skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
+        ModelPart& skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
 
         GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
 
@@ -233,5 +172,46 @@ namespace Testing {
         KRATOS_CHECK_EQUAL(results.size(), 12);
     }
  
+    /** Checks bins search nearest
+    */
+    KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchNearest, KratosFastSuite) {
+        constexpr double tolerance = 1e-12;
+
+        Model current_model;
+
+        const double cube_x = 0.6;
+        const double cube_y = 0.9;
+        const double cube_z = 0.3;
+
+        // Generate the cube skin
+        ModelPart& skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
+
+        GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
+
+        Point center_point{0.00,0.00,0.00};
+        auto result = bins.SearchNearest(center_point);
+
+        KRATOS_CHECK_NEAR(result.GetDistance(), cube_z, tolerance);
+        
+        std::size_t id = result.Get()->Id();
+        KRATOS_CHECK((id == 1) ||(id == 2) ||(id == 3) ||(id == 4)); 
+   }
+
+    /** Checks bins empty search nearest 
+    */
+    KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsEmptySearchNearest, KratosFastSuite) {
+        Model current_model;
+
+        // Generate the cube skin
+        ModelPart& skin_part = current_model.CreateModelPart("Skin");
+
+        GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
+
+        Point center_point{0.00,0.00,0.00};
+        auto result = bins.SearchNearest(center_point);
+
+        KRATOS_CHECK_IS_FALSE(result.IsObjectFound());
+    }
+
 } // namespace Testing.
 } // namespace Kratos.

--- a/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
@@ -1,0 +1,237 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Aditya Ghantasala
+//                   Vicente Mataix Ferrandiz
+//
+
+// System includes
+#include <limits>
+
+// External includes
+
+// Project includes
+#include "testing/testing.h"
+#include "spatial_containers/geometrical_objects_bins.h"
+#include "containers/model.h"
+#include "geometries/triangle_3d_3.h"
+
+namespace Kratos {
+namespace Testing {
+
+
+    /** Checks bins bounding box
+    */
+    KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsBoundingBox, KratosFastSuite) {
+        constexpr double tolerance = 1e-12;
+
+        Model current_model;
+
+        const double cube_x = 0.6;
+        const double cube_y = 0.9;
+        const double cube_z = 0.3;
+
+        // Generate the cube skin
+        ModelPart& skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(VELOCITY);
+        skin_part.CreateNewNode(1, -cube_x, -cube_y, -cube_z);
+        skin_part.CreateNewNode(2,  cube_x, -cube_y, -cube_z);
+        skin_part.CreateNewNode(3,  cube_x,  cube_y, -cube_z);
+        skin_part.CreateNewNode(4, -cube_x,  cube_y, -cube_z);
+        skin_part.CreateNewNode(5, -cube_x, -cube_y,  cube_z);
+        skin_part.CreateNewNode(6,  cube_x, -cube_y,  cube_z);
+        skin_part.CreateNewNode(7,  cube_x,  cube_y,  cube_z);
+        skin_part.CreateNewNode(8, -cube_x,  cube_y,  cube_z);
+        Properties::Pointer p_properties(new Properties(0));
+        skin_part.CreateNewElement("Element3D3N",  1, { 1,2,3 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  2, { 1,3,4 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  3, { 5,6,7 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  4, { 5,7,8 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  5, { 3,6,2 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  6, { 3,7,6 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  7, { 4,5,1 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  8, { 4,8,5 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  9, { 3,4,8 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 10, { 3,8,7 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 11, { 2,1,5 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
+
+        GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
+
+        auto bounding_box = bins.GetBoundingBox();
+
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[0],-cube_x, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[1],-cube_y, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMinPoint()[2],-cube_z, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[0], cube_x, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[1], cube_y, tolerance);
+        KRATOS_CHECK_NEAR(bounding_box.GetMaxPoint()[2], cube_z, tolerance);
+    }
+
+    /** Checks bins number of cells
+    */
+    KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsCellSizes, KratosFastSuite) {
+        constexpr double tolerance = 1e-12;
+
+        Model current_model;
+
+        const double cube_x = 0.6;
+        const double cube_y = 0.9;
+        const double cube_z = 0.3;
+
+        // Generate the cube skin
+        ModelPart& skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(VELOCITY);
+        skin_part.CreateNewNode(1, -cube_x, -cube_y, -cube_z);
+        skin_part.CreateNewNode(2,  cube_x, -cube_y, -cube_z);
+        skin_part.CreateNewNode(3,  cube_x,  cube_y, -cube_z);
+        skin_part.CreateNewNode(4, -cube_x,  cube_y, -cube_z);
+        skin_part.CreateNewNode(5, -cube_x, -cube_y,  cube_z);
+        skin_part.CreateNewNode(6,  cube_x, -cube_y,  cube_z);
+        skin_part.CreateNewNode(7,  cube_x,  cube_y,  cube_z);
+        skin_part.CreateNewNode(8, -cube_x,  cube_y,  cube_z);
+        Properties::Pointer p_properties(new Properties(0));
+        skin_part.CreateNewElement("Element3D3N",  1, { 1,2,3 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  2, { 1,3,4 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  3, { 5,6,7 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  4, { 5,7,8 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  5, { 3,6,2 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  6, { 3,7,6 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  7, { 4,5,1 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  8, { 4,8,5 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  9, { 3,4,8 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 10, { 3,8,7 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 11, { 2,1,5 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
+
+        GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
+
+        auto number_of_cells = bins.GetNumberOfCells();
+        KRATOS_CHECK_EQUAL(number_of_cells[0], 3);
+        KRATOS_CHECK_EQUAL(number_of_cells[1], 3);
+        KRATOS_CHECK_EQUAL(number_of_cells[2], 2);
+
+        auto cell_sizes = bins.GetCellSizes();
+        KRATOS_CHECK_NEAR(cell_sizes[0], 2.00 * cube_x / 3.00, tolerance);
+        KRATOS_CHECK_NEAR(cell_sizes[1], 2.00 * cube_y / 3.00, tolerance);
+        KRATOS_CHECK_NEAR(cell_sizes[2], 2.00 * cube_z / 2.00, tolerance);
+    }
+
+
+    /** Checks bins AddObjectsToCells
+    */
+    KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsAddObjectsToCells, KratosFastSuite) {
+        Model current_model;
+
+        const double cube_x = 0.6;
+        const double cube_y = 0.9;
+        const double cube_z = 0.3;
+
+        // Generate the cube skin
+        ModelPart& skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(VELOCITY);
+        skin_part.CreateNewNode(1, -cube_x, -cube_y, -cube_z);
+        skin_part.CreateNewNode(2,  cube_x, -cube_y, -cube_z);
+        skin_part.CreateNewNode(3,  cube_x,  cube_y, -cube_z);
+        skin_part.CreateNewNode(4, -cube_x,  cube_y, -cube_z);
+        skin_part.CreateNewNode(5, -cube_x, -cube_y,  cube_z);
+        skin_part.CreateNewNode(6,  cube_x, -cube_y,  cube_z);
+        skin_part.CreateNewNode(7,  cube_x,  cube_y,  cube_z);
+        skin_part.CreateNewNode(8, -cube_x,  cube_y,  cube_z);
+        Properties::Pointer p_properties(new Properties(0));
+        skin_part.CreateNewElement("Element3D3N",  1, { 1,2,3 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  2, { 1,3,4 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  3, { 5,6,7 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  4, { 5,7,8 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  5, { 3,6,2 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  6, { 3,7,6 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  7, { 4,5,1 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  8, { 4,8,5 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  9, { 3,4,8 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 10, { 3,8,7 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 11, { 2,1,5 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
+
+        GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
+
+        auto& cell = bins.GetCell(0,0,0);
+        KRATOS_CHECK_EQUAL(cell.size(), 4);
+        for(auto& geometrical_object : cell){
+            std::size_t id = geometrical_object->GetId();
+            KRATOS_CHECK((id == 1) ||(id == 2) ||(id == 7) ||(id == 11)); 
+        }
+
+        cell = bins.GetCell(2,2,1);
+        KRATOS_CHECK_EQUAL(cell.size(), 4);
+        for(auto& geometrical_object : cell){
+            std::size_t id = geometrical_object->GetId();
+            KRATOS_CHECK((id == 3) ||(id == 4) ||(id == 6) ||(id == 10)); 
+        }
+    }
+
+    /** Checks bins search in radius
+    */
+    KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchInRadius, KratosFastSuite) {
+        Model current_model;
+
+        const double cube_x = 0.6;
+        const double cube_y = 0.9;
+        const double cube_z = 0.3;
+
+        // Generate the cube skin
+        ModelPart& skin_part = current_model.CreateModelPart("Skin");
+        skin_part.AddNodalSolutionStepVariable(VELOCITY);
+        skin_part.CreateNewNode(1, -cube_x, -cube_y, -cube_z);
+        skin_part.CreateNewNode(2,  cube_x, -cube_y, -cube_z);
+        skin_part.CreateNewNode(3,  cube_x,  cube_y, -cube_z);
+        skin_part.CreateNewNode(4, -cube_x,  cube_y, -cube_z);
+        skin_part.CreateNewNode(5, -cube_x, -cube_y,  cube_z);
+        skin_part.CreateNewNode(6,  cube_x, -cube_y,  cube_z);
+        skin_part.CreateNewNode(7,  cube_x,  cube_y,  cube_z);
+        skin_part.CreateNewNode(8, -cube_x,  cube_y,  cube_z);
+        Properties::Pointer p_properties(new Properties(0));
+        skin_part.CreateNewElement("Element3D3N",  1, { 1,2,3 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  2, { 1,3,4 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  3, { 5,6,7 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  4, { 5,7,8 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  5, { 3,6,2 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  6, { 3,7,6 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  7, { 4,5,1 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  8, { 4,8,5 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N",  9, { 3,4,8 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 10, { 3,8,7 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 11, { 2,1,5 }, p_properties);
+        skin_part.CreateNewElement("Element3D3N", 12, { 2,5,6 }, p_properties);
+
+        GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
+
+        std::vector<GeometricalObjectsBins::ResultType> results;
+        Point center_point{0.00,0.00,0.00};
+
+        bins.SearchInRadius(center_point, .29, results);
+        KRATOS_CHECK_EQUAL(results.size(), 0);
+
+        bins.SearchInRadius(center_point, .3, results);
+        KRATOS_CHECK_EQUAL(results.size(), 4);
+
+        bins.SearchInRadius(center_point, .4, results);
+        KRATOS_CHECK_EQUAL(results.size(), 4);
+
+        bins.SearchInRadius(center_point, .6, results);
+        KRATOS_CHECK_EQUAL(results.size(), 8);
+
+        bins.SearchInRadius(center_point, .7, results);
+        KRATOS_CHECK_EQUAL(results.size(), 8);
+
+        bins.SearchInRadius(center_point, .9, results);
+        KRATOS_CHECK_EQUAL(results.size(), 12);
+    }
+ 
+} // namespace Testing.
+} // namespace Kratos.

--- a/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
@@ -174,6 +174,34 @@ namespace Testing {
  
     /** Checks bins search nearest
     */
+    KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchNearestInRadius, KratosFastSuite) {
+        constexpr double tolerance = 1e-12;
+
+        Model current_model;
+
+        const double cube_x = 0.6;
+        const double cube_y = 0.9;
+        const double cube_z = 0.3;
+
+        // Generate the cube skin
+        ModelPart& skin_part = CreateCubeSkinModelPart(current_model, cube_x, cube_y, cube_z);
+
+        GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
+
+        Point center_point{0.00,0.00,0.00};
+        auto result = bins.SearchNearestInRadius(center_point, cube_z - 1.e-6);
+
+        KRATOS_CHECK_IS_FALSE(result.IsObjectFound());
+
+        result = bins.SearchNearestInRadius(center_point, cube_z + 1.e-6);
+        KRATOS_CHECK_NEAR(result.GetDistance(), cube_z, tolerance);
+        
+        std::size_t id = result.Get()->Id();
+        KRATOS_CHECK((id == 1) ||(id == 2) ||(id == 3) ||(id == 4)); 
+   }
+ 
+    /** Checks bins search nearest
+    */
     KRATOS_TEST_CASE_IN_SUITE(GeometricalObjectsBinsSearchNearest, KratosFastSuite) {
         constexpr double tolerance = 1e-12;
 

--- a/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
@@ -188,16 +188,18 @@ namespace Testing {
 
         GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
 
-        Point center_point{0.00,0.00,0.00};
-        auto result = bins.SearchNearestInRadius(center_point, cube_z - 1.e-6);
+        double epsilon = 1.00e-6;
+        Point near_point{epsilon,epsilon,epsilon};
+        auto result = bins.SearchNearestInRadius(near_point, cube_z - 1.e-4);
 
         KRATOS_CHECK_IS_FALSE(result.IsObjectFound());
 
-        result = bins.SearchNearestInRadius(center_point, cube_z + 1.e-6);
-        KRATOS_CHECK_NEAR(result.GetDistance(), cube_z, tolerance);
+        result = bins.SearchNearestInRadius(near_point, cube_z + 1.e-4);
+        KRATOS_WATCH((result.GetDistance() - cube_z + epsilon));
+        KRATOS_CHECK_NEAR(result.GetDistance(), (cube_z - epsilon), tolerance);
         
         std::size_t id = result.Get()->Id();
-        KRATOS_CHECK((id == 1) ||(id == 2) ||(id == 3) ||(id == 4)); 
+        KRATOS_CHECK(id == 3); 
    }
  
     /** Checks bins search nearest
@@ -216,13 +218,14 @@ namespace Testing {
 
         GeometricalObjectsBins bins(skin_part.ElementsBegin(), skin_part.ElementsEnd());
 
-        Point center_point{0.00,0.00,0.00};
-        auto result = bins.SearchNearest(center_point);
+        double epsilon = 1.00e-6;
+        Point near_point{epsilon,epsilon,epsilon};
+        auto result = bins.SearchNearest(near_point);
 
-        KRATOS_CHECK_NEAR(result.GetDistance(), cube_z, tolerance);
+        KRATOS_CHECK_NEAR(result.GetDistance(), (cube_z - epsilon), tolerance);
         
         std::size_t id = result.Get()->Id();
-        KRATOS_CHECK((id == 1) ||(id == 2) ||(id == 3) ||(id == 4)); 
+        KRATOS_CHECK(id == 3); 
    }
 
     /** Checks bins empty search nearest 

--- a/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
+++ b/kratos/tests/cpp_tests/spatial_containers/test_geometrical_objects_bins.cpp
@@ -195,7 +195,6 @@ namespace Testing {
         KRATOS_CHECK_IS_FALSE(result.IsObjectFound());
 
         result = bins.SearchNearestInRadius(near_point, cube_z + 1.e-4);
-        KRATOS_WATCH((result.GetDistance() - cube_z + epsilon));
         KRATOS_CHECK_NEAR(result.GetDistance(), (cube_z - epsilon), tolerance);
         
         std::size_t id = result.Get()->Id();


### PR DESCRIPTION
This PR adds a new bins for efficient search of `GeometericalObject`s in Kratos. Some important points are:
* It implements a new interface for spatial search which is more c++ but not compatible with previous ones.
* Adds a new SpatialSearchResult type to be used in the new interface having a `GlobalPointer` to the resulted object.
* It adds a new BoundingBox class to the geometries. It is operational but can be improved.
* The bin at the moment is not templated but I'm not sure if in the future we should add some template to it in order to have it more configurable.
* At this moment it only works with triangles due to the lack of Distance methods in geometries (#5789)

This would replace the BinsDynamicObjects which is very complex to configure and works buggy in my experience.