### PR TITLE
[Core] Adding CAD input to the python solver

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -94,7 +94,7 @@ class MechanicalSolver(PythonSolver):
                 "input_type": "mdpa",
                 "input_filename": "unknown_name",
                 "physics_input_type": "ph.json",
-                "physics_file_name": "physics.ph.json"
+                "physics_file_name": "physics"
             },
             "computing_model_part_name" : "computing_domain",
             "use_computing_model_part" : true,

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -92,9 +92,7 @@ class MechanicalSolver(PythonSolver):
             "analysis_type": "non_linear",
             "model_import_settings": {
                 "input_type": "mdpa",
-                "input_filename": "unknown_name",
-                "physics_input_type": "ph.json",
-                "physics_file_name": "physics"
+                "input_filename": "unknown_name"
             },
             "computing_model_part_name" : "computing_domain",
             "use_computing_model_part" : true,

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -92,7 +92,9 @@ class MechanicalSolver(PythonSolver):
             "analysis_type": "non_linear",
             "model_import_settings": {
                 "input_type": "mdpa",
-                "input_filename": "unknown_name"
+                "input_filename": "unknown_name",
+                "physics_input_type": "ph.json",
+                "physics_file_name": "physics.ph.json"
             },
             "computing_model_part_name" : "computing_domain",
             "use_computing_model_part" : true,

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -187,7 +187,7 @@ class PythonSolver(object):
                 KratosMultiphysics.ReorderAndOptimizeModelPartProcess(model_part, tmp).Execute()
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished reading model part from mdpa file.")
 
-        elif (input_type == "cad_json")
+        elif (input_type == "cad.json")
             problem_path = os.getcwd()
             input_filename = model_part_import_settings["input_filename"].GetString()
 

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -199,7 +199,7 @@ class PythonSolver(object):
             # Create integration domain and elements.
             if model_part_import_settings.Has("physics_input_type"):
                 physics_input_type = model_part_import_settings["physics_input_type"].GetString()
-                if (physics_input_type == "ph.json"):
+                if physics_input_type == "ph.json":
                     physics_filename = model_part_import_settings["physics_file_name"].GetString()
                     KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Creating integration domain, elements and conditions from file: " + os.path.join(problem_path, physics_filename) + ".ph.json")
                     KratosMultiphysics.CadIntegrationDomain.CreateIntegrationDomain(physics_filename, model_part)

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -187,6 +187,15 @@ class PythonSolver(object):
                 KratosMultiphysics.ReorderAndOptimizeModelPartProcess(model_part, tmp).Execute()
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished reading model part from mdpa file.")
 
+        elif (input_type == "json")
+            problem_path = os.getcwd()
+            input_filename = model_part_import_settings["input_filename"].GetString()
+
+            # Import model part from mdpa file.
+            KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Reading CAD model from file: " + os.path.join(problem_path, input_filename) + ".json")
+            KratosMultiphysics.ModelPartIO(input_filename).ReadModelPart(model_part)
+            KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished reading CAD model.")
+
         elif (input_type == "rest"):
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Loading model part from restart file.")
             RestartUtility(model_part, self._GetRestartSettings(model_part_import_settings)).LoadRestart()

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -201,14 +201,14 @@ class PythonSolver(object):
                 physics_input_type = model_part_import_settings["physics_input_type"].GetString()
                 if physics_input_type == "ph.json":
                     physics_filename = model_part_import_settings["physics_file_name"].GetString()
-                    KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Creating integration domain, elements and conditions from file: " + os.path.join(problem_path, physics_filename) + ".ph.json")
+                    KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Creating integration domain, elements and conditions from file: "
+                        + os.path.join(problem_path, physics_filename) + ".ph.json")
                     KratosMultiphysics.CadIntegrationDomain.CreateIntegrationDomain(physics_filename, model_part)
                     KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished creation of integration domain, elements and conditions.")
                 else:
                     KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Unknown physics input type: " + physics_input_type)
             else:
                 KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "No automated integration domain, elements and conditions are created.")
-
 
         elif input_type == "rest":
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Loading model part from restart file.")

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -196,6 +196,13 @@ class PythonSolver(object):
             KratosMultiphysics.ModelPartIO(input_filename).ReadModelPart(model_part)
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished reading CAD model.")
 
+            # Create integration domain and elements.
+            if model_part_import_settings.Has("physics_file_name")
+                physics_filename = model_part_import_settings["input_filename"].GetString()
+                KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Creating integration domain, elements and conditions from file: " + os.path.join(problem_path, physics_filename) + ".json")
+                KratosMultiphysics.CadIntegrationDomain.CreateIntegrationDomain(physics_filename, model_part)
+                KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished creation of integration domain, elements and conditions.")
+
         elif (input_type == "rest"):
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Loading model part from restart file.")
             RestartUtility(model_part, self._GetRestartSettings(model_part_import_settings)).LoadRestart()

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -187,7 +187,7 @@ class PythonSolver(object):
                 KratosMultiphysics.ReorderAndOptimizeModelPartProcess(model_part, tmp).Execute()
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished reading model part from mdpa file.")
 
-        elif (input_type == "json")
+        elif (input_type == "cad_json")
             problem_path = os.getcwd()
             input_filename = model_part_import_settings["input_filename"].GetString()
 

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -187,7 +187,7 @@ class PythonSolver(object):
                 KratosMultiphysics.ReorderAndOptimizeModelPartProcess(model_part, tmp).Execute()
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished reading model part from mdpa file.")
 
-        elif (input_type == "cad.json")
+        elif (input_type == "cad.json"):
             problem_path = os.getcwd()
             input_filename = model_part_import_settings["input_filename"].GetString()
 
@@ -197,11 +197,18 @@ class PythonSolver(object):
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished reading CAD model.")
 
             # Create integration domain and elements.
-            if model_part_import_settings.Has("physics_file_name")
-                physics_filename = model_part_import_settings["input_filename"].GetString()
-                KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Creating integration domain, elements and conditions from file: " + os.path.join(problem_path, physics_filename) + ".json")
-                KratosMultiphysics.CadIntegrationDomain.CreateIntegrationDomain(physics_filename, model_part)
-                KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished creation of integration domain, elements and conditions.")
+            if model_part_import_settings.Has("physics_input_type"):
+                physics_input_type = model_part_import_settings["physics_input_type"].GetString()
+                if (physics_input_type == "ph.json"):
+                    physics_filename = model_part_import_settings["physics_file_name"].GetString()
+                    KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Creating integration domain, elements and conditions from file: " + os.path.join(problem_path, physics_filename) + ".ph.json")
+                    KratosMultiphysics.CadIntegrationDomain.CreateIntegrationDomain(physics_filename, model_part)
+                    KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished creation of integration domain, elements and conditions.")
+                else:
+                    KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Unknown physics input type: " + physics_input_type)
+            else:
+                KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "No automated integration domain, elements and conditions are created.")
+
 
         elif (input_type == "rest"):
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Loading model part from restart file.")

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -210,7 +210,7 @@ class PythonSolver(object):
                 KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "No automated integration domain, elements and conditions are created.")
 
 
-        elif (input_type == "rest"):
+        elif input_type == "rest":
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Loading model part from restart file.")
             RestartUtility(model_part, self._GetRestartSettings(model_part_import_settings)).LoadRestart()
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished loading model part from restart file.")

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -187,7 +187,7 @@ class PythonSolver(object):
                 KratosMultiphysics.ReorderAndOptimizeModelPartProcess(model_part, tmp).Execute()
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished reading model part from mdpa file.")
 
-        elif (input_type == "cad.json"):
+        elif input_type == "cad.json":
             problem_path = os.getcwd()
             input_filename = model_part_import_settings["input_filename"].GetString()
 

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -204,10 +204,13 @@ class PythonSolver(object):
             if model_part_import_settings.Has("physics_input_type"):
                 physics_input_type = model_part_import_settings["physics_input_type"].GetString()
                 if physics_input_type == "ph.json":
-                    physics_filename = model_part_import_settings["physics_file_name"].GetString()
+                    physics_filename = model_part_import_settings["physics_filename"].GetString()
+                    physics_filename += '.ph.json'
                     KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Creating integration domain, elements and conditions from file: "
                         + os.path.join(problem_path, physics_filename) + ".ph.json")
-                    KratosMultiphysics.CadIntegrationDomain.CreateIntegrationDomain(physics_filename, model_part, echo_level)
+                    with open(physics_filename,'r') as parameter_file:
+                        parameters_ph = KratosMultiphysics.Parameters(parameter_file.read())
+                    KratosMultiphysics.CreateIntegrationDomain(model_part, model_part, parameters_ph, echo_level)
                     KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished creation of integration domain, elements and conditions.")
                 else:
                     KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Unknown physics input type: " + physics_input_type)

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -197,7 +197,7 @@ class PythonSolver(object):
 
             # Import model part from mdpa file.
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Reading CAD model from file: " + os.path.join(problem_path, input_filename) + ".json")
-            KratosMultiphysics.ModelPartIO(input_filename, echo_level).ReadModelPart(model_part)
+            KratosMultiphysics.CadJsonInput(input_filename, echo_level).ReadModelPart(model_part)
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished reading CAD model.")
 
             # Create integration domain and elements.

--- a/kratos/python_scripts/python_solver.py
+++ b/kratos/python_scripts/python_solver.py
@@ -191,9 +191,13 @@ class PythonSolver(object):
             problem_path = os.getcwd()
             input_filename = model_part_import_settings["input_filename"].GetString()
 
+            echo_level = 0
+            if model_part_import_settings.Has("echo_level"):
+                echo_level = model_part_import_settings["physics_input_type"].GetInt()
+
             # Import model part from mdpa file.
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Reading CAD model from file: " + os.path.join(problem_path, input_filename) + ".json")
-            KratosMultiphysics.ModelPartIO(input_filename).ReadModelPart(model_part)
+            KratosMultiphysics.ModelPartIO(input_filename, echo_level).ReadModelPart(model_part)
             KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished reading CAD model.")
 
             # Create integration domain and elements.
@@ -203,7 +207,7 @@ class PythonSolver(object):
                     physics_filename = model_part_import_settings["physics_file_name"].GetString()
                     KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Creating integration domain, elements and conditions from file: "
                         + os.path.join(problem_path, physics_filename) + ".ph.json")
-                    KratosMultiphysics.CadIntegrationDomain.CreateIntegrationDomain(physics_filename, model_part)
+                    KratosMultiphysics.CadIntegrationDomain.CreateIntegrationDomain(physics_filename, model_part, echo_level)
                     KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Finished creation of integration domain, elements and conditions.")
                 else:
                     KratosMultiphysics.Logger.PrintInfo("::[PythonSolver]::", "Unknown physics input type: " + physics_input_type)


### PR DESCRIPTION
Finally,

all the efforts, for basically those lines in the python_solver. This will be the interface to use CAD facilities throughout KRATOS. So please feel free to discuss, how the interfaces, calls, or whatever should look like.

Basically, we need to read in the CAD model. We should decide to which model_part that goes.

Furthermore, from this CAD model can be created a integration domain. Which I used to control through another input file. The physics file. If the CAD model shall be used for other purposes. No physics file need to be attached. Also the question is if there will be cases where CAD plus mdpa will be read in with the same solver.

Feel free to share your thoughts. Thanks!