### PR TITLE
[Structural] change check for youngs modulus

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.cpp
+++ b/applications/StructuralMechanicsApplication/custom_constitutive/elastic_isotropic_3d.cpp
@@ -283,7 +283,7 @@ int ElasticIsotropic3D::Check(
     )
 {
     KRATOS_CHECK_VARIABLE_KEY(YOUNG_MODULUS);
-    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] <= 0.0) << "YOUNG_MODULUS is null or negative." << std::endl;
+    KRATOS_ERROR_IF(rMaterialProperties[YOUNG_MODULUS] < 0.0) << "YOUNG_MODULUS is negative." << std::endl;
 
     KRATOS_CHECK_VARIABLE_KEY(POISSON_RATIO);
     const double tolerance = 1.0e-12;


### PR DESCRIPTION
Hi, for the formfinding we set the Youngs Modulus to 0. This PR adjusts the check of the 3d_isotropic claw to allow for Youngs Modulus = 0. This is needed for PR #6391 as it adds the claw check in the element check