### PR TITLE
[FastPR][Core] Matrix square root and bugfix

### DIFF
--- a/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_math_utils.cpp
@@ -622,6 +622,28 @@ namespace Kratos
             KRATOS_CHECK_EQUAL(converged, true);
         }
 
+        KRATOS_TEST_CASE_IN_SUITE(MathUtilsMatrixSquareRoot, KratosCoreFastSuite)
+        {
+            // Input matrix
+            Matrix mat66(6,6);
+            mat66(0,0) = 6.77; mat66(0,1) = 2.52; mat66(0,2) = 1.98; mat66(0,3) = 0; mat66(0,4) = 0; mat66(0,5) = 4.44;
+            mat66(1,0) = 2.52; mat66(1,1) = 3.92; mat66(1,2) = 1.96; mat66(1,3) = 0; mat66(1,4) = 0; mat66(1,5) =-3.00;
+            mat66(2,0) = 1.98; mat66(2,1) = 1.96; mat66(2,2) = 5.10; mat66(2,3) = 0; mat66(2,4) = 0; mat66(2,5) = 9.90;
+            mat66(3,0) = 0; mat66(3,1) = 0; mat66(3,2) = 0; mat66(3,3) = 1.98; mat66(3,4) = 9.78; mat66(3,5) = 0;
+            mat66(4,0) = 0; mat66(4,1) = 0; mat66(4,2) = 0; mat66(4,3) = 9.78; mat66(4,4) = 2.17; mat66(4,5) = 0;
+            mat66(5,0) = 4.44; mat66(5,1) = -3.00; mat66(5,2) = 9.90; mat66(5,3) = 0; mat66(5,4) = 0; mat66(5,5) = 2.57;
+
+            // Calculate the input matrix square root
+            Matrix mat66sqroot;
+            const double tolerance = 1.0e-12;
+            MathUtils<double>::MatrixSquareRoot(mat66, mat66sqroot, tolerance);
+
+            // Check solution
+            const double test_tolerance = 1.0e-10;
+            const Matrix solution = prod(mat66sqroot, mat66sqroot);
+            KRATOS_CHECK_MATRIX_NEAR(solution, mat66, test_tolerance);
+        }
+
         /** Checks if it calculates the dot product
          * Checks if it calculates the dot product
          */

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -1698,6 +1698,10 @@ public:
         TDataType a, u, c, s, gamma, teta;
         IndexType index1, index2;
 
+        aux_A.resize(size,size,false);
+        aux_V_matrix.resize(size,size,false);
+        rotation_matrix.resize(size,size,false);
+
         for(IndexType iterations = 0; iterations < MaxIterations; ++iterations) {
             is_converged = true;
 
@@ -1808,6 +1812,31 @@ public:
                 rEigenVectorsMatrix(i, j) = V_matrix(j, i);
             }
         }
+
+        return is_converged;
+    }
+
+    template<class TMatrixType1, class TMatrixType2>
+    static inline bool MatrixSquareRoot(
+        const TMatrixType1 &rA,
+        TMatrixType2 &rMatrixSquareRoot,
+        const TDataType Tolerance = 1.0e-18,
+        const SizeType MaxIterations = 20)
+    {
+        // Do an eigenvalue decomposition of the input matrix
+        TMatrixType2 eigenvectors_matrix;
+        TMatrixType2 eigenvalues_matrix;
+        const bool is_converged = GaussSeidelEigenSystem(rA, eigenvectors_matrix, eigenvalues_matrix, Tolerance, MaxIterations);
+        KRATOS_WARNING_IF("MatrixSquareRoot", !is_converged) << "GaussSeidelEigenSystem did not converge.\n";
+
+        // Get the square root of the eigenvalues
+        SizeType size = eigenvalues_matrix.size1();
+        for (SizeType i = 0; i < size; ++i) {
+            eigenvalues_matrix(i,i) = std::sqrt(eigenvalues_matrix(i,i));
+        }
+
+        // Calculate the solution from the previous decomposition and eigenvalues square root
+        rMatrixSquareRoot = prod(eigenvectors_matrix, Matrix(prod(eigenvalues_matrix, trans(eigenvectors_matrix))));
 
         return is_converged;
     }

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -1818,7 +1818,7 @@ public:
 
     /**
      * @brief Calculates the square root of a matrix
-     * This function calculates the square root of a matrix by doing an eigenvalue decomposition
+     * @details This function calculates the square root of a matrix by doing an eigenvalue decomposition
      * The square root of a matrix A is defined as A = V*S*inv(V) where A is the eigenvectors matrix
      * and S the diagonal matrix containing the square root of the eigenvalues. Note that the previous
      * expression can be rewritten as A = V*S*trans(V) since V is orthogonal.

--- a/kratos/utilities/math_utils.h
+++ b/kratos/utilities/math_utils.h
@@ -1816,6 +1816,21 @@ public:
         return is_converged;
     }
 
+    /**
+     * @brief Calculates the square root of a matrix
+     * This function calculates the square root of a matrix by doing an eigenvalue decomposition
+     * The square root of a matrix A is defined as A = V*S*inv(V) where A is the eigenvectors matrix
+     * and S the diagonal matrix containing the square root of the eigenvalues. Note that the previous
+     * expression can be rewritten as A = V*S*trans(V) since V is orthogonal.
+     * @tparam TMatrixType1 Input matrix type
+     * @tparam TMatrixType2 Output matrix type
+     * @param rA Input matrix
+     * @param rMatrixSquareRoot Square root output matrix
+     * @param Tolerance Tolerance of the eigenvalue decomposition
+     * @param MaxIterations Maximum iterations of the eigenvalue decomposition
+     * @return true The eigenvalue decomposition problem converged
+     * @return false The eigenvalue decomposition problem did not converge
+     */
     template<class TMatrixType1, class TMatrixType2>
     static inline bool MatrixSquareRoot(
         const TMatrixType1 &rA,


### PR DESCRIPTION
There was a small bug in the `GaussSeidelEigenSystem`.  It gave a segfault when using unbounded matrices due to the `noalias`, which skips the check size in Ublas. It was straightforwardly fixed by resizing the matrices.

Besides this, I add a small function that calls the `GaussSeidelEigenSystem` to calculate the square root of a matrix.