### PR TITLE
Disable try/catch capture mode in debug.

### DIFF
--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -93,23 +93,20 @@ catch(Exception& e) { Block throw Exception(e) << KRATOS_CODE_LOCATION << MoreIn
 catch(std::exception& e) { Block KRATOS_THROW_ERROR(std::runtime_error, e.what(), MoreInfo) } \
 catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreInfo) }
 
-#ifdef KRATOS_DISABLE_TRYCATCH
-    #define KRATOS_CATCH_BLOCK_BEGIN
-    #define KRATOS_CATCH_BLOCK_END
+#ifdef KRATOS_DISABLE_CATCH
+    #define KRATOS_TRY { };
+    #define KRATOS_CATCH(MoreInfo) { };
 #else
-    #define KRATOS_CATCH_BLOCK_BEGIN class ExceptionBlock{public: void operator()(void){
-    #define KRATOS_CATCH_BLOCK_END }} exception_block; exception_block();
-#endif
+    #ifndef __SUNPRO_CC
+        #define KRATOS_TRY try {
 
-#ifndef __SUNPRO_CC
-#define KRATOS_TRY try {
+        #define KRATOS_CATCH(MoreInfo) \
+            KRATOS_CATCH_WITH_BLOCK(MoreInfo,{})
+    #else
+        #define KRATOS_TRY { };
 
-#define KRATOS_CATCH(MoreInfo) \
-  KRATOS_CATCH_WITH_BLOCK(MoreInfo,{})
-#else
-#define KRATOS_TRY { };
-
-#define KRATOS_CATCH(MoreInfo) { };
+        #define KRATOS_CATCH(MoreInfo) { };
+    #endif
 #endif
 
 //-----------------------------------------------------------------

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -93,12 +93,12 @@ catch(Exception& e) { Block throw Exception(e) << KRATOS_CODE_LOCATION << MoreIn
 catch(std::exception& e) { Block KRATOS_THROW_ERROR(std::runtime_error, e.what(), MoreInfo) } \
 catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreInfo) }
 
-#ifndef KRATOS_DEBUG
-    #define KRATOS_CATCH_BLOCK_BEGIN class ExceptionBlock{public: void operator()(void){
-    #define KRATOS_CATCH_BLOCK_END }} exception_block; exception_block();
-#else
+#ifdef KRATOS_DISABLE_TRYCATCH
     #define KRATOS_CATCH_BLOCK_BEGIN
     #define KRATOS_CATCH_BLOCK_END
+#else
+    #define KRATOS_CATCH_BLOCK_BEGIN class ExceptionBlock{public: void operator()(void){
+    #define KRATOS_CATCH_BLOCK_END }} exception_block; exception_block();
 #endif
 
 #ifndef __SUNPRO_CC

--- a/kratos/includes/define.h
+++ b/kratos/includes/define.h
@@ -93,8 +93,13 @@ catch(Exception& e) { Block throw Exception(e) << KRATOS_CODE_LOCATION << MoreIn
 catch(std::exception& e) { Block KRATOS_THROW_ERROR(std::runtime_error, e.what(), MoreInfo) } \
 catch(...) { Block KRATOS_THROW_ERROR(std::runtime_error, "Unknown error", MoreInfo) }
 
-#define KRATOS_CATCH_BLOCK_BEGIN class ExceptionBlock{public: void operator()(void){
-#define KRATOS_CATCH_BLOCK_END }} exception_block; exception_block();
+#ifndef KRATOS_DEBUG
+    #define KRATOS_CATCH_BLOCK_BEGIN class ExceptionBlock{public: void operator()(void){
+    #define KRATOS_CATCH_BLOCK_END }} exception_block; exception_block();
+#else
+    #define KRATOS_CATCH_BLOCK_BEGIN
+    #define KRATOS_CATCH_BLOCK_END
+#endif
 
 #ifndef __SUNPRO_CC
 #define KRATOS_TRY try {


### PR DESCRIPTION
Open for discussion

This prevents try catch from doing anything while in debug mode. My problems with the current implementation are the following:

- If I am debuging a code and it crashed, the try/catch block hides the line that caused the error and the exact error that caused it. I only get to see the class and the exception, which is fine for users but is useless for trying to fix it.
- If the error is happening in a class which does not have a try/catch block, the report indicate that the error is caused in the first class with a try/catch block in the call stack, which again can be fine for the final user but is misleading for a developer.
- While using it with a debuger it adds a level of indirection that prevents me from navigating the function stack at the moment of the crash and most of the time even prevents the debuger from being able to stop the execution at the crash point, as the exception will be handled before an automatic breakpoint can be set.

Adding a simple `ifdef` should solve all the problems above without affecting the current behavior in release