### PR TITLE
[Core] Analysis stage - avoid calling IsOutputStep twice

### DIFF
--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -153,20 +153,20 @@ class AnalysisStage(object):
     def OutputSolutionStep(self):
         """This function printed / writes output files after the solution of a step
         """
-        # first we check if one of the output processes will print output in this step
-        # this is done to save computation in case none of them will print
         is_output_step = False
+        is_output_step_list = []
         for output_process in self._GetListOfOutputProcesses():
-            if output_process.IsOutputStep():
+            is_output_for_this_process = output_process.IsOutputStep()
+            is_output_step_list.append(is_output_for_this_process)
+            if is_output_for_this_process:
                 is_output_step = True
-                break
 
         if is_output_step: # at least one of the output processes will print output
             for process in self._GetListOfProcesses():
                 process.ExecuteBeforeOutputStep()
 
-            for output_process in self._GetListOfOutputProcesses():
-                if output_process.IsOutputStep():
+            for index, output_process in enumerate(self._GetListOfOutputProcesses()):
+                if is_output_step_list[index]:
                     output_process.PrintOutput()
 
             for process in self._GetListOfProcesses():

--- a/kratos/python_scripts/analysis_stage.py
+++ b/kratos/python_scripts/analysis_stage.py
@@ -153,22 +153,17 @@ class AnalysisStage(object):
     def OutputSolutionStep(self):
         """This function printed / writes output files after the solution of a step
         """
-        is_output_step = False
-        is_output_step_list = []
+        execute_was_called = False
         for output_process in self._GetListOfOutputProcesses():
-            is_output_for_this_process = output_process.IsOutputStep()
-            is_output_step_list.append(is_output_for_this_process)
-            if is_output_for_this_process:
-                is_output_step = True
+            if output_process.IsOutputStep():
+                if not execute_was_called:
+                    for process in self._GetListOfProcesses():
+                        process.ExecuteBeforeOutputStep()
+                    execute_was_called = True
 
-        if is_output_step: # at least one of the output processes will print output
-            for process in self._GetListOfProcesses():
-                process.ExecuteBeforeOutputStep()
+                output_process.PrintOutput()
 
-            for index, output_process in enumerate(self._GetListOfOutputProcesses()):
-                if is_output_step_list[index]:
-                    output_process.PrintOutput()
-
+        if execute_was_called:
             for process in self._GetListOfProcesses():
                 process.ExecuteAfterOutputStep()
 


### PR DESCRIPTION
In @KratosMultiphysics/altair side, the functions that control whether IsOutputStep or not have some degree of complexity and calling them twice each time step is giving us some problems. I think this change makes sense so this function is only called once for each process and the output is stored to use it later in a list.