### PR TITLE
[TEMP] always run CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,33 +2,8 @@ name: CI
 
 on:
   pull_request:
-    paths:
-    - '.github/**'
-    - 'cmake_modules/**'
-    - 'scripts/**'
-    - 'CMakeLists.txt'
-    - 'external_libraries/**'
-    - 'kratos/**'
-    - 'applications/CableNetApplication/**'
-    - 'applications/CompressiblePotentialFlowApplication/**'
-    - 'applications/ContactStructuralMechanicsApplication/**'
-    - 'applications/CoSimulationApplication/**'
-    - 'applications/CSharpWrapperApplication/**'
-    - 'applications/DEMApplication/**'
-    - 'applications/EigenSolversApplication/**'
-    - 'applications/ExternalSolversApplication/**'
-    - 'applications/FluidDynamicsApplication/**'
-    - 'applications/FSIApplication/**'
-    - 'applications/MappingApplication/**'
-    - 'applications/MeshingApplication/**'
-    - 'applications/MeshMovingApplication/**'
-    - 'applications/MetisApplication/**'
-    - 'applications/RANSApplication/**'
-    - 'applications/ShapeOptimizationApplication/**'
-    - 'applications/StructuralMechanicsApplication/**'
-    - 'applications/SwimmingDEMApplication/**'
-    - 'applications/TrilinosApplication/**'
-    - 'applications/HDF5Application/**'
+    branches:
+      - master
 
   schedule:
     - cron:  '0 1 * * *'


### PR DESCRIPTION
so far the new CI was only executed if certain files are changed
This means that if e.g. the README is changed, then the CI does not run (which makes sense)

The problem is, that this will not work if we make the new CI required to pass for a PR to be merged, since this is not yet supported by Github, see e.g. https://github.community/t5/GitHub-Actions/Feature-request-conditional-required-checks/m-p/36938#M2735

Hence until Github supports this feature I enable to run the CI on every PR, same as for Appveyor & Travis

After this we can make it required