### PR TITLE
[Pfem] Adding all elements to the main model part

### DIFF
--- a/applications/PfemFluidDynamicsApplication/custom_processes/model_start_end_meshing_for_fluids_process.hpp
+++ b/applications/PfemFluidDynamicsApplication/custom_processes/model_start_end_meshing_for_fluids_process.hpp
@@ -215,7 +215,7 @@ protected:
                   vertices[i].Set(FLUID);
                 }
               }
-
+               i_elem->SetId(elemId);
               (rModelPart.Elements()).push_back(*(i_elem.base()));
               rModelPart.Elements().back().SetId(elemId);
               elemId += 1;
@@ -313,6 +313,21 @@ protected:
         // 	}
         //   }
       }
+
+        else {
+            // Skipping the Computing Model Part
+            if (!((i_mp->Is(ACTIVE) && i_mp->Is(SOLID)) || (i_mp->Is(ACTIVE) && i_mp->Is(FLUID)))) {
+                if (i_mp->NumberOfElements()) {
+                    // Adding the remaining elements to the Main Mode Part
+                    for (ModelPart::ElementsContainerType::iterator i_elem = i_mp->ElementsBegin(); i_elem != i_mp->ElementsEnd(); i_elem++) {
+                        i_elem->SetId(elemId);
+                        (rModelPart.Elements()).push_back(*(i_elem.base()));
+                        rModelPart.Elements().back().SetId(elemId);
+                        elemId += 1;
+                    }
+                }
+            }
+        }
     }
 
     // this->BuildBoundaryModelParts(rModelPart,PreservedConditions, nodeId, elemId, condId);

--- a/applications/PfemFluidDynamicsApplication/custom_processes/model_start_end_meshing_with_conditions_for_fluids_process.hpp
+++ b/applications/PfemFluidDynamicsApplication/custom_processes/model_start_end_meshing_with_conditions_for_fluids_process.hpp
@@ -215,7 +215,7 @@ protected:
                   vertices[i].Set(FLUID);
                 }
               }
-
+              i_elem->SetId(elemId);
               (rModelPart.Elements()).push_back(*(i_elem.base()));
               rModelPart.Elements().back().SetId(elemId);
               elemId += 1;
@@ -317,6 +317,20 @@ protected:
           }
         }
       }
+      else {
+            // Skipping the Computing Model Part
+            if (!((i_mp->Is(ACTIVE) && i_mp->Is(SOLID)) || (i_mp->Is(ACTIVE) && i_mp->Is(FLUID)))) {
+                if (i_mp->NumberOfElements()) {
+                    // Adding the remaining elements to the Main Mode Part
+                    for (ModelPart::ElementsContainerType::iterator i_elem = i_mp->ElementsBegin(); i_elem != i_mp->ElementsEnd(); i_elem++) {
+                        i_elem->SetId(elemId);
+                        (rModelPart.Elements()).push_back(*(i_elem.base()));
+                        rModelPart.Elements().back().SetId(elemId);
+                        elemId += 1;
+                    }
+                }
+            }
+        }
     }
 
     this->BuildBoundaryModelParts(rModelPart, PreservedConditions, nodeId, elemId, condId);


### PR DESCRIPTION
After this PR the Main Model Part will contain all the elements defined in its child Sub Model Parts. Furthermore, elements IDs are re-numbered to have consistency between the Main Model Part and its Sub Model Parts.
Post-process is updated accordingly.
This is for an easier coupling with other Kratos Apps.
All tests ran OK.
