### PR TITLE
[CMAKE] Update cmake policy 0074

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,11 @@ if(POLICY CMP0022)
   cmake_policy(SET CMP0022 NEW)
 endif(POLICY CMP0022)
 
+# Find package based on <packagename>_ROOT variable
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW)
+endif(POLICY CMP0074)
+
 # Set here the version number **** only update upon tagging a release!
 set (KratosMultiphysics_MAJOR_VERSION 7)
 set (KratosMultiphysics_MINOR_VERSION 1)


### PR DESCRIPTION
Set cmake policy 0074 to NEW in order to find e.g. boost based on the BOOST_ROOT variable. The old behavior is marked as deprecated (https://cmake.org/cmake/help/git-stage/policy/CMP0074.html).