### PR TITLE
Updating deprecated timers in PFEM

### DIFF
--- a/applications/PfemFluidDynamicsApplication/python_scripts/pfem_check_and_prepare_model_process_fluid.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/pfem_check_and_prepare_model_process_fluid.py
@@ -9,14 +9,14 @@ def StartTimeMeasuring():
     """This function starts time calculation
     """
     # Measure process time
-    time_ip = timer.clock()
+    time_ip = timer.process_time()
     return time_ip
 
 def StopTimeMeasuring(time_ip, process, report):
     """This function ends time calculation
     """
     # Measure process time
-    time_fp = timer.clock()
+    time_fp = timer.process_time()
     if( report ):
         used_time = time_fp - time_ip
         print("::[PFEM_FLUID_MODEL]:: [ %.2f" % round(used_time,2),"s", process," ] ")

--- a/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_dynamics_analysis.py
+++ b/applications/PfemFluidDynamicsApplication/python_scripts/pfem_fluid_dynamics_analysis.py
@@ -27,7 +27,7 @@ class PfemFluidDynamicsAnalysis(AnalysisStage):
         # Time control starts
         self.KratosPrintInfo(timer.ctime())
         # Measure process time
-        self.t0p = timer.clock()
+        self.t0p = timer.process_time()
         # Measure wall time
         self.t0w = timer.time()
         #### TIME MONITORING END ####
@@ -228,7 +228,7 @@ class PfemFluidDynamicsAnalysis(AnalysisStage):
         #### END SOLUTION ####
 
         # Measure process time
-        tfp = timer.clock()
+        tfp = timer.process_time()
         # Measure wall time
         tfw = timer.time()
 
@@ -315,14 +315,14 @@ class PfemFluidDynamicsAnalysis(AnalysisStage):
         """This function starts time calculation
         """
         # Measure process time
-        time_ip = timer.clock()
+        time_ip = timer.process_time()
         return time_ip
 
     def StopTimeMeasuring(self, time_ip, process, report):
         """This function ends time calculation
         """
         # Measure process time
-        time_fp = timer.clock()
+        time_fp = timer.process_time()
         if report:
             used_time = time_fp - time_ip
             print("::[PFEM Simulation]:: [ %.2f" % round(used_time,2),"s", process," ] ")


### PR DESCRIPTION
This fixes some timers in the Pfem using the old time.clock which was deprecated in pyhon 3.3