### PR TITLE
[PotentialFlow] Adding pseudo time stepping

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_analysis.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_analysis.py
@@ -101,10 +101,3 @@ class PotentialFlowAnalysis(AnalysisStage):
 
         return output
 
-    def RunSolutionLoop(self):
-        self.InitializeSolutionStep()
-        self._GetSolver().Predict()
-        self._GetSolver().SolveSolutionStep()
-        self.FinalizeSolutionStep()
-        self.OutputSolutionStep()
-

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -125,6 +125,13 @@ class PotentialFlowSolver(FluidSolver):
             "skin_parts":[""],
             "assign_neighbour_elements_to_conditions": false,
             "no_skin_parts": [""],
+            "time_stepping"                : {
+                "automatic_time_step" : false,
+                "CFL_number"          : 1,
+                "minimum_delta_time"  : 1e-4,
+                "maximum_delta_time"  : 1.0,
+                "time_step":            1.0
+            },
             "move_mesh_flag": false,
             "reference_chord": 1.0,
             "auxiliary_variables_list" : []
@@ -174,9 +181,6 @@ class PotentialFlowSolver(FluidSolver):
         solution_strategy.Initialize()
 
         KratosMultiphysics.Logger.PrintInfo(self.__class__.__name__, "Solver initialization finished.")
-
-    def AdvanceInTime(self, current_time):
-        raise Exception("AdvanceInTime is not implemented. Potential Flow simulations are steady state.")
 
     def _ComputeNodalElementalNeighbours(self):
         # Find nodal neigbours util call


### PR DESCRIPTION
Pseudo time stepping is added. 

This is useful to be able to do load control for nonlinear problems and it will also ease the coupling with the cosimulation application.

Basically RunSolutionLoop and AdvanceInTime are removed so that the ones in the base classes are used.