### PR TITLE
Structural/prebuckling symmetrization option

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/StructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -109,7 +109,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
 
     // Prebuckling Strategy
     py::class_< PrebucklingStrategyType, typename PrebucklingStrategyType::Pointer,BaseSolvingStrategyType >(m,"PrebucklingStrategy")
-        .def(py::init<ModelPart&, BaseSchemeType::Pointer, BuilderAndSolverPointer, BuilderAndSolverPointer, ConvergenceCriteriaPointer, int, double, double, double, double >())
+        .def(py::init<ModelPart&, BaseSchemeType::Pointer, BuilderAndSolverPointer, BuilderAndSolverPointer, ConvergenceCriteriaPointer, int, double, double, double, double, bool >())
         .def("GetSolutionFoundFlag", &PrebucklingStrategyType::GetSolutionFoundFlag)
         ;
     py::class_< FormfindingStrategyType,typename FormfindingStrategyType::Pointer, ResidualBasedNewtonRaphsonStrategyType >(m,"FormfindingStrategy")

--- a/applications/StructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/StructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -109,7 +109,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
 
     // Prebuckling Strategy
     py::class_< PrebucklingStrategyType, typename PrebucklingStrategyType::Pointer,BaseSolvingStrategyType >(m,"PrebucklingStrategy")
-        .def(py::init<ModelPart&, BaseSchemeType::Pointer, BuilderAndSolverPointer, BuilderAndSolverPointer, ConvergenceCriteriaPointer, int, double, double, double, double, bool >())
+        .def(py::init<ModelPart&, BaseSchemeType::Pointer, BuilderAndSolverPointer, BuilderAndSolverPointer, ConvergenceCriteriaPointer, int, Parameters >())
         .def("GetSolutionFoundFlag", &PrebucklingStrategyType::GetSolutionFoundFlag)
         ;
     py::class_< FormfindingStrategyType,typename FormfindingStrategyType::Pointer, ResidualBasedNewtonRaphsonStrategyType >(m,"FormfindingStrategy")

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/prebuckling_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/prebuckling_strategy.hpp
@@ -112,7 +112,8 @@ public:
         double InitialLoadIncrement,
         double SmallLoadIncrement,
         double PathFollowingStep,
-        double ConvergenceRatio )
+        double ConvergenceRatio,
+        bool MakeMatricesSymmetricFlag )
         : SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart)
     {
         KRATOS_TRY
@@ -134,6 +135,8 @@ public:
         mPathFollowingStep = PathFollowingStep;
 
         mConvergenceRatio = ConvergenceRatio;
+
+        mMakeMatricesSymmetricFlag = MakeMatricesSymmetricFlag;
 
         // Set Eigensolver flags
         mpEigenSolver->SetDofSetIsInitializedFlag(false);
@@ -552,6 +555,12 @@ public:
             // between the current and previous step
             rStiffnessMatrix = rStiffnessMatrixPrevious - rStiffnessMatrix;
 
+            // Symmetrice matrices if enabled
+            if( mMakeMatricesSymmetricFlag ){
+                rStiffnessMatrix = 0.5 * ( rStiffnessMatrix + boost::numeric::ublas::trans(rStiffnessMatrix) );
+                rStiffnessMatrixPrevious = 0.5 * ( rStiffnessMatrixPrevious + boost::numeric::ublas::trans(rStiffnessMatrixPrevious) );
+            }
+
             this->pGetEigenSolver()->GetLinearSystemSolver()->Solve(
                 rStiffnessMatrixPrevious,
                 rStiffnessMatrix,
@@ -744,6 +753,8 @@ private:
 
     double mLambda = 0.0;
     double mLambdaPrev = 1.0;
+
+    bool mMakeMatricesSymmetricFlag;
 
     ///@}
     ///@name Private Operators

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/prebuckling_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/prebuckling_strategy.hpp
@@ -553,6 +553,7 @@ public:
             rStiffnessMatrix = rStiffnessMatrixPrevious - rStiffnessMatrix;
 
             // Symmetrice matrices if enabled
+            // The ublas transpose function is called manually, because it is missing in the corresponding space
             if( mMakeMatricesSymmetricFlag ){
                 rStiffnessMatrix = 0.5 * ( rStiffnessMatrix + boost::numeric::ublas::trans(rStiffnessMatrix) );
                 rStiffnessMatrixPrevious = 0.5 * ( rStiffnessMatrixPrevious + boost::numeric::ublas::trans(rStiffnessMatrixPrevious) );

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/prebuckling_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/prebuckling_strategy.hpp
@@ -101,6 +101,7 @@ public:
      * @param SmallLoadIncrement Load increment of the small load step
      * @param PathFollowingStep Load increment of the big load step
      * @param ConvergenceRatio Convergence ratio for the computed eigenvalues
+     * @param MakeMatricesSymmetricFlag Flag to ensures that matrices are symmetric before eigenvalue problem is evaluated
      */
     PrebucklingStrategy(
         ModelPart &rModelPart,
@@ -109,11 +110,7 @@ public:
         BuilderAndSolverPointerType pBuilderAndSolver,
         typename ConvergenceCriteriaType::Pointer pConvergenceCriteria,
         int MaxIteration,
-        double InitialLoadIncrement,
-        double SmallLoadIncrement,
-        double PathFollowingStep,
-        double ConvergenceRatio,
-        bool MakeMatricesSymmetricFlag )
+        Parameters BucklingSettings )
         : SolvingStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart)
     {
         KRATOS_TRY
@@ -128,15 +125,15 @@ public:
 
         mMaxIteration = MaxIteration;
 
-        mInitialLoadIncrement = InitialLoadIncrement;
+        mInitialLoadIncrement = BucklingSettings["initial_load_increment"].GetDouble();
 
-        mSmallLoadIncrement = SmallLoadIncrement;
+        mSmallLoadIncrement = BucklingSettings["small_load_increment"].GetDouble();
 
-        mPathFollowingStep = PathFollowingStep;
+        mPathFollowingStep = BucklingSettings["path_following_step"].GetDouble();
 
-        mConvergenceRatio = ConvergenceRatio;
+        mConvergenceRatio = BucklingSettings["convergence_ratio"].GetDouble();
 
-        mMakeMatricesSymmetricFlag = MakeMatricesSymmetricFlag;
+        mMakeMatricesSymmetricFlag = BucklingSettings["make_matrices_symmetric"].GetBool();
 
         // Set Eigensolver flags
         mpEigenSolver->SetDofSetIsInitializedFlag(false);

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_prebuckling_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_prebuckling_solver.py
@@ -35,7 +35,7 @@ class PrebucklingSolver(MechanicalSolver):
                 "small_load_increment"      : 0.0005,
                 "path_following_step"       : 0.5,
                 "convergence_ratio"         : 0.05,
-                "make_matrices_symmetric"   : True
+                "make_matrices_symmetric"   : true
             },
             "eigensolver_settings" : {
                 "solver_type"           : "eigen_eigensystem",
@@ -117,8 +117,4 @@ class PrebucklingSolver(MechanicalSolver):
                                                                   builder_and_solver,
                                                                   convergence_criteria,
                                                                   self.settings["max_iteration"].GetInt(),
-                                                                  buckling_settings["initial_load_increment"].GetDouble(),
-                                                                  buckling_settings["small_load_increment"].GetDouble(),
-                                                                  buckling_settings["path_following_step"].GetDouble(),
-                                                                  buckling_settings["convergence_ratio"].GetDouble(),
-                                                                  buckling_settings["make_matrices_symmetric"].GetBoolean() )
+                                                                  buckling_settings )

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_prebuckling_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_prebuckling_solver.py
@@ -34,7 +34,8 @@ class PrebucklingSolver(MechanicalSolver):
                 "initial_load_increment"    : 1.0,
                 "small_load_increment"      : 0.0005,
                 "path_following_step"       : 0.5,
-                "convergence_ratio"         : 0.05
+                "convergence_ratio"         : 0.05,
+                "make_matrices_symmetric"   : True
             },
             "eigensolver_settings" : {
                 "solver_type"           : "eigen_eigensystem",
@@ -119,4 +120,5 @@ class PrebucklingSolver(MechanicalSolver):
                                                                   buckling_settings["initial_load_increment"].GetDouble(),
                                                                   buckling_settings["small_load_increment"].GetDouble(),
                                                                   buckling_settings["path_following_step"].GetDouble(),
-                                                                  buckling_settings["convergence_ratio"].GetDouble() )
+                                                                  buckling_settings["convergence_ratio"].GetDouble(),
+                                                                  buckling_settings["make_matrices_symmetric"].GetBoolean() )

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -312,8 +312,7 @@ def AssembleTestSuites():
     # Dynamic Eigenvalue Analysis
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestDynamicEigenvalueAnalysis]))
     # Buckling analysis test
-    #Change again!!!
-    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestPrebucklingAnalysis]))
+    nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestPrebucklingAnalysis]))
     # Nodal Damping
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TNodalDampingTests])) # TODO should be in smallSuite but is too slow
     # Dynamic basic tests

--- a/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication.py
@@ -312,7 +312,8 @@ def AssembleTestSuites():
     # Dynamic Eigenvalue Analysis
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestDynamicEigenvalueAnalysis]))
     # Buckling analysis test
-    nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestPrebucklingAnalysis]))
+    #Change again!!!
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TTestPrebucklingAnalysis]))
     # Nodal Damping
     nightSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TNodalDampingTests])) # TODO should be in smallSuite but is too slow
     # Dynamic basic tests

--- a/applications/StructuralMechanicsApplication/tests/test_prebuckling_analysis.py
+++ b/applications/StructuralMechanicsApplication/tests/test_prebuckling_analysis.py
@@ -97,6 +97,16 @@ class BaseTestPrebucklingAnalysis(KratosUnittest.TestCase):
         }
         """)
 
+        buckling_settings = KratosMultiphysics.Parameters("""
+        {
+            "initial_load_increment"    : 1.0,
+            "small_load_increment"      : 0.0005,
+            "path_following_step"       : 0.5,
+            "convergence_ratio"         : 0.005,
+            "make_matrices_symmetric"   : true
+        }
+        """)
+
         eigen_solver = EigenSolversApplication.EigensystemSolver(eigensolver_settings)
         eigen_solver_ = KratosMultiphysics.ResidualBasedEliminationBuilderAndSolver(eigen_solver)
         convergence_criterion = KratosMultiphysics.DisplacementCriteria(1e-4,1e-9)
@@ -111,11 +121,7 @@ class BaseTestPrebucklingAnalysis(KratosUnittest.TestCase):
                                                                            builder_and_solver,
                                                                            convergence_criterion,
                                                                            10,
-                                                                           1.0,
-                                                                           0.0005,
-                                                                           0.5,
-                                                                           0.005,
-                                                                           True )
+                                                                           buckling_settings )
         eig_strategy.SetEchoLevel(echo)
         LoadFactor = []
         for i in range(iterations):

--- a/applications/StructuralMechanicsApplication/tests/test_prebuckling_analysis.py
+++ b/applications/StructuralMechanicsApplication/tests/test_prebuckling_analysis.py
@@ -91,9 +91,9 @@ class BaseTestPrebucklingAnalysis(KratosUnittest.TestCase):
         {
             "max_iteration"         : 1000,
             "tolerance"             : 1e-6,
-            "number_of_eigenvalues" : 2,
+            "number_of_eigenvalues" : 1,
             "echo_level"            : 0,
-            "normalize_eigenvectors": true
+            "normalize_eigenvectors": false
         }
         """)
 
@@ -114,7 +114,8 @@ class BaseTestPrebucklingAnalysis(KratosUnittest.TestCase):
                                                                            1.0,
                                                                            0.0005,
                                                                            0.5,
-                                                                           0.005 )
+                                                                           0.005,
+                                                                           True )
         eig_strategy.SetEchoLevel(echo)
         LoadFactor = []
         for i in range(iterations):


### PR DESCRIPTION
This PR adds an option that enables to make matrices "artificially" symmetric before eigenvalue problem is evaluated. A slight asymmetry made the test fail, if MKl was enabled. This is related to the discussion #5938.
Any suggestions for a better parameter naming than "make_matrices_symmetric" ?

I put the test temporarily to the smallSuite. Should be changed before merging. 

Another comment: On my machine test passes now if MKL is enabled, however, test takes almost 10-times longer than without MKL support. Any thoughts? Is this, because of the minor size of the problem?
