### PR TITLE
[Pfem] add prepare model part method

### DIFF
--- a/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_dynamics_analysis.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_dynamics_analysis.py
@@ -91,8 +91,11 @@ class PfemFluidDynamicsAnalysis(AnalysisStage):
         # Add variables (always before importing the model part)
         self.AddNodalVariablesToModelPart()
 
-        # Read model_part (note: the buffer_size is set here) (restart is read here)
+        # Read model_part from mdpa file
         self._solver.ImportModelPart()
+
+        # Prepare model_part (note: the buffer_size is set here) (restart is read here)
+        self._solver.PrepareModelPart()
 
         # Add dofs (always after importing the model part)
         if((self.main_model_part.ProcessInfo).Has(KratosMultiphysics.IS_RESTARTED)):

--- a/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_solver.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_solver.py
@@ -217,15 +217,16 @@ class PfemFluidSolver(PythonSolver):
             node.AddDof(KratosMultiphysics.DISPLACEMENT_Z)
         print("::[Pfem Fluid Solver]:: DOF's ADDED")
 
-
     def ImportModelPart(self):
-
-        print("::[Pfem Fluid Solver]:: Model reading starts.")
-
-        self.computing_model_part_name = "fluid_computing_domain"
 
         # we can use the default implementation in the base class
         self._ImportModelPart(self.main_model_part,self.settings["model_import_settings"])
+
+    def PrepareModelPart(self):
+
+        print("::[Pfem Fluid Solver]:: Model preparing started.")
+
+        self.computing_model_part_name = "fluid_computing_domain"
 
         # Auxiliary Kratos parameters object to be called by the CheckAndPepareModelProcess
         params = KratosMultiphysics.Parameters("{}")
@@ -257,7 +258,7 @@ class PfemFluidSolver(PythonSolver):
 
         self.main_model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED] = False
 
-        print ("::[Pfem Fluid Solver]:: Model reading finished.")
+        print ("::[Pfem Fluid Solver]:: Model preparing finished.")
 
 
     def CheckAndPrepareModelProcess(self, params):


### PR DESCRIPTION
Another small PR to prepare the pfem to receive the thermal coupling files.
The previous `ImportModelPart` in the `pfem_fluid_solver.py` is splitted in `ImportModelPart` and `PrepareModelPart`. This is  done because the cloning of the thermal model part is done after reading the mdpa and before the preparing the model part.
Tests ran OK.
Examples with `nodal_integration_solver` ran OK.