### PR TITLE
[Structural] Hotfix in python 2.7 - missing def_static

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
+++ b/applications/StructuralMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp
@@ -51,7 +51,7 @@ void  AddCustomUtilitiesToPython(pybind11::module& m)
         ;
 
     py::class_<ProjectVectorOnSurfaceUtility>(m,"ProjectVectorOnSurfaceUtility")
-        .def("Execute",&ProjectVectorOnSurfaceUtility::Execute);
+        .def_static("Execute",&ProjectVectorOnSurfaceUtility::Execute);
 }
 
 }  // namespace Python.


### PR DESCRIPTION
This is throwing an error in python 2.7 test