### PR TITLE
Switch to checkout-v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         CXX: /usr/lib/ccache/g++
 
     steps:
-    - uses: actions/checkout@v2-beta
+    - uses: actions/checkout@v2
 
     - name: Cache Build
       id: cache-build
@@ -74,7 +74,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v2-beta
+    - uses: actions/checkout@v2
     - uses: actions/setup-python@v1
       with:
         python-version: '3.6'


### PR DESCRIPTION
Not 'beta' anymore.

BTW: It seems that GitHub has increased the cache limits: 2GB/cache and 5GB/repo