### PR TITLE
[Poro] Avoid copying of variable to fix windows compilation error

### DIFF
--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -220,7 +220,7 @@ private:
     // Private Operations
     
     template < class TValueType >
-    inline void ThreadSafeNodeWrite(NodeType& rNode, Variable<TValueType> Var, const TValueType Value)
+    inline void ThreadSafeNodeWrite(NodeType& rNode, const Variable<TValueType>& Var, const TValueType Value)
     {
         rNode.SetLock();
         rNode.FastGetSolutionStepValue(Var) = Value;


### PR DESCRIPTION
Variable is now passed by const& instead of by copy. Windows compilation fails otherwise. This relates to Issue [#6513](https://github.com/KratosMultiphysics/Kratos/issues/6513)