### PR TITLE
[NOT TO MERGE][PotentialFlow] Velocity Decomposition

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.h
@@ -202,7 +202,9 @@ private:
 
     void CalculateLocalSystemSubdividedElement(BoundedMatrix<double, NumNodes, NumNodes>& lhs_positive,
                                                BoundedMatrix<double, NumNodes, NumNodes>& lhs_negative,
-                                               const ProcessInfo& rCurrentProcessInfo);
+                                               const ProcessInfo& rCurrentProcessInfo,
+                                               double& rUpper_vol,
+                                               double& rLower_vol);
 
     void ComputeLHSGaussPointContribution(const double weight,
                                           BoundedMatrix<double, NumNodes, NumNodes>& lhs,

--- a/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_utilities/potential_flow_utilities.cpp
@@ -163,14 +163,14 @@ array_1d<double, Dim> ComputeVelocityLowerWakeElement(const Element& rElement)
 template <int Dim, int NumNodes>
 double ComputeIncompressiblePressureCoefficient(const Element& rElement, const ProcessInfo& rCurrentProcessInfo)
 {
-    const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
+    const array_1d<double, Dim> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
     const double free_stream_velocity_norm = inner_prod(free_stream_velocity, free_stream_velocity);
 
     KRATOS_ERROR_IF(free_stream_velocity_norm < std::numeric_limits<double>::epsilon())
         << "Error on element -> " << rElement.Id() << "\n"
         << "free_stream_velocity_norm must be larger than zero." << std::endl;
 
-    array_1d<double, Dim> v = ComputeVelocity<Dim,NumNodes>(rElement);
+    array_1d<double, Dim> v = free_stream_velocity + ComputeVelocity<Dim,NumNodes>(rElement);
 
     double pressure_coefficient = (free_stream_velocity_norm - inner_prod(v, v)) /
                free_stream_velocity_norm; // 0.5*(norm_2(free_stream_velocity) - norm_2(v));


### PR DESCRIPTION
Hi @marcnunezc,

JFYI As we discussed last week, this is just a branch to test the new formulation where the velocity is decomposed in free stream and perturbation components:

![velocity_decomposition](https://user-images.githubusercontent.com/28628414/74936601-b4438d00-53ea-11ea-97b6-84377028c4b0.png)

As you can see there are not many modifications, since the only required changes are in the:
- Computation of the velocity
- Computation of the right hand side

The advantage is that instead of solving for the full-potential, one solves for the perturbation potential, which doesn't undergo large variations in the domain. Consequences are:

- Initialization of the fluid field is not required (even for large mach numbers and angles of attack different than 0)
- The inlet potential is constant (even for angles of attack different than 0)
- The linear and non-linear solvers "suffer" less since the solution is bounded to smaller values
- No further assumptions are introduce, thus the range of application of the solver remains the same

I have compared the results using the formulation used up to now (**before**) with this way of decomposing the velocity (**after**) for the following cases and the results are exactly the same:

- Case 1 Incompressible AOA = 5°:
[cp_DS_100_AOA_5.0_before.pdf](https://github.com/KratosMultiphysics/Kratos/files/4230929/cp_DS_100_AOA_5.0_before.pdf)
[cp_DS_100_AOA_5.0_perturbation_after.pdf](https://github.com/KratosMultiphysics/Kratos/files/4230931/cp_DS_100_AOA_5.0_perturbation_after.pdf)

- Case 2 Incompressible AOA = 4° (from geometry) + 1° (from free-stream):
[cp_DS_100_AOA_4+1_before.pdf](https://github.com/KratosMultiphysics/Kratos/files/4230948/cp_DS_100_AOA_4%2B1_before.pdf)
[cp_DS_100_AOA_4+1_perturbation_after.pdf](https://github.com/KratosMultiphysics/Kratos/files/4230951/cp_DS_100_AOA_4%2B1_perturbation_after.pdf)

- Case 3 Compressible   AOA = 2°:
[cp_DS_100_AOA_2.0_before.pdf](https://github.com/KratosMultiphysics/Kratos/files/4230956/cp_DS_100_AOA_2.0_before.pdf)
[cp_DS_100_AOA_2.0_perturbation_after.pdf](https://github.com/KratosMultiphysics/Kratos/files/4230959/cp_DS_100_AOA_2.0_perturbation_after.pdf)

- Case 4 Compressible   AOA = 1° (from geometry) + 1° (from free-stream):
[cp_DS_100_AOA_1+1_before.pdf](https://github.com/KratosMultiphysics/Kratos/files/4230962/cp_DS_100_AOA_1%2B1_before.pdf)
[cp_DS_100_AOA_1+1_perturbation_after.pdf](https://github.com/KratosMultiphysics/Kratos/files/4230964/cp_DS_100_AOA_1%2B1_perturbation_after.pdf)

I am hoping that the extension to 3D is easier using this way, so I will add this formulation for two new elements:
- IncompressiblePerturbationPotentialFlowElement
- CompressiblePerturbationPotentialFlowElement

(I don't want to substitute the current elements until this is further tested and validated)

If you have any ideas or comments, let me know!







