### PR TITLE
[ShapeOpt] tests don't write output by default

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/data_logger_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/data_logger_factory.py
@@ -44,7 +44,7 @@ class DataLogger():
         {
             "output_directory"          : "Optimization_Results",
             "optimization_log_filename" : "optimization_log",
-            "design_output_mode"        : "WriteOptimizationModelPart",
+            "design_output_mode"        : "write_optimization_model_part",
             "nodal_results"             : [ "SHAPE_CHANGE" ],
             "output_format"             : { "name": "vtk" }
         }""")
@@ -73,13 +73,24 @@ class DataLogger():
 
     # -----------------------------------------------------------------------------
     def __CreateDesignLogger( self ):
-        valid_output_modes = ["WriteDesignSurface", "WriteOptimizationModelPart", "None"]
+        valid_output_modes = ["write_design_surface", "write_optimization_model_part", "none"]
         output_mode = self.OptimizationSettings["output"]["design_output_mode"].GetString()
+
+        # backward compatibility
+        if output_mode == "WriteDesignSurface":
+            KM.Logger.PrintWarning("ShapeOpt", "'design_output_mode': 'WriteDesignSurface' is deprecated and replaced with 'write_design_surface'.")
+            self.OptimizationSettings["output"]["design_output_mode"].SetString("write_design_surface")
+            output_mode = self.OptimizationSettings["output"]["design_output_mode"].GetString()
+
+        if output_mode == "WriteOptimizationModelPart":
+            KM.Logger.PrintWarning("ShapeOpt", "'design_output_mode': 'WriteOptimizationModelPart' is deprecated and replaced with 'write_optimization_model_part'.")
+            self.OptimizationSettings["output"]["design_output_mode"].SetString("write_optimization_model_part")
+            output_mode = self.OptimizationSettings["output"]["design_output_mode"].GetString()
 
         if output_mode not in valid_output_modes:
             raise RuntimeError("Invalid 'design_output_mode', available options are: {}".format(valid_output_modes))
 
-        if output_mode == "None":
+        if output_mode == "none":
             KM.Logger.Print("")
             KM.Logger.PrintInfo("ShapeOpt", "No design output will be created because 'design_output_mode' = 'None'.")
             return None

--- a/applications/ShapeOptimizationApplication/python_scripts/data_logger_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/data_logger_factory.py
@@ -46,6 +46,7 @@ class DataLogger():
             "optimization_log_filename" : "optimization_log",
             "design_output_mode"        : "WriteOptimizationModelPart",
             "nodal_results"             : [ "SHAPE_CHANGE" ],
+            "write_design_output"       : true,
             "output_format"             : { "name": "vtk" }
         }""")
 
@@ -74,6 +75,10 @@ class DataLogger():
     # -----------------------------------------------------------------------------
     def __CreateDesignLogger( self ):
         outputFormatName = self.OptimizationSettings["output"]["output_format"]["name"].GetString()
+        if not self.OptimizationSettings["output"]["write_design_output"].GetBool():
+            KM.Logger.Print("")
+            KM.Logger.PrintInfo("ShapeOpt", "No design output will be created because 'write_design_output = false'.")
+            return None
         if outputFormatName == "gid":
             return DesignLoggerGID( self.ModelPartController, self.OptimizationSettings )
         if outputFormatName == "unv":
@@ -109,12 +114,14 @@ class DataLogger():
 
     # --------------------------------------------------------------------------
     def InitializeDataLogging( self ):
-        self.DesignLogger.InitializeLogging()
+        if self.DesignLogger:
+            self.DesignLogger.InitializeLogging()
         self.ValueLogger.InitializeLogging()
 
     # --------------------------------------------------------------------------
     def LogCurrentDesign( self, current_iteration ):
-        self.DesignLogger.LogCurrentDesign( current_iteration )
+        if self.DesignLogger:
+            self.DesignLogger.LogCurrentDesign( current_iteration )
 
     # --------------------------------------------------------------------------
     def LogCurrentValues( self, current_iteration, additional_values ):
@@ -122,7 +129,8 @@ class DataLogger():
 
     # --------------------------------------------------------------------------
     def FinalizeDataLogging( self ):
-        self.DesignLogger.FinalizeLogging()
+        if self.DesignLogger:
+            self.DesignLogger.FinalizeLogging()
         self.ValueLogger.FinalizeLogging()
 
     # --------------------------------------------------------------------------

--- a/applications/ShapeOptimizationApplication/python_scripts/data_logger_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/data_logger_factory.py
@@ -46,7 +46,6 @@ class DataLogger():
             "optimization_log_filename" : "optimization_log",
             "design_output_mode"        : "WriteOptimizationModelPart",
             "nodal_results"             : [ "SHAPE_CHANGE" ],
-            "write_design_output"       : true,
             "output_format"             : { "name": "vtk" }
         }""")
 
@@ -74,11 +73,18 @@ class DataLogger():
 
     # -----------------------------------------------------------------------------
     def __CreateDesignLogger( self ):
-        outputFormatName = self.OptimizationSettings["output"]["output_format"]["name"].GetString()
-        if not self.OptimizationSettings["output"]["write_design_output"].GetBool():
+        valid_output_modes = ["WriteDesignSurface", "WriteOptimizationModelPart", "None"]
+        output_mode = self.OptimizationSettings["output"]["design_output_mode"].GetString()
+
+        if output_mode not in valid_output_modes:
+            raise RuntimeError("Invalid 'design_output_mode', available options are: {}".format(valid_output_modes))
+
+        if output_mode == "None":
             KM.Logger.Print("")
-            KM.Logger.PrintInfo("ShapeOpt", "No design output will be created because 'write_design_output = false'.")
+            KM.Logger.PrintInfo("ShapeOpt", "No design output will be created because 'design_output_mode' = 'None'.")
             return None
+
+        outputFormatName = self.OptimizationSettings["output"]["output_format"]["name"].GetString()
         if outputFormatName == "gid":
             return DesignLoggerGID( self.ModelPartController, self.OptimizationSettings )
         if outputFormatName == "unv":

--- a/applications/ShapeOptimizationApplication/python_scripts/design_logger_gid.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/design_logger_gid.py
@@ -51,10 +51,10 @@ class DesignLoggerGID( DesignLogger ):
     def __DetermineOutputMode( self ):
         output_mode = self.output_settings["design_output_mode"].GetString()
 
-        if output_mode == "WriteDesignSurface":
+        if output_mode == "write_design_surface":
             self.write_design_surface = True
             self.design_history_filename = self.design_surface.Name
-        elif output_mode == "WriteOptimizationModelPart":
+        elif output_mode == "write_optimization_model_part":
             if self.optimization_model_part.NumberOfElements() == 0:
                 raise NameError("Output of optimization model part in Gid-format requires definition of elements. No elements are given in current mdpa! You may change the design output mode.")
             self.write_optimization_model_part = True

--- a/applications/ShapeOptimizationApplication/python_scripts/design_logger_unv.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/design_logger_unv.py
@@ -38,10 +38,10 @@ class DesignLoggerUNV( DesignLogger ):
     def __DetermineOutputMode( self ):
         output_mode = self.output_settings["design_output_mode"].GetString()
 
-        if output_mode == "WriteDesignSurface":
+        if output_mode == "write_design_surface":
             self.write_design_surface = True
             self.design_history_filename = self.design_surface.Name
-        elif output_mode == "WriteOptimizationModelPart":
+        elif output_mode == "write_optimization_model_part":
             if self.optimization_model_part.NumberOfElements() == 0:
                 raise NameError("Output of optimization model part in UNV-format requires definition of elements. No elements are given in current mdpa! You may change the design output mode.")
             self.write_optimization_model_part = True

--- a/applications/ShapeOptimizationApplication/python_scripts/design_logger_vtk.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/design_logger_vtk.py
@@ -61,9 +61,9 @@ class DesignLoggerVTK( DesignLogger ):
         nodal_results = self.output_settings["nodal_results"]
         vtk_parameters.AddValue("nodal_solution_step_data_variables", nodal_results)
 
-        if output_mode == "WriteDesignSurface":
+        if output_mode == "write_design_surface":
             vtk_parameters["model_part_name"].SetString(self.design_surface.FullName())
-        elif output_mode == "WriteOptimizationModelPart":
+        elif output_mode == "write_optimization_model_part":
             vtk_parameters["model_part_name"].SetString(self.optimization_model_part.FullName())
         else:
             raise NameError("The following design output mode is not defined within a VTK output (name may be misspelled): " + output_mode)

--- a/applications/ShapeOptimizationApplication/tests/.gitignore
+++ b/applications/ShapeOptimizationApplication/tests/.gitignore
@@ -1,0 +1,7 @@
+**/Optimization_Results/
+
+**/response_combination.csv
+
+**/Optimization_Results*/
+**/algorithm_gradient_projection_test
+**/algorithm_penalized_projection_test2

--- a/applications/ShapeOptimizationApplication/tests/.gitignore
+++ b/applications/ShapeOptimizationApplication/tests/.gitignore
@@ -1,7 +1,3 @@
 **/Optimization_Results/
 
 **/response_combination.csv
-
-**/Optimization_Results*/
-**/algorithm_gradient_projection_test
-**/algorithm_penalized_projection_test2

--- a/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/analysis_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/analysis_parameters.json
@@ -69,7 +69,7 @@
           }
       }]
   },
-  "output_processes" : {
+  "_output_processes" : {
     "gid_output" : [{
         "python_module" : "gid_output_process",
         "kratos_module" : "KratosMultiphysics",

--- a/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/optimization_parameters.json
@@ -53,7 +53,7 @@
             }
         },
         "output" : {
-            "design_output_mode"      : "WriteDesignSurface",
+            "design_output_mode"      : "write_design_surface",
             "nodal_results"           : [ "NORMALIZED_SURFACE_NORMAL",
                                           "DF1DX",
                                           "DF1DALPHA",

--- a/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/optimization_parameters.json
@@ -66,8 +66,7 @@
                                           "SHAPE_CHANGE" ],
             "output_format" : {
                 "name" : "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/optimization_parameters.json
@@ -66,7 +66,8 @@
                                           "SHAPE_CHANGE" ],
             "output_format" : {
                 "name" : "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_bead_optimization_test/run_test.py
@@ -51,10 +51,3 @@ with open(optimization_log_filename, 'r') as csvfile:
     TestCase().assertAlmostEqual(resulting_penalty_factor, 3.26430E+01,5)
 
 os.chdir(original_directory)
-
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".post.bin")

--- a/applications/ShapeOptimizationApplication/tests/algorithm_penalized_projection_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_penalized_projection_test/parameters.json
@@ -63,19 +63,10 @@
         },
         "output" : {
             "design_output_mode" : "WriteDesignSurface",
-            "nodal_results"      : [
-                "SHAPE_CHANGE",
-                "DF1DX",
-                "DF1DX_MAPPED",
-                "DC1DX",
-                "DC1DX_MAPPED",
-                "SEARCH_DIRECTION",
-                "SHAPE_UPDATE"
-            ],
+            "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "vtk"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/algorithm_penalized_projection_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_penalized_projection_test/parameters.json
@@ -62,7 +62,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteDesignSurface",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "vtk"

--- a/applications/ShapeOptimizationApplication/tests/algorithm_penalized_projection_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_penalized_projection_test/parameters.json
@@ -63,10 +63,19 @@
         },
         "output" : {
             "design_output_mode" : "WriteDesignSurface",
-            "nodal_results"      : [ "SHAPE_CHANGE" ],
+            "nodal_results"      : [
+                "SHAPE_CHANGE",
+                "DF1DX",
+                "DF1DX_MAPPED",
+                "DC1DX",
+                "DC1DX_MAPPED",
+                "SEARCH_DIRECTION",
+                "SHAPE_UPDATE"
+            ],
             "output_format" : {
-                "name": "gid"
-            }
+                "name": "vtk"
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/algorithm_penalized_projection_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_penalized_projection_test/run_test.py
@@ -107,10 +107,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/algorithm_steepest_descent_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_steepest_descent_test/parameters.json
@@ -53,7 +53,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteDesignSurface",
+            "design_output_mode" : "none",
             "nodal_results"      : ["SHAPE_CHANGE"],
             "output_format" : {
                 "name": "gid"

--- a/applications/ShapeOptimizationApplication/tests/algorithm_steepest_descent_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_steepest_descent_test/parameters.json
@@ -57,7 +57,8 @@
             "nodal_results"      : ["SHAPE_CHANGE"],
             "output_format" : {
                 "name": "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/algorithm_steepest_descent_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_steepest_descent_test/parameters.json
@@ -57,8 +57,7 @@
             "nodal_results"      : ["SHAPE_CHANGE"],
             "output_format" : {
                 "name": "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/algorithm_steepest_descent_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_steepest_descent_test/run_test.py
@@ -46,10 +46,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/parameters.json
@@ -64,10 +64,11 @@
         },
         "output" : {
             "design_output_mode" : "WriteDesignSurface",
-            "nodal_results"      : [ "SHAPE_CHANGE" ],
+            "nodal_results"      : [ "SHAPE_CHANGE", "SHAPE_UPDATE" ],
             "output_format" : {
-                "name": "gid"
-            }
+                "name": "vtk"
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/parameters.json
@@ -64,11 +64,10 @@
         },
         "output" : {
             "design_output_mode" : "WriteDesignSurface",
-            "nodal_results"      : [ "SHAPE_CHANGE", "SHAPE_UPDATE" ],
+            "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "vtk"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/parameters.json
@@ -63,7 +63,7 @@
             "max_step_length"         : 0.5
         },
         "output" : {
-            "design_output_mode" : "WriteDesignSurface",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "vtk"

--- a/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/algorithm_trust_region_test/run_test.py
@@ -127,10 +127,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/in_plane_opt_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/in_plane_opt_test/optimization_parameters.json
@@ -61,7 +61,8 @@
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name" : "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/in_plane_opt_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/in_plane_opt_test/optimization_parameters.json
@@ -57,7 +57,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name" : "gid"

--- a/applications/ShapeOptimizationApplication/tests/in_plane_opt_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/in_plane_opt_test/optimization_parameters.json
@@ -57,12 +57,11 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteDesignSurface",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name" : "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/in_plane_opt_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/in_plane_opt_test/run_test.py
@@ -91,9 +91,4 @@ check_process.ExecuteInitializeSolutionStep()
 check_process.ExecuteFinalizeSolutionStep()
 check_process.ExecuteFinalize()
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(os.getcwd())+".post.lst")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/mapper_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/mapper_test/run_test.py
@@ -202,10 +202,3 @@ TestCase().assertAlmostEqual(norm_2_result, 0.610521887077, 12)
 # OutputResults(plate_with_quads,"results_quad_plate")
 
 # =======================================================================================================
-# Clean folder
-# =======================================================================================================
-
-kratos_utilities.DeleteFileIfExisting("plate_with_trias.time")
-kratos_utilities.DeleteFileIfExisting("plate_with_quads.time")
-
-# =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/optimization_parameters.json
@@ -49,7 +49,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"

--- a/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/optimization_parameters.json
@@ -49,12 +49,11 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteOptimizationModelPart",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/optimization_parameters.json
@@ -53,7 +53,8 @@
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_eigenfrequency_test/run_test.py
@@ -48,10 +48,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/opt_process_min_max/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_min_max/optimization_parameters.json
@@ -120,12 +120,11 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteOptimizationModelPart",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "SHAPE_CHANGE", "DF1DX" ],
             "output_format" : {
                 "name": "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_min_max/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_min_max/optimization_parameters.json
@@ -124,7 +124,8 @@
             "nodal_results"      : [ "SHAPE_CHANGE", "DF1DX" ],
             "output_format" : {
                 "name": "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_min_max/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_min_max/optimization_parameters.json
@@ -120,7 +120,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_CHANGE", "DF1DX" ],
             "output_format" : {
                 "name": "gid"

--- a/applications/ShapeOptimizationApplication/tests/opt_process_min_max/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_min_max/primal_parameters.json
@@ -55,7 +55,7 @@
             }
         }]
     },
-    "output_processes" : {
+    "_output_processes" : {
         "gid_output" : [{
             "python_module" : "gid_output_process",
             "kratos_module" : "KratosMultiphysics",

--- a/applications/ShapeOptimizationApplication/tests/opt_process_min_max/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_min_max/run_test.py
@@ -47,11 +47,4 @@ with open('response_combination.csv', 'r') as csvfile:
         TestCase().assertEqual(grad_norm_f1, "-")
         TestCase().assertAlmostEqual(grad_norm_f2, 1.43532E+07, 5)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting("response_combination.csv")
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".post.bin")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/opt_process_multiobjective_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_multiobjective_test/optimization_parameters.json
@@ -103,7 +103,8 @@
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_multiobjective_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_multiobjective_test/optimization_parameters.json
@@ -99,7 +99,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"

--- a/applications/ShapeOptimizationApplication/tests/opt_process_multiobjective_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_multiobjective_test/optimization_parameters.json
@@ -99,12 +99,11 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteDesignSurface",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_multiobjective_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_multiobjective_test/run_test.py
@@ -108,11 +108,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-kratos_utilities.DeleteFileIfExisting(response_combination_filename)
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/optimization_parameters.json
@@ -55,7 +55,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"

--- a/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/optimization_parameters.json
@@ -59,7 +59,8 @@
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/optimization_parameters.json
@@ -55,12 +55,11 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteDesignSurface",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_shell_test/run_test.py
@@ -48,10 +48,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
@@ -69,7 +69,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteOptimizationModelPart",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid",
@@ -81,8 +81,7 @@
                         "output_frequency"    : 1.0
                     }
                 }
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
@@ -80,9 +80,9 @@
                         },
                         "output_frequency"    : 1.0
                     }
-                },
-                "write_design_output": false
-            }
+                }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
@@ -80,7 +80,8 @@
                         },
                         "output_frequency"    : 1.0
                     }
-                }
+                },
+                "write_design_output": false
             }
         }
     }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/optimization_parameters.json
@@ -69,7 +69,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid",

--- a/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_solid_test/run_test.py
@@ -48,10 +48,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/opt_process_step_adaption_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_step_adaption_test/parameters.json
@@ -54,7 +54,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : ["SHAPE_CHANGE"],
             "output_format" : {
                 "name": "gid"

--- a/applications/ShapeOptimizationApplication/tests/opt_process_step_adaption_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_step_adaption_test/parameters.json
@@ -54,12 +54,11 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteDesignSurface",
+            "design_output_mode" : "None",
             "nodal_results"      : ["SHAPE_CHANGE"],
             "output_format" : {
                 "name": "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_step_adaption_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_step_adaption_test/parameters.json
@@ -58,7 +58,8 @@
             "nodal_results"      : ["SHAPE_CHANGE"],
             "output_format" : {
                 "name": "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_step_adaption_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_step_adaption_test/run_test.py
@@ -50,10 +50,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/optimization_parameters.json
@@ -61,7 +61,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"

--- a/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/optimization_parameters.json
@@ -61,12 +61,11 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteOptimizationModelPart",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/optimization_parameters.json
@@ -65,7 +65,8 @@
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/primal_parameters.json
@@ -55,7 +55,7 @@
             }
         }]
     },
-    "output_processes" : {
+    "_output_processes" : {
         "gid_output" : [{
             "python_module" : "gid_output_process",
             "kratos_module" : "KratosMultiphysics",

--- a/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_stress_test/run_test.py
@@ -92,11 +92,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".post.bin")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/parameters.json
@@ -46,7 +46,8 @@
                                      "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/parameters.json
@@ -41,13 +41,12 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteDesignSurface",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "SHAPE_UPDATE",
                                      "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/parameters.json
@@ -41,7 +41,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_UPDATE",
                                      "SHAPE_CHANGE" ],
             "output_format" : {

--- a/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/run_test.py
@@ -113,10 +113,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/optimization_parameters.json
@@ -54,7 +54,8 @@
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/optimization_parameters.json
@@ -50,7 +50,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"

--- a/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/optimization_parameters.json
@@ -50,12 +50,11 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteOptimizationModelPart",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_weighted_eigenfrequency_test/run_test.py
@@ -48,10 +48,4 @@ with open(optimization_log_filename, 'r') as csvfile:
 
 os.chdir(original_directory)
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(original_directory)+".post.lst")
-kratos_utilities.DeleteFileIfExisting(optimization_model_part_name+".time")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/packaging_mesh_based_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/packaging_mesh_based_test/optimization_parameters.json
@@ -71,7 +71,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "DF1DX", "DC1DX", "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "vtk"

--- a/applications/ShapeOptimizationApplication/tests/packaging_mesh_based_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/packaging_mesh_based_test/optimization_parameters.json
@@ -71,12 +71,11 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteDesignSurface",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "DF1DX", "DC1DX", "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "vtk"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/packaging_mesh_based_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/packaging_mesh_based_test/optimization_parameters.json
@@ -75,7 +75,8 @@
             "nodal_results"      : [ "DF1DX", "DC1DX", "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "vtk"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/packaging_mesh_based_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/packaging_mesh_based_test/run_test.py
@@ -97,9 +97,4 @@ check_process.ExecuteInitializeSolutionStep()
 check_process.ExecuteFinalizeSolutionStep()
 check_process.ExecuteFinalize()
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(os.getcwd())+".post.lst")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/packaging_plane_based_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/packaging_plane_based_test/optimization_parameters.json
@@ -72,7 +72,8 @@
             "nodal_results"      : [ "DF1DX", "DC1DX", "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            }
+            },
+            "write_design_output": false
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/packaging_plane_based_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/packaging_plane_based_test/optimization_parameters.json
@@ -68,12 +68,11 @@
             }
         },
         "output" : {
-            "design_output_mode" : "WriteDesignSurface",
+            "design_output_mode" : "None",
             "nodal_results"      : [ "DF1DX", "DC1DX", "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"
-            },
-            "write_design_output": false
+            }
         }
     }
 }

--- a/applications/ShapeOptimizationApplication/tests/packaging_plane_based_test/optimization_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/packaging_plane_based_test/optimization_parameters.json
@@ -68,7 +68,7 @@
             }
         },
         "output" : {
-            "design_output_mode" : "None",
+            "design_output_mode" : "none",
             "nodal_results"      : [ "DF1DX", "DC1DX", "SHAPE_CHANGE" ],
             "output_format" : {
                 "name": "gid"

--- a/applications/ShapeOptimizationApplication/tests/packaging_plane_based_test/run_test.py
+++ b/applications/ShapeOptimizationApplication/tests/packaging_plane_based_test/run_test.py
@@ -97,9 +97,4 @@ check_process.ExecuteInitializeSolutionStep()
 check_process.ExecuteFinalizeSolutionStep()
 check_process.ExecuteFinalize()
 
-# Cleaning
-kratos_utilities.DeleteDirectoryIfExisting("__pycache__")
-kratos_utilities.DeleteDirectoryIfExisting(output_directory)
-kratos_utilities.DeleteFileIfExisting(os.path.basename(os.getcwd())+".post.lst")
-
 # =======================================================================================================

--- a/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/primal_parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/sensitivity_verification_process_test/primal_parameters.json
@@ -56,7 +56,7 @@
             }
         }]
     },
-    "output_processes" : {
+    "_output_processes" : {
         "gid_output" : [{
             "python_module" : "gid_output_process",
             "kratos_module" : "KratosMultiphysics",


### PR DESCRIPTION
It was suggested in one of the previous MRs:

The tests do not delete the results after a succesful run, instead the result files are simply added to `.gitignore`. This makes it more convenient to actually have a look at the test results, e.g. for debugging or similar. 