### PR TITLE
[Fluid] clean includes

### DIFF
--- a/applications/FluidDynamicsApplication/custom_utilities/statistics_record.cpp
+++ b/applications/FluidDynamicsApplication/custom_utilities/statistics_record.cpp
@@ -1,6 +1,23 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+//  Main authors:    Jordi Cotela
+//
+
+// System includes
+
+// External includes
+
+// Project includes
 #include "includes/define.h"
-#include "includes/element.h"
 #include "containers/variable.h"
+#include "includes/model_part.h"
 #include "utilities/openmp_utils.h"
 
 #include "statistics_record.h"

--- a/applications/FluidDynamicsApplication/custom_utilities/statistics_record.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/statistics_record.h
@@ -22,7 +22,6 @@
 // Project includes
 #include "containers/pointer_vector.h"
 #include "includes/define.h"
-#include "includes/model_part.h"
 #include "includes/ublas_interface.h"
 #include "statistics_utilities.h"
 
@@ -33,6 +32,8 @@ namespace Kratos
 
 ///@name Kratos Classes
 ///@{
+
+class ModelPart; // forward-declaring to not having to include it here
 
 /// Main class for online statistics calculation.
 /** This class manages the definition, update and output of statistics calculated during a simulation.


### PR DESCRIPTION
I was wondering why the fluid elements are being recompiled when changing `model_part.h` or one of its includes
turned out this was the reason: `statistics_record.h` is included in `fluid_dynamics_application_variables.h` which is included in most elements

IMO forward declaration is perfectly applicable for solving this issue