### PR TITLE
[Core] Convert numpy to Kratos dense matrix

### DIFF
--- a/kratos/python/add_matrix_to_python.cpp
+++ b/kratos/python/add_matrix_to_python.cpp
@@ -76,18 +76,16 @@ namespace Python
         //here we add the dense matrix
         auto matrix_binder = CreateMatrixInterface< DenseMatrix<double> >(m,"Matrix");
         matrix_binder.def(py::init<const DenseMatrix<double>::size_type, const DenseMatrix<double>::size_type>());
-        matrix_binder.def("__init__", [](DenseMatrix<double> &m, py::buffer b){
+        matrix_binder.def("__init__", [](DenseMatrix<double> &matrix, py::buffer b){
           py::buffer_info info = b.request();
           KRATOS_ERROR_IF( info.format != py::format_descriptor<double>::value ) << "Expected a double array\n";
-          KRATOS_ERROR_IF( info.ndim != 2 ) << "Incompatible buffer dimension\n";
-          m = DenseMatrix<double>(info.shape[0], info.shape[1]);
+          KRATOS_ERROR_IF( info.ndim != 2 ) << "Buffer dimension of 2 is required, got: " << info.ndim << std::endl;
+          matrix = DenseMatrix<double>(info.shape[0], info.shape[1]);
 
           std::size_t count = 0;
-          for( int i=0; i<info.shape[0]; ++i )
-          {
-            for( int j=0; j<info.shape[1]; ++j )
-            {
-              m(i,j) = static_cast<double *>(info.ptr)[count];
+          for( int i=0; i<info.shape[0]; ++i ) {
+            for( int j=0; j<info.shape[1]; ++j ) {
+              matrix(i,j) = static_cast<double *>(info.ptr)[count];
               count++;
             }
           }
@@ -142,22 +140,20 @@ namespace Python
         //here we add the complex dense matrix
         auto cplx_matrix_binder = CreateMatrixInterface< ComplexMatrix >(m,"ComplexMatrix");
         cplx_matrix_binder.def(py::init<const ComplexMatrix::size_type, const ComplexMatrix::size_type>());
-        cplx_matrix_binder.def("__init__", [](ComplexMatrix &m, py::buffer b){
+        cplx_matrix_binder.def("__init__", [](ComplexMatrix &matrix, py::buffer b){
           py::buffer_info info = b.request();
           KRATOS_ERROR_IF( info.format != py::format_descriptor<std::complex<double>>::value &&
-            info.format != py::format_descriptor<double>::value ) << "Expected a double or complex array\n";
-          KRATOS_ERROR_IF( info.ndim != 2 ) << "Incompatible buffer dimension\n";
-          m = ComplexMatrix(info.shape[0], info.shape[1]);
+            info.format != py::format_descriptor<double>::value ) << "Expected a double or complex array" << std::endl;
+          KRATOS_ERROR_IF( info.ndim != 2 ) << "Buffer dimension of 2 is required, got: " << info.ndim << std::endl;
+          matrix = ComplexMatrix(info.shape[0], info.shape[1]);
 
           std::size_t count = 0;
           //if the python data is complex, copy the values
           if( info.format == py::format_descriptor<std::complex<double>>::value )
           {
-            for( int i=0; i<info.shape[0]; ++i )
-            {
-              for( int j=0; j<info.shape[1]; ++j )
-              {
-                m(i,j) = static_cast<std::complex<double> *>(info.ptr)[count];
+            for( int i=0; i<info.shape[0]; ++i ) {
+              for( int j=0; j<info.shape[1]; ++j ) {
+                matrix(i,j) = static_cast<std::complex<double> *>(info.ptr)[count];
                 count++;
               }
             }
@@ -165,11 +161,9 @@ namespace Python
           //if the python data is real, copy the values to the real part and initialize the imaginary part
           else if( info.format == py::format_descriptor<double>::value )
           {
-            for( int i=0; i<info.shape[0]; ++i )
-            {
-              for( int j=0; j<info.shape[1]; ++j )
-              {
-                m(i,j) = std::complex<double>(static_cast<double *>(info.ptr)[count], 0.0);
+            for( int i=0; i<info.shape[0]; ++i ) {
+              for( int j=0; j<info.shape[1]; ++j ) {
+                matrix(i,j) = std::complex<double>(static_cast<double *>(info.ptr)[count], 0.0);
                 count++;
               }
             }

--- a/kratos/python/add_matrix_to_python.cpp
+++ b/kratos/python/add_matrix_to_python.cpp
@@ -76,6 +76,22 @@ namespace Python
         //here we add the dense matrix
         auto matrix_binder = CreateMatrixInterface< DenseMatrix<double> >(m,"Matrix");
         matrix_binder.def(py::init<const DenseMatrix<double>::size_type, const DenseMatrix<double>::size_type>());
+        matrix_binder.def("__init__", [](DenseMatrix<double> &m, py::buffer b){
+          py::buffer_info info = b.request();
+          KRATOS_ERROR_IF( info.format != py::format_descriptor<double>::value ) << "Expected a double array\n";
+          KRATOS_ERROR_IF( info.ndim != 2 ) << "Incompatible buffer dimension\n";
+          m = DenseMatrix<double>(info.shape[0], info.shape[1]); //, static_cast<double*>(info.ptr)
+
+          size_t count = 0;
+          for( size_t i=0; i<static_cast<size_t>(info.shape[0]); ++i )
+          {
+            for( size_t j=0; j<static_cast<size_t>(info.shape[1]); ++j )
+            {
+              m(i,j) = static_cast<double *>(info.ptr)[count];
+              count++;
+            }
+          }
+        });
       #ifdef KRATOS_USE_AMATRIX   // This macro definition is for the migration period and to be removed afterward please do not use it
         // This constructor is not supported by AMatrix
         //matrix_binder.def(py::init<const DenseMatrix<double>::size_type, const DenseMatrix<double>::size_type, const DenseMatrix<double>::value_type >());
@@ -107,17 +123,17 @@ namespace Python
         auto compressed_matrix_binder = CreateMatrixInterface< CompressedMatrix >(m,"CompressedMatrix");
         compressed_matrix_binder.def(py::init<const CompressedMatrix::size_type, const CompressedMatrix::size_type>());
         compressed_matrix_binder.def(py::init<const CompressedMatrix& >());
-        compressed_matrix_binder.def("value_data", [](const CompressedMatrix& rA) ->  std::vector<double> 
+        compressed_matrix_binder.def("value_data", [](const CompressedMatrix& rA) ->  std::vector<double>
                                                     {return std::vector<double>(
                                                         rA.value_data().begin(),
                                                         rA.value_data().end()
                                                         ) ;});
-        compressed_matrix_binder.def("index1_data", [](const CompressedMatrix& rA) -> std::vector<std::size_t> 
+        compressed_matrix_binder.def("index1_data", [](const CompressedMatrix& rA) -> std::vector<std::size_t>
                                                     {return std::vector<std::size_t>(
                                                         rA.index1_data().begin(),
                                                         rA.index1_data().end()
                                                         ) ;});
-        compressed_matrix_binder.def("index2_data", [](const CompressedMatrix& rA) -> std::vector<std::size_t> 
+        compressed_matrix_binder.def("index2_data", [](const CompressedMatrix& rA) -> std::vector<std::size_t>
                                                     {return std::vector<std::size_t>(
                                                         rA.index2_data().begin(),
                                                         rA.index2_data().end()
@@ -150,12 +166,12 @@ namespace Python
                                                         rA.value_data().begin(),
                                                         rA.value_data().end()
                                                         ) ;});
-        cplx_compressed_matrix_binder.def("index1_data", [](const ComplexCompressedMatrix& rA) -> std::vector<std::size_t> 
+        cplx_compressed_matrix_binder.def("index1_data", [](const ComplexCompressedMatrix& rA) -> std::vector<std::size_t>
                                                     {return std::vector<std::size_t>(
                                                         rA.index1_data().begin(),
                                                         rA.index1_data().end()
                                                         ) ;});
-        cplx_compressed_matrix_binder.def("index2_data", [](const ComplexCompressedMatrix& rA) -> std::vector<std::size_t> 
+        cplx_compressed_matrix_binder.def("index2_data", [](const ComplexCompressedMatrix& rA) -> std::vector<std::size_t>
                                                     {return std::vector<std::size_t>(
                                                         rA.index2_data().begin(),
                                                         rA.index2_data().end()

--- a/kratos/python/add_matrix_to_python.cpp
+++ b/kratos/python/add_matrix_to_python.cpp
@@ -82,10 +82,10 @@ namespace Python
           KRATOS_ERROR_IF( info.ndim != 2 ) << "Incompatible buffer dimension\n";
           m = DenseMatrix<double>(info.shape[0], info.shape[1]);
 
-          size_t count = 0;
-          for( size_t i=0; i<static_cast<size_t>(info.shape[0]); ++i )
+          std::size_t count = 0;
+          for( int i=0; i<info.shape[0]; ++i )
           {
-            for( size_t j=0; j<static_cast<size_t>(info.shape[1]); ++j )
+            for( int j=0; j<info.shape[1]; ++j )
             {
               m(i,j) = static_cast<double *>(info.ptr)[count];
               count++;
@@ -149,13 +149,13 @@ namespace Python
           KRATOS_ERROR_IF( info.ndim != 2 ) << "Incompatible buffer dimension\n";
           m = ComplexMatrix(info.shape[0], info.shape[1]);
 
-          size_t count = 0;
+          std::size_t count = 0;
           //if the python data is complex, copy the values
           if( info.format == py::format_descriptor<std::complex<double>>::value )
           {
-            for( size_t i=0; i<static_cast<size_t>(info.shape[0]); ++i )
+            for( int i=0; i<info.shape[0]; ++i )
             {
-              for( size_t j=0; j<static_cast<size_t>(info.shape[1]); ++j )
+              for( int j=0; j<info.shape[1]; ++j )
               {
                 m(i,j) = static_cast<std::complex<double> *>(info.ptr)[count];
                 count++;
@@ -165,9 +165,9 @@ namespace Python
           //if the python data is real, copy the values to the real part and initialize the imaginary part
           else if( info.format == py::format_descriptor<double>::value )
           {
-            for( size_t i=0; i<static_cast<size_t>(info.shape[0]); ++i )
+            for( int i=0; i<info.shape[0]; ++i )
             {
-              for( size_t j=0; j<static_cast<size_t>(info.shape[1]); ++j )
+              for( int j=0; j<info.shape[1]; ++j )
               {
                 m(i,j) = std::complex<double>(static_cast<double *>(info.ptr)[count], 0.0);
                 count++;

--- a/kratos/tests/test_numpy_export_dense_matrix.py
+++ b/kratos/tests/test_numpy_export_dense_matrix.py
@@ -38,6 +38,32 @@ class TestNumpyExportDenseMatrix(KratosUnittest.TestCase):
         self.assertEqual(KratosMatrix[2,2], NumpyMatrix[2,2])
 
     @KratosUnittest.skipIf(missing_numpy,"Missing python libraries (numpy)")
+    def test_numpy_export_complex_dense_matrix_no_copying(self):
+        # Create a Kratos matrix
+        KratosMatrix = KratosMultiphysics.ComplexMatrix(3,3)
+        KratosMatrix.fill(1.0+1.0j)
+
+        # Export it to numpy array (No copying is performed)
+        NumpyMatrix = np.array(KratosMatrix,copy=False)
+
+        # Test correct creation
+        for i in range(3):
+            for j in range(3):
+                self.assertEqual(KratosMatrix[i,j], NumpyMatrix[i,j])
+
+        # Change an entry in Kratos Matrix
+        KratosMatrix[0,0] = 123-123j
+
+        # Test change in Numpy matrix
+        self.assertEqual(KratosMatrix[0,0], NumpyMatrix[0,0])
+
+        # Change an entry in Numpy matrix
+        NumpyMatrix[2,2] = 555-555j
+
+        # Test change in Kratos matrix
+        self.assertEqual(KratosMatrix[2,2], NumpyMatrix[2,2])
+
+    @KratosUnittest.skipIf(missing_numpy,"Missing python libraries (numpy)")
     def test_numpy_export_dense_matrix_copying(self):
         # Create a Kratos matrix
         KratosMatrix = KratosMultiphysics.Matrix(3,3)
@@ -73,6 +99,48 @@ class TestNumpyExportDenseMatrix(KratosUnittest.TestCase):
         for i in range(3):
             for j in range(2):
                 self.assertAlmostEqual(kratos_matrix[i,j], np_array[i,j], delta=1e-12)
+
+    @KratosUnittest.skipIf(missing_numpy,"Missing python libraries (numpy)")
+    def test_numpy_import_complex_dense_matrix(self):
+        # Create numpy array
+        np_array = np.ones((3,2), dtype=complex)
+        np_array[0,0] = 12.-3.j
+        np_array[2,1] = 42.-7.j
+
+        # Assert no double array can be created with complex data
+        with self.assertRaises(RuntimeError):
+            KratosMultiphysics.Matrix(np_array)
+
+        # Import (i.e. copy) to Kratos
+        kratos_matrix = KratosMultiphysics.ComplexMatrix(np_array)
+
+        # Test
+        for i in range(3):
+            for j in range(2):
+                self.assertAlmostEqual(kratos_matrix[i,j], np_array[i,j], delta=1e-12)
+
+    @KratosUnittest.skipIf(missing_numpy,"Missing python libraries (numpy)")
+    def test_numpy_import_real_to_complex_dense_matrix(self):
+        # Create numpy array
+        np_array = np.ones((3,2))
+        np_array[0,0] = 12.
+        np_array[2,1] = 42.
+
+        # Import (i.e. copy) to Kratos
+        kratos_matrix = KratosMultiphysics.ComplexMatrix(np_array)
+
+        # Test
+        for i in range(3):
+            for j in range(2):
+                self.assertAlmostEqual(kratos_matrix[i,j].real, np_array[i,j], delta=1e-12)
+                self.assertAlmostEqual(kratos_matrix[i,j].imag, 0.0, delta=1e-12)
+
+    @KratosUnittest.skipIf(missing_numpy,"Missing python libraries (numpy)")
+    def test_numpy_import_dense_matrix_format(self):
+        # Create three-dimensional numpy array
+        np_array = np.ones((3,2,4))
+        with self.assertRaises(RuntimeError):
+            KratosMultiphysics.Matrix(np_array)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/tests/test_numpy_export_dense_matrix.py
+++ b/kratos/tests/test_numpy_export_dense_matrix.py
@@ -36,7 +36,7 @@ class TestNumpyExportDenseMatrix(KratosUnittest.TestCase):
 
         # Test change in Kratos matrix
         self.assertEqual(KratosMatrix[2,2], NumpyMatrix[2,2])
-        
+
     @KratosUnittest.skipIf(missing_numpy,"Missing python libraries (numpy)")
     def test_numpy_export_dense_matrix_copying(self):
         # Create a Kratos matrix
@@ -59,6 +59,20 @@ class TestNumpyExportDenseMatrix(KratosUnittest.TestCase):
             for j in range(3):
                 self.assertAlmostEqual(1.0, CopyNumpyMatrix[i,j], delta=1e-12)
 
+    @KratosUnittest.skipIf(missing_numpy,"Missing python libraries (numpy)")
+    def test_numpy_import_dense_matrix(self):
+        # Create numpy array
+        np_array = np.ones((3,2))
+        np_array[0,0] = 12
+        np_array[2,1] = 42
+
+        # Import (i.e. copy) to Kratos
+        kratos_matrix = KratosMultiphysics.Matrix(np_array)
+
+        # Test
+        for i in range(3):
+            for j in range(2):
+                self.assertAlmostEqual(kratos_matrix[i,j], np_array[i,j], delta=1e-12)
 
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
This is continued work based on @Rbravo555 s #6524. This ...
- adds the export buffer also for complex matrices
- adds an initialize method to `Matrix` and `ComplexMatrix` which takes a numpy array as input and creates a corresponding ublas dense matrix

I created this as draft and I am open to suggestions, what to include (sparse matrix support etc.).