### PR TITLE
[Core] [Constraints] Master-Slave constraints initialize function call

### DIFF
--- a/kratos/solving_strategies/schemes/scheme.h
+++ b/kratos/solving_strategies/schemes/scheme.h
@@ -286,6 +286,25 @@ public:
         mConditionsAreInitialized = ConditionsAreInitializedFlag;
     }
 
+
+    /**
+     * @brief This method returns if the master-slave constraints are initialized
+     * @return True if initilized, false otherwise
+     */
+    bool MasterSlaveConstraintsAreInitialized()
+    {
+        return mMasterSlaveConstraintsInitialized;
+    }
+
+    /**
+     * @brief This method sets if the master-slave constraints have been initilized or not (true by default)
+     * @param MasterSlaveConstraintsAreInitializedFlag If the flag must be set to true or false
+     */
+    void SetMasterSlaveConstraintsAreInitialized(bool MasterSlaveConstraintsAreInitializedFlag = true)
+    {
+        mMasterSlaveConstraintsInitialized = MasterSlaveConstraintsAreInitializedFlag;
+    }
+
     /**
      * @brief This is the place to initialize the elements.
      * @details This is intended to be called just once when the strategy is initialized
@@ -328,6 +347,28 @@ public:
         }
 
         SetConditionsAreInitialized();
+
+        KRATOS_CATCH("")
+    }
+
+    /**
+     * @brief This is the place to initialize the master slave constraints.
+     * @details This is intended to be called just once when the strategy is initialized
+     * @param rModelPart The model part of the problem to solve
+     */
+    virtual void InitializeMasterSlaveConstraints(ModelPart& rModelPart)
+    {
+        KRATOS_TRY
+
+        const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
+
+        #pragma omp parallel for
+        for(int i=0; i<static_cast<int>(rModelPart.MasterSlaveConstraints().size()); i++) {
+            auto it_constraint = rModelPart.MasterSlaveConstraintsBegin() + i;
+            it_constraint->Initialize(r_current_process_info);
+        }
+
+        SetMasterSlaveConstraintsAreInitialized();
 
         KRATOS_CATCH("")
     }
@@ -1113,6 +1154,7 @@ protected:
     bool mSchemeIsInitialized;      /// Flag to be used in controlling if the Scheme has been intialized or not
     bool mElementsAreInitialized;   /// Flag taking in account if the elements were initialized correctly or not
     bool mConditionsAreInitialized; /// Flag taking in account if the conditions were initialized correctly or not
+    bool mMasterSlaveConstraintsInitialized; /// Flag taking in account if the m-s constraints are initialized correctly or not
 
     ///@}
     ///@name Protected Operators

--- a/kratos/solving_strategies/strategies/adaptive_residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/adaptive_residualbased_newton_raphson_strategy.h
@@ -902,6 +902,11 @@ protected:
         if (pScheme->ElementsAreInitialized() == false)
             pScheme->InitializeElements(BaseType::GetModelPart());
 
+        //Initialize The MasterSlaveConstraints - OPERATIONS TO BE DONE ONCE
+        if (p_scheme->MasterSlaveConstraintsAreInitialized() == false)
+            p_scheme->InitializeMasterSlaveConstraints(BaseType::GetModelPart());
+
+
         //initialisation of the convergence criteria
         if (mpConvergenceCriteria->IsInitialized() == false)
             mpConvergenceCriteria->Initialize(BaseType::GetModelPart());

--- a/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_linear_strategy.h
@@ -409,6 +409,10 @@ public:
             if (p_scheme->ConditionsAreInitialized() == false)
                 p_scheme->InitializeConditions(BaseType::GetModelPart());
 
+            //Initialize The MasterSlaveConstraints - OPERATIONS TO BE DONE ONCE
+            if (p_scheme->MasterSlaveConstraintsAreInitialized() == false)
+                p_scheme->InitializeMasterSlaveConstraints(BaseType::GetModelPart());
+
             mInitializeWasPerformed = true;
         }
 

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -571,6 +571,10 @@ class ResidualBasedNewtonRaphsonStrategy
             if (p_scheme->ConditionsAreInitialized() == false)
                 p_scheme->InitializeConditions(BaseType::GetModelPart());
 
+            //Initialize The MasterSlaveConstraints - OPERATIONS TO BE DONE ONCE
+            if (p_scheme->MasterSlaveConstraintsAreInitialized() == false)
+                p_scheme->InitializeMasterSlaveConstraints(BaseType::GetModelPart());
+
             //initialisation of the convergence criteria
             if (p_convergence_criteria->IsInitialized() == false)
                 p_convergence_criteria->Initialize(BaseType::GetModelPart());


### PR DESCRIPTION
Solves the issue mentioned in #6702 

- Adds `InitializeMasterSlaveConstraints`, `SetMasterSlaveConstraintsAreInitialized` and `MasterSlaveConstraintsAreInitialized` methods to base scheme.
- Adds `mMasterSlaveConstraintsInitialized` bool variable to the base scheme. 
- Adds usage of `InitializeMasterSlaveConstraints` to residual based newton raphson strategy. 
- Adds usage of `InitializeMasterSlaveConstraints` to residual based linear strategy. 
- Adds usage of `InitializeMasterSlaveConstraints` to adaptive residual based newton raphson strategy. 

closes #6702 

