### PR TITLE
[PotentialFlow] Fix 2D move model part process

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_processes/move_model_part_process.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_processes/move_model_part_process.cpp
@@ -66,7 +66,7 @@ void MoveModelPartProcess::Execute()
             // X-Y plane rotation
             r_coordinates[0] = mRotationPoint[0]+cos(mRotationAngle)*(old_coordinates[0]-mRotationPoint[0])-
                             sin(mRotationAngle)*(old_coordinates[1]-mRotationPoint[1]);
-            r_coordinates[1] = mRotationPoint[1]+sin(mRotationAngle)*(old_coordinates[0]-mRotationPoint[0])-
+            r_coordinates[1] = mRotationPoint[1]+sin(mRotationAngle)*(old_coordinates[0]-mRotationPoint[0])+
                             cos(mRotationAngle)*(old_coordinates[1]-mRotationPoint[1]);
         }
     }

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
@@ -49,14 +49,12 @@ namespace Kratos {
       MoveModelPartProcess MoveModelPartProcess(model_part, moving_parameters);
       MoveModelPartProcess.Execute();
 
-      Matrix reference = ZeroMatrix(3,3);
-      reference(0,0) = 5.0; reference(0,1) = 5.0;
-      reference(1,0) = 5.0; reference(1,1) = 7.0;
-      reference(2,0) = 5.0; reference(2,1) = 3.0;
+      // Matrix reference = ZeroMatrix(3,3);
+      std::array<double, 6> reference{5.0, 5.0, 5.0, 7.0, 5.0, 3.0};
 
-      for (std::size_t i_node = 0; i_node<reference.size1(); i_node++){
-        for (std::size_t i_dim = 0; i_dim<reference.size2(); i_dim++){
-          KRATOS_CHECK_NEAR(model_part.GetNode(i_node+1).Coordinates()[i_dim], reference(i_node,i_dim), 1e-6);
+      for (std::size_t i_node = 0; i_node<3; i_node++){
+        for (std::size_t i_dim = 0; i_dim<2; i_dim++){
+          KRATOS_CHECK_NEAR(model_part.GetNode(i_node+1).Coordinates()[i_dim], reference[i_node*2+i_dim], 1e-6);
         }
       }
     }

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_processes.cpp
@@ -49,8 +49,41 @@ namespace Kratos {
       MoveModelPartProcess MoveModelPartProcess(model_part, moving_parameters);
       MoveModelPartProcess.Execute();
 
-      // Matrix reference = ZeroMatrix(3,3);
       std::array<double, 6> reference{5.0, 5.0, 5.0, 7.0, 5.0, 3.0};
+
+      for (std::size_t i_node = 0; i_node<3; i_node++){
+        for (std::size_t i_dim = 0; i_dim<2; i_dim++){
+          KRATOS_CHECK_NEAR(model_part.GetNode(i_node+1).Coordinates()[i_dim], reference[i_node*2+i_dim], 1e-6);
+        }
+      }
+    }
+
+      KRATOS_TEST_CASE_IN_SUITE(MoveModelModelPartProcessOnlyRotation, CompressiblePotentialApplicationFastSuite)
+    {
+
+      Model this_model;
+      ModelPart& model_part = this_model.CreateModelPart("Main", 3);
+
+      // Nodes creation
+      model_part.CreateNewNode(1, 0.0, 0.0, 0.0);
+      model_part.CreateNewNode(2, 1.0, 0.0, 0.0);
+      model_part.CreateNewNode(3, -1.0, 0.0, 0.0);
+
+      // Process parameters
+      Parameters moving_parameters = Parameters(R"(
+        {
+            "origin"                        : [0.0,0.0,0.0],
+            "sizing_multiplier"             : 1.0
+
+        })" );
+
+      moving_parameters.AddEmptyValue("rotation_angle");
+      moving_parameters["rotation_angle"].SetDouble(Globals::Pi/6);
+
+      MoveModelPartProcess MoveModelPartProcess(model_part, moving_parameters);
+      MoveModelPartProcess.Execute();
+
+      std::array<double, 6> reference{0.0, 0.0, cos(Globals::Pi/6), sin(Globals::Pi/6) , -cos(Globals::Pi/6), -sin(Globals::Pi/6)};
 
       for (std::size_t i_node = 0; i_node<3; i_node++){
         for (std::size_t i_dim = 0; i_dim<2; i_dim++){


### PR DESCRIPTION
There was a wrong sign in the move_model_part_process in the PotentialFlow app. I did not realize about the error when writing the test at the time because I chose a 90º rotation that prevented the error from happening since cos(90)=0 anyway 😅. I have added a new test that would have failed with the wrong sign. 

This process should be replaced anyway with the transformation_utilities in the core soon. 