### PR TITLE
[BIG WIP] [MPI] Replacing Trilinos with AMGCL

### DIFF
--- a/kratos/mpi/CMakeLists.txt
+++ b/kratos/mpi/CMakeLists.txt
@@ -13,6 +13,7 @@ set( KRATOS_MPI_SOURCES
    utilities/gather_modelpart_utility.cpp
    utilities/mpi_normal_calculation_utilities.cpp;
    utilities/parallel_fill_communicator.cpp
+   factories/mpi_linear_solver_factory.cpp
 )
 
 ## Kratos MPI extension Python interface

--- a/kratos/mpi/factories/mpi_linear_solver_factory.cpp
+++ b/kratos/mpi/factories/mpi_linear_solver_factory.cpp
@@ -1,0 +1,45 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher), based on the work of Jordi Cotela
+//
+
+// Project includes
+#include "mpi/factories/mpi_linear_solver_factory.h"
+
+// Linear solvers
+
+// Those are in the TrilinosApp! => have to be refactored and moved
+// #include "amgcl_mpi_solver.h"
+// #include "amgcl_mpi_schur_complement_solver.h"
+
+
+namespace Kratos {
+
+void RegisterMPILinearSolvers()
+{
+    // typedef AmgclMPISolver<MPISparseSpaceType,
+    //     MPILocalSpaceType > AmgclMPISolverType;
+    // static auto AmgclMPISolverFactory = MPILinearSolverFactory<
+    //     MPISparseSpaceType,
+    //     MPILocalSpaceType,
+    //     AmgclMPISolverType>();
+    // KRATOS_REGISTER_MPI_LINEAR_SOLVER("amgcl", AmgclMPISolverFactory);
+
+    // typedef AmgclMPISchurComplementSolver<MPISparseSpaceType,
+    //     MPILocalSpaceType > AmgclMPISchurComplementSolverType;
+    // static auto AmgclMPISchurComplementSolverFactory = MPILinearSolverFactory<
+    //     MPISparseSpaceType,
+    //     MPILocalSpaceType,
+    //     AmgclMPISchurComplementSolverType>();
+    // KRATOS_REGISTER_MPI_LINEAR_SOLVER("amgcl_schur_complement", AmgclMPISchurComplementSolverFactory);
+}
+
+template class KratosComponents<MPILinearSolverFactoryType>;
+}

--- a/kratos/mpi/factories/mpi_linear_solver_factory.h
+++ b/kratos/mpi/factories/mpi_linear_solver_factory.h
@@ -1,0 +1,111 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher), based on the work of Jordi Cotela
+//
+
+#ifndef KRATOS_MPI_LINEAR_SOLVER_FACTORY_H_INCLUDED
+#define KRATOS_MPI_LINEAR_SOLVER_FACTORY_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+#include "mpi/spaces/amgcl_mpi_space.h"
+#include "factories/linear_solver_factory.h"
+
+
+namespace Kratos
+{
+///@name Kratos Classes
+///@{
+
+/**
+ * @class MPILinearSolverFactory
+ * @ingroup KratosMPICore
+ * @brief Here we add the functions needed for the registration of linear solvers
+ * @details Defines the standard linear solver factory
+ * @author Philipp Bucher
+ * @tparam TSparseSpace The sparse space definition
+ * @tparam TLocalSpace The dense space definition
+ * @tparam TLinearSolverType The linear solver type
+ */
+template <typename TSparseSpace, typename TLocalSpace, typename TLinearSolverType>
+class MPILinearSolverFactory
+    : public LinearSolverFactory<TSparseSpace,TLocalSpace>
+{
+    ///@name Type Definitions
+    ///@{
+
+    /// The definition of the preconditioner
+    typedef LinearSolver<TSparseSpace,TLocalSpace> LinearSolverType;
+
+    ///@}
+protected:
+    ///@name Protected Operators
+    ///@{
+
+    /**
+     * @brief This method is an auxiliar method to create a new solver
+     * @return The pointer to the solver of interest
+     */
+    typename LinearSolverType::Pointer CreateSolver(Kratos::Parameters settings) const override
+    {
+        return typename LinearSolverType::Pointer(new TLinearSolverType(settings));
+    }
+    ///@}
+};
+
+///@}
+
+///@name Type Definitions
+///@{
+
+///@}
+///@name Input and output
+///@{
+
+/// output stream function
+template <typename TSparseSpace, typename TLocalSpace, typename TLinearSolverType>
+inline std::ostream& operator << (std::ostream& rOStream,
+                                  const MPILinearSolverFactory<TSparseSpace,TLocalSpace,TLinearSolverType>& rThis)
+{
+    rOStream << "MPILinearSolverFactory" << std::endl;
+    return rOStream;
+}
+
+///@}
+///@name Input and output
+
+///@}
+
+void RegisterMPILinearSolvers();
+
+typedef amgcl::backend::builtin<double> Backend;
+typedef amgcl::mpi::distributed_matrix<Backend> amgcl_mpi_matrix;
+typedef typename Backend::vector amgcl_mpi_vector;
+
+typedef AmgclMPISpace<amgcl_mpi_matrix, amgcl_mpi_vector> MPISparseSpaceType;
+typedef UblasSpace<double, Matrix, Vector> MPILocalSpaceType;
+
+typedef LinearSolverFactory<MPISparseSpaceType,  MPILocalSpaceType> MPILinearSolverFactoryType;
+
+#ifdef KRATOS_REGISTER_MPI_LINEAR_SOLVER
+#undef KRATOS_REGISTER_MPI_LINEAR_SOLVER
+#endif
+#define KRATOS_REGISTER_MPI_LINEAR_SOLVER(name, reference) ; \
+    KratosComponents<MPILinearSolverFactoryType>::Add(name, reference);
+
+KRATOS_API_EXTERN template class KratosComponents<MPILinearSolverFactoryType>;
+
+}  // namespace Kratos.
+
+#endif // KRATOS_MPI_LINEAR_SOLVER_FACTORY_H_INCLUDED  defined

--- a/kratos/mpi/python/add_mpi_builder_and_solvers_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_builder_and_solvers_to_python.cpp
@@ -1,0 +1,89 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:     Philipp Bucher (https://github.com/philbucher)
+//
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+#include "includes/define_python.h"
+#include "mpi/python/add_mpi_builder_and_solvers_to_python.h"
+
+#include "mpi/spaces/amgcl_mpi_space.h"
+#include "spaces/ublas_space.h"
+
+#include "solving_strategies/builder_and_solvers/builder_and_solver.h"
+#include "linear_solvers/linear_solver.h"
+
+// BuilderAndSolvers
+#include "mpi/solving_strategies/builder_and_solvers/mpi_block_builder_and_solver.h"
+
+
+namespace Kratos {
+namespace Python {
+
+void AddMPIBuilderAndSolversToPython(pybind11::module& m)
+{
+    namespace py = pybind11;
+
+    // Amgcl type definitions
+    typedef amgcl::backend::builtin<double> Backend;
+    typedef amgcl::mpi::distributed_matrix<Backend> amgcl_mpi_matrix;
+    typedef typename Backend::vector amgcl_mpi_vector;
+
+    // Type definitions
+    typedef AmgclMPISpace<amgcl_mpi_matrix, amgcl_mpi_vector> MPISparseSpaceType;
+    typedef UblasSpace<double, Matrix, Vector> MPILocalSpaceType;
+    typedef LinearSolver<MPISparseSpaceType, MPILocalSpaceType > MPILinearSolverType;
+    typedef BuilderAndSolver< MPISparseSpaceType, MPILocalSpaceType, MPILinearSolverType > MPIBuilderAndSolverType;
+
+    // Base BuilderAndSolver
+    py::class_< MPIBuilderAndSolverType, typename MPIBuilderAndSolverType::Pointer >(m, "MPIResidualBasedBuilderAndSolver")
+        .def(py::init<MPILinearSolverType::Pointer> () )
+        .def( "SetCalculateReactionsFlag", &MPIBuilderAndSolverType::SetCalculateReactionsFlag )
+        .def( "GetCalculateReactionsFlag", &MPIBuilderAndSolverType::GetCalculateReactionsFlag )
+        .def( "SetDofSetIsInitializedFlag", &MPIBuilderAndSolverType::SetDofSetIsInitializedFlag )
+        .def( "GetDofSetIsInitializedFlag", &MPIBuilderAndSolverType::GetDofSetIsInitializedFlag )
+        .def( "SetReshapeMatrixFlag", &MPIBuilderAndSolverType::SetReshapeMatrixFlag )
+        .def( "GetReshapeMatrixFlag", &MPIBuilderAndSolverType::GetReshapeMatrixFlag )
+        .def( "GetEquationSystemSize", &MPIBuilderAndSolverType::GetEquationSystemSize )
+        .def( "BuildLHS", &MPIBuilderAndSolverType::BuildLHS )
+        .def( "BuildRHS", &MPIBuilderAndSolverType::BuildRHS )
+        .def( "Build", &MPIBuilderAndSolverType::Build )
+        .def( "SystemSolve", &MPIBuilderAndSolverType::SystemSolve )
+        .def( "BuildAndSolve", &MPIBuilderAndSolverType::BuildAndSolve )
+        .def( "BuildRHSAndSolve", &MPIBuilderAndSolverType::BuildRHSAndSolve )
+        .def( "ApplyDirichletConditions", &MPIBuilderAndSolverType::ApplyDirichletConditions )
+        .def( "SetUpDofSet", &MPIBuilderAndSolverType::SetUpDofSet )
+        .def( "GetDofSet", &MPIBuilderAndSolverType::GetDofSet, py::return_value_policy::reference_internal )
+        .def( "SetUpSystem", &MPIBuilderAndSolverType::SetUpSystem )
+        .def( "ResizeAndInitializeVectors", &MPIBuilderAndSolverType::ResizeAndInitializeVectors )
+        .def( "InitializeSolutionStep", &MPIBuilderAndSolverType::InitializeSolutionStep )
+        .def( "FinalizeSolutionStep", &MPIBuilderAndSolverType::FinalizeSolutionStep )
+        .def( "CalculateReactions", &MPIBuilderAndSolverType::CalculateReactions )
+        .def( "Clear", &MPIBuilderAndSolverType::Clear )
+        .def( "SetEchoLevel", &MPIBuilderAndSolverType::SetEchoLevel )
+        .def( "GetEchoLevel", &MPIBuilderAndSolverType::GetEchoLevel )
+        ;
+
+    // BuilderAndSolvers
+    typedef MPIBlockBuilderAndSolver< MPISparseSpaceType, MPILocalSpaceType, MPILinearSolverType > MPIBlockBuilderAndSolverType;
+    py::class_< MPIBlockBuilderAndSolverType, typename MPIBlockBuilderAndSolverType::Pointer,MPIBuilderAndSolverType >(m, "MPIBlockBuilderAndSolver")
+        .def(py::init<MPILinearSolverType::Pointer> () )
+        .def(py::init<MPILinearSolverType::Pointer, Parameters> () )
+        ;
+}
+
+} // namespace Python.
+} // Namespace Kratos

--- a/kratos/mpi/python/add_mpi_builder_and_solvers_to_python.h
+++ b/kratos/mpi/python/add_mpi_builder_and_solvers_to_python.h
@@ -1,0 +1,32 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:     Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef KRATOS_ADD_MPI_BUILDER_AND_SOLVERS_TO_PYTHON_H_INCLUDED
+#define KRATOS_ADD_MPI_BUILDER_AND_SOLVERS_TO_PYTHON_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+
+namespace Kratos {
+namespace Python {
+
+void AddMPIBuilderAndSolversToPython(pybind11::module& m);
+
+}  // namespace Python.
+}  // namespace Kratos.
+
+#endif // KRATOS_ADD_MPI_BUILDER_AND_SOLVERS_TO_PYTHON_H_INCLUDED defined

--- a/kratos/mpi/python/add_mpi_convergence_criteria_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_convergence_criteria_to_python.cpp
@@ -1,0 +1,81 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:     Philipp Bucher (https://github.com/philbucher)
+//
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+#include "includes/define_python.h"
+#include "mpi/python/add_mpi_convergence_criteria_to_python.h"
+
+#include "mpi/spaces/amgcl_mpi_space.h"
+#include "spaces/ublas_space.h"
+
+#include "solving_strategies/convergencecriterias/convergence_criteria.h"
+
+// ConvergenceCriterias
+#include "solving_strategies/convergencecriterias/residual_criteria.h"
+#include "solving_strategies/convergencecriterias/and_criteria.h"
+#include "solving_strategies/convergencecriterias/or_criteria.h"
+
+
+namespace Kratos {
+namespace Python {
+
+void AddMPIConvergenceCriteriasToPython(pybind11::module& m)
+{
+    namespace py = pybind11;
+
+    // Amgcl type definitions
+    typedef amgcl::backend::builtin<double> Backend;
+    typedef amgcl::mpi::distributed_matrix<Backend> amgcl_mpi_matrix;
+    typedef typename Backend::vector amgcl_mpi_vector;
+
+    // Type definitions
+    typedef AmgclMPISpace<amgcl_mpi_matrix, amgcl_mpi_vector> MPISparseSpaceType;
+    typedef UblasSpace<double, Matrix, Vector> MPILocalSpaceType;
+
+    // Base ConvergenceCriteria
+    typedef ConvergenceCriteria< MPISparseSpaceType, MPILocalSpaceType > MPIConvergenceCriteria;
+
+    typedef typename ConvergenceCriteria< MPISparseSpaceType, MPILocalSpaceType > ::Pointer MPIConvergenceCriteriaPointer;
+
+    py::class_< MPIConvergenceCriteria, MPIConvergenceCriteriaPointer > (m,"MPIConvergenceCriteria")
+        .def(py::init<>())
+        .def("SetActualizeRHSFlag", &ConvergenceCriteria<MPISparseSpaceType, MPILocalSpaceType >::SetActualizeRHSFlag)
+        .def("GetActualizeRHSflag", &ConvergenceCriteria<MPISparseSpaceType, MPILocalSpaceType >::GetActualizeRHSflag)
+        .def("PreCriteria", &ConvergenceCriteria<MPISparseSpaceType, MPILocalSpaceType >::PreCriteria)
+        .def("PostCriteria", &ConvergenceCriteria<MPISparseSpaceType, MPILocalSpaceType >::PostCriteria)
+        .def("Initialize", &ConvergenceCriteria<MPISparseSpaceType, MPILocalSpaceType >::Initialize)
+        .def("InitializeSolutionStep", &ConvergenceCriteria<MPISparseSpaceType, MPILocalSpaceType >::InitializeSolutionStep)
+        .def("FinalizeSolutionStep", &ConvergenceCriteria<MPISparseSpaceType, MPILocalSpaceType >::FinalizeSolutionStep)
+        .def("Check", &ConvergenceCriteria<MPISparseSpaceType, MPILocalSpaceType >::Check)
+        .def("SetEchoLevel", &ConvergenceCriteria<MPISparseSpaceType, MPILocalSpaceType >::SetEchoLevel)
+        ;
+
+    // ConvergenceCriterias
+    py::class_<And_Criteria<MPISparseSpaceType, MPILocalSpaceType >,
+            typename And_Criteria<MPISparseSpaceType, MPILocalSpaceType >::Pointer,
+            MPIConvergenceCriteria>(m,"MPIAndCriteria")
+        .def(py::init<MPIConvergenceCriteriaPointer, MPIConvergenceCriteriaPointer > ());
+
+    py::class_<Or_Criteria<MPISparseSpaceType, MPILocalSpaceType >,
+            typename Or_Criteria<MPISparseSpaceType, MPILocalSpaceType >::Pointer,
+            MPIConvergenceCriteria>(m,"MPIOrCriteria")
+        .def(py::init<MPIConvergenceCriteriaPointer, MPIConvergenceCriteriaPointer > ());
+}
+
+} // namespace Python.
+} // Namespace Kratos

--- a/kratos/mpi/python/add_mpi_convergence_criteria_to_python.h
+++ b/kratos/mpi/python/add_mpi_convergence_criteria_to_python.h
@@ -1,0 +1,32 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:     Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef KRATOS_ADD_MPI_CONVERGENCE_CRITERIAS_TO_PYTHON_H_INCLUDED
+#define KRATOS_ADD_MPI_CONVERGENCE_CRITERIAS_TO_PYTHON_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+
+namespace Kratos {
+namespace Python {
+
+void AddMPIConvergenceCriteriasToPython(pybind11::module& m);
+
+}  // namespace Python.
+}  // namespace Kratos.
+
+#endif // KRATOS_ADD_MPI_CONVERGENCE_CRITERIAS_TO_PYTHON_H_INCLUDED defined

--- a/kratos/mpi/python/add_mpi_schemes_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_schemes_to_python.cpp
@@ -1,0 +1,103 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:     Philipp Bucher (https://github.com/philbucher)
+//
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+#include "includes/define_python.h"
+#include "mpi/python/add_mpi_schemes_to_python.h"
+
+#include "mpi/spaces/amgcl_mpi_space.h"
+#include "spaces/ublas_space.h"
+
+#include "solving_strategies/schemes/scheme.h"
+
+// Schemes
+#include "solving_strategies/schemes/residualbased_incrementalupdate_static_scheme.h"
+#include "solving_strategies/schemes/residual_based_bossak_displacement_scheme.hpp"
+#include "solving_strategies/schemes/residual_based_bdf_displacement_scheme.h"
+#include "solving_strategies/schemes/residual_based_bdf_custom_scheme.h"
+
+
+namespace Kratos {
+namespace Python {
+
+void AddMPISchemesToPython(pybind11::module& m)
+{
+    namespace py = pybind11;
+
+    // Amgcl type definitions
+    typedef amgcl::backend::builtin<double> Backend;
+    typedef amgcl::mpi::distributed_matrix<Backend> amgcl_mpi_matrix;
+    typedef typename Backend::vector amgcl_mpi_vector;
+
+    // Type definitions
+    typedef AmgclMPISpace<amgcl_mpi_matrix, amgcl_mpi_vector> MPISparseSpaceType;
+    typedef UblasSpace<double, Matrix, Vector> MPILocalSpaceType;
+    typedef Scheme< MPISparseSpaceType, MPILocalSpaceType > MPISchemeType;
+
+    // Base Scheme
+    py::class_< MPISchemeType, typename MPISchemeType::Pointer >(m, "MPIScheme")
+        .def(py::init< >() )
+        .def("Initialize", &MPISchemeType::Initialize )
+        .def("SchemeIsInitialized", &MPISchemeType::SchemeIsInitialized )
+        .def("ElementsAreInitialized", &MPISchemeType::ElementsAreInitialized )
+        .def("ConditionsAreInitialized", &MPISchemeType::ConditionsAreInitialized )
+        .def("InitializeElements", &MPISchemeType::InitializeElements )
+        .def("InitializeConditions", &MPISchemeType::InitializeConditions )
+        .def("InitializeSolutionStep", &MPISchemeType::InitializeSolutionStep )
+        .def("FinalizeSolutionStep", &MPISchemeType::FinalizeSolutionStep )
+        .def("InitializeNonLinIteration", &MPISchemeType::InitializeNonLinIteration )
+        .def("FinalizeNonLinIteration", &MPISchemeType::FinalizeNonLinIteration )
+        .def("Predict", &MPISchemeType::Predict )
+        .def("Update", &MPISchemeType::Update )
+        .def("CalculateOutputData", &MPISchemeType::CalculateOutputData )
+        .def("Clean", &MPISchemeType::Clean )
+        .def("Clear", &MPISchemeType::Clear )
+        .def("Check", &MPISchemeType::Check )
+        ;
+
+    // Schemes
+    // there is an issue with the DofUpdater
+    // py::class_<ResidualBasedIncrementalUpdateStaticScheme< MPISparseSpaceType, MPILocalSpaceType>,
+    //     typename ResidualBasedIncrementalUpdateStaticScheme< MPISparseSpaceType, MPILocalSpaceType>::Pointer,
+    //     MPISchemeType >(m,"MPIResidualBasedIncrementalUpdateStaticScheme")
+    //        .def(py::init< >() );
+
+    // py::class_<ResidualBasedBossakDisplacementScheme< MPISparseSpaceType, MPILocalSpaceType>,
+    //     typename ResidualBasedBossakDisplacementScheme< MPISparseSpaceType, MPILocalSpaceType>::Pointer,
+    //     MPISchemeType > (m,"MPIResidualBasedBossakDisplacementScheme")
+    //     .def(py::init<double >())
+    //     ;
+
+    // py::class_<ResidualBasedBDFDisplacementScheme< MPISparseSpaceType, MPILocalSpaceType>,
+    //     typename ResidualBasedBDFDisplacementScheme< MPISparseSpaceType, MPILocalSpaceType>::Pointer,
+    //     MPISchemeType > (m,"MPIResidualBasedBDFDisplacementScheme")
+    //     .def(py::init<  >())
+    //     .def(py::init <const std::size_t>())
+    //     ;
+
+    // py::class_<ResidualBasedBDFCustomScheme< MPISparseSpaceType, MPILocalSpaceType>,
+    //     typename ResidualBasedBDFCustomScheme< MPISparseSpaceType, MPILocalSpaceType>::Pointer,
+    //     MPISchemeType > (m,"MPIResidualBasedBDFCustomScheme")
+    //     .def(py::init<  >())
+    //     .def(py::init <const std::size_t>())
+    //     .def(py::init <const std::size_t, Parameters>())
+    //     ;
+}
+
+} // namespace Python.
+} // Namespace Kratos

--- a/kratos/mpi/python/add_mpi_schemes_to_python.h
+++ b/kratos/mpi/python/add_mpi_schemes_to_python.h
@@ -1,0 +1,32 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:     Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef KRATOS_ADD_MPI_SCHEMES_TO_PYTHON_H_INCLUDED
+#define KRATOS_ADD_MPI_SCHEMES_TO_PYTHON_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+
+namespace Kratos {
+namespace Python {
+
+void AddMPISchemesToPython(pybind11::module& m);
+
+}  // namespace Python.
+}  // namespace Kratos.
+
+#endif // KRATOS_ADD_MPI_SCHEMES_TO_PYTHON_H_INCLUDED defined

--- a/kratos/mpi/python/add_mpi_solving_strategies_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_solving_strategies_to_python.cpp
@@ -1,0 +1,90 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:     Philipp Bucher (https://github.com/philbucher)
+//
+
+// System includes
+
+// External includes
+#include <pybind11/pybind11.h>
+
+// Project includes
+#include "includes/define_python.h"
+#include "mpi/python/add_mpi_solving_strategies_to_python.h"
+
+#include "mpi/spaces/amgcl_mpi_space.h"
+#include "spaces/ublas_space.h"
+
+#include "solving_strategies/builder_and_solvers/builder_and_solver.h"
+#include "solving_strategies/schemes/scheme.h"
+#include "linear_solvers/linear_solver.h"
+
+// SolvingStrategies
+#include "solving_strategies/strategies/residualbased_linear_strategy.h"
+#include "solving_strategies/strategies/residualbased_newton_raphson_strategy.h"
+
+
+namespace Kratos {
+namespace Python {
+
+void AddMPISolvingStrategiesToPython(pybind11::module& m)
+{
+    namespace py = pybind11;
+
+    // Amgcl type definitions
+    typedef amgcl::backend::builtin<double> Backend;
+    typedef amgcl::mpi::distributed_matrix<Backend> amgcl_mpi_matrix;
+    typedef typename Backend::vector amgcl_mpi_vector;
+
+    // Type definitions
+    typedef AmgclMPISpace<amgcl_mpi_matrix, amgcl_mpi_vector> MPISparseSpaceType;
+    typedef UblasSpace<double, Matrix, Vector> MPILocalSpaceType;
+    typedef LinearSolver<MPISparseSpaceType, MPILocalSpaceType > MPILinearSolverType;
+    typedef ConvergenceCriteria< MPISparseSpaceType, MPILocalSpaceType > MPIConvergenceCriteria;
+
+    typedef SolvingStrategy< MPISparseSpaceType, MPILocalSpaceType, MPILinearSolverType > MPIBaseSolvingStrategyType;
+    typedef Scheme< MPISparseSpaceType, MPILocalSpaceType > MPISchemeType;
+    typedef BuilderAndSolver< MPISparseSpaceType, MPILocalSpaceType, MPILinearSolverType > MPIBuilderAndSolverType;
+
+    // Base SolvingStrategy
+    py::class_< MPIBaseSolvingStrategyType, typename MPIBaseSolvingStrategyType::Pointer >(m, "MPISolvingStrategy")
+        .def(py::init< ModelPart&, bool >())
+        .def("Initialize", &MPIBaseSolvingStrategyType::Initialize)
+        .def("Check", &MPIBaseSolvingStrategyType::Check)
+        .def("Clear", &MPIBaseSolvingStrategyType::Clear)
+        .def("InitializeSolutionStep", &MPIBaseSolvingStrategyType::InitializeSolutionStep)
+        .def("Predict", &MPIBaseSolvingStrategyType::Predict)
+        .def("SolveSolutionStep", &MPIBaseSolvingStrategyType::SolveSolutionStep)
+        .def("FinalizeSolutionStep", &MPIBaseSolvingStrategyType::FinalizeSolutionStep)
+        .def("IsConverged", &MPIBaseSolvingStrategyType::IsConverged)
+        .def("SetEchoLevel", &MPIBaseSolvingStrategyType::SetEchoLevel)
+        .def("GetEchoLevel", &MPIBaseSolvingStrategyType::GetEchoLevel)
+        .def("SetRebuildLevel", &MPIBaseSolvingStrategyType::SetRebuildLevel)
+        .def("GetRebuildLevel", &MPIBaseSolvingStrategyType::GetRebuildLevel)
+        .def("SetMoveMeshFlag", &MPIBaseSolvingStrategyType::SetMoveMeshFlag)
+        .def("MoveMeshFlag", &MPIBaseSolvingStrategyType::MoveMeshFlag)
+        .def("MoveMesh", &MPIBaseSolvingStrategyType::MoveMesh)
+        ;
+
+    // SolvingStrategies
+    typedef ResidualBasedLinearStrategy< MPISparseSpaceType, MPILocalSpaceType, MPILinearSolverType> MPILinearStrategy;
+    py::class_< MPILinearStrategy , typename MPILinearStrategy::Pointer, MPIBaseSolvingStrategyType >
+    (m,"MPILinearStrategy")
+        .def(py::init< ModelPart&, MPISchemeType::Pointer, MPILinearSolverType::Pointer, MPIBuilderAndSolverType::Pointer, bool, bool, bool, bool >());
+
+    typedef ResidualBasedNewtonRaphsonStrategy< MPISparseSpaceType, MPILocalSpaceType, MPILinearSolverType> MPINewtonRaphsonStrategy;
+    py::class_< MPINewtonRaphsonStrategy , typename MPINewtonRaphsonStrategy::Pointer, MPIBaseSolvingStrategyType >
+    (m,"MPINewtonRaphsonStrategy")
+        .def(py::init< ModelPart&, MPISchemeType::Pointer, MPILinearSolverType::Pointer, MPIConvergenceCriteria::Pointer, MPIBuilderAndSolverType::Pointer, int, bool, bool, bool >());
+}
+
+} // namespace Python.
+} // Namespace Kratos

--- a/kratos/mpi/python/add_mpi_solving_strategies_to_python.h
+++ b/kratos/mpi/python/add_mpi_solving_strategies_to_python.h
@@ -1,0 +1,32 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:     Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef KRATOS_ADD_MPI_SOLVING_STRATEGIES_TO_PYTHON_H_INCLUDED
+#define KRATOS_ADD_MPI_SOLVING_STRATEGIES_TO_PYTHON_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+
+namespace Kratos {
+namespace Python {
+
+void AddMPISolvingStrategiesToPython(pybind11::module& m);
+
+}  // namespace Python.
+}  // namespace Kratos.
+
+#endif // KRATOS_ADD_MPI_SOLVING_STRATEGIES_TO_PYTHON_H_INCLUDED defined

--- a/kratos/mpi/python/add_mpi_spaces_to_python.cpp
+++ b/kratos/mpi/python/add_mpi_spaces_to_python.cpp
@@ -1,0 +1,48 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:     Philipp Bucher (https://github.com/philbucher)
+//
+
+
+// System includes
+
+
+// External includes
+#include <pybind11/pybind11.h>
+
+
+// Project includes
+#include "includes/define_python.h"
+#include "mpi/python/add_mpi_spaces_to_python.h"
+
+#include "mpi/spaces/amgcl_mpi_space.h"
+
+
+namespace Kratos {
+namespace Python {
+
+void AddMPISpacesToPython(pybind11::module& m)
+{
+    namespace py = pybind11;
+
+    typedef amgcl::backend::builtin<double> Backend;
+    typedef amgcl::mpi::distributed_matrix<Backend> amgcl_mpi_matrix;
+    typedef typename Backend::vector amgcl_mpi_vector;
+
+    typedef AmgclMPISpace<amgcl_mpi_matrix, amgcl_mpi_vector> AmgclMPISparseSpaceType;
+
+    py::class_<AmgclMPISparseSpaceType> (m,"AmgclMPISparseSpace")
+        .def(py::init<>())
+        ;
+}
+
+} // namespace Python.
+} // Namespace Kratos

--- a/kratos/mpi/python/add_mpi_spaces_to_python.h
+++ b/kratos/mpi/python/add_mpi_spaces_to_python.h
@@ -1,0 +1,33 @@
+
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:     Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef KRATOS_ADD_MPI_SPACES_TO_PYTHON_H_INCLUDED
+#define KRATOS_ADD_MPI_SPACES_TO_PYTHON_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define_python.h"
+
+
+namespace Kratos {
+namespace Python {
+
+void AddMPISpacesToPython(pybind11::module& m);
+
+}  // namespace Python.
+}  // namespace Kratos.
+
+#endif // KRATOS_ADD_MPI_SPACES_TO_PYTHON_H_INCLUDED defined

--- a/kratos/mpi/python/kratos_mpi_python.cpp
+++ b/kratos/mpi/python/kratos_mpi_python.cpp
@@ -20,6 +20,11 @@
 #include "add_mpi_communicator_to_python.h"
 #include "add_mpi_data_communicator_to_python.h"
 #include "add_mpi_utilities_to_python.h"
+#include "add_mpi_spaces_to_python.h"
+#include "add_mpi_solving_strategies_to_python.h"
+#include "add_mpi_builder_and_solvers_to_python.h"
+#include "add_mpi_schemes_to_python.h"
+#include "add_mpi_convergence_criteria_to_python.h"
 
 #include "includes/parallel_environment.h"
 
@@ -41,6 +46,11 @@ PYBIND11_MODULE(KratosMPI, m)
     AddMPICommunicatorToPython(m);
     AddMPIDataCommunicatorToPython(m);
     AddMPIUtilitiesToPython(m);
+    AddMPISpacesToPython(m);
+    AddMPISolvingStrategiesToPython(m);
+    AddMPIBuilderAndSolversToPython(m);
+    AddMPISchemesToPython(m);
+    AddMPIConvergenceCriteriasToPython(m);
 }
 
 }

--- a/kratos/mpi/solving_strategies/builder_and_solvers/mpi_block_builder_and_solver.h
+++ b/kratos/mpi/solving_strategies/builder_and_solvers/mpi_block_builder_and_solver.h
@@ -1,0 +1,412 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef KRATOS_MPI_BLOCK_BUILDER_AND_SOLVER_H_INCLUDED
+#define KRATOS_MPI_BLOCK_BUILDER_AND_SOLVER_H_INCLUDED
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "solving_strategies/builder_and_solvers/builder_and_solver.h"
+
+
+namespace Kratos
+{
+
+///@name Kratos Classes
+///@{
+
+/// Short class definition.
+/** Detail class definition.
+*/
+template<class TSparseSpace,
+         class TDenseSpace, //= DenseSpace<double>,
+         class TLinearSolver //= LinearSolver<TSparseSpace,TDenseSpace>
+         >
+class MPIBlockBuilderAndSolver
+    : public BuilderAndSolver< TSparseSpace, TDenseSpace, TLinearSolver >
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of MPIBlockBuilderAndSolver
+    KRATOS_CLASS_POINTER_DEFINITION(MPIBlockBuilderAndSolver);
+
+    /// Definition of the base class
+    typedef BuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver> BaseType;
+
+    // The size_t types
+    typedef std::size_t SizeType;
+    typedef std::size_t IndexType;
+
+    /// Definition of the classes from the base class
+    typedef typename BaseType::TSchemeType TSchemeType;
+    typedef typename BaseType::TSystemMatrixType TSystemMatrixType;
+    typedef typename BaseType::TSystemVectorType TSystemVectorType;
+    typedef typename BaseType::TSystemMatrixPointerType TSystemMatrixPointerType;
+    typedef typename BaseType::TSystemVectorPointerType TSystemVectorPointerType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /**
+     * @brief Default constructor. (with parameters)
+     */
+    explicit MPIBlockBuilderAndSolver(
+        typename TLinearSolver::Pointer pNewLinearSystemSolver,
+        Parameters ThisParameters
+        ) : BaseType(pNewLinearSystemSolver)
+    {
+        // Validate default parameters
+        Parameters default_parameters = Parameters(R"(
+        {
+            "name" : "MPIBlockBuilderAndSolver"
+        })" );
+
+        ThisParameters.ValidateAndAssignDefaults(default_parameters);
+    }
+
+    /**
+     * @brief Default constructor.
+     */
+    explicit MPIBlockBuilderAndSolver(
+        typename TLinearSolver::Pointer pNewLinearSystemSolver)
+        : BaseType(pNewLinearSystemSolver)
+    {
+    }
+
+    /// Destructor.
+    ~MPIBlockBuilderAndSolver() override = default;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /**
+     * @brief Function to perform the build of the RHS. The vector could be sized as the total number
+     * of dofs or as the number of unrestrained ones
+     * @param pScheme The integration scheme considered
+     * @param rModelPart The model part of the problem to solve
+     * @param A The LHS matrix
+     * @param b The RHS vector
+     */
+    void Build(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart,
+        TSystemMatrixType& A,
+        TSystemVectorType& b) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /**
+     * @brief Function to perform the building of the LHS
+     * @details Depending on the implementation choosen the size of the matrix could
+     * be equal to the total number of Dofs or to the number of unrestrained dofs
+     * @param pScheme The integration scheme considered
+     * @param rModelPart The model part of the problem to solve
+     * @param A The LHS matrix
+     */
+    void BuildLHS(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart,
+        TSystemMatrixType& A) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /**
+     * @brief This is a call to the linear system solver
+     * @param A The LHS matrix
+     * @param Dx The Unknowns vector
+     * @param b The RHS vector
+     */
+    void SystemSolve(
+        TSystemMatrixType& A,
+        TSystemVectorType& Dx,
+        TSystemVectorType& b
+    ) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /**
+     * @brief Function to perform the building and solving phase at the same time.
+     * @details It is ideally the fastest and safer function to use when it is possible to solve
+     * just after building
+     * @param pScheme The integration scheme considered
+     * @param rModelPart The model part of the problem to solve
+     * @param A The LHS matrix
+     * @param Dx The Unknowns vector
+     * @param b The RHS vector
+     */
+    void BuildAndSolve(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart,
+        TSystemMatrixType& A,
+        TSystemVectorType& Dx,
+        TSystemVectorType& b) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /**
+     * @brief Corresponds to the previews, but the System's matrix is considered already built and only the RHS is built again
+     * @param pScheme The integration scheme considered
+     * @param rModelPart The model part of the problem to solve
+     * @param A The LHS matrix
+     * @param Dx The Unknowns vector
+     * @param b The RHS vector
+     */
+    void BuildRHSAndSolve(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart,
+        TSystemMatrixType& A,
+        TSystemVectorType& Dx,
+        TSystemVectorType& b) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /**
+     * @brief Function to perform the build of the RHS.
+     * @details The vector could be sized as the total number of dofs or as the number of unrestrained ones
+     * @param pScheme The integration scheme considered
+     * @param rModelPart The model part of the problem to solve
+     */
+    void BuildRHS(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart,
+        TSystemVectorType& b) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /**
+     * @brief Builds the list of the DofSets involved in the problem by "asking" to each element
+     * and condition its Dofs.
+     * @details The list of dofs is stores insde the BuilderAndSolver as it is closely connected to the
+     * way the matrix and RHS are built
+     * @param pScheme The integration scheme considered
+     * @param rModelPart The model part of the problem to solve
+     */
+    void SetUpDofSet(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart
+    ) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /**
+     * @brief Organises the dofset in order to speed up the building phase
+     * @param rModelPart The model part of the problem to solve
+     */
+    void SetUpSystem(
+        ModelPart& rModelPart
+    ) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    //**************************************************************************
+    //**************************************************************************
+
+    void ResizeAndInitializeVectors(
+        typename TSchemeType::Pointer pScheme,
+        TSystemMatrixPointerType& pA,
+        TSystemVectorPointerType& pDx,
+        TSystemVectorPointerType& pb,
+        ModelPart& rModelPart
+    ) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    //**************************************************************************
+    //**************************************************************************
+
+    void InitializeSolutionStep(
+        ModelPart& rModelPart,
+        TSystemMatrixType& rA,
+        TSystemVectorType& rDx,
+        TSystemVectorType& rb) override
+    {
+        KRATOS_TRY
+
+        BaseType::InitializeSolutionStep(rModelPart, rA, rDx, rb);
+
+        // Getting process info
+        const ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
+
+        // Computing constraints
+        // TODO only local constraints
+        const int n_constraints = static_cast<int>(rModelPart.MasterSlaveConstraints().size());
+        auto constraints_begin = rModelPart.MasterSlaveConstraintsBegin();
+        #pragma omp parallel for schedule(guided, 512) firstprivate(n_constraints, constraints_begin)
+        for (int k = 0; k < n_constraints; ++k) {
+            auto it = constraints_begin + k;
+            it->InitializeSolutionStep(r_process_info); // Here each constraint constructs and stores its T and C matrices. Also its equation slave_ids.
+        }
+
+        KRATOS_CATCH("")
+    }
+
+    //**************************************************************************
+    //**************************************************************************
+
+    void FinalizeSolutionStep(
+        ModelPart& rModelPart,
+        TSystemMatrixType& rA,
+        TSystemVectorType& rDx,
+        TSystemVectorType& rb) override
+    {
+        BaseType::FinalizeSolutionStep(rModelPart, rA, rDx, rb);
+
+        // Getting process info
+        const ProcessInfo& r_process_info = rModelPart.GetProcessInfo();
+
+        // Computing constraints
+        // TODO only local constraints
+        const int n_constraints = static_cast<int>(rModelPart.MasterSlaveConstraints().size());
+        const auto constraints_begin = rModelPart.MasterSlaveConstraintsBegin();
+        #pragma omp parallel for schedule(guided, 512) firstprivate(n_constraints, constraints_begin)
+        for (int k = 0; k < n_constraints; ++k) {
+            auto it = constraints_begin + k;
+            it->FinalizeSolutionStep(r_process_info);
+        }
+    }
+
+    //**************************************************************************
+    //**************************************************************************
+
+    void CalculateReactions(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart,
+        TSystemMatrixType& A,
+        TSystemVectorType& Dx,
+        TSystemVectorType& b) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /**
+     * @brief Applies the dirichlet conditions. This operation may be very heavy or completely
+     * unexpensive depending on the implementation choosen and on how the System Matrix is built.
+     * @details For explanation of how it works for a particular implementation the user
+     * should refer to the particular Builder And Solver choosen
+     * @param pScheme The integration scheme considered
+     * @param rModelPart The model part of the problem to solve
+     * @param A The LHS matrix
+     * @param Dx The Unknowns vector
+     * @param b The RHS vector
+     */
+    void ApplyDirichletConditions(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart,
+        TSystemMatrixType& A,
+        TSystemVectorType& Dx,
+        TSystemVectorType& b) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    void ApplyConstraints(
+        typename TSchemeType::Pointer pScheme,
+        ModelPart& rModelPart,
+        TSystemMatrixType& rA,
+        TSystemVectorType& rb) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /**
+     * @brief This function is intended to be called at the end of the solution step to clean up memory storage not needed
+     */
+    void Clear() override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /**
+     * @brief This function is designed to be called once to perform all the checks needed
+     * on the input provided. Checks can be "expensive" as the function is designed
+     * to catch user's errors.
+     * @param rModelPart The model part of the problem to solve
+     * @return 0 all ok
+     */
+    int Check(ModelPart& rModelPart) override
+    {
+        KRATOS_TRY
+
+        return 0;
+        KRATOS_CATCH("");
+    }
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        std::stringstream buffer;
+        buffer << "MPIBlockBuilderAndSolver" ;
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << "MPIBlockBuilderAndSolver";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override {}
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    MPIBlockBuilderAndSolver& operator=(MPIBlockBuilderAndSolver const& rOther){}
+
+    /// Copy constructor.
+    MPIBlockBuilderAndSolver(MPIBlockBuilderAndSolver const& rOther){}
+
+    ///@}
+
+}; // Class MPIBlockBuilderAndSolver
+
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_MPI_BLOCK_BUILDER_AND_SOLVER_H_INCLUDED defined

--- a/kratos/mpi/spaces/amgcl_mpi_space.h
+++ b/kratos/mpi/spaces/amgcl_mpi_space.h
@@ -1,0 +1,274 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+#ifndef KRATOS_AMGCL_MPI_SPACE_H_INCLUDED
+#define KRATOS_AMGCL_MPI_SPACE_H_INCLUDED
+
+// System includes
+
+// External includes
+#include "amgcl/mpi/distributed_matrix.hpp"
+
+// Project includes
+#include "includes/define.h"
+#include "mpi/utilities/amgcl_mpi_dof_updater.h"
+
+
+namespace Kratos
+{
+///@name Kratos Classes
+///@{
+
+/// Short class definition.
+/** Detail class definition.
+*/
+template<class TMatrixType, class TVectorType>
+class AmgclMPISpace
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of AmgclMPISpace
+    KRATOS_CLASS_POINTER_DEFINITION(AmgclMPISpace);
+
+    typedef double DataType;
+
+    typedef TMatrixType MatrixType;
+
+    typedef TVectorType VectorType;
+
+    typedef std::size_t IndexType;
+
+    typedef std::size_t SizeType;
+
+    typedef typename Kratos::shared_ptr< TMatrixType > MatrixPointerType;
+    typedef typename Kratos::shared_ptr< TVectorType > VectorPointerType;
+
+    typedef AmgclMPIDofUpdater< AmgclMPISpace<TMatrixType,TVectorType> > DofUpdaterType;
+    typedef typename DofUpdaterType::UniquePointer DofUpdaterPointerType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    AmgclMPISpace(){}
+
+    /// Destructor.
+    virtual ~AmgclMPISpace(){}
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    static MatrixPointerType CreateEmptyMatrixPointer()
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    static VectorPointerType CreateEmptyVectorPointer()
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /// return size of vector rV
+    static IndexType Size(VectorType const& rV)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /// return number of rows of rM
+    static IndexType Size1(MatrixType const& rM)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /// return number of columns of rM
+    static IndexType Size2(MatrixType const& rM)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /// rY = rX
+    static void Copy(MatrixType const& rX, MatrixType& rY)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /// rY = rX
+    static void Copy(VectorType const& rX, VectorType& rY)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /// rX * rY
+    static double Dot(VectorType& rX, VectorType& rY)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /// ||rX||2
+    static double TwoNorm(VectorType const& rX)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    static void Mult(MatrixType& rA, VectorType& rX, VectorType& rY)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    // rY = rAT * rX
+    static void TransposeMult(MatrixType& rA, VectorType& rX, VectorType& rY)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    static void InplaceMult(VectorType& rX, const double A)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    //checks if a multiplication is needed and tries to do otherwise
+    //ATTENTION it is assumed no aliasing between rX and rY
+    // X = A*y;
+    static void Assign(VectorType& rX, const double A, const VectorType& rY)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    //checks if a multiplication is needed and tries to do otherwise
+    //ATTENTION it is assumed no aliasing between rX and rY
+    // X += A*y;
+    static void UnaliasedAdd(VectorType& rX, const double A, const VectorType& rY)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    // rZ = (A * rX) + (B * rY)
+    static void ScaleAndAdd(const double A, const VectorType& rX, const double B, const VectorType& rY, VectorType& rZ)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    // rY = (A * rX) + (B * rY)
+    static void ScaleAndAdd(const double A, const VectorType& rX, const double B, VectorType& rY)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    static void Clear(MatrixPointerType& pA)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    static void Clear(VectorPointerType& pX)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    template<class TOtherMatrixType>
+    static void SetToZero(TOtherMatrixType& rA)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    static void SetToZero(VectorType& rX)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    static constexpr bool IsDistributed()
+    {
+        return true;
+    }
+
+    //***********************************************************************
+
+    static double GetValue(const VectorType& x, std::size_t I)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+    //***********************************************************************
+
+    static void GatherValues(const VectorType& x, const std::vector<std::size_t>& IndexArray, double* pValues)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    template< class TOtherMatrixType >
+    static bool WriteMatrixMarketMatrix(const char* pFileName, /*const*/ TOtherMatrixType& rM, const bool Symmetric)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    template< class VectorType >
+    static bool WriteMatrixMarketVector(const char* pFileName, const VectorType& rV)
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    static DofUpdaterPointerType CreateDofUpdater()
+    {
+        DofUpdaterType tmp;
+        return tmp.Create();
+    }
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    virtual std::string Info() const
+    {
+std::stringstream buffer;
+    buffer << "AmgclMPISpace" ;
+    return buffer.str();
+    }
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream& rOStream) const {rOStream << "AmgclMPISpace";}
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const {}
+
+    ///@}
+
+private:
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    AmgclMPISpace& operator=(AmgclMPISpace const& rOther) = delete;
+
+    /// Copy constructor.
+    AmgclMPISpace(AmgclMPISpace const& rOther) = delete;
+
+    ///@}
+
+}; // Class AmgclMPISpace
+
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_AMGCL_MPI_SPACE_H_INCLUDED  defined
+
+

--- a/kratos/mpi/tests/sources/test_mpi_block_builder_and_solver.cpp
+++ b/kratos/mpi/tests/sources/test_mpi_block_builder_and_solver.cpp
@@ -1,0 +1,22 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+//
+
+#include "mpi/solving_strategies/builder_and_solvers/mpi_block_builder_and_solver.h"
+
+#include "testing/testing.h"
+
+namespace Kratos {
+namespace Testing {
+
+}
+}

--- a/kratos/mpi/utilities/amgcl_mpi_dof_updater.h
+++ b/kratos/mpi/utilities/amgcl_mpi_dof_updater.h
@@ -1,0 +1,179 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher), based on the work of Jordi Cotela
+//
+
+#ifndef KRATOS_AMGCL_MPI_DOF_UPDATER_H_INCLUDED
+#define KRATOS_AMGCL_MPI_DOF_UPDATER_H_INCLUDED
+
+// Project includes
+#include "includes/define.h"
+#include "includes/model_part.h"
+#include "utilities/dof_updater.h"
+
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/// Utility class to update the values of degree of freedom (Dof) variables after solving the system.
+/** This class encapsulates the operation of updating nodal degrees of freedom after a system solution.
+ *  In pseudo-code, the operation to be performed is
+ *  for each dof: dof.variable += dx[dof.equation_id]
+ *  This operation is a simple loop in shared memory, but requires additional infrastructure in MPI,
+ *  to obtain out-of-process update data. AmgclMPIDofUpdater manages both the update operation and the
+ *  auxiliary infrastructure.
+ */
+template< class TSparseSpace >
+class AmgclMPIDofUpdater : public DofUpdater<TSparseSpace>
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of AmgclMPIDofUpdater
+    KRATOS_CLASS_POINTER_DEFINITION(AmgclMPIDofUpdater);
+
+    using BaseType = DofUpdater<TSparseSpace>;
+    using DofsArrayType = typename BaseType::DofsArrayType;
+    using SystemVectorType = typename BaseType::SystemVectorType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    AmgclMPIDofUpdater():
+        DofUpdater<TSparseSpace>()
+    {}
+
+    /// Deleted copy constructor
+    AmgclMPIDofUpdater(AmgclMPIDofUpdater const& rOther) = delete;
+
+    /// Destructor.
+    ~AmgclMPIDofUpdater() override {}
+
+    /// Deleted assignment operator
+    AmgclMPIDofUpdater& operator=(AmgclMPIDofUpdater const& rOther) = delete;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /// Create a new instance of this class.
+    /** This function is used by the SparseSpace class to create new
+     *  DofUpdater instances of the appropriate type.
+     *  @return a std::unique_pointer to the new instance.
+     *  Note that the pointer is actually a pointer to the base class type.
+     *  @see UblasSpace::CreateDofUpdater(), TrilinosSpace::CreateDofUpdater().
+     */
+    typename BaseType::UniquePointer Create() const override
+    {
+        return Kratos::make_unique<AmgclMPIDofUpdater>();
+    }
+
+    /// Initialize the DofUpdater in preparation for a subsequent UpdateDofs call.
+    /** @param[in] rDofSet The list of degrees of freedom.
+     *  @param[in] rDx The update vector.
+     *  The DofUpdater needs to be initialized only if the dofset changes.
+     *  If the problem does not require creating/destroying nodes or changing the
+     *  mesh graph, it is in general enough to intialize this tool once at the
+     *  begining of the problem.
+     *  If the dofset only changes under certain conditions (for example because
+     *  the domain is remeshed every N iterations), it is enough to call the
+     *  Clear method to let this class know that its auxiliary data has to be re-generated
+     *  and Initialize will be called as part of the next UpdateDofs call.
+     */
+    void Initialize(
+        const DofsArrayType& rDofSet,
+        const SystemVectorType& rDx) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    /// Calculate new values for the problem's degrees of freedom using the update vector rDx.
+    /** For each Dof in rDofSet, this function calculates the updated value for the corresponding
+     *  variable as value += rDx[dof.EquationId()].
+     *  @param[in/out] rDofSet The list of degrees of freedom.
+     *  @param[in] rDx The update vector.
+     *  This method will check if Initialize() was called before and call it if necessary.
+     */
+    void UpdateDofs(
+        DofsArrayType& rDofSet,
+        const SystemVectorType& rDx) override
+    {
+        KRATOS_ERROR << "THIS FUNCTION IS NOT YET IMPLEMENTED!" << std::endl;
+    }
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        std::stringstream buffer;
+        buffer << "AmgclMPIDofUpdater" ;
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << this->Info() << std::endl;
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override
+    {
+        rOStream << this->Info() << std::endl;
+    }
+
+    ///@}
+
+}; // Class AmgclMPIDofUpdater
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+template< class TSparseSpace >
+inline std::istream& operator >> (
+    std::istream& rIStream,
+    AmgclMPIDofUpdater<TSparseSpace>& rThis)
+{
+    return rIStream;
+}
+
+/// output stream function
+template< class TSparseSpace >
+inline std::ostream& operator << (
+    std::ostream& rOStream,
+    const AmgclMPIDofUpdater<TSparseSpace>& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_AMGCL_MPI_DOF_UPDATER_H_INCLUDED  defined

--- a/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
@@ -374,7 +374,7 @@ public:
             for(int i=0; i<static_cast<int>(local_number_of_constraints); ++i)
                  (it_begin+i)->Apply(rProcessInfo);
 
-            //the following is needed since we need to eventually compute time derivatives after applying 
+            //the following is needed since we need to eventually compute time derivatives after applying
             //Master slave relations
             TSparseSpace::SetToZero(rDx);
             this->GetScheme()->Update(BaseType::GetModelPart(), r_dof_set, rA, rDx, rb);
@@ -825,14 +825,14 @@ private:
     virtual void EchoInfo()
     {
         TSystemMatrixType& rA  = *mpA;
-        TSystemVectorType& rDx = *mpDx;
+        // TSystemVectorType& rDx = *mpDx;
         TSystemVectorType& rb  = *mpb;
 
         if (BaseType::GetEchoLevel() == 3) //if it is needed to print the debug info
         {
-            KRATOS_INFO("LHS") << "SystemMatrix = " << rA << std::endl;
-            KRATOS_INFO("Dx")  << "Solution obtained = " << rDx << std::endl;
-            KRATOS_INFO("RHS") << "RHS  = " << rb << std::endl;
+            // KRATOS_INFO("LHS") << "SystemMatrix = " << rA << std::endl;
+            // KRATOS_INFO("Dx")  << "Solution obtained = " << rDx << std::endl;
+            // KRATOS_INFO("RHS") << "RHS  = " << rb << std::endl;
         }
         if (this->GetEchoLevel() == 4) //print to matrix market file
         {

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -1127,19 +1127,19 @@ class ResidualBasedNewtonRaphsonStrategy
     virtual void EchoInfo(const unsigned int IterationNumber)
     {
         TSystemMatrixType& rA  = *mpA;
-        TSystemVectorType& rDx = *mpDx;
+        // TSystemVectorType& rDx = *mpDx;
         TSystemVectorType& rb  = *mpb;
 
         if (this->GetEchoLevel() == 2) //if it is needed to print the debug info
         {
-            KRATOS_INFO("Dx")  << "Solution obtained = " << rDx << std::endl;
-            KRATOS_INFO("RHS") << "RHS  = " << rb << std::endl;
+            // KRATOS_INFO("Dx")  << "Solution obtained = " << rDx << std::endl;
+            // KRATOS_INFO("RHS") << "RHS  = " << rb << std::endl;
         }
         else if (this->GetEchoLevel() == 3) //if it is needed to print the debug info
         {
-            KRATOS_INFO("LHS") << "SystemMatrix = " << rA << std::endl;
-            KRATOS_INFO("Dx")  << "Solution obtained = " << rDx << std::endl;
-            KRATOS_INFO("RHS") << "RHS  = " << rb << std::endl;
+            // KRATOS_INFO("LHS") << "SystemMatrix = " << rA << std::endl;
+            // KRATOS_INFO("Dx")  << "Solution obtained = " << rDx << std::endl;
+            // KRATOS_INFO("RHS") << "RHS  = " << rb << std::endl;
         }
         else if (this->GetEchoLevel() == 4) //print to matrix market file
         {


### PR DESCRIPTION
Right now we use Trilinos for our MPI-capabilities, which is mainly the distributed matrices and the mpi-solvers.
The problem with Trilinos is that is a very large library and not easy to compile, especially on clusters it can be quite tough. Since we anyway only use a small part of it, it would be nice to no longer depend on Trilinos.

In order to replace Trilinos we basically need a different library that offers distributed linear algebra functionalities.
In discussions it came up several times if AMGCL could do this job. This would be very convenient for us since we are already using it.
I thought of making an issue but then it seemed easier to create the framework of files that is needed right away, this way it is easier to see what we actually need from AMGCL.

@ddemidov when you have time it would be nice to take a look at this, I guess we will need your assistance here. First if what we are thinking of is possible with AMGCL and second how to do things in a smart way.

Here is a rough list of **functionalities that we need from the Kratos point of view** (basically everything would go into the MPI-Core):
- A `BuilderAndSolver` that is built around the AMGCL distributed matrix
- An `AmgclMPISpace` which wraps certain things like getting the size of matrices
- An `AmgclMPIDofUpdater` for the `Scheme`s. @RiccardoRossi I think you said that this could be done with `GlobalPointer`s right?
- Exposure of the already existing Schemes, Strategies etc with the `AmgclMPISpace`. I did most of this already since I wanted to see what functions we need in the `AmgclMPISpace`.
- Exposure of the MPI-linear solvers through the MPI-Core. This needs a bit of refactor, not sure how the Trilinos solvers would word without Epetra. However from what I saw in AMGCL I think this can be made working. In the meantime we would already have the AmgclMPI-Solver which has a very good performance.

Here is a rough list of **functionalities that we need from the AMGCL**:
- Creating the Matrix Graph and filling it later in the FE assembly with values.
- The functionalities that are in the `AmgclMPISpace`
- Solving the system of equations, but this is ofc already there (needs some refactor though)

I checked the [distributed matrix of AMGCL](https://github.com/ddemidov/amgcl/blob/master/amgcl/mpi/distributed_matrix.hpp) and I think it does not have all those functionalities yet, but I am not sure.
Also I couldn't find the distributed-vector, but I guess it exists (?). At least I think I found sth based on the builtin-backend

@ddemidov @KratosMultiphysics/technical-committee what are your thoughts/opinion on this? Is it realistic / does it make sense to use AMGCL or not?

@KratosMultiphysics/technical-committee please feel free to add requirements etc in case I forgot sth