### PR TITLE
[PotentialFlow] Rename penalty coefficient to stabilization factor

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
@@ -65,7 +65,7 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSy
 
     if (is_embedded && wake == 0 && kutta == 0) {
         CalculateEmbeddedLocalSystem(rLeftHandSideMatrix,rRightHandSideVector,rCurrentProcessInfo);
-        if (std::abs(rCurrentProcessInfo[PENALTY_COEFFICIENT]) > std::numeric_limits<double>::epsilon()) {
+        if (std::abs(rCurrentProcessInfo[STABILIZATION_FACTOR]) > std::numeric_limits<double>::epsilon()) {
             AddPotentialGradientStabilizationTerm(rLeftHandSideMatrix,rRightHandSideVector,rCurrentProcessInfo);
         }
     }
@@ -198,10 +198,10 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::AddPotentialGrad
 
     auto penalty_term_nodal_gradient = data.vol*prod(data.DN_DX, averaged_nodal_gradient);
     auto penalty_term_potential = data.vol*prod(data.DN_DX,trans(data.DN_DX));
-    auto penalty_coefficient = rCurrentProcessInfo[PENALTY_COEFFICIENT];
+    auto stabilization_factor = rCurrentProcessInfo[STABILIZATION_FACTOR];
 
-    noalias(rLeftHandSideMatrix) +=  penalty_coefficient*penalty_term_potential;
-    noalias(rRightHandSideVector) += penalty_coefficient*(penalty_term_nodal_gradient-prod(penalty_term_potential, potential));
+    noalias(rLeftHandSideMatrix) +=  stabilization_factor*penalty_term_potential;
+    noalias(rRightHandSideVector) += stabilization_factor*(penalty_term_nodal_gradient-prod(penalty_term_potential, potential));
 }
 
 template <>

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
@@ -196,12 +196,12 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::AddPotentialGrad
     PotentialFlowUtilities::ElementalData<NumNodes,Dim> data;
     GeometryUtils::CalculateGeometryData(this->GetGeometry(), data.DN_DX, data.N, data.vol);
 
-    auto penalty_term_nodal_gradient = data.vol*prod(data.DN_DX, averaged_nodal_gradient);
-    auto penalty_term_potential = data.vol*prod(data.DN_DX,trans(data.DN_DX));
+    auto stabilization_term_nodal_gradient = data.vol*prod(data.DN_DX, averaged_nodal_gradient);
+    auto stabilization_term_potential = data.vol*prod(data.DN_DX,trans(data.DN_DX));
     auto stabilization_factor = rCurrentProcessInfo[STABILIZATION_FACTOR];
 
-    noalias(rLeftHandSideMatrix) +=  stabilization_factor*penalty_term_potential;
-    noalias(rRightHandSideVector) += stabilization_factor*(penalty_term_nodal_gradient-prod(penalty_term_potential, potential));
+    noalias(rLeftHandSideMatrix) +=  stabilization_factor*stabilization_term_potential;
+    noalias(rRightHandSideVector) += stabilization_factor*(stabilization_term_nodal_gradient-prod(stabilization_term_potential, potential));
 }
 
 template <>

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_adjoint_solver.py
@@ -37,7 +37,7 @@ class PotentialFlowAdjointFormulation(PotentialFlowFormulation):
         default_settings = KratosMultiphysics.Parameters(r"""{
             "element_type": "",
             "gradient_mode": "",
-            "penalty_coefficient": 0.0
+            "stabilization_factor": 0.0
         }""")
         formulation_settings.ValidateAndAssignDefaults(default_settings)
 

--- a/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
+++ b/applications/CompressiblePotentialFlowApplication/python_scripts/potential_flow_solver.py
@@ -82,14 +82,14 @@ class PotentialFlowFormulation(object):
     def _SetUpEmbeddedIncompressibleElement(self, formulation_settings):
         default_settings = KratosMultiphysics.Parameters(r"""{
             "element_type": "embedded_incompressible",
-            "penalty_coefficient": 0.0
+            "stabilization_factor": 0.0
 
         }""")
         formulation_settings.ValidateAndAssignDefaults(default_settings)
 
         self.element_name = "EmbeddedIncompressiblePotentialFlowElement"
         self.condition_name = "PotentialWallCondition"
-        self.process_info_data[KratosMultiphysics.FluidDynamicsApplication.PENALTY_COEFFICIENT] = formulation_settings["penalty_coefficient"].GetDouble()
+        self.process_info_data[KratosMultiphysics.STABILIZATION_FACTOR] = formulation_settings["stabilization_factor"].GetDouble()
 
     def _SetUpEmbeddedCompressibleElement(self, formulation_settings):
         default_settings = KratosMultiphysics.Parameters(r"""{
@@ -203,9 +203,9 @@ class PotentialFlowSolver(FluidSolver):
     def _GetStrategyType(self):
         element_type = self.settings["formulation"]["element_type"].GetString()
         if "incompressible" in element_type:
-            if not self.settings["formulation"].Has("penalty_coefficient"):
+            if not self.settings["formulation"].Has("stabilization_factor"):
                 strategy_type = "linear"
-            elif self.settings["formulation"]["penalty_coefficient"].GetDouble() == 0.0:
+            elif self.settings["formulation"]["stabilization_factor"].GetDouble() == 0.0:
                 strategy_type = "linear"
             else:
                 strategy_type = "non_linear"

--- a/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_penalty_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/embedded_test/embedded_circle_penalty_parameters.json
@@ -15,7 +15,7 @@
         },
         "formulation": {
             "element_type":"embedded_incompressible",
-            "penalty_coefficient": 1.0
+            "stabilization_factor": 1.0
          },
         "maximum_iterations"     : 10,
         "echo_level"             : 0,


### PR DESCRIPTION
Hi,

In this PR I switch from using the variable "PENALTY_COEFFICIENT" to "STABILIZATION_FACTOR" as the second is more accurate (it is used in a stabilization term in the embedded formulation).

It also releases the variable "PENALTY_COEFFICIENT" that I want to use in later PRs with another purpose.

There is no functionalities being added or modified in this PR