### PR TITLE
[Core][Element] adding missing version of CalculateOnIntegrationPoints

### DIFF
--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -1035,6 +1035,13 @@ public:
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
     }
 
+    virtual void CalculateOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
+                         std::vector<ConstitutiveLaw::Pointer>& rOutput,
+                         const ProcessInfo& rCurrentProcessInfo)
+    {
+        this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+    }
+
     /**
      * Access for variables on Integration points.
      * This gives access to variables stored in the constitutive law on each integration point.


### PR DESCRIPTION
for #6643 I realized that we are missing one overload of the `CalculateOnIntegrationPoints` in the `Element`, namely the one that used `Variable<ConstitutiveLaw::Pointer>`

This seems to be the interface for getting the Constitutive laws from the elements

To me it seems a bit weird that this fct is being used for this purpose, I think it would make more sense to have an explicit interface for it, but this is a separate discussion IMO
BTW the `SetValuesOnIntegrationPoints` method has the same overload