### PR TITLE
[Core] Improve filesystem test

### DIFF
--- a/kratos/tests/cpp_tests/sources/test_filesystem.cpp
+++ b/kratos/tests/cpp_tests/sources/test_filesystem.cpp
@@ -8,11 +8,20 @@
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Philipp Bucher
+//                   Vicente Mataix Ferrándiz
 //
 
 // System includes
 #include <fstream>
 #include <string>
+#include <stdio.h>  /* defines FILENAME_MAX */
+#ifdef _WIN32
+#include <direct.h>
+#define GetCurrentDir _getcwd
+#else
+#include <unistd.h>
+#define GetCurrentDir getcwd
+#endif
 
 // External includes
 
@@ -37,6 +46,18 @@ KRATOS_TEST_CASE_IN_SUITE(FilesystemExists, KratosCoreFastSuite)
     Kratos::filesystem::remove(file_name);
 
     KRATOS_CHECK_IS_FALSE(Kratos::filesystem::exists(file_name));
+}
+
+KRATOS_TEST_CASE_IN_SUITE(FilesystemCurrentPath, KratosCoreFastSuite)
+{
+    // This test check that the current path method works
+    const std::string current_path = (Kratos::filesystem::current_path()).string();
+    
+    char buff[FILENAME_MAX];
+    GetCurrentDir( buff, FILENAME_MAX );
+    const std::string current_working_dir(buff);
+    
+    KRATOS_CHECK_STRING_EQUAL(current_working_dir, current_path);
 }
 
 } // namespace Testing

--- a/kratos/tests/cpp_tests/sources/test_filesystem.cpp
+++ b/kratos/tests/cpp_tests/sources/test_filesystem.cpp
@@ -39,10 +39,10 @@ KRATOS_TEST_CASE_IN_SUITE(FilesystemExists, KratosCoreFastSuite)
     const std::string file_name("dummy_file.txt");
     std::ofstream output_file;
     output_file.open(file_name);
+    output_file.close();
 
     KRATOS_CHECK(Kratos::filesystem::exists(file_name));
 
-    output_file.close();
     Kratos::filesystem::remove(file_name);
 
     KRATOS_CHECK_IS_FALSE(Kratos::filesystem::exists(file_name));

--- a/kratos/tests/cpp_tests/sources/test_filesystem.cpp
+++ b/kratos/tests/cpp_tests/sources/test_filesystem.cpp
@@ -33,6 +33,7 @@ KRATOS_TEST_CASE_IN_SUITE(FilesystemExists, KratosCoreFastSuite)
 
     KRATOS_CHECK(Kratos::filesystem::exists(file_name));
 
+    output_file.close();
     Kratos::filesystem::remove(file_name);
 
     KRATOS_CHECK_IS_FALSE(Kratos::filesystem::exists(file_name));


### PR DESCRIPTION
This PR adds a correction of the previous test (in Windows you need to close a file in order to be able to remove it). Additionally adds a test for the current file directory based on the previous OSUtilities implementation. This PR will additionally help to discover why #6218 fails in appveyor