### PR TITLE
Kratos-Docker: correcting setting of env-vars

### DIFF
--- a/scripts/docker_files/docker_file_kratos_ubuntu_bionic/DockerFile
+++ b/scripts/docker_files/docker_file_kratos_ubuntu_bionic/DockerFile
@@ -1,6 +1,8 @@
 FROM kratosmultiphysics/kratos-image-ci-ubuntu-bionic
 
 ENV HOME /root
+ENV PYTHONPATH ${PYTHONPATH}:/software/Kratos/bin/Release
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/software/Kratos/bin/Release/libs
 
 RUN git clone --depth 1 https://github.com/KratosMultiphysics/Kratos.git /software/Kratos && \
     # setting some environment variables for the build
@@ -11,8 +13,6 @@ RUN git clone --depth 1 https://github.com/KratosMultiphysics/Kratos.git /softwa
     export KRATOS_CMAKE_OPTIONS_FLAGS="-DUSE_EIGEN_MKL=ON" && \
     export KRATOS_CMAKE_CXX_FLAGS="-Wno-deprecated-declarations" && \
     . /opt/intel/mkl/bin/mklvars.sh && \
-    export PYTHONPATH=${PYTHONPATH}:/software/Kratos/bin/Release && \
-    export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/software/Kratos/bin/Release/libs && \
     # using the configure file from the CI
     cp /software/Kratos/.github/workflows/configure.sh /software/Kratos/configure.sh && \
     cd /software/Kratos && \


### PR DESCRIPTION
`export` is only temporary, `ENV` should be available also after rebooting the container