### PR TITLE
Using linux rpath

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,9 @@ else(NOT DEFINED ENV{KRATOS_INSTALL_PYTHON_USING_LINKS})
   SET(INSTALL_PYTHON_USING_LINKS $ENV{KRATOS_INSTALL_PYTHON_USING_LINKS})
 endif(NOT DEFINED ENV{KRATOS_INSTALL_PYTHON_USING_LINKS})
 
+# Setting the libs folder for the shared objects built in kratos
+set(CMAKE_INSTALL_RPATH "$ORIGIN/../libs")
+
 # If no test policy enable by default
 if(NOT DEFINED KRATOS_BUILD_TESTING)
 	message("--No KRATOS_BUILD_TESTING is defined. Setting to ON")


### PR DESCRIPTION
I open it more as a discussion than a merge, but should work in any case. By directly setting the rpath this way (an no through the configure like we did with the old config) we ensure that all of the targets know where the libraries are located. 

Technically that means that only setting the `PYTHONPATH` should be enough to run Kratos with all the paths set correctly.

I am not sure what is the interaction with nuitca or similar, but feel free to try.

To your amazement , none of this works in Windows.