### PR TITLE
[Core] Add decorators to Parameters

### DIFF
--- a/kratos/includes/kratos_parameters.h
+++ b/kratos/includes/kratos_parameters.h
@@ -706,6 +706,13 @@ public:
     void Append(const Parameters& rValue);
 
     /**
+     * @brief This method extracts the decorators of the parameters
+     * @details Removes the decorators from the name of the parameters, also returns a parameter containing an integer wich describes if it is required (the integer can be adapted to future uses)
+     * @return The Parameters containing an integer which describes how to be used
+     */
+    Parameters ExtractDecorators();
+
+    /**
      * @brief This method looks in a recursive way in the json structure
      * @param rBaseValue The value where to find
      * @param rValueToFind The value to look
@@ -937,6 +944,16 @@ private:
      * @warning Please DO NOT use this method. It is a low level accessor, and may change in the future
      */
     void InternalSetValue(const Parameters& rOtherValue);
+
+    /**
+     * @brief This generates a Parameters which replies the structure of the original
+     * @param rDecoratorParameters Contains the integers describing how the original parameters must be used
+     * @param DefaultDecorator If all parameters have the same default decorator
+     */
+    void GenerateParametersDecorator(
+        Parameters& rDecoratorParameters,
+        const int DefaultDecorator = 0
+        );
 
 }; // Parameters class
 

--- a/kratos/python/add_kratos_parameters_to_python.cpp
+++ b/kratos/python/add_kratos_parameters_to_python.cpp
@@ -82,6 +82,7 @@ void  AddKratosParametersToPython(pybind11::module& m)
     .def("RecursivelyAddMissingParameters", &Parameters::RecursivelyAddMissingParameters)
     .def("ValidateDefaults", &Parameters::ValidateDefaults)
     .def("RecursivelyValidateDefaults", &Parameters::RecursivelyValidateDefaults)
+    .def("ExtractDecorators",&Parameters::ExtractDecorators)
     .def("IsEquivalentTo",&Parameters::IsEquivalentTo)
     .def("HasSameKeysAndTypeOfValuesAs",&Parameters::HasSameKeysAndTypeOfValuesAs)
     //.def("GetValue", GetValue) //Do not export this method. users shall adopt the operator [] syntax

--- a/kratos/tests/test_kratos_parameters.py
+++ b/kratos/tests/test_kratos_parameters.py
@@ -470,6 +470,50 @@ class TestParameters(KratosUnittest.TestCase):
         self.assertFalse(kp.Has("int_value"))
         self.assertFalse(kp.Has("level1"))
 
+    def test_extract_decorators(self):
+        # This method checks all the "IsXXX" Methods
+        tmp = Parameters("""{
+            "int_value" : 10,
+            "double_value@mandatory": 2.0,
+            "bool_value" : true,
+            "more_parameters" :  {
+                "sub_int_value@mandatory" : 30
+            },
+            "even_more_parameters@mandatory" :  {
+                "sub_int_value" : 30,
+                "sub_double_value": 2.0
+            }
+        }""")
+        decorator_tmp = tmp.ExtractDecorators()
+
+        extracted = Parameters("""{
+            "bool_value": true,
+            "double_value": 2.0,
+            "even_more_parameters": {
+                "sub_double_value": 2.0,
+                "sub_int_value": 30
+            },
+            "int_value": 10,
+            "more_parameters": {
+                "sub_int_value": 30
+            }
+        }""")
+        decorators = Parameters("""{
+            "bool_value": 0,
+            "double_value": 1,
+            "even_more_parameters": {
+                "sub_double_value": 1,
+                "sub_int_value": 1
+            },
+            "int_value": 0,
+            "more_parameters": {
+                "sub_int_value": 1
+            }
+        }""")
+
+        self.assertTrue( tmp.IsEquivalentTo(extracted) )
+        self.assertTrue( decorator_tmp.IsEquivalentTo(decorators) )
+
     def test_is_methods(self):
         # This method checks all the "IsXXX" Methods
         tmp = Parameters("""{


### PR DESCRIPTION
Partially fix #5106. This tackles comment 2 from #5106. It adds the possibility to consider decorators in the parameters, so we can know for example if a parameter is mandatory