### PR TITLE
Adding OpenMP parallelism to RomB&S

### DIFF
--- a/applications/RomApplication/costum_strategies/rom_builder_and_solver.h
+++ b/applications/RomApplication/costum_strategies/rom_builder_and_solver.h
@@ -316,16 +316,18 @@ public:
         //define a dense matrix to hold the reduced problem
         Matrix Arom = ZeroMatrix(mRomDofs, mRomDofs);
         Vector brom = ZeroVector(mRomDofs);
+        
+        // This section projects the Full Order Model unknown onto the space spaned by the basis
+        /**
         TSystemVectorType x(Dx.size());
-
         //find the rom basis
         this->GetDofValues(mDofList, x);
-
         double project_to_reduced_start = OpenMPUtils::GetCurrentTime();
         Vector xrom = ZeroVector(mRomDofs);
-        //this->ProjectToReducedBasis(x, rModelPart.Nodes(),xrom);
+        this->ProjectToReducedBasis(x, rModelPart.Nodes(),xrom);
         const double project_to_reduced_end = OpenMPUtils::GetCurrentTime();
         KRATOS_INFO_IF("ROMBuilderAndSolver", (this->GetEchoLevel() >= 1 && rModelPart.GetCommunicator().MyPID() == 0)) << "Project to reduced basis time: " << project_to_reduced_end - project_to_reduced_start << std::endl;
+        */
 
         //build the system matrix by looping over elements and conditions and assembling to A
         KRATOS_ERROR_IF(!pScheme) << "No scheme provided!" << std::endl;
@@ -443,7 +445,7 @@ public:
         KRATOS_INFO_IF("ROMBuilderAndSolver", (this->GetEchoLevel() > 2 && rModelPart.GetCommunicator().MyPID() == 0)) << "Finished parallel building" << std::endl;
 
         //solve for the rom unkowns dunk = Arom^-1 * brom
-        Vector dxrom(xrom.size());
+        Vector dxrom = ZeroVector(mRomDofs);        
         double start_solve = OpenMPUtils::GetCurrentTime();
         MathUtils<double>::Solve(Arom, dxrom, brom);
         const double stop_solve = OpenMPUtils::GetCurrentTime();
@@ -451,7 +453,7 @@ public:
         KRATOS_INFO_IF("ROMBuilderAndSolver", (this->GetEchoLevel() >= 1 && rModelPart.GetCommunicator().MyPID() == 0)) << "Solve reduced system time: " << stop_solve - start_solve << std::endl;
 
         //update database
-        noalias(xrom) += dxrom;
+        //noalias(xrom) += dxrom;
 
         double project_to_fine_start = OpenMPUtils::GetCurrentTime();
         ProjectToFineBasis(dxrom, rModelPart.Nodes(), Dx);

--- a/applications/RomApplication/costum_strategies/rom_builder_and_solver.h
+++ b/applications/RomApplication/costum_strategies/rom_builder_and_solver.h
@@ -278,9 +278,9 @@ public:
         TSystemVectorType &rX)
     {
         TSparseSpace::SetToZero(rX);
-        auto nodes_begin = rNodes.begin();
-        auto nodes_number = rNodes.size();    
-        #pragma omp parallel for firstprivate(nodes_number)
+        const auto nodes_begin = rNodes.begin();
+        const auto nodes_number = rNodes.size();    
+        #pragma omp parallel for firstprivate(nodes_number, nodes_begin)
         for (int kkk = 0; kkk < nodes_number; kkk++ ){
             auto it = nodes_begin + kkk;
             unsigned int node_aux_id = it->GetValue(AUX_ID);
@@ -380,9 +380,9 @@ public:
                         const Matrix &rom_nodal_basis = geom[i].GetValue(ROM_BASIS);
                         for (unsigned int k = 0; k < rom_nodal_basis.size1(); ++k){
                             if (dofs[i * mNodalDofs + k]->IsFixed())
-                                row(PhiElemental, i * mNodalDofs + k) = ZeroVector(PhiElemental.size2());
+                                noalias(row(PhiElemental, i * mNodalDofs + k)) = ZeroVector(PhiElemental.size2());
                             else
-                                row(PhiElemental, i * mNodalDofs + k) = row(rom_nodal_basis, k);
+                                noalias(row(PhiElemental, i * mNodalDofs + k)) = row(rom_nodal_basis, k);
                         }
                     }
                     Matrix aux = prod(LHS_Contribution, PhiElemental);
@@ -419,9 +419,9 @@ public:
                         const Matrix &rom_nodal_basis = r_geom[i].GetValue(ROM_BASIS);
                         for (unsigned int k = 0; k < rom_nodal_basis.size1(); ++k){
                             if (dofs[i * mNodalDofs + k]->IsFixed())
-                                row(PhiElemental, i * mNodalDofs + k) = ZeroVector(PhiElemental.size2());
+                                noalias(row(PhiElemental, i * mNodalDofs + k)) = ZeroVector(PhiElemental.size2());
                             else
-                                row(PhiElemental, i * mNodalDofs + k) = row(rom_nodal_basis, k);
+                                noalias(row(PhiElemental, i * mNodalDofs + k)) = row(rom_nodal_basis, k);
                         }
                     }
                     Matrix aux = prod(LHS_Contribution, PhiElemental);

--- a/applications/RomApplication/tests/NonlinearTestFiles/ProjectParametersROM.json
+++ b/applications/RomApplication/tests/NonlinearTestFiles/ProjectParametersROM.json
@@ -45,7 +45,7 @@
             "nodal_unknowns": [
                 "TEMPERATURE"
             ],
-            "number_of_rom_dofs": 15
+            "number_of_rom_dofs": 14
         },
         "element_replace_settings": {
             "element_name": "LaplacianElement",


### PR DESCRIPTION
This PR acts on two functions of the RomB&S:

  -BuildAndSolve
  -ProjectToFineBasis

Both of these functions could potentially benefit from parallelism, specially the latter, as the skin in an H-ROM model contains still a relatively large number of Conditions.

When approved, the same implementation is to be added to other scripts which also project some elemental contribution to the reduced space.