### PR TITLE
[Structural] clean harmonic analysis tests

### DIFF
--- a/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_eigenproblem_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_eigenproblem_parameters.json
@@ -8,7 +8,7 @@
     },
     "solver_settings"          : {
         "solver_type"                        : "eigen_value",
-        "echo_level"                         : 1,
+        "echo_level"                         : 0,
         "model_part_name" : "Structure",
         "domain_size"     : 3,
         "time_stepping"                      : {

--- a/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_eigenproblem_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/harmonic_analysis_test/harmonic_analysis_test_eigenproblem_parameters.json
@@ -8,13 +8,12 @@
     },
     "solver_settings"          : {
         "solver_type"                        : "eigen_value",
-        "echo_level"                         : 0,
+        "echo_level"                         : 1,
         "model_part_name" : "Structure",
         "domain_size"     : 3,
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "analysis_type"                      : "linear",
         "model_import_settings"              : {
             "input_type"       : "mdpa",
             "input_filename"   : "harmonic_analysis_test/harmonic_analysis_test"
@@ -22,25 +21,6 @@
         "material_import_settings"           : {
             "materials_filename" : "harmonic_analysis_test/harmonic_analysis_test_materials.json"
         },
-        "line_search"                        : false,
-        "convergence_criterion"              : "residual_criterion",
-        "displacement_relative_tolerance"    : 0.0001,
-        "displacement_absolute_tolerance"    : 1e-9,
-        "residual_relative_tolerance"        : 0.0001,
-        "residual_absolute_tolerance"        : 1e-9,
-        "max_iteration"                      : 10,
-        "eigensolver_settings":{
-            "solver_type": "FEAST",
-            "print_feast_output": false,
-            "perform_stochastic_estimate": false,
-            "solve_eigenvalue_problem": true,
-            "lambda_min": 1.0e4,
-            "lambda_max": 1.0e7,
-            "search_dimension": 35,
-            "linear_solver_settings":{
-                "solver_type": "skyline_lu_complex"
-            }
-	},
         "rotation_dofs"                      : true
     },
     "processes" : {

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -413,7 +413,6 @@ def AssembleTestSuites():
             nightSuite.addTest(TEigen3D3NThinCircleTests('test_execution'))
             # Harmonic analysis test
             smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([THarmonicAnalysisTests]))
-            nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([THarmonicAnalysisTestsWithHDF5]))
             # Rayleigh process test
             nightSuite.addTest(TRayleighProcessTest('test_execution'))
         else:
@@ -424,6 +423,7 @@ def AssembleTestSuites():
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestAdjointSensitivityAnalysisLinearTrussStructure]))
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestAdjointSensitivityAnalysisNonLinearTrussStructure]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestAdjointSensitivityAnalysisSpringDamperStructure]))
+    nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([THarmonicAnalysisTestsWithHDF5]))
     nightSuite.addTest(TTestMassResponseFunction('test_execution'))
     nightSuite.addTest(TTestStrainEnergyResponseFunction('test_execution'))
     nightSuite.addTest(TTestEigenfrequencyResponseFunction('test_execution'))

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -317,6 +317,8 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestTrussLinearAdjointElement]))
     # RVE tests
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestRVESimplestTest]))
+    # Element damping test
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TSpringDamperElementTests]))
 
     ### Adding Small Tests
     # Basic moving mesh test (leave these in the smallSuite to have the Exection script tested)
@@ -412,8 +414,6 @@ def AssembleTestSuites():
             # Harmonic analysis test
             smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([THarmonicAnalysisTests]))
             nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([THarmonicAnalysisTestsWithHDF5]))
-            # Element damping test
-            nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TSpringDamperElementTests])) # TODO should be in smallSuite but is too slow
             # Rayleigh process test
             nightSuite.addTest(TRayleighProcessTest('test_execution'))
         else:

--- a/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
+++ b/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
@@ -13,8 +13,6 @@ hdf5_application_available = kratos_utils.CheckIfApplicationsAvailable("HDF5Appl
 
 from math import sqrt
 from cmath import phase
-import os
-
 
 class HarmonicAnalysisTests(KratosUnittest.TestCase):
 

--- a/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
+++ b/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
@@ -7,6 +7,10 @@ import KratosMultiphysics.kratos_utilities as kratos_utils
 
 from KratosMultiphysics.StructuralMechanicsApplication import structural_mechanics_analysis
 
+external_solvers_application_available = kratos_utils.CheckIfApplicationsAvailable("ExternalSolversApplication")
+eigen_solvers_application_available = kratos_utils.CheckIfApplicationsAvailable("EigenSolversApplication")
+hdf5_application_available = kratos_utils.CheckIfApplicationsAvailable("HDF5Application")
+
 from math import sqrt
 from cmath import phase
 import os
@@ -102,7 +106,9 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
 
         return mp
 
+    @KratosUnittest.skipUnless(external_solvers_application_available,"Missing required application: ExternalSolversApplication")
     def test_undamped_mdof_harmonic(self):
+        import KratosMultiphysics.ExternalSolversApplication as ExternalSolversApplication
         current_model = KratosMultiphysics.Model()
         #analytic solution taken from Humar - Dynamics of Structures p. 675
 
@@ -120,7 +126,7 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
         harmonic_solver = self._setup_harmonic_solver(mp)
 
         exfreq = 1.0
-        max_exfreq = 20.0
+        max_exfreq = 2.0
         df = 0.05
 
         while(exfreq <= max_exfreq):
@@ -139,7 +145,9 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
 
             exfreq = exfreq + df
 
+    @KratosUnittest.skipUnless(external_solvers_application_available,"Missing required application: ExternalSolversApplication")
     def test_damped_mdof_harmonic(self):
+        import KratosMultiphysics.ExternalSolversApplication as ExternalSolversApplication
         current_model = KratosMultiphysics.Model()
 
         #analytic solution taken from Humar - Dynamics of Structures p. 677
@@ -159,7 +167,7 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
         harmonic_solver = self._setup_harmonic_solver(mp)
 
         exfreq = 1.0
-        max_exfreq = 20.0
+        max_exfreq = 2.0
         df = 0.05
 
         while(exfreq <= max_exfreq):
@@ -197,11 +205,10 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
             exfreq = exfreq + df
 
 class HarmonicAnalysisTestsWithHDF5(KratosUnittest.TestCase):
+    @KratosUnittest.skipUnless(hdf5_application_available and eigen_solvers_application_available,"Missing required application: HDF5Application, EigenSolversApplication")
     def test_harmonic_mdpa_input(self):
-        if not kratos_utils.CheckIfApplicationsAvailable("HDF5Application"):
-            self.skipTest("HDF5Application not found: Skipping harmonic analysis mdpa test")
 
-        with ControlledExecutionScope(os.path.dirname(os.path.realpath(__file__))):
+        with KratosUnittest.WorkFolderScope(".",__file__):
             #run simulation and write to hdf5 file
             model = KratosMultiphysics.Model()
             project_parameter_file_name = "harmonic_analysis_test/harmonic_analysis_test_eigenproblem_parameters.json"

--- a/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
+++ b/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
@@ -2,7 +2,6 @@ from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
-import KratosMultiphysics.ExternalSolversApplication as ExternalSolversApplication
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils
 
@@ -12,16 +11,6 @@ from math import sqrt
 from cmath import phase
 import os
 
-class ControlledExecutionScope:
-    def __init__(self, scope):
-        self.currentPath = os.getcwd()
-        self.scope = scope
-
-    def __enter__(self):
-        os.chdir(self.scope)
-
-    def __exit__(self, type, value, traceback):
-        os.chdir(self.currentPath)
 
 class HarmonicAnalysisTests(KratosUnittest.TestCase):
 

--- a/applications/StructuralMechanicsApplication/tests/test_spring_damper_element.py
+++ b/applications/StructuralMechanicsApplication/tests/test_spring_damper_element.py
@@ -324,7 +324,7 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
                 "number_of_eigenvalues": 2,
                 "search_dimension": 18,
                 "linear_solver_settings": {
-                    "solver_type" : "skyline_lu_complex",
+                    "solver_type" : "pastix",
                     "echo_level" : 0
                 }
             }""")

--- a/applications/StructuralMechanicsApplication/tests/test_spring_damper_element.py
+++ b/applications/StructuralMechanicsApplication/tests/test_spring_damper_element.py
@@ -7,6 +7,9 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 from math import sqrt, sin, cos, pi, exp, atan
 
+from KratosMultiphysics import kratos_utilities as kratos_utils
+external_solvers_application_available = kratos_utils.CheckIfApplicationsAvailable("ExternalSolversApplication")
+
 class SpringDamperElementTests(KratosUnittest.TestCase):
     def setUp(self):
         pass
@@ -58,7 +61,6 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
         linear_solver = KratosMultiphysics.SkylineLUFactorizationSolver()
         builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(linear_solver)
         scheme = KratosMultiphysics.ResidualBasedBossakDisplacementScheme(damp_factor_m)
-        # convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-14,1e-20)
         convergence_criterion = KratosMultiphysics.ResidualCriteria(1e-4,1e-9)
         convergence_criterion.SetEchoLevel(0)
 
@@ -182,7 +184,7 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
         #time integration parameters
         dt = 0.001
         time = 0.0
-        end_time = 4.0
+        end_time = 0.01
         step = 0
 
         self._set_and_fill_buffer(mp,2,dt)
@@ -232,7 +234,7 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
         #time integration parameters
         dt = 0.01
         time = 0.0
-        end_time = 10.0
+        end_time = 0.1
         step = 0
 
         self._set_and_fill_buffer(mp,2,dt)
@@ -275,7 +277,7 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
         #time integration parameters
         dt = 0.05
         time = 0.0
-        end_time = 20.0
+        end_time = 1.0
         step = 0
 
         self._set_and_fill_buffer(mp,2,dt)
@@ -294,9 +296,9 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
             self.assertAlmostEqual(mp.Nodes[2].GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y,0), \
                 current_analytical_displacement_y_2,delta=5e-2)
 
+    @KratosUnittest.skipUnless(external_solvers_application_available,"Missing required application: ExternalSolversApplication")
     def test_undamped_mdof_system_eigen(self):
         import KratosMultiphysics.ExternalSolversApplication as ExternalSolversApplication
-        # FEAST is available otherwise this test is not being called
         if not hasattr(KratosMultiphysics.ExternalSolversApplication, "PastixSolver"):
             self.skipTest("Pastix Solver is not available")
 
@@ -322,7 +324,7 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
                 "number_of_eigenvalues": 2,
                 "search_dimension": 18,
                 "linear_solver_settings": {
-                    "solver_type" : "pastix",
+                    "solver_type" : "skyline_lu_complex",
                     "echo_level" : 0
                 }
             }""")


### PR DESCRIPTION
This still uses the ExternalSolversApp hardcoded, can you please refactor and add tests in case the App does not exist?
If you can drop completely the usage of the ExternalSolversApp and use the solvers from the EigenSolversApp that would be even better 
Thx

BTW `ControlledExecutionScope` is now (with a different name) available in `KratosUnittest`