### PR TITLE
Mpi - Calculate normals fix

### DIFF
--- a/applications/ULFapplication/python_scripts/SurfaceTension_monolithic_solver.py
+++ b/applications/ULFapplication/python_scripts/SurfaceTension_monolithic_solver.py
@@ -254,7 +254,7 @@ class STMonolithicSolver:
             if self.use_spalart_allmaras:
                 self.neighbour_search.Execute()
 
-        NormalCalculationUtils().CalculateOnSimplex(self.model_part.Conditions, self.domain_size)
+        NormalCalculationUtils().CalculateOnSimplex(self.model_part, self.domain_size)
         for node in self.model_part.Nodes:
             if (node.GetSolutionStepValue(IS_BOUNDARY) != 1.0):# and node.GetSolutionStepValue(TRIPLE_POINT) == 0):
                 node.SetSolutionStepValue(NORMAL_X,0,0.0)
@@ -318,7 +318,7 @@ class STMonolithicSolver:
         ##############THIS IS FOR EMBEDDED"""""""""""""""""""""""""
 ######################################################################################################
         #FOR PFEM
-        NormalCalculationUtils().CalculateOnSimplex(self.model_part.Conditions, self.domain_size)
+        NormalCalculationUtils().CalculateOnSimplex(self.model_part, self.domain_size)
         if (self.domain_size == 2):
             for node in self.model_part.Nodes:
                 node.SetSolutionStepValue(FLAG_VARIABLE,0,0.0)

--- a/applications/ULFapplication/python_scripts/runge_kutta_frac_step_solver.py
+++ b/applications/ULFapplication/python_scripts/runge_kutta_frac_step_solver.py
@@ -93,7 +93,7 @@ class RungeKuttaFracStepSolver:
         (self.neighbour_search).Execute()
         # calculate the normals to the overall domain
         self.normal_tools.CalculateOnSimplex(
-            self.model_part.Conditions,
+            self.model_part,
             self.domain_size)
         # for SLIP condition we need to save these Conditions in a list
         # by now SLIP conditions are identified by FLAG_VARIABLE=3.0. this is

--- a/applications/ULFapplication/python_scripts/ulf_PGLASS.py
+++ b/applications/ULFapplication/python_scripts/ulf_PGLASS.py
@@ -361,7 +361,7 @@ class ULF_FSISolver:
             if (node.GetSolutionStepValue(FLAG_VARIABLE)==1.0 and node.GetSolutionStepValue(IS_FREE_SURFACE)==1.0):
                 node.SetSolutionStepValue(EXTERNAL_PRESSURE,0, self.blow_pressure)
         #FOR PFEM
-        NormalCalculationUtils().CalculateOnSimplex(self.fluid_model_part.Conditions, self.domain_size)
+        NormalCalculationUtils().CalculateOnSimplex(self.fluid_model_part, self.domain_size)
 
         for node in self.fluid_model_part.Nodes:
           if (node.GetSolutionStepValue(FLAG_VARIABLE)!=1.0):

--- a/kratos/utilities/normal_calculation_utils.h
+++ b/kratos/utilities/normal_calculation_utils.h
@@ -173,7 +173,7 @@ public:
 
         for(auto & node: rModelPart.Nodes()) {
             if(node->Is(VISITED)) {
-                noalias((rNodes[in]).FastGetSolutionStepValue(NORMAL)) = zero;
+                node.FastGetSolutionStepValue(NORMAL)) = zero;
             }
         }
 

--- a/kratos/utilities/normal_calculation_utils.h
+++ b/kratos/utilities/normal_calculation_utils.h
@@ -162,16 +162,16 @@ public:
         VariableUtils().SetFlag(VISITED, false, rModelPart.Nodes());
 
         for(auto & cond: rModelPart.Conditions()) {
-            for(auto & node: cond.GetGeometry() {
+            for(auto & node: cond.GetGeometry()) {
                 node.Set(VISITED, true);
             }
         }
 
-        rModelPart.GetCommunicator().SynchronizeAndNodalFlags();
+        rModelPart.GetCommunicator().SynchronizeAndNodalFlags(VISITED);
 
         for(auto & node: rModelPart.Nodes()) {
             if(node.Is(VISITED)) {
-                node.FastGetSolutionStepValue(NORMAL)) = zero;
+                node.FastGetSolutionStepValue(NORMAL) = zero;
             }
         }
 

--- a/kratos/utilities/normal_calculation_utils.h
+++ b/kratos/utilities/normal_calculation_utils.h
@@ -25,6 +25,7 @@
 
 /* Project includes */
 #include "utilities/math_utils.h"
+#include "utilities/variable_utils.h"
 #include "includes/deprecated_variables.h"
 
 
@@ -160,18 +161,16 @@ public:
 
         VariableUtils().SetFlag(VISITED, false, rModelPart.Nodes());
 
-        for(ConditionsArrayType::iterator it =  rConditions.begin();
-                it !=rConditions.end(); it++)
-        {
-            Element::GeometryType& rNodes = it->GetGeometry();
-            for(unsigned int in = 0; in<rNodes.size(); in++)
-                in->Set(VISITED, true);
+        for(auto & cond: rModelPart.Conditions() {
+            for(auto & node: cond.GetGeometry() {
+                node.Set(VISITED, true);
+            }
         }
 
         rModelPart.GetCommunicator().SynchronizeAndNodalFlags();
 
         for(auto & node: rModelPart.Nodes()) {
-            if(node->Is(VISITED)) {
+            if(node.Is(VISITED)) {
                 node.FastGetSolutionStepValue(NORMAL)) = zero;
             }
         }

--- a/kratos/utilities/normal_calculation_utils.h
+++ b/kratos/utilities/normal_calculation_utils.h
@@ -157,7 +157,6 @@ public:
     {   
         // Resetting the normals
         const array_1d<double,3> zero = ZeroVector(3);
-        noalias(zero) = ZeroVector(3);
 
         VariableUtils().SetFlag(VISITED, false, rModelPart.Nodes());
 

--- a/kratos/utilities/normal_calculation_utils.h
+++ b/kratos/utilities/normal_calculation_utils.h
@@ -156,7 +156,7 @@ public:
                             int Dimension)
     {   
         // Resetting the normals
-        array_1d<double,3> zero = Vector(3);
+        const array_1d<double,3> zero = ZeroVector(3);
         noalias(zero) = ZeroVector(3);
 
         VariableUtils().SetFlag(VISITED, false, rModelPart.Nodes());
@@ -637,4 +637,3 @@ private:
 }  /* namespace Kratos.*/
 
 #endif /* KRATOS_NORMAL_CALCULATION_UTILS  defined */
-

--- a/kratos/utilities/normal_calculation_utils.h
+++ b/kratos/utilities/normal_calculation_utils.h
@@ -114,7 +114,6 @@ public:
                 noalias((rNodes[in]).GetSolutionStepValue(NORMAL)) = zero;
         }
 
-
         //calculating the normals and storing on the conditions
         array_1d<double,3> An;
         if(dimension == 2)
@@ -167,7 +166,29 @@ public:
       */
     void CalculateOnSimplex(ModelPart& rModelPart,
                             int Dimension)
-    {
+    {   
+        // Resetting the normals
+        array_1d<double,3> zero = Vector(3);
+        noalias(zero) = ZeroVector(3);
+
+        VariableUtils().SetFlag(VISITED, false, rModelPart.Nodes());
+
+        for(ConditionsArrayType::iterator it =  rConditions.begin();
+                it !=rConditions.end(); it++)
+        {
+            Element::GeometryType& rNodes = it->GetGeometry();
+            for(unsigned int in = 0; in<rNodes.size(); in++)
+                in->Set(VISITED, true);
+        }
+
+        rModelPart.GetCommunicator().SynchronizeAndNodalFlags();
+
+        for(auto & node: rModelPart.Nodes()) {
+            if(node->Is(VISITED)) {
+                noalias((rNodes[in]).FastGetSolutionStepValue(NORMAL)) = zero;
+            }
+        }
+
         this->CalculateOnSimplex(rModelPart.Conditions(),Dimension);
         rModelPart.GetCommunicator().AssembleCurrentData(NORMAL);
     }

--- a/kratos/utilities/normal_calculation_utils.h
+++ b/kratos/utilities/normal_calculation_utils.h
@@ -161,7 +161,7 @@ public:
 
         VariableUtils().SetFlag(VISITED, false, rModelPart.Nodes());
 
-        for(auto & cond: rModelPart.Conditions() {
+        for(auto & cond: rModelPart.Conditions()) {
             for(auto & node: cond.GetGeometry() {
                 node.Set(VISITED, true);
             }

--- a/kratos/utilities/normal_calculation_utils.h
+++ b/kratos/utilities/normal_calculation_utils.h
@@ -102,18 +102,6 @@ public:
     {
         KRATOS_TRY
 
-        //resetting the normals
-        array_1d<double,3> zero = Vector(3);
-        noalias(zero) = ZeroVector(3);
-
-        for(ConditionsArrayType::iterator it =  rConditions.begin();
-                it !=rConditions.end(); it++)
-        {
-            Element::GeometryType& rNodes = it->GetGeometry();
-            for(unsigned int in = 0; in<rNodes.size(); in++)
-                noalias((rNodes[in]).GetSolutionStepValue(NORMAL)) = zero;
-        }
-
         //calculating the normals and storing on the conditions
         array_1d<double,3> An;
         if(dimension == 2)


### PR DESCRIPTION
I understand from #6797 we should  a more in deep cleaning, but this is quite urgent.

This changes the way normals are reset in the nodes so orphan nodes get reset too to avoid assemble to accumulate results.

The problem is that conditions with ghost nodes would not have the real nodes reset in their origin processors as they cannot be access through the remote conditions (because there are no ghost conditions that hold the local counterparts).

ULFApplication had some calls directly to this function (probably direct access should be removed from python or at least reworked...) which essentially could be replaced with the model part version that takes care of the reset. I added you @juliobarna because you edited those files at some point, but feel free to ping someone else.