### PR TITLE
[Core] Extend Integration points extrapolation process for mpi

### DIFF
--- a/kratos/processes/integration_values_extrapolation_to_nodes_process.cpp
+++ b/kratos/processes/integration_values_extrapolation_to_nodes_process.cpp
@@ -217,6 +217,47 @@ void IntegrationValuesExtrapolationToNodesProcess::ExecuteFinalizeSolutionStep()
             }
         }
     }
+
+    // Assemble nodal data
+    if (mExtrapolateNonHistorical)
+    {
+        for (const auto p_var : mDoubleVariable)
+        {
+            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
+        }
+        for (const auto p_var : mArrayVariable)
+        {
+            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
+        }
+        for (const auto p_var : mVectorVariable)
+        {
+            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
+        }
+        for (const auto p_var : mMatrixVariable)
+        {
+            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
+        }
+    }
+    else
+    {
+        for (const auto p_var : mDoubleVariable)
+        {
+            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
+        }
+        for (const auto p_var : mArrayVariable)
+        {
+            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
+        }
+        for (const auto p_var : mVectorVariable)
+        {
+            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
+        }
+        for (const auto p_var : mMatrixVariable)
+        {
+            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
+        }
+    }
+
 }
 
 /***********************************************************************************/
@@ -301,6 +342,8 @@ void IntegrationValuesExtrapolationToNodesProcess::InitializeMaps()
             }
         }
     }
+
+    mrModelPart.GetCommunicator().AssembleNonHistoricalData(*mpAverageVariable);
 
     // The process info
     const ProcessInfo& r_process_info = mrModelPart.GetProcessInfo();

--- a/kratos/processes/integration_values_extrapolation_to_nodes_process.cpp
+++ b/kratos/processes/integration_values_extrapolation_to_nodes_process.cpp
@@ -221,40 +221,32 @@ void IntegrationValuesExtrapolationToNodesProcess::ExecuteFinalizeSolutionStep()
     // Assemble nodal data
     if (mExtrapolateNonHistorical)
     {
-        for (const auto p_var : mDoubleVariable)
-        {
-            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
+        for (const auto p_var : mDoubleVariable) {
+            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
         }
-        for (const auto p_var : mArrayVariable)
-        {
-            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
+        for (const auto p_var : mArrayVariable)  {
+            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
         }
-        for (const auto p_var : mVectorVariable)
-        {
-            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
+        for (const auto p_var : mVectorVariable) {
+            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
         }
-        for (const auto p_var : mMatrixVariable)
-        {
-            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
+        for (const auto p_var : mMatrixVariable) {
+            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
         }
     }
     else
     {
-        for (const auto p_var : mDoubleVariable)
-        {
-            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
+        for (const auto p_var : mDoubleVariable) {
+            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
         }
-        for (const auto p_var : mArrayVariable)
-        {
-            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
+        for (const auto p_var : mArrayVariable) {
+            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
         }
-        for (const auto p_var : mVectorVariable)
-        {
-            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
+        for (const auto p_var : mVectorVariable) {
+            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
         }
-        for (const auto p_var : mMatrixVariable)
-        {
-            mrModelPart.GetCommunicator().AssembleNonHistoricalData(*p_var);
+        for (const auto p_var : mMatrixVariable) {
+            mrModelPart.GetCommunicator().AssembleCurrentData(*p_var);
         }
     }
 

--- a/kratos/processes/integration_values_extrapolation_to_nodes_process.cpp
+++ b/kratos/processes/integration_values_extrapolation_to_nodes_process.cpp
@@ -47,6 +47,7 @@ IntegrationValuesExtrapolationToNodesProcess::IntegrationValuesExtrapolationToNo
         "list_of_variables"          : [],
         "extrapolate_non_historical" : true
     })");
+
     ThisParameters.ValidateAndAssignDefaults(default_parameters);
 
     mEchoLevel = ThisParameters["echo_level"].GetInt();


### PR DESCRIPTION
I was using this process in mpi, and realize that some of the methods for mpi is missing (so my answers in omp and mpi is way off). So I added mpi methods as I see is required to perform the same calculation in mpi. (but still mpi result doesn't match omp result perfectly, but they are close. I guess this is because of communication tolerances ryt?)