### PR TITLE
[Core][Container] Bugfix in pointer_hash_map_set

### DIFF
--- a/kratos/containers/pointer_hash_map_set.h
+++ b/kratos/containers/pointer_hash_map_set.h
@@ -284,14 +284,14 @@ public:
 
     iterator insert(TPointerType pData)
     {
-		std::string key=KeyOf(*pData);
-		typename ContainerType::value_type item(key, pData);
-		std::pair<typename ContainerType::iterator, bool> result = mData.insert(item);
-	// TODO: I should enable this after adding the KRATOS_ERROR to define.h. Pooyan.
-	//if(result.second != true)
-	//	KRATOS_ERROR << "Error in adding the new item" << std::endl
-		return result.first;
-	}
+        key_type key=KeyOf(*pData);
+        typename ContainerType::value_type item(key, pData);
+        std::pair<typename ContainerType::iterator, bool> result = mData.insert(item);
+        // TODO: I should enable this after adding the KRATOS_ERROR to define.h. Pooyan.
+        //if(result.second != true)
+        //	KRATOS_ERROR << "Error in adding the new item" << std::endl
+        return result.first;
+    }
 
     template <class InputIterator>
     void insert(InputIterator First, InputIterator Last)


### PR DESCRIPTION
I am fixing here the hard coded std::string type to the template dependent type key_type.

It is required when the HashType is not of type string, e.g. in the following:
```c++
typedef PointerHashMapSet<
         GeometryType,
         std::hash<std::size_t>,
         GetGeometryId,
         Kratos::shared_ptr<GeometryType>
     > GeometriesContainerType;
```
