### PR TITLE
[StatsApp] Temporal methods restart capability

### DIFF
--- a/applications/StatisticsApplication/README.md
+++ b/applications/StatisticsApplication/README.md
@@ -51,12 +51,10 @@ import KratosMultiphysics.StatisticsApplication as KratosStats
 model = Kratos.Model()
 model_part = model.CreateModelPart("test_model_part")
 sum_method = KratosStats.TemporalMethods.NonHistorical.Nodes.ValueMethods.Sum.Array(model_part, "", Kratos.VELOCITY, 0, Kratos.DISPLACEMENT)
-sum_method.InitializeStatisticsMethod()
-previous_time = 2
+integration_starting_time = 2.0
+sum_method.InitializeStatisticsMethod(integration_starting_time)
 for t in range(3, 6):
-    delta_time = t - previous_time
-    sum_method.CalculateStatistics(delta_time)
-    previous_time = t
+    sum_method.CalculateStatistics()
 ```
 
 #### Mean
@@ -87,12 +85,10 @@ import KratosMultiphysics.StatisticsApplication as KratosStats
 model = Kratos.Model()
 model_part = model.CreateModelPart("test_model_part")
 mean_method = KratosStats.TemporalMethods.NonHistorical.Nodes.ValueMethods.Mean.Array(model_part, "", Kratos.VELOCITY, 0, KratosStats.VECTOR_3D_MEAN)
-mean_method.InitializeStatisticsMethod()
-previous_time = 2
+integration_starting_time = 2.0
+mean_method.InitializeStatisticsMethod(integration_starting_time)
 for t in range(3, 6):
-    delta_time = t - previous_time
-    mean_method.CalculateStatistics(delta_time)
-    previous_time = t
+    mean_method.CalculateStatistics()
 ```
 
 #### Root mean square
@@ -123,12 +119,10 @@ import KratosMultiphysics.StatisticsApplication as KratosStats
 model = Kratos.Model()
 model_part = model.CreateModelPart("test_model_part")
 rms_method = KratosStats.TemporalMethods.NonHistorical.Nodes.ValueMethods.RootMeanSquare.Array(model_part, "", Kratos.VELOCITY, 0, KratosStats.VECTOR_3D_MEAN)
-rms_method.InitializeStatisticsMethod()
-previous_time = 2
+integration_starting_time = 2.0
+rms_method.InitializeStatisticsMethod(integration_starting_time)
 for t in range(3, 6):
-    delta_time = t - previous_time
-    rms_method.CalculateStatistics(delta_time)
-    previous_time = t
+    rms_method.CalculateStatistics()
 ```
 
 #### Variance
@@ -159,12 +153,10 @@ import KratosMultiphysics.StatisticsApplication as KratosStats
 model = Kratos.Model()
 model_part = model.CreateModelPart("test_model_part")
 variance_method = KratosStats.TemporalMethods.NonHistorical.Nodes.ValueMethods.Variance.Array(model_part, "", Kratos.VELOCITY, 0, KratosStats.VECTOR_3D_MEAN, KratosStats.VECTOR_3D_VARIANCE)
-variance_method.InitializeStatisticsMethod()
-previous_time = 2
+integration_starting_time = 2.0
+variance_method.InitializeStatisticsMethod(integration_starting_time)
 for t in range(3, 6):
-    delta_time = t - previous_time
-    variance_method.CalculateStatistics(delta_time)
-    previous_time = t
+    variance_method.CalculateStatistics()
 ```
 
 #### Min
@@ -195,12 +187,10 @@ import KratosMultiphysics.StatisticsApplication as KratosStats
 model = Kratos.Model()
 model_part = model.CreateModelPart("test_model_part")
 min_method = KratosStats.TemporalMethods.NonHistorical.Nodes.NormMethods.Min.Array(model_part, "magnitude", Kratos.VELOCITY, 0, KratosStats.VECTOR_3D_NORM, Kratos.TIME)
-min_method.InitializeStatisticsMethod()
-previous_time = 2
+integration_starting_time = 2.0
+min_method.InitializeStatisticsMethod(integration_starting_time)
 for t in range(3, 6):
-    delta_time = t - previous_time
-    min_method.CalculateStatistics(delta_time)
-    previous_time = t
+    min_method.CalculateStatistics()
 ```
 
 #### Max
@@ -231,12 +221,10 @@ import KratosMultiphysics.StatisticsApplication as KratosStats
 model = Kratos.Model()
 model_part = model.CreateModelPart("test_model_part")
 max_method = KratosStats.TemporalMethods.NonHistorical.Nodes.NormMethods.Max.Array(model_part, "magnitude", Kratos.VELOCITY, 0, KratosStats.VECTOR_3D_NORM, Kratos.TIME)
-max_method.InitializeStatisticsMethod()
-previous_time = 2
+integration_starting_time = 2.0
+max_method.InitializeStatisticsMethod(integration_starting_time)
 for t in range(3, 6):
-    delta_time = t - previous_time
-    max_method.CalculateStatistics(delta_time)
-    previous_time = t
+    max_method.CalculateStatistics()
 ```
 
 #### Median

--- a/applications/StatisticsApplication/custom_methods/temporal_max_method.h
+++ b/applications/StatisticsApplication/custom_methods/temporal_max_method.h
@@ -73,13 +73,15 @@ public:
             KRATOS_CATCH("");
         }
 
-        void CalculateStatistics(const double DeltaTime) override
+        void CalculateStatistics() override
         {
             TContainerType& r_container =
                 MethodUtilities::GetDataContainer<TContainerType>(this->GetModelPart());
 
             const auto& norm_method =
                 MethodUtilities::GetNormMethod(mrInputVariable, mNormType);
+
+            const double total_time = this->GetTotalTime();
 
             const int number_of_items = r_container.size();
 #pragma omp parallel for
@@ -98,11 +100,9 @@ public:
                 if (input_norm_value > r_output_value)
                 {
                     r_output_value = input_norm_value;
-                    r_max_time_value = this->GetTotalTime() + DeltaTime;
+                    r_max_time_value = total_time;
                 }
             }
-
-            TemporalMethod::CalculateStatistics(DeltaTime);
 
             KRATOS_INFO_IF("TemporalNormMaxMethod", this->GetEchoLevel() > 1)
                 << "Calculated temporal norm max for " << mrInputVariable.Name()

--- a/applications/StatisticsApplication/custom_methods/temporal_method.h
+++ b/applications/StatisticsApplication/custom_methods/temporal_method.h
@@ -20,6 +20,8 @@
 // Project includes
 #include "includes/define.h"
 #include "includes/model_part.h"
+#include "includes/process_info.h"
+#include "includes/variables.h"
 
 // Application includes
 
@@ -42,7 +44,7 @@ public:
     KRATOS_CLASS_POINTER_DEFINITION(TemporalMethod);
 
     TemporalMethod(ModelPart& rModelPart, const int EchoLevel)
-        : mrModelPart(rModelPart), mEchoLevel(EchoLevel), mTotalTime(0.0)
+        : mrModelPart(rModelPart), mEchoLevel(EchoLevel)
     {
     }
 
@@ -56,20 +58,20 @@ public:
         KRATOS_CATCH("");
     }
 
-    virtual void InitializeStatisticsMethod()
+    virtual void InitializeStatisticsMethod(double IntegrationStartTime)
     {
-        mTotalTime = 0.0;
+        mIntegrationStartTime = IntegrationStartTime;
         this->InitializeStatisticsVariables();
     }
 
-    virtual void CalculateStatistics(const double DeltaTime)
+    virtual void CalculateStatistics()
     {
-        this->FinalizeStatisticsTimeStep(DeltaTime);
-    }
+        KRATOS_TRY
 
-    virtual void FinalizeStatisticsTimeStep(const double DeltaTime)
-    {
-        mTotalTime += DeltaTime;
+        KRATOS_ERROR << "Calling base class CalculateStatistics. "
+                        "Please implement it in derrived class.\n";
+
+        KRATOS_CATCH("");
     }
 
     ModelPart& GetModelPart() const
@@ -79,7 +81,26 @@ public:
 
     double GetTotalTime() const
     {
-        return mTotalTime;
+        KRATOS_TRY
+
+        const ProcessInfo& r_process_info = this->GetModelPart().GetProcessInfo();
+        const double current_time = r_process_info[TIME];
+        const double total_time = current_time - mIntegrationStartTime;
+
+        KRATOS_ERROR_IF(total_time < 0.0)
+            << "Total integration time should be greater than or equal to zero. [ "
+               "total_time  = "
+            << total_time << ", TIME = " << current_time << " ].\n";
+
+        return total_time;
+
+        KRATOS_CATCH("");
+    }
+
+    double GetDeltaTime() const
+    {
+        const ProcessInfo& r_process_info = this->GetModelPart().GetProcessInfo();
+        return r_process_info[DELTA_TIME];
     }
 
     int GetEchoLevel() const
@@ -90,7 +111,7 @@ public:
 private:
     ModelPart& mrModelPart;
     int mEchoLevel;
-    double mTotalTime;
+    double mIntegrationStartTime;
 };
 } // namespace TemporalMethods
 } // namespace Kratos

--- a/applications/StatisticsApplication/custom_methods/temporal_method.h
+++ b/applications/StatisticsApplication/custom_methods/temporal_method.h
@@ -61,7 +61,11 @@ public:
     virtual void InitializeStatisticsMethod(double IntegrationStartTime)
     {
         mIntegrationStartTime = IntegrationStartTime;
-        this->InitializeStatisticsVariables();
+        const ProcessInfo& r_process_info = this->GetModelPart().GetProcessInfo();
+        if (!r_process_info[IS_RESTARTED])
+        {
+            this->InitializeStatisticsVariables();
+        }
     }
 
     virtual void CalculateStatistics()
@@ -88,7 +92,8 @@ public:
         const double total_time = current_time - mIntegrationStartTime;
 
         KRATOS_ERROR_IF(total_time < 0.0)
-            << "Total integration time should be greater than or equal to zero. [ "
+            << "Total integration time should be greater than or equal to "
+               "zero. [ "
                "total_time  = "
             << total_time << ", TIME = " << current_time << " ].\n";
 

--- a/applications/StatisticsApplication/custom_methods/temporal_method.h
+++ b/applications/StatisticsApplication/custom_methods/temporal_method.h
@@ -20,7 +20,6 @@
 // Project includes
 #include "includes/define.h"
 #include "includes/model_part.h"
-#include "includes/process_info.h"
 #include "includes/variables.h"
 
 // Application includes

--- a/applications/StatisticsApplication/custom_methods/temporal_min_method.h
+++ b/applications/StatisticsApplication/custom_methods/temporal_min_method.h
@@ -73,13 +73,15 @@ public:
             KRATOS_CATCH("");
         }
 
-        void CalculateStatistics(const double DeltaTime) override
+        void CalculateStatistics() override
         {
             TContainerType& r_container =
                 MethodUtilities::GetDataContainer<TContainerType>(this->GetModelPart());
 
             const auto& norm_method =
                 MethodUtilities::GetNormMethod(mrInputVariable, mNormType);
+
+            const double total_time = this->GetTotalTime();
 
             const int number_of_items = r_container.size();
 #pragma omp parallel for
@@ -98,11 +100,10 @@ public:
                 if (input_norm_value < r_output_value)
                 {
                     r_output_value = input_norm_value;
-                    r_min_time_value = this->GetTotalTime() + DeltaTime;
+                    r_min_time_value = total_time;
                 }
             }
 
-            TemporalMethod::CalculateStatistics(DeltaTime);
             KRATOS_INFO_IF("TemporalNormMinMethod", this->GetEchoLevel() > 1)
                 << "Calculated temporal norm min for " << mrInputVariable.Name()
                 << " input variable with " << mrOutputVariable.Name()

--- a/applications/StatisticsApplication/custom_methods/temporal_sum_method.h
+++ b/applications/StatisticsApplication/custom_methods/temporal_sum_method.h
@@ -57,10 +57,12 @@ public:
         {
         }
 
-        void CalculateStatistics(const double DeltaTime) override
+        void CalculateStatistics() override
         {
             TContainerType& r_container =
                 MethodUtilities::GetDataContainer<TContainerType>(this->GetModelPart());
+
+            const double delta_time = this->GetDeltaTime();
 
             const int number_of_items = r_container.size();
 #pragma omp parallel for
@@ -74,10 +76,9 @@ public:
                 MethodUtilities::DataTypeSizeChecker(r_input_value, r_output_value);
 
                 TemporalSumMethod::CalculateSum<TDataType>(
-                    r_output_value, r_input_value, DeltaTime, this->GetTotalTime());
+                    r_output_value, r_input_value, delta_time);
             }
 
-            TemporalMethod::CalculateStatistics(DeltaTime);
             KRATOS_INFO_IF("TemporalValueSumMethod", this->GetEchoLevel() > 1)
                 << "Calculated temporal value sum for " << mrInputVariable.Name()
                 << " input variable with " << mrOutputVariable.Name()
@@ -91,7 +92,7 @@ public:
 
             auto& initializer_method =
                 TemporalMethodUtilities::InitializeVariables<TContainerType, TContainerItemType, TDataRetrievalFunctor,
-                                                              TDataStorageFunctor, TDataType>;
+                                                             TDataStorageFunctor, TDataType>;
             initializer_method(r_container, mrOutputVariable, mrInputVariable);
 
             KRATOS_INFO_IF("TemporalValueSumMethod", this->GetEchoLevel() > 0)
@@ -124,13 +125,15 @@ public:
         {
         }
 
-        void CalculateStatistics(const double DeltaTime) override
+        void CalculateStatistics() override
         {
             TContainerType& r_container =
                 MethodUtilities::GetDataContainer<TContainerType>(this->GetModelPart());
 
             const auto& norm_method =
                 MethodUtilities::GetNormMethod(mrInputVariable, mNormType);
+
+            const double delta_time = this->GetDeltaTime();
 
             const int number_of_items = r_container.size();
 #pragma omp parallel for
@@ -144,10 +147,9 @@ public:
                     TDataStorageFunctor<TContainerItemType>()(r_item, mrOutputVariable);
 
                 TemporalSumMethod::CalculateSum<double>(
-                    r_output_value, input_norm_value, DeltaTime, this->GetTotalTime());
+                    r_output_value, input_norm_value, delta_time);
             }
 
-            TemporalMethod::CalculateStatistics(DeltaTime);
             KRATOS_INFO_IF("TemporalNormSumMethod", this->GetEchoLevel() > 1)
                 << "Calculated temporal norm sum for " << mrInputVariable.Name()
                 << " input variable with " << mrOutputVariable.Name()
@@ -232,10 +234,7 @@ public:
 
 private:
     template <typename TDataType>
-    void static CalculateSum(TDataType& rSum,
-                             const TDataType& rNewDataPoint,
-                             const double DeltaTime,
-                             const double TotalTime)
+    void static CalculateSum(TDataType& rSum, const TDataType& rNewDataPoint, const double DeltaTime)
     {
         rSum = (rSum + rNewDataPoint * DeltaTime);
     }

--- a/applications/StatisticsApplication/custom_python/add_custom_temporal_methods_to_python.cpp
+++ b/applications/StatisticsApplication/custom_python/add_custom_temporal_methods_to_python.cpp
@@ -257,9 +257,7 @@ void AddCustomTemporalMethodsToPython(pybind11::module& m)
         .def("GetTotalTime", &TemporalMethods::TemporalMethod::GetTotalTime)
         .def("GetEchoLevel", &TemporalMethods::TemporalMethod::GetEchoLevel)
         .def("InitializeStatisticsMethod", &TemporalMethods::TemporalMethod::InitializeStatisticsMethod)
-        .def("CalculateStatistics", &TemporalMethods::TemporalMethod::CalculateStatistics)
-        .def("FinalizeStatisticsTimeStep", &TemporalMethods::TemporalMethod::FinalizeStatisticsTimeStep)
-    ;
+        .def("CalculateStatistics", &TemporalMethods::TemporalMethod::CalculateStatistics);
 
     auto temporal_historical_method = temporal_method_module.def_submodule("Historical");
     auto temporal_historical_historical_method = temporal_historical_method.def_submodule("HistoricalOutput");

--- a/applications/StatisticsApplication/python_scripts/spatial_statistics_process.py
+++ b/applications/StatisticsApplication/python_scripts/spatial_statistics_process.py
@@ -24,6 +24,16 @@ def Factory(settings, model):
 
 
 class SpatialStatisticsProcess(Kratos.Process):
+    """A process to calculate spatial statistics on Kratos containers
+
+    This process calculates spatial statistics for given variables in a given container.
+
+    This process is compatible with OpenMP and MPI with restart
+
+    Args:
+        model (Kratos.Model): Model used in problem
+        settings (Kratos.Parameters): Kratos parameter settings for process
+    """
     def __init__(self, model, settings):
         Kratos.Process.__init__(self)
 

--- a/applications/StatisticsApplication/python_scripts/spatial_utilities.py
+++ b/applications/StatisticsApplication/python_scripts/spatial_utilities.py
@@ -87,7 +87,7 @@ def GetVariableHeaders(norm_type, variable_name):
         variable_type = Kratos.KratosGlobals.GetVariableType(variable_name)
         if (variable_type == "Double"):
             return [variable_name]
-        elif (variable_type == "Array" and Kratos.KratosGlobals.GetVariableType(variable_name + "_X") == "Component"):
+        elif (variable_type == "Array" and Kratos.KratosGlobals.GetVariableType(variable_name + "_X") == "Double"):
             return [variable_name + "_X", variable_name + "_Y", variable_name + "_Z"]
         else:
             raise Exception("Unsupported variable type " + variable_type)

--- a/applications/StatisticsApplication/python_scripts/temporal_statistics_process.py
+++ b/applications/StatisticsApplication/python_scripts/temporal_statistics_process.py
@@ -15,7 +15,17 @@ def Factory(settings, model):
         )
     return TemporalStatisticsProcess(model, settings["Parameters"])
 
+'''
+    Temporal Statistics process
 
+    This process calculates temporal statistics for given input variables in given container, and outputs to chosen variables
+    and chosen container.
+
+    This is compatible in OpenMP and MPI
+
+    Note: When this process is used with restarting, please don't use restarting start timestep and "statistics_start_point_control_value" time step
+          same. This will have an error in averaging, once simulation is restarted.
+'''
 class TemporalStatisticsProcess(Kratos.Process):
     def __init__(self, model, settings):
         Kratos.Process.__init__(self)

--- a/applications/StatisticsApplication/python_scripts/temporal_statistics_process.py
+++ b/applications/StatisticsApplication/python_scripts/temporal_statistics_process.py
@@ -15,18 +15,21 @@ def Factory(settings, model):
         )
     return TemporalStatisticsProcess(model, settings["Parameters"])
 
-'''
-    Temporal Statistics process
+class TemporalStatisticsProcess(Kratos.Process):
+    """A process to use temporal statistics for Kratos containers
 
     This process calculates temporal statistics for given input variables in given container, and outputs to chosen variables
     and chosen container.
 
-    This is compatible in OpenMP and MPI
+    This is compatible in OpenMP and MPI with restart
 
     Note: When this process is used with restarting, please don't use restarting start timestep and "statistics_start_point_control_value" time step
           same. This will have an error in averaging, once simulation is restarted.
-'''
-class TemporalStatisticsProcess(Kratos.Process):
+
+    Args:
+        model (Kratos.Model): Model used in problem
+        settings (Kratos.Parameters): Kratos parameter settings for process
+    """
     def __init__(self, model, settings):
         Kratos.Process.__init__(self)
 

--- a/applications/StatisticsApplication/python_scripts/temporal_statistics_process.py
+++ b/applications/StatisticsApplication/python_scripts/temporal_statistics_process.py
@@ -57,6 +57,11 @@ class TemporalStatisticsProcess(Kratos.Process):
         if (not Kratos.KratosGlobals.HasVariable(statistics_control_variable_name)):
             raise Exception("Unknown statistics control variable. [ \"statistics_control_variable_name\" = \"" + statistics_control_variable_name + "\" ]")
 
+        ## this is required to support restarting capabilities. If STEP is used, there need to be a way to retrieve
+        ## initial starting time for integration in the case of restarting.
+        if (statistics_control_variable_name != "TIME"):
+            raise Exception("Only \"TIME\" is supported as statistics_start_point_control_variable_name.")
+
         self.statistics_control_variable = Kratos.KratosGlobals.GetVariable(statistics_control_variable_name)
         statistics_control_variable_type = Kratos.KratosGlobals.GetVariableType(statistics_control_variable_name)
         if (statistics_control_variable_type == "Integer"):
@@ -88,16 +93,13 @@ class TemporalStatisticsProcess(Kratos.Process):
             self.method_list.extend(method_objects)
 
         for method in self.method_list:
-            method.InitializeStatisticsMethod()
-        self.previous_value = 0.0
+            method.InitializeStatisticsMethod(self.statistics_control_value)
 
     def ExecuteFinalizeSolutionStep(self):
         current_value = self.model_part.ProcessInfo[self.statistics_control_variable]
         if (current_value >= self.statistics_control_value):
-            delta_time = current_value - self.previous_value
             for method in self.method_list:
-                method.CalculateStatistics(delta_time)
-        self.previous_value = current_value
+                method.CalculateStatistics()
 
     def __get_model_part(self):
         if (not hasattr(self, "model_part")):


### PR DESCRIPTION
This PR makes it possible to use statistics application's temporal methods with restarting. Documentation is also revised accordingly.

Tested in OpenMP and MPI both.

Found a testing bug after #6849, and is fixed in this PR