### PR TITLE
[WIP][ShapeOpt] reactivate some small tests

### DIFF
--- a/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
+++ b/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
@@ -61,6 +61,7 @@ def AssembleTestSuites():
     smallSuite = suites['small']
     smallSuite.addTest(mapper_test('test_execution'))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([WrlIOTest]))
+    smallSuite.addTest(trust_region_projector_test('test_execution'))
 
     # Adding nightly tests (tests that take < 10min)
     nightSuite = suites['nightly']
@@ -77,7 +78,6 @@ def AssembleTestSuites():
     nightSuite.addTest(algorithm_steepest_descent_test('test_execution'))
     nightSuite.addTest(algorithm_penalized_projection_test('test_execution'))
     nightSuite.addTest(algorithm_trust_region_test('test_execution'))
-    nightSuite.addTest(trust_region_projector_test('test_execution'))
     nightSuite.addTest(opt_process_multiobjective_test('test_execution'))
     nightSuite.addTest(opt_process_stress_test('test_execution'))
     nightSuite.addTest(sensitivity_verification_semi_analytic_process_test('test_execution'))

--- a/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
+++ b/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
@@ -63,6 +63,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([WrlIOTest]))
     smallSuite.addTest(trust_region_projector_test('test_execution'))
     smallSuite.addTest(in_plane_opt_test('test_execution'))
+    smallSuite.addTest(packaging_plane_based_test('test_execution'))
 
     # Adding nightly tests (tests that take < 10min)
     nightSuite = suites['nightly']
@@ -71,7 +72,6 @@ def AssembleTestSuites():
     nightSuite.addTest(algorithm_bead_optimization_test('test_execution'))
     nightSuite.addTest(opt_process_step_adaption_test('test_execution'))
     nightSuite.addTest(packaging_mesh_based_test('test_execution'))
-    nightSuite.addTest(packaging_plane_based_test('test_execution'))
     nightSuite.addTest(opt_process_vertex_morphing_test('test_execution'))
     nightSuite.addTest(opt_process_eigenfrequency_test('test_execution'))
     nightSuite.addTest(opt_process_weighted_eigenfrequency_test('test_execution'))

--- a/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
+++ b/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
@@ -62,7 +62,7 @@ def AssembleTestSuites():
     smallSuite.addTest(mapper_test('test_execution'))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([WrlIOTest]))
     smallSuite.addTest(trust_region_projector_test('test_execution'))
-    smallSuite.addTest(algorithm_steepest_descent_test('test_execution'))
+    smallSuite.addTest(in_plane_opt_test('test_execution'))
 
     # Adding nightly tests (tests that take < 10min)
     nightSuite = suites['nightly']
@@ -70,12 +70,12 @@ def AssembleTestSuites():
     nightSuite.addTest(opt_process_solid_test('test_execution'))
     nightSuite.addTest(algorithm_bead_optimization_test('test_execution'))
     nightSuite.addTest(opt_process_step_adaption_test('test_execution'))
-    nightSuite.addTest(in_plane_opt_test('test_execution'))
     nightSuite.addTest(packaging_mesh_based_test('test_execution'))
     nightSuite.addTest(packaging_plane_based_test('test_execution'))
     nightSuite.addTest(opt_process_vertex_morphing_test('test_execution'))
     nightSuite.addTest(opt_process_eigenfrequency_test('test_execution'))
     nightSuite.addTest(opt_process_weighted_eigenfrequency_test('test_execution'))
+    nightSuite.addTest(algorithm_steepest_descent_test('test_execution'))
     nightSuite.addTest(algorithm_penalized_projection_test('test_execution'))
     nightSuite.addTest(algorithm_trust_region_test('test_execution'))
     nightSuite.addTest(opt_process_multiobjective_test('test_execution'))

--- a/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
+++ b/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
@@ -65,6 +65,7 @@ def AssembleTestSuites():
     smallSuite.addTest(in_plane_opt_test('test_execution'))
     smallSuite.addTest(packaging_plane_based_test('test_execution'))
     smallSuite.addTest(packaging_mesh_based_test('test_execution'))
+    smallSuite.addTest(opt_process_shell_test('test_execution'))
 
     # Adding nightly tests (tests that take < 10min)
     nightSuite = suites['nightly']

--- a/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
+++ b/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
@@ -64,6 +64,7 @@ def AssembleTestSuites():
     smallSuite.addTest(trust_region_projector_test('test_execution'))
     smallSuite.addTest(in_plane_opt_test('test_execution'))
     smallSuite.addTest(packaging_plane_based_test('test_execution'))
+    smallSuite.addTest(packaging_mesh_based_test('test_execution'))
 
     # Adding nightly tests (tests that take < 10min)
     nightSuite = suites['nightly']
@@ -71,7 +72,6 @@ def AssembleTestSuites():
     nightSuite.addTest(opt_process_solid_test('test_execution'))
     nightSuite.addTest(algorithm_bead_optimization_test('test_execution'))
     nightSuite.addTest(opt_process_step_adaption_test('test_execution'))
-    nightSuite.addTest(packaging_mesh_based_test('test_execution'))
     nightSuite.addTest(opt_process_vertex_morphing_test('test_execution'))
     nightSuite.addTest(opt_process_eigenfrequency_test('test_execution'))
     nightSuite.addTest(opt_process_weighted_eigenfrequency_test('test_execution'))

--- a/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
+++ b/applications/ShapeOptimizationApplication/tests/test_ShapeOptimizationApplication.py
@@ -62,6 +62,7 @@ def AssembleTestSuites():
     smallSuite.addTest(mapper_test('test_execution'))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([WrlIOTest]))
     smallSuite.addTest(trust_region_projector_test('test_execution'))
+    smallSuite.addTest(algorithm_steepest_descent_test('test_execution'))
 
     # Adding nightly tests (tests that take < 10min)
     nightSuite = suites['nightly']
@@ -75,7 +76,6 @@ def AssembleTestSuites():
     nightSuite.addTest(opt_process_vertex_morphing_test('test_execution'))
     nightSuite.addTest(opt_process_eigenfrequency_test('test_execution'))
     nightSuite.addTest(opt_process_weighted_eigenfrequency_test('test_execution'))
-    nightSuite.addTest(algorithm_steepest_descent_test('test_execution'))
     nightSuite.addTest(algorithm_penalized_projection_test('test_execution'))
     nightSuite.addTest(algorithm_trust_region_test('test_execution'))
     nightSuite.addTest(opt_process_multiobjective_test('test_execution'))


### PR DESCRIPTION
In this PR, some tests are moved one by one from nightly to small. This happens in order to find the ones that take too long on CI.

Time for small tests before this PR: 2.820s
total time with tests activated step by step:
* trust region projector: 3.949s
* (steepest descent: too slow - process killed)
* in plane: 5.860s
* packaging plane: 6.104s
* packaging mesh: 7.534s
* shell test: 13.480s