### PR TITLE
[Core] fix clang 10 warning

### DIFF
--- a/kratos/python/kratos_python.cpp
+++ b/kratos/python/kratos_python.cpp
@@ -73,11 +73,11 @@ namespace Kratos
 namespace Python
 {
 
-char const* greet()
+std::string Hello()
 {
     std::stringstream header;
-    header << "Hello, I am Kratos Multi-Physics " << GetVersionString() <<" ;-)";
-    return header.str().c_str();
+    header << "Hello, I am Kratos Multi-Physics " << GetVersionString() << " ;-)";
+    return header.str();
 }
 
 PYBIND11_MODULE(Kratos, m)
@@ -105,9 +105,6 @@ PYBIND11_MODULE(Kratos, m)
     AddMATVariablesToPython(m);
     AddDeprecatedVariablesToPython(m);
     AddGlobalPointersToPython(m);
-
-//     AddQuadraturesToPython();
-//     AddIntegrationPointsToPython();
 
     AddProcessesToPython(m);
     AddIOToPython(m);
@@ -141,7 +138,7 @@ PYBIND11_MODULE(Kratos, m)
     AddDataCommunicatorToPython(m);
     AddParallelEnvironmentToPython(m);
 
-    m.def("Hello", greet);
+    m.def("Hello", Hello);
 }
 
 


### PR DESCRIPTION
clang issues a warning that the address of a local var is returned

~~~
/home/philippb/software/Kratos_master/kratos/python/kratos_python.cpp:80:12: warning: returning address of local temporary object [-Wreturn-stack-address]
    return header.str().c_str();
~~~