### PR TITLE
Require at least python 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ set(PYBIND11_LTO_LINKER_FLAGS "" CACHE INTERNAL "")
 
 # check version of Python, needs to be done after including pybind
 if(${PYTHON_VERSION_MAJOR} LESS 3)
-message( FATAL_ERROR "Kratos only supports Python version 3.5 and above")
+    message( FATAL_ERROR "Kratos only supports Python version 3.5 and above")
 elseif(${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 5)
     message( FATAL_ERROR "Kratos only supports Python version 3.5 and above")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,9 +261,7 @@ set(PYBIND11_LTO_CXX_FLAGS "" CACHE INTERNAL "")
 set(PYBIND11_LTO_LINKER_FLAGS "" CACHE INTERNAL "")
 
 # check version of Python, needs to be done after including pybind
-if(${PYTHON_VERSION_MAJOR} LESS 3)
-    message( FATAL_ERROR "Kratos only supports Python version 3.5 and above")
-elseif(${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 5)
+if(${PYTHON_VERSION_MAJOR} LESS 3 OR (${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 5))
     message( FATAL_ERROR "Kratos only supports Python version 3.5 and above")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,13 @@ include(pybind11Tools)
 set(PYBIND11_LTO_CXX_FLAGS "" CACHE INTERNAL "")
 set(PYBIND11_LTO_LINKER_FLAGS "" CACHE INTERNAL "")
 
+# check version of Python, needs to be done after including pybind
+if(${PYTHON_VERSION_MAJOR} LESS 3)
+message( FATAL_ERROR "Kratos only supports Python version 3.5 and above")
+elseif(${PYTHON_VERSION_MAJOR} EQUAL 3 AND ${PYTHON_VERSION_MINOR} LESS 5)
+    message( FATAL_ERROR "Kratos only supports Python version 3.5 and above")
+endif()
+
 # Set installation directory. TODO: Delete this and use CMAKE_INSTALL_PREFIX
 if(DEFINED KRATOS_INSTALL_PREFIX)
     set(CMAKE_INSTALL_PREFIX ${KRATOS_INSTALL_PREFIX} )

--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -3,6 +3,9 @@ import os
 import sys
 from . import kratos_globals
 
+if sys.version_info < (3, 5):
+    raise Exception("Kratos only supports Python version 3.5 and above")
+
 class KratosPaths(object):
     kratos_install_path = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
 


### PR DESCRIPTION
as discussed in #6610 

Now that the support is dropped, this will make Kratos no longer compile if Python versions < 3.5 are used

closes #6610 