### PR TITLE
[RANS][FastPR] Avoid fixing KINEMATIC_VISCOSITY

### DIFF
--- a/applications/RANSApplication/tests/OneElement/one_element_steady_parameters.json
+++ b/applications/RANSApplication/tests/OneElement/one_element_steady_parameters.json
@@ -133,7 +133,8 @@
                     "mesh_id": 0,
                     "model_part_name": "MainModelPart",
                     "variable_name": "KINEMATIC_VISCOSITY",
-                    "value": 10.0
+                    "value": 10.0,
+                    "constrained": false
                 }
             },
             {


### PR DESCRIPTION
Before #6492 this was creating a DOF for the `KINEMATIC_VISCOSITY` when applying the default fixity. Now it crashes.