### PR TITLE
[CI] disabling PotentialFlow

### DIFF
--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -39,7 +39,7 @@ add_app ${KRATOS_APP_DIR}/RANSApplication;
 add_app ${KRATOS_APP_DIR}/MappingApplication;
 add_app ${KRATOS_APP_DIR}/FSIApplication;
 add_app ${KRATOS_APP_DIR}/MeshingApplication;
-add_app ${KRATOS_APP_DIR}/CompressiblePotentialFlowApplication;
+# add_app ${KRATOS_APP_DIR}/CompressiblePotentialFlowApplication;
 add_app ${KRATOS_APP_DIR}/HDF5Application;
 add_app ${KRATOS_APP_DIR}/ContactStructuralMechanicsApplication;
 


### PR DESCRIPTION
apparently this takes longer than expected :/
Problem is that now the CI is always failing and this may cover up an actual error if none is looking at the output anymore since it always fails anyway

ofc it can be reenabled once it is working, but I think it makes more sense now to get the docker image and try locally