### PR TITLE
[CoSim] switching tests to SparseQR

### DIFF
--- a/applications/CoSimulationApplication/tests/fsi_mok/ProjectParametersCSM.json
+++ b/applications/CoSimulationApplication/tests/fsi_mok/ProjectParametersCSM.json
@@ -31,8 +31,8 @@
         "residual_relative_tolerance"        : 1e-6,
         "residual_absolute_tolerance"        : 1e-6,
         "max_iteration"                      : 25,
-            "linear_solver_settings"             : {
-            "solver_type" : "EigenSolversApplication.sparse_lu"
+        "linear_solver_settings"             : {
+            "solver_type" : "EigenSolversApplication.sparse_qr"
         },
 		"use_computing_model_part" : false,
         "rotation_dofs"            : false

--- a/applications/CoSimulationApplication/tests/fsi_sdof_static/naca0012_small_parameters_coupling.json
+++ b/applications/CoSimulationApplication/tests/fsi_sdof_static/naca0012_small_parameters_coupling.json
@@ -26,7 +26,7 @@
             "maximum_iterations"     : 5,
             "echo_level"             : 0,
             "linear_solver_settings"  : {
-                    "solver_type"             : "EigenSolversApplication.sparse_lu"
+                    "solver_type"             : "EigenSolversApplication.sparse_qr"
             },
             "volume_model_part_name" : "Parts_Parts_Auto1",
             "skin_parts"             : ["PotentialWallCondition2D_Far_field_Auto1","Body2D_Body"],

--- a/applications/CoSimulationApplication/tests/fsi_wall/ProjectParametersCSM.json
+++ b/applications/CoSimulationApplication/tests/fsi_wall/ProjectParametersCSM.json
@@ -33,7 +33,7 @@
         "residual_absolute_tolerance"        : 1e-7,
         "max_iteration"                      : 20,
         "linear_solver_settings"             : {
-            "solver_type" : "EigenSolversApplication.sparse_lu"
+            "solver_type" : "EigenSolversApplication.sparse_qr"
         },
         "use_computing_model_part" : false,
         "rotation_dofs"            : false

--- a/applications/CoSimulationApplication/tests/mpm_fem_beam/ProjectParametersFEM.json
+++ b/applications/CoSimulationApplication/tests/mpm_fem_beam/ProjectParametersFEM.json
@@ -12,6 +12,9 @@
         "domain_size"                     : 2,
         "echo_level"                      : 0,
         "analysis_type"                   : "non_linear",
+        "linear_solver_settings"          : {
+            "solver_type"   : "EigenSolversApplication.sparse_qr"
+        },
         "model_import_settings"           : {
             "input_type"     : "mdpa",
             "input_filename" : "mpm_fem_beam/structure"

--- a/applications/CoSimulationApplication/tests/mpm_fem_beam/ProjectParametersMPM.json
+++ b/applications/CoSimulationApplication/tests/mpm_fem_beam/ProjectParametersMPM.json
@@ -35,7 +35,7 @@
         },
         "pressure_dofs"                      : false,
         "linear_solver_settings"             :{
-            "solver_type"   : "EigenSolversApplication.sparse_lu",
+            "solver_type"   : "EigenSolversApplication.sparse_qr",
             "scaling": false
         }
     },


### PR DESCRIPTION
as reported in #6716 and #6717 there seems to be a problem when running the tests in a certain order if if MKL is enabled and the SparseLU solver is used
The problems seem to be related to OpenMP

I tested the following configurations:
| MKL enabled | number of OMP-threads | solver used | outcome |
|---|---|---|---|
| yes | 2 | sparse-lu | **segfault** |
| yes | 1 | sparse-lu | **works** |
| no | 2 | sparse-lu | **works** |
| yes | 2 | sparse-qr | **works** |
| yes | 1 | sparse-qr | **works** |
| no | 2 | sparse-qr | **works** |

closes #6716, closes #6717

@inigolcanalejo can you please try this?