### PR TITLE
[dem] Removing obsolete method FinalizeTimeStep

### DIFF
--- a/applications/DEMApplication/python_scripts/DEM_analysis_stage.py
+++ b/applications/DEMApplication/python_scripts/DEM_analysis_stage.py
@@ -547,8 +547,6 @@ class DEMAnalysisStage(AnalysisStage):
             if output_process.IsOutputStep():
                 output_process.PrintOutput()
 
-        self.FinalizeTimeStep(self.time)
-
     def AfterSolveOperations(self):
         message = 'Warning!'
         message += '\nFunction \'AfterSolveOperations\' is deprecated.'
@@ -563,8 +561,6 @@ class DEMAnalysisStage(AnalysisStage):
         #Phantom Walls
         self.RunAnalytics(self.time, self.IsTimeToPrintPostProcess())
 
-    def FinalizeTimeStep(self, time):
-        pass
 
     def BreakSolutionStepsLoop(self):
         return False
@@ -703,8 +699,6 @@ class DEMAnalysisStage(AnalysisStage):
         if self.DEM_parameters["OutputTimeStep"].GetDouble() - time_to_print < 1e-2 * self._GetSolver().dt:
             self.PrintResultsForGid(self.time)
             self.time_old_print = self.time
-        self.FinalizeTimeStep(self.time)
-
 
 if __name__ == "__main__":
     with open("ProjectParametersDEM.json",'r') as parameter_file:

--- a/applications/DEMApplication/python_scripts/time_step_testing_stage.py
+++ b/applications/DEMApplication/python_scripts/time_step_testing_stage.py
@@ -261,8 +261,8 @@ class CustomizedSolutionForTimeStepTesting(DEM_analysis_stage.DEMAnalysisStage):
         properties_walls[KratosMultiphysics.POISSON_RATIO] = 0.30
 
 
-    def FinalizeTimeStep(self, time):
-        super(CustomizedSolutionForTimeStepTesting, self).FinalizeTimeStep(time)
+    def FinalizeSolutionStep(self):
+        super(CustomizedSolutionForTimeStepTesting, self).FinalizeSolutionStep()
 
         current_test_energy = self.ComputeEnergy()
         #if not self.step%200:

--- a/applications/DEMApplication/test_examples/basic_benchmarks/DEM_benchmarks.py
+++ b/applications/DEMApplication/test_examples/basic_benchmarks/DEM_benchmarks.py
@@ -160,8 +160,8 @@ class Solution(main_script.Solution):
 
         self.procedures.RemoveFoldersWithResults(self.main_path, self.problem_name)
 
-    def FinalizeTimeStep(self, time):
-        super(Solution, self).FinalizeTimeStep(time)
+    def FinalizeSolutionStep(self):
+        super(Solution, self).FinalizeSolutionStep()
         if self.nodeplotter:
             os.chdir(self.main_path)
             self.plotter.plot_variables(time) #Related to the benchmark in Chung, Ooi

--- a/applications/DEMApplication/test_examples/basic_benchmarks/DEM_benchmarks_analysis.py
+++ b/applications/DEMApplication/test_examples/basic_benchmarks/DEM_benchmarks_analysis.py
@@ -151,8 +151,8 @@ class DEMBenchmarksAnalysisStage(DEMAnalysisStage):
         self.procedures.RemoveFoldersWithResults(self.main_path, self.problem_name)
         super(DEMBenchmarksAnalysisStage, self).Finalize()
 
-    def FinalizeTimeStep(self, time):
-        super(DEMBenchmarksAnalysisStage, self).FinalizeTimeStep(time)
+    def FinalizeSolutionStep(self):
+        super(DEMBenchmarksAnalysisStage, self).FinalizeSolutionStep()
         if self.nodeplotter:
             os.chdir(self.main_path)
             self.plotter.plot_variables(time) #Related to the benchmark in Chung, Ooi

--- a/applications/DEMApplication/tests/test_DEM_2D.py
+++ b/applications/DEMApplication/tests/test_DEM_2D.py
@@ -35,20 +35,21 @@ class DEM2DTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEM
     def GetProblemNameWithPath(self):
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
 
-    def FinalizeTimeStep(self, time):
+    def FinalizeSolutionStep(self):
+        super(DEM2DTestSolution, self).FinalizeSolutionStep()
         tolerance = 1e-3
         for node in self.spheres_model_part.Nodes:
             normal_impact_vel = node.GetSolutionStepValue(Kratos.VELOCITY_X)
             if node.Id == 1:
-                if time > 0.2:
+                if self.time > 0.2:
                     expected_value = 6.076801447242313
                     self.CheckValueOfVelocity(normal_impact_vel, expected_value, tolerance)
             if node.Id == 2:
-                if time > 0.2:
+                if self.time > 0.2:
                     expected_value = 8.604163136887411
                     self.CheckValueOfVelocity(normal_impact_vel, expected_value, tolerance)
             if node.Id == 3:
-                if time > 0.2:
+                if self.time > 0.2:
                     expected_value = 10.016439272775422
                     self.CheckValueOfVelocity(normal_impact_vel, expected_value, tolerance)
 

--- a/applications/DEMApplication/tests/test_DEM_2D_contact.py
+++ b/applications/DEMApplication/tests/test_DEM_2D_contact.py
@@ -36,19 +36,20 @@ class DEM2D_ContactTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_s
     def GetProblemNameWithPath(self):
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
 
-    def FinalizeTimeStep(self, time):
+    def FinalizeSolutionStep(self):
+        super(DEM2D_ContactTestSolution, self).FinalizeSolutionStep()
         tolerance = 1.001
         for node in self.rigid_face_model_part.Nodes:
             dem_pressure = node.GetSolutionStepValue(DEM.DEM_PRESSURE)
             contact_force = node.GetSolutionStepValue(DEM.CONTACT_FORCES_Y)
             if node.Id == 13:
-                if time > 0.3:
+                if self.time > 0.3:
                     expected_value = 45126
                     self.CheckPressure(dem_pressure, expected_value, tolerance)
                     expected_value = -23141
                     self.CheckContactF(contact_force, expected_value, tolerance)
             if node.Id == 22:
-                if time > 0.3:
+                if self.time > 0.3:
                     expected_value = 26712
                     self.CheckPressure(dem_pressure, expected_value, tolerance)
                     expected_value = -13698

--- a/applications/DEMApplication/tests/test_DEM_2D_inlet.py
+++ b/applications/DEMApplication/tests/test_DEM_2D_inlet.py
@@ -42,13 +42,14 @@ class DEM2D_InletTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_sta
     def GetProblemNameWithPath(self):
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
 
-    def FinalizeTimeStep(self, time):
+    def FinalizeSolutionStep(self):
+        super(DEM2D_InletTestSolution, self).FinalizeSolutionStep()
         tolerance = 1.001
         for node in self.spheres_model_part.Nodes:
             node_vel = node.GetSolutionStepValue(KratosMultiphysics.VELOCITY_Y)
             node_force = node.GetSolutionStepValue(KratosMultiphysics.TOTAL_FORCES_Y)
             if node.Id == 7:
-                if time >= 1.15:
+                if self.time >= 1.15:
                     print(node_vel)
                     print(node_force)
                     expected_value = 0.380489240

--- a/applications/DEMApplication/tests/test_DEM_3D_contact.py
+++ b/applications/DEMApplication/tests/test_DEM_3D_contact.py
@@ -36,19 +36,20 @@ class DEM3D_ContactTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_s
     def GetProblemNameWithPath(self):
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
 
-    def FinalizeTimeStep(self, time):
+    def FinalizeSolutionStep(self):
+        super(DEM3D_ContactTestSolution, self).FinalizeSolutionStep()
         tolerance = 1.001
         for node in self.rigid_face_model_part.Nodes:
             dem_pressure = node.GetSolutionStepValue(DEM.DEM_PRESSURE)
             contact_force = node.GetSolutionStepValue(DEM.CONTACT_FORCES_Z)
             if node.Id == 9:
-                if time > 0.35:
+                if self.time > 0.35:
                     expected_value = 1621
                     self.CheckPressure(dem_pressure, expected_value, tolerance)
                     expected_value = -6484
                     self.CheckContactF(contact_force, expected_value, tolerance)
             if node.Id == 13:
-                if time > 0.35:
+                if self.time > 0.35:
                     expected_value = 841
                     self.CheckPressure(dem_pressure, expected_value, tolerance)
                     expected_value = -3366

--- a/applications/DEMApplication/tests/test_analytics.py
+++ b/applications/DEMApplication/tests/test_analytics.py
@@ -36,23 +36,24 @@ class AnalyticsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage
     def GetProblemNameWithPath(self):
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
 
-    def FinalizeTimeStep(self, time):
+    def FinalizeSolutionStep(self):
+        super(AnalyticsTestSolution, self).FinalizeSolutionStep()
         tolerance = 1e-3
         for node in self.spheres_model_part.Nodes:
             normal_impact_vel = node.GetSolutionStepValue(DEM.NORMAL_IMPACT_VELOCITY)
             face_normal_impact_vel = node.GetSolutionStepValue(DEM.FACE_NORMAL_IMPACT_VELOCITY)
             if node.Id == 1:
-                if time > 0.099:
+                if self.time > 0.099:
                     expected_value = 11.07179
                     self.CheckValueOfNormalImpactVelocity(normal_impact_vel, expected_value, tolerance)
                     expected_value = 6.941702
                     self.CheckValueOfFaceNormalImpactVelocity(face_normal_impact_vel, expected_value, tolerance)
             if node.Id == 2:
-                if time > 0.099:
+                if self.time > 0.099:
                     expected_value = 16.29633
                     self.CheckValueOfNormalImpactVelocity(normal_impact_vel, expected_value, tolerance)
             if node.Id == 3:
-                if time > 0.099:
+                if self.time > 0.099:
                     expected_value = 16.29633
                     self.CheckValueOfNormalImpactVelocity(normal_impact_vel, expected_value, tolerance)
 

--- a/applications/DEMApplication/tests/test_glued_particles.py
+++ b/applications/DEMApplication/tests/test_glued_particles.py
@@ -36,20 +36,21 @@ class GluedParticlesTestSolution(DEM_analysis_stage.DEMAnalysisStage):
     def GetProblemNameWithPath(self):
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
 
-    def FinalizeTimeStep(self, time):
+    def FinalizeSolutionStep(self):
+        super(GluedParticlesTestSolution, self).FinalizeSolutionStep()
         tolerance = 1e-4
         for node in self.spheres_model_part.Nodes:
             angular_velocity = node.GetSolutionStepValue(Kratos.ANGULAR_VELOCITY)
             if node.Id == 1:
-                if time > 0.01:
-                    self.CheckValue("Angular Velocity at time "+ str(time), angular_velocity[0], 2.0, tolerance)
+                if self.time > 0.01:
+                    self.CheckValue("Angular Velocity at time "+ str(self.time), angular_velocity[0], 2.0, tolerance)
 
-                if time > 0.499999 and time < 0.5000001:
+                if self.time > 0.499999 and self.time < 0.5000001:
                     self.CheckValue("X Coordinate at time 0.5", node.X, -1.0, tolerance)
                     self.CheckValue("Y Coordinate at time 0.5", node.Y, 0.6634116060768411, tolerance)
                     self.CheckValue("Z Coordinate at time 0.5", node.Z, 0.21612092234725555, tolerance)
 
-                if time > 0.999999 and time < 1.0000001:
+                if self.time > 0.999999 and self.time < 1.0000001:
                     self.CheckValue("X Coordinate at time 1.0", node.X, -1.0, tolerance)
                     self.CheckValue("Y Coordinate at time 1.0", node.Y, 0.6362810292697275, tolerance)
                     self.CheckValue("Z Coordinate at time 1.0", node.Z, -0.16645873461885752, tolerance)

--- a/applications/DEMApplication/tests/test_kinematic_constraints.py
+++ b/applications/DEMApplication/tests/test_kinematic_constraints.py
@@ -35,13 +35,14 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
     def GetProblemNameWithPath(self):
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
 
-    def FinalizeTimeStep(self, time):
+    def FinalizeSolutionStep(self):
+        super(KinematicConstraintsTestSolution, self).FinalizeSolutionStep()
         tolerance = 1e-3
         for node in self.spheres_model_part.Nodes:
             velocity = node.GetSolutionStepValue(Kratos.VELOCITY)
             angular_velocity = node.GetSolutionStepValue(Kratos.ANGULAR_VELOCITY)
             if node.Id == 1:
-                if time > 0.18 and time < 0.2:
+                if self.time > 0.18 and self.time < 0.2:
                     expected_value = 0.0
                     self.CheckValueOfVelocity(velocity, 0, expected_value, tolerance)
                     expected_value = 0.0
@@ -54,20 +55,20 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
                     self.CheckValueOfAngularVelocity(angular_velocity, 1, expected_value, tolerance)
                     expected_value = 0.0
                     self.CheckValueOfAngularVelocity(angular_velocity, 2, expected_value, tolerance)
-                elif time > 0.31999 and time < 0.32:
+                elif self.time > 0.31999 and self.time < 0.32:
                     expected_value = -1.179
                     self.CheckValueOfVelocity(velocity, 1, expected_value, tolerance)
 
             if node.Id == 2:
-                if time > 0.25 and time < 0.3:
-                    expected_value = -10.0 * time
+                if self.time > 0.25 and self.time < 0.3:
+                    expected_value = -10.0 * self.time
                     self.CheckValueOfVelocity(velocity, 0, expected_value, tolerance)
-                if time > 0.59999 and time < 0.6:
+                if self.time > 0.59999 and self.time < 0.6:
                     expected_value = -1.962
                     self.CheckValueOfVelocity(velocity, 1, expected_value, tolerance)
 
             if node.Id == 3:
-                if time < 0.1:
+                if self.time < 0.1:
                     expected_value = -5.0
                     self.CheckValueOfVelocity(velocity, 0, expected_value, tolerance)
                     expected_value = 0.0
@@ -81,7 +82,7 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
                     expected_value = -10.0
                     self.CheckValueOfAngularVelocity(angular_velocity, 2, expected_value, tolerance)
             if node.Id == 4:
-                if time > 0.22 and time < 0.25:
+                if self.time > 0.22 and self.time < 0.25:
                     expected_value = 0.2192
                     self.CheckValueOfAngularVelocity(angular_velocity, 2, expected_value, tolerance)
 

--- a/applications/DemStructuresCouplingApplication/python_scripts/dem_fem_coupling_algorithm.py
+++ b/applications/DemStructuresCouplingApplication/python_scripts/dem_fem_coupling_algorithm.py
@@ -219,8 +219,6 @@ class Algorithm(object):
                     self.dem_solution.demio.PrintMultifileLists(self.dem_solution.time, self.dem_solution.post_path)
                     self.dem_solution.time_old_print = self.dem_solution.time
 
-                self.dem_solution.FinalizeTimeStep(self.dem_solution.time)
-
             DemFem.InterpolateStructuralSolutionForDEM().RestoreStructuralSolution(self.structural_mp)
 
     def ReadDemModelParts(self,

--- a/applications/DemStructuresCouplingApplication/python_scripts/sp_dem_fem_coupling_algorithm.py
+++ b/applications/DemStructuresCouplingApplication/python_scripts/sp_dem_fem_coupling_algorithm.py
@@ -212,8 +212,6 @@ class SPAlgorithm(Algorithm):
                     if self.test_number:
                         self.stress_failure_check_utility.ExecuteFinalizeSolutionStep()
 
-                self.dem_solution.FinalizeTimeStep(self.dem_solution.time)
-
             DemFem.InterpolateStructuralSolutionForDEM().RestoreStructuralSolution(self.structural_mp)
 
             # Write SP data

--- a/applications/FemToDemApplication/python_scripts/MainCouplingFemDem.py
+++ b/applications/FemToDemApplication/python_scripts/MainCouplingFemDem.py
@@ -94,7 +94,7 @@ class MainCoupledFemDem_Solution:
         else:
             self.DEMFEM_contact = self.FEM_Solution.ProjectParameters["DEM_FEM_contact"].GetBool()
         self.FEM_Solution.main_model_part.ProcessInfo[KratosFemDem.DEMFEM_CONTACT] = self.DEMFEM_contact
-        
+
 
         # Initialize IP variables to zero
         self.InitializeIntegrationPointsVariables()
@@ -218,8 +218,6 @@ class MainCoupledFemDem_Solution:
         # DEM GiD print output
         self.PrintDEMResults()
 
-        self.DEM_Solution.FinalizeTimeStep(self.DEM_Solution.time)
-
         # Transfer the contact forces of the DEM to the FEM nodes
         if self.TransferDEMContactForcesToFEM:
             self.TransferNodalForcesToFEM()
@@ -287,7 +285,7 @@ class MainCoupledFemDem_Solution:
             utils.SetNonHistoricalVariable(KratosFemDem.STRESS_VECTOR, [0.0,0.0,0.0], elements)
             utils.SetNonHistoricalVariable(KratosFemDem.STRAIN_VECTOR, [0.0,0.0,0.0], elements)
             utils.SetNonHistoricalVariable(KratosFemDem.STRESS_VECTOR_INTEGRATED, [0.0, 0.0, 0.0], elements)
-        
+
         if self.PressureLoad:
             utils.SetNonHistoricalVariable(KratosFemDem.PRESSURE_ID, 0, nodes)
 
@@ -489,7 +487,7 @@ class MainCoupledFemDem_Solution:
                 # We assign the flag to recompute neighbours inside the 3D elements
                 utils = KratosMultiphysics.VariableUtils()
                 utils.SetNonHistoricalVariable(KratosFemDem.RECOMPUTE_NEIGHBOURS, True, self.FEM_Solution.main_model_part.Elements)
-            
+
             # We update the skin for the DE-FE contact
             self.ComputeSkinSubModelPart()
             if self.DEMFEM_contact:
@@ -716,7 +714,7 @@ class MainCoupledFemDem_Solution:
                     strain_vector = Elem.GetValue(KratosFemDem.STRAIN_VECTOR)
 
                     damage = Elem.GetValue(KratosFemDem.DAMAGE_ELEMENT)
-                    
+
                     if self.domain_size == 2:
                         Sxx = stress_tensor[0][0]
                         Syy = stress_tensor[0][1]
@@ -841,12 +839,12 @@ class MainCoupledFemDem_Solution:
             self.FEM_Solution.KratosPrintInfo("FEM-DEM:: RemoveAloneDEMElements")
 
         remove_alone_DEM_elements_process = KratosFemDem.RemoveAloneDEMElementsProcess(
-                                                         self.FEM_Solution.main_model_part, 
+                                                         self.FEM_Solution.main_model_part,
                                                          self.SpheresModelPart)
         remove_alone_DEM_elements_process.Execute()
 
 #ExecuteBeforeGeneratingDEM============================================================================================================================
-    def ExecuteBeforeGeneratingDEM(self): 
+    def ExecuteBeforeGeneratingDEM(self):
         """Here the erased are labeled as INACTIVE so you can access to them. After calling
            GenerateDEM they are totally erased """
         if self.PressureLoad:
@@ -885,7 +883,7 @@ class MainCoupledFemDem_Solution:
             dem_walls_mp = self.DEM_Solution.rigid_face_model_part.CreateSubModelPart("SkinTransferredFromStructure")
             dem_walls_mp.AddProperties(props)
             DemFem.DemStructuresCouplingUtilities().TransferStructuresSkinToDem(fem_skin_mp, dem_walls_mp, props)
-    
+
     #-----------------------------------
     def EraseConditionsAndNodesSubModelPart(self):
         DEM_sub_model_part = self.DEM_Solution.rigid_face_model_part.GetSubModelPart("SkinTransferredFromStructure")

--- a/applications/FemToDemApplication/python_scripts/MainCouplingFemDemSubstepping.py
+++ b/applications/FemToDemApplication/python_scripts/MainCouplingFemDemSubstepping.py
@@ -31,7 +31,7 @@ class MainCoupledFemDemSubstepping_Solution(MainCouplingFemDem.MainCoupledFemDem
         if self.DEM_Solution.spheres_model_part.NumberOfElements() > 0:
             self.FEM_Solution.KratosPrintInfo("Performing DEM Substepping...")
             while pseudo_substepping_time <= self.FEM_Solution.delta_time:
-                ### Begin Substepping 
+                ### Begin Substepping
                 self.BeforeSolveDEMOperations()
                 FEMDEM_utilities.InterpolateStructuralSolution(self.FEM_Solution.main_model_part,
                                                                self.FEM_Solution.delta_time,
@@ -54,8 +54,6 @@ class MainCoupledFemDemSubstepping_Solution(MainCouplingFemDem.MainCoupledFemDem
 
                 # DEM GiD print output
                 self.PrintDEMResults()
-
-                self.DEM_Solution.FinalizeTimeStep(self.DEM_Solution.time)
 
                 # Advancing in DEM explicit scheme
                 pseudo_substepping_time += self.DEM_Solution.solver.dt


### PR DESCRIPTION
Hard removal. No warning will be printed, as this old style was deprecated long ago, and this method was converted into FinalizeSolutionStep by all users.