### PR TITLE
[ShapeOpt] fix vtk logger full mdpa name

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/design_logger_vtk.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/design_logger_vtk.py
@@ -62,9 +62,9 @@ class DesignLoggerVTK( DesignLogger ):
         vtk_parameters.AddValue("nodal_solution_step_data_variables", nodal_results)
 
         if output_mode == "WriteDesignSurface":
-            vtk_parameters["model_part_name"].SetString(self.design_surface.Name)
+            vtk_parameters["model_part_name"].SetString(self.design_surface.FullName())
         elif output_mode == "WriteOptimizationModelPart":
-            vtk_parameters["model_part_name"].SetString(self.optimization_model_part.Name)
+            vtk_parameters["model_part_name"].SetString(self.optimization_model_part.FullName())
         else:
             raise NameError("The following design output mode is not defined within a VTK output (name may be misspelled): " + output_mode)
 

--- a/applications/ShapeOptimizationApplication/tests/packaging_mesh_based_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/packaging_mesh_based_test/optimization_parameters.json
@@ -74,7 +74,7 @@
             "design_output_mode" : "WriteDesignSurface",
             "nodal_results"      : [ "DF1DX", "DC1DX", "SHAPE_CHANGE" ],
             "output_format" : {
-                "name": "gid"
+                "name": "vtk"
             }
         }
     }


### PR DESCRIPTION
The model_parts have to be retrieved using their full name since end of 2019.
The VTK IO in the design_logger_vtk is set up accordingly.

Also one of the tests is using vtk logging now, so that such errors do not go unnoticed in the future.