### PR TITLE
[Kratos-Unittest] using len instead of Size

### DIFF
--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -80,7 +80,7 @@ class TestCase(TestCase):
             yield err_msg
 
         self.assertEqual(len(vector1), len(vector2), msg="\nCheck failed because vector arguments do not have the same size")
-        for i, (v1, v2) in enumerate(zip(vector1, vector2):
+        for i, (v1, v2) in enumerate(zip(vector1, vector2)):
             self.assertAlmostEqual(v1, v2, prec, msg=GetErrMsg(i))
 
     def assertMatrixAlmostEqual(self, matrix1, matrix2, prec=7):

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -79,8 +79,8 @@ class TestCase(TestCase):
             err_msg += '\nVector 1:\n{}\nVector 2:\n{}'.format(vector1, vector2)
             yield err_msg
 
-        self.assertEqual(vector1.Size(), vector2.Size(), msg="\nCheck failed because vector arguments do not have the same size")
-        for i in range(vector1.Size()):
+        self.assertEqual(len(vector1), len(vector2), msg="\nCheck failed because vector arguments do not have the same size")
+        for i in range(len(vector1)):
             self.assertAlmostEqual(vector1[i], vector2[i], prec, msg=GetErrMsg(i))
 
     def assertMatrixAlmostEqual(self, matrix1, matrix2, prec=7):

--- a/kratos/python_scripts/KratosUnittest.py
+++ b/kratos/python_scripts/KratosUnittest.py
@@ -80,8 +80,8 @@ class TestCase(TestCase):
             yield err_msg
 
         self.assertEqual(len(vector1), len(vector2), msg="\nCheck failed because vector arguments do not have the same size")
-        for i in range(len(vector1)):
-            self.assertAlmostEqual(vector1[i], vector2[i], prec, msg=GetErrMsg(i))
+        for i, (v1, v2) in enumerate(zip(vector1, vector2):
+            self.assertAlmostEqual(v1, v2, prec, msg=GetErrMsg(i))
 
     def assertMatrixAlmostEqual(self, matrix1, matrix2, prec=7):
         def GetDimErrMsg():


### PR DESCRIPTION
this way it also supports the native python datatypes

This is a proposal bcs the fct is called `assertVectorAlmostEqual`

alternatively we could leave `assertVectorAlmostEqual` as is and have a second fct called `assertSequenceAlmostEqual` (that works with `list`, `set`, `tuple` `KM.Vector`) etc

Up for discussion