### PR TITLE
[FluDyn] Embedded elements - fix issue in omp

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
@@ -447,11 +447,11 @@ protected:
         // Initialize the nodal EMBEDDED_VELOCITY variable (make it threadsafe)
         const array_1d<double,3> zero_vel = ZeroVector(3);
         for (auto &r_node : this->GetGeometry()) {
+            r_node.SetLock();
             if (!r_node.Has(EMBEDDED_VELOCITY)) {
-                r_node.SetLock();
                 r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
-                r_node.UnSetLock();
             }
+            r_node.UnSetLock();
         }
 
         KRATOS_CATCH("");

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.cpp
@@ -70,11 +70,11 @@ void EmbeddedFluidElement<TBaseElement>::Initialize()
     // Initialize the nodal EMBEDDED_VELOCITY variable (make it threadsafe)
     const array_1d<double,3> zero_vel = ZeroVector(3);
     for (auto &r_node : this->GetGeometry()) {
+        r_node.SetLock();
         if (!r_node.Has(EMBEDDED_VELOCITY)) {
-            r_node.SetLock();
             r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
-            r_node.UnSetLock();
         }
+        r_node.UnSetLock();
     }
 
     KRATOS_CATCH("");

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
@@ -84,11 +84,11 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::Initialize()
     // Initialize the nodal EMBEDDED_VELOCITY variable (make it threadsafe)
     const array_1d<double,3> zero_vel = ZeroVector(3);
     for (auto &r_node : this->GetGeometry()) {
+        r_node.SetLock();
         if (!r_node.Has(EMBEDDED_VELOCITY)) {
-            r_node.SetLock();
             r_node.SetValue(EMBEDDED_VELOCITY, zero_vel);
-            r_node.UnSetLock();
         }
+        r_node.UnSetLock();
     }
 
     KRATOS_CATCH("");


### PR DESCRIPTION
Found these errors running tests in FullDebug with Windows. It seems they do not arise usually in gcc.

I think this fixes https://github.com/KratosMultiphysics/Kratos/issues/6431 
(The original error @philbucher mentioned in `embedded_couette_test`)

Problem is that one thread could change the mData of the node while another thread is still finding if EMBEDDED_VELOCITY was present in the mData. This explains the strange error "difference between a singular iterator to a singular iterator."

