### PR TITLE
[Core] Avoid MPI race condition in compare_two_files_check_process

### DIFF
--- a/kratos/python_scripts/compare_two_files_check_process.py
+++ b/kratos/python_scripts/compare_two_files_check_process.py
@@ -84,6 +84,9 @@ class CompareTwoFilesCheckProcess(KratosMultiphysics.Process, KratosUnittest.Tes
         """
 
         KratosMultiphysics.DataCommunicator.GetDefault().Barrier()
+        ## only do the check in ranks zero, otherwise this can experience in race condition
+        if (KratosMultiphysics.DataCommunicator.GetDefault().Rank() != 0):
+            return        
 
         if (self.comparison_type == "deterministic"):
             value = filecmp.cmp(self.reference_file_name, self.output_file_name)

--- a/kratos/python_scripts/compare_two_files_check_process.py
+++ b/kratos/python_scripts/compare_two_files_check_process.py
@@ -86,7 +86,7 @@ class CompareTwoFilesCheckProcess(KratosMultiphysics.Process, KratosUnittest.Tes
         KratosMultiphysics.DataCommunicator.GetDefault().Barrier()
         ## only do the check in ranks zero, otherwise this can experience in race condition
         if (KratosMultiphysics.DataCommunicator.GetDefault().Rank() != 0):
-            return        
+            return
 
         if (self.comparison_type == "deterministic"):
             value = filecmp.cmp(self.reference_file_name, self.output_file_name)


### PR DESCRIPTION
Hi,

I am using this process in MPI. I have experienced when tests are used with more than one thread with MPI (no trilinos, or epetra calls), makes the whole test slower (due to mdpas having only 5-8 elements), so it gives race condition. This fixes it.