### PR TITLE
[StructuralMechanicsApplication] Compilation fails without cotire

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_processes/distribute_load_on_surface_process.h
+++ b/applications/StructuralMechanicsApplication/custom_processes/distribute_load_on_surface_process.h
@@ -20,6 +20,7 @@
 // Project includes
 #include "includes/define.h"
 #include "processes/process.h"
+#include "includes/model_part.h"
 #include "includes/kratos_parameters.h"
 
 namespace Kratos {


### PR DESCRIPTION
#include "includes/model_part.h" is missing