### PR TITLE
[Core] Add gauss point evaluation methods to geometry utilities

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -106,6 +106,7 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/delaunator_utilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/string_utilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/result_dabatase.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utilities/geometry_utilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/tetrahedra_ball.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/tetrahedra_edge_shell.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modified_shape_functions/modified_shape_functions.cpp;

--- a/kratos/tests/cpp_tests/utilities/test_geometry_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometry_utils.cpp
@@ -363,7 +363,7 @@ namespace Testing {
         const double check_pressure = N[0] + 2.0 * N[1] + 3.0 * N[2] + 4.0 * N[3];
         double pressure;
         GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint(pressure, tetrahedra, PRESSURE, N);
-        KRATOS_CHECK_NEAR(check_pressure, pressure, 1e-7);
+        KRATOS_CHECK_NEAR(check_pressure, pressure, 1e-15);
 
         // testing for previous step
         tetrahedra[0].FastGetSolutionStepValue(PRESSURE, 1) = 10.0;
@@ -374,7 +374,7 @@ namespace Testing {
         const double check_old_pressure = 10.0 * N[0] + 20.0 * N[1] + 30.0 * N[2] + 40.0 * N[3];
         double old_pressure;
         GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint(old_pressure, tetrahedra, PRESSURE, N, 1);
-        KRATOS_CHECK_NEAR(check_old_pressure, old_pressure, 1e-7);
+        KRATOS_CHECK_NEAR(check_old_pressure, old_pressure, 1e-15);
     }
 
     KRATOS_TEST_CASE_IN_SUITE(EvaluateHistoricalVariableValueAtGaussPointArray, KratosCoreFastSuite)
@@ -414,7 +414,7 @@ namespace Testing {
         const array_1d<double, 3> check_velocity = n0 * N[0] + n1* N[1] + n2 * N[2] + n3 * N[3];
         array_1d<double, 3> velocity;
         GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint(velocity, tetrahedra, VELOCITY, N);
-        KRATOS_CHECK_VECTOR_NEAR(check_velocity, velocity, 1e-7);
+        KRATOS_CHECK_VECTOR_NEAR(check_velocity, velocity, 1e-15);
 
         // testing for previous step
         array_1d<double, 3> n0_old(3, 10.0);
@@ -428,7 +428,7 @@ namespace Testing {
         const array_1d<double, 3> check_old_velocity = n0_old * N[0] + n1_old* N[1] + n2_old * N[2] + n3_old * N[3];
         array_1d<double, 3> old_velocity;
         GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint(old_velocity, tetrahedra, VELOCITY, N, 1);
-        KRATOS_CHECK_VECTOR_NEAR(check_old_velocity, old_velocity, 1e-7);
+        KRATOS_CHECK_VECTOR_NEAR(check_old_velocity, old_velocity, 1e-15);
     }
 
     KRATOS_TEST_CASE_IN_SUITE(EvaluateHistoricalVariableGradientAtGaussPointDouble, KratosCoreFastSuite)
@@ -468,7 +468,7 @@ namespace Testing {
 
         array_1d<double, 3> pressure_gradient;
         GeometryUtils::EvaluateHistoricalVariableGradientAtGaussPoint(pressure_gradient, tetrahedra, PRESSURE, DN_DX);
-        KRATOS_CHECK_VECTOR_NEAR(check_pressure_gradient, pressure_gradient, 1e-7);
+        KRATOS_CHECK_VECTOR_NEAR(check_pressure_gradient, pressure_gradient, 1e-15);
 
         // testing for previous step
         tetrahedra[0].FastGetSolutionStepValue(PRESSURE, 1) = 10.0;
@@ -483,7 +483,7 @@ namespace Testing {
 
         array_1d<double, 3> old_pressure_gradient;
         GeometryUtils::EvaluateHistoricalVariableGradientAtGaussPoint(old_pressure_gradient, tetrahedra, PRESSURE, DN_DX, 1);
-        KRATOS_CHECK_VECTOR_NEAR(check_old_pressure_gradient, old_pressure_gradient, 1e-7);
+        KRATOS_CHECK_VECTOR_NEAR(check_old_pressure_gradient, old_pressure_gradient, 1e-15);
     }
 
     KRATOS_TEST_CASE_IN_SUITE(EvaluateHistoricalVariableGradientAtGaussPointArray, KratosCoreFastSuite)
@@ -535,7 +535,7 @@ namespace Testing {
 
         BoundedMatrix<double, 3, 3> velocity_gradient;
         GeometryUtils::EvaluateHistoricalVariableGradientAtGaussPoint(velocity_gradient, tetrahedra, VELOCITY, DN_DX);
-        KRATOS_CHECK_MATRIX_NEAR(check_velocity_gradient, velocity_gradient, 1e-7);
+        KRATOS_CHECK_MATRIX_NEAR(check_velocity_gradient, velocity_gradient, 1e-15);
 
         // testing for previous step
         array_1d<double, 3> n0_old(3, 1.0);
@@ -562,7 +562,7 @@ namespace Testing {
 
         BoundedMatrix<double, 3, 3> old_velocity_gradient;
         GeometryUtils::EvaluateHistoricalVariableGradientAtGaussPoint(old_velocity_gradient, tetrahedra, VELOCITY, DN_DX, 1);
-        KRATOS_CHECK_MATRIX_NEAR(check_old_velocity_gradient, old_velocity_gradient, 1e-7);
+        KRATOS_CHECK_MATRIX_NEAR(check_old_velocity_gradient, old_velocity_gradient, 1e-15);
     }
 }  // namespace Testing.
 }  // namespace Kratos.

--- a/kratos/tests/cpp_tests/utilities/test_geometry_utils.cpp
+++ b/kratos/tests/cpp_tests/utilities/test_geometry_utils.cpp
@@ -20,6 +20,7 @@
 #include "geometries/triangle_2d_3.h"
 #include "geometries/triangle_3d_3.h"
 #include "geometries/tetrahedra_3d_4.h"
+#include "containers/variables_list.h"
 
 namespace Kratos {
 namespace Testing {
@@ -250,7 +251,7 @@ namespace Testing {
 //         distances[2] = 0.2;
 //         array_1d<Point, 4> intersection_points;
 //         const int intersections = GeometryUtils::CalculateTetrahedraIntersectionPoints(tetrahedra, distances, intersection_points);
-// 
+//
 //        KRATOS_CHECK_EQUAL(intersections, 1);
 //     }
 
@@ -327,6 +328,241 @@ namespace Testing {
                 KRATOS_CHECK_NEAR(J(i, j), auxiliar_J(i, j), tolerance);
             }
         }
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(EvaluateHistoricalVariableValueAtGaussPointDouble, KratosCoreFastSuite)
+    {
+        VariablesList::Pointer current_variable_list = Kratos::make_intrusive<VariablesList>();
+        current_variable_list->Add(PRESSURE);
+
+        Tetrahedra3D4 <NodeType> tetrahedra = GenerateExampleTetrahedra();
+
+        tetrahedra[0].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[1].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[2].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[3].SetSolutionStepVariablesList(current_variable_list);
+
+        tetrahedra[0].SetBufferSize(2);
+        tetrahedra[1].SetBufferSize(2);
+        tetrahedra[2].SetBufferSize(2);
+        tetrahedra[3].SetBufferSize(2);
+
+        // Computing the info
+        BoundedMatrix<double,4,3> DN_DX;
+        array_1d<double,4> N;
+        double volume;
+
+        GeometryUtils::CalculateGeometryData(tetrahedra, DN_DX, N, volume);
+
+        // testing for current step
+        tetrahedra[0].FastGetSolutionStepValue(PRESSURE) = 1.0;
+        tetrahedra[1].FastGetSolutionStepValue(PRESSURE) = 2.0;
+        tetrahedra[2].FastGetSolutionStepValue(PRESSURE) = 3.0;
+        tetrahedra[3].FastGetSolutionStepValue(PRESSURE) = 4.0;
+
+        const double check_pressure = N[0] + 2.0 * N[1] + 3.0 * N[2] + 4.0 * N[3];
+        double pressure;
+        GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint(pressure, tetrahedra, PRESSURE, N);
+        KRATOS_CHECK_NEAR(check_pressure, pressure, 1e-7);
+
+        // testing for previous step
+        tetrahedra[0].FastGetSolutionStepValue(PRESSURE, 1) = 10.0;
+        tetrahedra[1].FastGetSolutionStepValue(PRESSURE, 1) = 20.0;
+        tetrahedra[2].FastGetSolutionStepValue(PRESSURE, 1) = 30.0;
+        tetrahedra[3].FastGetSolutionStepValue(PRESSURE, 1) = 40.0;
+
+        const double check_old_pressure = 10.0 * N[0] + 20.0 * N[1] + 30.0 * N[2] + 40.0 * N[3];
+        double old_pressure;
+        GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint(old_pressure, tetrahedra, PRESSURE, N, 1);
+        KRATOS_CHECK_NEAR(check_old_pressure, old_pressure, 1e-7);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(EvaluateHistoricalVariableValueAtGaussPointArray, KratosCoreFastSuite)
+    {
+        VariablesList::Pointer current_variable_list = Kratos::make_intrusive<VariablesList>();
+        current_variable_list->Add(VELOCITY);
+
+        Tetrahedra3D4 <NodeType> tetrahedra = GenerateExampleTetrahedra();
+
+        tetrahedra[0].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[1].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[2].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[3].SetSolutionStepVariablesList(current_variable_list);
+
+        tetrahedra[0].SetBufferSize(2);
+        tetrahedra[1].SetBufferSize(2);
+        tetrahedra[2].SetBufferSize(2);
+        tetrahedra[3].SetBufferSize(2);
+
+        // Computing the info
+        BoundedMatrix<double,4,3> DN_DX;
+        array_1d<double,4> N;
+        double volume;
+
+        GeometryUtils::CalculateGeometryData(tetrahedra, DN_DX, N, volume);
+
+        // testing for current step
+        array_1d<double, 3> n0(3, 1.0);
+        array_1d<double, 3> n1(3, 2.0);
+        array_1d<double, 3> n2(3, 3.0);
+        array_1d<double, 3> n3(3, 4.0);
+        tetrahedra[0].FastGetSolutionStepValue(VELOCITY) = n0;
+        tetrahedra[1].FastGetSolutionStepValue(VELOCITY) = n1;
+        tetrahedra[2].FastGetSolutionStepValue(VELOCITY) = n2;
+        tetrahedra[3].FastGetSolutionStepValue(VELOCITY) = n3;
+
+        const array_1d<double, 3> check_velocity = n0 * N[0] + n1* N[1] + n2 * N[2] + n3 * N[3];
+        array_1d<double, 3> velocity;
+        GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint(velocity, tetrahedra, VELOCITY, N);
+        KRATOS_CHECK_VECTOR_NEAR(check_velocity, velocity, 1e-7);
+
+        // testing for previous step
+        array_1d<double, 3> n0_old(3, 10.0);
+        array_1d<double, 3> n1_old(3, 20.0);
+        array_1d<double, 3> n2_old(3, 30.0);
+        array_1d<double, 3> n3_old(3, 40.0);
+        tetrahedra[0].FastGetSolutionStepValue(VELOCITY, 1) = n0_old;
+        tetrahedra[1].FastGetSolutionStepValue(VELOCITY, 1) = n1_old;
+        tetrahedra[2].FastGetSolutionStepValue(VELOCITY, 1) = n2_old;
+        tetrahedra[3].FastGetSolutionStepValue(VELOCITY, 1) = n3_old;
+        const array_1d<double, 3> check_old_velocity = n0_old * N[0] + n1_old* N[1] + n2_old * N[2] + n3_old * N[3];
+        array_1d<double, 3> old_velocity;
+        GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint(old_velocity, tetrahedra, VELOCITY, N, 1);
+        KRATOS_CHECK_VECTOR_NEAR(check_old_velocity, old_velocity, 1e-7);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(EvaluateHistoricalVariableGradientAtGaussPointDouble, KratosCoreFastSuite)
+    {
+        VariablesList::Pointer current_variable_list = Kratos::make_intrusive<VariablesList>();
+        current_variable_list->Add(PRESSURE);
+
+        Tetrahedra3D4 <NodeType> tetrahedra = GenerateExampleTetrahedra();
+
+        tetrahedra[0].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[1].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[2].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[3].SetSolutionStepVariablesList(current_variable_list);
+
+        tetrahedra[0].SetBufferSize(2);
+        tetrahedra[1].SetBufferSize(2);
+        tetrahedra[2].SetBufferSize(2);
+        tetrahedra[3].SetBufferSize(2);
+
+        // Computing the info
+        BoundedMatrix<double,4,3> DN_DX;
+        array_1d<double,4> N;
+        double volume;
+
+        GeometryUtils::CalculateGeometryData(tetrahedra, DN_DX, N, volume);
+
+        // testing for current step
+        tetrahedra[0].FastGetSolutionStepValue(PRESSURE) = 1.0;
+        tetrahedra[1].FastGetSolutionStepValue(PRESSURE) = 2.0;
+        tetrahedra[2].FastGetSolutionStepValue(PRESSURE) = 3.0;
+        tetrahedra[3].FastGetSolutionStepValue(PRESSURE) = 4.0;
+
+        array_1d<double, 3> check_pressure_gradient;
+        check_pressure_gradient[0] = DN_DX(0, 0) * 1.0 + DN_DX(1, 0) * 2.0 + DN_DX(2, 0) * 3.0 + DN_DX(3, 0) * 4.0;
+        check_pressure_gradient[1] = DN_DX(0, 1) * 1.0 + DN_DX(1, 1) * 2.0 + DN_DX(2, 1) * 3.0 + DN_DX(3, 1) * 4.0;
+        check_pressure_gradient[2] = DN_DX(0, 2) * 1.0 + DN_DX(1, 2) * 2.0 + DN_DX(2, 2) * 3.0 + DN_DX(3, 2) * 4.0;
+
+        array_1d<double, 3> pressure_gradient;
+        GeometryUtils::EvaluateHistoricalVariableGradientAtGaussPoint(pressure_gradient, tetrahedra, PRESSURE, DN_DX);
+        KRATOS_CHECK_VECTOR_NEAR(check_pressure_gradient, pressure_gradient, 1e-7);
+
+        // testing for previous step
+        tetrahedra[0].FastGetSolutionStepValue(PRESSURE, 1) = 10.0;
+        tetrahedra[1].FastGetSolutionStepValue(PRESSURE, 1) = 20.0;
+        tetrahedra[2].FastGetSolutionStepValue(PRESSURE, 1) = 30.0;
+        tetrahedra[3].FastGetSolutionStepValue(PRESSURE, 1) = 40.0;
+
+        array_1d<double, 3> check_old_pressure_gradient;
+        check_old_pressure_gradient[0] = DN_DX(0, 0) * 10.0 + DN_DX(1, 0) * 20.0 + DN_DX(2, 0) * 30.0 + DN_DX(3, 0) * 40.0;
+        check_old_pressure_gradient[1] = DN_DX(0, 1) * 10.0 + DN_DX(1, 1) * 20.0 + DN_DX(2, 1) * 30.0 + DN_DX(3, 1) * 40.0;
+        check_old_pressure_gradient[2] = DN_DX(0, 2) * 10.0 + DN_DX(1, 2) * 20.0 + DN_DX(2, 2) * 30.0 + DN_DX(3, 2) * 40.0;
+
+        array_1d<double, 3> old_pressure_gradient;
+        GeometryUtils::EvaluateHistoricalVariableGradientAtGaussPoint(old_pressure_gradient, tetrahedra, PRESSURE, DN_DX, 1);
+        KRATOS_CHECK_VECTOR_NEAR(check_old_pressure_gradient, old_pressure_gradient, 1e-7);
+    }
+
+    KRATOS_TEST_CASE_IN_SUITE(EvaluateHistoricalVariableGradientAtGaussPointArray, KratosCoreFastSuite)
+    {
+        VariablesList::Pointer current_variable_list = Kratos::make_intrusive<VariablesList>();
+        current_variable_list->Add(VELOCITY);
+
+        Tetrahedra3D4 <NodeType> tetrahedra = GenerateExampleTetrahedra();
+
+        tetrahedra[0].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[1].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[2].SetSolutionStepVariablesList(current_variable_list);
+        tetrahedra[3].SetSolutionStepVariablesList(current_variable_list);
+
+        tetrahedra[0].SetBufferSize(2);
+        tetrahedra[1].SetBufferSize(2);
+        tetrahedra[2].SetBufferSize(2);
+        tetrahedra[3].SetBufferSize(2);
+
+        // Computing the info
+        BoundedMatrix<double,4,3> DN_DX;
+        array_1d<double,4> N;
+        double volume;
+
+        GeometryUtils::CalculateGeometryData(tetrahedra, DN_DX, N, volume);
+
+        // testing for current step
+        array_1d<double, 3> n0(3, 1.0);
+        array_1d<double, 3> n1(3, 2.0);
+        array_1d<double, 3> n2(3, 3.0);
+        array_1d<double, 3> n3(3, 4.0);
+        tetrahedra[0].FastGetSolutionStepValue(VELOCITY) = n0;
+        tetrahedra[1].FastGetSolutionStepValue(VELOCITY) = n1;
+        tetrahedra[2].FastGetSolutionStepValue(VELOCITY) = n2;
+        tetrahedra[3].FastGetSolutionStepValue(VELOCITY) = n3;
+
+        BoundedMatrix<double, 3, 3> check_velocity_gradient;
+        check_velocity_gradient(0, 0) = n0[0] * DN_DX(0, 0) + n1[0] * DN_DX(1, 0) + n2[0] * DN_DX(2, 0) + n3[0] * DN_DX(3, 0);
+        check_velocity_gradient(0, 1) = n0[0] * DN_DX(0, 1) + n1[0] * DN_DX(1, 1) + n2[0] * DN_DX(2, 1) + n3[0] * DN_DX(3, 1);
+        check_velocity_gradient(0, 2) = n0[0] * DN_DX(0, 2) + n1[0] * DN_DX(1, 2) + n2[0] * DN_DX(2, 2) + n3[0] * DN_DX(3, 2);
+
+        check_velocity_gradient(1, 0) = n0[1] * DN_DX(0, 0) + n1[1] * DN_DX(1, 0) + n2[1] * DN_DX(2, 0) + n3[1] * DN_DX(3, 0);
+        check_velocity_gradient(1, 1) = n0[1] * DN_DX(0, 1) + n1[1] * DN_DX(1, 1) + n2[1] * DN_DX(2, 1) + n3[1] * DN_DX(3, 1);
+        check_velocity_gradient(1, 2) = n0[1] * DN_DX(0, 2) + n1[1] * DN_DX(1, 2) + n2[1] * DN_DX(2, 2) + n3[1] * DN_DX(3, 2);
+
+        check_velocity_gradient(2, 0) = n0[2] * DN_DX(0, 0) + n1[2] * DN_DX(1, 0) + n2[2] * DN_DX(2, 0) + n3[2] * DN_DX(3, 0);
+        check_velocity_gradient(2, 1) = n0[2] * DN_DX(0, 1) + n1[2] * DN_DX(1, 1) + n2[2] * DN_DX(2, 1) + n3[2] * DN_DX(3, 1);
+        check_velocity_gradient(2, 2) = n0[2] * DN_DX(0, 2) + n1[2] * DN_DX(1, 2) + n2[2] * DN_DX(2, 2) + n3[2] * DN_DX(3, 2);
+
+        BoundedMatrix<double, 3, 3> velocity_gradient;
+        GeometryUtils::EvaluateHistoricalVariableGradientAtGaussPoint(velocity_gradient, tetrahedra, VELOCITY, DN_DX);
+        KRATOS_CHECK_MATRIX_NEAR(check_velocity_gradient, velocity_gradient, 1e-7);
+
+        // testing for previous step
+        array_1d<double, 3> n0_old(3, 1.0);
+        array_1d<double, 3> n1_old(3, 2.0);
+        array_1d<double, 3> n2_old(3, 3.0);
+        array_1d<double, 3> n3_old(3, 4.0);
+        tetrahedra[0].FastGetSolutionStepValue(VELOCITY, 1) = n0_old;
+        tetrahedra[1].FastGetSolutionStepValue(VELOCITY, 1) = n1_old;
+        tetrahedra[2].FastGetSolutionStepValue(VELOCITY, 1) = n2_old;
+        tetrahedra[3].FastGetSolutionStepValue(VELOCITY, 1) = n3_old;
+
+        BoundedMatrix<double, 3, 3> check_old_velocity_gradient;
+        check_old_velocity_gradient(0, 0) = n0_old[0] * DN_DX(0, 0) + n1_old[0] * DN_DX(1, 0) + n2_old[0] * DN_DX(2, 0) + n3_old[0] * DN_DX(3, 0);
+        check_old_velocity_gradient(0, 1) = n0_old[0] * DN_DX(0, 1) + n1_old[0] * DN_DX(1, 1) + n2_old[0] * DN_DX(2, 1) + n3_old[0] * DN_DX(3, 1);
+        check_old_velocity_gradient(0, 2) = n0_old[0] * DN_DX(0, 2) + n1_old[0] * DN_DX(1, 2) + n2_old[0] * DN_DX(2, 2) + n3_old[0] * DN_DX(3, 2);
+
+        check_old_velocity_gradient(1, 0) = n0_old[1] * DN_DX(0, 0) + n1_old[1] * DN_DX(1, 0) + n2_old[1] * DN_DX(2, 0) + n3_old[1] * DN_DX(3, 0);
+        check_old_velocity_gradient(1, 1) = n0_old[1] * DN_DX(0, 1) + n1_old[1] * DN_DX(1, 1) + n2_old[1] * DN_DX(2, 1) + n3_old[1] * DN_DX(3, 1);
+        check_old_velocity_gradient(1, 2) = n0_old[1] * DN_DX(0, 2) + n1_old[1] * DN_DX(1, 2) + n2_old[1] * DN_DX(2, 2) + n3_old[1] * DN_DX(3, 2);
+
+        check_old_velocity_gradient(2, 0) = n0_old[2] * DN_DX(0, 0) + n1_old[2] * DN_DX(1, 0) + n2_old[2] * DN_DX(2, 0) + n3_old[2] * DN_DX(3, 0);
+        check_old_velocity_gradient(2, 1) = n0_old[2] * DN_DX(0, 1) + n1_old[2] * DN_DX(1, 1) + n2_old[2] * DN_DX(2, 1) + n3_old[2] * DN_DX(3, 1);
+        check_old_velocity_gradient(2, 2) = n0_old[2] * DN_DX(0, 2) + n1_old[2] * DN_DX(1, 2) + n2_old[2] * DN_DX(2, 2) + n3_old[2] * DN_DX(3, 2);
+
+        BoundedMatrix<double, 3, 3> old_velocity_gradient;
+        GeometryUtils::EvaluateHistoricalVariableGradientAtGaussPoint(old_velocity_gradient, tetrahedra, VELOCITY, DN_DX, 1);
+        KRATOS_CHECK_MATRIX_NEAR(check_old_velocity_gradient, old_velocity_gradient, 1e-7);
     }
 }  // namespace Testing.
 }  // namespace Kratos.

--- a/kratos/utilities/geometry_utilities.cpp
+++ b/kratos/utilities/geometry_utilities.cpp
@@ -1,0 +1,126 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                     Kratos default license: kratos/license.txt
+//
+//  Main authors:    Riccardo Rossi
+//
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+
+// Include base h
+#include "geometry_utilities.h"
+
+namespace Kratos
+{
+template <class TDataType>
+void GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint(
+    TDataType& rOutput,
+    const GeometryType& rGeometry,
+    const Variable<TDataType>& rVariable,
+    const Vector& rGaussPointShapeFunctionValues,
+    const int Step)
+{
+    KRATOS_TRY
+
+    const SizeType number_of_nodes = rGeometry.PointsNumber();
+
+    noalias(rOutput) = rGeometry[0].FastGetSolutionStepValue(rVariable, Step) *
+                       rGaussPointShapeFunctionValues[0];
+
+    for (SizeType i_node = 1; i_node < number_of_nodes; ++i_node)
+    {
+        noalias(rOutput) += rGeometry[i_node].FastGetSolutionStepValue(rVariable, Step) *
+                            rGaussPointShapeFunctionValues[i_node];
+    }
+
+    KRATOS_CATCH("");
+}
+
+template <>
+void GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint<double>(
+    double& rOutput,
+    const GeometryType& rGeometry,
+    const Variable<double>& rVariable,
+    const Vector& rGaussPointShapeFunctionValues,
+    const int Step)
+{
+    KRATOS_TRY
+
+    const SizeType number_of_nodes = rGeometry.PointsNumber();
+
+    rOutput = rGeometry[0].FastGetSolutionStepValue(rVariable, Step) *
+              rGaussPointShapeFunctionValues[0];
+    for (SizeType i_node = 1; i_node < number_of_nodes; ++i_node)
+    {
+        rOutput += rGeometry[i_node].FastGetSolutionStepValue(rVariable, Step) *
+                   rGaussPointShapeFunctionValues[i_node];
+    }
+
+    KRATOS_CATCH("");
+}
+
+void GeometryUtils::EvaluateHistoricalVariableGradientAtGaussPoint(
+    array_1d<double, 3>& rOutput,
+    const GeometryType& rGeometry,
+    const Variable<double>& rVariable,
+    const Matrix& rGaussPointShapeFunctionDerivativeValues,
+    const int Step)
+{
+    noalias(rOutput) = ZeroVector(3);
+    const SizeType number_of_nodes = rGeometry.PointsNumber();
+    const SizeType dimension = rGaussPointShapeFunctionDerivativeValues.size2();
+
+    for (SizeType a = 0; a < number_of_nodes; ++a)
+    {
+        const double value = rGeometry[a].FastGetSolutionStepValue(rVariable, Step);
+        for (SizeType i = 0; i < dimension; ++i)
+            rOutput[i] += rGaussPointShapeFunctionDerivativeValues(a, i) * value;
+    }
+}
+
+void GeometryUtils::EvaluateHistoricalVariableGradientAtGaussPoint(
+    BoundedMatrix<double, 3, 3>& rOutput,
+    const GeometryType& rGeometry,
+    const Variable<array_1d<double, 3>>& rVariable,
+    const Matrix& rGaussPointShapeFunctionDerivativeValues,
+    const int Step)
+{
+    noalias(rOutput) = ZeroMatrix(3, 3);
+    const SizeType number_of_nodes = rGeometry.PointsNumber();
+    const SizeType dimension = rGaussPointShapeFunctionDerivativeValues.size2();
+
+    for (SizeType a = 0; a < number_of_nodes; ++a)
+    {
+        const array_1d<double, 3>& r_value =
+            rGeometry[a].FastGetSolutionStepValue(rVariable, Step);
+        for (SizeType i = 0; i < dimension; ++i)
+        {
+            for (SizeType j = 0; j < dimension; ++j)
+            {
+                rOutput(i, j) +=
+                    rGaussPointShapeFunctionDerivativeValues(a, j) * r_value[i];
+            }
+        }
+    }
+}
+
+// template instantiations
+
+template void GeometryUtils::EvaluateHistoricalVariableValueAtGaussPoint<array_1d<double, 3>>(
+    array_1d<double, 3>& rOutput,
+    const GeometryType&,
+    const Variable<array_1d<double, 3>>&,
+    const Vector&,
+    const int);
+
+} // namespace Kratos.

--- a/kratos/utilities/geometry_utilities.h
+++ b/kratos/utilities/geometry_utilities.h
@@ -674,7 +674,7 @@ public:
         if (rDN_DX.size1() != rDN_De.size1() || rDN_DX.size2() != rInvJ.size2())
             rDN_DX.resize(rDN_De.size1(), rInvJ.size2(), false);
     #endif // KRATOS_USE_AMATRIX
-        
+
         noalias(rDN_DX) = prod(rDN_De, rInvJ);
     }
 
@@ -698,7 +698,7 @@ public:
         if (rF.size1() != rJ.size1() || rF.size2() != rInvJ0.size2())
             rF.resize(rJ.size1(), rInvJ0.size2(), false);
     #endif // KRATOS_USE_AMATRIX
-        
+
         noalias(rF) = prod(rJ, rInvJ0);
     }
 
@@ -786,6 +786,68 @@ public:
             }
         }
     }
+
+    /**
+     * @brief Evaluates variable value at gauss point
+     *
+     * This method evaluates variable value at gauss point given by gauss point shape function values.
+     *
+     * @tparam TDataType                        Data type
+     * @param rOutput                           Output which holds evaluated value
+     * @param rGeometry                         Geometry from which gauss point values are interpolated
+     * @param rVariable                         Variable for value interpolation
+     * @param rGaussPointShapeFunctionValues    Shape function values evaluated at gauss point
+     * @param Step                              Step to be used in historical variable value interpolation
+     */
+    template <class TDataType>
+    static void EvaluateHistoricalVariableValueAtGaussPoint(
+        TDataType& rOutput,
+        const GeometryType& rGeometry,
+        const Variable<TDataType>& rVariable,
+        const Vector& rGaussPointShapeFunctionValues,
+        const int Step = 0);
+
+    /**
+     * @brief Evaluates gradient of scalar at gauss point
+     *
+     * This method evaluates gradient of a scalar variable for given shape function derivative values.
+     * For 2D, it returns 3rd component as zero.
+     *
+     * @param rOutput                                   Output 3d variable containing gradients at gauss point
+     * @param rGeometry                                 Geometry from which gauss point values are interpolated
+     * @param rVariable                                 Variable for value interpolation
+     * @param rGaussPointShapeFunctionDerivativeValues  Shape function derivatives evaluated at gauss point
+     * @param Step                                      Step to be used in historical variable value interpolation
+     */
+    static void EvaluateHistoricalVariableGradientAtGaussPoint(
+        array_1d<double, 3>& rOutput,
+        const GeometryType& rGeometry,
+        const Variable<double>& rVariable,
+        const Matrix& rGaussPointShapeFunctionDerivativeValues,
+        const int Step = 0);
+
+    /**
+     * @brief Evaluates gradient of a 3d vector at gauss point
+     *
+     * This method evaluates gradient of a vector variable for given shape function derivative values.
+     * \[
+     *      rOutput(i, j) = \frac{\partial u_i}{\partial x_j}
+     * \]
+     * Where $u_i$ is the component of 3D rVariable, and $x_j$ is the cartesian coordinate component.
+     * In 2D, it returns 3rd row and 3rd column with zeros.
+     *
+     * @param rOutput                                   Output matrix containing gradients at gauss point
+     * @param rGeometry                                 Geometry from which gauss point values are interpolated
+     * @param rVariable                                 Variable for value interpolation
+     * @param rGaussPointShapeFunctionDerivativeValues  Shape function derivatives evaluated at gauss point
+     * @param Step                                      Step to be used in historical variable value interpolation
+     */
+    static void EvaluateHistoricalVariableGradientAtGaussPoint(
+        BoundedMatrix<double, 3, 3>& rOutput,
+        const GeometryType& rGeometry,
+        const Variable<array_1d<double, 3>>& rVariable,
+        const Matrix& rGaussPointShapeFunctionDerivativeValues,
+        const int Step = 0);
 };
 
 }  // namespace Kratos.


### PR DESCRIPTION
This PR adds gauss point value and derivative evaluation to geoemtry utilities.

Instead of having them in the utilities, can we have them in the `GeometricalObject` class?