### PR TITLE
[Structural] Fix LOCAL_ELEMENT_ORIENTATION output

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -1191,10 +1191,25 @@ CrBeamElement3D2N::GetCurrentNodalPosition() const
 void CrBeamElement3D2N::Calculate(const Variable<Matrix>& rVariable, Matrix& rOutput, const ProcessInfo& rCurrentProcessInfo)
 {
     if (rVariable == LOCAL_ELEMENT_ORIENTATION) {
-        if(rOutput.size1() != msElementSize || rOutput.size2() != msElementSize) {
-            rOutput.resize(msElementSize, msElementSize, false);
+        if(rOutput.size1() != msDimension || rOutput.size2() != msDimension) {
+            rOutput.resize(msDimension, msDimension, false);
         }
-        noalias(rOutput) = GetTransformationMatrixGlobal();
+
+        Matrix  transformation_matrix = GetTransformationMatrixGlobal();
+
+        Vector base_1 = ZeroVector(3);
+        Vector base_2 = ZeroVector(3);
+        Vector base_3 = ZeroVector(3);
+
+        for (SizeType i=0;i<msDimension;++i){
+            base_1[i] = transformation_matrix(i,0);
+            base_2[i] = transformation_matrix(i,1);
+            base_3[i] = transformation_matrix(i,1);
+        }
+
+        column(rOutput,0) = base_1;
+        column(rOutput,1) = base_2;
+        column(rOutput,2) = base_3;
     }
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/cr_beam_element_3D2N.cpp
@@ -1204,7 +1204,7 @@ void CrBeamElement3D2N::Calculate(const Variable<Matrix>& rVariable, Matrix& rOu
         for (SizeType i=0;i<msDimension;++i){
             base_1[i] = transformation_matrix(i,0);
             base_2[i] = transformation_matrix(i,1);
-            base_3[i] = transformation_matrix(i,1);
+            base_3[i] = transformation_matrix(i,2);
         }
 
         column(rOutput,0) = base_1;

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -298,10 +298,23 @@ void TrussElement3D2N::Calculate(const Variable<Matrix>& rVariable, Matrix& rOut
     if (rVariable == LOCAL_ELEMENT_ORIENTATION) {
         BoundedMatrix<double, msLocalSize, msLocalSize> transformation_matrix = ZeroMatrix(msLocalSize, msLocalSize);
         CreateTransformationMatrix(transformation_matrix);
-        if(rOutput.size1() != msLocalSize || rOutput.size2() != msLocalSize) {
-            rOutput.resize(msLocalSize, msLocalSize, false);
+        if(rOutput.size1() != msDimension || rOutput.size2() != msDimension) {
+            rOutput.resize(msDimension, msDimension, false);
         }
-        noalias(rOutput) = transformation_matrix;
+
+        Vector base_1 = ZeroVector(3);
+        Vector base_2 = ZeroVector(3);
+        Vector base_3 = ZeroVector(3);
+
+        for (SizeType i=0;i<msDimension;++i){
+            base_1[i] = transformation_matrix(i,0);
+            base_2[i] = transformation_matrix(i,1);
+            base_3[i] = transformation_matrix(i,1);
+        }
+
+        column(rOutput,0) = base_1;
+        column(rOutput,1) = base_2;
+        column(rOutput,2) = base_3;
     }
 }
 

--- a/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
+++ b/applications/StructuralMechanicsApplication/custom_elements/truss_element_3D2N.cpp
@@ -309,7 +309,7 @@ void TrussElement3D2N::Calculate(const Variable<Matrix>& rVariable, Matrix& rOut
         for (SizeType i=0;i<msDimension;++i){
             base_1[i] = transformation_matrix(i,0);
             base_2[i] = transformation_matrix(i,1);
-            base_3[i] = transformation_matrix(i,1);
+            base_3[i] = transformation_matrix(i,2);
         }
 
         column(rOutput,0) = base_1;

--- a/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/adjoint_local_stress_response_function.cpp
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/response_utilities/adjoint_local_stress_response_function.cpp
@@ -356,10 +356,20 @@ namespace Kratos
             // delivers particular solution of influence function in local coordinates
             this->CalculateParticularSolutionLinearElement2N(particular_solution);
             // transform particular solution into global coordinates
-            Matrix transformation_matrix;
-            mpTracedElement->Calculate(LOCAL_ELEMENT_ORIENTATION, transformation_matrix, mrModelPart.GetProcessInfo());
-            KRATOS_ERROR_IF_NOT(transformation_matrix.size1() == particular_solution.size())
-                << "Size of transformation matrix does not fit!" << std::endl;
+            Matrix transformation_matrix = ZeroMatrix(particular_solution.size());
+            Matrix local_element_orientation = ZeroMatrix(3);
+            mpTracedElement->Calculate(LOCAL_ELEMENT_ORIENTATION, local_element_orientation, mrModelPart.GetProcessInfo());
+
+            const SizeType dimension(3);
+            KRATOS_ERROR_IF_NOT((particular_solution.size()%dimension)==0) << "Size of particular solution does not fit!" << std::endl;
+            const SizeType check_a(particular_solution.size()/dimension);
+
+            SizeType iterator_count(0);
+            for (SizeType i=0;  i<check_a;++i){
+                iterator_count = i*dimension;
+                project(transformation_matrix, range(iterator_count,iterator_count+dimension),range(iterator_count,iterator_count+dimension)) += local_element_orientation;
+            }
+
             particular_solution = prod(transformation_matrix, particular_solution);
             // set particular solution as non-historical result
             mpTracedElement->SetValue(ADJOINT_PARTICULAR_DISPLACEMENT, particular_solution);


### PR DESCRIPTION
Hi, this blocks #6247. The output of `LOCAL_ELEMENT_ORIENTATION` has different sizes for different elements.

- For membrane, shells, etc. we defined it as a 3x3 matrix, containing the 3 base_vectors
- The truss + beam element are writing the total transformation matrix (dofs x dofs)

This PR adjusts the 1 dimensional elements and provides a suggestion for the change in the response function. @MFusseder please check this and try it with one of your tests.