### PR TITLE
[Core] fix circular dependency

### DIFF
--- a/kratos/utilities/stl_vector_io.h
+++ b/kratos/utilities/stl_vector_io.h
@@ -18,9 +18,6 @@
 #include <iostream>
 #include <vector>
 
-// Project includes
-#include "includes/define.h"
-
 namespace Kratos {
 
 template<class T>


### PR DESCRIPTION
`stl_vector_io.h` is included in `exception.h` which is included in `define.h`