### PR TITLE
[Core] Connectivity preserve modeller

### DIFF
--- a/kratos/modeler/connectivity_preserve_modeler.h
+++ b/kratos/modeler/connectivity_preserve_modeler.h
@@ -188,7 +188,7 @@ private:
             for (int i_item = 0; i_item < number_of_items; ++i_item)
             {
                 const auto& r_item = *(rContainer.begin() + i_item);
-                local_id = std::max(local_id, r_item.Id());
+                local_id = std::max(local_id, static_cast<long unsigned int>(r_item.Id()));
             }
 #pragma omp critical
             {

--- a/kratos/modeler/connectivity_preserve_modeler.h
+++ b/kratos/modeler/connectivity_preserve_modeler.h
@@ -128,6 +128,14 @@ public:
     ///@}
 
 private:
+    ///@name Private member Variables
+    ///@{
+
+    IndexType mElementOffset;
+    IndexType mConditionOffset;
+
+    ///@}
+
     ///@name Private Operations
     ///@{
 
@@ -144,13 +152,13 @@ private:
         ModelPart& rOriginModelPart,
         ModelPart& rDestinationModelPart,
         const Element& rReferenceElement
-    ) const;
+    );
 
     void DuplicateConditions(
         ModelPart& rOriginModelPart,
         ModelPart& rDestinationModelPart,
         const Condition& rReferenceBoundaryCondition
-    ) const;
+    );
 
     void DuplicateCommunicatorData(
         ModelPart& rOriginModelPart,

--- a/kratos/modeler/connectivity_preserve_modeler.h
+++ b/kratos/modeler/connectivity_preserve_modeler.h
@@ -131,8 +131,8 @@ private:
     ///@name Private member Variables
     ///@{
 
-    IndexType mElementOffset;
-    IndexType mConditionOffset;
+    long unsigned int mElementOffset;
+    long unsigned int mConditionOffset;
 
     ///@}
 
@@ -171,13 +171,16 @@ private:
     ) const;
 
     template <typename TContainer>
-    IndexType GetMaxId(const TContainer& rContainer, const Communicator& rCommunicator) const
+    long unsigned int GetMaxId(
+        const TContainer& rContainer,
+        const Communicator& rCommunicator
+    ) const
     {
         KRATOS_TRY
 
         const int number_of_items = rContainer.size();
 
-        IndexType max_item_id{0}, local_id{0};
+        long unsigned int max_item_id{0}, local_id{0};
         // using customized max reduction since windows doesnt support max reduction in omp
 #pragma omp parallel firstprivate(local_id)
         {

--- a/kratos/sources/connectivity_preserve_modeler.cpp
+++ b/kratos/sources/connectivity_preserve_modeler.cpp
@@ -253,6 +253,7 @@ ModelPart& rDestinationModelPart) const
 {
     // If we copy root model part into a submodel part, then it will create element/condition whith ids which may
     // conflict with destination model part root model part ids
+    // or we need to add all the submodel part elements and conditions in the origin model part as well
     if (!rDestinationModelPart.IsSubModelPart())
     {
         for (auto i_part = rOriginModelPart.SubModelPartsBegin(); i_part != rOriginModelPart.SubModelPartsEnd(); ++i_part) {

--- a/kratos/tests/test_connectivity_preserve_modeler.py
+++ b/kratos/tests/test_connectivity_preserve_modeler.py
@@ -5,7 +5,202 @@ import KratosMultiphysics
 
 class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
 
-    def test_connectivity_preserve_modeler(self):
+    # def test_connectivity_preserve_modeler(self):
+    #     current_model = KratosMultiphysics.Model()
+    #     model_part1 = current_model.CreateModelPart("Main")
+    #     model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+
+    #     model_part1.CreateNewNode(1,0.0,0.1,0.2)
+    #     model_part1.CreateNewNode(2,2.0,0.1,0.2)
+    #     model_part1.CreateNewNode(3,1.0,1.1,0.2)
+    #     model_part1.CreateNewNode(4,2.0,3.1,10.2)
+
+    #     sub1 = model_part1.CreateSubModelPart("sub1")
+    #     sub2 = model_part1.CreateSubModelPart("sub2")
+    #     subsub1 = sub1.CreateSubModelPart("subsub1")
+    #     subsub1.AddNodes([1,2])
+    #     sub2.AddNodes([3])
+
+    #     model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
+    #     model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
+
+    #     model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
+    #     sub1.AddConditions([2])
+
+    #     current_model = KratosMultiphysics.Model()
+    #     new_model_part = current_model.CreateModelPart("Other")
+
+    #     modeler = KratosMultiphysics.ConnectivityPreserveModeler()
+    #     modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
+
+    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
+    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
+    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+
+    #     ##assign a value to an element in model_part1, the corresponding element in the other model part
+    #     # will change as they are pointing to the same geometry
+    #     model_part1.Elements[1].SetValue(KratosMultiphysics.DISTANCE, 1.0)
+    #     self.assertEqual(model_part1.Elements[1].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
+    #     self.assertEqual(new_model_part.Elements[1].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
+
+    #     ##assign a value to an condition in model_part1, the corresponding condition in the other model part
+    #     # will change as they are pointing to the same geometry
+    #     model_part1.Conditions[2].SetValue(KratosMultiphysics.DISTANCE, 1.0)
+    #     self.assertEqual(model_part1.Conditions[2].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
+    #     self.assertEqual(new_model_part.Conditions[2].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
+
+    #     #assign a value to a node of new_model_part --> affects both model parts
+    #     new_model_part.Nodes[1].SetSolutionStepValue(KratosMultiphysics.DISTANCE,0,2.0)
+    #     self.assertEqual(model_part1.Nodes[1].GetSolutionStepValue(KratosMultiphysics.DISTANCE)   , 2.0)
+    #     self.assertEqual(new_model_part.Nodes[1].GetSolutionStepValue(KratosMultiphysics.DISTANCE), 2.0)
+
+    #     #test if submodelparts are created correctly
+    #     for part in model_part1.SubModelParts:
+    #         new_part = new_model_part.GetSubModelPart(part.Name)
+    #         for node in part.Nodes:
+    #             self.assertTrue( node.Id in new_part.Nodes)
+    #         for cond in part.Conditions:
+    #             self.assertTrue( cond.Id in new_part.Conditions)
+    #         for elem in part.Elements:
+    #             self.assertTrue( elem.Id in new_part.Elements)
+
+    #     model_part1.GetSubModelPart("sub1").Conditions[2].SetValue(KratosMultiphysics.TEMPERATURE, 1234.0)
+    #     self.assertEqual(model_part1.Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
+    #     self.assertEqual(model_part1.GetSubModelPart("sub1").Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
+    #     self.assertEqual(new_model_part.Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
+    #     self.assertEqual(new_model_part.GetSubModelPart("sub1").Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
+
+    # def test_repeated_call(self):
+    #     current_model = KratosMultiphysics.Model()
+    #     model_part1 = current_model.CreateModelPart("Main")
+    #     model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+
+    #     model_part1.CreateNewNode(1,0.0,0.1,0.2)
+    #     model_part1.CreateNewNode(2,2.0,0.1,0.2)
+    #     model_part1.CreateNewNode(3,1.0,1.1,0.2)
+    #     model_part1.CreateNewNode(4,2.0,3.1,10.2)
+
+    #     sub1 = model_part1.CreateSubModelPart("sub1")
+    #     subsub1 = sub1.CreateSubModelPart("subsub1")
+    #     subsub1.AddNodes([1,2])
+
+    #     model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
+    #     model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
+
+    #     model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
+    #     model_part1.CreateNewCondition("LineCondition2D2N", 1, [1,2], model_part1.GetProperties()[1])
+    #     sub1.AddConditions([2])
+
+    #     current_model = KratosMultiphysics.Model()
+    #     new_model_part = current_model.CreateModelPart("New1")
+    #     new_model_part2 = current_model.CreateModelPart("New2")
+
+    #     modeler = KratosMultiphysics.ConnectivityPreserveModeler()
+    #     modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
+    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
+    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
+    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+
+    #     modeler.GenerateModelPart(model_part1, new_model_part2, "Element2D3N", "LineCondition2D2N")
+    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part2.Nodes))
+    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part2.Conditions))
+    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part2.Elements))
+
+    #     modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
+    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
+    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
+    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+
+    #     modeler.GenerateModelPart(model_part1, new_model_part2, "Element2D3N", "LineCondition2D2N")
+    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part2.Nodes))
+    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part2.Conditions))
+    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part2.Elements))
+
+    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
+    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
+    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+
+    # def test_variable_list_merging(self):
+    #     current_model = KratosMultiphysics.Model()
+    #     model_part1 = current_model.CreateModelPart("mp1")
+    #     model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+    #     model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+
+    #     model_part2 = current_model.CreateModelPart("mp2")
+    #     model_part2.AddNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE)
+    #     model_part2.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
+
+    #     #check before merging variable lists
+    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
+    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
+    #     self.assertFalse(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
+    #     self.assertFalse(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
+    #     self.assertFalse(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
+    #     self.assertFalse(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
+    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
+    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
+
+    #     KratosMultiphysics.MergeVariableListsUtility().Merge(model_part1, model_part2)
+
+    #     #check after merging variable lists
+    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
+    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
+    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
+    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
+    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
+    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
+    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
+    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
+
+    # def test_element_only_copy(self):
+    #     current_model = KratosMultiphysics.Model()
+    #     model_part1 = current_model.CreateModelPart("Main")
+    #     model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+
+    #     model_part1.CreateNewNode(1,0.0,0.1,0.2)
+    #     model_part1.CreateNewNode(2,2.0,0.1,0.2)
+    #     model_part1.CreateNewNode(3,1.0,1.1,0.2)
+    #     model_part1.CreateNewNode(4,2.0,3.1,10.2)
+
+    #     sub1 = model_part1.CreateSubModelPart("sub1")
+
+    #     model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
+    #     model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
+
+    #     model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
+    #     sub1.AddConditions([2])
+
+    #     element_model_part = current_model.CreateModelPart("ElementCopy")
+
+    #     modeler = KratosMultiphysics.ConnectivityPreserveModeler()
+
+    #     modeler.GenerateModelPart(model_part1, element_model_part, "Element2D3N")
+
+    #     self.assertEqual(len(element_model_part.Nodes) , len(model_part1.Nodes))
+    #     self.assertEqual(len(element_model_part.Elements) , len(model_part1.Elements))
+    #     self.assertEqual(len(element_model_part.Conditions) , 0)
+
+    #     element_sub1_copy = element_model_part.GetSubModelPart("sub1")
+
+    #     self.assertEqual(len(element_sub1_copy.Nodes) , len(sub1.Nodes))
+    #     self.assertEqual(len(element_sub1_copy.Elements) , len(sub1.Elements))
+    #     self.assertEqual(len(element_sub1_copy.Conditions) , 0)
+
+    #     condition_model_part = current_model.CreateModelPart("ConditionCopy")
+
+    #     modeler.GenerateModelPart(model_part1, condition_model_part, "LineCondition2D2N")
+
+    #     self.assertEqual(len(condition_model_part.Nodes) , len(model_part1.Nodes))
+    #     self.assertEqual(len(condition_model_part.Elements) , 0)
+    #     self.assertEqual(len(condition_model_part.Conditions) , len(model_part1.Conditions))
+
+    #     condition_sub1_copy = condition_model_part.GetSubModelPart("sub1")
+
+    #     self.assertEqual(len(condition_sub1_copy.Nodes) , len(sub1.Nodes))
+    #     self.assertEqual(len(condition_sub1_copy.Elements) , 0)
+    #     self.assertEqual(len(condition_sub1_copy.Conditions) , len(sub1.Conditions))
+
+    def test_copy_to_sub_model_part(self):
         current_model = KratosMultiphysics.Model()
         model_part1 = current_model.CreateModelPart("Main")
         model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
@@ -24,53 +219,32 @@ class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
         model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
         model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
 
-        model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
-        sub1.AddConditions([2])
+        model_part1.CreateNewCondition("LineCondition2D2N", 3, [2,4], model_part1.GetProperties()[1])
+        sub1.AddConditions([3])
 
         current_model = KratosMultiphysics.Model()
-        new_model_part = current_model.CreateModelPart("Other")
+        new_model_part = model_part1.CreateSubModelPart("Other")
 
         modeler = KratosMultiphysics.ConnectivityPreserveModeler()
         modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
 
-        self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
-        self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
-        self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+        element_id_offset = 2
+        for duplicate_element in new_model_part.Elements:
+            duplicate_element_id = duplicate_element.Id
+            original_element_id = duplicate_element_id - element_id_offset
+            original_element = model_part1.GetElement(original_element_id)
+            self.assertFalse(original_element == duplicate_element)
+            self.assertTrue(original_element.GetGeometry() == duplicate_element.GetGeometry())
 
-        ##assign a value to an element in model_part1, the corresponding element in the other model part
-        # will change as they are pointing to the same geometry
-        model_part1.Elements[1].SetValue(KratosMultiphysics.DISTANCE, 1.0)
-        self.assertEqual(model_part1.Elements[1].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
-        self.assertEqual(new_model_part.Elements[1].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
+        condition_id_offset = 3
+        for duplicate_condition in new_model_part.Conditions:
+            duplicate_condition_id = duplicate_condition.Id
+            original_condition_id = duplicate_condition_id - condition_id_offset
+            original_condition = model_part1.GetCondition(original_condition_id)
+            self.assertFalse(original_condition == duplicate_condition)
+            self.assertTrue(original_condition.GetGeometry() == duplicate_condition.GetGeometry())
 
-        ##assign a value to an condition in model_part1, the corresponding condition in the other model part
-        # will change as they are pointing to the same geometry
-        model_part1.Conditions[2].SetValue(KratosMultiphysics.DISTANCE, 1.0)
-        self.assertEqual(model_part1.Conditions[2].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
-        self.assertEqual(new_model_part.Conditions[2].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
-
-        #assign a value to a node of new_model_part --> affects both model parts
-        new_model_part.Nodes[1].SetSolutionStepValue(KratosMultiphysics.DISTANCE,0,2.0)
-        self.assertEqual(model_part1.Nodes[1].GetSolutionStepValue(KratosMultiphysics.DISTANCE)   , 2.0)
-        self.assertEqual(new_model_part.Nodes[1].GetSolutionStepValue(KratosMultiphysics.DISTANCE), 2.0)
-
-        #test if submodelparts are created correctly
-        for part in model_part1.SubModelParts:
-            new_part = new_model_part.GetSubModelPart(part.Name)
-            for node in part.Nodes:
-                self.assertTrue( node.Id in new_part.Nodes)
-            for cond in part.Conditions:
-                self.assertTrue( cond.Id in new_part.Conditions)
-            for elem in part.Elements:
-                self.assertTrue( elem.Id in new_part.Elements)
-
-        model_part1.GetSubModelPart("sub1").Conditions[2].SetValue(KratosMultiphysics.TEMPERATURE, 1234.0)
-        self.assertEqual(model_part1.Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
-        self.assertEqual(model_part1.GetSubModelPart("sub1").Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
-        self.assertEqual(new_model_part.Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
-        self.assertEqual(new_model_part.GetSubModelPart("sub1").Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
-
-    def test_repeated_call(self):
+    def test_copy_to_and_from_sub_model_part(self):
         current_model = KratosMultiphysics.Model()
         model_part1 = current_model.CreateModelPart("Main")
         model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
@@ -81,78 +255,43 @@ class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
         model_part1.CreateNewNode(4,2.0,3.1,10.2)
 
         sub1 = model_part1.CreateSubModelPart("sub1")
+        sub2 = model_part1.CreateSubModelPart("sub2")
         subsub1 = sub1.CreateSubModelPart("subsub1")
         subsub1.AddNodes([1,2])
+        sub2.AddNodes([3])
 
         model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
         model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
 
-        model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
-        model_part1.CreateNewCondition("LineCondition2D2N", 1, [1,2], model_part1.GetProperties()[1])
-        sub1.AddConditions([2])
+        model_part1.CreateNewCondition("LineCondition2D2N", 3, [2,4], model_part1.GetProperties()[1])
+        model_part1.CreateNewCondition("LineCondition2D2N", 4, [3,4], model_part1.GetProperties()[1])
+        sub1.AddConditions([3])
+        sub2.AddConditions([4])
+        sub2.AddElements([1])
 
         current_model = KratosMultiphysics.Model()
-        new_model_part = current_model.CreateModelPart("New1")
-        new_model_part2 = current_model.CreateModelPart("New2")
+        new_model_part = model_part1.CreateSubModelPart("Other")
 
         modeler = KratosMultiphysics.ConnectivityPreserveModeler()
-        modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
-        self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
-        self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
-        self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+        modeler.GenerateModelPart(sub2, new_model_part, "Element2D3N", "LineCondition2D2N")
 
-        modeler.GenerateModelPart(model_part1, new_model_part2, "Element2D3N", "LineCondition2D2N")
-        self.assertEqual(len(model_part1.Nodes) , len(new_model_part2.Nodes))
-        self.assertEqual(len(model_part1.Conditions) , len(new_model_part2.Conditions))
-        self.assertEqual(len(model_part1.Elements) , len(new_model_part2.Elements))
+        element_id_offset = 2
+        for duplicate_element in new_model_part.Elements:
+            duplicate_element_id = duplicate_element.Id
+            original_element_id = duplicate_element_id - element_id_offset
+            original_element = sub2.GetElement(original_element_id)
+            self.assertFalse(original_element == duplicate_element)
+            self.assertTrue(original_element.GetGeometry() == duplicate_element.GetGeometry())
 
-        modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
-        self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
-        self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
-        self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+        condition_id_offset = 4
+        for duplicate_condition in new_model_part.Conditions:
+            duplicate_condition_id = duplicate_condition.Id
+            original_condition_id = duplicate_condition_id - condition_id_offset
+            original_condition = sub2.GetCondition(original_condition_id)
+            self.assertFalse(original_condition == duplicate_condition)
+            self.assertTrue(original_condition.GetGeometry() == duplicate_condition.GetGeometry())
 
-        modeler.GenerateModelPart(model_part1, new_model_part2, "Element2D3N", "LineCondition2D2N")
-        self.assertEqual(len(model_part1.Nodes) , len(new_model_part2.Nodes))
-        self.assertEqual(len(model_part1.Conditions) , len(new_model_part2.Conditions))
-        self.assertEqual(len(model_part1.Elements) , len(new_model_part2.Elements))
-
-        self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
-        self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
-        self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
-
-    def test_variable_list_merging(self):
-        current_model = KratosMultiphysics.Model()
-        model_part1 = current_model.CreateModelPart("mp1")
-        model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
-        model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
-
-        model_part2 = current_model.CreateModelPart("mp2")
-        model_part2.AddNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE)
-        model_part2.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
-
-        #check before merging variable lists
-        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
-        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
-        self.assertFalse(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
-        self.assertFalse(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
-        self.assertFalse(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
-        self.assertFalse(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
-        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
-        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
-
-        KratosMultiphysics.MergeVariableListsUtility().Merge(model_part1, model_part2)
-
-        #check after merging variable lists
-        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
-        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
-        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
-        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
-        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
-        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
-        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
-        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
-
-    def test_element_only_copy(self):
+    def test_copy_to_different_model_part(self):
         current_model = KratosMultiphysics.Model()
         model_part1 = current_model.CreateModelPart("Main")
         model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
@@ -163,43 +302,40 @@ class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
         model_part1.CreateNewNode(4,2.0,3.1,10.2)
 
         sub1 = model_part1.CreateSubModelPart("sub1")
+        sub2 = model_part1.CreateSubModelPart("sub2")
+        subsub1 = sub1.CreateSubModelPart("subsub1")
+        subsub1.AddNodes([1,2])
+        sub2.AddNodes([3])
 
         model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
         model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
 
-        model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
-        sub1.AddConditions([2])
+        model_part1.CreateNewCondition("LineCondition2D2N", 3, [2,4], model_part1.GetProperties()[1])
+        sub1.AddConditions([3])
 
-        element_model_part = current_model.CreateModelPart("ElementCopy")
+        current_model = KratosMultiphysics.Model()
+        model_part2 = current_model.CreateModelPart("Duplicated")
 
         modeler = KratosMultiphysics.ConnectivityPreserveModeler()
+        modeler.GenerateModelPart(model_part1, model_part2, "Element2D3N", "LineCondition2D2N")
+        new_model_part = model_part2.CreateSubModelPart("Other")
+        modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
 
-        modeler.GenerateModelPart(model_part1, element_model_part, "Element2D3N")
+        element_id_offset = 2
+        for duplicate_element in new_model_part.Elements:
+            duplicate_element_id = duplicate_element.Id
+            original_element_id = duplicate_element_id - element_id_offset
+            original_element = model_part1.GetElement(original_element_id)
+            self.assertFalse(original_element == duplicate_element)
+            self.assertTrue(original_element.GetGeometry() == duplicate_element.GetGeometry())
 
-        self.assertEqual(len(element_model_part.Nodes) , len(model_part1.Nodes))
-        self.assertEqual(len(element_model_part.Elements) , len(model_part1.Elements))
-        self.assertEqual(len(element_model_part.Conditions) , 0)
-
-        element_sub1_copy = element_model_part.GetSubModelPart("sub1")
-
-        self.assertEqual(len(element_sub1_copy.Nodes) , len(sub1.Nodes))
-        self.assertEqual(len(element_sub1_copy.Elements) , len(sub1.Elements))
-        self.assertEqual(len(element_sub1_copy.Conditions) , 0)
-
-        condition_model_part = current_model.CreateModelPart("ConditionCopy")
-
-        modeler.GenerateModelPart(model_part1, condition_model_part, "LineCondition2D2N")
-
-        self.assertEqual(len(condition_model_part.Nodes) , len(model_part1.Nodes))
-        self.assertEqual(len(condition_model_part.Elements) , 0)
-        self.assertEqual(len(condition_model_part.Conditions) , len(model_part1.Conditions))
-
-        condition_sub1_copy = condition_model_part.GetSubModelPart("sub1")
-
-        self.assertEqual(len(condition_sub1_copy.Nodes) , len(sub1.Nodes))
-        self.assertEqual(len(condition_sub1_copy.Elements) , 0)
-        self.assertEqual(len(condition_sub1_copy.Conditions) , len(sub1.Conditions))
-
+        condition_id_offset = 3
+        for duplicate_condition in new_model_part.Conditions:
+            duplicate_condition_id = duplicate_condition.Id
+            original_condition_id = duplicate_condition_id - condition_id_offset
+            original_condition = model_part1.GetCondition(original_condition_id)
+            self.assertFalse(original_condition == duplicate_condition)
+            self.assertTrue(original_condition.GetGeometry() == duplicate_condition.GetGeometry())
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/kratos/tests/test_connectivity_preserve_modeler.py
+++ b/kratos/tests/test_connectivity_preserve_modeler.py
@@ -5,200 +5,200 @@ import KratosMultiphysics
 
 class TestConnectivityPreserveModeler(KratosUnittest.TestCase):
 
-    # def test_connectivity_preserve_modeler(self):
-    #     current_model = KratosMultiphysics.Model()
-    #     model_part1 = current_model.CreateModelPart("Main")
-    #     model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+    def test_connectivity_preserve_modeler(self):
+        current_model = KratosMultiphysics.Model()
+        model_part1 = current_model.CreateModelPart("Main")
+        model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
 
-    #     model_part1.CreateNewNode(1,0.0,0.1,0.2)
-    #     model_part1.CreateNewNode(2,2.0,0.1,0.2)
-    #     model_part1.CreateNewNode(3,1.0,1.1,0.2)
-    #     model_part1.CreateNewNode(4,2.0,3.1,10.2)
+        model_part1.CreateNewNode(1,0.0,0.1,0.2)
+        model_part1.CreateNewNode(2,2.0,0.1,0.2)
+        model_part1.CreateNewNode(3,1.0,1.1,0.2)
+        model_part1.CreateNewNode(4,2.0,3.1,10.2)
 
-    #     sub1 = model_part1.CreateSubModelPart("sub1")
-    #     sub2 = model_part1.CreateSubModelPart("sub2")
-    #     subsub1 = sub1.CreateSubModelPart("subsub1")
-    #     subsub1.AddNodes([1,2])
-    #     sub2.AddNodes([3])
+        sub1 = model_part1.CreateSubModelPart("sub1")
+        sub2 = model_part1.CreateSubModelPart("sub2")
+        subsub1 = sub1.CreateSubModelPart("subsub1")
+        subsub1.AddNodes([1,2])
+        sub2.AddNodes([3])
 
-    #     model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
-    #     model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
+        model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
+        model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
 
-    #     model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
-    #     sub1.AddConditions([2])
+        model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
+        sub1.AddConditions([2])
 
-    #     current_model = KratosMultiphysics.Model()
-    #     new_model_part = current_model.CreateModelPart("Other")
+        current_model = KratosMultiphysics.Model()
+        new_model_part = current_model.CreateModelPart("Other")
 
-    #     modeler = KratosMultiphysics.ConnectivityPreserveModeler()
-    #     modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
+        modeler = KratosMultiphysics.ConnectivityPreserveModeler()
+        modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
 
-    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
-    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
-    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+        self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
+        self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
+        self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
 
-    #     ##assign a value to an element in model_part1, the corresponding element in the other model part
-    #     # will change as they are pointing to the same geometry
-    #     model_part1.Elements[1].SetValue(KratosMultiphysics.DISTANCE, 1.0)
-    #     self.assertEqual(model_part1.Elements[1].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
-    #     self.assertEqual(new_model_part.Elements[1].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
+        ##assign a value to an element in model_part1, the corresponding element in the other model part
+        # will change as they are pointing to the same geometry
+        model_part1.Elements[1].SetValue(KratosMultiphysics.DISTANCE, 1.0)
+        self.assertEqual(model_part1.Elements[1].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
+        self.assertEqual(new_model_part.Elements[1].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
 
-    #     ##assign a value to an condition in model_part1, the corresponding condition in the other model part
-    #     # will change as they are pointing to the same geometry
-    #     model_part1.Conditions[2].SetValue(KratosMultiphysics.DISTANCE, 1.0)
-    #     self.assertEqual(model_part1.Conditions[2].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
-    #     self.assertEqual(new_model_part.Conditions[2].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
+        ##assign a value to an condition in model_part1, the corresponding condition in the other model part
+        # will change as they are pointing to the same geometry
+        model_part1.Conditions[2].SetValue(KratosMultiphysics.DISTANCE, 1.0)
+        self.assertEqual(model_part1.Conditions[2].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
+        self.assertEqual(new_model_part.Conditions[2].GetValue(KratosMultiphysics.DISTANCE) , 1.0)
 
-    #     #assign a value to a node of new_model_part --> affects both model parts
-    #     new_model_part.Nodes[1].SetSolutionStepValue(KratosMultiphysics.DISTANCE,0,2.0)
-    #     self.assertEqual(model_part1.Nodes[1].GetSolutionStepValue(KratosMultiphysics.DISTANCE)   , 2.0)
-    #     self.assertEqual(new_model_part.Nodes[1].GetSolutionStepValue(KratosMultiphysics.DISTANCE), 2.0)
+        #assign a value to a node of new_model_part --> affects both model parts
+        new_model_part.Nodes[1].SetSolutionStepValue(KratosMultiphysics.DISTANCE,0,2.0)
+        self.assertEqual(model_part1.Nodes[1].GetSolutionStepValue(KratosMultiphysics.DISTANCE)   , 2.0)
+        self.assertEqual(new_model_part.Nodes[1].GetSolutionStepValue(KratosMultiphysics.DISTANCE), 2.0)
 
-    #     #test if submodelparts are created correctly
-    #     for part in model_part1.SubModelParts:
-    #         new_part = new_model_part.GetSubModelPart(part.Name)
-    #         for node in part.Nodes:
-    #             self.assertTrue( node.Id in new_part.Nodes)
-    #         for cond in part.Conditions:
-    #             self.assertTrue( cond.Id in new_part.Conditions)
-    #         for elem in part.Elements:
-    #             self.assertTrue( elem.Id in new_part.Elements)
+        #test if submodelparts are created correctly
+        for part in model_part1.SubModelParts:
+            new_part = new_model_part.GetSubModelPart(part.Name)
+            for node in part.Nodes:
+                self.assertTrue( node.Id in new_part.Nodes)
+            for cond in part.Conditions:
+                self.assertTrue( cond.Id in new_part.Conditions)
+            for elem in part.Elements:
+                self.assertTrue( elem.Id in new_part.Elements)
 
-    #     model_part1.GetSubModelPart("sub1").Conditions[2].SetValue(KratosMultiphysics.TEMPERATURE, 1234.0)
-    #     self.assertEqual(model_part1.Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
-    #     self.assertEqual(model_part1.GetSubModelPart("sub1").Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
-    #     self.assertEqual(new_model_part.Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
-    #     self.assertEqual(new_model_part.GetSubModelPart("sub1").Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
+        model_part1.GetSubModelPart("sub1").Conditions[2].SetValue(KratosMultiphysics.TEMPERATURE, 1234.0)
+        self.assertEqual(model_part1.Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
+        self.assertEqual(model_part1.GetSubModelPart("sub1").Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
+        self.assertEqual(new_model_part.Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
+        self.assertEqual(new_model_part.GetSubModelPart("sub1").Conditions[2].GetValue(KratosMultiphysics.TEMPERATURE), 1234.0)
 
-    # def test_repeated_call(self):
-    #     current_model = KratosMultiphysics.Model()
-    #     model_part1 = current_model.CreateModelPart("Main")
-    #     model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+    def test_repeated_call(self):
+        current_model = KratosMultiphysics.Model()
+        model_part1 = current_model.CreateModelPart("Main")
+        model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
 
-    #     model_part1.CreateNewNode(1,0.0,0.1,0.2)
-    #     model_part1.CreateNewNode(2,2.0,0.1,0.2)
-    #     model_part1.CreateNewNode(3,1.0,1.1,0.2)
-    #     model_part1.CreateNewNode(4,2.0,3.1,10.2)
+        model_part1.CreateNewNode(1,0.0,0.1,0.2)
+        model_part1.CreateNewNode(2,2.0,0.1,0.2)
+        model_part1.CreateNewNode(3,1.0,1.1,0.2)
+        model_part1.CreateNewNode(4,2.0,3.1,10.2)
 
-    #     sub1 = model_part1.CreateSubModelPart("sub1")
-    #     subsub1 = sub1.CreateSubModelPart("subsub1")
-    #     subsub1.AddNodes([1,2])
+        sub1 = model_part1.CreateSubModelPart("sub1")
+        subsub1 = sub1.CreateSubModelPart("subsub1")
+        subsub1.AddNodes([1,2])
 
-    #     model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
-    #     model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
+        model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
+        model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
 
-    #     model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
-    #     model_part1.CreateNewCondition("LineCondition2D2N", 1, [1,2], model_part1.GetProperties()[1])
-    #     sub1.AddConditions([2])
+        model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
+        model_part1.CreateNewCondition("LineCondition2D2N", 1, [1,2], model_part1.GetProperties()[1])
+        sub1.AddConditions([2])
 
-    #     current_model = KratosMultiphysics.Model()
-    #     new_model_part = current_model.CreateModelPart("New1")
-    #     new_model_part2 = current_model.CreateModelPart("New2")
+        current_model = KratosMultiphysics.Model()
+        new_model_part = current_model.CreateModelPart("New1")
+        new_model_part2 = current_model.CreateModelPart("New2")
 
-    #     modeler = KratosMultiphysics.ConnectivityPreserveModeler()
-    #     modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
-    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
-    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
-    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+        modeler = KratosMultiphysics.ConnectivityPreserveModeler()
+        modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
+        self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
+        self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
+        self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
 
-    #     modeler.GenerateModelPart(model_part1, new_model_part2, "Element2D3N", "LineCondition2D2N")
-    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part2.Nodes))
-    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part2.Conditions))
-    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part2.Elements))
+        modeler.GenerateModelPart(model_part1, new_model_part2, "Element2D3N", "LineCondition2D2N")
+        self.assertEqual(len(model_part1.Nodes) , len(new_model_part2.Nodes))
+        self.assertEqual(len(model_part1.Conditions) , len(new_model_part2.Conditions))
+        self.assertEqual(len(model_part1.Elements) , len(new_model_part2.Elements))
 
-    #     modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
-    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
-    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
-    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+        modeler.GenerateModelPart(model_part1, new_model_part, "Element2D3N", "LineCondition2D2N")
+        self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
+        self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
+        self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
 
-    #     modeler.GenerateModelPart(model_part1, new_model_part2, "Element2D3N", "LineCondition2D2N")
-    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part2.Nodes))
-    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part2.Conditions))
-    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part2.Elements))
+        modeler.GenerateModelPart(model_part1, new_model_part2, "Element2D3N", "LineCondition2D2N")
+        self.assertEqual(len(model_part1.Nodes) , len(new_model_part2.Nodes))
+        self.assertEqual(len(model_part1.Conditions) , len(new_model_part2.Conditions))
+        self.assertEqual(len(model_part1.Elements) , len(new_model_part2.Elements))
 
-    #     self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
-    #     self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
-    #     self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
+        self.assertEqual(len(model_part1.Nodes) , len(new_model_part.Nodes))
+        self.assertEqual(len(model_part1.Conditions) , len(new_model_part.Conditions))
+        self.assertEqual(len(model_part1.Elements) , len(new_model_part.Elements))
 
-    # def test_variable_list_merging(self):
-    #     current_model = KratosMultiphysics.Model()
-    #     model_part1 = current_model.CreateModelPart("mp1")
-    #     model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
-    #     model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
+    def test_variable_list_merging(self):
+        current_model = KratosMultiphysics.Model()
+        model_part1 = current_model.CreateModelPart("mp1")
+        model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+        model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
 
-    #     model_part2 = current_model.CreateModelPart("mp2")
-    #     model_part2.AddNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE)
-    #     model_part2.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
+        model_part2 = current_model.CreateModelPart("mp2")
+        model_part2.AddNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE)
+        model_part2.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
 
-    #     #check before merging variable lists
-    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
-    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
-    #     self.assertFalse(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
-    #     self.assertFalse(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
-    #     self.assertFalse(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
-    #     self.assertFalse(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
-    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
-    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
+        #check before merging variable lists
+        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
+        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
+        self.assertFalse(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
+        self.assertFalse(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
+        self.assertFalse(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
+        self.assertFalse(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
+        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
+        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
 
-    #     KratosMultiphysics.MergeVariableListsUtility().Merge(model_part1, model_part2)
+        KratosMultiphysics.MergeVariableListsUtility().Merge(model_part1, model_part2)
 
-    #     #check after merging variable lists
-    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
-    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
-    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
-    #     self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
-    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
-    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
-    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
-    #     self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
+        #check after merging variable lists
+        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
+        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
+        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
+        self.assertTrue(model_part1.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
+        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISTANCE))
+        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT))
+        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.TEMPERATURE))
+        self.assertTrue(model_part2.HasNodalSolutionStepVariable(KratosMultiphysics.VELOCITY))
 
-    # def test_element_only_copy(self):
-    #     current_model = KratosMultiphysics.Model()
-    #     model_part1 = current_model.CreateModelPart("Main")
-    #     model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
+    def test_element_only_copy(self):
+        current_model = KratosMultiphysics.Model()
+        model_part1 = current_model.CreateModelPart("Main")
+        model_part1.AddNodalSolutionStepVariable(KratosMultiphysics.DISTANCE)
 
-    #     model_part1.CreateNewNode(1,0.0,0.1,0.2)
-    #     model_part1.CreateNewNode(2,2.0,0.1,0.2)
-    #     model_part1.CreateNewNode(3,1.0,1.1,0.2)
-    #     model_part1.CreateNewNode(4,2.0,3.1,10.2)
+        model_part1.CreateNewNode(1,0.0,0.1,0.2)
+        model_part1.CreateNewNode(2,2.0,0.1,0.2)
+        model_part1.CreateNewNode(3,1.0,1.1,0.2)
+        model_part1.CreateNewNode(4,2.0,3.1,10.2)
 
-    #     sub1 = model_part1.CreateSubModelPart("sub1")
+        sub1 = model_part1.CreateSubModelPart("sub1")
 
-    #     model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
-    #     model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
+        model_part1.CreateNewElement("Element2D3N", 1, [1,2,3], model_part1.GetProperties()[1])
+        model_part1.CreateNewElement("Element2D3N", 2, [1,2,4], model_part1.GetProperties()[1])
 
-    #     model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
-    #     sub1.AddConditions([2])
+        model_part1.CreateNewCondition("LineCondition2D2N", 2, [2,4], model_part1.GetProperties()[1])
+        sub1.AddConditions([2])
 
-    #     element_model_part = current_model.CreateModelPart("ElementCopy")
+        element_model_part = current_model.CreateModelPart("ElementCopy")
 
-    #     modeler = KratosMultiphysics.ConnectivityPreserveModeler()
+        modeler = KratosMultiphysics.ConnectivityPreserveModeler()
 
-    #     modeler.GenerateModelPart(model_part1, element_model_part, "Element2D3N")
+        modeler.GenerateModelPart(model_part1, element_model_part, "Element2D3N")
 
-    #     self.assertEqual(len(element_model_part.Nodes) , len(model_part1.Nodes))
-    #     self.assertEqual(len(element_model_part.Elements) , len(model_part1.Elements))
-    #     self.assertEqual(len(element_model_part.Conditions) , 0)
+        self.assertEqual(len(element_model_part.Nodes) , len(model_part1.Nodes))
+        self.assertEqual(len(element_model_part.Elements) , len(model_part1.Elements))
+        self.assertEqual(len(element_model_part.Conditions) , 0)
 
-    #     element_sub1_copy = element_model_part.GetSubModelPart("sub1")
+        element_sub1_copy = element_model_part.GetSubModelPart("sub1")
 
-    #     self.assertEqual(len(element_sub1_copy.Nodes) , len(sub1.Nodes))
-    #     self.assertEqual(len(element_sub1_copy.Elements) , len(sub1.Elements))
-    #     self.assertEqual(len(element_sub1_copy.Conditions) , 0)
+        self.assertEqual(len(element_sub1_copy.Nodes) , len(sub1.Nodes))
+        self.assertEqual(len(element_sub1_copy.Elements) , len(sub1.Elements))
+        self.assertEqual(len(element_sub1_copy.Conditions) , 0)
 
-    #     condition_model_part = current_model.CreateModelPart("ConditionCopy")
+        condition_model_part = current_model.CreateModelPart("ConditionCopy")
 
-    #     modeler.GenerateModelPart(model_part1, condition_model_part, "LineCondition2D2N")
+        modeler.GenerateModelPart(model_part1, condition_model_part, "LineCondition2D2N")
 
-    #     self.assertEqual(len(condition_model_part.Nodes) , len(model_part1.Nodes))
-    #     self.assertEqual(len(condition_model_part.Elements) , 0)
-    #     self.assertEqual(len(condition_model_part.Conditions) , len(model_part1.Conditions))
+        self.assertEqual(len(condition_model_part.Nodes) , len(model_part1.Nodes))
+        self.assertEqual(len(condition_model_part.Elements) , 0)
+        self.assertEqual(len(condition_model_part.Conditions) , len(model_part1.Conditions))
 
-    #     condition_sub1_copy = condition_model_part.GetSubModelPart("sub1")
+        condition_sub1_copy = condition_model_part.GetSubModelPart("sub1")
 
-    #     self.assertEqual(len(condition_sub1_copy.Nodes) , len(sub1.Nodes))
-    #     self.assertEqual(len(condition_sub1_copy.Elements) , 0)
-    #     self.assertEqual(len(condition_sub1_copy.Conditions) , len(sub1.Conditions))
+        self.assertEqual(len(condition_sub1_copy.Nodes) , len(sub1.Nodes))
+        self.assertEqual(len(condition_sub1_copy.Elements) , 0)
+        self.assertEqual(len(condition_sub1_copy.Conditions) , len(sub1.Conditions))
 
     def test_copy_to_sub_model_part(self):
         current_model = KratosMultiphysics.Model()


### PR DESCRIPTION
This adds connectivity preserve modeller the following capabilities.

1. Copy model part to another root model part
2. Copy model part to another submodel part (with or without same root model part)
3. Copy submodel part to another submodel part
4. Copy model part to another root model part's submodel part

This removes the Id check when adding elements and conditions thus saving computational time.

Tests are also added.

This relates to #6579  as well, I also encountered slow down in using connectivity preserve modeller due to id checks.

All suggestions are welcome. :)