### PR TITLE
[Mapping] fix cotire errors

### DIFF
--- a/applications/MappingApplication/CMakeLists.txt
+++ b/applications/MappingApplication/CMakeLists.txt
@@ -68,6 +68,9 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 
 # Cotire
 if(USE_COTIRE MATCHES ON)
+    set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/custom_mappers/interpolative_mapper_base.cpp PROPERTIES COTIRE_EXCLUDED TRUE)
+    set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/mapping_matrix_utilities.cpp PROPERTIES COTIRE_EXCLUDED TRUE)
+    set_source_files_properties (${CMAKE_CURRENT_SOURCE_DIR}/custom_utilities/interface_vector_container.cpp PROPERTIES COTIRE_EXCLUDED TRUE)
     cotire(KratosMappingApplication)
 endif(USE_COTIRE MATCHES ON)
 

--- a/applications/MappingApplication/custom_utilities/interface_vector_container_mpi.cpp
+++ b/applications/MappingApplication/custom_utilities/interface_vector_container_mpi.cpp
@@ -24,37 +24,37 @@
 
 namespace Kratos
 {
-typedef typename MapperDefinitions::MPISparseSpaceType MPISparseSpaceType;
+typedef typename MapperDefinitions::MPISparseSpaceType SparseSpaceType;
 typedef typename MapperDefinitions::DenseSpaceType DenseSpaceType;
 
-typedef InterfaceVectorContainer<MPISparseSpaceType, DenseSpaceType> MPIVectorContainerType;
+typedef InterfaceVectorContainer<SparseSpaceType, DenseSpaceType> VectorContainerType;
 
 /***********************************************************************************/
 /* PUBLIC Methods */
 /***********************************************************************************/
 template<>
-void MPIVectorContainerType::UpdateSystemVectorFromModelPart(const DoubleVariableType& rVariable,
+void VectorContainerType::UpdateSystemVectorFromModelPart(const DoubleVariableType& rVariable,
                                                           const Kratos::Flags& rMappingOptions)
 {
     MapperUtilities::UpdateSystemVectorFromModelPart((*mpInterfaceVector)[0], mrModelPart, rVariable, rMappingOptions);
 }
 
 template<>
-void MPIVectorContainerType::UpdateSystemVectorFromModelPart(const ComponentVariableType& rVariable,
+void VectorContainerType::UpdateSystemVectorFromModelPart(const ComponentVariableType& rVariable,
                                                           const Kratos::Flags& rMappingOptions)
 {
     MapperUtilities::UpdateSystemVectorFromModelPart((*mpInterfaceVector)[0], mrModelPart, rVariable, rMappingOptions);
 }
 
 template<>
-void MPIVectorContainerType::UpdateModelPartFromSystemVector(const DoubleVariableType& rVariable,
+void VectorContainerType::UpdateModelPartFromSystemVector(const DoubleVariableType& rVariable,
                                                           const Kratos::Flags& rMappingOptions)
 {
     MapperUtilities::UpdateModelPartFromSystemVector((*mpInterfaceVector)[0], mrModelPart, rVariable, rMappingOptions);
 }
 
 template<>
-void MPIVectorContainerType::UpdateModelPartFromSystemVector(const ComponentVariableType& rVariable,
+void VectorContainerType::UpdateModelPartFromSystemVector(const ComponentVariableType& rVariable,
                                                           const Kratos::Flags& rMappingOptions)
 {
     MapperUtilities::UpdateModelPartFromSystemVector((*mpInterfaceVector)[0], mrModelPart, rVariable, rMappingOptions);
@@ -62,6 +62,6 @@ void MPIVectorContainerType::UpdateModelPartFromSystemVector(const ComponentVari
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 // Class template instantiation
-template class InterfaceVectorContainer< MPISparseSpaceType, DenseSpaceType >;
+template class InterfaceVectorContainer< SparseSpaceType, DenseSpaceType >;
 
 }  // namespace Kratos.

--- a/applications/MappingApplication/custom_utilities/mapping_matrix_utilities_mpi.cpp
+++ b/applications/MappingApplication/custom_utilities/mapping_matrix_utilities_mpi.cpp
@@ -32,7 +32,7 @@ namespace MappingMatrixUtilities
 
 namespace
 {
-typedef typename MapperDefinitions::MPISparseSpaceType MPISparseSpaceType;
+typedef typename MapperDefinitions::MPISparseSpaceType SparseSpaceType;
 typedef typename MapperDefinitions::DenseSpaceType DenseSpaceType;
 
 typedef typename MapperLocalSystem::MatrixType MatrixType;
@@ -75,7 +75,7 @@ void ConstructMatrixStructure(Epetra_FECrsGraph& rGraph,
     }
 }
 
-void BuildMatrix(Kratos::unique_ptr<typename MPISparseSpaceType::MatrixType>& rpMdo,
+void BuildMatrix(Kratos::unique_ptr<typename SparseSpaceType::MatrixType>& rpMdo,
                  std::vector<Kratos::unique_ptr<MapperLocalSystem>>& rMapperLocalSystems)
 {
     MatrixType local_mapping_matrix;
@@ -110,10 +110,10 @@ void BuildMatrix(Kratos::unique_ptr<typename MPISparseSpaceType::MatrixType>& rp
 }
 
 template<>
-void BuildMappingMatrix<MPISparseSpaceType, DenseSpaceType>(
-    Kratos::unique_ptr<typename MPISparseSpaceType::MatrixType>& rpMappingMatrix,
-    Kratos::unique_ptr<typename MPISparseSpaceType::VectorType>& rpInterfaceVectorOrigin,
-    Kratos::unique_ptr<typename MPISparseSpaceType::VectorType>& rpInterfaceVectorDestination,
+void BuildMappingMatrix<SparseSpaceType, DenseSpaceType>(
+    Kratos::unique_ptr<typename SparseSpaceType::MatrixType>& rpMappingMatrix,
+    Kratos::unique_ptr<typename SparseSpaceType::VectorType>& rpInterfaceVectorOrigin,
+    Kratos::unique_ptr<typename SparseSpaceType::VectorType>& rpInterfaceVectorDestination,
     const ModelPart& rModelPartOrigin,
     const ModelPart& rModelPartDestination,
     std::vector<Kratos::unique_ptr<MapperLocalSystem>>& rMapperLocalSystems,
@@ -121,7 +121,7 @@ void BuildMappingMatrix<MPISparseSpaceType, DenseSpaceType>(
 {
     KRATOS_TRY
 
-    KRATOS_ERROR_IF_NOT(MPISparseSpaceType::IsDistributed())
+    KRATOS_ERROR_IF_NOT(SparseSpaceType::IsDistributed())
         << "Using a non-distributed Space!" << std::endl;
 
     // ***** Creating vectors with information abt which IDs are local *****
@@ -206,8 +206,8 @@ void BuildMappingMatrix<MPISparseSpaceType, DenseSpaceType>(
     epetra_graph.OptimizeStorage(); // TODO is an extra-call needed?
 
     // ***** Creating the MappingMatrix *****
-    Kratos::unique_ptr<typename MPISparseSpaceType::MatrixType> p_Mdo =
-        Kratos::make_unique<typename MPISparseSpaceType::MatrixType>(Epetra_DataAccess::Copy, epetra_graph);
+    Kratos::unique_ptr<typename SparseSpaceType::MatrixType> p_Mdo =
+        Kratos::make_unique<typename SparseSpaceType::MatrixType>(Epetra_DataAccess::Copy, epetra_graph);
 
     BuildMatrix(p_Mdo, rMapperLocalSystems);
 
@@ -219,16 +219,16 @@ void BuildMappingMatrix<MPISparseSpaceType, DenseSpaceType>(
 
     if (EchoLevel > 2) {
         const std::string file_name = "TrilinosMappingMatrix_O_" + rModelPartOrigin.Name() + "__D_" + rModelPartDestination.Name() +".mm";
-        MPISparseSpaceType::WriteMatrixMarketMatrix(file_name.c_str(), *p_Mdo, false);
+        SparseSpaceType::WriteMatrixMarketMatrix(file_name.c_str(), *p_Mdo, false);
     }
 
     rpMappingMatrix.swap(p_Mdo);
 
     // ***** Creating the SystemVectors *****
-    Kratos::unique_ptr<typename MPISparseSpaceType::VectorType> p_new_vector_destination =
-        Kratos::make_unique<typename MPISparseSpaceType::VectorType>(epetra_range_map);
-    Kratos::unique_ptr<typename MPISparseSpaceType::VectorType> p_new_vector_origin =
-        Kratos::make_unique<typename MPISparseSpaceType::VectorType>(epetra_domain_map);
+    Kratos::unique_ptr<typename SparseSpaceType::VectorType> p_new_vector_destination =
+        Kratos::make_unique<typename SparseSpaceType::VectorType>(epetra_range_map);
+    Kratos::unique_ptr<typename SparseSpaceType::VectorType> p_new_vector_origin =
+        Kratos::make_unique<typename SparseSpaceType::VectorType>(epetra_domain_map);
     rpInterfaceVectorDestination.swap(p_new_vector_destination);
     rpInterfaceVectorOrigin.swap(p_new_vector_origin);
 

--- a/applications/MappingApplication/tests/test_MappingApplication_mpi.py
+++ b/applications/MappingApplication/tests/test_MappingApplication_mpi.py
@@ -1,6 +1,8 @@
 # import Kratos
 import KratosMultiphysics
-from KratosMultiphysics.mpi import mpi # make sure mpi is imported, independent of "--using-mpi"
+if not KratosMultiphysics.IsDistributedRun():
+    raise Exception("These tests can only be executed in MPI / distributed!")
+
 import KratosMultiphysics.MappingApplication
 
 # Import Kratos "wrapper" for unittests


### PR DESCRIPTION
reverting some changes from #6121 and excluding the files from cotire, since otherwise it doesn't compile in newer Clangs

Also minor fix in MPI-tests