### PR TITLE
Fixing line_search_strategy for MPI

### DIFF
--- a/kratos/solving_strategies/strategies/line_search_strategy.h
+++ b/kratos/solving_strategies/strategies/line_search_strategy.h
@@ -356,7 +356,7 @@ protected:
         typename TSchemeType::Pointer pScheme = this->GetScheme();
         typename TBuilderAndSolverType::Pointer pBuilderAndSolver = this->GetBuilderAndSolver();
 
-        TSystemVectorType aux(TSparseSpace::Size(b));
+        TSystemVectorType aux(Dx);
         
         double x1 = mFirstAlphaValue;
         double x2 = mSecondAlphaValue;


### PR DESCRIPTION
It was failing because epetra dos not have a resize function. I used the copy constructor since Dx is being copied anyway.

Open to other solutions if they are available.

Its needed for the altair project.