### PR TITLE
[Structural] Fix bug in damage constitutive laws

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.cpp
@@ -124,24 +124,8 @@ void SmallStrainIsotropicDamage3D::InitializeMaterial(
 //************************************************************************************
 //************************************************************************************
 
-bool SmallStrainIsotropicDamage3D::RequiresInitializeMaterialResponse()
-{
-    return false;
-}
-
-//************************************************************************************
-//************************************************************************************
-
 void SmallStrainIsotropicDamage3D::InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
 {
-}
-
-//************************************************************************************
-//************************************************************************************
-
-bool SmallStrainIsotropicDamage3D::RequiresFinalizeMaterialResponse()
-{
-    return true;
 }
 
 //************************************************************************************

--- a/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.cpp
@@ -131,6 +131,14 @@ void SmallStrainIsotropicDamage3D::InitializeMaterialResponseCauchy(Constitutive
 //************************************************************************************
 //************************************************************************************
 
+bool SmallStrainIsotropicDamage3D::RequiresFinalizeMaterialResponse()
+{
+    return true;
+}
+
+//************************************************************************************
+//************************************************************************************
+
 void SmallStrainIsotropicDamage3D::FinalizeMaterialResponseCauchy(Parameters& rValues)
 {
     Vector internal_variables(1);

--- a/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.cpp
@@ -124,6 +124,14 @@ void SmallStrainIsotropicDamage3D::InitializeMaterial(
 //************************************************************************************
 //************************************************************************************
 
+bool SmallStrainIsotropicDamage3D::RequiresInitializeMaterialResponse()
+{
+    return false;
+}
+
+//************************************************************************************
+//************************************************************************************
+
 void SmallStrainIsotropicDamage3D::InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues)
 {
 }

--- a/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.h
@@ -164,6 +164,12 @@ public:
     void CalculateMaterialResponsePK2(Parameters& rValues) override;
 
     /**
+     * @brief Indicates if this CL requires initialization of the material response,
+     * called by the element in InitializeSolutionStep.
+     */
+    bool RequiresInitializeMaterialResponse() override;
+
+    /**
      * @brief Initialize the material response in terms of Cauchy stresses
      * @param rValues The specific parameters of the current constitutive law
      * @see Parameters
@@ -171,7 +177,9 @@ public:
     void InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) override;
 
     /**
-     * @brief This CL requires to finalize the material response, called by the element in FinalizeSolutionStep.
+     * @brief Indicates if this CL requires finalization step the material
+     * response (e.g. update of the internal variables), called by the element
+     * in FinalizeSolutionStep.
      */
     bool RequiresFinalizeMaterialResponse() override;
 

--- a/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.h
@@ -167,7 +167,10 @@ public:
      * @brief Indicates if this CL requires initialization of the material response,
      * called by the element in InitializeSolutionStep.
      */
-    bool RequiresInitializeMaterialResponse() override;
+    bool RequiresInitializeMaterialResponse() override
+    {
+        return false;
+    }
 
     /**
      * @brief Initialize the material response in terms of Cauchy stresses
@@ -181,7 +184,10 @@ public:
      * response (e.g. update of the internal variables), called by the element
      * in FinalizeSolutionStep.
      */
-    bool RequiresFinalizeMaterialResponse() override;
+    bool RequiresFinalizeMaterialResponse() override
+    {
+        return true;
+    }
 
     /**
      * @brief Finalize the material response in terms of Cauchy stresses

--- a/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_advanced_constitutive/small_strain_isotropic_damage_3d.h
@@ -171,6 +171,11 @@ public:
     void InitializeMaterialResponseCauchy(ConstitutiveLaw::Parameters& rValues) override;
 
     /**
+     * @brief This CL requires to finalize the material response, called by the element in FinalizeSolutionStep.
+     */
+    bool RequiresFinalizeMaterialResponse() override;
+
+    /**
      * @brief Finalize the material response in terms of Cauchy stresses
      * @param rValues The specific parameters of the current constitutive law
      * @see Parameters

--- a/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.h
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.h
@@ -248,7 +248,7 @@ public:
     }
 
     /**
-     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     * @brief If the CL requires to finalize the material response, called by the element in FinalizeSolutionStep.
      */
     bool RequiresFinalizeMaterialResponse() override
     {

--- a/applications/StructuralMechanicsApplication/tests/cpp_advanced_constitutive_tests/test_small_strain_isotropic_damage_3d.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_advanced_constitutive_tests/test_small_strain_isotropic_damage_3d.cpp
@@ -144,9 +144,13 @@ KRATOS_TEST_CASE_IN_SUITE(_ConstitutiveLaw_SmallStrainIsotropicDamage3D, KratosS
         for (std::size_t comp = 0; comp < 6; ++comp) {
             strain_vector[comp] = epr(t, comp);
         }
-        cl.InitializeMaterialResponseCauchy(cl_parameters);
+        if (cl.RequiresInitializeMaterialResponse()){
+            cl.InitializeMaterialResponseCauchy(cl_parameters);
+        }
         cl.CalculateMaterialResponseCauchy(cl_parameters);
-        cl.FinalizeMaterialResponseCauchy(cl_parameters);
+        if (cl.RequiresFinalizeMaterialResponse()){
+            cl.FinalizeMaterialResponseCauchy(cl_parameters);
+        }
         double value;
 
         // Check damage variable

--- a/applications/StructuralMechanicsApplication/tests/cpp_advanced_constitutive_tests/test_small_strain_isotropic_damage_traction_only_3d.cpp
+++ b/applications/StructuralMechanicsApplication/tests/cpp_advanced_constitutive_tests/test_small_strain_isotropic_damage_traction_only_3d.cpp
@@ -134,9 +134,13 @@ KRATOS_TEST_CASE_IN_SUITE(_ConstitutiveLaw_SmallStrainIsotropicDamageTractionOnl
         for (std::size_t comp = 0; comp < 6; ++comp) {
             strain_vector[comp] = epr(t, comp);
         }
-        cl.InitializeMaterialResponseCauchy(cl_parameters);
+        if (cl.RequiresInitializeMaterialResponse()){
+            cl.InitializeMaterialResponseCauchy(cl_parameters);
+        }
         cl.CalculateMaterialResponseCauchy(cl_parameters);
-        cl.FinalizeMaterialResponseCauchy(cl_parameters);
+        if (cl.RequiresFinalizeMaterialResponse()) {
+            cl.FinalizeMaterialResponseCauchy(cl_parameters);
+        }
         double value;
 
         // Check damage variable

--- a/kratos/includes/constitutive_law.h
+++ b/kratos/includes/constitutive_law.h
@@ -972,7 +972,7 @@ public:
     virtual void InitializeMaterialResponseCauchy (Parameters& rValues);
 
     /**
-     * @brief If the CL requires to initialize the material response, called by the element in InitializeSolutionStep.
+     * @brief If the CL requires to finalize the material response, called by the element in FinalizeSolutionStep.
      */
     virtual bool RequiresFinalizeMaterialResponse()
     {


### PR DESCRIPTION
- Adds missing `RequiresFinalizeMaterialResponse()` (= true) to SmallStrainIsotropicDamage CL.
- Updates corresponding cpp tests
- Fixes minor copy-paste error in description of base functions