### PR TITLE
Adding compatibility with hdf5 1.12

### DIFF
--- a/applications/HDF5Application/CMakeLists.txt
+++ b/applications/HDF5Application/CMakeLists.txt
@@ -41,6 +41,8 @@ set( KRATOS_HDF5_APPLICATION_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_hdf5_condition_flag_value_io.cpp  
 )
 
+add_definitions(-DH5_USE_110_API)
+
 set(HDF5_USE_STATIC_LIBRARIES OFF)
 if(USE_MPI)
   message(STATUS "Searching for parallel HDF5 libraries.")


### PR DESCRIPTION
This should allow us to compile with HDF5 1.12.

This is important as some hdf5-openmpi dev packages have already moved to that API version and there are some API changes which makes it incompatible with the regular 1.10 version.

don't really know who takes care of this app but please feel free to ping anyone who should be aware.