### PR TITLE
[Core] Unifying Integration Point methods

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -975,49 +975,55 @@ public:
      * Note, that these functions expect a std::vector of values for the specified variable type that
      * contains a value for each integration point!
      * CalculateValueOnIntegrationPoints: calculates the values of given Variable.
-     * these methods are: OPTIONAL
      */
 
     virtual void CalculateOnIntegrationPoints(const Variable<bool>& rVariable,
                           std::vector<bool>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<int>& rVariable,
                           std::vector<int>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                           std::vector<double>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
-                          std::vector< array_1d<double, 3 > >& Output,
+                          std::vector< array_1d<double, 3 > >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
-                          std::vector< array_1d<double, 6 > >& Output,
+                          std::vector< array_1d<double, 6 > >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<Vector >& rVariable,
-                          std::vector< Vector >& Output,
+                          std::vector< Vector >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<Matrix >& rVariable,
-                          std::vector< Matrix >& Output,
+                          std::vector< Matrix >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     /**
@@ -1071,42 +1077,49 @@ public:
 
     //GET ON INTEGRATION POINTS METHODS
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<bool>& rVariable,
                          std::vector<bool>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<int>& rVariable,
                          std::vector<int>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
                          std::vector<double>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
                          std::vector<array_1d<double, 3 > >& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
                          std::vector<array_1d<double, 6 > >& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
                          std::vector<Vector>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
                          std::vector<Matrix>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -982,49 +982,55 @@ public:
      * Note, that these functions expect a std::vector of values for the specified variable type that
      * contains a value for each integration point!
      * CalculateValueOnIntegrationPoints: calculates the values of given Variable.
-     * these methods are: OPTIONAL
      */
 
     virtual void CalculateOnIntegrationPoints(const Variable<bool>& rVariable,
                           std::vector<bool>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<int>& rVariable,
                           std::vector<int>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                           std::vector<double>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
                           std::vector< array_1d<double, 3 > >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
                           std::vector< array_1d<double, 6 > >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<Vector >& rVariable,
                           std::vector< Vector >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<Matrix >& rVariable,
                           std::vector< Matrix >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
     /**
@@ -1088,48 +1094,56 @@ public:
 
     //GET ON INTEGRATION POINTS METHODS
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<bool>& rVariable,
                          std::vector<bool>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<int>& rVariable,
                          std::vector<int>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
                          std::vector<double>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
                          std::vector<array_1d<double, 3 > >& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
                          std::vector<array_1d<double, 6 > >& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
                          std::vector<Vector>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
                          std::vector<Matrix>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
+    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
                          std::vector<ConstitutiveLaw::Pointer>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)

--- a/kratos/includes/gid_gauss_point_container.h
+++ b/kratos/includes/gid_gauss_point_container.h
@@ -138,7 +138,7 @@ public:
             if( mMeshElements.size() != 0 ) {
                 for( auto it = mMeshElements.begin(); it != mMeshElements.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -151,7 +151,7 @@ public:
                 for( auto it = mMeshConditions.begin(); it != mMeshConditions.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) )
                     {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -175,7 +175,7 @@ public:
             if( mMeshElements.size() != 0 ) {
                 for( auto it = mMeshElements.begin(); it != mMeshElements.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -187,7 +187,7 @@ public:
             if( mMeshConditions.size() != 0 ) {
                 for( auto it = mMeshConditions.begin(); it != mMeshConditions.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -212,7 +212,7 @@ public:
             if( mMeshElements.size() != 0 ) {
                 for( auto it = mMeshElements.begin(); it != mMeshElements.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -224,7 +224,7 @@ public:
             if( mMeshConditions.size() != 0 ) {
                 for( auto it = mMeshConditions.begin(); it != mMeshConditions.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -248,7 +248,7 @@ public:
             if( mMeshElements.size() != 0 ) {
                 for( auto it = mMeshElements.begin(); it != mMeshElements.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -262,7 +262,7 @@ public:
             if( mMeshConditions.size() != 0 ) {
                 for( auto it = mMeshConditions.begin(); it != mMeshConditions.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -289,7 +289,7 @@ public:
                 for( auto it = mMeshElements.begin(); it != mMeshElements.end(); ++it ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) )
                     {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -304,7 +304,7 @@ public:
             if( mMeshConditions.size() != 0 ) {
                 for( auto it = mMeshConditions.begin(); it != mMeshConditions.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -334,7 +334,7 @@ public:
             if( mMeshElements.size() != 0 ) {
                 for( auto it = mMeshElements.begin(); it != mMeshElements.end(); ++it ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -351,7 +351,7 @@ public:
             if( mMeshConditions.size() != 0 ) {
                 for( auto it = mMeshConditions.begin(); it != mMeshConditions.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -380,7 +380,7 @@ public:
             if( mMeshElements.size() != 0 ) {
                 for( auto it = mMeshElements.begin(); it != mMeshElements.end(); ++it ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
                         for(unsigned int i=0; i<mIndexContainer.size(); i++) {
                             int index = mIndexContainer[i];
@@ -427,7 +427,7 @@ public:
             if( mMeshConditions.size() != 0 ) {
                 for( auto it = mMeshConditions.begin(); it != mMeshConditions.end(); it++ ) {
                     if( !(it->IsDefined(ACTIVE)) || it->Is(ACTIVE) ) {
-                        it->GetValueOnIntegrationPoints( rVariable, ValuesOnIntPoint,
+                        it->CalculateOnIntegrationPoints( rVariable, ValuesOnIntPoint,
                                                          rModelPart.GetProcessInfo() );
 
                         if (ValuesOnIntPoint[0].size1() == 0 && ValuesOnIntPoint[0].size2() == 0) {

--- a/kratos/processes/integration_values_extrapolation_to_nodes_process.cpp
+++ b/kratos/processes/integration_values_extrapolation_to_nodes_process.cpp
@@ -153,7 +153,7 @@ void IntegrationValuesExtrapolationToNodesProcess::ExecuteFinalizeSolutionStep()
             // We add the doubles values
             for ( const auto p_var : mDoubleVariable) {
                 std::vector<double> aux_result(integration_points_number);
-                it_elem->GetValueOnIntegrationPoints(*p_var, aux_result, r_process_info);
+                it_elem->CalculateOnIntegrationPoints(*p_var, aux_result, r_process_info);
                 for (IndexType i_gauss_point = 0; i_gauss_point < integration_points_number; ++i_gauss_point) {
                     for (IndexType i_node = 0; i_node < number_of_nodes; ++i_node) {
                         double& aux_value = (mExtrapolateNonHistorical) ? r_this_geometry[i_node].GetValue(*p_var) : r_this_geometry[i_node].FastGetSolutionStepValue(*p_var);
@@ -166,7 +166,7 @@ void IntegrationValuesExtrapolationToNodesProcess::ExecuteFinalizeSolutionStep()
             // We add the arrays values
             for ( const auto p_var : mArrayVariable) {
                 std::vector<array_1d<double, 3>> aux_result(integration_points_number);
-                it_elem->GetValueOnIntegrationPoints(*p_var, aux_result, r_process_info);
+                it_elem->CalculateOnIntegrationPoints(*p_var, aux_result, r_process_info);
                 for (IndexType i_gauss_point = 0; i_gauss_point < integration_points_number; ++i_gauss_point) {
                     for (IndexType i_node = 0; i_node < number_of_nodes; ++i_node) {
                         array_1d<double, 3>& aux_value = (mExtrapolateNonHistorical) ? r_this_geometry[i_node].GetValue(*p_var) : r_this_geometry[i_node].FastGetSolutionStepValue(*p_var);
@@ -182,7 +182,7 @@ void IntegrationValuesExtrapolationToNodesProcess::ExecuteFinalizeSolutionStep()
             // We add the vectors values
             for ( const auto p_var : mVectorVariable) {
                 std::vector<Vector> aux_result(integration_points_number);
-                it_elem->GetValueOnIntegrationPoints(*p_var, aux_result, r_process_info);
+                it_elem->CalculateOnIntegrationPoints(*p_var, aux_result, r_process_info);
                 for (IndexType i_gauss_point = 0; i_gauss_point < integration_points_number; ++i_gauss_point) {
                     for (IndexType i_node = 0; i_node < number_of_nodes; ++i_node) {
                         Vector& aux_value = (mExtrapolateNonHistorical) ? r_this_geometry[i_node].GetValue(*p_var) : r_this_geometry[i_node].FastGetSolutionStepValue(*p_var);
@@ -198,7 +198,7 @@ void IntegrationValuesExtrapolationToNodesProcess::ExecuteFinalizeSolutionStep()
             // We add the matrix values
             for ( const auto p_var : mMatrixVariable) {
                 std::vector<Matrix> aux_result(integration_points_number);
-                it_elem->GetValueOnIntegrationPoints(*p_var, aux_result, r_process_info);
+                it_elem->CalculateOnIntegrationPoints(*p_var, aux_result, r_process_info);
                 for (IndexType i_gauss_point = 0; i_gauss_point < integration_points_number; ++i_gauss_point) {
                     for (IndexType i_node = 0; i_node < number_of_nodes; ++i_node) {
                         Matrix& aux_value = (mExtrapolateNonHistorical) ? r_this_geometry[i_node].GetValue(*p_var) : r_this_geometry[i_node].FastGetSolutionStepValue(*p_var);
@@ -350,14 +350,14 @@ void IntegrationValuesExtrapolationToNodesProcess::InitializeMaps()
         // We init the vector sizes
         for ( const auto p_var : mVectorVariable) {
             std::vector<Vector> aux_result(integration_points_number);
-            it_elem_begin->GetValueOnIntegrationPoints(*p_var, aux_result, r_process_info);
+            it_elem_begin->CalculateOnIntegrationPoints(*p_var, aux_result, r_process_info);
             mSizeVectors.insert({p_var, aux_result[0].size()});
         }
 
         // We init the matrix sizes
         for ( const auto p_var : mMatrixVariable) {
             std::vector<Matrix> aux_result(integration_points_number);
-            it_elem_begin->GetValueOnIntegrationPoints(*p_var, aux_result, r_process_info);
+            it_elem_begin->CalculateOnIntegrationPoints(*p_var, aux_result, r_process_info);
             std::pair<SizeType, SizeType> aux_pair(aux_result[0].size1(), aux_result[0].size2());
             mSizeMatrixes.insert({p_var, aux_pair});
         }


### PR DESCRIPTION
Now that the method `GetValuesOnIntegrationPoints` is removed from python (#6528) I think it is time to unify this also in C++
This PR basically replaces `GetValueOnIntegrationPoints` (note the missing `s` and hence the inconsistency with python) with `CalculateValuesOnIntegrationPoints`.
This change is BACKWARD COMPATIBLE, I used the same mechanism as in #4938

I think right now is the perfect time to do this, since we are also updating some other interfaces in `Element` and `Condition` (see #4938)
=> then the updates can be done at once and we will FINALLY have a CONSISTENT and CLEAN interface for `Element` and `Condition`

@jcotela this is the backward compatible version of #2194 :)

(Finally) closes #523