### PR TITLE
[core] Newton Raphson strategy - initialise convergence criteria just before NL loop

### DIFF
--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -791,6 +791,8 @@ class ResidualBasedNewtonRaphsonStrategy
         mpConvergenceCriteria->FinalizeNonLinearIteration(r_model_part, r_dof_set, rA, rDx, rb);
 
         if (is_converged) {
+            mpConvergenceCriteria->InitializeSolutionStep(r_model_part, r_dof_set, rA, rDx, rb);
+
             if (mpConvergenceCriteria->GetActualizeRHSflag()) {
                 TSparseSpace::SetToZero(rb);
 


### PR DESCRIPTION
As per [this](https://github.com/KratosMultiphysics/Kratos/pull/6807#discussion_r413423786), initialising the convergence criteria just before the NL loop in the NR SolveSolutionStep decreased the number of iterations need for an MPM solve by 1. This PR continues that investigation.

@philbucher 