### PR TITLE
[KratosUtilities] sort Apps

### DIFF
--- a/kratos/python_scripts/kratos_utilities.py
+++ b/kratos/python_scripts/kratos_utilities.py
@@ -42,9 +42,9 @@ def GetListOfAvailableApplications():
     """
     kratos_path = GetKratosMultiphysicsPath()
 
-    apps = [
+    apps = sorted([
         f.split('.')[0] for f in os.listdir(kratos_path) if re.match(r'.*Application*', f)
-    ]
+    ])
 
     return apps
 


### PR DESCRIPTION
`os.listdir` returns the apps in random order (https://stackoverflow.com/a/4813738)
This way we might not be able to spot errors e.g. in the CI