### PR TITLE
[FastPR][Hotfix][Core] Fix Aitken scheme compilation

### DIFF
--- a/kratos/solving_strategies/schemes/residualbased_incremental_aitken_static_scheme.h
+++ b/kratos/solving_strategies/schemes/residualbased_incremental_aitken_static_scheme.h
@@ -74,22 +74,24 @@ public:
     ///@name Life Cycle
     ///@{
 
+    static Parameters GetDefaultSettings()
+    {
+        Parameters default_parameters = Parameters(R"(
+        {
+            "name"          : "ResidualBasedIncrementalAitkenStaticScheme",
+            "default_omega" : 0.1
+        })");
+
+        return default_parameters;
+    }
+
     /**
      * @brief Default constructor. (with parameters)
      * @param ThisParameters Default relaxation factor to use in the first iteration, where Aitken's factor cannot be computed. Use a value between 0 and 1.
     */
-    explicit ResidualBasedIncrementalAitkenStaticScheme(Parameters ThisParameters)
+    explicit ResidualBasedIncrementalAitkenStaticScheme(Parameters ThisParameters) :
+        ResidualBasedIncrementalAitkenStaticScheme([](Parameters x) -> double {x.ValidateAndAssignDefaults(GetDefaultSettings()); return x["default_omega"].GetDouble(); }(ThisParameters))
     {
-        // Validate default parameters
-        Parameters default_parameters = Parameters(R"(
-        {
-            "name"          : "ResidualBasedIncrementalAitkenStaticScheme",
-            "default_omega" : 0.0
-        })" );
-        ThisParameters.ValidateAndAssignDefaults(default_parameters);
-
-        mDefaultOmega = ThisParameters["default_omega"].GetDouble();
-        mOldOmega = ThisParameters["default_omega"].GetDouble();
     }
 
     /**


### PR DESCRIPTION
My machine with Clang11 do not compile because of this. Actually I don't understand how this compiles as it is right now (we are trying to change the value of a const member variable).

I slightly change the code to do the json defaults checks in a lambda function so we can keep the `const` specifier in such member variable.

Besides, I changed the default value as the one we have right now makes no sense (it is a relaxation parameter with zero value, meaning that there is no update so the solution will remain stuck in the iteration guess).