### PR TITLE
[Contact] add dependency on StructuralMechanics in CMake

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/CMakeLists.txt
+++ b/applications/ContactStructuralMechanicsApplication/CMakeLists.txt
@@ -2,6 +2,8 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 message("**** Configuring KratosContactStructuralMechanicsApplication ****")
 
+kratos_add_dependency(${KRATOS_SOURCE_DIR}/applications/StructuralMechanicsApplication)
+
 ################### PYBIND11
 include(pybind11Tools)
 


### PR DESCRIPTION
Contact links against StructuralMechanics, hence it cannot be used without