### PR TITLE
[Core] Add MatrixMarket output for complex matrices and vectors

### DIFF
--- a/kratos/includes/matrix_market_interface.h
+++ b/kratos/includes/matrix_market_interface.h
@@ -258,6 +258,26 @@ template <typename CompressedMatrixType> inline bool ReadMatrixMarketMatrix(cons
     return true;
 }
 
+inline void SetMatrixMarketValueTypeCode(MM_typecode& mm_code, const double& value)
+{
+    mm_set_real(&mm_code);
+}
+
+inline void SetMatrixMarketValueTypeCode(MM_typecode& mm_code, const std::complex<double>& value)
+{
+    mm_set_complex(&mm_code);
+}
+
+inline int WriteMatrixMarketMatrixEntry(FILE *f, int I, int J, const double& entry)
+{
+    return fprintf(f, "%d %d %.12e\n", I, J, entry);
+}
+
+inline int WriteMatrixMarketMatrixEntry(FILE *f, int I, int J, const std::complex<double>& entry)
+{
+    return fprintf(f, "%d %d %.12e %.12e\n", I, J, std::real(entry), std::imag(entry));
+}
+
 template <typename CompressedMatrixType> inline bool WriteMatrixMarketMatrix(const char *FileName, CompressedMatrixType &M, bool Symmetric)
 {
     // Open MM file for writing
@@ -276,7 +296,7 @@ template <typename CompressedMatrixType> inline bool WriteMatrixMarketMatrix(con
 
     mm_set_matrix(&mm_code);
     mm_set_coordinate(&mm_code);
-    mm_set_real(&mm_code);
+    SetMatrixMarketValueTypeCode(mm_code, *M.begin1().begin());
 
     if (Symmetric)
         mm_set_symmetric(&mm_code);
@@ -330,7 +350,7 @@ template <typename CompressedMatrixType> inline bool WriteMatrixMarketMatrix(con
                 int I = a_iterator.index1(), J = row_iterator.index2();
 
                 if (I >= J)
-                    if (fprintf(f, "%d %d %g\n", I + 1, J + 1, *row_iterator) < 0)
+                    if (WriteMatrixMarketMatrixEntry(f, I+1, J+1, *row_iterator) < 0)
                     {
                         printf("WriteMatrixMarketMatrix(): unable to write data.\n");
                         fclose(f);
@@ -355,7 +375,7 @@ template <typename CompressedMatrixType> inline bool WriteMatrixMarketMatrix(con
             {
                 int I = a_iterator.index1(), J = row_iterator.index2();
 
-                if (fprintf(f, "%d %d %g\n", I + 1, J + 1, *row_iterator) < 0)
+                if (WriteMatrixMarketMatrixEntry(f, I+1, J+1, *row_iterator) < 0)
                 {
                     printf("WriteMatrixMarketMatrix(): unable to write data.\n");
                     fclose(f);
@@ -455,6 +475,16 @@ template <typename VectorType> inline bool ReadMatrixMarketVector(const char *Fi
     return true;
 }
 
+inline int WriteMatrixMarketVectorEntry(FILE *f, const double& entry)
+{
+    return fprintf(f, "%e\n", entry);
+}
+
+inline int WriteMatrixMarketVectorEntry(FILE *f, const std::complex<double>& entry)
+{
+    return fprintf(f, "%e %e\n", std::real(entry), std::imag(entry));
+}
+
 template <typename VectorType> inline bool WriteMatrixMarketVector(const char *FileName, VectorType &V)
 {
     // Open MM file for writing
@@ -473,7 +503,7 @@ template <typename VectorType> inline bool WriteMatrixMarketVector(const char *F
 
     mm_set_matrix(&mm_code);
     mm_set_array(&mm_code);
-    mm_set_real(&mm_code);
+    SetMatrixMarketValueTypeCode(mm_code, V(0));
 
     mm_write_banner(f, mm_code);
 
@@ -481,7 +511,7 @@ template <typename VectorType> inline bool WriteMatrixMarketVector(const char *F
     mm_write_mtx_array_size(f, V.size(), 1);
 
     for (unsigned int i = 0; i < V.size(); i++)
-        if (fprintf(f, "%g\n", V(i)) < 0)
+        if (WriteMatrixMarketVectorEntry(f, V(i)) < 0)
         {
             printf("WriteMatrixMarketVector(): unable to write data.\n");
             fclose(f);
@@ -496,4 +526,3 @@ template <typename VectorType> inline bool WriteMatrixMarketVector(const char *F
 } // namespace Kratos
 
 #endif // KRATOS_MATRIX_MARKET_INTERFACE_H_INCLUDED  defined
-

--- a/kratos/includes/matrix_market_interface.h
+++ b/kratos/includes/matrix_market_interface.h
@@ -45,10 +45,37 @@ extern "C"
 namespace Kratos
 {
 
+// Type checks
+inline bool IsCorrectType(MM_typecode& mm_code, const double& value)
+{
+    return mm_is_real(mm_code);
+}
+
+inline bool IsCorrectType(MM_typecode& mm_code, const std::complex<double>& value)
+{
+    return mm_is_complex(mm_code);
+}
+
 // Matrix I/O routines
+inline bool ReadMatrixMarketMatrixEntry(FILE *f, int& I, int& J, double& V)
+{
+
+    return fscanf(f, "%d %d %lg", &I, &J, &V) == 3;
+}
+
+inline bool ReadMatrixMarketMatrixEntry(FILE *f, int& I, int& J, std::complex<double>& V)
+{
+    double real;
+    double imag;
+    const int i = fscanf(f, "%d %d %lg %lg", &I, &J, &real, &imag);
+    V = std::complex<double>(real, imag);
+    return i == 4;
+}
 
 template <typename CompressedMatrixType> inline bool ReadMatrixMarketMatrix(const char *FileName, CompressedMatrixType &M)
 {
+    typedef typename CompressedMatrixType::value_type ValueType;
+
     // Open MM file for reading
     FILE *f = fopen(FileName, "r");
 
@@ -76,9 +103,9 @@ template <typename CompressedMatrixType> inline bool ReadMatrixMarketMatrix(cons
     }
 
     // Check for supported types of MM file
-    if (!((mm_is_real(mm_code) || mm_is_integer(mm_code) || mm_is_pattern(mm_code)) && mm_is_coordinate(mm_code) && mm_is_sparse(mm_code)))
+    if (!(mm_is_coordinate(mm_code) && mm_is_sparse(mm_code)))
     {
-        printf("ReadMatrixMarketMatrix(): invalid MatrixMarket type, \"%s\".\n",  mm_typecode_to_str(mm_code));
+        printf("ReadMatrixMarketMatrix(): unspported MatrixMarket type, \"%s\".\n",  mm_typecode_to_str(mm_code));
         fclose(f);
         return false;
     }
@@ -96,7 +123,15 @@ template <typename CompressedMatrixType> inline bool ReadMatrixMarketMatrix(cons
     // Allocate temporary arrays
     int *I = new int[nnz];
     int *J = new int[nnz];
-    double *V = new double[nnz];
+    ValueType *V = new ValueType[nnz];
+
+    // Check if matrix type matches MM file
+    if (!IsCorrectType(mm_code, V[0]))
+    {
+        printf("ReadMatrixMarketMatrix(): MatrixMarket type, \"%s\" does not match provided matrix type.\n",  mm_typecode_to_str(mm_code));
+        fclose(f);
+        return false;
+    }
 
     // Read MM file
 
@@ -126,7 +161,7 @@ template <typename CompressedMatrixType> inline bool ReadMatrixMarketMatrix(cons
     else
         for (int i = 0; i < nnz; i++)
         {
-            if (fscanf(f, "%d %d %lg", &I[i], &J[i], &V[i]) != 3)
+            if (! ReadMatrixMarketMatrixEntry(f, I[i], J[i], V[i]))
             {
                 printf("ReadMatrixMarketMatrix(): invalid data.\n");
                 fclose(f);
@@ -187,7 +222,7 @@ template <typename CompressedMatrixType> inline bool ReadMatrixMarketMatrix(cons
     int *filled = new int[size1];
     int *indices = new int[size1];
     int *columns = new int[nnz2];
-    double *values = new double[nnz2];
+    ValueType *values = new ValueType[nnz2];
 
     indices[0] = 0;
     for (int i = 1; i < size1; i++)
@@ -394,8 +429,24 @@ template <typename CompressedMatrixType> inline bool WriteMatrixMarketMatrix(con
 
 // Vector I/O routines
 
+inline bool ReadMatrixMarketVectorEntry(FILE *f, double& entry)
+{
+    return fscanf(f, "%lg", &entry) == 1;
+}
+
+inline bool ReadMatrixMarketVectorEntry(FILE *f, std::complex<double>& entry)
+{
+    double real;
+    double imag;
+    const int i = fscanf(f, "%lg %lg", &real, &imag);
+    entry = std::complex<double>(real, imag);
+    return i == 2;
+}
+
 template <typename VectorType> inline bool ReadMatrixMarketVector(const char *FileName, VectorType &V)
 {
+    typedef typename VectorType::value_type ValueType;
+    
     // Open MM file for reading
     FILE *f = fopen(FileName, "r");
 
@@ -423,9 +474,9 @@ template <typename VectorType> inline bool ReadMatrixMarketVector(const char *Fi
     }
 
     // Check for supported types of MM file
-    if (!((mm_is_real(mm_code) || mm_is_integer(mm_code)) && mm_is_array(mm_code)))
+    if (!((!mm_is_pattern(mm_code)) && mm_is_array(mm_code)))
     {
-        printf("ReadMatrixMarketVector(): invalid MatrixMarket type, \"%s\".\n",  mm_typecode_to_str(mm_code));
+        printf("ReadMatrixMarketVector(): unsupported MatrixMarket type, \"%s\".\n",  mm_typecode_to_str(mm_code));
         fclose(f);
         return false;
     }
@@ -449,13 +500,21 @@ template <typename VectorType> inline bool ReadMatrixMarketVector(const char *Fi
     }
 
     VectorType *v = new VectorType(size1);
-    double T;
+    ValueType T;
+
+    // Check if vector type matches MM file
+    if (!IsCorrectType(mm_code, T))
+    {
+        printf("ReadMatrixMarketVector(): MatrixMarket type, \"%s\" does not match provided vector type.\n",  mm_typecode_to_str(mm_code));
+        fclose(f);
+        return false;
+    }
 
     // Read MM file
 
     for (int i = 0; i < size1; i++)
     {
-        if (fscanf(f, "%lg", &T) != 1)
+        if (! ReadMatrixMarketVectorEntry(f, T))
         {
             printf("ReadMatrixMarketVector(): invalid data.\n");
             fclose(f);

--- a/kratos/python/add_matrix_market_interface_to_python.cpp
+++ b/kratos/python/add_matrix_market_interface_to_python.cpp
@@ -21,6 +21,7 @@
 #include "includes/define_python.h"
 #include "includes/matrix_market_interface.h"
 #include "includes/ublas_interface.h"
+#include "includes/ublas_complex_interface.h"
 #include "python/add_matrix_market_interface_to_python.h"
 
 namespace Kratos
@@ -34,10 +35,14 @@ void  AddMatrixMarketInterfaceToPython(pybind11::module& m)
     namespace py = pybind11;
 
     m.def("ReadMatrixMarketMatrix", ReadMatrixMarketMatrix <Kratos::CompressedMatrix>);
+    m.def("ReadMatrixMarketMatrix", ReadMatrixMarketMatrix <Kratos::ComplexCompressedMatrix>);
     m.def("WriteMatrixMarketMatrix", WriteMatrixMarketMatrix <Kratos::CompressedMatrix>);
+    m.def("WriteMatrixMarketMatrix", WriteMatrixMarketMatrix <Kratos::ComplexCompressedMatrix>);
 
     m.def("ReadMatrixMarketVector", ReadMatrixMarketVector <Kratos::Vector>);
+    m.def("ReadMatrixMarketVector", ReadMatrixMarketVector <Kratos::ComplexVector>);
     m.def("WriteMatrixMarketVector", WriteMatrixMarketVector <Kratos::Vector>);
+    m.def("WriteMatrixMarketVector", WriteMatrixMarketVector <Kratos::ComplexVector>);
 
 }
 

--- a/kratos/tests/test_KratosCore.py
+++ b/kratos/tests/test_KratosCore.py
@@ -52,6 +52,7 @@ import test_scipy_conversion_tools
 import test_linear_constraints
 import test_cad_json_input
 import test_compare_elements_conditions
+import test_matrix_market_interface
 
 def AssembleTestSuites():
     ''' Populates the test suites to run.
@@ -121,6 +122,7 @@ def AssembleTestSuites():
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_linear_constraints.TestLinearConstraints]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_cad_json_input.TestCadJsonInput]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_compare_elements_conditions.TestCompareElementsAndConditionsUtility]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([test_matrix_market_interface.TestMatrixMarketInterface]))
 
     # Create a test suite with the selected tests plus all small tests
     nightSuite = suites['nightly']

--- a/kratos/tests/test_matrix_market_interface.py
+++ b/kratos/tests/test_matrix_market_interface.py
@@ -1,0 +1,38 @@
+from __future__ import print_function, absolute_import, division
+
+import KratosMultiphysics
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+import KratosMultiphysics.kratos_utilities as kratos_utils
+
+class TestMatrixMarketInterface(KratosUnittest.TestCase):
+
+    def test_mm_matrix_io(self):
+        A = KratosMultiphysics.CompressedMatrix(3,3)
+        A[0,0] = 1.0
+        A[1,1] = 2.0
+        A[2,2] = 3.0
+        A[0,2] = 4.0
+
+        KratosMultiphysics.WriteMatrixMarketMatrix('A.mm', A, False)
+
+        B = KratosMultiphysics.CompressedMatrix()
+        KratosMultiphysics.ReadMatrixMarketMatrix('A.mm', B)
+
+        self.assertMatrixAlmostEqual(A, B)
+        kratos_utils.DeleteFileIfExisting('A.mm')
+
+    def test_mm_vector_io(self):
+        a = KratosMultiphysics.Vector(5,0)
+        a[0] = 1.0
+        a[3] = 5.0
+
+        KratosMultiphysics.WriteMatrixMarketVector('a.mm', a)
+
+        b = KratosMultiphysics.Vector()
+        KratosMultiphysics.ReadMatrixMarketVector('a.mm', b)
+
+        self.assertVectorAlmostEqual(a, b)
+        kratos_utils.DeleteFileIfExisting("a.mm")
+
+if __name__ == '__main__':
+    KratosUnittest.main()

--- a/kratos/tests/test_matrix_market_interface.py
+++ b/kratos/tests/test_matrix_market_interface.py
@@ -34,5 +34,33 @@ class TestMatrixMarketInterface(KratosUnittest.TestCase):
         self.assertVectorAlmostEqual(a, b)
         kratos_utils.DeleteFileIfExisting("a.mm")
 
+    def test_mm_matrix_io_cplx(self):
+        A = KratosMultiphysics.ComplexCompressedMatrix(3,3)
+        A[0,0] = 1.0-1.0j
+        A[1,1] = 2.0+2.0j
+        A[2,2] = 3.0-3.0j
+        A[0,2] = 4.0+4.0j
+
+        KratosMultiphysics.WriteMatrixMarketMatrix('A.mm', A, False)
+
+        B = KratosMultiphysics.ComplexCompressedMatrix()
+        KratosMultiphysics.ReadMatrixMarketMatrix('A.mm', B)
+
+        self.assertMatrixAlmostEqual(A, B)
+        kratos_utils.DeleteFileIfExisting('A.mm')
+
+    def test_mm_vector_io_cplx(self):
+        a = KratosMultiphysics.ComplexVector(5,0)
+        a[0] = 1.0-1.0j
+        a[3] = 5.0+3.0j
+
+        KratosMultiphysics.WriteMatrixMarketVector('a.mm', a)
+
+        b = KratosMultiphysics.ComplexVector()
+        KratosMultiphysics.ReadMatrixMarketVector('a.mm', b)
+        
+        self.assertVectorAlmostEqual(a, b)
+        kratos_utils.DeleteFileIfExisting("a.mm")
+
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
This adds support for complex matrix and vector output to the matrix market interface by overloading the write functions.