### PR TITLE
Cps/transonic assembly of velocity shape func with add nodes

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.cpp
@@ -996,14 +996,14 @@ array_1d<size_t, TNumNodes> TransonicPerturbationPotentialFlowElement<TDim, TNum
     current_element_ids.resize(TNumNodes, false);
     array_1d<size_t, TNumNodes> upwind_node_key;
 
-    for (int i = 0; i < TNumNodes; i++)
+    for (unsigned int i = 0; i < TNumNodes; i++)
     {
-        current_element_ids[i] = rGeom[i].Id();
+        current_element_ids[i] = rGeom[i].GetDof(VELOCITY_POTENTIAL).EquationId();
     }
 
     for (int i = 0; i < TNumNodes; i++) { 
         auto current_id = std::find(current_element_ids.begin(), current_element_ids.end(),
-                rUpwindGeom[i].Id());
+                rUpwindGeom[i].GetDof(VELOCITY_POTENTIAL).EquationId());
 
         if( current_id == current_element_ids.end()) {
             upwind_node_key[i] = TNumNodes;

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.cpp
@@ -592,26 +592,6 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateLeftHa
 }
 
 template <int TDim, int TNumNodes>
-void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::TestAssemblyFunction(const ProcessInfo& rCurrentProcessInfo)
-{
-    const array_1d<double, TDim> velocity = PotentialFlowUtilities::ComputePerturbedVelocity<TDim,TNumNodes>(*this, rCurrentProcessInfo);
-
-    const double local_mach_number_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<TDim, TNumNodes>(velocity, rCurrentProcessInfo);
-
-    if (this->IsNot(INLET)) {
-        const array_1d<double, TDim> upwind_velocity = 
-            PotentialFlowUtilities::ComputePerturbedVelocity<TDim,TNumNodes>(*pGetUpwindElement(), rCurrentProcessInfo);
-        const double upwind_mach_number_squared = 
-            PotentialFlowUtilities::ComputeLocalMachNumberSquared<TDim, TNumNodes>(upwind_velocity, rCurrentProcessInfo);
-        
-        const double DrhoDu2 = PotentialFlowUtilities::ComputeUpwindedDensityDerivativeWRTVelocitySquaredSupersonicAccelerating<TDim, TNumNodes>(velocity, local_mach_number_squared, upwind_mach_number_squared, rCurrentProcessInfo);
-        const double DrhoDu2_up = PotentialFlowUtilities::ComputeUpwindedDensityDerivativeWRTUpwindVelocitySquaredSupersonicAccelerating<TDim, TNumNodes>(local_mach_number_squared, upwind_mach_number_squared, rCurrentProcessInfo);
-        auto DNV = AssembleDensityDerivativeAndShapeFunctions(DrhoDu2, DrhoDu2_up, velocity, upwind_velocity, rCurrentProcessInfo);
-    }
-}
-
-
-template <int TDim, int TNumNodes>
 void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateRightHandSideNormalElement(
     VectorType& rRightHandSideVector,
     const ProcessInfo& rCurrentProcessInfo)

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
@@ -284,6 +284,8 @@ private:
                                     const ElementalData<TNumNodes, TDim>& rData,
                                     unsigned int& rRow) const;
 
+    void AssembleDensityDerivativeAndShapeFunctions(const double densityDerivativeWRTVelocitySquared, const double densityDerivativeWRTUpwindVelocitySquared, const array_1d<double, TDim>& velocity, const array_1d<double, TDim>& upwindVelocity,const ProcessInfo& rCurrentProcessInfo);
+
     void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
 
     void FindUpwindElement(const ProcessInfo& rCurrentProcessInfo);

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
@@ -283,10 +283,10 @@ private:
                                     const BoundedVector<double, TNumNodes>& rWake_rhs,
                                     const ElementalData<TNumNodes, TDim>& rData,
                                     unsigned int& rRow) const;
-
+    
     BoundedVector<double, TNumNodes + 1> AssembleDensityDerivativeAndShapeFunctions(const double densityDerivativeWRTVelocitySquared, const double densityDerivativeWRTUpwindVelocitySquared, const array_1d<double, TDim>& velocity, const array_1d<double, TDim>& upwindVelocity,const ProcessInfo& rCurrentProcessInfo);
 
-    array_1d<size_t, TNumNodes> GetAssemblyKey(const GeometryType& rGeom, const GeometryType& rUpwindGeom);
+    array_1d<size_t, TNumNodes> GetAssemblyKey(const GeometryType& rGeom, const GeometryType& rUpwindGeom, const ProcessInfo& rCurrentProcessInfo);
 
     void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
@@ -288,8 +288,6 @@ private:
 
     array_1d<size_t, TNumNodes> GetAssemblyKey(const GeometryType& rGeom, const GeometryType& rUpwindGeom);
 
-    void TestAssemblyFunction(const ProcessInfo& rCurrentProcessInfo);
-
     void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
 
     void FindUpwindElement(const ProcessInfo& rCurrentProcessInfo);

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
@@ -284,7 +284,11 @@ private:
                                     const ElementalData<TNumNodes, TDim>& rData,
                                     unsigned int& rRow) const;
 
-    void AssembleDensityDerivativeAndShapeFunctions(const double densityDerivativeWRTVelocitySquared, const double densityDerivativeWRTUpwindVelocitySquared, const array_1d<double, TDim>& velocity, const array_1d<double, TDim>& upwindVelocity,const ProcessInfo& rCurrentProcessInfo);
+    BoundedVector<double, TNumNodes + 1> AssembleDensityDerivativeAndShapeFunctions(const double densityDerivativeWRTVelocitySquared, const double densityDerivativeWRTUpwindVelocitySquared, const array_1d<double, TDim>& velocity, const array_1d<double, TDim>& upwindVelocity,const ProcessInfo& rCurrentProcessInfo);
+
+    array_1d<size_t, TNumNodes> GetAssemblyKey(const GeometryType& rGeom, const GeometryType& rUpwindGeom);
+
+    void TestAssemblyFunction(const ProcessInfo& rCurrentProcessInfo);
 
     void ComputePotentialJump(const ProcessInfo& rCurrentProcessInfo);
 


### PR DESCRIPTION
Function to complete the assembly the highlighted vectors shown below to account for the additional nodes introduced by the upwind element.

Ultimately based on the definition of the residual in Section A.2.7 of Fully Simultaneous Coupling of the Full Potential Equation and the Integral Boundary Layer Equations in Three Dimensions by Brian Allen Nishida (MIT, 1996).

![Screen Shot 2020-06-19 at 4 46 43 PM](https://user-images.githubusercontent.com/60355972/85145348-b872a080-b24c-11ea-8568-b87274f0fbfb.png)
