### PR TITLE
[FSI][Hotfix] Submodelpart retrieve through model

### DIFF
--- a/applications/FSIApplication/python_scripts/partitioned_embedded_fsi_base_solver.py
+++ b/applications/FSIApplication/python_scripts/partitioned_embedded_fsi_base_solver.py
@@ -597,7 +597,7 @@ class PartitionedEmbeddedFSIBaseSolver(PythonSolver):
 
     def __GetStructureInterfaceSubmodelPart(self):
         # Returns the structure interface submodelpart that will be used in the residual minimization
-        return self.structure_solver.main_model_part.GetSubModelPart(self.structure_interface_submodelpart_name)
+        return self.model.GetModelPart(self.structure_interface_submodelpart_name)
 
     def __GetDomainSize(self):
         fluid_domain_size = self.fluid_solver.main_model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE]


### PR DESCRIPTION
A minor change to retrieve the embedded skin submodelpart through the model.