### PR TITLE
Femdem/fixing non explicit declaration in c11

### DIFF
--- a/applications/FemToDemApplication/CMakeLists.txt
+++ b/applications/FemToDemApplication/CMakeLists.txt
@@ -49,7 +49,7 @@ set( KRATOS_FEM_TO_DEM_APPLICATION_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_processes/update_flag_no_remesh_femdem_boundary_process.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/base_solid_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/generic_total_lagrangian_femdem_element.cpp
-    #${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/generic_total_lagrangian_mixtures_femdem_element.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/generic_total_lagrangian_mixtures_femdem_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_elements/generic_small_strain_femdem_element.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/linear_plane_strain.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/custom_constitutive/linear_plane_stress.cpp

--- a/applications/FemToDemApplication/FemToDemApplication.py
+++ b/applications/FemToDemApplication/FemToDemApplication.py
@@ -1,6 +1,11 @@
 # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 from __future__ import print_function, absolute_import, division
 
+from KratosMultiphysics.SolidMechanicsApplication import *
+from KratosMultiphysics.MeshingApplication import *
+from KratosMultiphysics.PfemFluidDynamicsApplication import *
+from KratosMultiphysics.DEMApplication import *
+
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
 from KratosFemToDemApplication import *

--- a/applications/FemToDemApplication/custom_elements/generic_small_strain_femdem_element.hpp
+++ b/applications/FemToDemApplication/custom_elements/generic_small_strain_femdem_element.hpp
@@ -223,8 +223,7 @@ protected:
     void CalculateKinematicVariables(
         BaseSolidElement::KinematicVariables& rThisKinematicVariables,
         const IndexType PointNumber,
-        const GeometryType::IntegrationMethod& rIntegrationMethod
-        );
+        const GeometryType::IntegrationMethod& rIntegrationMethod) override;
 
     /**
      * @brief This method computes the deformation matrix B
@@ -244,14 +243,14 @@ protected:
         ConstitutiveLaw::Parameters& rValues,
         const IndexType PointNumber,
         const GeometryType::IntegrationPointsArrayType& IntegrationPoints,
-        const ConstitutiveLaw::StressMeasure ThisStressMeasure);
+        const ConstitutiveLaw::StressMeasure ThisStressMeasure) override;
 
     void SetConstitutiveVariables(
         BaseSolidElement::KinematicVariables& rThisKinematicVariables,
         BaseSolidElement::ConstitutiveVariables& rThisConstitutiveVariables,
         ConstitutiveLaw::Parameters& rValues,
         const IndexType PointNumber,
-        const GeometryType::IntegrationPointsArrayType& IntegrationPoints);
+        const GeometryType::IntegrationPointsArrayType& IntegrationPoints) override;
 
     /**
      * @brief Sets on rValues the nodal displacements
@@ -263,7 +262,7 @@ protected:
         int Step = 0
         ) override;
 
-    bool UseElementProvidedStrain() const;
+    bool UseElementProvidedStrain() const override;
 
         
     ///@name Static Member Variables

--- a/applications/FemToDemApplication/custom_elements/generic_small_strain_femdem_element.hpp
+++ b/applications/FemToDemApplication/custom_elements/generic_small_strain_femdem_element.hpp
@@ -290,6 +290,9 @@ protected:
     ///@{
 }; // Class GenericSmallStrainFemDemElement
 
+template<unsigned int TDim, unsigned int TyieldSurf> constexpr SizeType GenericSmallStrainFemDemElement<TDim, TyieldSurf>::VoigtSize;
+template<unsigned int TDim, unsigned int TyieldSurf> constexpr SizeType GenericSmallStrainFemDemElement<TDim, TyieldSurf>::NumberOfEdges;
+
 ///@}
 ///@name Type Definitions
 ///@{

--- a/applications/FemToDemApplication/custom_elements/generic_total_lagrangian_femdem_element.cpp
+++ b/applications/FemToDemApplication/custom_elements/generic_total_lagrangian_femdem_element.cpp
@@ -2162,8 +2162,7 @@ template<unsigned int TDim, unsigned int TyieldSurf>
 void GenericTotalLagrangianFemDemElement<TDim,TyieldSurf>::SetValuesOnIntegrationPoints(
     const Variable<double> &rVariable,
     std::vector<double> &rValues,
-    const ProcessInfo &rCurrentProcessInfo
-)
+    const ProcessInfo &rCurrentProcessInfo)
 {
     if (rVariable == DAMAGE_ELEMENT) {
         mDamage = rValues[0];

--- a/applications/FemToDemApplication/custom_elements/generic_total_lagrangian_femdem_element.h
+++ b/applications/FemToDemApplication/custom_elements/generic_total_lagrangian_femdem_element.h
@@ -540,6 +540,10 @@ private:
 
 }; // Class GenericTotalLagrangianFemDemElement
 
+template<unsigned int TDim, unsigned int TyieldSurf> constexpr SizeType GenericTotalLagrangianFemDemElement<TDim, TyieldSurf>::VoigtSize;
+template<unsigned int TDim, unsigned int TyieldSurf> constexpr SizeType GenericTotalLagrangianFemDemElement<TDim, TyieldSurf>::NumberOfEdges;
+
+
 ///@}
 ///@name Type Definitions
 ///@{

--- a/applications/FemToDemApplication/custom_elements/generic_total_lagrangian_femdem_element.h
+++ b/applications/FemToDemApplication/custom_elements/generic_total_lagrangian_femdem_element.h
@@ -245,8 +245,7 @@ protected:
         VectorType& rRightHandSideVector,
         const ProcessInfo& rCurrentProcessInfo,
         const bool CalculateStiffnessMatrixFlag,
-        const bool CalculateResidualVectorFlag
-        ) override;
+        const bool CalculateResidualVectorFlag) override;
 
     /**
      * @brief This functions updates the kinematics variables
@@ -257,8 +256,7 @@ protected:
     void CalculateKinematicVariables(
         KinematicVariables& rThisKinematicVariables,
         const IndexType PointNumber,
-        const GeometryType::IntegrationMethod& rIntegrationMethod
-        ) override;
+        const GeometryType::IntegrationMethod& rIntegrationMethod) override;
 
     // ************** Methods to compute the tangent constitutive tensor via numerical derivation ************** 
     /**
@@ -402,9 +400,10 @@ protected:
         std::vector<double> &rValues,
         const ProcessInfo &rCurrentProcessInfo) override;
 
-    void SetValuesOnIntegrationPoints(const Variable<double> &rVariable,
-                                      std::vector<double> &rValues,
-                                      const ProcessInfo &rCurrentProcessInfo);
+    void SetValuesOnIntegrationPoints(
+        const Variable<double> &rVariable,
+        std::vector<double> &rValues,
+        const ProcessInfo &rCurrentProcessInfo) override;
 
     void CalculateOnIntegrationPoints(
         const Variable<double> &rVariable,
@@ -424,8 +423,7 @@ protected:
 
     virtual void CheckIfEraseElement(
         ProcessInfo &rCurrentProcessInfo, 
-        const Properties& rProperties
-        )
+        const Properties& rProperties)
     {
         if (mDamage >= 0.98) {
             this->Set(ACTIVE, false);

--- a/applications/FemToDemApplication/custom_elements/generic_total_lagrangian_mixtures_femdem_element.hpp
+++ b/applications/FemToDemApplication/custom_elements/generic_total_lagrangian_mixtures_femdem_element.hpp
@@ -304,6 +304,9 @@ protected:
     ///@{
 }; // Class GenericTotalLagrangianMixturesFemDemElement
 
+template<unsigned int TDim, unsigned int TyieldSurf> constexpr SizeType GenericTotalLagrangianMixturesFemDemElement<TDim, TyieldSurf>::VoigtSize;
+template<unsigned int TDim, unsigned int TyieldSurf> constexpr SizeType GenericTotalLagrangianMixturesFemDemElement<TDim, TyieldSurf>::NumberOfEdges;
+
 ///@}
 ///@name Type Definitions
 ///@{

--- a/applications/FemToDemApplication/fem_to_dem_application.cpp
+++ b/applications/FemToDemApplication/fem_to_dem_application.cpp
@@ -50,21 +50,21 @@ mTotalLagrangianVonMisesFemDemElement3D(0, Element::GeometryType::Pointer(new Te
 mTotalLagrangianTrescaFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
 mTotalLagrangianTrescaFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
 mTotalLagrangianMohrCoulombFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-mTotalLagrangianMohrCoulombFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4))))
-// mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-// mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
-// mTotalLagrangianMixturesRankineFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-// mTotalLagrangianMixturesRankineFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
-// mTotalLagrangianMixturesSimoJuFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-// mTotalLagrangianMixturesSimoJuFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
-// mTotalLagrangianMixturesDruckerPragerFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-// mTotalLagrangianMixturesDruckerPragerFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
-// mTotalLagrangianMixturesVonMisesFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-// mTotalLagrangianMixturesVonMisesFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
-// mTotalLagrangianMixturesTrescaFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-// mTotalLagrangianMixturesTrescaFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
-// mTotalLagrangianMixturesMohrCoulombFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-// mTotalLagrangianMixturesMohrCoulombFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4))))
+mTotalLagrangianMohrCoulombFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+mTotalLagrangianMixturesRankineFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+mTotalLagrangianMixturesRankineFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+mTotalLagrangianMixturesSimoJuFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+mTotalLagrangianMixturesSimoJuFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+mTotalLagrangianMixturesDruckerPragerFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+mTotalLagrangianMixturesDruckerPragerFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+mTotalLagrangianMixturesVonMisesFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+mTotalLagrangianMixturesVonMisesFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+mTotalLagrangianMixturesTrescaFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+mTotalLagrangianMixturesTrescaFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+mTotalLagrangianMixturesMohrCoulombFemDemElement2D(0, Element::GeometryType::Pointer(new Triangle2D3 <Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+mTotalLagrangianMixturesMohrCoulombFemDemElement3D(0, Element::GeometryType::Pointer(new Tetrahedra3D4 <Node<3> >(Element::GeometryType::PointsArrayType(4))))
 {}
 
 void KratosFemToDemApplication::Register()
@@ -198,20 +198,20 @@ void KratosFemToDemApplication::Register()
     KRATOS_REGISTER_ELEMENT("TotalLagrangianMohrCoulombFemDemElement2D", mTotalLagrangianMohrCoulombFemDemElement2D)
     KRATOS_REGISTER_ELEMENT("TotalLagrangianMohrCoulombFemDemElement3D", mTotalLagrangianMohrCoulombFemDemElement3D)
 
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesModifiedMohrCoulombFemDemElement2D", mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement2D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesModifiedMohrCoulombFemDemElement3D", mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement3D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesRankineFemDemElement2D", mTotalLagrangianMixturesRankineFemDemElement2D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesRankineFemDemElement3D", mTotalLagrangianMixturesRankineFemDemElement3D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesSimoJuFemDemElement2D", mTotalLagrangianMixturesSimoJuFemDemElement2D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesSimoJuFemDemElement3D", mTotalLagrangianMixturesSimoJuFemDemElement3D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesDruckerPragerFemDemElement2D", mTotalLagrangianMixturesDruckerPragerFemDemElement2D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesDruckerPragerFemDemElement3D", mTotalLagrangianMixturesDruckerPragerFemDemElement3D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesVonMisesFemDemElement2D", mTotalLagrangianMixturesVonMisesFemDemElement2D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesVonMisesFemDemElement3D", mTotalLagrangianMixturesVonMisesFemDemElement3D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesTrescaFemDemElement2D", mTotalLagrangianMixturesTrescaFemDemElement2D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesTrescaFemDemElement3D", mTotalLagrangianMixturesTrescaFemDemElement3D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesMohrCoulombFemDemElement2D", mTotalLagrangianMixturesMohrCoulombFemDemElement2D)
-    // KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesMohrCoulombFemDemElement3D", mTotalLagrangianMixturesMohrCoulombFemDemElement3D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesModifiedMohrCoulombFemDemElement2D", mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement2D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesModifiedMohrCoulombFemDemElement3D", mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement3D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesRankineFemDemElement2D", mTotalLagrangianMixturesRankineFemDemElement2D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesRankineFemDemElement3D", mTotalLagrangianMixturesRankineFemDemElement3D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesSimoJuFemDemElement2D", mTotalLagrangianMixturesSimoJuFemDemElement2D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesSimoJuFemDemElement3D", mTotalLagrangianMixturesSimoJuFemDemElement3D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesDruckerPragerFemDemElement2D", mTotalLagrangianMixturesDruckerPragerFemDemElement2D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesDruckerPragerFemDemElement3D", mTotalLagrangianMixturesDruckerPragerFemDemElement3D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesVonMisesFemDemElement2D", mTotalLagrangianMixturesVonMisesFemDemElement2D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesVonMisesFemDemElement3D", mTotalLagrangianMixturesVonMisesFemDemElement3D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesTrescaFemDemElement2D", mTotalLagrangianMixturesTrescaFemDemElement2D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesTrescaFemDemElement3D", mTotalLagrangianMixturesTrescaFemDemElement3D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesMohrCoulombFemDemElement2D", mTotalLagrangianMixturesMohrCoulombFemDemElement2D)
+    KRATOS_REGISTER_ELEMENT("TotalLagrangianMixturesMohrCoulombFemDemElement3D", mTotalLagrangianMixturesMohrCoulombFemDemElement3D)
 
     //Register Constitutive Laws
     Serializer::Register("ElasticIsotropic3D", mElasticIsotropic3D);

--- a/applications/FemToDemApplication/fem_to_dem_application.h
+++ b/applications/FemToDemApplication/fem_to_dem_application.h
@@ -36,7 +36,7 @@
 #include "custom_constitutive/linear_plane_strain.h"
 #include "custom_elements/generic_small_strain_femdem_element.hpp"
 #include "custom_elements/generic_total_lagrangian_femdem_element.h"
-// #include "custom_elements/generic_total_lagrangian_mixtures_femdem_element.hpp"
+#include "custom_elements/generic_total_lagrangian_mixtures_femdem_element.hpp"
 
 #include "fem_to_dem_application_variables.h"
 
@@ -136,20 +136,20 @@ private:
     const GenericTotalLagrangianFemDemElement<2,6> mTotalLagrangianMohrCoulombFemDemElement2D;
     const GenericTotalLagrangianFemDemElement<3,6> mTotalLagrangianMohrCoulombFemDemElement3D;
 
-    // const GenericTotalLagrangianMixturesFemDemElement<2,0> mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement2D;
-    // const GenericTotalLagrangianMixturesFemDemElement<3,0> mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement3D;
-    // const GenericTotalLagrangianMixturesFemDemElement<2,1> mTotalLagrangianMixturesRankineFemDemElement2D;
-    // const GenericTotalLagrangianMixturesFemDemElement<3,1> mTotalLagrangianMixturesRankineFemDemElement3D;
-    // const GenericTotalLagrangianMixturesFemDemElement<2,2> mTotalLagrangianMixturesSimoJuFemDemElement2D;
-    // const GenericTotalLagrangianMixturesFemDemElement<3,2> mTotalLagrangianMixturesSimoJuFemDemElement3D;
-    // const GenericTotalLagrangianMixturesFemDemElement<2,3> mTotalLagrangianMixturesDruckerPragerFemDemElement2D;
-    // const GenericTotalLagrangianMixturesFemDemElement<3,3> mTotalLagrangianMixturesDruckerPragerFemDemElement3D;
-    // const GenericTotalLagrangianMixturesFemDemElement<2,4> mTotalLagrangianMixturesVonMisesFemDemElement2D;
-    // const GenericTotalLagrangianMixturesFemDemElement<3,4> mTotalLagrangianMixturesVonMisesFemDemElement3D;
-    // const GenericTotalLagrangianMixturesFemDemElement<2,5> mTotalLagrangianMixturesTrescaFemDemElement2D;
-    // const GenericTotalLagrangianMixturesFemDemElement<3,5> mTotalLagrangianMixturesTrescaFemDemElement3D;
-    // const GenericTotalLagrangianMixturesFemDemElement<2,6> mTotalLagrangianMixturesMohrCoulombFemDemElement2D;
-    // const GenericTotalLagrangianMixturesFemDemElement<3,6> mTotalLagrangianMixturesMohrCoulombFemDemElement3D;
+    const GenericTotalLagrangianMixturesFemDemElement<2,0> mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement2D;
+    const GenericTotalLagrangianMixturesFemDemElement<3,0> mTotalLagrangianMixturesModifiedMohrCoulombFemDemElement3D;
+    const GenericTotalLagrangianMixturesFemDemElement<2,1> mTotalLagrangianMixturesRankineFemDemElement2D;
+    const GenericTotalLagrangianMixturesFemDemElement<3,1> mTotalLagrangianMixturesRankineFemDemElement3D;
+    const GenericTotalLagrangianMixturesFemDemElement<2,2> mTotalLagrangianMixturesSimoJuFemDemElement2D;
+    const GenericTotalLagrangianMixturesFemDemElement<3,2> mTotalLagrangianMixturesSimoJuFemDemElement3D;
+    const GenericTotalLagrangianMixturesFemDemElement<2,3> mTotalLagrangianMixturesDruckerPragerFemDemElement2D;
+    const GenericTotalLagrangianMixturesFemDemElement<3,3> mTotalLagrangianMixturesDruckerPragerFemDemElement3D;
+    const GenericTotalLagrangianMixturesFemDemElement<2,4> mTotalLagrangianMixturesVonMisesFemDemElement2D;
+    const GenericTotalLagrangianMixturesFemDemElement<3,4> mTotalLagrangianMixturesVonMisesFemDemElement3D;
+    const GenericTotalLagrangianMixturesFemDemElement<2,5> mTotalLagrangianMixturesTrescaFemDemElement2D;
+    const GenericTotalLagrangianMixturesFemDemElement<3,5> mTotalLagrangianMixturesTrescaFemDemElement3D;
+    const GenericTotalLagrangianMixturesFemDemElement<2,6> mTotalLagrangianMixturesMohrCoulombFemDemElement2D;
+    const GenericTotalLagrangianMixturesFemDemElement<3,6> mTotalLagrangianMixturesMohrCoulombFemDemElement3D;
 
     //Hiperelastic and elastic laws
    const LinearPlaneStrain mLinearPlaneStrain;


### PR DESCRIPTION
Problem seem to be this: https://stackoverflow.com/questions/8016780/undefined-reference-to-static-constexpr-char

That should fix it until we move to C++14/17 officially. Windows compiler already has, but some "old" linux ones have not, so that's why it was working there.

I've added a couple of missing overrides as well. 