### PR TITLE
[Fluid][FSI] Import Metis before Trilinos application

### DIFF
--- a/applications/FSIApplication/python_scripts/trilinos_partitioned_fsi_base_solver.py
+++ b/applications/FSIApplication/python_scripts/trilinos_partitioned_fsi_base_solver.py
@@ -8,6 +8,7 @@ import KratosMultiphysics
 import KratosMultiphysics.mpi as KratosMPI
 
 # Import applications
+import KratosMultiphysics.MetisApplication
 import KratosMultiphysics.TrilinosApplication as KratosTrilinos
 import KratosMultiphysics.MappingApplication as KratosMapping
 import KratosMultiphysics.StructuralMechanicsApplication as KratosStructural

--- a/applications/FSIApplication/python_scripts/trilinos_partitioned_fsi_dirichlet_neumann_solver.py
+++ b/applications/FSIApplication/python_scripts/trilinos_partitioned_fsi_dirichlet_neumann_solver.py
@@ -4,6 +4,7 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 import KratosMultiphysics
 
 # Import applications
+import KratosMultiphysics.MetisApplication
 import KratosMultiphysics.TrilinosApplication as KratosTrilinos
 import KratosMultiphysics.MappingApplication as KratosMapping
 import KratosMultiphysics.StructuralMechanicsApplication as KratosStructural

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_adjoint_vmsmonolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_adjoint_vmsmonolithic_solver.py
@@ -3,6 +3,7 @@ import KratosMultiphysics
 import KratosMultiphysics.mpi as KratosMPI
 
 # Import applications
+import KratosMultiphysics.MetisApplication
 import KratosMultiphysics.TrilinosApplication as TrilinosApplication
 from KratosMultiphysics.TrilinosApplication import trilinos_linear_solver_factory
 from KratosMultiphysics.FluidDynamicsApplication.adjoint_vmsmonolithic_solver import AdjointVMSMonolithicSolver

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_embedded_solver.py
@@ -3,6 +3,7 @@ import KratosMultiphysics
 import KratosMultiphysics.mpi as KratosMPI                          # MPI-python interface
 
 # Import applications
+import KratosMultiphysics.MetisApplication                          # Mesh artitioning (always import before Trilinos)
 import KratosMultiphysics.TrilinosApplication as KratosTrilinos     # MPI solvers
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid   # Fluid dynamics application
 from KratosMultiphysics.TrilinosApplication import trilinos_linear_solver_factory

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_fractionalstep.py
@@ -3,6 +3,7 @@ import KratosMultiphysics
 import KratosMultiphysics.mpi as KratosMPI                          # MPI-python interface
 
 # Import applications
+import KratosMultiphysics.MetisApplication                          # Mesh artitioning (always import before Trilinos)
 import KratosMultiphysics.TrilinosApplication as KratosTrilinos     # MPI solvers
 from KratosMultiphysics.FluidDynamicsApplication import TrilinosExtension as TrilinosFluid
 from KratosMultiphysics.TrilinosApplication import trilinos_linear_solver_factory

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_solver_vmsmonolithic.py
@@ -3,6 +3,7 @@ import KratosMultiphysics
 import KratosMultiphysics.mpi as KratosMPI                          # MPI-python interface
 
 # Import applications
+import KratosMultiphysics.MetisApplication                          # Mesh artitioning (always import before Trilinos)
 import KratosMultiphysics.TrilinosApplication as KratosTrilinos     # MPI solvers
 import KratosMultiphysics.FluidDynamicsApplication as KratosCFD     # Fluid dynamics application
 from KratosMultiphysics.FluidDynamicsApplication import TrilinosExtension as TrilinosFluid

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_navier_stokes_two_fluids_solver.py
@@ -3,6 +3,7 @@ import KratosMultiphysics
 import KratosMultiphysics.mpi as KratosMPI                          # MPI-python interface
 
 # Import applications
+import KratosMultiphysics.MetisApplication                          # Mesh artitioning (always import before Trilinos)
 import KratosMultiphysics.TrilinosApplication as KratosTrilinos     # MPI solvers
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid   # Fluid dynamics application
 from KratosMultiphysics.TrilinosApplication import trilinos_linear_solver_factory


### PR DESCRIPTION
Trying to run an MPI case in our in-house cluster raised a weird Metis symbols error.

As we experienced some time ago, importing the `MetisApplication` before the `TrilinosApplication` solved this.