### PR TITLE
[DEM] removing virtual

### DIFF
--- a/applications/DEMApplication/custom_utilities/properties_proxies.h
+++ b/applications/DEMApplication/custom_utilities/properties_proxies.h
@@ -140,9 +140,9 @@ namespace Kratos {
 
         friend class Serializer;
 
-        virtual void save(Serializer& rSerializer) const;
+        void save(Serializer& rSerializer) const;
 
-        virtual void load(Serializer& rSerializer);
+        void load(Serializer& rSerializer);
     }; // class PropertiesProxy
 
 


### PR DESCRIPTION
This seems to not be a virtual class
The problem is that this throws a warning with newer CLANG if the corresponding virtual destructor is missing

please check