### PR TITLE
[PotentialFlow] Adding Perturbation Potential Flow Elements 1 of 3

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/CMakeLists.txt
+++ b/applications/CompressiblePotentialFlowApplication/CMakeLists.txt
@@ -20,9 +20,11 @@ set( KRATOS_COMPRESSIBLE_POTENTIAL_APPLICATION_CORE
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/adjoint_analytical_incompressible_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/adjoint_base_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/adjoint_finite_difference_potential_flow_element.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/compressible_perturbation_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/compressible_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/embedded_compressible_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/embedded_incompressible_potential_flow_element.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/incompressible_perturbation_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/incompressible_potential_flow_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/apply_far_field_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/compute_embedded_lift_process.cpp

--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.cpp
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.cpp
@@ -31,6 +31,10 @@ KratosCompressiblePotentialFlowApplication::KratosCompressiblePotentialFlowAppli
     mIncompressiblePotentialFlowElement3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
     mCompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mCompressiblePotentialFlowElement3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+    mIncompressiblePerturbationPotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+    mIncompressiblePerturbationPotentialFlowElement3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+    mCompressiblePerturbationPotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+    mCompressiblePerturbationPotentialFlowElement3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
     mAdjointAnalyticalIncompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mAdjointIncompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mAdjointCompressiblePotentialFlowElement2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
@@ -120,6 +124,10 @@ void KratosCompressiblePotentialFlowApplication::Register()
   KRATOS_REGISTER_ELEMENT("IncompressiblePotentialFlowElement3D4N", mIncompressiblePotentialFlowElement3D4N);
   KRATOS_REGISTER_ELEMENT("CompressiblePotentialFlowElement2D3N", mCompressiblePotentialFlowElement2D3N);
   KRATOS_REGISTER_ELEMENT("CompressiblePotentialFlowElement3D4N", mCompressiblePotentialFlowElement3D4N);
+  KRATOS_REGISTER_ELEMENT("IncompressiblePerturbationPotentialFlowElement2D3N", mIncompressiblePerturbationPotentialFlowElement2D3N);
+  KRATOS_REGISTER_ELEMENT("IncompressiblePerturbationPotentialFlowElement3D4N", mIncompressiblePerturbationPotentialFlowElement3D4N);
+  KRATOS_REGISTER_ELEMENT("CompressiblePerturbationPotentialFlowElement2D3N", mCompressiblePerturbationPotentialFlowElement2D3N);
+  KRATOS_REGISTER_ELEMENT("CompressiblePerturbationPotentialFlowElement3D4N", mCompressiblePerturbationPotentialFlowElement3D4N);
   KRATOS_REGISTER_ELEMENT("AdjointAnalyticalIncompressiblePotentialFlowElement2D3N", mAdjointAnalyticalIncompressiblePotentialFlowElement2D3N);
   KRATOS_REGISTER_ELEMENT("AdjointIncompressiblePotentialFlowElement2D3N", mAdjointIncompressiblePotentialFlowElement2D3N);
   KRATOS_REGISTER_ELEMENT("AdjointCompressiblePotentialFlowElement2D3N", mAdjointCompressiblePotentialFlowElement2D3N);

--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
@@ -103,13 +103,13 @@ private:
     ///@name Member Variables
     ///@{
 
-	const IncompressiblePotentialFlowElement<2,3> mIncompressiblePotentialFlowElement2D3N;
+    const IncompressiblePotentialFlowElement<2, 3> mIncompressiblePotentialFlowElement2D3N;
     const IncompressiblePotentialFlowElement<3, 4> mIncompressiblePotentialFlowElement3D4N;
     const CompressiblePotentialFlowElement<2, 3> mCompressiblePotentialFlowElement2D3N;
     const CompressiblePotentialFlowElement<3, 4> mCompressiblePotentialFlowElement3D4N;
-	const IncompressiblePerturbationPotentialFlowElement<2,3> mIncompressiblePerturbationPotentialFlowElement2D3N;
+    const IncompressiblePerturbationPotentialFlowElement<2, 3> mIncompressiblePerturbationPotentialFlowElement2D3N;
     const IncompressiblePerturbationPotentialFlowElement<3, 4> mIncompressiblePerturbationPotentialFlowElement3D4N;
-	const CompressiblePerturbationPotentialFlowElement<2, 3> mCompressiblePerturbationPotentialFlowElement2D3N;
+    const CompressiblePerturbationPotentialFlowElement<2, 3> mCompressiblePerturbationPotentialFlowElement2D3N;
     const CompressiblePerturbationPotentialFlowElement<3, 4> mCompressiblePerturbationPotentialFlowElement3D4N;
     const AdjointAnalyticalIncompressiblePotentialFlowElement<IncompressiblePotentialFlowElement<2, 3>> mAdjointAnalyticalIncompressiblePotentialFlowElement2D3N;
     const AdjointFiniteDifferencePotentialFlowElement<IncompressiblePotentialFlowElement<2,3>> mAdjointIncompressiblePotentialFlowElement2D3N;

--- a/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
+++ b/applications/CompressiblePotentialFlowApplication/compressible_potential_flow_application.h
@@ -24,6 +24,8 @@
 #include "includes/variables.h"
 #include "custom_elements/compressible_potential_flow_element.h"
 #include "custom_elements/incompressible_potential_flow_element.h"
+#include "custom_elements/compressible_perturbation_potential_flow_element.h"
+#include "custom_elements/incompressible_perturbation_potential_flow_element.h"
 #include "custom_elements/embedded_incompressible_potential_flow_element.h"
 #include "custom_elements/embedded_compressible_potential_flow_element.h"
 #include "custom_conditions/potential_wall_condition.h"
@@ -101,10 +103,14 @@ private:
     ///@name Member Variables
     ///@{
 
-    const IncompressiblePotentialFlowElement<2,3> mIncompressiblePotentialFlowElement2D3N;
+	const IncompressiblePotentialFlowElement<2,3> mIncompressiblePotentialFlowElement2D3N;
     const IncompressiblePotentialFlowElement<3, 4> mIncompressiblePotentialFlowElement3D4N;
     const CompressiblePotentialFlowElement<2, 3> mCompressiblePotentialFlowElement2D3N;
     const CompressiblePotentialFlowElement<3, 4> mCompressiblePotentialFlowElement3D4N;
+	const IncompressiblePerturbationPotentialFlowElement<2,3> mIncompressiblePerturbationPotentialFlowElement2D3N;
+    const IncompressiblePerturbationPotentialFlowElement<3, 4> mIncompressiblePerturbationPotentialFlowElement3D4N;
+	const CompressiblePerturbationPotentialFlowElement<2, 3> mCompressiblePerturbationPotentialFlowElement2D3N;
+    const CompressiblePerturbationPotentialFlowElement<3, 4> mCompressiblePerturbationPotentialFlowElement3D4N;
     const AdjointAnalyticalIncompressiblePotentialFlowElement<IncompressiblePotentialFlowElement<2, 3>> mAdjointAnalyticalIncompressiblePotentialFlowElement2D3N;
     const AdjointFiniteDifferencePotentialFlowElement<IncompressiblePotentialFlowElement<2,3>> mAdjointIncompressiblePotentialFlowElement2D3N;
     const AdjointFiniteDifferencePotentialFlowElement<CompressiblePotentialFlowElement<2,3>> mAdjointCompressiblePotentialFlowElement2D3N;

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
@@ -1,0 +1,740 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Inigo Lopez and Riccardo Rossi
+//
+
+#include "compressible_perturbation_potential_flow_element.h"
+#include "compressible_potential_flow_application_variables.h"
+#include "fluid_dynamics_application_variables.h"
+#include "includes/cfd_variables.h"
+#include "fluid_dynamics_application_variables.h"
+#include "custom_utilities/potential_flow_utilities.h"
+
+namespace Kratos
+{
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Public Operations
+
+template <int Dim, int NumNodes>
+Element::Pointer CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Create(
+    IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const
+{
+    KRATOS_TRY
+    return Kratos::make_intrusive<CompressiblePerturbationPotentialFlowElement>(
+        NewId, GetGeometry().Create(ThisNodes), pProperties);
+    KRATOS_CATCH("");
+}
+
+template <int Dim, int NumNodes>
+Element::Pointer CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Create(
+    IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
+{
+    KRATOS_TRY
+    return Kratos::make_intrusive<CompressiblePerturbationPotentialFlowElement>(NewId, pGeom, pProperties);
+    KRATOS_CATCH("");
+}
+
+template <int Dim, int NumNodes>
+Element::Pointer CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Clone(
+    IndexType NewId, NodesArrayType const& ThisNodes) const
+{
+    KRATOS_TRY
+    return Kratos::make_intrusive<CompressiblePerturbationPotentialFlowElement>(
+        NewId, GetGeometry().Create(ThisNodes), pGetProperties());
+    KRATOS_CATCH("");
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+{
+    const CompressiblePerturbationPotentialFlowElement& r_this = *this;
+    const int wake = r_this.GetValue(WAKE);
+
+    if (wake == 0) // Normal element (non-wake) - eventually an embedded
+        CalculateLocalSystemNormalElement(
+            rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo);
+    else // Wake element
+        CalculateLocalSystemWakeElement(
+            rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo);
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRightHandSide(
+    VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+{
+    // TODO: improve speed
+    Matrix tmp;
+    CalculateLocalSystem(tmp, rRightHandSideVector, rCurrentProcessInfo);
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftHandSide(
+    MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+{
+    // TODO: improve speed
+    VectorType tmp;
+    CalculateLocalSystem(rLeftHandSideMatrix, tmp, rCurrentProcessInfo);
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::EquationIdVector(
+    EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+{
+    const CompressiblePerturbationPotentialFlowElement& r_this = *this;
+    const int wake = r_this.GetValue(WAKE);
+
+    if (wake == 0) // Normal element
+    {
+        if (rResult.size() != NumNodes)
+            rResult.resize(NumNodes, false);
+
+        const int kutta = r_this.GetValue(KUTTA);
+
+        if (kutta == 0)
+            GetEquationIdVectorNormalElement(rResult);
+        else
+            GetEquationIdVectorKuttaElement(rResult);
+    }
+    else // Wake element
+    {
+        if (rResult.size() != 2 * NumNodes)
+            rResult.resize(2 * NumNodes, false);
+
+        GetEquationIdVectorWakeElement(rResult);
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofList(DofsVectorType& rElementalDofList,
+                                                                 ProcessInfo& CurrentProcessInfo)
+{
+    const CompressiblePerturbationPotentialFlowElement& r_this = *this;
+    const int wake = r_this.GetValue(WAKE);
+
+    if (wake == 0) // Normal element
+    {
+        if (rElementalDofList.size() != NumNodes)
+            rElementalDofList.resize(NumNodes);
+
+        const int kutta = r_this.GetValue(KUTTA);
+
+        if (kutta == 0)
+            GetDofListNormalElement(rElementalDofList);
+        else
+            GetDofListKuttaElement(rElementalDofList);
+    }
+    else // wake element
+    {
+        if (rElementalDofList.size() != 2 * NumNodes)
+            rElementalDofList.resize(2 * NumNodes);
+
+        GetDofListWakeElement(rElementalDofList);
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+{
+    bool active = true;
+    if ((this)->IsDefined(ACTIVE))
+        active = (this)->Is(ACTIVE);
+
+    const CompressiblePerturbationPotentialFlowElement& r_this = *this;
+    const int wake = r_this.GetValue(WAKE);
+
+    if (wake != 0 && active == true)
+    {
+        ComputePotentialJump(rCurrentProcessInfo);
+    }
+    ComputeElementInternalEnergy();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Inquiry
+
+template <int Dim, int NumNodes>
+int CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Check(const ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    // Generic geometry check
+    int out = Element::Check(rCurrentProcessInfo);
+    if (out != 0)
+    {
+        return out;
+    }
+
+    KRATOS_ERROR_IF(GetGeometry().Area() <= 0.0)
+        << this->Id() << "Area cannot be less than or equal to 0" << std::endl;
+
+    for (unsigned int i = 0; i < this->GetGeometry().size(); i++)
+    {
+        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY_POTENTIAL, this->GetGeometry()[i]);
+    }
+
+    return out;
+
+    KRATOS_CATCH("");
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetValueOnIntegrationPoints(
+    const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo)
+{
+    if (rValues.size() != 1)
+        rValues.resize(1);
+
+    if (rVariable == PRESSURE_COEFFICIENT)
+    {
+        rValues[0] = PotentialFlowUtilities::ComputeCompressiblePressureCoefficient<Dim, NumNodes>(*this, rCurrentProcessInfo);
+    }
+    else if (rVariable == DENSITY)
+    {
+        rValues[0] = ComputeDensity(rCurrentProcessInfo);
+    }
+    else if (rVariable == MACH)
+    {
+        rValues[0] = PotentialFlowUtilities::ComputeLocalMachNumber<Dim, NumNodes>(*this, rCurrentProcessInfo);
+    }
+    else if (rVariable == SOUND_VELOCITY)
+    {
+        rValues[0] = PotentialFlowUtilities::ComputeLocalSpeedOfSound<Dim, NumNodes>(*this, rCurrentProcessInfo);
+    }
+    else if (rVariable == WAKE)
+    {
+        const CompressiblePerturbationPotentialFlowElement& r_this = *this;
+        rValues[0] = r_this.GetValue(WAKE);
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetValueOnIntegrationPoints(
+    const Variable<int>& rVariable, std::vector<int>& rValues, const ProcessInfo& rCurrentProcessInfo)
+{
+    if (rValues.size() != 1)
+        rValues.resize(1);
+    if (rVariable == TRAILING_EDGE)
+        rValues[0] = this->GetValue(TRAILING_EDGE);
+    else if (rVariable == KUTTA)
+        rValues[0] = this->GetValue(KUTTA);
+    else if (rVariable == WAKE)
+        rValues[0] = this->GetValue(WAKE);
+    else if (rVariable == ZERO_VELOCITY_CONDITION)
+        rValues[0] = this->GetValue(ZERO_VELOCITY_CONDITION);
+    else if (rVariable == TRAILING_EDGE_ELEMENT)
+        rValues[0] = this->GetValue(TRAILING_EDGE_ELEMENT);
+    else if (rVariable == DECOUPLED_TRAILING_EDGE_ELEMENT)
+        rValues[0] = this->GetValue(DECOUPLED_TRAILING_EDGE_ELEMENT);
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetValueOnIntegrationPoints(
+    const Variable<array_1d<double, 3>>& rVariable,
+    std::vector<array_1d<double, 3>>& rValues,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    if (rValues.size() != 1)
+        rValues.resize(1);
+    if (rVariable == VELOCITY)
+    {
+        array_1d<double, 3> v(3, 0.0);
+        array_1d<double, Dim> vaux = PotentialFlowUtilities::ComputeVelocity<Dim, NumNodes>(*this);
+        for (unsigned int k = 0; k < Dim; k++)
+            v[k] = vaux[k];
+        rValues[0] = v;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Input and output
+
+template <int Dim, int NumNodes>
+std::string CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Info() const
+{
+    std::stringstream buffer;
+    buffer << "CompressiblePerturbationPotentialFlowElement #" << Id();
+    return buffer.str();
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::PrintInfo(std::ostream& rOStream) const
+{
+    rOStream << "CompressiblePerturbationPotentialFlowElement #" << Id();
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::PrintData(std::ostream& rOStream) const
+{
+    pGetGeometry()->PrintData(rOStream);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Private functions
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetWakeDistances(
+    array_1d<double, NumNodes>& distances) const
+{
+    noalias(distances) = GetValue(WAKE_ELEMENTAL_DISTANCES);
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetEquationIdVectorNormalElement(
+    EquationIdVectorType& rResult) const
+{
+    for (unsigned int i = 0; i < NumNodes; i++)
+        rResult[i] = GetGeometry()[i].GetDof(VELOCITY_POTENTIAL).EquationId();
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetEquationIdVectorKuttaElement(
+    EquationIdVectorType& rResult) const
+{
+    // Kutta elements have only negative part
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (!GetGeometry()[i].GetValue(TRAILING_EDGE))
+            rResult[i] = GetGeometry()[i].GetDof(VELOCITY_POTENTIAL).EquationId();
+        else
+            rResult[i] = GetGeometry()[i].GetDof(AUXILIARY_VELOCITY_POTENTIAL).EquationId();
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetEquationIdVectorWakeElement(
+    EquationIdVectorType& rResult) const
+{
+    array_1d<double, NumNodes> distances;
+    GetWakeDistances(distances);
+
+    // Positive part
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (distances[i] > 0.0)
+            rResult[i] = GetGeometry()[i].GetDof(VELOCITY_POTENTIAL).EquationId();
+        else
+            rResult[i] =
+                GetGeometry()[i].GetDof(AUXILIARY_VELOCITY_POTENTIAL, 0).EquationId();
+    }
+
+    // Negative part - sign is opposite to the previous case
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (distances[i] < 0.0)
+            rResult[NumNodes + i] =
+                GetGeometry()[i].GetDof(VELOCITY_POTENTIAL).EquationId();
+        else
+            rResult[NumNodes + i] =
+                GetGeometry()[i].GetDof(AUXILIARY_VELOCITY_POTENTIAL).EquationId();
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofListNormalElement(DofsVectorType& rElementalDofList) const
+{
+    for (unsigned int i = 0; i < NumNodes; i++)
+        rElementalDofList[i] = GetGeometry()[i].pGetDof(VELOCITY_POTENTIAL);
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofListKuttaElement(DofsVectorType& rElementalDofList) const
+{
+    // Kutta elements have only negative part
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (!GetGeometry()[i].GetValue(TRAILING_EDGE))
+            rElementalDofList[i] = GetGeometry()[i].pGetDof(VELOCITY_POTENTIAL);
+        else
+            rElementalDofList[i] = GetGeometry()[i].pGetDof(AUXILIARY_VELOCITY_POTENTIAL);
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofListWakeElement(DofsVectorType& rElementalDofList) const
+{
+    array_1d<double, NumNodes> distances;
+    GetWakeDistances(distances);
+
+    // Positive part
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (distances[i] > 0)
+            rElementalDofList[i] = GetGeometry()[i].pGetDof(VELOCITY_POTENTIAL);
+        else
+            rElementalDofList[i] = GetGeometry()[i].pGetDof(AUXILIARY_VELOCITY_POTENTIAL);
+    }
+
+    // Negative part - sign is opposite to the previous case
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (distances[i] < 0)
+            rElementalDofList[NumNodes + i] = GetGeometry()[i].pGetDof(VELOCITY_POTENTIAL);
+        else
+            rElementalDofList[NumNodes + i] =
+                GetGeometry()[i].pGetDof(AUXILIARY_VELOCITY_POTENTIAL);
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocalSystemNormalElement(
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
+{
+    if (rLeftHandSideMatrix.size1() != NumNodes || rLeftHandSideMatrix.size2() != NumNodes)
+        rLeftHandSideMatrix.resize(NumNodes, NumNodes, false);
+    if (rRightHandSideVector.size() != NumNodes)
+        rRightHandSideVector.resize(NumNodes, false);
+    rLeftHandSideMatrix.clear();
+
+    ElementalData<NumNodes, Dim> data;
+
+    // Calculate shape functions
+    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+
+    const double density = ComputeDensity(rCurrentProcessInfo);
+    const double DrhoDu2 = ComputeDensityDerivative(density, rCurrentProcessInfo);
+
+    // Computing local velocity
+    array_1d<double, Dim> v =  PotentialFlowUtilities::ComputeVelocity<Dim, NumNodes> (*this);
+
+    const BoundedVector<double, NumNodes> DNV = prod(data.DN_DX, v);
+
+    noalias(rLeftHandSideMatrix) +=
+        data.vol * density * prod(data.DN_DX, trans(data.DN_DX));
+    noalias(rLeftHandSideMatrix) += data.vol * 2 * DrhoDu2 * outer_prod(DNV, trans(DNV));
+
+    const BoundedMatrix<double, NumNodes, NumNodes> rLaplacianMatrix =
+        data.vol * density * prod(data.DN_DX, trans(data.DN_DX));
+
+    data.potentials= PotentialFlowUtilities::GetPotentialOnNormalElement<Dim, NumNodes>(*this);
+    noalias(rRightHandSideVector) = -prod(rLaplacianMatrix, data.potentials);
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocalSystemWakeElement(
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
+{
+    // Note that the lhs and rhs have double the size
+    if (rLeftHandSideMatrix.size1() != 2 * NumNodes ||
+        rLeftHandSideMatrix.size2() != 2 * NumNodes)
+        rLeftHandSideMatrix.resize(2 * NumNodes, 2 * NumNodes, false);
+    if (rRightHandSideVector.size() != 2 * NumNodes)
+        rRightHandSideVector.resize(2 * NumNodes, false);
+    rLeftHandSideMatrix.clear();
+    rRightHandSideVector.clear();
+
+    MatrixType rLaplacianMatrix = ZeroMatrix(2 * NumNodes, 2 * NumNodes);
+
+    ElementalData<NumNodes, Dim> data;
+
+    // Calculate shape functions
+    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+    GetWakeDistances(data.distances);
+
+    const double density = ComputeDensity(rCurrentProcessInfo);
+    const double DrhoDu2 = ComputeDensityDerivative(density, rCurrentProcessInfo);
+
+    // Computing local velocity
+    array_1d<double, Dim> v = PotentialFlowUtilities::ComputeVelocityUpperWakeElement<Dim, NumNodes>(*this);
+
+    const BoundedVector<double, NumNodes> DNV = prod(data.DN_DX, v);
+
+    const BoundedMatrix<double, NumNodes, NumNodes> laplacian_total =
+        data.vol * density * prod(data.DN_DX, trans(data.DN_DX));
+
+    const BoundedMatrix<double, NumNodes, NumNodes> lhs_total =
+        data.vol * density * prod(data.DN_DX, trans(data.DN_DX)) +
+        data.vol * 2 * DrhoDu2 * outer_prod(DNV, trans(DNV));
+
+    if (this->Is(STRUCTURE))
+    {
+        Matrix lhs_positive = ZeroMatrix(NumNodes, NumNodes);
+        Matrix lhs_negative = ZeroMatrix(NumNodes, NumNodes);
+
+        Matrix laplacian_positive = ZeroMatrix(NumNodes, NumNodes);
+        Matrix laplacian_negative = ZeroMatrix(NumNodes, NumNodes);
+
+        CalculateLocalSystemSubdividedElement(lhs_positive, lhs_negative, laplacian_positive,
+                                              laplacian_negative, rCurrentProcessInfo);
+        AssignLocalSystemSubdividedElement(
+            rLeftHandSideMatrix, lhs_positive, lhs_negative, lhs_total, rLaplacianMatrix,
+            laplacian_positive, laplacian_negative, laplacian_total, data);
+    }
+    else
+    {
+        AssignLocalSystemWakeElement(rLeftHandSideMatrix, lhs_total, data);
+        AssignLocalSystemWakeElement(rLaplacianMatrix, laplacian_total, data);
+    }
+
+    Vector split_element_values(2 * NumNodes);
+    split_element_values = PotentialFlowUtilities::GetPotentialOnWakeElement<Dim, NumNodes>(*this, data.distances);
+    noalias(rRightHandSideVector) = -prod(rLaplacianMatrix, split_element_values);
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocalSystemSubdividedElement(
+    Matrix& lhs_positive,
+    Matrix& lhs_negative,
+    Matrix& laplacian_positive,
+    Matrix& laplacian_negative,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    ElementalData<NumNodes, Dim> data;
+
+    // Calculate shape functions
+    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+
+    GetWakeDistances(data.distances);
+
+    // Subdivide the element
+    constexpr unsigned int nvolumes = 3 * (Dim - 1);
+    BoundedMatrix<double, NumNodes, Dim> Points;
+    array_1d<double, nvolumes> PartitionsSign;
+    BoundedMatrix<double, nvolumes, NumNodes> GPShapeFunctionValues;
+    array_1d<double, nvolumes> Volumes;
+    std::vector<Matrix> GradientsValue(nvolumes);
+    BoundedMatrix<double, nvolumes, 2> NEnriched;
+    for (unsigned int i = 0; i < GradientsValue.size(); ++i)
+        GradientsValue[i].resize(2, Dim, false);
+    for (unsigned int i = 0; i < NumNodes; ++i)
+    {
+        const array_1d<double, 3>& coords = GetGeometry()[i].Coordinates();
+        for (unsigned int k = 0; k < Dim; ++k)
+        {
+            Points(i, k) = coords[k];
+        }
+    }
+
+    const unsigned int nsubdivisions = EnrichmentUtilities::CalculateEnrichedShapeFuncions(
+        Points, data.DN_DX, data.distances, Volumes, GPShapeFunctionValues,
+        PartitionsSign, GradientsValue, NEnriched);
+
+    const double density = ComputeDensity(rCurrentProcessInfo);
+    const double DrhoDu2 = ComputeDensityDerivative(density, rCurrentProcessInfo);
+
+    // Computing local velocity
+    array_1d<double, Dim> v = PotentialFlowUtilities::ComputeVelocityUpperWakeElement<Dim, NumNodes>(*this);
+
+    const BoundedVector<double, NumNodes> DNV = prod(data.DN_DX, v);
+
+    // Compute the lhs and rhs that would correspond to it being divided
+    for (unsigned int i = 0; i < nsubdivisions; ++i)
+    {
+        if (PartitionsSign[i] > 0)
+        {
+            noalias(lhs_positive) +=
+                Volumes[i] * density * prod(data.DN_DX, trans(data.DN_DX));
+            noalias(lhs_positive) +=
+                Volumes[i] * 2 * DrhoDu2 * outer_prod(DNV, trans(DNV));
+
+            noalias(laplacian_positive) +=
+                Volumes[i] * density * prod(data.DN_DX, trans(data.DN_DX));
+        }
+        else
+        {
+            noalias(lhs_negative) +=
+                Volumes[i] * density * prod(data.DN_DX, trans(data.DN_DX));
+            noalias(lhs_negative) +=
+                Volumes[i] * 2 * DrhoDu2 * outer_prod(DNV, trans(DNV));
+
+            noalias(laplacian_negative) +=
+                Volumes[i] * density * prod(data.DN_DX, trans(data.DN_DX));
+        }
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputeLHSGaussPointContribution(
+    const double weight, Matrix& lhs, const ElementalData<NumNodes, Dim>& data) const
+{
+    noalias(lhs) += weight * prod(data.DN_DX, trans(data.DN_DX));
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLocalSystemSubdividedElement(
+    Matrix& rLeftHandSideMatrix,
+    Matrix& lhs_positive,
+    Matrix& lhs_negative,
+    const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+    MatrixType& rLaplacianMatrix,
+    Matrix& laplacian_positive,
+    Matrix& laplacian_negative,
+    const BoundedMatrix<double, NumNodes, NumNodes>& laplacian_total,
+    const ElementalData<NumNodes, Dim>& data) const
+{
+    for (unsigned int i = 0; i < NumNodes; ++i)
+    {
+        // The TE node takes the contribution of the subdivided element and
+        // we do not apply the wake condition on the TE node
+        if (GetGeometry()[i].GetValue(TRAILING_EDGE))
+        {
+            for (unsigned int j = 0; j < NumNodes; ++j)
+            {
+                rLeftHandSideMatrix(i, j) = lhs_positive(i, j);
+                rLeftHandSideMatrix(i + NumNodes, j + NumNodes) = lhs_negative(i, j);
+
+                rLaplacianMatrix(i, j) = laplacian_positive(i, j);
+                rLaplacianMatrix(i + NumNodes, j + NumNodes) = laplacian_negative(i, j);
+            }
+        }
+        else
+        {
+            AssignLocalSystemWakeNode(rLeftHandSideMatrix, lhs_total, data, i);
+            AssignLocalSystemWakeNode(rLaplacianMatrix, laplacian_total, data, i);
+        }
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLocalSystemWakeElement(
+    MatrixType& rLeftHandSideMatrix,
+    const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+    const ElementalData<NumNodes, Dim>& data) const
+{
+    for (unsigned int row = 0; row < NumNodes; ++row)
+        AssignLocalSystemWakeNode(rLeftHandSideMatrix, lhs_total, data, row);
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLocalSystemWakeNode(
+    MatrixType& rLeftHandSideMatrix,
+    const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+    const ElementalData<NumNodes, Dim>& data,
+    unsigned int& row) const
+{
+    // Filling the diagonal blocks (i.e. decoupling upper and lower dofs)
+    for (unsigned int column = 0; column < NumNodes; ++column)
+    {
+        rLeftHandSideMatrix(row, column) = lhs_total(row, column);
+        rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = lhs_total(row, column);
+    }
+
+    // Applying wake condition on the AUXILIARY_VELOCITY_POTENTIAL dofs
+    if (data.distances[row] < 0.0)
+        for (unsigned int column = 0; column < NumNodes; ++column)
+            rLeftHandSideMatrix(row, column + NumNodes) = -lhs_total(row, column); // Side 1
+    else if (data.distances[row] > 0.0)
+        for (unsigned int column = 0; column < NumNodes; ++column)
+            rLeftHandSideMatrix(row + NumNodes, column) = -lhs_total(row, column); // Side 2
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo)
+{
+    const array_1d<double, 3>& vinfinity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
+    const double vinfinity_norm = sqrt(inner_prod(vinfinity, vinfinity));
+
+    array_1d<double, NumNodes> distances;
+    GetWakeDistances(distances);
+
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        double aux_potential =
+            GetGeometry()[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
+        double potential = GetGeometry()[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
+        double potential_jump = aux_potential - potential;
+
+        if (distances[i] > 0)
+        {
+            GetGeometry()[i].SetValue(POTENTIAL_JUMP,
+                                      -2.0 / vinfinity_norm * (potential_jump));
+        }
+        else
+        {
+            GetGeometry()[i].SetValue(POTENTIAL_JUMP, 2.0 / vinfinity_norm * (potential_jump));
+        }
+    }
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputeElementInternalEnergy()
+{
+    array_1d<double, Dim> velocity = PotentialFlowUtilities::ComputeVelocity<Dim, NumNodes>(*this);
+
+    double internal_energy = 0.5 * inner_prod(velocity, velocity);
+    this->SetValue(INTERNAL_ENERGY, std::abs(internal_energy));
+}
+
+template <int Dim, int NumNodes>
+double CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputeDensity(const ProcessInfo& rCurrentProcessInfo) const
+{
+    // Reading free stream conditions
+    const double rho_inf = rCurrentProcessInfo[FREE_STREAM_DENSITY];
+    const double M_inf = rCurrentProcessInfo[FREE_STREAM_MACH];
+    const double heat_capacity_ratio = rCurrentProcessInfo[HEAT_CAPACITY_RATIO];
+    const double mach_number_limit = rCurrentProcessInfo[MACH_LIMIT];
+
+    // Computing local mach number
+    double local_mach_number = PotentialFlowUtilities::ComputeLocalMachNumber<Dim, NumNodes>(*this, rCurrentProcessInfo);
+
+    if (local_mach_number > mach_number_limit)
+    { // Clamping the mach number to mach_number_limit
+        KRATOS_WARNING("ComputeDensity") << "Clamping the local mach number to " << mach_number_limit << std::endl;
+        local_mach_number = mach_number_limit;
+    }
+
+    // Computing squares
+    const double M_inf_2 = M_inf * M_inf;
+    const double M_2 = local_mach_number * local_mach_number;
+
+    // Computing density according to Equation 8.9 of Drela, M. (2014) Flight Vehicle
+    // Aerodynamics, The MIT Press, London
+    const double numerator = 1 + (heat_capacity_ratio - 1) * M_inf_2 / 2;
+    const double denominator = 1 + (heat_capacity_ratio - 1) * M_2 / 2;
+    const double base = numerator / denominator;
+
+    if (base > 0.0)
+    {
+        return rho_inf * pow(base, 1 / (heat_capacity_ratio - 1));
+    }
+    else
+    {
+        KRATOS_WARNING("ComputeDensity") << "Using density correction" << std::endl;
+        return rho_inf * 0.00001;
+    }
+}
+
+template <int Dim, int NumNodes>
+double CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputeDensityDerivative(
+    const double rho, const ProcessInfo& rCurrentProcessInfo) const
+{
+    // Reading free stream conditions
+    const double rho_inf = rCurrentProcessInfo[FREE_STREAM_DENSITY];
+    const double heat_capacity_ratio = rCurrentProcessInfo[HEAT_CAPACITY_RATIO];
+    const double a_inf = rCurrentProcessInfo[SOUND_VELOCITY];
+
+    return -pow(rho_inf, heat_capacity_ratio - 1) *
+           pow(rho, 2 - heat_capacity_ratio) / (2 * a_inf * a_inf);
+}
+
+// serializer
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::save(Serializer& rSerializer) const
+{
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
+}
+
+template <int Dim, int NumNodes>
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::load(Serializer& rSerializer)
+{
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Template class instantiation
+
+template class CompressiblePerturbationPotentialFlowElement<2, 3>;
+template class CompressiblePerturbationPotentialFlowElement<3, 4>;
+
+} // namespace Kratos

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
@@ -1,0 +1,315 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Inigo Lopez, Marc Nuñez and Riccardo Rossi
+//
+
+#if !defined(KRATOS_COMPRESSIBLE_PERTURBATION_POTENTIAL_FLOW_ELEMENT_H)
+#define KRATOS_COMPRESSIBLE_PERTURBATION_POTENTIAL_FLOW_ELEMENT_H
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/element.h"
+#include "includes/kratos_flags.h"
+#include "utilities/geometry_utilities.h"
+#include "utilities/enrichment_utilities.h"
+namespace Kratos
+{
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+template <int Dim, int NumNodes>
+class CompressiblePerturbationPotentialFlowElement : public Element
+{
+public:
+    template <unsigned int TNumNodes, unsigned int TDim>
+    struct ElementalData
+    {
+        array_1d<double, TNumNodes> potentials, distances;
+        double vol;
+
+        BoundedMatrix<double, TNumNodes, TDim> DN_DX;
+        array_1d<double, TNumNodes> N;
+    };
+
+    ///@name Type Definitions
+    ///@{
+
+    typedef Element BaseType;
+    static constexpr int TNumNodes = NumNodes;
+    static constexpr int TDim = Dim;
+
+    ///@}
+    ///@name Pointer Definitions
+    /// Pointer definition of CompressiblePerturbationPotentialFlowElement
+    KRATOS_CLASS_POINTER_DEFINITION(CompressiblePerturbationPotentialFlowElement);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    // Constructors.
+
+    /// Default constuctor.
+    /**
+     * @param NewId Index number of the new element (optional)
+     */
+    explicit CompressiblePerturbationPotentialFlowElement(IndexType NewId = 0)
+    {
+    }
+
+    /**
+     * Constructor using an array of nodes
+     */
+    CompressiblePerturbationPotentialFlowElement(IndexType NewId, const NodesArrayType& ThisNodes)
+        : Element(NewId, ThisNodes)
+    {
+    }
+
+    /**
+     * Constructor using Geometry
+     */
+    CompressiblePerturbationPotentialFlowElement(IndexType NewId, GeometryType::Pointer pGeometry)
+        : Element(NewId, pGeometry)
+    {
+    }
+
+    /**
+     * Constructor using Properties
+     */
+    CompressiblePerturbationPotentialFlowElement(IndexType NewId,
+                                     GeometryType::Pointer pGeometry,
+                                     PropertiesType::Pointer pProperties)
+        : Element(NewId, pGeometry, pProperties)
+    {
+    }
+
+    /**
+     * Copy Constructor
+     */
+    CompressiblePerturbationPotentialFlowElement(CompressiblePerturbationPotentialFlowElement const& rOther) = delete;
+
+    /**
+     * Move Constructor
+     */
+    CompressiblePerturbationPotentialFlowElement(CompressiblePerturbationPotentialFlowElement&& rOther) = delete;
+
+    /**
+     * Destructor
+     */
+    ~CompressiblePerturbationPotentialFlowElement() override
+    {
+    }
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Assignment operator.
+    CompressiblePerturbationPotentialFlowElement& operator=(CompressiblePerturbationPotentialFlowElement const& rOther) = delete;
+
+    /// Move operator.
+    CompressiblePerturbationPotentialFlowElement& operator=(CompressiblePerturbationPotentialFlowElement&& rOther) = delete;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    Element::Pointer Create(IndexType NewId,
+                            NodesArrayType const& ThisNodes,
+                            PropertiesType::Pointer pProperties) const override;
+
+    Element::Pointer Create(IndexType NewId,
+                            GeometryType::Pointer pGeom,
+                            PropertiesType::Pointer pProperties) const override;
+
+    Element::Pointer Clone(IndexType NewId, NodesArrayType const& ThisNodes) const override;
+
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+                              VectorType& rRightHandSideVector,
+                              ProcessInfo& rCurrentProcessInfo) override;
+
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                ProcessInfo& rCurrentProcessInfo) override;
+
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                               ProcessInfo& rCurrentProcessInfo) override;
+
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo) override;
+
+    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+
+    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+                                     std::vector<double>& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
+
+    void GetValueOnIntegrationPoints(const Variable<int>& rVariable,
+                                     std::vector<int>& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
+
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
+                                     std::vector<array_1d<double, 3>>& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override;
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override;
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override;
+
+    ///@}
+protected:
+
+    double ComputeDensity(const ProcessInfo& rCurrentProcessInfo) const;
+
+    double ComputeDensityDerivative(const double density,
+                                    const ProcessInfo& rCurrentProcessInfo) const;
+
+private:
+    ///@name Private Operators
+    ///@{
+
+    void GetWakeDistances(array_1d<double, NumNodes>& distances) const;
+
+    void GetEquationIdVectorNormalElement(EquationIdVectorType& rResult) const;
+
+    void GetEquationIdVectorKuttaElement(EquationIdVectorType& rResult) const;
+
+    void GetEquationIdVectorWakeElement(EquationIdVectorType& rResult) const;
+
+    void GetDofListNormalElement(DofsVectorType& rElementalDofList) const;
+
+    void GetDofListKuttaElement(DofsVectorType& rElementalDofList) const;
+
+    void GetDofListWakeElement(DofsVectorType& rElementalDofList) const;
+
+    void CalculateLocalSystemNormalElement(MatrixType& rLeftHandSideMatrix,
+                                           VectorType& rRightHandSideVector,
+                                           const ProcessInfo& rCurrentProcessInfo);
+
+    void CalculateLocalSystemWakeElement(MatrixType& rLeftHandSideMatrix,
+                                         VectorType& rRightHandSideVector,
+                                         const ProcessInfo& rCurrentProcessInfo);
+
+    void CalculateLocalSystemSubdividedElement(Matrix& lhs_positive,
+                                               Matrix& lhs_negative,
+                                               Matrix& laplacian_positive,
+                                               Matrix& laplacian_negative,
+                                               const ProcessInfo& rCurrentProcessInfo);
+
+    void ComputeLHSGaussPointContribution(const double weight,
+                                          Matrix& lhs,
+                                          const ElementalData<NumNodes, Dim>& data) const;
+
+    void AssignLocalSystemSubdividedElement(
+        Matrix& rLeftHandSideMatrix,
+        Matrix& lhs_positive,
+        Matrix& lhs_negative,
+        const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+        MatrixType& rLaplacianMatrix,
+        Matrix& laplacian_positive,
+        Matrix& laplacian_negative,
+        const BoundedMatrix<double, NumNodes, NumNodes>& laplacian_total,
+        const ElementalData<NumNodes, Dim>& data) const;
+
+    void AssignLocalSystemWakeElement(MatrixType& rLeftHandSideMatrix,
+                                      const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+                                      const ElementalData<NumNodes, Dim>& data) const;
+
+    void AssignLocalSystemWakeNode(MatrixType& rLeftHandSideMatrix,
+                                   const BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+                                   const ElementalData<NumNodes, Dim>& data,
+                                   unsigned int& row) const;
+
+    void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
+
+    void ComputeElementInternalEnergy();
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+    ///@}
+    ///@name Serialization
+    ///@{
+
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override;
+
+    void load(Serializer& rSerializer) override;
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    ///@}
+
+}; // Class CompressiblePerturbationPotentialFlowElement
+
+///@}
+
+///@name Type Definitions
+///@{
+
+///@}
+///@name Input and output
+///@{
+
+///@}
+
+} // namespace Kratos.
+
+#endif // KRATOS_COMPRESSIBLE_PERTURBATION_POTENTIAL_FLOW_ELEMENT_H  defined

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.cpp
@@ -1,0 +1,634 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Inigo Lopez and Riccardo Rossi
+//
+
+#include "incompressible_perturbation_potential_flow_element.h"
+#include "compressible_potential_flow_application_variables.h"
+#include "includes/cfd_variables.h"
+#include "fluid_dynamics_application_variables.h"
+#include "custom_utilities/potential_flow_utilities.h"
+
+namespace Kratos
+{
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Public Operations
+
+template <int Dim, int NumNodes>
+Element::Pointer IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Create(
+    IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const
+{
+    KRATOS_TRY
+    return Kratos::make_intrusive<IncompressiblePerturbationPotentialFlowElement>(
+        NewId, GetGeometry().Create(ThisNodes), pProperties);
+    KRATOS_CATCH("");
+}
+
+template <int Dim, int NumNodes>
+Element::Pointer IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Create(
+    IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const
+{
+    KRATOS_TRY
+    return Kratos::make_intrusive<IncompressiblePerturbationPotentialFlowElement>(
+        NewId, pGeom, pProperties);
+    KRATOS_CATCH("");
+}
+
+template <int Dim, int NumNodes>
+Element::Pointer IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Clone(
+    IndexType NewId, NodesArrayType const& ThisNodes) const
+{
+    KRATOS_TRY
+    return Kratos::make_intrusive<IncompressiblePerturbationPotentialFlowElement>(
+        NewId, GetGeometry().Create(ThisNodes), pGetProperties());
+    KRATOS_CATCH("");
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+{
+    const IncompressiblePerturbationPotentialFlowElement& r_this = *this;
+    const int wake = r_this.GetValue(WAKE);
+
+    if (wake == 0) // Normal element (non-wake) - eventually an embedded
+        CalculateLocalSystemNormalElement(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo);
+    else // Wake element
+        CalculateLocalSystemWakeElement(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo);
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRightHandSide(
+    VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+{
+    // TODO: improve speed
+    Matrix tmp;
+    CalculateLocalSystem(tmp, rRightHandSideVector, rCurrentProcessInfo);
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftHandSide(
+    MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+{
+    // TODO: improve speed
+    VectorType tmp;
+    CalculateLocalSystem(rLeftHandSideMatrix, tmp, rCurrentProcessInfo);
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::EquationIdVector(
+    EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+{
+    const IncompressiblePerturbationPotentialFlowElement& r_this = *this;
+    const int wake = r_this.GetValue(WAKE);
+
+    if (wake == 0) // Normal element
+    {
+        if (rResult.size() != NumNodes)
+            rResult.resize(NumNodes, false);
+
+        const int kutta = r_this.GetValue(KUTTA);
+
+        if (kutta == 0)
+            GetEquationIdVectorNormalElement(rResult);
+        else
+            GetEquationIdVectorKuttaElement(rResult);
+    }
+    else // Wake element
+    {
+        if (rResult.size() != 2 * NumNodes)
+            rResult.resize(2 * NumNodes, false);
+
+        GetEquationIdVectorWakeElement(rResult);
+    }
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofList(DofsVectorType& rElementalDofList,
+                                                                   ProcessInfo& CurrentProcessInfo)
+{
+    const IncompressiblePerturbationPotentialFlowElement& r_this = *this;
+    const int wake = r_this.GetValue(WAKE);
+
+    if (wake == 0) // Normal element
+    {
+        if (rElementalDofList.size() != NumNodes)
+            rElementalDofList.resize(NumNodes);
+
+        const int kutta = r_this.GetValue(KUTTA);
+
+        if (kutta == 0)
+            GetDofListNormalElement(rElementalDofList);
+        else
+            GetDofListKuttaElement(rElementalDofList);
+    }
+    else // wake element
+    {
+        if (rElementalDofList.size() != 2 * NumNodes)
+            rElementalDofList.resize(2 * NumNodes);
+
+        GetDofListWakeElement(rElementalDofList);
+    }
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+{
+    bool active = true;
+    if ((this)->IsDefined(ACTIVE))
+        active = (this)->Is(ACTIVE);
+
+    const IncompressiblePerturbationPotentialFlowElement& r_this = *this;
+    const int wake = r_this.GetValue(WAKE);
+
+    if (wake != 0 && active == true)
+    {
+        ComputePotentialJump(rCurrentProcessInfo);
+    }
+    ComputeElementInternalEnergy();
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Inquiry
+
+template <int Dim, int NumNodes>
+int IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Check(const ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY
+
+    // Generic geometry check
+    int out = Element::Check(rCurrentProcessInfo);
+    if (out != 0)
+    {
+        return out;
+    }
+
+    KRATOS_ERROR_IF(GetGeometry().Area() <= 0.0)
+        << this->Id() << "Area cannot be less than or equal to 0" << std::endl;
+
+    for (unsigned int i = 0; i < this->GetGeometry().size(); i++)
+    {
+        KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY_POTENTIAL,this->GetGeometry()[i]);
+    }
+
+    return out;
+
+    KRATOS_CATCH("");
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetValueOnIntegrationPoints(
+    const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo)
+{
+    if (rValues.size() != 1)
+        rValues.resize(1);
+
+    if (rVariable == PRESSURE_COEFFICIENT)
+    {
+        rValues[0] = PotentialFlowUtilities::ComputeIncompressiblePressureCoefficient<Dim,NumNodes>(*this,rCurrentProcessInfo);
+    }
+    else if (rVariable == DENSITY)
+    {
+        rValues[0] = rCurrentProcessInfo[FREE_STREAM_DENSITY];
+    }
+    else if (rVariable == MACH)
+    {
+        array_1d<double, Dim> velocity = PotentialFlowUtilities::ComputeVelocity<Dim, NumNodes>(*this);
+        const double velocity_module = sqrt(inner_prod(velocity, velocity));
+        rValues[0] = velocity_module / rCurrentProcessInfo[SOUND_VELOCITY];
+    }
+    else if (rVariable == SOUND_VELOCITY)
+    {
+        rValues[0] = rCurrentProcessInfo[SOUND_VELOCITY];
+    }
+    else if (rVariable == WAKE)
+    {
+        const IncompressiblePerturbationPotentialFlowElement& r_this = *this;
+        rValues[0] = r_this.GetValue(WAKE);
+    }
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetValueOnIntegrationPoints(
+    const Variable<int>& rVariable, std::vector<int>& rValues, const ProcessInfo& rCurrentProcessInfo)
+{
+    if (rValues.size() != 1)
+        rValues.resize(1);
+    if (rVariable == TRAILING_EDGE)
+        rValues[0] = this->GetValue(TRAILING_EDGE);
+    else if (rVariable == KUTTA)
+        rValues[0] = this->GetValue(KUTTA);
+    else if (rVariable == WAKE)
+        rValues[0] = this->GetValue(WAKE);
+    else if (rVariable == ZERO_VELOCITY_CONDITION)
+        rValues[0] = this->GetValue(ZERO_VELOCITY_CONDITION);
+    else if (rVariable == TRAILING_EDGE_ELEMENT)
+        rValues[0] = this->GetValue(TRAILING_EDGE_ELEMENT);
+    else if (rVariable == DECOUPLED_TRAILING_EDGE_ELEMENT)
+        rValues[0] = this->GetValue(DECOUPLED_TRAILING_EDGE_ELEMENT);
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetValueOnIntegrationPoints(
+    const Variable<array_1d<double, 3>>& rVariable,
+    std::vector<array_1d<double, 3>>& rValues,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    if (rValues.size() != 1)
+        rValues.resize(1);
+    if (rVariable == VELOCITY)
+    {
+        array_1d<double, 3> v(3, 0.0);
+        array_1d<double, Dim> vaux = PotentialFlowUtilities::ComputeVelocity<Dim,NumNodes>(*this);
+        for (unsigned int k = 0; k < Dim; k++)
+            v[k] = vaux[k];
+        rValues[0] = v;
+    }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Input and output
+
+template <int Dim, int NumNodes>
+std::string IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Info() const
+{
+    std::stringstream buffer;
+    buffer << "IncompressiblePerturbationPotentialFlowElement #" << Id();
+    return buffer.str();
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::PrintInfo(std::ostream& rOStream) const
+{
+    rOStream << "IncompressiblePerturbationPotentialFlowElement #" << Id();
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::PrintData(std::ostream& rOStream) const
+{
+    pGetGeometry()->PrintData(rOStream);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Private functions
+///////////////////////////////////////////////////////////////////////////////////////////////////
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetWakeDistances(array_1d<double, NumNodes>& distances) const
+{
+    noalias(distances) = GetValue(WAKE_ELEMENTAL_DISTANCES);
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetEquationIdVectorNormalElement(EquationIdVectorType& rResult) const
+{
+    for (unsigned int i = 0; i < NumNodes; i++)
+        rResult[i] = GetGeometry()[i].GetDof(VELOCITY_POTENTIAL).EquationId();
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetEquationIdVectorKuttaElement(EquationIdVectorType& rResult) const
+{
+    // Kutta elements have only negative part
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (!GetGeometry()[i].GetValue(TRAILING_EDGE))
+            rResult[i] = GetGeometry()[i].GetDof(VELOCITY_POTENTIAL).EquationId();
+        else
+            rResult[i] = GetGeometry()[i].GetDof(AUXILIARY_VELOCITY_POTENTIAL).EquationId();
+    }
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetEquationIdVectorWakeElement(EquationIdVectorType& rResult) const
+{
+    array_1d<double, NumNodes> distances;
+    GetWakeDistances(distances);
+
+    // Positive part
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (distances[i] > 0.0)
+            rResult[i] = GetGeometry()[i].GetDof(VELOCITY_POTENTIAL).EquationId();
+        else
+            rResult[i] =
+                GetGeometry()[i].GetDof(AUXILIARY_VELOCITY_POTENTIAL, 0).EquationId();
+    }
+
+    // Negative part - sign is opposite to the previous case
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (distances[i] < 0.0)
+            rResult[NumNodes + i] =
+                GetGeometry()[i].GetDof(VELOCITY_POTENTIAL).EquationId();
+        else
+            rResult[NumNodes + i] =
+                GetGeometry()[i].GetDof(AUXILIARY_VELOCITY_POTENTIAL).EquationId();
+    }
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofListNormalElement(DofsVectorType& rElementalDofList) const
+{
+    for (unsigned int i = 0; i < NumNodes; i++)
+        rElementalDofList[i] = GetGeometry()[i].pGetDof(VELOCITY_POTENTIAL);
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofListKuttaElement(DofsVectorType& rElementalDofList) const
+{
+    // Kutta elements have only negative part
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (!GetGeometry()[i].GetValue(TRAILING_EDGE))
+            rElementalDofList[i] = GetGeometry()[i].pGetDof(VELOCITY_POTENTIAL);
+        else
+            rElementalDofList[i] = GetGeometry()[i].pGetDof(AUXILIARY_VELOCITY_POTENTIAL);
+    }
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofListWakeElement(DofsVectorType& rElementalDofList) const
+{
+    array_1d<double, NumNodes> distances;
+    GetWakeDistances(distances);
+
+    // Positive part
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (distances[i] > 0)
+            rElementalDofList[i] = GetGeometry()[i].pGetDof(VELOCITY_POTENTIAL);
+        else
+            rElementalDofList[i] = GetGeometry()[i].pGetDof(AUXILIARY_VELOCITY_POTENTIAL);
+    }
+
+    // Negative part - sign is opposite to the previous case
+    for (unsigned int i = 0; i < NumNodes; i++)
+    {
+        if (distances[i] < 0)
+            rElementalDofList[NumNodes + i] = GetGeometry()[i].pGetDof(VELOCITY_POTENTIAL);
+        else
+            rElementalDofList[NumNodes + i] =
+                GetGeometry()[i].pGetDof(AUXILIARY_VELOCITY_POTENTIAL);
+    }
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocalSystemNormalElement(
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
+{
+    if (rLeftHandSideMatrix.size1() != NumNodes || rLeftHandSideMatrix.size2() != NumNodes)
+        rLeftHandSideMatrix.resize(NumNodes, NumNodes, false);
+    if (rRightHandSideVector.size() != NumNodes)
+        rRightHandSideVector.resize(NumNodes, false);
+    rLeftHandSideMatrix.clear();
+
+    ElementalData<NumNodes, Dim> data;
+
+    // Calculate shape functions
+    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+
+    const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
+
+    noalias(rLeftHandSideMatrix) =
+        data.vol * free_stream_density * prod(data.DN_DX, trans(data.DN_DX));
+
+    data.potentials = PotentialFlowUtilities::GetPotentialOnNormalElement<Dim,NumNodes>(*this);
+    noalias(rRightHandSideVector) = -prod(rLeftHandSideMatrix, data.potentials);
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocalSystemWakeElement(
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
+{
+    // Note that the lhs and rhs have double the size
+    if (rLeftHandSideMatrix.size1() != 2 * NumNodes ||
+        rLeftHandSideMatrix.size2() != 2 * NumNodes)
+        rLeftHandSideMatrix.resize(2 * NumNodes, 2 * NumNodes, false);
+    if (rRightHandSideVector.size() != 2 * NumNodes)
+        rRightHandSideVector.resize(2 * NumNodes, false);
+    rLeftHandSideMatrix.clear();
+    rRightHandSideVector.clear();
+
+    ElementalData<NumNodes, Dim> data;
+
+    // Calculate shape functions
+    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+
+    const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
+
+    GetWakeDistances(data.distances);
+
+    BoundedMatrix<double, NumNodes, NumNodes> lhs_total = ZeroMatrix(NumNodes, NumNodes);
+
+    ComputeLHSGaussPointContribution(data.vol*free_stream_density, lhs_total, data);
+
+    if (this->Is(STRUCTURE))
+    {
+        BoundedMatrix<double, NumNodes, NumNodes> lhs_positive = ZeroMatrix(NumNodes, NumNodes);
+        BoundedMatrix<double, NumNodes, NumNodes> lhs_negative = ZeroMatrix(NumNodes, NumNodes);
+
+        CalculateLocalSystemSubdividedElement(lhs_positive, lhs_negative, rCurrentProcessInfo);
+        AssignLocalSystemSubdividedElement(rLeftHandSideMatrix, lhs_positive,
+                                           lhs_negative, lhs_total, data);
+    }
+    else
+        AssignLocalSystemWakeElement(rLeftHandSideMatrix, lhs_total, data);
+
+    BoundedVector<double, 2*NumNodes> split_element_values;
+    split_element_values = PotentialFlowUtilities::GetPotentialOnWakeElement<Dim, NumNodes>(*this, data.distances);
+    noalias(rRightHandSideVector) = -prod(rLeftHandSideMatrix, split_element_values);
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocalSystemSubdividedElement(
+    BoundedMatrix<double, NumNodes, NumNodes>& lhs_positive,
+    BoundedMatrix<double, NumNodes, NumNodes>& lhs_negative,
+    const ProcessInfo& rCurrentProcessInfo)
+{
+    ElementalData<NumNodes, Dim> data;
+
+    // Calculate shape functions
+    GeometryUtils::CalculateGeometryData(GetGeometry(), data.DN_DX, data.N, data.vol);
+
+    const double free_stream_density = rCurrentProcessInfo[FREE_STREAM_DENSITY];
+
+    GetWakeDistances(data.distances);
+
+    // Subdivide the element
+    constexpr unsigned int nvolumes = 3 * (Dim - 1);
+    BoundedMatrix<double, NumNodes, Dim> Points;
+    array_1d<double, nvolumes> PartitionsSign;
+    BoundedMatrix<double, nvolumes, NumNodes> GPShapeFunctionValues;
+    array_1d<double, nvolumes> Volumes;
+    std::vector<Matrix> GradientsValue(nvolumes);
+    BoundedMatrix<double, nvolumes, 2> NEnriched;
+    for (unsigned int i = 0; i < GradientsValue.size(); ++i)
+        GradientsValue[i].resize(2, Dim, false);
+    for (unsigned int i = 0; i < NumNodes; ++i)
+    {
+        const array_1d<double, 3>& coords = GetGeometry()[i].Coordinates();
+        for (unsigned int k = 0; k < Dim; ++k)
+        {
+            Points(i, k) = coords[k];
+        }
+    }
+
+    const unsigned int nsubdivisions = EnrichmentUtilities::CalculateEnrichedShapeFuncions(
+        Points, data.DN_DX, data.distances, Volumes, GPShapeFunctionValues,
+        PartitionsSign, GradientsValue, NEnriched);
+
+    // Compute the lhs and rhs that would correspond to it being divided
+    for (unsigned int i = 0; i < nsubdivisions; ++i)
+    {
+        if (PartitionsSign[i] > 0)
+            ComputeLHSGaussPointContribution(Volumes[i]*free_stream_density, lhs_positive, data);
+        else
+            ComputeLHSGaussPointContribution(Volumes[i]*free_stream_density, lhs_negative, data);
+    }
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputeLHSGaussPointContribution(
+    const double weight,
+    BoundedMatrix<double, NumNodes, NumNodes>& lhs,
+    const ElementalData<NumNodes, Dim>& data) const
+{
+    noalias(lhs) += weight * prod(data.DN_DX, trans(data.DN_DX));
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLocalSystemSubdividedElement(
+    MatrixType& rLeftHandSideMatrix,
+    BoundedMatrix<double, NumNodes, NumNodes>& lhs_positive,
+    BoundedMatrix<double, NumNodes, NumNodes>& lhs_negative,
+    BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+    const ElementalData<NumNodes, Dim>& data) const
+{
+    for (unsigned int i = 0; i < NumNodes; ++i)
+    {
+        // The TE node takes the contribution of the subdivided element and
+        // we do not apply the wake condition on the TE node
+        if (GetGeometry()[i].GetValue(TRAILING_EDGE))
+        {
+            for (unsigned int j = 0; j < NumNodes; ++j)
+            {
+                rLeftHandSideMatrix(i, j) = lhs_positive(i, j);
+                rLeftHandSideMatrix(i + NumNodes, j + NumNodes) = lhs_negative(i, j);
+            }
+        }
+        else
+            AssignLocalSystemWakeNode(rLeftHandSideMatrix, lhs_total, data, i);
+    }
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLocalSystemWakeElement(
+    MatrixType& rLeftHandSideMatrix,
+    BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+    const ElementalData<NumNodes, Dim>& data) const
+{
+    for (unsigned int row = 0; row < NumNodes; ++row)
+        AssignLocalSystemWakeNode(rLeftHandSideMatrix, lhs_total, data, row);
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::AssignLocalSystemWakeNode(
+    MatrixType& rLeftHandSideMatrix,
+    BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+    const ElementalData<NumNodes, Dim>& data,
+    unsigned int& row) const
+{
+    // Filling the diagonal blocks (i.e. decoupling upper and lower dofs)
+    for (unsigned int column = 0; column < NumNodes; ++column)
+    {
+        rLeftHandSideMatrix(row, column) = lhs_total(row, column);
+        rLeftHandSideMatrix(row + NumNodes, column + NumNodes) = lhs_total(row, column);
+    }
+
+    // Applying wake condition on the AUXILIARY_VELOCITY_POTENTIAL dofs
+    if (data.distances[row] < 0.0)
+        for (unsigned int column = 0; column < NumNodes; ++column)
+            rLeftHandSideMatrix(row, column + NumNodes) = -lhs_total(row, column); // Side 1
+    else if (data.distances[row] > 0.0)
+        for (unsigned int column = 0; column < NumNodes; ++column)
+            rLeftHandSideMatrix(row + NumNodes, column) = -lhs_total(row, column); // Side 2
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo)
+{
+    const array_1d<double, 3> free_stream_velocity = rCurrentProcessInfo[FREE_STREAM_VELOCITY];
+    const double free_stream_velocity_norm = sqrt(inner_prod(free_stream_velocity, free_stream_velocity));
+    const double reference_chord = rCurrentProcessInfo[REFERENCE_CHORD];
+
+    array_1d<double, NumNodes> distances;
+    GetWakeDistances(distances);
+
+    auto r_geometry = GetGeometry();
+    for (unsigned int i = 0; i < NumNodes; i++){
+        double aux_potential = r_geometry[i].FastGetSolutionStepValue(AUXILIARY_VELOCITY_POTENTIAL);
+        double potential = r_geometry[i].FastGetSolutionStepValue(VELOCITY_POTENTIAL);
+        double potential_jump = aux_potential - potential;
+
+        if (distances[i] > 0){
+            r_geometry[i].SetLock();
+            r_geometry[i].SetValue(POTENTIAL_JUMP, - (2.0 * potential_jump) / (free_stream_velocity_norm * reference_chord));
+            r_geometry[i].UnSetLock();
+        }
+        else{
+            r_geometry[i].SetLock();
+            r_geometry[i].SetValue(POTENTIAL_JUMP, (2.0 * potential_jump) / (free_stream_velocity_norm * reference_chord));
+            r_geometry[i].UnSetLock();
+        }
+    }
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::ComputeElementInternalEnergy()
+{
+    double internal_energy = 0.0;
+    array_1d<double, Dim> velocity;
+
+    const IncompressiblePerturbationPotentialFlowElement& r_this = *this;
+    const int wake = r_this.GetValue(WAKE);
+
+    if (wake == 0) // Normal element (non-wake) - eventually an embedded
+        velocity = PotentialFlowUtilities::ComputeVelocityNormalElement<Dim,NumNodes>(*this);
+    else // Wake element
+        velocity = PotentialFlowUtilities::ComputeVelocityUpperWakeElement<Dim,NumNodes>(*this);
+
+    internal_energy = 0.5 * inner_prod(velocity, velocity);
+    this->SetValue(INTERNAL_ENERGY, std::abs(internal_energy));
+}
+
+// serializer
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::save(Serializer& rSerializer) const
+{
+    KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Element);
+}
+
+template <int Dim, int NumNodes>
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::load(Serializer& rSerializer)
+{
+    KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Element);
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+// Template class instantiation
+
+template class IncompressiblePerturbationPotentialFlowElement<2, 3>;
+template class IncompressiblePerturbationPotentialFlowElement<3, 4>;
+
+} // namespace Kratos

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.h
@@ -1,0 +1,247 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Inigo Lopez and Riccardo Rossi
+//
+
+#if !defined(KRATOS_INCOMPRESSIBLE_PERTURBATION_POTENTIAL_FLOW_ELEMENT_H)
+#define KRATOS_INCOMPRESSIBLE_PERTURBATION_POTENTIAL_FLOW_ELEMENT_H
+
+// Project includes
+#include "includes/element.h"
+#include "includes/kratos_flags.h"
+
+#include "utilities/geometry_utilities.h"
+#include "utilities/enrichment_utilities.h"
+
+namespace Kratos
+{
+///@name Kratos Classes
+///@{
+
+template <int Dim, int NumNodes>
+class IncompressiblePerturbationPotentialFlowElement : public Element
+{
+public:
+    template <unsigned int TNumNodes, unsigned int TDim>
+    struct ElementalData
+    {
+        array_1d<double, TNumNodes> potentials, distances;
+        double vol;
+
+        BoundedMatrix<double, TNumNodes, TDim> DN_DX;
+        array_1d<double, TNumNodes> N;
+    };
+    ///@name Type Definitions
+    ///@{
+
+    typedef Element BaseType;
+    static constexpr int TNumNodes = NumNodes;
+    static constexpr int TDim = Dim;
+
+    ///@}
+    ///@name Pointer Definitions
+    /// Pointer definition of IncompressiblePerturbationPotentialFlowElement
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(IncompressiblePerturbationPotentialFlowElement);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    // Constructors.
+
+    /// Default constuctor.
+    /**
+     * @param NewId Index number of the new element (optional)
+     */
+    explicit IncompressiblePerturbationPotentialFlowElement(IndexType NewId = 0){}
+
+    /**
+     * Constructor using an array of nodes
+     */
+    IncompressiblePerturbationPotentialFlowElement(IndexType NewId, const NodesArrayType& ThisNodes)
+        : Element(NewId, ThisNodes){}
+
+    /**
+     * Constructor using Geometry
+     */
+    IncompressiblePerturbationPotentialFlowElement(IndexType NewId, GeometryType::Pointer pGeometry)
+        : Element(NewId, pGeometry){}
+
+    /**
+     * Constructor using Properties
+     */
+    IncompressiblePerturbationPotentialFlowElement(IndexType NewId,
+                                       GeometryType::Pointer pGeometry,
+                                       PropertiesType::Pointer pProperties)
+        : Element(NewId, pGeometry, pProperties){}
+
+    /**
+     * Copy Constructor
+     */
+    IncompressiblePerturbationPotentialFlowElement(IncompressiblePerturbationPotentialFlowElement const& rOther) = delete;
+
+    /**
+     * Move Constructor
+     */
+    IncompressiblePerturbationPotentialFlowElement(IncompressiblePerturbationPotentialFlowElement&& rOther) = delete;
+
+    /**
+     * Destructor
+     */
+    ~IncompressiblePerturbationPotentialFlowElement() override{}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Assignment operator.
+    IncompressiblePerturbationPotentialFlowElement& operator=(IncompressiblePerturbationPotentialFlowElement const& rOther) = delete;
+
+    /// Move operator.
+    IncompressiblePerturbationPotentialFlowElement& operator=(IncompressiblePerturbationPotentialFlowElement&& rOther) = delete;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    Element::Pointer Create(IndexType NewId,
+                            NodesArrayType const& ThisNodes,
+                            PropertiesType::Pointer pProperties) const override;
+
+    Element::Pointer Create(IndexType NewId,
+                            GeometryType::Pointer pGeom,
+                            PropertiesType::Pointer pProperties) const override;
+
+    Element::Pointer Clone(IndexType NewId, NodesArrayType const& ThisNodes) const override;
+
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
+                              VectorType& rRightHandSideVector,
+                              ProcessInfo& rCurrentProcessInfo) override;
+
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,
+                                ProcessInfo& rCurrentProcessInfo) override;
+
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
+                                ProcessInfo& rCurrentProcessInfo) override;
+
+    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo) override;
+
+    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+
+    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+
+    ///@}
+    ///@name Access
+    ///@{
+
+    void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
+                                     std::vector<double>& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
+
+    void GetValueOnIntegrationPoints(const Variable<int>& rVariable,
+                                     std::vector<int>& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
+
+    void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3>>& rVariable,
+                                     std::vector<array_1d<double, 3>>& rValues,
+                                     const ProcessInfo& rCurrentProcessInfo) override;
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override;
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override;
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override;
+
+    ///@}
+
+private:
+    ///@name Private Operators
+    ///@{
+
+    void GetWakeDistances(array_1d<double, NumNodes>& distances) const;
+
+    void GetEquationIdVectorNormalElement(EquationIdVectorType& rResult) const;
+
+    void GetEquationIdVectorKuttaElement(EquationIdVectorType& rResult) const;
+
+    void GetEquationIdVectorWakeElement(EquationIdVectorType& rResult) const;
+
+    void GetDofListNormalElement(DofsVectorType& rElementalDofList) const;
+
+    void GetDofListKuttaElement(DofsVectorType& rElementalDofList) const;
+
+    void GetDofListWakeElement(DofsVectorType& rElementalDofList) const;
+
+    void CalculateLocalSystemNormalElement(MatrixType& rLeftHandSideMatrix,
+                                           VectorType& rRightHandSideVector,
+                                           const ProcessInfo& rCurrentProcessInfo);
+
+    void CalculateLocalSystemWakeElement(MatrixType& rLeftHandSideMatrix,
+                                         VectorType& rRightHandSideVector,
+                                         const ProcessInfo& rCurrentProcessInfo);
+
+    void CalculateLocalSystemSubdividedElement(BoundedMatrix<double, NumNodes, NumNodes>& lhs_positive,
+                                               BoundedMatrix<double, NumNodes, NumNodes>& lhs_negative,
+                                               const ProcessInfo& rCurrentProcessInfo);
+
+    void ComputeLHSGaussPointContribution(const double weight,
+                                          BoundedMatrix<double, NumNodes, NumNodes>& lhs,
+                                          const ElementalData<NumNodes, Dim>& data) const;
+
+    void AssignLocalSystemSubdividedElement(MatrixType& rLeftHandSideMatrix,
+                                            BoundedMatrix<double, NumNodes, NumNodes>& lhs_positive,
+                                            BoundedMatrix<double, NumNodes, NumNodes>& lhs_negative,
+                                            BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+                                            const ElementalData<NumNodes, Dim>& data) const;
+
+    void AssignLocalSystemWakeElement(MatrixType& rLeftHandSideMatrix,
+                                      BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+                                      const ElementalData<NumNodes, Dim>& data) const;
+
+    void AssignLocalSystemWakeNode(MatrixType& rLeftHandSideMatrix,
+                                   BoundedMatrix<double, NumNodes, NumNodes>& lhs_total,
+                                   const ElementalData<NumNodes, Dim>& data,
+                                   unsigned int& row) const;
+
+    void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
+
+    void ComputeElementInternalEnergy();
+
+    ///@}
+    ///@name Serialization
+    ///@{
+
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override;
+
+    void load(Serializer& rSerializer) override;
+
+    ///@}
+
+}; // Class IncompressiblePerturbationPotentialFlowElement
+
+///@}
+} // namespace Kratos.
+
+#endif // KRATOS_INCOMPRESSIBLE_PERTURBATION_POTENTIAL_FLOW_ELEMENT_H  defined

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -23,6 +23,10 @@ class PotentialFlowFormulation(object):
                 self._SetUpEmbeddedIncompressibleElement(formulation_settings)
             elif element_type == "embedded_compressible":
                 self._SetUpEmbeddedCompressibleElement(formulation_settings)
+            elif element_type == "perturbation_incompressible":
+                self._SetUpIncompressiblePerturbationElement(formulation_settings)
+            elif element_type == "perturbation_compressible":
+                self._SetUpCompressiblePerturbationElement(formulation_settings)
         else:
             raise RuntimeError("Argument \'element_type\' not found in formulation settings.")
 
@@ -46,6 +50,24 @@ class PotentialFlowFormulation(object):
         formulation_settings.ValidateAndAssignDefaults(default_settings)
 
         self.element_name = "CompressiblePotentialFlowElement"
+        self.condition_name = "PotentialWallCondition"
+
+    def _SetUpIncompressiblePerturbationElement(self, formulation_settings):
+        default_settings = KratosMultiphysics.Parameters(r"""{
+            "element_type": "perturbation_incompressible"
+        }""")
+        formulation_settings.ValidateAndAssignDefaults(default_settings)
+
+        self.element_name = "IncompressiblePerturbationPotentialFlowElement"
+        self.condition_name = "PotentialWallCondition"
+
+    def _SetUpCompressiblePerturbationElement(self, formulation_settings):
+        default_settings = KratosMultiphysics.Parameters(r"""{
+            "element_type": "perturbation_compressible"
+        }""")
+        formulation_settings.ValidateAndAssignDefaults(default_settings)
+
+        self.element_name = "CompressiblePerturbationPotentialFlowElement"
         self.condition_name = "PotentialWallCondition"
 
     def _SetUpEmbeddedIncompressibleElement(self, formulation_settings):


### PR DESCRIPTION
This is the first PR of three, to add the perturbation potential flow elements (introduced in https://github.com/KratosMultiphysics/Kratos/pull/6440).

This PR has no major changes, the elements are defined identically to the current incompressible and compressible implementations.

The required modifications to use the perturbation potential will be done in the next PR.