### PR TITLE
[Core][Geometry] Add missing member assignment mpNurbsCurve(pCurve)

### DIFF
--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -75,6 +75,7 @@ public:
         typename NurbsCurveType::Pointer pCurve)
         : BaseType(PointsArrayType(), &msGeometryData)
         , mpNurbsSurface(pSurface)
+        , mpNurbsCurve(pCurve)
     {
     }
 


### PR DESCRIPTION
Small bugfix, member is not assigned correctly.