### PR TITLE
[CI] Run github actions for branches that start with "run-ci/"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         ccache -s
 
     - name: Running small tests
-      if: github.event_name == 'pull_request' || github.even_name != 'schedule'
+      if: github.event_name == 'pull_request' || github.event_name != 'schedule'
       run: |
         export MKLVARS_ARCHITECTURE=intel64
         export MKLVARS_INTERFACE=lp64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         ccache -s
 
     - name: Running small tests
-      if: github.event_name == 'pull_request' || github.event_name != 'schedule'
+      if: github.event_name == 'pull_request'
       run: |
         export MKLVARS_ARCHITECTURE=intel64
         export MKLVARS_INTERFACE=lp64
@@ -83,7 +83,7 @@ jobs:
         python3 kratos/python_scripts/run_tests.py -l small -c python3
 
     - name: Running nightly tests
-      if: github.event_name == 'schedule' # this is the nightly build
+      if: github.event_name == 'schedule' || github.event_name != 'pull_request' # schedule is the nightly build
       run: |
         export MKLVARS_ARCHITECTURE=intel64
         export MKLVARS_INTERFACE=lp64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 
 on:
+  push:
+    branch:
+      -run-ci/**
   pull_request:
     paths:
     - '.github/**'
@@ -70,7 +73,7 @@ jobs:
         ccache -s
 
     - name: Running small tests
-      if: github.event_name == 'pull_request'
+      if: github.event_name == 'pull_request' || github.even_name != 'schedule'
       run: |
         export MKLVARS_ARCHITECTURE=intel64
         export MKLVARS_INTERFACE=lp64


### PR DESCRIPTION
With this change the Github CI can be triggered by a branch name.
The CI will run on every branch with a name that starts with "run-ci/", indepently if there is a PR.

This is useful for quickly testing the CI, which currently leads to many "draft" PRs with the "do not merge" label.