### PR TITLE
[core] ModelPartIO accepts 'True', 'true' or 1 for bool variables in mdpa files

### DIFF
--- a/kratos/includes/model_part_io.h
+++ b/kratos/includes/model_part_io.h
@@ -655,6 +655,8 @@ private:
     template<class TValueType>
     TValueType& ExtractValue(std::string rWord, TValueType & rValue);
 
+    bool& ExtractValue(std::string rWord, bool & rValue);
+
     void ReadConstitutiveLawValue(ConstitutiveLaw::Pointer& rValue);
 
     ModelPartIO& ReadWord(std::string& Word);

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -4495,6 +4495,19 @@ TValueType& ModelPartIO::ExtractValue(std::string rWord, TValueType & rValue)
     return rValue;
 }
 
+bool& ModelPartIO::ExtractValue(std::string rWord, bool & rValue)
+{
+    KRATOS_WATCH(rWord)
+
+    if (rWord == "1" || rWord == "true" || rWord == "True") {
+        rValue = true;
+    }
+
+    else rValue = false;
+
+    return rValue;
+}
+
 void ModelPartIO::ReadConstitutiveLawValue(ConstitutiveLaw::Pointer& rValue) {
     std::string value;
     ReadWord(value);

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -4500,9 +4500,9 @@ bool& ModelPartIO::ExtractValue(std::string rWord, bool & rValue)
 
     if (rWord == "1" || rWord == "true" || rWord == "True") {
         rValue = true;
+    } else {
+          rValue = false;
     }
-
-    else rValue = false;
 
     return rValue;
 }

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -4500,8 +4500,10 @@ bool& ModelPartIO::ExtractValue(std::string rWord, bool & rValue)
 
     if (rWord == "1" || rWord == "true" || rWord == "True") {
         rValue = true;
+    } else if (rWord == "0" || rWord == "false" || rWord == "False") {
+        rValue = false;
     } else {
-          rValue = false;
+        KRATOS_ERROR << "Boolean argument could not be determined: " << rWord << std::endl;
     }
 
     return rValue;

--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -4497,7 +4497,6 @@ TValueType& ModelPartIO::ExtractValue(std::string rWord, TValueType & rValue)
 
 bool& ModelPartIO::ExtractValue(std::string rWord, bool & rValue)
 {
-    KRATOS_WATCH(rWord)
 
     if (rWord == "1" || rWord == "true" || rWord == "True") {
         rValue = true;

--- a/kratos/tests/auxiliar_files_for_python_unittest/mdpa_files/test_model_part_io_read.mdpa
+++ b/kratos/tests/auxiliar_files_for_python_unittest/mdpa_files/test_model_part_io_read.mdpa
@@ -12,6 +12,7 @@ End Table
 
 Begin Properties 1
 IS_RESTARTED 1
+COMPUTE_LUMPED_MASS_MATRIX False
 COMPUTE_DYNAMIC_TANGENT 0
 DENSITY 3.4E-5  //scalar
 THICKNESS 19.5
@@ -85,7 +86,8 @@ End NodalData
 Begin SubModelPart Inlets
 	Begin SubModelPartData
 	IS_RESTARTED True
-	COMPUTE_DYNAMIC_TANGENT 0
+	COMPUTE_LUMPED_MASS_MATRIX true
+	COMPUTE_DYNAMIC_TANGENT false
 	End SubModelPartData
 
 	Begin SubModelPartTables

--- a/kratos/tests/auxiliar_files_for_python_unittest/mdpa_files/test_model_part_io_read.mdpa
+++ b/kratos/tests/auxiliar_files_for_python_unittest/mdpa_files/test_model_part_io_read.mdpa
@@ -84,7 +84,7 @@ End NodalData
 
 Begin SubModelPart Inlets
 	Begin SubModelPartData
-	IS_RESTARTED 1
+	IS_RESTARTED True
 	COMPUTE_DYNAMIC_TANGENT 0
 	End SubModelPartData
 

--- a/kratos/tests/test_model_part_io.py
+++ b/kratos/tests/test_model_part_io.py
@@ -140,6 +140,7 @@ class TestModelPartIO(KratosUnittest.TestCase):
         #Bools
         self.assertTrue(properties_1[KratosMultiphysics.IS_RESTARTED])
         self.assertFalse(properties_1[KratosMultiphysics.COMPUTE_DYNAMIC_TANGENT])
+        self.assertFalse(properties_1[KratosMultiphysics.COMPUTE_LUMPED_MASS_MATRIX])
         #Double
         self.assertEqual(properties_1[KratosMultiphysics.DENSITY], 3.4E-5)
         #Array3
@@ -159,6 +160,7 @@ class TestModelPartIO(KratosUnittest.TestCase):
 
         #SubModelPartData
         self.assertTrue(inlets_model_part[KratosMultiphysics.IS_RESTARTED])
+        self.assertTrue(inlets_model_part[KratosMultiphysics.COMPUTE_LUMPED_MASS_MATRIX])
         self.assertFalse(inlets_model_part[KratosMultiphysics.COMPUTE_DYNAMIC_TANGENT])
 
     def test_model_part_io_read_model_part_mesh_only(self):


### PR DESCRIPTION
This is just a proposal, nothing crucial, to accept other formats for bool variables.
It was triggered by an error in the GiD GUI, which was printing True instead of 1, but I thought this might be useful.
However, the implementation I came to was not as nice as intended, because I had to specialize a template function.
I am totally open to suggestions and rejections.