### PR TITLE
[CI] separate redundant build canceling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
       - master
 
 jobs:
+  cancel-redundant-builds: # needed until github implements this
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    
   ubuntu:
     runs-on: ubuntu-latest
     strategy:
@@ -29,10 +36,6 @@ jobs:
         FC: gfortran-7
 
     steps:
-    - uses: rokroskar/workflow-run-cleanup-action@v0.2.2
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-
     - uses: actions/checkout@v2
 
     - name: Cache Build


### PR DESCRIPTION
I think this way it is cleaner, before this was for some reason executed multiple times (see previous build logs)