### PR TITLE
Hotfix/dam and poromechanics compilation issues

### DIFF
--- a/applications/DamApplication/custom_processes/dam_added_mass_condition_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_added_mass_condition_process.hpp
@@ -88,7 +88,7 @@ class DamAddedMassConditionProcess : public Process
     {
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
         double added_mass;
@@ -142,7 +142,7 @@ class DamAddedMassConditionProcess : public Process
     {
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
         double added_mass;

--- a/applications/DamApplication/custom_processes/dam_azenha_heat_source_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_azenha_heat_source_process.hpp
@@ -109,7 +109,7 @@ class DamAzenhaHeatFluxProcess : public Process
         if (mAging == false)
         {
             const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
-            Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+            const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
             if (nnodes != 0)
             {
@@ -148,7 +148,7 @@ class DamAzenhaHeatFluxProcess : public Process
         if (mAging == false)
         {
             const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
-            Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+            const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
             double delta_time = mrModelPart.GetProcessInfo()[DELTA_TIME];
 
             if (nnodes != 0)
@@ -194,7 +194,7 @@ class DamAzenhaHeatFluxProcess : public Process
         KRATOS_TRY;
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         if (nnodes != 0)
         {
@@ -227,7 +227,7 @@ class DamAzenhaHeatFluxProcess : public Process
         KRATOS_TRY;
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         double delta_time = mrModelPart.GetProcessInfo()[DELTA_TIME];
 
         if (nnodes != 0)

--- a/applications/DamApplication/custom_processes/dam_bofang_condition_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_bofang_condition_temperature_process.hpp
@@ -119,7 +119,7 @@ class DamBofangConditionTemperatureProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
 
@@ -164,7 +164,7 @@ class DamBofangConditionTemperatureProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         // Getting the values of table in case that it exist
         if (mTableIdWater != 0)
@@ -225,7 +225,7 @@ class DamBofangConditionTemperatureProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 

--- a/applications/DamApplication/custom_processes/dam_chemo_mechanical_aging_young_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_chemo_mechanical_aging_young_process.hpp
@@ -99,7 +99,7 @@ class DamChemoMechanicalAgingYoungProcess : public Process
     {
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         // This model works in years so it is necessary to convert time in this unit
@@ -132,7 +132,7 @@ class DamChemoMechanicalAgingYoungProcess : public Process
     {
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         // This model works in years so it is necessary to convert time in this unit

--- a/applications/DamApplication/custom_processes/dam_fix_temperature_condition_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_fix_temperature_condition_process.hpp
@@ -95,7 +95,7 @@ class DamFixTemperatureConditionProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if (nnodes != 0)
@@ -126,7 +126,7 @@ class DamFixTemperatureConditionProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         // Getting the values of table in case that it exist
         if (mTableId != 0)
@@ -166,7 +166,7 @@ class DamFixTemperatureConditionProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 

--- a/applications/DamApplication/custom_processes/dam_grouting_reference_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_grouting_reference_temperature_process.hpp
@@ -91,7 +91,7 @@ public:
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents< Variable<double> >::Get(mVariableName);
+        const Variable<double>& var = KratosComponents< Variable<double> >::Get(mVariableName);
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
@@ -121,7 +121,7 @@ public:
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents< Variable<double> >::Get(mVariableName);
+        const Variable<double>& var = KratosComponents< Variable<double> >::Get(mVariableName);
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 

--- a/applications/DamApplication/custom_processes/dam_hydro_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_hydro_condition_load_process.hpp
@@ -101,7 +101,7 @@ class DamHydroConditionLoadProcess : public Process
     {
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
 
@@ -146,7 +146,7 @@ class DamHydroConditionLoadProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         // Getting the values of table in case that it exist
         if (mTableId != 0)

--- a/applications/DamApplication/custom_processes/dam_nodal_reference_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_nodal_reference_temperature_process.hpp
@@ -91,7 +91,7 @@ public:
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents< Variable<double> >::Get(mVariableName);
+        const Variable<double>& var = KratosComponents< Variable<double> >::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if(nnodes != 0)
@@ -132,7 +132,7 @@ public:
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents< Variable<double> >::Get(mVariableName);
+        const Variable<double>& var = KratosComponents< Variable<double> >::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
 

--- a/applications/DamApplication/custom_processes/dam_nodal_young_modulus_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_nodal_young_modulus_process.hpp
@@ -94,7 +94,7 @@ class DamNodalYoungModulusProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if (nnodes != 0)
@@ -132,7 +132,7 @@ class DamNodalYoungModulusProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 
         if (nnodes != 0)

--- a/applications/DamApplication/custom_processes/dam_noorzai_heat_source_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_noorzai_heat_source_process.hpp
@@ -92,7 +92,7 @@ class DamNoorzaiHeatFluxProcess : public Process
         KRATOS_TRY;
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         const double time = mrModelPart.GetProcessInfo()[TIME];
         const double delta_time = mrModelPart.GetProcessInfo()[DELTA_TIME];

--- a/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_reservoir_constant_temperature_process.hpp
@@ -108,7 +108,7 @@ class DamReservoirConstantTemperatureProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
 
@@ -150,7 +150,7 @@ class DamReservoirConstantTemperatureProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         // Getting the values of table in case that it exist
 
@@ -209,7 +209,7 @@ class DamReservoirConstantTemperatureProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 

--- a/applications/DamApplication/custom_processes/dam_reservoir_monitoring_temperature_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_reservoir_monitoring_temperature_process.hpp
@@ -141,7 +141,7 @@ class DamReservoirMonitoringTemperatureProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
 
@@ -202,7 +202,7 @@ class DamReservoirMonitoringTemperatureProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         // Getting the values of table in case that it exist
         if (mTableIdWater != 0)
@@ -300,7 +300,7 @@ class DamReservoirMonitoringTemperatureProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
 

--- a/applications/DamApplication/custom_processes/dam_t_sol_air_heat_flux_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_t_sol_air_heat_flux_process.hpp
@@ -107,7 +107,7 @@ class DamTSolAirHeatFluxProcess : public Process
         KRATOS_TRY;
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         // Computing the t_soil_air according to t_sol_air criteria
         double t_sol_air = mAmbientTemperature + (mAbsorption_index * mTotalInsolation / mH0) - (mEmisivity * mDeltaR / mH0);
@@ -138,7 +138,7 @@ class DamTSolAirHeatFluxProcess : public Process
         KRATOS_TRY;
 
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         // Getting the values of table in case that it exist
         if (mTableId != 0)

--- a/applications/DamApplication/custom_processes/dam_temperature_by_device_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_temperature_by_device_process.hpp
@@ -101,7 +101,7 @@ class DamTemperaturebyDeviceProcess : public Process
         KRATOS_TRY;
 
         const int nelements = mrModelPart.GetMesh(0).Elements().size();
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         bool IsInside = false;
         array_1d<double, 3> LocalCoordinates;
         Element::Pointer pSelectedElement;

--- a/applications/DamApplication/custom_processes/dam_uplift_circular_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_uplift_circular_condition_load_process.hpp
@@ -130,7 +130,7 @@ class DamUpliftCircularConditionLoadProcess : public Process
         KRATOS_TRY;
 
         //Defining necessary variables
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         array_1d<double, 3> auxiliar_vector;
 
@@ -247,7 +247,7 @@ class DamUpliftCircularConditionLoadProcess : public Process
         KRATOS_TRY;
 
         //Defining necessary variables
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         array_1d<double, 3> auxiliar_vector;
 

--- a/applications/DamApplication/custom_processes/dam_uplift_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_uplift_condition_load_process.hpp
@@ -132,7 +132,7 @@ class DamUpliftConditionLoadProcess : public Process
         KRATOS_TRY;
 
         //Defining necessary variables
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         BoundedMatrix<double, 3, 3> RotationMatrix;
 
@@ -235,7 +235,7 @@ class DamUpliftConditionLoadProcess : public Process
         KRATOS_TRY;
 
         //Defining necessary variables
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         BoundedMatrix<double, 3, 3> RotationMatrix;
 

--- a/applications/DamApplication/custom_processes/dam_westergaard_condition_load_process.hpp
+++ b/applications/DamApplication/custom_processes/dam_westergaard_condition_load_process.hpp
@@ -107,7 +107,7 @@ class DamWestergaardConditionLoadProcess : public Process
     {
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
         const int nnodes = mrModelPart.GetMesh(0).Nodes().size();
         int direction;
         double pressure;
@@ -153,7 +153,7 @@ class DamWestergaardConditionLoadProcess : public Process
 
         KRATOS_TRY;
 
-        Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
+        const Variable<double>& var = KratosComponents<Variable<double>>::Get(mVariableName);
 
         // Getting the values of table in case that it exist
         if (mTableIdWater != 0)

--- a/applications/FemToDemApplication/custom_processes/apply_double_table_process.hpp
+++ b/applications/FemToDemApplication/custom_processes/apply_double_table_process.hpp
@@ -46,7 +46,7 @@ public:
     {
         KRATOS_TRY;
                 
-        Variable<double> var = KratosComponents< Variable<double> >::Get(mVariableName);
+        const Variable<double>& var = KratosComponents< Variable<double> >::Get(mVariableName);
         const int number_nodes = static_cast<int>(mrModelPart.Nodes().size());
 
         if(number_nodes != 0) {
@@ -69,7 +69,7 @@ public:
     {
         KRATOS_TRY;
         
-        Variable<double> var = KratosComponents< Variable<double> >::Get(mVariableName);
+        const Variable<double>& var = KratosComponents< Variable<double> >::Get(mVariableName);
         
         double time;
         if (mTimeUnitConverter != 0) {

--- a/applications/PoromechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.hpp
+++ b/applications/PoromechanicsApplication/custom_processes/apply_constant_hydrostatic_pressure_process.hpp
@@ -81,7 +81,7 @@ public:
     {
         KRATOS_TRY;
         
-        Variable<double> var = KratosComponents< Variable<double> >::Get(mvariable_name);
+        const Variable<double>& var = KratosComponents< Variable<double> >::Get(mvariable_name);
         
         const int nnodes = static_cast<int>(mr_model_part.Nodes().size());
         

--- a/applications/PoromechanicsApplication/custom_processes/apply_double_table_process.hpp
+++ b/applications/PoromechanicsApplication/custom_processes/apply_double_table_process.hpp
@@ -47,7 +47,7 @@ public:
     {
         KRATOS_TRY;
                 
-        Variable<double> var = KratosComponents< Variable<double> >::Get(mvariable_name);
+        const Variable<double>& var = KratosComponents< Variable<double> >::Get(mvariable_name);
         
         const int nnodes = static_cast<int>(mr_model_part.Nodes().size());
 
@@ -77,7 +77,7 @@ public:
     {
         KRATOS_TRY;
         
-        Variable<double> var = KratosComponents< Variable<double> >::Get(mvariable_name);
+        const Variable<double>& var = KratosComponents< Variable<double> >::Get(mvariable_name);
         
         const double Time = mr_model_part.GetProcessInfo()[TIME]/mTimeUnitConverter;
         double value = mpTable->GetValue(Time);

--- a/applications/PoromechanicsApplication/custom_processes/apply_hydrostatic_pressure_table_process.hpp
+++ b/applications/PoromechanicsApplication/custom_processes/apply_hydrostatic_pressure_table_process.hpp
@@ -59,7 +59,7 @@ public:
     {
         KRATOS_TRY;
         
-        Variable<double> var = KratosComponents< Variable<double> >::Get(mvariable_name);
+        const Variable<double>& var = KratosComponents< Variable<double> >::Get(mvariable_name);
         
         const double Time = mr_model_part.GetProcessInfo()[TIME]/mTimeUnitConverter;
         double reference_coordinate = mpTable->GetValue(Time);

--- a/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_newton_raphson_strategy.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_newton_raphson_strategy.hpp
@@ -294,7 +294,7 @@ private:
 
             if( KratosComponents< Variable<double> >::Has( VariableName ) )
             {
-                Variable<double> var = KratosComponents< Variable<double> >::Get( VariableName );
+                const Variable<double>& var = KratosComponents< Variable<double> >::Get( VariableName );
 
                 #pragma omp parallel
                 {
@@ -357,7 +357,7 @@ private:
 
             if( KratosComponents< Variable<double> >::Has( VariableName ) )
             {
-                Variable<double> var = KratosComponents< Variable<double> >::Get( VariableName );
+                const Variable<double>& var = KratosComponents< Variable<double> >::Get( VariableName );
 
                 #pragma omp parallel
                 {

--- a/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_ramm_arc_length_strategy.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/strategies/poromechanics_ramm_arc_length_strategy.hpp
@@ -577,7 +577,7 @@ protected:
 
             if( KratosComponents< Variable<double> >::Has( VariableName ) )
             {
-                Variable<double> var = KratosComponents< Variable<double> >::Get( VariableName );
+                const Variable<double>& var = KratosComponents< Variable<double> >::Get( VariableName );
 
                 #pragma omp parallel
                 {


### PR DESCRIPTION
I was getting tons of errors like this in build time:
```

dam_python_application.cpp
E:\PROYECTOS\Kratos\applications\DamApplication\custom_processes/dam_fix_temperature_condition_process.hpp(98,1): error C2440: 'initializing': cannot convert from 'const TComponentType' to 'K
ratos::Variable<double>' [E:\PROYECTOS\Kratos\build\Release\applications\DamApplication\KratosDamApplication.vcxproj]
          with
          [
              TComponentType=Kratos::Variable<double>
          ] (compiling source file E:\PROYECTOS\Kratos\applications\DamApplication\custom_python\add_custom_processes_to_python.cpp)
E:\PROYECTOS\Kratos\applications\DamApplication\custom_processes/dam_fix_temperature_condition_process.hpp(98,1): message : Constructor for class 'Kratos::Variable<double>' is declared 'expli
cit' (compiling source file E:\PROYECTOS\Kratos\applications\DamApplication\custom_python\add_custom_processes_to_python.cpp) [E:\PROYECTOS\Kratos\build\Release\applications\DamApplication\Kr
atosDamApplication.vcxproj]
```

Variable<double> var = KratosComponents<Variable<double>>::Get(mVariableName);
has been replaced by
const Variable<double>& var = ...

@KratosMultiphysics/dam 
@KratosMultiphysics/poromechanics 