### PR TITLE
[StructuralMechanics] Remove ExternalSolversApplication from the tests

### DIFF
--- a/applications/StructuralMechanicsApplication/python_scripts/automatic_rayleigh_parameters_computation_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/automatic_rayleigh_parameters_computation_process.py
@@ -118,7 +118,9 @@ class AutomaticRayleighComputationProcess(KM.Process):
                 eigen_linear_solver = eigen_solver_factory.ConstructSolver(self.settings["eigen_system_settings"])
                 builder_and_solver = KM.ResidualBasedBlockBuilderAndSolver(eigen_linear_solver)
                 eigen_scheme = SMA.EigensolverDynamicScheme()
-                eigen_solver = SMA.EigensolverStrategy(self.main_model_part, eigen_scheme, builder_and_solver)
+                eigen_solver = SMA.EigensolverStrategy(self.main_model_part, eigen_scheme, builder_and_solver,
+                    self.mass_matrix_diagonal_value,
+                    self.stiffness_matrix_diagonal_value)
                 eigen_solver.Solve()
 
                 # Setting the variable RESET_EQUATION_IDS
@@ -175,6 +177,8 @@ class AutomaticRayleighComputationProcess(KM.Process):
                 }
             }
             """)
+            self.mass_matrix_diagonal_value = 1.0
+            self.stiffness_matrix_diagonal_value = -1.0
         else:
             eigen_system_settings = KM.Parameters("""
             {
@@ -184,4 +188,6 @@ class AutomaticRayleighComputationProcess(KM.Process):
             }
             """)
             eigen_system_settings["eigen_system_settings"]["solver_type"].SetString(solver_type)
+            self.mass_matrix_diagonal_value = 0.0
+            self.stiffness_matrix_diagonal_value = 1.0
         return eigen_system_settings

--- a/applications/StructuralMechanicsApplication/python_scripts/automatic_rayleigh_parameters_computation_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/automatic_rayleigh_parameters_computation_process.py
@@ -179,6 +179,23 @@ class AutomaticRayleighComputationProcess(KM.Process):
             """)
             self.mass_matrix_diagonal_value = 1.0
             self.stiffness_matrix_diagonal_value = -1.0
+        elif solver_type == "eigen_feast":
+            eigen_system_settings = KM.Parameters("""
+            {
+                "eigen_system_settings" : {
+                    "solver_type"           : "eigen_feast",
+                    "echo_level"            : 0,
+                    "tolerance"             : 1e-10,
+                    "symmetric"             : true,
+                    "e_min"                 : 0.0,
+                    "e_max"                 : 4.0e5,
+                    "number_of_eigenvalues" : 2,
+                    "subspace_size"         : 15
+                }
+            }
+            """)
+            self.mass_matrix_diagonal_value = 1.0
+            self.stiffness_matrix_diagonal_value = -1.0
         else:
             eigen_system_settings = KM.Parameters("""
             {

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
@@ -78,7 +78,7 @@ class EigenSolver(MechanicalSolver):
         if solver_type == "eigen_eigensystem":
             mass_matrix_diagonal_value = 0.0
             stiffness_matrix_diagonal_value = 1.0
-        elif solver_type == "feast":
+        elif solver_type == "feast" or solver_type == "eigen_feast":
             mass_matrix_diagonal_value = 1.0
             stiffness_matrix_diagonal_value = -1.0
         else:

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_3D3N_Thin_Circle_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_3D3N_Thin_Circle_test_parameters.json
@@ -23,16 +23,11 @@
             "materials_filename": "eigen_test/Eigen_3D3N_Thin_Circle_test_materials.json"
         },
         "eigensolver_settings":{
-            "solver_type": "feast",
-            "print_feast_output": false,
-            "perform_stochastic_estimate": false,
-            "solve_eigenvalue_problem": true,
-            "lambda_min": 0.0,
-            "lambda_max": 4.0e5,
-            "search_dimension": 15,
-            "linear_solver_settings":{
-                "solver_type": "skyline_lu_complex"
-            }
+            "solver_type": "eigen_feast",
+            "symmetric": true,
+            "e_min": 0.0,
+            "e_max": 4.0e5,
+            "subspace_size": 15
         },
         "rotation_dofs"                      : true
     },

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_Q4_Thick_2x2_Plate_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_Q4_Thick_2x2_Plate_test_parameters.json
@@ -22,17 +22,12 @@
         "material_import_settings" :{
             "materials_filename": "eigen_test/Eigen_Q4_Thick_2x2_Plate_test_materials.json"
         },
-	"eigensolver_settings":{
-        "solver_type": "feast",
-        "print_feast_output": false,
-        "perform_stochastic_estimate": false,
-        "solve_eigenvalue_problem": true,
-        "lambda_min": 0.0,
-        "lambda_max": 1.0e4,
-        "search_dimension": 9,
-        "linear_solver_settings":{
-            "solver_type": "skyline_lu_complex"
-        }
+        "eigensolver_settings":{
+            "solver_type": "eigen_feast",
+            "symmetric": true,
+            "e_min": 0.0,
+            "e_max": 1.0e4,
+            "subspace_size": 9
         },
         "rotation_dofs"                      : true
     },

--- a/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_TL_3D8N_Cube_test_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/eigen_test/Eigen_TL_3D8N_Cube_test_parameters.json
@@ -22,17 +22,12 @@
         "material_import_settings" :{
             "materials_filename": "eigen_test/Eigen_TL_3D8N_Cube_test_materials.json"
         },
-	"eigensolver_settings":{
-        "solver_type": "feast",
-        "print_feast_output": false,
-        "perform_stochastic_estimate": false,
-        "solve_eigenvalue_problem": true,
-        "lambda_min": 0.0,
-        "lambda_max": 2.5e3,
-        "search_dimension": 6,
-        "linear_solver_settings":{
-            "solver_type": "skyline_lu_complex"
-        }
+        "eigensolver_settings":{
+            "solver_type": "eigen_feast",
+            "symmetric": true,
+            "e_min": 0.0,
+            "e_max": 2.5e3,
+            "subspace_size": 6
         },
         "rotation_dofs"                      : false
     },

--- a/applications/StructuralMechanicsApplication/tests/rayleigh_process_test/test_rayleigh_parameters.json
+++ b/applications/StructuralMechanicsApplication/tests/rayleigh_process_test/test_rayleigh_parameters.json
@@ -86,14 +86,11 @@
                 "damping_ratio_0"     : 0.001,
                 "damping_ratio_1"     : -1.0,
                 "eigen_system_settings" : {
-                    "solver_type"                : "feast",
-                    "print_feast_output"         : false,
-                    "perform_stochastic_estimate": true,
-                    "solve_eigenvalue_problem"   : true,
-                    "lambda_min"                 : 0.0,
-                    "lambda_max"                 : 4.0e5,
-                    "number_of_eigenvalues"      : 2,
-                    "search_dimension"           : 15
+                    "solver_type"                : "eigen_feast",
+                    "symmetric"             : true,
+                    "e_min"                 : 3000.0,
+                    "e_max"                 : 4.0e5,
+                    "subspace_size"         : 15
                 }
             }
         }]

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -9,10 +9,10 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 import os, subprocess
 
-if kratos_utilities.CheckIfApplicationsAvailable("ExternalSolversApplication"):
-    has_external_solvers_application = True
+if kratos_utilities.CheckIfApplicationsAvailable("EigenSolversApplication"):
+    has_eigen_solvers_application = True
 else:
-    has_external_solvers_application = False
+    has_eigen_solvers_application = False
 
 # Import the tests or test_classes to create the suits
 
@@ -422,9 +422,9 @@ def AssembleTestSuites():
     # 2.5D solid element test
     nightSuite.addTest(TSolid2p5DElementTest('test_execution'))
 
-    if has_external_solvers_application:
-        import KratosMultiphysics.ExternalSolversApplication
-        if (hasattr(KratosMultiphysics.ExternalSolversApplication, "FEASTSolver")):
+    if has_eigen_solvers_application:
+        import KratosMultiphysics.EigenSolversApplication as EiSA
+        if EiSA.HasFEAST():
             # Eigenvalues tests
             smallSuite.addTest(TEigenQ4Thick2x2PlateTests('test_execution'))
             smallSuite.addTest(TEigenTL3D8NCubeTests('test_execution'))
@@ -434,7 +434,7 @@ def AssembleTestSuites():
             # Rayleigh process test
             nightSuite.addTest(TRayleighProcessTest('test_execution'))
         else:
-            print("FEASTSolver solver is not included in the compilation of the External Solvers Application")
+            print("FEAST not available in EigenSolversApplication")
 
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([THarmonicAnalysisTestsWithHDF5]))
 

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -9,7 +9,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 import os, subprocess
 
-if kratos_utilities.CheckIfApplicationsAvailable("EigenSolversApplication"):
+has_eigen_solvers_application = kratos_utilities.CheckIfApplicationsAvailable("EigenSolversApplication")
     has_eigen_solvers_application = True
 else:
     has_eigen_solvers_application = False

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -10,9 +10,6 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 import os, subprocess
 
 has_eigen_solvers_application = kratos_utilities.CheckIfApplicationsAvailable("EigenSolversApplication")
-    has_eigen_solvers_application = True
-else:
-    has_eigen_solvers_application = False
 
 # Import the tests or test_classes to create the suits
 

--- a/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
+++ b/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
@@ -6,9 +6,8 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utils
 
 from KratosMultiphysics.StructuralMechanicsApplication import structural_mechanics_analysis
+from KratosMultiphysics import eigen_solver_factory
 
-external_solvers_application_available = kratos_utils.CheckIfApplicationsAvailable("ExternalSolversApplication")
-eigen_solvers_application_available = kratos_utils.CheckIfApplicationsAvailable("EigenSolversApplication")
 hdf5_application_available = kratos_utils.CheckIfApplicationsAvailable("HDF5Application")
 
 from math import sqrt
@@ -31,27 +30,25 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
         mp.AddNodalSolutionStepVariable(StructuralMechanicsApplication.POINT_LOAD)
 
     def _solve_eigen(self,mp,echo=0):
-        feast_system_solver_settings = KratosMultiphysics.Parameters("""{ }""")
+        eigensolver_settings = KratosMultiphysics.Parameters("""{
+            "solver_type": "eigen_feast",
+            "symmetric": true,
+            "e_min": 1.0e-2,
+            "e_max": 25.0,
+            "subspace_size": 7
+        }""")
 
-        eigensolver_settings = KratosMultiphysics.Parameters("""
-        {
-                "perform_stochastic_estimate": false,
-                "lambda_min": 1.0e-2,
-                "lambda_max": 25.0,
-                "search_dimension": 7
-        }
-        """)
-        if not (hasattr(KratosMultiphysics.ExternalSolversApplication,"PastixComplexSolver")):
-            self.skipTest('"PastixComplexSolver" not available')
-
-        feast_system_solver = ExternalSolversApplication.PastixComplexSolver(feast_system_solver_settings)
-        eigen_solver = ExternalSolversApplication.FEASTSolver(eigensolver_settings, feast_system_solver)
+        eigen_solver = eigen_solver_factory.ConstructSolver(eigensolver_settings)
         builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(eigen_solver)
 
         eigen_scheme = StructuralMechanicsApplication.EigensolverDynamicScheme()
+        mass_matrix_diagonal_value = 1.0
+        stiffness_matrix_diagonal_value = -1.0
         eig_strategy = StructuralMechanicsApplication.EigensolverStrategy(mp,
                                                                     eigen_scheme,
-                                                                    builder_and_solver)
+                                                                    builder_and_solver,
+                                                                    mass_matrix_diagonal_value,
+                                                                    stiffness_matrix_diagonal_value)
 
         eig_strategy.SetEchoLevel(echo)
         eig_strategy.Solve()
@@ -104,11 +101,9 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
 
         return mp
 
-    @KratosUnittest.skipUnless(external_solvers_application_available,"Missing required application: ExternalSolversApplication")
     def test_undamped_mdof_harmonic(self):
-        import KratosMultiphysics.ExternalSolversApplication as ExternalSolversApplication
-        current_model = KratosMultiphysics.Model()
         #analytic solution taken from Humar - Dynamics of Structures p. 675
+        current_model = KratosMultiphysics.Model()
 
         #material properties
         stiffness = 10.0
@@ -143,12 +138,9 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
 
             exfreq = exfreq + df
 
-    @KratosUnittest.skipUnless(external_solvers_application_available,"Missing required application: ExternalSolversApplication")
     def test_damped_mdof_harmonic(self):
-        import KratosMultiphysics.ExternalSolversApplication as ExternalSolversApplication
-        current_model = KratosMultiphysics.Model()
-
         #analytic solution taken from Humar - Dynamics of Structures p. 677
+        current_model = KratosMultiphysics.Model()
 
         #material properties
         stiffness = 10.0
@@ -203,7 +195,7 @@ class HarmonicAnalysisTests(KratosUnittest.TestCase):
             exfreq = exfreq + df
 
 class HarmonicAnalysisTestsWithHDF5(KratosUnittest.TestCase):
-    @KratosUnittest.skipUnless(hdf5_application_available and eigen_solvers_application_available,"Missing required application: HDF5Application, EigenSolversApplication")
+    @KratosUnittest.skipUnless(hdf5_application_available,"Missing required application: HDF5Application")
     def test_harmonic_mdpa_input(self):
 
         with KratosUnittest.WorkFolderScope(".",__file__):

--- a/applications/StructuralMechanicsApplication/tests/test_spring_damper_element.py
+++ b/applications/StructuralMechanicsApplication/tests/test_spring_damper_element.py
@@ -4,11 +4,12 @@ import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 import KratosMultiphysics.KratosUnittest as KratosUnittest
+from KratosMultiphysics import eigen_solver_factory
 
 from math import sqrt, sin, cos, pi, exp, atan
 
 from KratosMultiphysics import kratos_utilities as kratos_utils
-external_solvers_application_available = kratos_utils.CheckIfApplicationsAvailable("ExternalSolversApplication")
+eigen_solvers_application_available = kratos_utils.CheckIfApplicationsAvailable("EigenSolversApplication")
 
 class SpringDamperElementTests(KratosUnittest.TestCase):
     def setUp(self):
@@ -296,14 +297,9 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
             self.assertAlmostEqual(mp.Nodes[2].GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y,0), \
                 current_analytical_displacement_y_2,delta=5e-2)
 
-    @KratosUnittest.skipUnless(external_solvers_application_available,"Missing required application: ExternalSolversApplication")
+    @KratosUnittest.skipUnless(eigen_solvers_application_available,"Missing required application: EigenSolversApplication")
     def test_undamped_mdof_system_eigen(self):
-        import KratosMultiphysics.ExternalSolversApplication as ExternalSolversApplication
-        if not hasattr(KratosMultiphysics.ExternalSolversApplication, "PastixSolver"):
-            self.skipTest("Pastix Solver is not available")
-
         current_model = KratosMultiphysics.Model()
-
         mp = self._set_up_mdof_system(current_model)
 
         #set parameters
@@ -313,32 +309,27 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
         mp.Elements[4].SetValue(StructuralMechanicsApplication.NODAL_DISPLACEMENT_STIFFNESS,[400.0,400.0,400.0])
 
         #create solver
-        eigen_solver_parameters = KratosMultiphysics.Parameters("""
-            {
-                "solver_type": "FEAST",
-                "print_feast_output": false,
-                "perform_stochastic_estimate": false,
-                "solve_eigenvalue_problem": true,
-                "lambda_min": 0.0,
-                "lambda_max": 4.0e5,
-                "number_of_eigenvalues": 2,
-                "search_dimension": 18,
-                "linear_solver_settings": {
-                    "solver_type" : "pastix",
-                    "echo_level" : 0
-                }
-            }""")
-        feast_system_solver = ExternalSolversApplication.PastixComplexSolver(eigen_solver_parameters["linear_solver_settings"])
-        eigen_solver = ExternalSolversApplication.FEASTSolver(eigen_solver_parameters, feast_system_solver)
-        scheme = StructuralMechanicsApplication.EigensolverDynamicScheme()
+        eigensolver_settings = KratosMultiphysics.Parameters("""{
+            "solver_type": "eigen_feast",
+            "symmetric": true,
+            "e_min": 0.0,
+            "e_max": 4.0e5,
+            "subspace_size": 18
+        }""")
+
+        eigen_solver = eigen_solver_factory.ConstructSolver(eigensolver_settings)
         builder_and_solver = KratosMultiphysics.ResidualBasedBlockBuilderAndSolver(eigen_solver)
 
-        solver = StructuralMechanicsApplication.EigensolverStrategy(
-            mp,
-            scheme,
-            builder_and_solver)
+        eigen_scheme = StructuralMechanicsApplication.EigensolverDynamicScheme()
+        mass_matrix_diagonal_value = 1.0
+        stiffness_matrix_diagonal_value = -1.0
+        eig_strategy = StructuralMechanicsApplication.EigensolverStrategy(mp,
+                                                                    eigen_scheme,
+                                                                    builder_and_solver,
+                                                                    mass_matrix_diagonal_value,
+                                                                    stiffness_matrix_diagonal_value)
 
-        solver.Solve()
+        eig_strategy.Solve()
 
         current_eigenvalues = [ev for ev in mp.ProcessInfo[StructuralMechanicsApplication.EIGENVALUE_VECTOR]]
         analytical_eigenvalues = [5,20]

--- a/applications/StructuralMechanicsApplication/tests/test_spring_damper_element.py
+++ b/applications/StructuralMechanicsApplication/tests/test_spring_damper_element.py
@@ -10,6 +10,11 @@ from math import sqrt, sin, cos, pi, exp, atan
 
 from KratosMultiphysics import kratos_utilities as kratos_utils
 eigen_solvers_application_available = kratos_utils.CheckIfApplicationsAvailable("EigenSolversApplication")
+if eigen_solvers_application_available:
+    import KratosMultiphysics.EigenSolversApplication as EiSA
+    feast_available = EiSA.HasFEAST()
+else:
+    feast_available = False
 
 class SpringDamperElementTests(KratosUnittest.TestCase):
     def setUp(self):
@@ -297,7 +302,7 @@ class SpringDamperElementTests(KratosUnittest.TestCase):
             self.assertAlmostEqual(mp.Nodes[2].GetSolutionStepValue(KratosMultiphysics.DISPLACEMENT_Y,0), \
                 current_analytical_displacement_y_2,delta=5e-2)
 
-    @KratosUnittest.skipUnless(eigen_solvers_application_available,"Missing required application: EigenSolversApplication")
+    @KratosUnittest.skipUnless(feast_available,"FEAST is missing")
     def test_undamped_mdof_system_eigen(self):
         current_model = KratosMultiphysics.Model()
         mp = self._set_up_mdof_system(current_model)


### PR DESCRIPTION
As requested after #6482, this removes the dependency on the ExternalSolversApplication from the tests in StructuralMechanicsApplication. The new version of FEAST available from EigenSolversApplication is now used  for the tests.

@loumalouomega I had to add default diagonal values in `automatic_rayleigh_parameters_computation_process.py` in order to make the utility working again (see #6434 and 28c5d2b912fd0ff0f23bbe0ef1b43915467f29b8)