### PR TITLE
Making mpi out visible in TEST_OUTPUT level

### DIFF
--- a/kratos/testing/tester.cpp
+++ b/kratos/testing/tester.cpp
@@ -270,7 +270,7 @@ namespace Kratos
 
 			std::stringstream secondary_stream;
 			std::streambuf* original_buffer = nullptr;
-			if (ParallelEnvironment::GetDefaultRank() != 0) {
+			if (GetInstance().mVerbosity != Verbosity::TESTS_OUTPUTS && ParallelEnvironment::GetDefaultRank() != 0) {
 				original_buffer = std::cout.rdbuf(secondary_stream.rdbuf());
 			}
 
@@ -298,7 +298,7 @@ namespace Kratos
 
 			auto tmp = ReportResults(std::cout, number_of_run_tests, elapsed.count());
 
-			if (ParallelEnvironment::GetDefaultRank() != 0) {
+			if (GetInstance().mVerbosity != Verbosity::TESTS_OUTPUTS && ParallelEnvironment::GetDefaultRank() != 0) {
 				std::cout.rdbuf(original_buffer);
 			}
 			return tmp;


### PR DESCRIPTION
Prevents the output from processes non-0 to be hidden if the TEST_OUTPUT  verbosity level is selected.

closes #6615