### PR TITLE
Cps/adding compute local mach

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.cpp
@@ -674,8 +674,7 @@ double CompressiblePotentialFlowElement<Dim, NumNodes>::ComputeDensity(const Pro
     double v_2 = inner_prod(v, v);
 
     // Computing local mach number
-    const double u = sqrt(v_2);
-    const double M = u / a_inf;
+    const double M = PotentialFlowUtilities::ComputeLocalMachNumber<Dim, NumNodes>(*this, rCurrentProcessInfo);
 
     if (M > 0.94)
     { // Clamping the mach number to 0.94

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -204,6 +204,41 @@ double ComputeCompressiblePressureCoefficient(const Element& rElement, const Pro
 }
 
 template <int Dim, int NumNodes>
+double ComputeLocalSpeedOfSound(const Element& rElement, const ProcessInfo& rCurrentProcessInfo)
+{
+    // Reading free stream conditions
+    const array_1d<double, 3>& v_inf = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
+    const double M_inf = rCurrentProcessInfo[FREE_STREAM_MACH];
+    const double heat_capacity_ratio = rCurrentProcessInfo[HEAT_CAPACITY_RATIO];
+    const double a_inf = rCurrentProcessInfo[SOUND_VELOCITY];
+
+    // Computing local velocity
+    array_1d<double, Dim> v = ComputeVelocity<Dim, NumNodes>(rElement);
+
+    // Computing squares
+    const double v_inf_2 = inner_prod(v_inf, v_inf);
+    const double M_inf_2 = M_inf * M_inf;
+    const double v_2 = inner_prod(v, v);
+
+    KRATOS_ERROR_IF(v_inf_2 < std::numeric_limits<double>::epsilon())
+        << "Error on element -> " << rElement.Id() << "\n"
+        << "v_inf_2 must be larger than zero." << std::endl;
+
+    return a_inf * sqrt(1 + (heat_capacity_ratio - 1) * M_inf_2 * (1 - v_2 / v_inf_2) / 2);
+}
+
+template <int Dim, int NumNodes>
+double ComputeLocalMachNumber(const Element& rElement, const ProcessInfo& rCurrentProcessInfo)
+{
+    // Computing local velocity and speed of sound
+    array_1d<double, Dim> velocity = ComputeVelocity<Dim, NumNodes>(rElement);
+    const double velocity_module = sqrt(inner_prod(velocity,velocity));
+    const double local_speed_of_sound = ComputeLocalSpeedOfSound<Dim, NumNodes>(rElement, rCurrentProcessInfo);
+
+    return velocity_module / local_speed_of_sound;
+}
+
+template <int Dim, int NumNodes>
 bool CheckIfElementIsCutByDistance(const BoundedVector<double, NumNodes>& rNodalDistances)
 {
     // Initialize counters
@@ -284,6 +319,8 @@ template array_1d<double, 2> ComputeVelocityLowerWakeElement<2, 3>(const Element
 template array_1d<double, 2> ComputeVelocity<2, 3>(const Element& rElement);
 template double ComputeIncompressiblePressureCoefficient<2, 3>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
 template double ComputeCompressiblePressureCoefficient<2, 3>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
+template double ComputeLocalSpeedOfSound<2, 3>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
+template double ComputeLocalMachNumber<2, 3>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
 template bool CheckIfElementIsCutByDistance<2, 3>(const BoundedVector<double, 3>& rNodalDistances);
 template void KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) CheckIfWakeConditionsAreFulfilled<2>(const ModelPart&, const double& rTolerance, const int& rEchoLevel);
 template bool CheckWakeCondition<2, 3>(const Element& rElement, const double& rTolerance, const int& rEchoLevel);
@@ -303,6 +340,8 @@ template array_1d<double, 3> ComputeVelocityLowerWakeElement<3, 4>(const Element
 template array_1d<double, 3> ComputeVelocity<3, 4>(const Element& rElement);
 template double ComputeIncompressiblePressureCoefficient<3, 4>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
 template double ComputeCompressiblePressureCoefficient<3, 4>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
+template double ComputeLocalSpeedOfSound<3, 4>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
+template double ComputeLocalMachNumber<3, 4>(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
 template bool CheckIfElementIsCutByDistance<3, 4>(const BoundedVector<double, 4>& rNodalDistances);
 template void  KRATOS_API(COMPRESSIBLE_POTENTIAL_FLOW_APPLICATION) CheckIfWakeConditionsAreFulfilled<3>(const ModelPart&, const double& rTolerance, const int& rEchoLevel);
 template bool CheckWakeCondition<3, 4>(const Element& rElement, const double& rTolerance, const int& rEchoLevel);

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -206,6 +206,8 @@ double ComputeCompressiblePressureCoefficient(const Element& rElement, const Pro
 template <int Dim, int NumNodes>
 double ComputeLocalSpeedOfSound(const Element& rElement, const ProcessInfo& rCurrentProcessInfo)
 {
+    // Implemented according to Equation 8.7 of Drela, M. (2014) Flight Vehicle
+    // Aerodynamics, The MIT Press, London
     // Reading free stream conditions
     const array_1d<double, 3>& v_inf = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
     const double M_inf = rCurrentProcessInfo[FREE_STREAM_MACH];
@@ -230,9 +232,11 @@ double ComputeLocalSpeedOfSound(const Element& rElement, const ProcessInfo& rCur
 template <int Dim, int NumNodes>
 double ComputeLocalMachNumber(const Element& rElement, const ProcessInfo& rCurrentProcessInfo)
 {
-    // Computing local velocity and speed of sound
+    // Implemented according to Equation 8.8 of Drela, M. (2014) Flight Vehicle
+    // Aerodynamics, The MIT Press, London
+
     array_1d<double, Dim> velocity = ComputeVelocity<Dim, NumNodes>(rElement);
-    const double velocity_module = sqrt(inner_prod(velocity,velocity));
+    const double velocity_module = sqrt(inner_prod(velocity, velocity));
     const double local_speed_of_sound = ComputeLocalSpeedOfSound<Dim, NumNodes>(rElement, rCurrentProcessInfo);
 
     return velocity_module / local_speed_of_sound;

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.h
@@ -71,6 +71,12 @@ template <int Dim, int NumNodes>
 double ComputeCompressiblePressureCoefficient(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
 
 template <int Dim, int NumNodes>
+double ComputeLocalSpeedOfSound(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
+
+template <int Dim, int NumNodes>
+double ComputeLocalMachNumber(const Element& rElement, const ProcessInfo& rCurrentProcessInfo);
+
+template <int Dim, int NumNodes>
 bool CheckIfElementIsCutByDistance(const BoundedVector<double, NumNodes>& rNodalDistances);
 
 template <int Dim>

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_potential_flow_utilities.cpp
@@ -1,0 +1,91 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Inigo Lopez
+//
+//
+
+// Project includes
+#include "containers/model.h"
+#include "testing/testing.h"
+#include "compressible_potential_flow_application_variables.h"
+#include "custom_elements/compressible_potential_flow_element.h"
+
+
+namespace Kratos {
+  namespace Testing {
+
+    typedef ModelPart::IndexType IndexType;
+    typedef ModelPart::NodeIterator NodeIteratorType;
+
+    void GenerateCompressibleElement(ModelPart& rModelPart)
+    {
+      // Variables addition
+      rModelPart.AddNodalSolutionStepVariable(VELOCITY_POTENTIAL);
+      rModelPart.AddNodalSolutionStepVariable(AUXILIARY_VELOCITY_POTENTIAL);
+
+      // Set the element properties
+      Properties::Pointer pElemProp = rModelPart.CreateNewProperties(0);
+      BoundedVector<double, 3> v_inf = ZeroVector(3);
+      v_inf(0) = 34.0;
+
+      rModelPart.GetProcessInfo()[FREE_STREAM_VELOCITY] = v_inf;
+      rModelPart.GetProcessInfo()[FREE_STREAM_DENSITY] = 1.225;
+      rModelPart.GetProcessInfo()[FREE_STREAM_MACH] = 0.1;
+      rModelPart.GetProcessInfo()[HEAT_CAPACITY_RATIO] = 1.4;
+      rModelPart.GetProcessInfo()[SOUND_VELOCITY] = 340.0;
+
+      // Geometry creation
+      rModelPart.CreateNewNode(1, 0.0, 0.0, 0.0);
+      rModelPart.CreateNewNode(2, 1.0, 0.0, 0.0);
+      rModelPart.CreateNewNode(3, 1.0, 1.0, 0.0);
+      std::vector<ModelPart::IndexType> elemNodes{ 1, 2, 3 };
+      rModelPart.CreateNewElement("CompressiblePotentialFlowElement2D3N", 1, elemNodes, pElemProp);
+    }
+
+    /** Checks the IncompressiblePotentialFlowElement element.
+     * Checks the LHS and RHS computation.
+     */
+    KRATOS_TEST_CASE_IN_SUITE(CompressiblePotentialFlowElementLHS, CompressiblePotentialApplicationFastSuite)
+    {
+      Model this_model;
+      ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+      GenerateCompressibleElement(model_part);
+      Element::Pointer pElement = model_part.pGetElement(1);
+
+      // Define the nodal values
+      std::array<double,3> potential;
+      potential[0] = 1.0;
+      potential[1] = 2.0;
+      potential[2] = 3.0;
+
+      for (unsigned int i = 0; i < 3; i++){
+        pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) = potential[i];
+      }
+      // Compute RHS and LHS
+      Vector RHS = ZeroVector(3);
+      Matrix LHS = ZeroMatrix(3, 3);
+
+      pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+
+      std::array<double,9> reference({0.615556466,-0.615561780,5.314318652e-06,
+                                      -0.615561780,1.231123561,-0.615561780,
+                                      5.314318652e-06,-0.615561780, 0.615556466});
+
+      for (unsigned int i = 0; i < LHS.size1(); i++) {
+        for (unsigned int j = 0; j < LHS.size2(); j++) {
+          KRATOS_CHECK_NEAR(LHS(i,j), reference[i*3+j], 1e-6);
+        }
+      }
+    }
+
+
+  } // namespace Testing
+}  // namespace Kratos.

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_potential_flow_utilities.cpp
@@ -17,75 +17,72 @@
 #include "compressible_potential_flow_application_variables.h"
 #include "custom_elements/compressible_potential_flow_element.h"
 
-
 namespace Kratos {
-  namespace Testing {
+namespace Testing {
 
-    typedef ModelPart::IndexType IndexType;
-    typedef ModelPart::NodeIterator NodeIteratorType;
+typedef ModelPart::IndexType IndexType;
+typedef ModelPart::NodeIterator NodeIteratorType;
 
-    void GenerateCompressibleElement(ModelPart& rModelPart)
-    {
-      // Variables addition
-      rModelPart.AddNodalSolutionStepVariable(VELOCITY_POTENTIAL);
-      rModelPart.AddNodalSolutionStepVariable(AUXILIARY_VELOCITY_POTENTIAL);
+void GenerateCompressibleElement(ModelPart& rModelPart) {
+    // Variables addition
+    rModelPart.AddNodalSolutionStepVariable(VELOCITY_POTENTIAL);
+    rModelPart.AddNodalSolutionStepVariable(AUXILIARY_VELOCITY_POTENTIAL);
 
-      // Set the element properties
-      Properties::Pointer pElemProp = rModelPart.CreateNewProperties(0);
-      BoundedVector<double, 3> v_inf = ZeroVector(3);
-      v_inf(0) = 34.0;
+    // Set the element properties
+    Properties::Pointer pElemProp = rModelPart.CreateNewProperties(0);
+    BoundedVector<double, 3> v_inf = ZeroVector(3);
+    v_inf(0) = 34.0;
 
-      rModelPart.GetProcessInfo()[FREE_STREAM_VELOCITY] = v_inf;
-      rModelPart.GetProcessInfo()[FREE_STREAM_DENSITY] = 1.225;
-      rModelPart.GetProcessInfo()[FREE_STREAM_MACH] = 0.1;
-      rModelPart.GetProcessInfo()[HEAT_CAPACITY_RATIO] = 1.4;
-      rModelPart.GetProcessInfo()[SOUND_VELOCITY] = 340.0;
+    rModelPart.GetProcessInfo()[FREE_STREAM_VELOCITY] = v_inf;
+    rModelPart.GetProcessInfo()[FREE_STREAM_DENSITY] = 1.225;
+    rModelPart.GetProcessInfo()[FREE_STREAM_MACH] = 0.1;
+    rModelPart.GetProcessInfo()[HEAT_CAPACITY_RATIO] = 1.4;
+    rModelPart.GetProcessInfo()[SOUND_VELOCITY] = 340.0;
 
-      // Geometry creation
-      rModelPart.CreateNewNode(1, 0.0, 0.0, 0.0);
-      rModelPart.CreateNewNode(2, 1.0, 0.0, 0.0);
-      rModelPart.CreateNewNode(3, 1.0, 1.0, 0.0);
-      std::vector<ModelPart::IndexType> elemNodes{ 1, 2, 3 };
-      rModelPart.CreateNewElement("CompressiblePotentialFlowElement2D3N", 1, elemNodes, pElemProp);
+    // Geometry creation
+    rModelPart.CreateNewNode(1, 0.0, 0.0, 0.0);
+    rModelPart.CreateNewNode(2, 1.0, 0.0, 0.0);
+    rModelPart.CreateNewNode(3, 1.0, 1.0, 0.0);
+    std::vector<ModelPart::IndexType> elemNodes{1, 2, 3};
+    rModelPart.CreateNewElement("CompressiblePotentialFlowElement2D3N", 1, elemNodes, pElemProp);
+}
+
+/** Checks the IncompressiblePotentialFlowElement element.
+ * Checks the LHS and RHS computation.
+ */
+KRATOS_TEST_CASE_IN_SUITE(CompressiblePotentialFlowElementLHS, CompressiblePotentialApplicationFastSuite) {
+    Model this_model;
+    ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+    GenerateCompressibleElement(model_part);
+    Element::Pointer pElement = model_part.pGetElement(1);
+
+    // Define the nodal values
+    std::array<double, 3> potential;
+    potential[0] = 1.0;
+    potential[1] = 2.0;
+    potential[2] = 3.0;
+
+    for (unsigned int i = 0; i < 3; i++) {
+        pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) =
+            potential[i];
     }
+    // Compute RHS and LHS
+    Vector RHS = ZeroVector(3);
+    Matrix LHS = ZeroMatrix(3, 3);
 
-    /** Checks the IncompressiblePotentialFlowElement element.
-     * Checks the LHS and RHS computation.
-     */
-    KRATOS_TEST_CASE_IN_SUITE(CompressiblePotentialFlowElementLHS, CompressiblePotentialApplicationFastSuite)
-    {
-      Model this_model;
-      ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+    pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
 
-      GenerateCompressibleElement(model_part);
-      Element::Pointer pElement = model_part.pGetElement(1);
+    std::array<double, 9> reference({0.615556466, -0.615561780, 5.314318652e-06,
+                                     -0.615561780, 1.231123561, -0.615561780,
+                                     5.314318652e-06, -0.615561780, 0.615556466});
 
-      // Define the nodal values
-      std::array<double,3> potential;
-      potential[0] = 1.0;
-      potential[1] = 2.0;
-      potential[2] = 3.0;
-
-      for (unsigned int i = 0; i < 3; i++){
-        pElement->GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL) = potential[i];
-      }
-      // Compute RHS and LHS
-      Vector RHS = ZeroVector(3);
-      Matrix LHS = ZeroMatrix(3, 3);
-
-      pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
-
-      std::array<double,9> reference({0.615556466,-0.615561780,5.314318652e-06,
-                                      -0.615561780,1.231123561,-0.615561780,
-                                      5.314318652e-06,-0.615561780, 0.615556466});
-
-      for (unsigned int i = 0; i < LHS.size1(); i++) {
+    for (unsigned int i = 0; i < LHS.size1(); i++) {
         for (unsigned int j = 0; j < LHS.size2(); j++) {
-          KRATOS_CHECK_NEAR(LHS(i,j), reference[i*3+j], 1e-6);
+            KRATOS_CHECK_NEAR(LHS(i, j), reference[i * 3 + j], 1e-6);
         }
-      }
     }
+}
 
-
-  } // namespace Testing
-}  // namespace Kratos.
+} // namespace Testing
+} // namespace Kratos.


### PR DESCRIPTION
The formula for the local mach number is corrected.

The functions ComputeLocalMachNumber and ComputeLocalSpeedOfSound and their corresponding tests are added. The formulas used are:

![local_mach](https://user-images.githubusercontent.com/28628414/73466954-e7ae7100-4382-11ea-9712-e9ce53f24af6.png)

This changes the behavior of the examples with very high local velocities. However, since the tests  for the compressible elements are set for low velocities, this PR does not break the tests. I will update the tests in a following PR to make sure that we test also for large local velocities.

