### PR TITLE
[Fluid] Fix embedded skin visualization with reform

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
@@ -49,7 +49,8 @@ EmbeddedSkinVisualizationProcess::EmbeddedSkinVisualizationProcess(
     mVisualizationVectorVariables(rVisualizationVectorVariables),
     mVisualizationComponentVariables(rVisualizationComponentVariables),
     mShapeFunctions(rShapeFunctions),
-    mReformModelPartAtEachTimeStep(ReformModelPartAtEachTimeStep){
+    mReformModelPartAtEachTimeStep(ReformModelPartAtEachTimeStep)
+{
 }
 
 EmbeddedSkinVisualizationProcess::EmbeddedSkinVisualizationProcess(
@@ -58,8 +59,8 @@ EmbeddedSkinVisualizationProcess::EmbeddedSkinVisualizationProcess(
     Parameters& rParameters) :
     Process(),
     mrModelPart(rModelPart),
-    mrVisualizationModelPart(rVisualizationModelPart) {
-
+    mrVisualizationModelPart(rVisualizationModelPart)
+{
     Parameters default_parameters( R"(
     {
         "shape_functions"                     : "standard",
@@ -98,7 +99,8 @@ EmbeddedSkinVisualizationProcess::EmbeddedSkinVisualizationProcess(
     }
 }
 
-void EmbeddedSkinVisualizationProcess::ExecuteInitialize() {
+void EmbeddedSkinVisualizationProcess::ExecuteInitialize()
+{
     KRATOS_TRY;
 
     // Check that model part is not empty
@@ -126,7 +128,8 @@ void EmbeddedSkinVisualizationProcess::ExecuteInitialize() {
     KRATOS_CATCH("");
 }
 
-void EmbeddedSkinVisualizationProcess::ExecuteBeforeSolutionLoop() {
+void EmbeddedSkinVisualizationProcess::ExecuteBeforeSolutionLoop()
+{
     if (mSetVisualizationMesh){
         // Copy the original nodes to the visualization model part
         this->CopyOriginNodes();
@@ -139,13 +142,18 @@ void EmbeddedSkinVisualizationProcess::ExecuteBeforeSolutionLoop() {
     }
 }
 
-void EmbeddedSkinVisualizationProcess::ExecuteInitializeSolutionStep() {
-    if (mReformModelPartAtEachTimeStep){
+void EmbeddedSkinVisualizationProcess::ExecuteInitializeSolutionStep()
+{
+    mrVisualizationModelPart.GetProcessInfo().GetValue(STEP) = mrModelPart.GetProcessInfo().GetValue(STEP);
+    mrVisualizationModelPart.GetProcessInfo().GetValue(TIME) = mrModelPart.GetProcessInfo().GetValue(TIME);
+
+    if (mReformModelPartAtEachTimeStep) {
         this->ExecuteBeforeSolutionLoop();
     }
 }
 
-void EmbeddedSkinVisualizationProcess::ExecuteBeforeOutputStep() {
+void EmbeddedSkinVisualizationProcess::ExecuteBeforeOutputStep()
+{
     // Copy the origin model part nodal values for the non-intersection nodes
     this->CopyOriginNodalValues();
 
@@ -153,7 +161,8 @@ void EmbeddedSkinVisualizationProcess::ExecuteBeforeOutputStep() {
     this->ComputeNewNodesInterpolation();
 }
 
-void EmbeddedSkinVisualizationProcess::ExecuteFinalizeSolutionStep(){
+void EmbeddedSkinVisualizationProcess::ExecuteAfterOutputStep()
+{
     if (mReformModelPartAtEachTimeStep){
         // Clear the new nodes hash map
         mCutNodesMap.clear();
@@ -171,6 +180,9 @@ void EmbeddedSkinVisualizationProcess::ExecuteFinalizeSolutionStep(){
         mrVisualizationModelPart.RemoveElements(TO_ERASE);
         mrVisualizationModelPart.RemoveConditions(TO_ERASE);
 
+        // Remove the positive and negative sides properties
+        RemoveVisualizationProperties();
+
         // Initialize the create visualization mesh flag again
         mSetVisualizationMesh = true;
     }
@@ -180,7 +192,8 @@ void EmbeddedSkinVisualizationProcess::ExecuteFinalizeSolutionStep(){
 
 /* Private functions ******************************************************/
 
-void EmbeddedSkinVisualizationProcess::ComputeNewNodesInterpolation(){
+void EmbeddedSkinVisualizationProcess::ComputeNewNodesInterpolation()
+{
     // For all the new elements, compute the interpolation with the proper shape functions
     // Note that this can be done in parallel since the intersection nodes are duplicated
     const int n_new_elems = mNewElementsPointers.size();
@@ -238,7 +251,8 @@ void EmbeddedSkinVisualizationProcess::ComputeNewNodesInterpolation(){
     }
 }
 
-void EmbeddedSkinVisualizationProcess::CopyOriginNodes(){
+void EmbeddedSkinVisualizationProcess::CopyOriginNodes()
+{
     // Creates a copy of all the origin model part nodes to the visualization model part
     // Note that the original nodes will be reused when creating the splitting geometries
     const int n_nodes = mrModelPart.NumberOfNodes();
@@ -249,7 +263,8 @@ void EmbeddedSkinVisualizationProcess::CopyOriginNodes(){
     }
 }
 
-void EmbeddedSkinVisualizationProcess::CopyOriginNodalValues(){
+void EmbeddedSkinVisualizationProcess::CopyOriginNodalValues()
+{
     const unsigned int n_old_nodes = mrModelPart.NumberOfNodes();
 
     #pragma omp parallel for
@@ -274,8 +289,8 @@ void EmbeddedSkinVisualizationProcess::CopyOriginNodalValues(){
     }
 }
 
-void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries(){
-
+void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries()
+{
     int n_nodes = mrModelPart.NumberOfNodes();
     int n_elems = mrModelPart.NumberOfElements();
     int n_conds = mrModelPart.NumberOfConditions();
@@ -525,8 +540,8 @@ void EmbeddedSkinVisualizationProcess::CreateVisualizationGeometries(){
 
 bool EmbeddedSkinVisualizationProcess::ElementIsPositive(
     Geometry<Node<3>>::Pointer pGeometry,
-    const Vector &rNodalDistances){
-
+    const Vector &rNodalDistances)
+{
     const unsigned int pts_number = pGeometry->PointsNumber();
     unsigned int n_pos (0);
 
@@ -542,8 +557,8 @@ bool EmbeddedSkinVisualizationProcess::ElementIsPositive(
 
 bool EmbeddedSkinVisualizationProcess::ElementIsSplit(
     Geometry<Node<3>>::Pointer pGeometry,
-    const Vector &rNodalDistances){
-
+    const Vector &rNodalDistances)
+{
     const unsigned int pts_number = pGeometry->PointsNumber();
     unsigned int n_pos (0), n_neg(0);
 
@@ -559,9 +574,9 @@ bool EmbeddedSkinVisualizationProcess::ElementIsSplit(
     return is_split;
 }
 
-const Vector EmbeddedSkinVisualizationProcess::SetDistancesVector(ModelPart::ElementIterator ItElem){
-
-    auto &r_geom = ItElem->GetGeometry();
+const Vector EmbeddedSkinVisualizationProcess::SetDistancesVector(ModelPart::ElementIterator ItElem)
+{
+    const auto &r_geom = ItElem->GetGeometry();
     Vector nodal_distances(r_geom.PointsNumber());
 
     if (mShapeFunctions == "standard"){
@@ -581,8 +596,8 @@ const Vector EmbeddedSkinVisualizationProcess::SetDistancesVector(ModelPart::Ele
 
 ModifiedShapeFunctions::Pointer EmbeddedSkinVisualizationProcess::SetModifiedShapeFunctionsUtility(
     const Geometry<Node<3>>::Pointer pGeometry,
-    const Vector& rNodalDistances){
-
+    const Vector& rNodalDistances)
+{
     // Get the geometry type
     const GeometryData::KratosGeometryType geometry_type = pGeometry->GetGeometryType();
 
@@ -612,8 +627,8 @@ ModifiedShapeFunctions::Pointer EmbeddedSkinVisualizationProcess::SetModifiedSha
 
 Geometry< Node<3> >::Pointer EmbeddedSkinVisualizationProcess::SetNewConditionGeometry(
     const GeometryData::KratosGeometryType &rOriginGeometryType,
-    const Condition::NodesArrayType &rNewNodesArray){
-
+    const Condition::NodesArrayType &rNewNodesArray)
+{
     switch(rOriginGeometryType){
         case GeometryData::KratosGeometryType::Kratos_Line2D2:
             return Kratos::make_shared<Line2D2< Node<3> > >(rNewNodesArray);
@@ -624,10 +639,8 @@ Geometry< Node<3> >::Pointer EmbeddedSkinVisualizationProcess::SetNewConditionGe
     }
 }
 
-std::tuple< Properties::Pointer , Properties::Pointer > EmbeddedSkinVisualizationProcess::SetVisualizationProperties(){
-    // Set the properties for the new elements depending if the
-    // element is in the positive or negative side of the cut.
-    // In this way, two layers will appear in GiD.
+std::tuple< Properties::Pointer , Properties::Pointer > EmbeddedSkinVisualizationProcess::SetVisualizationProperties()
+{
     unsigned int max_prop_id = 0;
     for (auto it_prop = mrModelPart.GetRootModelPart().PropertiesBegin(); it_prop < mrModelPart.GetRootModelPart().PropertiesEnd(); ++it_prop){
         if (max_prop_id < it_prop->Id()){
@@ -640,6 +653,25 @@ std::tuple< Properties::Pointer , Properties::Pointer > EmbeddedSkinVisualizatio
     mrVisualizationModelPart.AddProperties(p_neg_prop);
 
     return std::make_tuple(p_pos_prop , p_neg_prop);
+}
+
+void EmbeddedSkinVisualizationProcess::RemoveVisualizationProperties()
+{
+    // Search for the maximum property id in the base model part
+    unsigned int max_prop_id = 0;
+    for (auto it_prop = mrModelPart.GetRootModelPart().PropertiesBegin(); it_prop < mrModelPart.GetRootModelPart().PropertiesEnd(); ++it_prop){
+        if (max_prop_id < it_prop->Id()){
+            max_prop_id = it_prop->Id();
+        }
+    }
+
+    // Check that the positive and negative sides properties exist
+    KRATOS_ERROR_IF_NOT(mrVisualizationModelPart.HasProperties(max_prop_id + 1)) << "Visualization model part has no property " << max_prop_id + 1 << std::endl;
+    KRATOS_ERROR_IF_NOT(mrVisualizationModelPart.HasProperties(max_prop_id + 2)) << "Visualization model part has no property " << max_prop_id + 2 << std::endl;
+
+    // Remove the positive and negative sides properties
+    mrVisualizationModelPart.RemoveProperties(max_prop_id + 1);
+    mrVisualizationModelPart.RemoveProperties(max_prop_id + 2);
 }
 
 };  // namespace Kratos.

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.cpp
@@ -125,35 +125,25 @@ void EmbeddedSkinVisualizationProcess::ExecuteInitialize()
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(mVisualizationComponentVariables[i_var], r_orig_node);
     }
 
+    // Initialize the visualization mesh creation flag
+    mSetVisualizationMesh = true;
+
     KRATOS_CATCH("");
-}
-
-void EmbeddedSkinVisualizationProcess::ExecuteBeforeSolutionLoop()
-{
-    if (mSetVisualizationMesh){
-        // Copy the original nodes to the visualization model part
-        this->CopyOriginNodes();
-
-        // Creates the visualization model part geometrical entities (elements and conditions)
-        this->CreateVisualizationGeometries();
-
-        // Avoid creating the visualization mesh again
-        mSetVisualizationMesh = false;
-    }
 }
 
 void EmbeddedSkinVisualizationProcess::ExecuteInitializeSolutionStep()
 {
     mrVisualizationModelPart.GetProcessInfo().GetValue(STEP) = mrModelPart.GetProcessInfo().GetValue(STEP);
     mrVisualizationModelPart.GetProcessInfo().GetValue(TIME) = mrModelPart.GetProcessInfo().GetValue(TIME);
-
-    if (mReformModelPartAtEachTimeStep) {
-        this->ExecuteBeforeSolutionLoop();
-    }
 }
 
 void EmbeddedSkinVisualizationProcess::ExecuteBeforeOutputStep()
 {
+    // If required, set the visualization mesh
+    if (mSetVisualizationMesh) {
+        this->CreateVisualizationMesh();
+    }
+
     // Copy the origin model part nodal values for the non-intersection nodes
     this->CopyOriginNodalValues();
 
@@ -249,6 +239,18 @@ void EmbeddedSkinVisualizationProcess::ComputeNewNodesInterpolation()
             }
         }
     }
+}
+
+void EmbeddedSkinVisualizationProcess::CreateVisualizationMesh()
+{
+    // Copy the original nodes to the visualization model part
+    this->CopyOriginNodes();
+
+    // Creates the visualization model part geometrical entities (elements and conditions)
+    this->CreateVisualizationGeometries();
+
+    // Set the visualization mesh flag to false
+    mSetVisualizationMesh = false;
 }
 
 void EmbeddedSkinVisualizationProcess::CopyOriginNodes()

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
@@ -159,7 +159,7 @@ public:
 
     void ExecuteBeforeOutputStep() override;
 
-    void ExecuteFinalizeSolutionStep() override;
+    void ExecuteAfterOutputStep() override;
 
     ///@}
     ///@name Inquiry
@@ -293,21 +293,26 @@ private:
         const Condition::NodesArrayType &rNewNodesArray);
 
     /**
-     * Sets the visualization properties (one for the positive side
-     * and one for the negative)
-     * @return Tuple containing two properties pointers
+     * @brief Sets the visualization properties (one for the positive side and one for the negative)
+     * Set the properties for the new elements depending if they are in the positive or negative side of the cut.
+     * By doing this, two different layers will be created when printing this model part GiD.
+     * @return std::tuple< Properties::Pointer , Properties::Pointer > Tuple containing two properties pointers
      */
     std::tuple< Properties::Pointer , Properties::Pointer > SetVisualizationProperties();
+
+    /**
+     * @brief Removes the visualization properties
+     * When it is required, this function searchs for the visualization properties to remove them.
+     */
+    void RemoveVisualizationProperties();
 
     ///@}
     ///@name Private  Access
     ///@{
 
-
     ///@}
     ///@name Private Inquiry
     ///@{
-
 
     ///@}
     ///@name Un accessible methods

--- a/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/embedded_skin_visualization_process.h
@@ -153,8 +153,6 @@ public:
 
     void ExecuteInitialize() override;
 
-    void ExecuteBeforeSolutionLoop() override;
-
     void ExecuteInitializeSolutionStep() override;
 
     void ExecuteBeforeOutputStep() override;
@@ -222,6 +220,12 @@ private:
     ///@}
     ///@name Private Operations
     ///@{
+
+    /**
+     * @brief Create a Visualization Mesh object
+     * Fills the visualization model part with the corresponding geometrical entities
+     */
+    void CreateVisualizationMesh();
 
     /**
      * Computes the interpolation in the new (interface) nodes

--- a/applications/FluidDynamicsApplication/python_scripts/apply_embedded_skin_visualization_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_embedded_skin_visualization_process.py
@@ -90,20 +90,21 @@ class ApplyEmbeddedSkinVisualizationProcess(KratosMultiphysics.Process):
         self.gid_output.ExecuteBeforeSolutionLoop()
 
     def ExecuteInitializeSolutionStep(self):
-        # Set time in case the GiD process control output is time
-        self.visualization_model_part.ProcessInfo[KratosMultiphysics.TIME] = self.origin_model_part.ProcessInfo[KratosMultiphysics.TIME]
-
         self.EmbeddedSkinVisualizationProcess.ExecuteInitializeSolutionStep()
         self.gid_output.ExecuteInitializeSolutionStep()
 
     def ExecuteFinalizeSolutionStep(self):
         self.EmbeddedSkinVisualizationProcess.ExecuteFinalizeSolutionStep()
-        self.gid_output.ExecuteInitializeSolutionStep()
+        self.gid_output.ExecuteFinalizeSolutionStep()
 
     def ExecuteBeforeOutputStep(self):
         self.EmbeddedSkinVisualizationProcess.ExecuteBeforeOutputStep()
         if (self.gid_output.IsOutputStep()):
             self.gid_output.PrintOutput()
+
+    def ExecuteAfterOutputStep(self):
+        self.EmbeddedSkinVisualizationProcess.ExecuteAfterOutputStep()
+        self.gid_output.ExecuteAfterOutputStep()
 
     def ExecuteFinalize(self):
         self.EmbeddedSkinVisualizationProcess.ExecuteFinalize()


### PR DESCRIPTION
This PR fixes several issues that arose when doing moving boundaries and FSI with the embedded solver.

Long story short, the problems were related to the re-construction of the visualization model part. I did also rearrange the process to always ensure that the visualization model part is constructed after the `SolveSolutionStep` of the solver, so the distance is properly corrected to avoid splitting issues.