### PR TITLE
adding initial version of CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# see https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+
+/kratos/              @KratosMultiphysics/technical-committee
+/.github/             @KratosMultiphysics/technical-committee
+/cmake_modules/       @KratosMultiphysics/technical-committee
+/external_libraries/  @KratosMultiphysics/technical-committee
+/scripts/             @KratosMultiphysics/technical-committee


### PR DESCRIPTION
see https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
"You can use a CODEOWNERS file to define individuals or teams that are responsible for code in a repository."

=> I.e. if sth in a file that has a codeowner is modified, the owner is requested for review. This way always the right ppl will automatically be asked for review.

We can also enable that the codeoweners have to approve if their files are changed. Since we are a large repo with many ppl working on it I think this would good. We can discuss it, probably enable it in the future
![image](https://user-images.githubusercontent.com/25484702/76713292-db5a5980-671f-11ea-9ea6-6c7debf5f649.png)


I took inspiration in what the [Trilinos-Repo is doing](https://github.com/trilinos/Trilinos/blob/master/.github/CODEOWNERS)

@KratosMultiphysics/technical-committee this is what I told you about some time ago

Note that so far I have only done this for the core, but the same can/should be applied to the Apps one we have a bit experience with it.