### PR TITLE
[structural] overwrite initialize(ProcessInfo)

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.h
+++ b/applications/StructuralMechanicsApplication/custom_response_functions/adjoint_elements/adjoint_finite_difference_base_element.h
@@ -137,6 +137,11 @@ public:
         mpPrimalElement->Initialize();
     }
 
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override
+    {
+        mpPrimalElement->Initialize(rCurrentProcessInfo);
+    }
+
     void ResetConstitutiveLaw() override
     {
         mpPrimalElement->ResetConstitutiveLaw();


### PR DESCRIPTION
Hi, while refactoring some code I observed segfaults in the adjoint tests.
I finally figured out that `void Initialize(const ProcessInfo& rCurrentProcessInfo)` was not overwritten.
This is added in this PR