### PR TITLE
[CI] separating nightly build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           export CC=/usr/lib/ccache/gcc
           export CXX=/usr/lib/ccache/g++
           export KRATOS_CMAKE_OPTIONS_FLAGS="-DUSE_EIGEN_MKL=ON"
-          export KRATOS_CMAKE_CXX_FLAGS="-Wignored-qualifiers -Werror=ignored-qualifiers -Werror=suggest-override -Werror=unused-variable -Werror=misleading-indentation -Werror=return-type -Werror=sign-compare -Werror=unused-but-set-variable -Werror=unused-local-typedefs -Werror=reorder -Werror=maybe-uninitialized -Wno-deprecated-declarations"
+          export KRATOS_CMAKE_CXX_FLAGS="-Wignored-qualifiers -Werror=ignored-qualifiers -Werror=suggest-override -Werror=unused-variable -Werror=misleading-indentation -Werror=return-type -Werror=sign-compare -Werror=unused-but-set-variable -Werror=unused-local-typedefs -Werror=reorder -Werror=maybe-uninitialized"
         elif [ ${{ matrix.compiler }} = clang ]; then
           export CC=clang-9
           export CXX=clang++-9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,6 @@ on:
     branches:
       - master
 
-  schedule:
-    - cron:  '0 1 * * *'
-
 jobs:
   ubuntu:
     runs-on: ubuntu-latest
@@ -62,20 +59,12 @@ jobs:
         ccache -s
 
     - name: Running small tests
-      if: github.event_name == 'pull_request'
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
         python3 kratos/python_scripts/run_tests.py -l small -c python3
 
-    - name: Running nightly tests
-      if: github.event_name == 'schedule' # this is the nightly build
-      run: |
-        . /opt/intel/mkl/bin/mklvars.sh
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
-        python3 kratos/python_scripts/run_tests.py -l nightly -c python3
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,10 +1,6 @@
 name: Nightly Build
 
 on:
-  pull_request: # this is only for testing, will be removed before merging
-    branches:
-      - master
-
   schedule:
     - cron:  '0 1 * * *'
 

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -14,17 +14,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        build-type: [Release]
         compiler: [gcc, clang]
     env:
-      KRATOS_BUILD_TYPE: ${{ matrix.build-type }}
+      KRATOS_BUILD_TYPE: Release
       MKLVARS_ARCHITECTURE: intel64
       MKLVARS_INTERFACE: lp64
+      FC: gfortran-7
 
     container:
       image: oberbichler/kratos-dev:latest
-      env:
-        FC: gfortran-7
 
     steps:
     - uses: actions/checkout@v2
@@ -50,25 +48,21 @@ jobs:
     - name: Running tests
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
-        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
-        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
+        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${KRATOS_BUILD_TYPE}/libs
         python3 kratos/python_scripts/run_tests.py -l nightly -c python3
+
 
   windows:
     runs-on: windows-latest
 
     steps:
     - uses: actions/checkout@v2
+
     - uses: actions/setup-python@v1
       with:
         python-version: '3.6'
-    - name: Cache Build
-      id: cache-build
-      uses: actions/cache@v1
-      with:
-        path: build
-        key: ${{ runner.os }}-build-${{ github.sha }}
-        restore-keys: ${{ runner.os }}-build-
+
     - name: Build
       shell: cmd
       run: |

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -1,0 +1,115 @@
+name: Nightly Build
+
+on:
+  pull_request: # this is only for testing, will be removed before merging
+    branches:
+      - master
+
+  schedule:
+    - cron:  '0 1 * * *'
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        build-type: [Release]
+        compiler: [gcc, clang]
+    env:
+      KRATOS_BUILD_TYPE: ${{ matrix.build-type }}
+      MKLVARS_ARCHITECTURE: intel64
+      MKLVARS_INTERFACE: lp64
+
+    container:
+      image: oberbichler/kratos-dev:latest
+      env:
+        FC: gfortran-7
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Build
+      run: |
+        if [ ${{ matrix.compiler }} = gcc ]; then
+          export CC=gcc
+          export CXX=g++
+          export KRATOS_CMAKE_OPTIONS_FLAGS="-DUSE_EIGEN_MKL=ON"
+          export KRATOS_CMAKE_CXX_FLAGS="-Wignored-qualifiers"
+        elif [ ${{ matrix.compiler }} = clang ]; then
+          export CC=clang-9
+          export CXX=clang++-9
+        else
+          echo 'Unsupported compiler: ${{ matrix.compiler }}'
+          exit 1
+        fi
+        . /opt/intel/mkl/bin/mklvars.sh
+        cp .github/workflows/configure.sh configure.sh # maybe use different configure script in the future
+        bash configure.sh
+
+    - name: Running tests
+      run: |
+        . /opt/intel/mkl/bin/mklvars.sh
+        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
+        python3 kratos/python_scripts/run_tests.py -l nightly -c python3
+
+  windows:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.6'
+    - name: Cache Build
+      id: cache-build
+      uses: actions/cache@v1
+      with:
+        path: build
+        key: ${{ runner.os }}-build-${{ github.sha }}
+        restore-keys: ${{ runner.os }}-build-
+    - name: Build
+      shell: cmd
+      run: |
+        call "%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64 || goto :error
+
+        set CC=cl.exe
+        set CXX=cl.exe
+
+        set KRATOS_BUILD_TYPE=Release
+        set KRATOS_SOURCE=%cd%
+        set KRATOS_BUILD=%cd%\build
+        set KRATOS_APP_DIR=applications
+
+        set KRATOS_APPLICATIONS=
+        set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\FluidDynamicsApplication;
+        set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\StructuralMechanicsApplication;
+        set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\ContactStructuralMechanicsApplication;
+        set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\MeshingApplication;
+        set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\MeshMovingApplication;
+        set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\DEMApplication;
+        set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\SwimmingDEMApplication;
+        set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\CSharpWrapperApplication;
+        set KRATOS_APPLICATIONS=%KRATOS_APPLICATIONS%%KRATOS_APP_DIR%\EigenSolversApplication;
+
+        del /F /Q "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%\cmake_install.cmake"
+        del /F /Q "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%\CMakeCache.txt"
+        del /F /Q "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%\CMakeFiles"
+
+        cmake                                                ^
+          -G"Visual Studio 16 2019"                          ^
+          -H"%KRATOS_SOURCE%"                                ^
+          -B"%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%"             ^
+          -DBOOST_ROOT="%BOOST_ROOT%"                        ^
+          -DINCLUDE_FEAST=OFF                                ^
+          -DINSTALL_RUNKRATOS=OFF                            ^
+          -DUSE_COTIRE=ON                                    || goto :error
+
+        cmake --build "%KRATOS_BUILD%\%KRATOS_BUILD_TYPE%" --target all_unity || goto :error
+
+        goto :EOF
+
+        :error
+        echo Failed with error #%errorlevel%.
+        exit /b %errorlevel%


### PR DESCRIPTION
the CI and the nightly build are starting to deviate quite a bit, hence I think it makes sense to separate them
- Nightly now runs in `Release`
- We can eventually add more apps to the nightly if wanted
- no caching required in the nightly build