### PR TITLE
[CoSim][CoupledSolver] adding ProcessInfo

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
@@ -49,6 +49,8 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
 
         super(CoSimulationCoupledSolver, self).__init__(settings, solver_name)
 
+        self.process_info = KM.ProcessInfo()
+
         self.solver_wrappers = self.__CreateSolverWrappers()
 
         self.coupling_sequence = self.__GetSolverCoSimulationDetails()


### PR DESCRIPTION
I am adding a `ProcessInfo` to the `CoupledSolver`
In a follow-up PR this will be passed to the classes used by the `CoupledSolver` (e.g. `SolverWrapper`, `Predictor` etc)

It should contain things like `TIME`, `STEP`, `IS_RESTARTED` ...

=> this is used for communication btw these classes, bcs many implementations need those "global" informations