### PR TITLE
[PotentialFlow] Test bugfix, wrong copy of element

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
@@ -244,7 +244,7 @@ namespace Kratos {
       std::vector<ModelPart::IndexType> elemNodes_1{ 1, 2, 3 };
       model_part.CreateNewElement("IncompressiblePotentialFlowElement2D3N", 1, elemNodes_1, pElemProp);
 
-      auto r_element = model_part.GetElement(1);
+      auto& r_element = model_part.GetElement(1);
 
       r_element.GetValue(WAKE) = 1;
       Vector wake_elemental_distances(3);
@@ -282,10 +282,10 @@ namespace Kratos {
         KRATOS_CHECK_NEAR(nodal_area, 0.166667, 1e-6);
         auto nodal_velocity = r_node.GetValue(VELOCITY);
         KRATOS_CHECK_NEAR(nodal_velocity[0], 1, 1e-6);
-        KRATOS_CHECK_NEAR(nodal_velocity[1], 2, 1e-6);
+        KRATOS_CHECK_NEAR(nodal_velocity[1], 1, 1e-6);
         KRATOS_CHECK_NEAR(nodal_velocity[2], 0, 1e-6);
         auto nodal_pressure = r_node.GetValue(PRESSURE_COEFFICIENT);
-        KRATOS_CHECK_NEAR(nodal_pressure, 0.95, 1e-6);
+        KRATOS_CHECK_NEAR(nodal_pressure, 0.98, 1e-6);
       }
     }
   } // namespace Testing


### PR DESCRIPTION
Details here https://github.com/KratosMultiphysics/Kratos/pull/5624/files/3e975938fb0b3e824dbafa2be7dd5b038c86cdcb#r380263325

> This test was failing because there was a bug in the test! This means that the reference values of the test were wrong.
> 
> r_element was not referencing the Element(1) of the model_part so all the definitons that we do of the element below did not appear in the original model part (specifically, r_element.GetValue(WAKE)=1 was only performed at the copy, not at the original model part element)
> 
> With the new changes, both point to the same geometry data (as I understand) so r_element.GetValue(WAKE)=1 was correctly setting the element as WAKE in the original model part.
