### PR TITLE
[Pfem] hotfix remesh before output

### DIFF
--- a/applications/PfemFluidDynamicsApplication/python_scripts/remesh_fluid_domains_process.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/remesh_fluid_domains_process.py
@@ -30,7 +30,7 @@ class RemeshFluidDomainsProcess(KratosMultiphysics.Process):
             "model_part_name"       : "Fluid Domain",
             "meshing_control_type"  : "step",
             "meshing_frequency"     : 1.0,
-            "meshing_before_output" : true,
+            "meshing_before_output" : false,
             "meshing_domains"       : [],
             "write_totalVolumeBeforeMeshing" : true
         }""")
@@ -105,7 +105,7 @@ class RemeshFluidDomainsProcess(KratosMultiphysics.Process):
                 domain.Initialize()
                 if(domain.Active()):
                     domain.ComputeInitialAverageMeshParameters()
-                    domain.SetTimeDataOnProcessInfo()     
+                    domain.SetTimeDataOnProcessInfo()
 
 
     def InitializeDomains(self):
@@ -154,7 +154,7 @@ class RemeshFluidDomainsProcess(KratosMultiphysics.Process):
         model_part_name = self.settings["model_part_name"].GetString()
 
         """
-        choose just one of the following two options: 
+        choose just one of the following two options:
         use this if you want conditions
         ATTENTION: this is slow, and must be used together with ModelMeshingWithConditionsForFluids and GenerateNewConditionsForFluids
         skin_build = KratosDelaunay.BuildModelPartBoundary(self.main_model_part, model_part_name, self.echo_level)
@@ -191,11 +191,10 @@ class RemeshFluidDomainsProcess(KratosMultiphysics.Process):
             variable_utils.SetVectorVar(KratosMultiphysics.VOLUME_ACCELERATION, volume_acceleration, self.main_model_part.Nodes)
 
         if self.remesh_domains_active:
-            if self.meshing_before_output:
-                if self.IsMeshingStep():
-                    if self.echo_level>1:
-                        print("::[Remesh_Fluid_Domains_Process]:: RemeshFluidDomains ")
-                    self.RemeshFluidDomains()
+            if self.IsMeshingStep():
+                if self.echo_level>1:
+                    print("::[Remesh_Fluid_Domains_Process]:: RemeshFluidDomains")
+                self.RemeshFluidDomains()
 
         if currentStep > 1 and self.fileTotalVolume is not None:
             for domain in self.meshing_domains:
@@ -219,21 +218,15 @@ class RemeshFluidDomainsProcess(KratosMultiphysics.Process):
 
 
     def ExecuteBeforeOutputStep(self):
-
-        pass
-        #if(self.remesh_domains_active):
-             #if( self.meshing_before_output ):
-                # if(self.IsMeshingStep()):
-                   #  print("::[Remesh_Fluid_Domains_Process]:: RemeshFluidDomains ")
-                    # self.RemeshFluidDomains()
+        if(self.remesh_domains_active):
+            if( self.meshing_before_output):
+                if(self.IsMeshingStep()):
+                    print("::[Remesh_Fluid_Domains_Process]:: RemeshFluidDomainsBeforeOutputStep")
+                    self.RemeshFluidDomains()
 
     #
     def ExecuteAfterOutputStep(self):
-
-        if(self.remesh_domains_active):
-            if( not self.meshing_before_output ):
-                if(self.IsMeshingStep()):
-                    self.RemeshFluidDomains()
+        pass
 
     #
     def ExecuteMeshing(domain):
@@ -248,7 +241,7 @@ class RemeshFluidDomainsProcess(KratosMultiphysics.Process):
 
         #if( self.main_model_part.ProcessInfo[KratosMultiphysics.TIME] >= 0.025):
             #return False
-            
+
         if(self.meshing_control_is_time):
             #print( str(self.main_model_part.ProcessInfo[KratosMultiphysics.TIME])+">"+ str(self.next_meshing) )
             return ( self.main_model_part.ProcessInfo[KratosMultiphysics.TIME] >= self.next_meshing )

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Bingham/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Bingham/ProjectParameters.json
@@ -60,7 +60,7 @@
             "meshing_control_type"  : "step",
             "meshing_frequency"     : 1.0,
             "write_totalVolumeBeforeMeshing" : false,
-            "meshing_before_output" : true,
+            "meshing_before_output" : false,
             "meshing_domains"       : [{
                 "model_part_name"                 : "Body1",
                 "python_module"                   : "fluid_meshing_domain",

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_FSI/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_FSI/ProjectParameters.json
@@ -68,7 +68,7 @@
             "meshing_control_type"  : "step",
             "meshing_frequency"     : 1.0,
             "write_totalVolumeBeforeMeshing" : false,
-            "meshing_before_output" : true,
+            "meshing_before_output" : false,
             "meshing_domains"       : [{
                 "model_part_name"                 : "Body1",
                 "python_module"                   : "fluid_meshing_domain",

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Newtonian_Sloshing/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_Newtonian_Sloshing/ProjectParameters.json
@@ -64,7 +64,7 @@
             "meshing_control_type"  : "step",
             "meshing_frequency"     : 1.0,
             "write_totalVolumeBeforeMeshing" : false,
-            "meshing_before_output" : true,
+            "meshing_before_output" : false,
             "meshing_domains"       : [{
                 "model_part_name"                 : "Body1",
                 "python_module"                   : "fluid_meshing_domain",

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_muIrheology/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_2D_muIrheology/ProjectParameters.json
@@ -60,7 +60,7 @@
             "meshing_control_type"  : "step",
             "meshing_frequency"     : 1.0,
             "write_totalVolumeBeforeMeshing" : false,
-            "meshing_before_output" : true,
+            "meshing_before_output" : false,
             "meshing_domains"       : [{
                 "model_part_name"                 : "Body1",
                 "python_module"                   : "fluid_meshing_domain",

--- a/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_3D_Newtonian_Sloshing/ProjectParameters.json
+++ b/applications/PfemFluidDynamicsApplication/tests/fluid_element_tests/Test_3D_Newtonian_Sloshing/ProjectParameters.json
@@ -64,7 +64,7 @@
             "meshing_control_type"  : "step",
             "meshing_frequency"     : 1.0,
             "write_totalVolumeBeforeMeshing" : false,
-            "meshing_before_output" : true,
+            "meshing_before_output" : false,
             "meshing_domains"       : [{
                 "model_part_name"                 : "Body1",
                 "python_module"                   : "fluid_meshing_domain",

--- a/applications/SwimmingDEMApplication/tests/PFEM-DEM_tests/ProjectParameters.json
+++ b/applications/SwimmingDEMApplication/tests/PFEM-DEM_tests/ProjectParameters.json
@@ -205,7 +205,7 @@
             "write_totalVolumeBeforeMeshing" : false,
             "meshing_control_type" : "step",
             "meshing_frequency" : 1.0,
-            "meshing_before_output" : true,
+            "meshing_before_output" : false,
             "meshing_domains" : [{
                 "model_part_name" : "Body1",
                 "python_module" : "fluid_meshing_domain",


### PR DESCRIPTION
This was a bit obscure for me:
with the flag `remesh_before_output` set to `true` (which was the default in the ProjectParameter.json from GiD) the `remesh_fluid_domains_process.py`:

- simply pass in the `ExecuteBeforeOutputStep`;
- remesh if this flag is set to `false` in `ExecuteAfterOutputStep`;

- check for the flag value before remesh in `ExecuteInitializeSolutionStep`.

With this PR (and the related one https://github.com/KratosMultiphysics/GiDInterface/pull/702):

- if the flag is set to `true` the remesh is done in `ExecuteBeforeOutputStep` as expected;

- simply pass in `ExecuteAfterOutputStep`;

- default value for the flag is set to false;

- the flag value before remesh in `ExecuteInitializeSolutionStep` is not longer checked.

- test (pfem and sdem) updated accordingly;

or am I missing something?


