### PR TITLE
Enabling CI builds on release branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - Release-*.*
 
 jobs:
   ubuntu:


### PR DESCRIPTION
That should allow the CI to activate when making PR against a Release branch such as hot-fixes, etc...
If it works it should be merged to master too

It should also allow this PR to auto-trigger, if now we can force merge