### PR TITLE
[CoSim] adding Process for creating point-based entities

### DIFF
--- a/applications/CableNetApplication/tests/ring_set_up_dem_fem/FEMProjectParameter.json
+++ b/applications/CableNetApplication/tests/ring_set_up_dem_fem/FEMProjectParameter.json
@@ -114,7 +114,7 @@
 			"python_module"   : "create_point_based_entites_process",
 			"kratos_module" : "KratosMultiphysics.CoSimulationApplication.processes",
 			"Parameters"            : {
-				"root_model_part_name"       : "Structure",
+				"model_part_name"       : "Structure",
 				"new_sub_model_part_name"    : "struct_sub",
 				"sub_model_part_names"       : [],
 				"entity_name"                : "PointLoadCondition3D1N",

--- a/applications/CableNetApplication/tests/ring_set_up_dem_fem/FEMProjectParameter.json
+++ b/applications/CableNetApplication/tests/ring_set_up_dem_fem/FEMProjectParameter.json
@@ -110,7 +110,19 @@
 				"tolerance"        : 3e-1
 			}
 		}],
-		"list_other_processes"             :  [],
+		"list_other_processes"             :  [{
+			"python_module"   : "create_point_based_entites_process",
+			"kratos_module" : "KratosMultiphysics.CoSimulationApplication.processes",
+			"Parameters"            : {
+				"root_model_part_name"       : "Structure",
+				"new_sub_model_part_name"    : "struct_sub",
+				"sub_model_part_names"       : [],
+				"entity_name"                : "PointLoadCondition3D1N",
+				"entity_type"                : "condition",
+				"properties_id"              : 0,
+				"kratos_application"         : ""
+			}
+		}],
 		"json_output_process"              :  []
 	},
 	"output_processes"                 : {

--- a/applications/CableNetApplication/tests/ring_set_up_dem_fem/cosim_dem_fem_cable_net_parameters.json
+++ b/applications/CableNetApplication/tests/ring_set_up_dem_fem/cosim_dem_fem_cable_net_parameters.json
@@ -19,14 +19,6 @@
                 }
             }
         },
-        "coupling_operations" : {
-            "create_sub_load_condition" : {
-                "type"                  : "create_point_load_model_part",
-                "solver"                : "structure",
-                "sub_model_part_name"   : "struct_sub",
-                "computing_model_part_name"   : "Structure"
-            }
-        },
         "coupling_sequence":
         [
             {

--- a/applications/CableNetApplication/tests/sliding_edges_with_friction_dem_fem/FEMProjectParameter.json
+++ b/applications/CableNetApplication/tests/sliding_edges_with_friction_dem_fem/FEMProjectParameter.json
@@ -88,7 +88,7 @@
 		"python_module"   : "create_point_based_entites_process",
 		"kratos_module" : "KratosMultiphysics.CoSimulationApplication.processes",
 		"Parameters"            : {
-			"root_model_part_name"       : "Structure",
+			"model_part_name"       : "Structure",
 			"new_sub_model_part_name"    : "struct_sub",
 			"sub_model_part_names"       : [],
 			"entity_name"                : "PointLoadCondition3D1N",

--- a/applications/CableNetApplication/tests/sliding_edges_with_friction_dem_fem/FEMProjectParameter.json
+++ b/applications/CableNetApplication/tests/sliding_edges_with_friction_dem_fem/FEMProjectParameter.json
@@ -84,7 +84,19 @@
             "time_frequency"   : 8e-3,
             "tolerance"        : 1e-2
         }
-    }]
+    },{
+		"python_module"   : "create_point_based_entites_process",
+		"kratos_module" : "KratosMultiphysics.CoSimulationApplication.processes",
+		"Parameters"            : {
+			"root_model_part_name"       : "Structure",
+			"new_sub_model_part_name"    : "struct_sub",
+			"sub_model_part_names"       : [],
+			"entity_name"                : "PointLoadCondition3D1N",
+			"entity_type"                : "condition",
+			"properties_id"              : 0,
+			"kratos_application"         : ""
+		}
+	}]
 	},
 	"output_processes" : {
         "gid_output" : []

--- a/applications/CableNetApplication/tests/sliding_edges_with_friction_dem_fem/cosim_dem_fem_cable_net_parameters.json
+++ b/applications/CableNetApplication/tests/sliding_edges_with_friction_dem_fem/cosim_dem_fem_cable_net_parameters.json
@@ -19,14 +19,6 @@
                 }
             }
         },
-        "coupling_operations" : {
-            "create_sub_load_condition" : {
-                "type"                  : "create_point_load_model_part",
-                "solver"                : "structure",
-                "sub_model_part_name"   : "struct_sub",
-                "computing_model_part_name"   : "Structure"
-            }
-        },
         "coupling_sequence":
         [
             {

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/create_point_load_model_part.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/create_point_load_model_part.py
@@ -2,6 +2,7 @@ from __future__ import print_function, absolute_import, division  # makes these 
 
 # Importing the Kratos Library
 import KratosMultiphysics as KM
+from KratosMultiphysics.kratos_utilities import IssueDeprecationWarning
 
 # Importing the base class
 from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_coupling_operation import CoSimulationCouplingOperation
@@ -17,6 +18,7 @@ class CreatePointLoadModelPart(CoSimulationCouplingOperation):
     """This operation creates a submodelpart containing PointLoad Conidtions for transferring loads
     """
     def __init__(self, settings, solver_wrappers):
+        IssueDeprecationWarning('CreatePointLoadModelPart', 'please use CreatePointBasedEntitiesProcess" instead')
         super(CreatePointLoadModelPart, self).__init__(settings)
         self.model = solver_wrappers[self.settings["solver"].GetString()].model
 

--- a/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
+++ b/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
@@ -53,8 +53,7 @@ class CreatePointBasedEntitiesProcess(KM.Process):
 
         model_parts = [Model[root_model_part_name+"."+model_part_name] for model_part_name in settings["sub_model_part_names"].GetStringArray()]
 
-        # TODO create recursive if name contains "."
-        new_model_part = root_model_part.CreateSubModelPart(settings["new_sub_model_part_name"].GetString())
+        new_model_part = RecursiveCreateModelParts(root_model_part, settings["new_sub_model_part_name"].GetString())
 
         [node.Id for mp in model_parts for node in mp.GetCommunicator().LocalMesh().Nodes]
 
@@ -94,4 +93,5 @@ def RecursiveCreateModelParts(model_part, model_part_name):
     model_part_name, *sub_model_part_names = model_part_name.split(".")
     model_part = model_part.CreateSubModelPart(model_part_name)
     if len(sub_model_part_names) > 0:
-        RecursiveCreateModelParts(model_part, ".".join(sub_model_part_names))
+        model_part = RecursiveCreateModelParts(model_part, ".".join(sub_model_part_names))
+    return model_part

--- a/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
+++ b/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
@@ -49,9 +49,10 @@ class CreatePointBasedEntitiesProcess(KM.Process):
             import_module("KratosMultiphysics." + kratos_application) # this registers the entities
 
         if settings["sub_model_part_names"].size() == 0:
-            raise Exception('"sub_model_part_names" cannot be empty!')
-
-        model_parts = [Model[root_model_part_name+"."+model_part_name] for model_part_name in settings["sub_model_part_names"].GetStringArray()]
+            # if no sub-model-parts are specified then taking the root-model-part
+            model_parts = [root_model_part]
+        else:
+            model_parts = [Model[root_model_part_name+"."+model_part_name] for model_part_name in settings["sub_model_part_names"].GetStringArray()]
 
         new_model_part = RecursiveCreateModelParts(root_model_part, settings["new_sub_model_part_name"].GetString())
 

--- a/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
+++ b/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
@@ -13,16 +13,26 @@ def Factory(settings, Model):
 
 
 class CreatePointBasedEntitiesProcess(KM.Process):
-    """This process sets a given value for a certain flag in all the nodes of a submodelpart
+    """This process creates point based entities on the nodes of SubModelPart(s). This process should be used only once per ModelPart to not create the same entities multiple times on the same nodes.
+    It works with restarts as well as in MPI. Also the numbering of the newly created entities is done consistently.
     """
 
     def __init__(self, Model, settings ):
         KM.Process.__init__(self)
 
+        """
+        model_part_name: The name of the MainModelPart for which the entities should be created
+        sub_model_part_names: <optional> Names of the SubModelParts on which the entities should be created. This is needed to not create multiple entities on the same nodes, if model-part are overlapping/contain the same nodes.
+        new_sub_model_part_name: The name of the SubModelPart that will be created as base of MainModelPart. The created entities will be in this ModelPart
+        entity_name: The name of the entities to create
+        entity_type: "condition" or "element"
+        properties_id: Id of the properties to be used for the newly created entities
+        kratos_application: <optional> Application in which the entities to create are implemented, needs to be imported before creating them
+        """
         default_settings = KM.Parameters("""{
             "model_part_name"          : "PLEASE_SPECIFY",
-            "new_sub_model_part_name"  : "PLEASE_SPECIFY",
             "sub_model_part_names"     : [],
+            "new_sub_model_part_name"  : "PLEASE_SPECIFY",
             "entity_name"              : "PointLoadCondition3D1N",
             "entity_type"              : "condition",
             "properties_id"            : 0,
@@ -50,7 +60,7 @@ class CreatePointBasedEntitiesProcess(KM.Process):
             import_module("KratosMultiphysics." + kratos_application) # this registers the entities
 
         if settings["sub_model_part_names"].size() == 0:
-            # if no sub-model-parts are specified then taking the root-model-part
+            # if no sub-model-parts are specified then taking the main-model-part
             model_parts = [model_part]
         else:
             model_parts = [Model[model_part_name+"."+sub_model_part_name] for sub_model_part_name in settings["sub_model_part_names"].GetStringArray()]

--- a/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
+++ b/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
@@ -20,23 +20,24 @@ class CreatePointBasedEntitiesProcess(KM.Process):
         KM.Process.__init__(self)
 
         default_settings = KM.Parameters("""{
-            "root_model_part_name"       : "PLEASE_SPECIFY",
-            "new_sub_model_part_name"    : "PLEASE_SPECIFY",
-            "sub_model_part_names"       : [],
-            "entity_name"                : "PointLoadCondition3D1N",
-            "entity_type"                : "condition",
-            "properties_id"              : 0,
-            "kratos_application"         : ""
+            "model_part_name"          : "PLEASE_SPECIFY",
+            "new_sub_model_part_name"  : "PLEASE_SPECIFY",
+            "sub_model_part_names"     : [],
+            "entity_name"              : "PointLoadCondition3D1N",
+            "entity_type"              : "condition",
+            "properties_id"            : 0,
+            "kratos_application"       : ""
         }""")
 
         settings.ValidateAndAssignDefaults(default_settings)
 
-        root_model_part = Model[settings["root_model_part_name"].GetString()]
-        if root_model_part.ProcessInfo[KM.IS_RESTARTED]:
+        model_part_name = settings["model_part_name"].GetString()
+        model_part = Model[model_part_name]
+        if model_part.ProcessInfo[KM.IS_RESTARTED]:
             # Do nothing in case of restart
             return
 
-        root_model_part_name = settings["root_model_part_name"].GetString()
+        root_model_part = model_part.GetRootModelPart()
         entity_name = settings["entity_name"].GetString()
         entity_type = settings["entity_type"].GetString()
         properties_id = settings["properties_id"].GetInt()
@@ -50,11 +51,11 @@ class CreatePointBasedEntitiesProcess(KM.Process):
 
         if settings["sub_model_part_names"].size() == 0:
             # if no sub-model-parts are specified then taking the root-model-part
-            model_parts = [root_model_part]
+            model_parts = [model_part]
         else:
-            model_parts = [Model[root_model_part_name+"."+model_part_name] for model_part_name in settings["sub_model_part_names"].GetStringArray()]
+            model_parts = [Model[model_part_name+"."+sub_model_part_name] for sub_model_part_name in settings["sub_model_part_names"].GetStringArray()]
 
-        new_model_part = RecursiveCreateModelParts(root_model_part, settings["new_sub_model_part_name"].GetString())
+        new_model_part = RecursiveCreateModelParts(model_part, settings["new_sub_model_part_name"].GetString())
 
         node_ids = [node.Id
             for mp in model_parts

--- a/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
+++ b/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
@@ -1,0 +1,92 @@
+# Importing the Kratos Library
+import KratosMultiphysics as KM
+from KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable
+
+# other imports
+from importlib import import_module
+
+
+def Factory(settings, Model):
+    if not isinstance(settings, KM.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+    return CreatePointBasedEntitiesProcess(Model, settings["Parameters"])
+
+
+class CreatePointBasedEntitiesProcess(KM.Process):
+    """This process sets a given value for a certain flag in all the nodes of a submodelpart
+    """
+
+    def __init__(self, Model, settings ):
+        KM.Process.__init__(self)
+
+        default_settings = KM.Parameters("""{
+            "root_model_part_name"       : "PLEASE_SPECIFY",
+            "new_sub_model_part_name"    : "PLEASE_SPECIFY",
+            "sub_model_part_names"       : [],
+            "entity_name"                : "PointLoadCondition3D1N",
+            "entity_type"                : "condition",
+            "properties_id"              : 0,
+            "kratos_application"         : ""
+        }""")
+
+        settings.ValidateAndAssignDefaults(default_settings)
+
+        root_model_part = Model[settings["root_model_part_name"].GetString()]
+        root_model_part_name = settings["root_model_part_name"].GetString()
+        entity_name = settings["entity_name"].GetString()
+        entity_type = settings["entity_type"].GetString()
+        properties_id = settings["properties_id"].GetInt()
+
+        # importing the Application where the entites are registered (optional)
+        kratos_application = settings["kratos_application"].GetString()
+        if kratos_application != "":
+            if not CheckIfApplicationsAvailable(kratos_application):
+                raise Exception('Application "{}" is not available!'.format(kratos_application))
+            import_module("KratosMultiphysics." + kratos_application) # this registers the entities
+
+        if settings["sub_model_part_names"].size() == 0:
+            raise Exception('"sub_model_part_names" cannot be empty!')
+
+        model_parts = [Model[root_model_part_name+"."+model_part_name] for model_part_name in settings["sub_model_part_names"].GetStringArray()]
+
+        # TODO create recursive if name contains "."
+        new_model_part = root_model_part.CreateSubModelPart(settings["new_sub_model_part_name"].GetString())
+
+        [node.Id for mp in model_parts for node in mp.GetCommunicator().LocalMesh().Nodes]
+
+        node_ids = [node.Id
+            for mp in model_parts
+                for node in mp.GetCommunicator().LocalMesh().Nodes
+        ]
+        node_ids = list(set(node_ids)) # make sure the node-Ids are unique. This is needed to not create multiple entities for the same node
+
+        new_model_part.AddNodes(node_ids)
+
+        props = root_model_part.GetProperties(properties_id, 0) # 0 is mesh-id
+        mp_comm = root_model_part.GetCommunicator()
+
+        if entity_type == "element":
+            num_global_entities = mp_comm.GlobalNumberOfElements()
+            creation_fct_ptr = new_model_part.CreateNewElement
+        elif entity_type == "condition":
+            num_global_entities = mp_comm.GlobalNumberOfConditions()
+            creation_fct_ptr = new_model_part.CreateNewCondition
+        else:
+            raise Exception('"entity_type" "{}" is not valid, only "element" or "condition" are possible!'.format(entity_type))
+
+        # using ScanSum to compute the local Id-start. Otherwise the Ids would start with the same value on every rank
+        data_comm = mp_comm.GetDataCommunicator()
+        scan_sum_nodes = data_comm.ScanSum(len(node_ids))
+        local_id_start = scan_sum_nodes + 1 + num_global_entities - len(node_ids)
+
+        for i, node_id in enumerate(node_ids):
+            creation_fct_ptr(entity_name, i+local_id_start, [node_id], props)
+
+
+def RecursiveCreateModelParts(model_part, model_part_name):
+    '''This function creates a hierarchy of SubModelParts on a given ModelPart
+    '''
+    model_part_name, *sub_model_part_names = model_part_name.split(".")
+    model_part = model_part.CreateSubModelPart(model_part_name)
+    if len(sub_model_part_names) > 0:
+        RecursiveCreateModelParts(model_part, ".".join(sub_model_part_names))

--- a/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
+++ b/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
@@ -62,7 +62,7 @@ class CreatePointBasedEntitiesProcess(KM.Process):
 
         new_model_part.AddNodes(node_ids)
 
-        props = root_model_part.GetProperties(properties_id, 0) # 0 is mesh-id
+        props = root_model_part.GetProperties(properties_id, 0) # 0 is mesh-id # maybe check and then create the props
         mp_comm = root_model_part.GetCommunicator()
 
         if entity_type == "element":

--- a/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
+++ b/applications/CoSimulationApplication/python_scripts/processes/create_point_based_entites_process.py
@@ -55,8 +55,6 @@ class CreatePointBasedEntitiesProcess(KM.Process):
 
         new_model_part = RecursiveCreateModelParts(root_model_part, settings["new_sub_model_part_name"].GetString())
 
-        [node.Id for mp in model_parts for node in mp.GetCommunicator().LocalMesh().Nodes]
-
         node_ids = [node.Id
             for mp in model_parts
                 for node in mp.GetCommunicator().LocalMesh().Nodes

--- a/applications/CoSimulationApplication/tests/dem_fem_cable_net/ProjectParametersFEM.json
+++ b/applications/CoSimulationApplication/tests/dem_fem_cable_net/ProjectParametersFEM.json
@@ -29,27 +29,39 @@
 		}
 	},
 	"processes" : {
-	"my_processes"  : [{
-		"python_module" : "fix_vector_variable_process",
-		"kratos_module" : "KratosMultiphysics",
-		"help" : "This process fixes the selected components of a given vector variable",
-		"Parameters" : {
-			"model_part_name" : "Structure.DISPLACEMENT_dirichXYZ",
-			"variable_name" : "DISPLACEMENT",
-			"constrained" : [true, true, true]
+		"my_processes"  : [{
+			"python_module" : "fix_vector_variable_process",
+			"kratos_module" : "KratosMultiphysics",
+			"help" : "This process fixes the selected components of a given vector variable",
+			"Parameters" : {
+				"model_part_name" : "Structure.DISPLACEMENT_dirichXYZ",
+				"variable_name" : "DISPLACEMENT",
+				"constrained" : [true, true, true]
+				}
+		},{
+			"python_module"   : "from_json_check_result_process",
+			"kratos_module" : "KratosMultiphysics",
+			"help"                  : "",
+			"process_name"          : "FromJsonCheckResultProcess",
+			"Parameters"            : {
+				"check_variables"  : ["DISPLACEMENT_Z"],
+				"input_file_name"  : "dem_fem_cable_net/dem_fem_cable_net_test_results.json",
+				"model_part_name"  : "Structure.RESULT_middleNode",
+				"time_frequency"   : 5e-04,
+				"tolerance"        : 1e-2
 			}
-	},{
-        "python_module"   : "from_json_check_result_process",
-        "kratos_module" : "KratosMultiphysics",
-        "help"                  : "",
-        "process_name"          : "FromJsonCheckResultProcess",
-        "Parameters"            : {
-            "check_variables"  : ["DISPLACEMENT_Z"],
-            "input_file_name"  : "dem_fem_cable_net/dem_fem_cable_net_test_results.json",
-            "model_part_name"  : "Structure.RESULT_middleNode",
-			"time_frequency"   : 5e-04,
-			"tolerance"        : 1e-2
-        }
-    }]
+		},{
+			"python_module"   : "create_point_based_entites_process",
+			"kratos_module" : "KratosMultiphysics.CoSimulationApplication.processes",
+			"Parameters"            : {
+				"root_model_part_name"       : "Structure",
+				"new_sub_model_part_name"    : "struct_sub",
+				"sub_model_part_names"       : [],
+				"entity_name"                : "PointLoadCondition3D1N",
+				"entity_type"                : "condition",
+				"properties_id"              : 0,
+				"kratos_application"         : ""
+			}
+		}]
 	}
 }

--- a/applications/CoSimulationApplication/tests/dem_fem_cable_net/ProjectParametersFEM.json
+++ b/applications/CoSimulationApplication/tests/dem_fem_cable_net/ProjectParametersFEM.json
@@ -54,13 +54,11 @@
 			"python_module"   : "create_point_based_entites_process",
 			"kratos_module" : "KratosMultiphysics.CoSimulationApplication.processes",
 			"Parameters"            : {
-				"root_model_part_name"       : "Structure",
-				"new_sub_model_part_name"    : "struct_sub",
-				"sub_model_part_names"       : [],
-				"entity_name"                : "PointLoadCondition3D1N",
-				"entity_type"                : "condition",
-				"properties_id"              : 0,
-				"kratos_application"         : ""
+				"model_part_name"         : "Structure",
+				"new_sub_model_part_name" : "struct_sub",
+				"entity_name"             : "PointLoadCondition3D1N",
+				"entity_type"             : "condition",
+				"properties_id"           : 0
 			}
 		}]
 	}

--- a/applications/CoSimulationApplication/tests/dem_fem_cable_net/cosim_dem_fem_cable_net_parameters.json
+++ b/applications/CoSimulationApplication/tests/dem_fem_cable_net/cosim_dem_fem_cable_net_parameters.json
@@ -19,14 +19,6 @@
                 }
             }
         },
-        "coupling_operations" : {
-            "create_sub_load_condition" : {
-                "type"                      : "create_point_load_model_part",
-                "solver"                    : "structure",
-                "sub_model_part_name"       : "struct_sub",
-                "computing_model_part_name" : "Structure"
-            }
-        },
         "coupling_sequence":
         [
             {

--- a/applications/CoSimulationApplication/tests/test_CoSimulationApplication.py
+++ b/applications/CoSimulationApplication/tests/test_CoSimulationApplication.py
@@ -14,6 +14,7 @@ from co_simulation_test_factory import TestSmallCoSimulationCases
 from co_simulation_test_factory import TestCoSimulationCases
 from test_function_callback_utility import TestGenericCallFunction
 from test_ping_pong_coupling import TestPingPong
+from test_processes import TestCreatePointBasedEntitiesProcess
 
 if numpy_available:
     from test_coupling_interface_data import TestCouplingInterfaceData
@@ -47,6 +48,7 @@ def AssembleTestSuites():
     ################################################################################
     smallSuite = suites['small'] # These tests are executed by the continuous integration tool
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestGenericCallFunction]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCreatePointBasedEntitiesProcess]))
     if numpy_available:
         smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCouplingInterfaceData]))
         smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestDataTransferOperators]))

--- a/applications/CoSimulationApplication/tests/test_CoSimulationApplication_mpi.py
+++ b/applications/CoSimulationApplication/tests/test_CoSimulationApplication_mpi.py
@@ -10,6 +10,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 # Import tests
 from test_convergence_criteria import TestConvergenceCriteriaWrapper
 from test_convergence_accelerators import TestConvergenceAcceleratorWrapper
+from test_processes import TestCreatePointBasedEntitiesProcess
 
 
 def AssembleTestSuites():
@@ -29,6 +30,7 @@ def AssembleTestSuites():
     smallSuite = suites['mpi_small'] # These tests are executed by the continuous integration tool
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestConvergenceCriteriaWrapper]))
     smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestConvergenceAcceleratorWrapper]))
+    smallSuite.addTests(KratosUnittest.TestLoader().loadTestsFromTestCases([TestCreatePointBasedEntitiesProcess]))
 
     ################################################################################
     nightSuite = suites['mpi_nightly'] # These tests are executed in the nightly build

--- a/applications/CoSimulationApplication/tests/test_flower_coupling.py
+++ b/applications/CoSimulationApplication/tests/test_flower_coupling.py
@@ -16,6 +16,7 @@ class TestFLOWerCoupling(KratosUnittest.TestCase):
     '''
 
     def test_dummy_flower_solver(self):
+        self.skipTestIfApplicationsNotAvailable("MappingApplication")
         self._createTest("FLOWer_coupling", "cosim", "dummy_flower_solver")
         self._runTest()
 

--- a/applications/CoSimulationApplication/tests/test_processes.py
+++ b/applications/CoSimulationApplication/tests/test_processes.py
@@ -21,9 +21,9 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
         self.root_model_part.CreateNewProperties(0)
 
         data_comm = KM.DataCommunicator.GetDefault()
-        self.my_pid = data_comm.Rank()
-        self.num_nodes = self.my_pid % 5 + 4 # num_nodes in range (4 ... 8)
-        if self.my_pid == 4:
+        my_pid = data_comm.Rank()
+        self.num_nodes = my_pid % 5 + 4 # num_nodes in range (4 ... 8)
+        if my_pid == 4:
             self.num_nodes = 0 # in order to emulate one partition not having local nodes
 
         smp_nodes_1 = self.root_model_part.CreateSubModelPart("smp_nodes_1")
@@ -41,7 +41,7 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
                     smp_nodes_2.CreateNewNode(id_node+1, 1.3, 0.1*i_node, 0.0)
 
         for node in self.root_model_part.Nodes:
-            node.SetSolutionStepValue(KM.PARTITION_INDEX, self.my_pid)
+            node.SetSolutionStepValue(KM.PARTITION_INDEX, my_pid)
 
         # adding the first node of each smp to another smp to emulate an "overlapping" interface
         for node in smp_nodes_1.Nodes:
@@ -53,6 +53,7 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
 
         if KM.IsDistributedRun():
             KratosMPI.ParallelFillCommunicator(self.root_model_part).Execute()
+
 
     def test_create_entities_from_one_model_part(self):
         settings = KM.Parameters("""{
@@ -108,24 +109,45 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
 
         self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.Conditions)
 
-    # def test_create_entities_with_preexisting_entites(self):
-    #     pass
+    def test_create_entities_with_preexisting_entites(self):
+        settings = KM.Parameters("""{
+            "Parameters" : {
+                "root_model_part_name"       : "root_mp",
+                "new_sub_model_part_name"    : "smp_with_conditions",
+                "sub_model_part_names"       : ["smp_nodes_1", "smp_nodes_2"],
+                "entity_name"                : "PointCondition2D1N",
+                "entity_type"                : "condition",
+                "properties_id"              : 0
+            }
+        }""")
+
+        data_comm = KM.DataCommunicator.GetDefault()
+        my_pid = data_comm.Rank()
+        num_procs = data_comm.Size()
+
+        props = self.root_model_part.GetProperties(0, 0)
+
+        num_local_nodes = self.root_model_part.NumberOfNodes()
+        scan_sum_num_nodes = KM.DataCommunicator.GetDefault().ScanSum(num_local_nodes)
+        for i_node, node in enumerate(self.root_model_part.Nodes):
+            self.root_model_part.CreateNewCondition("PointCondition3D1N", i_node+scan_sum_num_nodes-num_local_nodes+1, [node.Id], props)
+
+        self.process = self.__CreateProcess(settings)
+        self.assertTrue(self.root_model_part.HasSubModelPart("smp_with_conditions"))
+        self.assertEqual(self.root_model_part.NumberOfNodes()*2, self.root_model_part.NumberOfConditions())
+
+        self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.GetSubModelPart("smp_with_conditions").Conditions, self.root_model_part.GetCommunicator().GlobalNumberOfNodes())
+
 
     def __CreateProcess(self, settings):
         return create_point_based_entites_process.Factory(settings, self.model)
 
-    def __CheckCreatedEntitiesIdAreCorrectlyNumbered(self, entities):
+    def __CheckCreatedEntitiesIdAreCorrectlyNumbered(self, entities, id_offset=0):
         num_local_entites = len(entities)
-        local_ids = [entity.Id for entity in entities]
-
-        for entity in entities:
-            local_first_id = entity.Id
-            break
-
         scan_sum_num_entities = KM.DataCommunicator.GetDefault().ScanSum(num_local_entites)
 
         for exp_id, entity in zip(range(scan_sum_num_entities-num_local_entites, scan_sum_num_entities), entities):
-            self.assertEqual(exp_id+1, entity.Id)
+            self.assertEqual(exp_id+1+id_offset, entity.Id)
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/CoSimulationApplication/tests/test_processes.py
+++ b/applications/CoSimulationApplication/tests/test_processes.py
@@ -1,0 +1,101 @@
+from __future__ import print_function, absolute_import, division  # makes these scripts backward compatible with python 2.6 and 2.7
+
+import KratosMultiphysics as KM
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+from KratosMultiphysics.CoSimulationApplication.processes import create_point_based_entites_process
+
+
+if KM.IsDistributedRun():
+    import KratosMultiphysics.mpi as KratosMPI
+
+class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
+
+    def setUp(self):
+        self.model = KM.Model()
+        self.root_model_part = self.model.CreateModelPart("root_mp")
+        self.root_model_part.AddNodalSolutionStepVariable(KM.PRESSURE)
+        self.root_model_part.AddNodalSolutionStepVariable(KM.PARTITION_INDEX)
+        self.dimension = 3
+
+        self.root_model_part.CreateNewProperties(0)
+
+        data_comm = KM.DataCommunicator.GetDefault()
+        self.my_pid = data_comm.Rank()
+        self.num_nodes = self.my_pid % 5 + 4 # num_nodes in range (4 ... 8)
+        if self.my_pid == 4:
+            self.num_nodes = 0 # in order to emulate one partition not having local nodes
+
+        smp_nodes_1 = self.root_model_part.CreateSubModelPart("smp_nodes_1")
+        smp_nodes_2 = self.root_model_part.CreateSubModelPart("smp_nodes_2")
+        smp_nodes_3 = self.root_model_part.CreateSubModelPart("smp_nodes_3")
+
+        scan_sum_num_nodes = data_comm.ScanSum(self.num_nodes)
+
+        if self.num_nodes > 0:
+            for i_node, id_node in enumerate(range(scan_sum_num_nodes-self.num_nodes, scan_sum_num_nodes)):
+                # this creates the same coords in different ranks, which does not matter for this test
+                if i_node < self.num_nodes-2: # last two nodes go to other sub-model-part
+                    smp_nodes_1.CreateNewNode(id_node+1, 0.1*i_node, 0.0, 0.0)
+                else:
+                    smp_nodes_2.CreateNewNode(id_node+1, 1.3, 0.1*i_node, 0.0)
+
+        for node in self.root_model_part.Nodes:
+            node.SetSolutionStepValue(KM.PARTITION_INDEX, self.my_pid)
+
+        # adding the first node of each smp to another smp to emulate an "overlapping" interface
+        for node in smp_nodes_1.Nodes:
+            smp_nodes_3.AddNodes([node.Id])
+            break
+        for node in smp_nodes_2.Nodes:
+            smp_nodes_3.AddNodes([node.Id])
+            break
+
+        if KM.IsDistributedRun():
+            KratosMPI.ParallelFillCommunicator(self.root_model_part).Execute()
+
+    def test_create_entities_from_one_model_part(self):
+        settings = KM.Parameters("""{
+            "Parameters" : {
+                "root_model_part_name"       : "root_mp",
+                "new_sub_model_part_name"    : "smp_with_conditions",
+                "sub_model_part_names"       : ["smp_nodes_1"],
+                "entity_name"                : "PointCondition2D1N",
+                "entity_type"                : "condition",
+                "properties_id"              : 0
+            }
+        }""")
+
+        self.process = self.__CreateProcess(settings)
+        self.assertTrue(self.root_model_part.HasSubModelPart("smp_with_conditions"))
+        self.assertEqual(self.root_model_part.GetSubModelPart("smp_nodes_1").NumberOfNodes(), self.root_model_part.NumberOfConditions())
+
+        self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.Conditions)
+
+    # def test_create_entities_from_multiple_model_parts(self):
+    #     pass
+
+    # def test_create_entities_from_overlapping_model_parts(self):
+    #     pass
+
+    # def test_create_entities_with_preexisting_entites(self):
+    #     pass
+
+    def __CreateProcess(self, settings):
+        return create_point_based_entites_process.Factory(settings, self.model)
+
+    def __CheckCreatedEntitiesIdAreCorrectlyNumbered(self, entities):
+        num_local_entites = len(entities)
+        local_ids = [entity.Id for entity in entities]
+
+        for entity in entities:
+            local_first_id = entity.Id
+            break
+
+        scan_sum_num_entities = KM.DataCommunicator.GetDefault().ScanSum(num_local_entites)
+
+        for exp_id, entity in zip(range(scan_sum_num_entities-num_local_entites, scan_sum_num_entities), entities):
+            self.assertEqual(exp_id+1, entity.Id)
+
+if __name__ == '__main__':
+    KratosUnittest.main()

--- a/applications/CoSimulationApplication/tests/test_processes.py
+++ b/applications/CoSimulationApplication/tests/test_processes.py
@@ -72,8 +72,23 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
 
         self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.Conditions)
 
-    # def test_create_entities_from_multiple_model_parts(self):
-    #     pass
+    def test_create_entities_from_multiple_model_parts(self):
+        settings = KM.Parameters("""{
+            "Parameters" : {
+                "root_model_part_name"       : "root_mp",
+                "new_sub_model_part_name"    : "smp_with_conditions",
+                "sub_model_part_names"       : ["smp_nodes_1", "smp_nodes_2"],
+                "entity_name"                : "PointCondition2D1N",
+                "entity_type"                : "condition",
+                "properties_id"              : 0
+            }
+        }""")
+
+        self.process = self.__CreateProcess(settings)
+        self.assertTrue(self.root_model_part.HasSubModelPart("smp_with_conditions"))
+        self.assertEqual(self.root_model_part.NumberOfNodes(), self.root_model_part.NumberOfConditions())
+
+        self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.Conditions)
 
     # def test_create_entities_from_overlapping_model_parts(self):
     #     pass

--- a/applications/CoSimulationApplication/tests/test_processes.py
+++ b/applications/CoSimulationApplication/tests/test_processes.py
@@ -77,7 +77,7 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
         settings = KM.Parameters("""{
             "Parameters" : {
                 "root_model_part_name"       : "root_mp",
-                "new_sub_model_part_name"    : "smp_with_conditions",
+                "new_sub_model_part_name"    : "manual_smp.create_conds",
                 "sub_model_part_names"       : ["smp_nodes_1", "smp_nodes_2"],
                 "entity_name"                : "PointCondition2D1N",
                 "entity_type"                : "condition",
@@ -86,7 +86,9 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
         }""")
 
         self.process = self.__CreateProcess(settings)
-        self.assertTrue(self.root_model_part.HasSubModelPart("smp_with_conditions"))
+        self.assertTrue(self.root_model_part.HasSubModelPart("manual_smp"))
+        man_smp = self.root_model_part.GetSubModelPart("manual_smp")
+        self.assertTrue(man_smp.HasSubModelPart("create_conds")) # ensure the recursive creation works
         self.assertEqual(self.root_model_part.NumberOfNodes(), self.root_model_part.NumberOfConditions())
 
         self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.Conditions)

--- a/applications/CoSimulationApplication/tests/test_processes.py
+++ b/applications/CoSimulationApplication/tests/test_processes.py
@@ -57,12 +57,12 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
     def test_create_entities_from_one_model_part(self):
         settings = KM.Parameters("""{
             "Parameters" : {
-                "root_model_part_name"       : "root_mp",
-                "new_sub_model_part_name"    : "smp_with_conditions",
-                "sub_model_part_names"       : ["smp_nodes_1"],
-                "entity_name"                : "PointCondition2D1N",
-                "entity_type"                : "condition",
-                "properties_id"              : 0
+                "model_part_name"         : "root_mp",
+                "new_sub_model_part_name" : "smp_with_conditions",
+                "sub_model_part_names"    : ["smp_nodes_1"],
+                "entity_name"             : "PointCondition2D1N",
+                "entity_type"             : "condition",
+                "properties_id"           : 0
             }
         }""")
 
@@ -75,7 +75,7 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
     def test_create_entities_from_multiple_model_parts(self):
         settings = KM.Parameters("""{
             "Parameters" : {
-                "root_model_part_name"       : "root_mp",
+                "model_part_name"            : "root_mp",
                 "new_sub_model_part_name"    : "manual_smp.create_conds",
                 "sub_model_part_names"       : ["smp_nodes_1", "smp_nodes_2"],
                 "entity_name"                : "PointCondition2D1N",
@@ -95,7 +95,7 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
     def test_create_entities_from_overlapping_model_parts(self):
         settings = KM.Parameters("""{
             "Parameters" : {
-                "root_model_part_name"       : "root_mp",
+                "model_part_name"            : "root_mp",
                 "new_sub_model_part_name"    : "smp_with_conditions",
                 "sub_model_part_names"       : ["smp_nodes_1", "smp_nodes_2", "smp_nodes_3"],
                 "entity_name"                : "PointCondition2D1N",
@@ -113,7 +113,7 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
     def test_create_entities_with_preexisting_entites(self):
         settings = KM.Parameters("""{
             "Parameters" : {
-                "root_model_part_name"       : "root_mp",
+                "model_part_name"            : "root_mp",
                 "new_sub_model_part_name"    : "smp_with_conditions",
                 "sub_model_part_names"       : ["smp_nodes_1", "smp_nodes_2"],
                 "entity_name"                : "PointCondition2D1N",
@@ -121,7 +121,7 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
                 "properties_id"              : 0
             }
         }""")
-        
+
         props = self.root_model_part.GetProperties(0, 0)
 
         num_local_nodes = self.root_model_part.NumberOfNodes()
@@ -139,7 +139,7 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
         # in a restart no new entities should be created!
         settings = KM.Parameters("""{
             "Parameters" : {
-                "root_model_part_name"       : "root_mp",
+                "model_part_name"            : "root_mp",
                 "new_sub_model_part_name"    : "smp_with_conditions",
                 "sub_model_part_names"       : ["smp_nodes_1"],
                 "entity_name"                : "PointCondition2D1N",

--- a/applications/CoSimulationApplication/tests/test_processes.py
+++ b/applications/CoSimulationApplication/tests/test_processes.py
@@ -90,8 +90,23 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
 
         self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.Conditions)
 
-    # def test_create_entities_from_overlapping_model_parts(self):
-    #     pass
+    def test_create_entities_from_overlapping_model_parts(self):
+        settings = KM.Parameters("""{
+            "Parameters" : {
+                "root_model_part_name"       : "root_mp",
+                "new_sub_model_part_name"    : "smp_with_conditions",
+                "sub_model_part_names"       : ["smp_nodes_1", "smp_nodes_2", "smp_nodes_3"],
+                "entity_name"                : "PointCondition2D1N",
+                "entity_type"                : "condition",
+                "properties_id"              : 0
+            }
+        }""")
+
+        self.process = self.__CreateProcess(settings)
+        self.assertTrue(self.root_model_part.HasSubModelPart("smp_with_conditions"))
+        self.assertEqual(self.root_model_part.NumberOfNodes(), self.root_model_part.NumberOfConditions())
+
+        self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.Conditions)
 
     # def test_create_entities_with_preexisting_entites(self):
     #     pass

--- a/applications/CoSimulationApplication/tests/test_processes.py
+++ b/applications/CoSimulationApplication/tests/test_processes.py
@@ -72,6 +72,44 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
 
         self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.Conditions)
 
+    def test_create_entities_from_entire_root_model_part(self):
+        settings = KM.Parameters("""{
+            "Parameters" : {
+                "model_part_name"         : "root_mp",
+                "new_sub_model_part_name" : "smp_with_conditions",
+                "sub_model_part_names"    : [],
+                "entity_name"             : "PointCondition2D1N",
+                "entity_type"             : "condition",
+                "properties_id"           : 0
+            }
+        }""")
+
+        self.process = self.__CreateProcess(settings)
+        self.assertTrue(self.root_model_part.HasSubModelPart("smp_with_conditions"))
+        self.assertEqual(self.root_model_part.NumberOfNodes(), self.root_model_part.NumberOfConditions())
+
+        self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.Conditions)
+
+    def test_create_entities_from_one_sub_model_part(self):
+        settings = KM.Parameters("""{
+            "Parameters" : {
+                "model_part_name"         : "root_mp.smp_nodes_1",
+                "new_sub_model_part_name" : "smp_with_conditions",
+                "sub_model_part_names"    : [],
+                "entity_name"             : "PointCondition2D1N",
+                "entity_type"             : "condition",
+                "properties_id"           : 0
+            }
+        }""")
+
+        sub_mp = self.root_model_part.GetSubModelPart("smp_nodes_1")
+        self.process = self.__CreateProcess(settings)
+        self.assertFalse(self.root_model_part.HasSubModelPart("smp_with_conditions"))
+        self.assertTrue(sub_mp.HasSubModelPart("smp_with_conditions"))
+        self.assertEqual(self.root_model_part.GetSubModelPart("smp_nodes_1").NumberOfNodes(), self.root_model_part.NumberOfConditions())
+
+        self.__CheckCreatedEntitiesIdAreCorrectlyNumbered(self.root_model_part.Conditions)
+
     def test_create_entities_from_multiple_model_parts(self):
         settings = KM.Parameters("""{
             "Parameters" : {

--- a/applications/CoSimulationApplication/tests/test_processes.py
+++ b/applications/CoSimulationApplication/tests/test_processes.py
@@ -121,11 +121,7 @@ class TestCreatePointBasedEntitiesProcess(KratosUnittest.TestCase):
                 "properties_id"              : 0
             }
         }""")
-
-        data_comm = KM.DataCommunicator.GetDefault()
-        my_pid = data_comm.Rank()
-        num_procs = data_comm.Size()
-
+        
         props = self.root_model_part.GetProperties(0, 0)
 
         num_local_nodes = self.root_model_part.NumberOfNodes()


### PR DESCRIPTION
Often for coupled problems we need `PointLoadConditions` on the structure such that the loads (`POINT_LOAD`) are considered in the RHS.

This can ofc be done in the preprocessor, but in the past this has proven to be inefficient. Hence here I add a process (to be used like any other `Process`) with which those conditions (or other point-based conditions) can be created
I also took care that on overlapping interfaces the conditions are only created once (relevant for practical problems)
EDIT: This should also work properly in MPI (=> numbering is important) and with restarts

I thought long where to put it put eventually I think that the CoSimApp is the correct place since this is usually where it is used

@inigolcanalejo this is what I told you abt yesterday
@shahrokh-shayegan this is what I spoke with you abt some time ago
@KlausBSautter this replaces the `CreatePointLoadModelPart` with sth more generic. Can you please refactor the test in CoSim that uses that after this PR is done?