### PR TITLE
[MPI] fix ParallelFillCommunicator warning

### DIFF
--- a/kratos/mpi/utilities/parallel_fill_communicator.cpp
+++ b/kratos/mpi/utilities/parallel_fill_communicator.cpp
@@ -28,6 +28,7 @@ ParallelFillCommunicator::ParallelFillCommunicator(ModelPart& r_model_part)
 void ParallelFillCommunicator::Execute()
 {
     KRATOS_TRY
+    mPartitionIndexCheckPerformed = false;
     ComputeCommunicationPlan(mrBaseModelPart);
     KRATOS_CATCH("");
 }
@@ -196,10 +197,6 @@ void ParallelFillCommunicator::ComputeCommunicationPlan(ModelPart& rModelPart)
 {
     KRATOS_TRY;
 
-    if (rModelPart.NumberOfNodes() > 0) {
-        KRATOS_ERROR_IF_NOT(rModelPart.NodesBegin()->SolutionStepsDataHas(PARTITION_INDEX)) << "\"PARTITION_INDEX\" missing as solution step variable for nodes of ModelPart \"" << rModelPart.Name() << "\"!" << std::endl;
-    }
-
     constexpr unsigned root_id = 0;
 
     Communicator::Pointer pnew_comm = Kratos::make_shared< MPICommunicator >(&rModelPart.GetNodalSolutionStepVariablesList(), DataCommunicator::GetDefault());
@@ -208,18 +205,26 @@ void ParallelFillCommunicator::ComputeCommunicationPlan(ModelPart& rModelPart)
     const auto& r_data_communicator = pnew_comm->GetDataCommunicator();
 
     // Check if the nodes have been assigned a partition index (i.e. some value different from 0). If not issue a warning
-    int non_zero_partition_index_found = 0;
-    for (const auto& r_node : rModelPart.Nodes()) {
-        const int node_partition_index = r_node.FastGetSolutionStepValue(PARTITION_INDEX);
-        if (node_partition_index != 0) {
-            non_zero_partition_index_found = 1;
-            break;
+    if (!mPartitionIndexCheckPerformed) { // needs to be protected bcs this function is called recursively for SubModelParts
+        mPartitionIndexCheckPerformed = true;
+
+        if (rModelPart.NumberOfNodes() > 0) {
+            KRATOS_ERROR_IF_NOT(rModelPart.NodesBegin()->SolutionStepsDataHas(PARTITION_INDEX)) << "\"PARTITION_INDEX\" missing as solution step variable for nodes of ModelPart \"" << rModelPart.Name() << "\"!" << std::endl;
         }
+
+        int non_zero_partition_index_found = 0;
+        for (const auto& r_node : rModelPart.Nodes()) {
+            const int node_partition_index = r_node.FastGetSolutionStepValue(PARTITION_INDEX);
+            if (node_partition_index != 0) {
+                non_zero_partition_index_found = 1;
+                break;
+            }
+        }
+
+        non_zero_partition_index_found = r_data_communicator.SumAll(non_zero_partition_index_found);
+
+        KRATOS_WARNING_IF("ParallelFillCommunicator", r_data_communicator.Size() > 1 && non_zero_partition_index_found == 0) << "All nodes have a PARTITION_INDEX index of 0! This could mean that PARTITION_INDEX was not assigned" << std::endl;
     }
-
-    non_zero_partition_index_found = r_data_communicator.SumAll(non_zero_partition_index_found);
-
-    KRATOS_WARNING_IF("ParallelFillCommunicator", r_data_communicator.Size() > 1 && non_zero_partition_index_found == 0) << "All nodes have a PARTITION_INDEX index of 0! This could mean that PARTITION_INDEX was not assigned" << std::endl;
 
     // Get rank of current processor.
     const unsigned my_rank = r_data_communicator.Rank();

--- a/kratos/mpi/utilities/parallel_fill_communicator.cpp
+++ b/kratos/mpi/utilities/parallel_fill_communicator.cpp
@@ -212,18 +212,18 @@ void ParallelFillCommunicator::ComputeCommunicationPlan(ModelPart& rModelPart)
             KRATOS_ERROR_IF_NOT(rModelPart.NodesBegin()->SolutionStepsDataHas(PARTITION_INDEX)) << "\"PARTITION_INDEX\" missing as solution step variable for nodes of ModelPart \"" << rModelPart.Name() << "\"!" << std::endl;
         }
 
-        int non_zero_partition_index_found = 0;
+        bool non_zero_partition_index_found = false;
         for (const auto& r_node : rModelPart.Nodes()) {
             const int node_partition_index = r_node.FastGetSolutionStepValue(PARTITION_INDEX);
             if (node_partition_index != 0) {
-                non_zero_partition_index_found = 1;
+                non_zero_partition_index_found = true;
                 break;
             }
         }
 
-        non_zero_partition_index_found = r_data_communicator.SumAll(non_zero_partition_index_found);
+        non_zero_partition_index_found = r_data_communicator.OrReduceAll(non_zero_partition_index_found);
 
-        KRATOS_WARNING_IF("ParallelFillCommunicator", r_data_communicator.Size() > 1 && non_zero_partition_index_found == 0) << "All nodes have a PARTITION_INDEX index of 0! This could mean that PARTITION_INDEX was not assigned" << std::endl;
+        KRATOS_WARNING_IF("ParallelFillCommunicator", r_data_communicator.Size() > 1 && !non_zero_partition_index_found) << "All nodes have a PARTITION_INDEX index of 0! This could mean that PARTITION_INDEX was not assigned" << std::endl;
     }
 
     // Get rank of current processor.

--- a/kratos/mpi/utilities/parallel_fill_communicator.h
+++ b/kratos/mpi/utilities/parallel_fill_communicator.h
@@ -170,8 +170,10 @@ private:
     ///@}
     ///@name Member Variables
     ///@{
+
     ModelPart& mrBaseModelPart;
 
+    bool mPartitionIndexCheckPerformed = false;
 
     ///@}
     ///@name Private Operators


### PR DESCRIPTION
now the warning should appear only if it actually means sth :)

@sunethwarna can you confirm this please?

EDIT: I took the change and applied the change [suggested by @jcotela](https://github.com/KratosMultiphysics/Kratos/pull/6001/files#r351781510)