### PR TITLE
[CoSim] Pass Coupled-Solver ProcessInfo to CouplingOperations

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
@@ -69,6 +69,7 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
         self.coupling_operations_dict = factories_helper.CreateCouplingOperations(
             self.settings["coupling_operations"],
             self.solver_wrappers,
+            self.process_info,
             self.echo_level)
 
         ### Creating the data transfer operators

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
@@ -3,14 +3,19 @@ from __future__ import print_function, absolute_import, division  # makes these 
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 
+# CoSimulation imports
+from KratosMultiphysics.CoSimulationApplication.co_simulation_tools import SettingsTypeCheck
+
 class CoSimulationCouplingOperation(object):
     """Baseclass for the coupling operations used for CoSimulation
     This class can be used to customize the behavior of the CoSimulation,
     by providing a large interface and access to the solvers/models
     """
-    def __init__(self, settings):
+    def __init__(self, settings, parent_coupled_solver_process_info):
+        SettingsTypeCheck(settings)
         self.settings = settings
         self.settings.ValidateAndAssignDefaults(self._GetDefaultSettings())
+        self.process_info = parent_coupled_solver_process_info
         self.echo_level = self.settings["echo_level"].GetInt()
 
     def Initialize(self):

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/compute_normals.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/compute_normals.py
@@ -6,18 +6,14 @@ import KratosMultiphysics as KM
 # Importing the base class
 from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_coupling_operation import CoSimulationCouplingOperation
 
-# CoSimulation imports
-import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
-
-def Create(settings, solver_wrappers):
-    cs_tools.SettingsTypeCheck(settings)
-    return ComputeNormalsOperation(settings, solver_wrappers)
+def Create(*args):
+    return ComputeNormalsOperation(*args)
 
 class ComputeNormalsOperation(CoSimulationCouplingOperation):
     """This operation computes the Normals (NORMAL) on a given ModelPart
     """
-    def __init__(self, settings, solver_wrappers):
-        super(ComputeNormalsOperation, self).__init__(settings)
+    def __init__(self, settings, solver_wrappers, process_info):
+        super(ComputeNormalsOperation, self).__init__(settings, process_info)
         solver_name = self.settings["solver"].GetString()
         data_name = self.settings["data_name"].GetString()
         self.interface_data = solver_wrappers[solver_name].GetInterfaceData(data_name)

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/create_point_load_model_part.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/create_point_load_model_part.py
@@ -9,15 +9,14 @@ from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_coupl
 # CoSimulation imports
 import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
 
-def Create(settings, solver_wrappers):
-    cs_tools.SettingsTypeCheck(settings)
-    return CreatePointLoadModelPart(settings, solver_wrappers)
+def Create(*args):
+    return CreatePointLoadModelPart(*args)
 
 class CreatePointLoadModelPart(CoSimulationCouplingOperation):
     """This operation creates a submodelpart containing PointLoad Conidtions for transferring loads
     """
-    def __init__(self, settings, solver_wrappers):
-        super(CreatePointLoadModelPart, self).__init__(settings)
+    def __init__(self, settings, solver_wrappers, process_info):
+        super(CreatePointLoadModelPart, self).__init__(settings, process_info)
         self.model = solver_wrappers[self.settings["solver"].GetString()].model
 
     def Initialize(self):

--- a/applications/CoSimulationApplication/python_scripts/coupling_operations/scaling.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_operations/scaling.py
@@ -10,15 +10,14 @@ from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_coupl
 import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
 from KratosMultiphysics.CoSimulationApplication.function_callback_utility import GenericCallFunction
 
-def Create(settings, solver_wrappers):
-    cs_tools.SettingsTypeCheck(settings)
-    return ScalingOperation(settings, solver_wrappers)
+def Create(*args):
+    return ScalingOperation(*args)
 
 class ScalingOperation(CoSimulationCouplingOperation):
     """This operation performs scaling of values on an InterfaceData
     The value can be given directly as a value or as a string containing an evaluable function
     """
-    def __init__(self, settings, solver_wrappers):
+    def __init__(self, settings, solver_wrappers, process_info):
         if not settings.Has("scaling_factor"):
             raise Exception('Please provide a "scaling_factor"!')
 
@@ -32,7 +31,7 @@ class ScalingOperation(CoSimulationCouplingOperation):
         # removing since the type of "scaling_factor" can be double or string and hence would fail in the validation
         settings.RemoveValue("scaling_factor")
 
-        super(ScalingOperation, self).__init__(settings)
+        super(ScalingOperation, self).__init__(settings, process_info)
 
         solver_name = self.settings["solver"].GetString()
         data_name = self.settings["data_name"].GetString()

--- a/applications/CoSimulationApplication/python_scripts/factories/coupling_operation_factory.py
+++ b/applications/CoSimulationApplication/python_scripts/factories/coupling_operation_factory.py
@@ -2,6 +2,6 @@ from __future__ import print_function, absolute_import, division  # makes these 
 
 from KratosMultiphysics.CoSimulationApplication.factories import base_factory
 
-def CreateCouplingOperation(coupling_operation_settings, solvers):
+def CreateCouplingOperation(coupling_operation_settings, solvers, parent_coupled_solver_process_info):
     """This function creates and returns the Coupling Operation used for CoSimulation"""
-    return base_factory.Create(coupling_operation_settings, [solvers], "KratosMultiphysics.CoSimulationApplication.coupling_operations")
+    return base_factory.Create(coupling_operation_settings, [solvers, parent_coupled_solver_process_info], "KratosMultiphysics.CoSimulationApplication.coupling_operations")

--- a/applications/CoSimulationApplication/python_scripts/factories/helpers.py
+++ b/applications/CoSimulationApplication/python_scripts/factories/helpers.py
@@ -42,11 +42,11 @@ def CreateConvergenceCriteria(convergence_criterion_settings_list, solvers, pare
 
     return convergence_criteria
 
-def CreateCouplingOperations(coupling_operations_settings_dict, solvers, parent_echo_level):
+def CreateCouplingOperations(coupling_operations_settings_dict, solvers, parent_coupled_solver_process_info, parent_echo_level):
     coupling_operations = {}
     for coupling_operation_name, coupling_operation_settings in coupling_operations_settings_dict.items():
         AddEchoLevelToSettings(coupling_operation_settings, parent_echo_level)
-        coupling_operations[coupling_operation_name] = CreateCouplingOperation(coupling_operation_settings, solvers)
+        coupling_operations[coupling_operation_name] = CreateCouplingOperation(coupling_operation_settings, solvers, parent_coupled_solver_process_info)
 
     return coupling_operations
 

--- a/applications/CoSimulationApplication/tests/test_coupling_operations.py
+++ b/applications/CoSimulationApplication/tests/test_coupling_operations.py
@@ -34,6 +34,8 @@ class TestScalingOperation(KratosUnittest.TestCase):
 
         self.solver_wrappers = {"dummy_solver" : DummySolverWrapper({"data_4_testing" : self.interface_data})}
 
+        self.solver_process_info = KM.ProcessInfo()
+
     def test_constant_scaling(self):
         scaling_op_settings = KM.Parameters("""{
             "type"           : "scaling",
@@ -43,7 +45,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "echo_level"     : 0
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
 
         factors = [1.5] * 3
 
@@ -58,7 +60,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "echo_level"     : 0
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
 
         factors = [1.5] * 3
 
@@ -73,7 +75,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "echo_level"     : 0
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
 
         factors = [1.5*0.25, 1.5*0.5, 1.5*0.75]
 
@@ -88,7 +90,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "echo_level"     : 0
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
 
         factors = [1.5*pi*sqrt(1), 1.5*pi*sqrt(2), 1.5*pi*sqrt(3), 1.5*pi*sqrt(4), 1.5*pi*sqrt(5)]
 
@@ -106,7 +108,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "interval"       : [0.0, 0.3]
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
 
         factors = [1.0] * 5
         factors[0] = 1.22
@@ -125,7 +127,7 @@ class TestScalingOperation(KratosUnittest.TestCase):
             "interval"       : [0.8, "End"]
         }""")
 
-        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers)
+        scaling_op = coupling_operation_factory.CreateCouplingOperation(scaling_op_settings, self.solver_wrappers, self.solver_process_info)
 
         factors = [1.0] * 3
         factors.extend([1.22] * 3)


### PR DESCRIPTION
continuation of #6831 

As title says, now the `ProcessInfo` of the coupled solver is being passed to the `CouplingOperation`s
This way in the future global things like `TIME` or `STEP` can be shared which is necessary e.g. for the `ScalingOperation`