### PR TITLE
[Core][MasterSlaveConstraint] deprecating Create with VariableComponent

### DIFF
--- a/kratos/includes/master_slave_constraint.h
+++ b/kratos/includes/master_slave_constraint.h
@@ -223,7 +223,7 @@ public:
      * @param Constant The constant in the master slave relation
      * @return A Pointer to the new constraint
      */
-    virtual MasterSlaveConstraint::Pointer Create(
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please remove it") virtual MasterSlaveConstraint::Pointer Create(
         IndexType Id,
         NodeType& rMasterNode,
         const VariableComponentType& rMasterVariable,


### PR DESCRIPTION
Some more cleaning related to #6686 
Deprecating it first since this is a baseclass, we can then one by one remove the other occurences