### PR TITLE
[Core] Removing warning from ReadMaterialsUtility

### DIFF
--- a/kratos/python/add_utilities_to_python.cpp
+++ b/kratos/python/add_utilities_to_python.cpp
@@ -39,14 +39,12 @@
 
 // #include "utilities/signed_distance_calculator_bin_based.h"
 #include "utilities/timer.h"
-
 #include "utilities/binbased_fast_point_locator.h"
 #include "utilities/binbased_fast_point_locator_conditions.h"
 #include "utilities/binbased_nodes_in_element_locator.h"
 #include "utilities/embedded_skin_utility.h"
 #include "utilities/geometry_tester.h"
 #include "utilities/cutting_utility.h"
-
 #include "utilities/python_function_callback_utility.h"
 #include "utilities/interval_utility.h"
 #include "utilities/table_stream_utility.h"

--- a/kratos/utilities/read_materials_utility.h
+++ b/kratos/utilities/read_materials_utility.h
@@ -102,6 +102,9 @@ class KRATOS_API(KRATOS_CORE) ReadMaterialsUtility
      */
     ReadMaterialsUtility(const std::string& rParametersName, Model& rModel);
 
+    /// Destructor.
+    virtual ~ReadMaterialsUtility() {}
+
     ///@}
     ///@name Operators
     ///@{


### PR DESCRIPTION
~~~
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h:629:8: warning: delete called on non-final 'Kratos::ReadMaterialsUtility' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
              delete __p;
              ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h:636:4: note: in instantiation of function template specialization 'std::__shared_count<__gnu_cxx::_S_atomic>::__shared_count<Kratos::ReadMaterialsUtility *>' requested here
        : __shared_count(__p)
          ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h:1125:17: note: in instantiation of function template specialization 'std::__shared_count<__gnu_cxx::_S_atomic>::__shared_count<Kratos::ReadMaterialsUtility *>' requested here
        : _M_ptr(__p), _M_refcount(__p, typename is_array<_Tp>::type())
                       ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr.h:139:25: note: in instantiation of function template specialization 'std::__shared_ptr<Kratos::ReadMaterialsUtility, __gnu_cxx::_S_atomic>::__shared_ptr<Kratos::ReadMaterialsUtility, void>' requested here
        shared_ptr(_Yp* __p) : __shared_ptr<_Tp>(__p) { }
                               ^
/home/vicente/src/Kratos/external_libraries/pybind11/pybind11.h:1298:61: note: in instantiation of function template specialization 'std::shared_ptr<Kratos::ReadMaterialsUtility>::shared_ptr<Kratos::ReadMaterialsUtility, void>' requested here
            new (std::addressof(v_h.holder<holder_type>())) holder_type(v_h.value_ptr<type>());
                                                            ^
/home/vicente/src/Kratos/external_libraries/pybind11/pybind11.h:1313:9: note: in instantiation of member function 'pybind11::class_<Kratos::ReadMaterialsUtility, std::shared_ptr<Kratos::ReadMaterialsUtility> >::init_holder' requested here
        init_holder(inst, v_h, (const holder_type *) holder_ptr, v_h.value_ptr<type>());
        ^
/home/vicente/src/Kratos/external_libraries/pybind11/pybind11.h:1053:32: note: in instantiation of member function 'pybind11::class_<Kratos::ReadMaterialsUtility, std::shared_ptr<Kratos::ReadMaterialsUtility> >::init_instance' requested here
        record.init_instance = init_instance;
                               ^
/home/vicente/src/Kratos/kratos/python/add_utilities_to_python.cpp:953:5: note: in instantiation of function template specialization 'pybind11::class_<Kratos::ReadMaterialsUtility, std::shared_ptr<Kratos::ReadMaterialsUtility> >::class_<>' requested here
    py::class_<ReadMaterialsUtility, typename ReadMaterialsUtility::Pointer>(m, "ReadMaterialsUtility")
    ^
In file included from /home/vicente/src/Kratos/kratos/python/add_utilities_to_python.cpp:20:
In file included from /home/vicente/src/Kratos/kratos/includes/define_python.h:18:
In file included from /home/vicente/src/Kratos/external_libraries/pybind11/pybind11.h:43:
In file included from /home/vicente/src/Kratos/external_libraries/pybind11/detail/../attr.h:13:
In file included from /home/vicente/src/Kratos/external_libraries/pybind11/cast.h:13:
In file included from /home/vicente/src/Kratos/external_libraries/pybind11/detail/../pytypes.h:12:
In file included from /home/vicente/src/Kratos/external_libraries/pybind11/detail/common.h:146:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/memory:81:
In file included from /usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr.h:52:
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h:377:9: warning: delete called on non-final 'Kratos::ReadMaterialsUtility' that has virtual functions but non-virtual destructor [-Wdelete-non-abstract-non-virtual-dtor]
      { delete _M_ptr; }
        ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h:372:7: note: in instantiation of member function 'std::_Sp_counted_ptr<Kratos::ReadMaterialsUtility *, __gnu_cxx::_S_atomic>::_M_dispose' requested here
      _Sp_counted_ptr(_Ptr __p) noexcept
      ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h:625:20: note: in instantiation of member function 'std::_Sp_counted_ptr<Kratos::ReadMaterialsUtility *, __gnu_cxx::_S_atomic>::_Sp_counted_ptr' requested here
              _M_pi = new _Sp_counted_ptr<_Ptr, _Lp>(__p);
                          ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h:636:4: note: in instantiation of function template specialization 'std::__shared_count<__gnu_cxx::_S_atomic>::__shared_count<Kratos::ReadMaterialsUtility *>' requested here
        : __shared_count(__p)
          ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr_base.h:1125:17: note: in instantiation of function template specialization 'std::__shared_count<__gnu_cxx::_S_atomic>::__shared_count<Kratos::ReadMaterialsUtility *>' requested here
        : _M_ptr(__p), _M_refcount(__p, typename is_array<_Tp>::type())
                       ^
/usr/bin/../lib/gcc/x86_64-linux-gnu/9/../../../../include/c++/9/bits/shared_ptr.h:139:25: note: in instantiation of function template specialization 'std::__shared_ptr<Kratos::ReadMaterialsUtility, __gnu_cxx::_S_atomic>::__shared_ptr<Kratos::ReadMaterialsUtility, void>' requested here
        shared_ptr(_Yp* __p) : __shared_ptr<_Tp>(__p) { }
                               ^
/home/vicente/src/Kratos/external_libraries/pybind11/pybind11.h:1298:61: note: in instantiation of function template specialization 'std::shared_ptr<Kratos::ReadMaterialsUtility>::shared_ptr<Kratos::ReadMaterialsUtility, void>' requested here
            new (std::addressof(v_h.holder<holder_type>())) holder_type(v_h.value_ptr<type>());
                                                            ^
/home/vicente/src/Kratos/external_libraries/pybind11/pybind11.h:1313:9: note: in instantiation of member function 'pybind11::class_<Kratos::ReadMaterialsUtility, std::shared_ptr<Kratos::ReadMaterialsUtility> >::init_holder' requested here
        init_holder(inst, v_h, (const holder_type *) holder_ptr, v_h.value_ptr<type>());
        ^
/home/vicente/src/Kratos/external_libraries/pybind11/pybind11.h:1053:32: note: in instantiation of member function 'pybind11::class_<Kratos::ReadMaterialsUtility, std::shared_ptr<Kratos::ReadMaterialsUtility> >::init_instance' requested here
        record.init_instance = init_instance;
                               ^
/home/vicente/src/Kratos/kratos/python/add_utilities_to_python.cpp:953:5: note: in instantiation of function template specialization 'pybind11::class_<Kratos::ReadMaterialsUtility, std::shared_ptr<Kratos::ReadMaterialsUtility> >::class_<>' requested here
    py::class_<ReadMaterialsUtility, typename ReadMaterialsUtility::Pointer>(m, "ReadMaterialsUtility")
~~~
Missing virtual destructor