### PR TITLE
Fix trilinos extension

### DIFF
--- a/applications/FluidDynamicsApplication/trilinos_extension/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/trilinos_extension/CMakeLists.txt
@@ -25,10 +25,6 @@ pybind11_add_module( KratosFluidDynamicsTrilinosExtension MODULE THIN_LTO ${KRAT
 target_link_libraries( KratosFluidDynamicsTrilinosExtension PRIVATE KratosFluidDynamicsCore KratosTrilinosCore KratosMPICore ${TRILINOS_LIBRARIES})
 set_target_properties( KratosFluidDynamicsTrilinosExtension PROPERTIES PREFIX "")
 
-if(USE_COTIRE MATCHES ON)
-  cotire(KratosFluidDynamicsTrilinosExtension)
-endif(USE_COTIRE MATCHES ON)
-
 ###############################################################################
 # changing the .dll suffix to .pyd
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
@@ -39,6 +35,10 @@ endif(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
 if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 	set_target_properties(KratosFluidDynamicsTrilinosExtension PROPERTIES SUFFIX .so)
 endif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+
+if(USE_COTIRE MATCHES ON)
+	cotire(KratosFluidDynamicsTrilinosExtension)
+endif(USE_COTIRE MATCHES ON)
 
 ###############################################################################
 ## installing the resulting libraries

--- a/applications/FluidDynamicsApplication/trilinos_extension/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/trilinos_extension/CMakeLists.txt
@@ -21,12 +21,13 @@ file(
 
 ## Python module
 pybind11_add_module( KratosFluidDynamicsTrilinosExtension MODULE THIN_LTO ${KRATOS_FLUID_DYNAMICS_TRILINOS_EXTENSION_PYTHON_INTERFACE_SOURCES} )
-if(USE_COTIRE MATCHES ON)
-  set_target_properties(KratosFluidDynamicsTrilinosExtension PROPERTIES COTIRE_UNITY_LINK_LIBRARIES_INIT "COPY_UNITY")
-  cotire(KratosFluidDynamicsTrilinosExtension)
-endif(USE_COTIRE MATCHES ON)
+
 target_link_libraries( KratosFluidDynamicsTrilinosExtension PRIVATE KratosFluidDynamicsCore KratosTrilinosCore KratosMPICore ${TRILINOS_LIBRARIES})
 set_target_properties( KratosFluidDynamicsTrilinosExtension PROPERTIES PREFIX "")
+
+if(USE_COTIRE MATCHES ON)
+  cotire(KratosFluidDynamicsTrilinosExtension)
+endif(USE_COTIRE MATCHES ON)
 
 ###############################################################################
 # changing the .dll suffix to .pyd


### PR DESCRIPTION
This should solve #7001 

I also removed the copy unity as its the default behavior in cotire >1.7, which is what we have so its not necessary.

closes #7001 