### PR TITLE
[Element/Condition] added GetPropertiesAsConst

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -1305,6 +1305,14 @@ public:
         return *mpProperties;
     }
 
+    PropertiesType const& GetPropertiesAsConst() const
+    {
+        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
+            << "Tryining to get the properties of " << Info()
+            << ", which are uninitialized." << std::endl;
+        return *mpProperties;
+    }
+
     void SetProperties(PropertiesType::Pointer pProperties)
     {
         mpProperties = pProperties;

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -1333,6 +1333,14 @@ public:
         return *mpProperties;
     }
 
+    PropertiesType const& GetPropertiesAsConst() const
+    {
+        KRATOS_DEBUG_ERROR_IF(mpProperties == nullptr)
+            << "Tryining to get the properties of " << Info()
+            << ", which are uninitialized." << std::endl;
+        return *mpProperties;
+    }
+
     void SetProperties(PropertiesType::Pointer pProperties)
     {
         mpProperties = pProperties;


### PR DESCRIPTION
This PR adds a function `GetPropertiesAsConst` to `Element` and `Condition`
This function should **ALWAYS** be used inside the Elements and Conditions in order to prevent 
1. Elements/Conditions modifying the Properties, which is by design not allowed!
2. Prevent race conditions that can typically happen with uninitialized variables. 
E.g for the truss-elements the `TRUSS_PRESTRESS_PK2` is optional. This means that one first has to check if the `Properties` have a variable before getting it. Otherwise due to the behavior of the `DataValueContainer` the variable would be allocated which violates both things I pointed out above

In code this looks like this:
~~~c++
double prestress = 0.00;
if (GetProperties().Has(TRUSS_PRESTRESS_PK2)) {
    prestress = GetProperties()[TRUSS_PRESTRESS_PK2];
}
~~~

a rather awkward workaround that is often done now is:
~~~c++
const auto& r_properties = GetProperties():
double prestress = r_properties[TRUSS_PRESTRESS_PK2];
~~~
My problem with this approach is that this is a quite deep hidden implementational detail that many devs don't know

With the addition I am proposing this would be simplified to:
~~~c++
double prestress = GetPropertiesAsConst()[TRUSS_PRESTRESS_PK2];
~~~

The good thing about this approach is that it is completely optional, hence we can let others know and adopt this style over time.

BTW the name is on the basis of [std::as_const](https://en.cppreference.com/w/cpp/utility/as_const)