### PR TITLE
[Core] UblasSpace fix TwoNorm

### DIFF
--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -280,24 +280,12 @@ public:
     static TDataType TwoNorm(Matrix const& rA) // Frobenious norm
     {
         TDataType aux_sum = TDataType();
-#ifndef _OPENMP
-        for (int i = 0; i < static_cast<int>(rA.size1()); i++)
-        {
-            for (int j = 0; j < static_cast<int>(rA.size2()); j++)
-            {
-                aux_sum += rA(i,j) * rA(i,j);
-            }
-        }
-#else
         #pragma omp parallel for reduction(+:aux_sum)
-        for (int i = 0; i < static_cast<int>(rA.size1()); i++)
-        {
-            for (int j = 0; j < static_cast<int>(rA.size2()); j++)
-            {
+        for (int i = 0; i < static_cast<int>(rA.size1()); i++) {
+            for (int j = 0; j < static_cast<int>(rA.size2()); j++) {
                 aux_sum += rA(i,j) * rA(i,j);
             }
         }
-#endif
         return std::sqrt(aux_sum);
     }
 

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -277,7 +277,7 @@ public:
         return std::sqrt(Dot(rX, rX));
     }
 
-    static TDataType TwoNorm(Matrix const& rA) // Frobenious norm
+    static TDataType TwoNorm(const Matrix& rA) // Frobenious norm
     {
         TDataType aux_sum = TDataType();
         #pragma omp parallel for reduction(+:aux_sum)
@@ -289,7 +289,7 @@ public:
         return std::sqrt(aux_sum);
     }
 
-    static TDataType TwoNorm(compressed_matrix<TDataType> const& rA) // Frobenious norm
+    static TDataType TwoNorm(const compressed_matrix<TDataType> & rA) // Frobenious norm
     {
         TDataType aux_sum = TDataType();
 
@@ -313,7 +313,7 @@ public:
      * @param rA The matrix to compute the Jacobi norm
      * @return aux_sum: The Jacobi norm
      */
-    static TDataType JacobiNorm(Matrix const& rA)
+    static TDataType JacobiNorm(const Matrix& rA)
     {
         TDataType aux_sum = TDataType();
         #pragma omp parallel for reduction(+:aux_sum)

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -301,6 +301,25 @@ public:
         return std::sqrt(aux_sum);
     }
 
+    static TDataType TwoNorm(compressed_matrix<TDataType> const& rA) // Frobenious norm
+    {
+        TDataType aux_sum = TDataType();
+
+        const auto& r_row_indices = rA.index1_data();
+        const auto& r_col_indices = rA.index2_data();
+
+        #pragma omp parallel for reduction(+:aux_sum)
+        for (int i=0; i<static_cast<int>(r_row_indices.size()); ++i) {
+            const IndexType row_index = r_row_indices[i];
+
+            for (int j=0; j<static_cast<int>(r_col_indices.size()); ++j) {
+                const IndexType col_index = r_col_indices[j];
+                aux_sum += rA(row_index, col_index) * rA(row_index, col_index);
+            }
+        }
+        return std::sqrt(aux_sum);
+    }
+
     /**
      * This method computes the Jacobi norm
      * @param rA The matrix to compute the Jacobi norm

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -327,6 +327,27 @@ public:
         return aux_sum;
     }
 
+    static TDataType JacobiNorm(const compressed_matrix<TDataType>& rA)
+    {
+        TDataType aux_sum = TDataType();
+
+        const auto& r_row_indices = rA.index1_data();
+        const auto& r_col_indices = rA.index2_data();
+
+        #pragma omp parallel for reduction(+:aux_sum)
+        for (int i=0; i<static_cast<int>(r_row_indices.size()); ++i) {
+            const IndexType row_index = r_row_indices[i];
+
+            for (int j=0; j<static_cast<int>(r_col_indices.size()); ++j) {
+                const IndexType col_index = r_col_indices[j];
+                if (row_index != col_index) {
+                    aux_sum += std::abs(rA(row_index, col_index));
+                }
+            }
+        }
+        return aux_sum;
+    }
+
     static void Mult(const Matrix& rA, VectorType& rX, VectorType& rY)
     {
         axpy_prod(rA, rX, rY, true);

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -283,7 +283,7 @@ public:
         #pragma omp parallel for reduction(+:aux_sum)
         for (int i=0; i<static_cast<int>(rA.size1()); ++i) {
             for (int j=0; j<static_cast<int>(rA.size2()); ++j) {
-                aux_sum += rA(i,j) * rA(i,j);
+                aux_sum += std::pow(rA(i,j),2);
             }
         }
         return std::sqrt(aux_sum);

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -327,16 +327,14 @@ public:
 
         const auto& r_row_indices = rA.index1_data();
         const auto& r_col_indices = rA.index2_data();
+        const auto& r_values = rA.value_data();
 
         #pragma omp parallel for reduction(+:aux_sum)
-        for (int i=0; i<static_cast<int>(r_row_indices.size()); ++i) {
+        for (int i=0; i<static_cast<int>(r_values.size()); ++i) {
             const IndexType row_index = r_row_indices[i];
-
-            for (int j=0; j<static_cast<int>(r_col_indices.size()); ++j) {
-                const IndexType col_index = r_col_indices[j];
-                if (row_index != col_index) {
-                    aux_sum += std::abs(rA(row_index, col_index));
-                }
+            const IndexType col_index = r_col_indices[i];
+            if (row_index != col_index) {
+                aux_sum += std::abs(r_values[i]);
             }
         }
         return aux_sum;

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -302,7 +302,7 @@ public:
 
             for (int j=0; j<static_cast<int>(r_col_indices.size()); ++j) {
                 const IndexType col_index = r_col_indices[j];
-                aux_sum += rA(row_index, col_index) * rA(row_index, col_index);
+                aux_sum += std::pow(rA(row_index, col_index) , 2);
             }
         }
         return std::sqrt(aux_sum);

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -281,8 +281,8 @@ public:
     {
         TDataType aux_sum = TDataType();
         #pragma omp parallel for reduction(+:aux_sum)
-        for (int i = 0; i < static_cast<int>(rA.size1()); i++) {
-            for (int j = 0; j < static_cast<int>(rA.size2()); j++) {
+        for (int i=0; i<static_cast<int>(rA.size1()); ++i) {
+            for (int j=0; j<static_cast<int>(rA.size2()); ++j) {
                 aux_sum += rA(i,j) * rA(i,j);
             }
         }

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -313,35 +313,17 @@ public:
      * @param rA The matrix to compute the Jacobi norm
      * @return aux_sum: The Jacobi norm
      */
-    static TDataType JacobiNorm(MatrixType const& rA)
+    static TDataType JacobiNorm(Matrix const& rA)
     {
         TDataType aux_sum = TDataType();
-
-#ifndef _OPENMP
-        for (int i = 0; i < static_cast<int>(rA.size1()); i++)
-        {
-            for (int j = 0; j < static_cast<int>(rA.size2()); j++)
-            {
-                if (i != j)
-                {
-                    aux_sum += std::abs(rA(i,j));
-                }
-            }
-        }
-#else
         #pragma omp parallel for reduction(+:aux_sum)
-        for (int i = 0; i < static_cast<int>(rA.size1()); i++)
-        {
-            for (int j = 0; j < static_cast<int>(rA.size2()); j++)
-            {
-                if (i != j)
-                {
+        for (int i=0; i<static_cast<int>(rA.size1()); ++i) {
+            for (int j=0; j<static_cast<int>(rA.size2()); ++j) {
+                if (i != j) {
                     aux_sum += std::abs(rA(i,j));
                 }
             }
         }
-#endif
-
         return aux_sum;
     }
 

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -277,7 +277,7 @@ public:
         return std::sqrt(Dot(rX, rX));
     }
 
-    static TDataType TwoNorm(MatrixType const& rA) // Frobenious norm
+    static TDataType TwoNorm(Matrix const& rA) // Frobenious norm
     {
         TDataType aux_sum = TDataType();
 #ifndef _OPENMP

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -325,16 +325,14 @@ public:
     {
         TDataType aux_sum = TDataType();
 
-        const auto& r_row_indices = rA.index1_data();
-        const auto& r_col_indices = rA.index2_data();
-        const auto& r_values = rA.value_data();
+        typedef typename compressed_matrix<TDataType>::const_iterator1 t_it_1;
+        typedef typename compressed_matrix<TDataType>::const_iterator2 t_it_2;
 
-        #pragma omp parallel for reduction(+:aux_sum)
-        for (int i=0; i<static_cast<int>(r_values.size()); ++i) {
-            const IndexType row_index = r_row_indices[i];
-            const IndexType col_index = r_col_indices[i];
-            if (row_index != col_index) {
-                aux_sum += std::abs(r_values[i]);
+        for (t_it_1 it_1 = rA.begin1(); it_1 != rA.end1(); ++it_1) {
+            for (t_it_2 it_2 = it_1.begin(); it_2 != it_1.end(); ++it_2) {
+                if (it_2.index1() != it_2.index2()) {
+                    aux_sum += std::abs(*it_2);
+                }
             }
         }
         return aux_sum;

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -289,7 +289,7 @@ public:
             }
         }
 #else
-        #pragma omp parallel reduction(+:aux_sum)
+        #pragma omp parallel for reduction(+:aux_sum)
         for (int i = 0; i < static_cast<int>(rA.size1()); i++)
         {
             for (int j = 0; j < static_cast<int>(rA.size2()); j++)

--- a/kratos/spaces/ublas_space.h
+++ b/kratos/spaces/ublas_space.h
@@ -293,17 +293,11 @@ public:
     {
         TDataType aux_sum = TDataType();
 
-        const auto& r_row_indices = rA.index1_data();
-        const auto& r_col_indices = rA.index2_data();
+        const auto& r_values = rA.value_data();
 
         #pragma omp parallel for reduction(+:aux_sum)
-        for (int i=0; i<static_cast<int>(r_row_indices.size()); ++i) {
-            const IndexType row_index = r_row_indices[i];
-
-            for (int j=0; j<static_cast<int>(r_col_indices.size()); ++j) {
-                const IndexType col_index = r_col_indices[j];
-                aux_sum += std::pow(rA(row_index, col_index) , 2);
-            }
+        for (int i=0; i<static_cast<int>(r_values.size()); ++i) {
+            aux_sum += std::pow(r_values[i] , 2);
         }
         return std::sqrt(aux_sum);
     }

--- a/kratos/tests/cpp_tests/spaces/test_ublas_space.cpp
+++ b/kratos/tests/cpp_tests/spaces/test_ublas_space.cpp
@@ -1,0 +1,62 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher (https://github.com/philbucher)
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+#include "testing/testing.h"
+#include "spaces/ublas_space.h"
+
+
+namespace Kratos {
+namespace Testing {
+
+typedef UblasSpace<double, CompressedMatrix, boost::numeric::ublas::vector<double>> SparseSpaceType;
+typedef UblasSpace<double, Matrix, Vector> LocalSpaceType;
+
+KRATOS_TEST_CASE_IN_SUITE(UblasSpaceNormSparseMatrix, KratosCoreFastSuite)
+{
+    const std::size_t size = 10;
+    SparseSpaceType::MatrixType mat(size, size);
+
+    for (std::size_t i=0; i<mat.size1(); ++i)	{
+        if (i>=1) {mat.push_back(i, i-1, -1.123);}
+        mat.push_back(i, i, 4.5);
+        if (i+1<mat.size2()) {mat.push_back(i, i+1, 2.336);}
+    }
+
+    KRATOS_CHECK_NEAR(16.216110045260546, SparseSpaceType::TwoNorm(mat), 1e-12);
+    KRATOS_CHECK_NEAR(31.131, SparseSpaceType::JacobiNorm(mat), 1e-12);
+}
+
+KRATOS_TEST_CASE_IN_SUITE(UblasSpaceNormDenseMatrix, KratosCoreFastSuite)
+{
+    const std::size_t size = 10;
+    LocalSpaceType::MatrixType mat(size, size, 0.0);
+
+    for (std::size_t i=0; i<mat.size1(); ++i)	{
+        mat(i,i) = 4.5;
+
+        if (i>=1) {mat(i,i-1) = -1.123;}
+
+        if (i+1<mat.size2()) {mat(i,i+1) = 2.336;}
+    }
+
+    KRATOS_CHECK_NEAR(16.216110045260546, SparseSpaceType::TwoNorm(mat), 1e-12);
+    KRATOS_CHECK_NEAR(31.131, SparseSpaceType::JacobiNorm(mat), 1e-12);
+}
+
+} // namespace Testing
+} // namespace Kratos.


### PR DESCRIPTION
The old implementation of `TwoNorm` looped also the non-zero entries of the Sparse matrix. I am not sure if this is a problem for the `compressed_matrix` or not.
In any case, now there is a dedicated version for each, dense and sparse matrix. 
The sparse matrix version only loops the non-zero entries.
Also and omp-problem is fixed (missing keyword `for`)

@manuelmessmer can you please try this and see if the norms you get are now consistent?