### PR TITLE
Remove gidio from a bunch of tests

### DIFF
--- a/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_ausas_modified_shape_functions.cpp
@@ -15,7 +15,6 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
-#include "includes/gid_io.h"
 #include "utilities/divide_tetrahedra_3d_4.h"
 #include "modified_shape_functions/tetrahedra_3d_4_ausas_modified_shape_functions.h"
 

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_tetrahedra_3d_4_modified_shape_functions.cpp
@@ -15,7 +15,6 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
-#include "includes/gid_io.h"
 #include "utilities/divide_tetrahedra_3d_4.h"
 #include "modified_shape_functions/tetrahedra_3d_4_modified_shape_functions.h"
 

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_ausas_modified_shape_functions.cpp
@@ -15,7 +15,6 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
-#include "includes/gid_io.h"
 #include "utilities/divide_triangle_2d_3.h"
 #include "modified_shape_functions/triangle_2d_3_ausas_modified_shape_functions.h"
 

--- a/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_modified_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/modified_shape_functions/test_triangle_2d_3_modified_shape_functions.cpp
@@ -15,7 +15,6 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
-#include "includes/gid_io.h"
 #include "utilities/divide_triangle_2d_3.h"
 #include "modified_shape_functions/triangle_2d_3_modified_shape_functions.h"
 

--- a/kratos/tests/cpp_tests/processes/test_apply_ray_casting_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_apply_ray_casting_process.cpp
@@ -15,7 +15,6 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
-// #include "includes/gid_io.h"
 #include "geometries/hexahedra_3d_8.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "geometries/tetrahedra_3d_4.h"

--- a/kratos/tests/cpp_tests/processes/test_calculate_distance_to_skin_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_calculate_distance_to_skin_process.cpp
@@ -15,7 +15,6 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
-// #include "includes/gid_io.h"
 #include "geometries/hexahedra_3d_8.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "processes/structured_mesh_generator_process.h"

--- a/kratos/tests/cpp_tests/processes/test_coarsening_process.cpp
+++ b/kratos/tests/cpp_tests/processes/test_coarsening_process.cpp
@@ -25,7 +25,6 @@
 #include "processes/find_nodal_neighbours_process.h"
 #include "geometries/quadrilateral_2d_4.h"
 #include "geometries/hexahedra_3d_8.h"
-#include "includes/gid_io.h"
 
 
 namespace Kratos {

--- a/kratos/tests/cpp_tests/utilities/test_discont_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_discont_utils.cpp
@@ -15,7 +15,6 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
-#include "includes/gid_io.h"
 #include "geometries/triangle_2d_3.h"
 #include "geometries/tetrahedra_3d_4.h"
 #include "utilities/discont_utils.h"

--- a/kratos/tests/cpp_tests/utilities/test_divide_tetrahedra_3d_4.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_tetrahedra_3d_4.cpp
@@ -15,7 +15,6 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
-#include "includes/gid_io.h"
 #include "utilities/divide_tetrahedra_3d_4.h"
 
 namespace Kratos

--- a/kratos/tests/cpp_tests/utilities/test_divide_triangle_2d_3.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_divide_triangle_2d_3.cpp
@@ -15,7 +15,6 @@
 #include "testing/testing.h"
 #include "containers/model.h"
 #include "includes/checks.h"
-#include "includes/gid_io.h"
 #include "utilities/divide_triangle_2d_3.h"
 
 namespace Kratos

--- a/kratos/tests/cpp_tests/utilities/test_geometry_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometry_utils.cpp
@@ -20,7 +20,6 @@
 #include "geometries/triangle_2d_3.h"
 #include "geometries/triangle_3d_3.h"
 #include "geometries/tetrahedra_3d_4.h"
-// #include "includes/gid_io.h"
 
 namespace Kratos {
 namespace Testing {


### PR DESCRIPTION
So, when I was doing some other PR I detected that there are some tests that are making use of `gid_io.h` header file without actually using it.

I removed those but after some digging I found that this is due to the case that some tests have debug code embedded in them. I assume this is for manually checking if the result of the test is ok while its being developed, or in case it fails and one needs to print the results.

I would propose that the tests that are still using these mechanism do it under a ward so it compiles only in FULLDEBUG but not in DEBUG instead of commenting the include in the code.

