### PR TITLE
[FluDyn] Embedded elements - initialize output variable in Calculate

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.cpp
@@ -144,7 +144,7 @@ void EmbeddedFluidElement<TBaseElement>::CalculateLocalSystem(
 template <class TBaseElement>
 void EmbeddedFluidElement<TBaseElement>::Calculate(
     const Variable<double> &rVariable,
-    double& rOutput,
+    double &rOutput,
     const ProcessInfo &rCurrentProcessInfo)
 {
     if (rVariable == CUTTED_AREA) {
@@ -154,6 +154,7 @@ void EmbeddedFluidElement<TBaseElement>::Calculate(
         this->InitializeGeometryData(data);
         // Calculate the intersection area as the Gauss weights summation
         const unsigned int n_int_pos_gauss = data.PositiveInterfaceWeights.size();
+        rOutput = 0.0;
         for (unsigned int g = 0; g < n_int_pos_gauss; ++g) {
             rOutput += data.PositiveInterfaceWeights[g];
         }


### PR DESCRIPTION
This was also failing in FullDebug with VS, it surprises me that gcc did not complain about this.