### PR TITLE
[ShapeOpt] fix compiler warning about deprecated function

### DIFF
--- a/applications/ShapeOptimizationApplication/custom_utilities/geometry_utilities.h
+++ b/applications/ShapeOptimizationApplication/custom_utilities/geometry_utilities.h
@@ -179,11 +179,7 @@ public:
             KRATOS_ERROR_IF(elem_i.GetGeometry().Dimension() < domain_size) << "ExtractBoundaryNodes: This function does only work"
                 <<" for solid elements in 3D and surface elements in 2D!" << std::endl;
 
-            Element::GeometryType::GeometriesArrayType boundaries;
-            if (domain_size==3)
-                boundaries = elem_i.GetGeometry().Faces();
-            else if (domain_size == 2)
-                boundaries = elem_i.GetGeometry().Edges();
+            Element::GeometryType::GeometriesArrayType boundaries = elem_i.GetGeometry().GenerateBoundariesEntities();
 
             for(unsigned int boundary=0; boundary<boundaries.size(); boundary++)
             {


### PR DESCRIPTION
Use the newer and more convenient alternative for getting the boundary entities (faces/edges)