### PR TITLE
[PotentialFlow] Importing fluid dynamic first

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/CompressiblePotentialFlowApplication.py
+++ b/applications/CompressiblePotentialFlowApplication/CompressiblePotentialFlowApplication.py
@@ -3,6 +3,7 @@ from __future__ import print_function, absolute_import, division
 
 # Application dependent names and paths
 import KratosMultiphysics as KM
+import KratosMultiphysics.FluidDynamicsApplication
 from KratosCompressiblePotentialFlowApplication import *
 application = KratosCompressiblePotentialFlowApplication()
 application_name = "KratosCompressiblePotentialFlowApplication"


### PR DESCRIPTION
This is a cherry-pick from #6259, which imports the fluid dynamics application first automatically every time the potential flow is imported.

Without this, using variables from the FluidApp like in #6316 cause a segmentation fault unless the user imports manually the FluidApp first.