### PR TITLE
[Fluid] Two fluid wall condition

### DIFF
--- a/applications/FluidDynamicsApplication/CMakeLists.txt
+++ b/applications/FluidDynamicsApplication/CMakeLists.txt
@@ -52,6 +52,7 @@ set( KRATOS_FLUID_DYNAMICS_APPLICATION_CORE_SOURCES
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/stokes_wall_condition.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/fs_periodic_condition.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/navier_stokes_wall_condition.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/two_fluid_navier_stokes_wall_condition.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/custom_conditions/embedded_ausas_navier_stokes_wall_condition.cpp
 
 

--- a/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.h
@@ -334,6 +334,32 @@ protected:
 
     void ComputeRHSOutletInflowContribution(array_1d<double,TNumNodes*(TDim+1)>& rhs, const ConditionDataStruct& data);
 
+    /**
+     * @brief Computes the right-hand side of the Navier slip contribution as e.g. described in BEHR2004
+     * The (Navier) slip length is read as a nodal variable.
+     * If a smaller value is set, tangential velocities lead to a higher tangential traction.
+     * Though only tangential velocities should appear, a tangetial projection is added.
+     * (Reference BEHR2004: https://onlinelibrary.wiley.com/doi/abs/10.1002/fld.663)
+     * @param rRightHandSideVector reference to the RHS vector
+     * @param rDataStruct reference to a struct to hand over data
+     */
+    virtual void ComputeGaussPointNavierSlipRHSContribution(
+        array_1d<double, TNumNodes*(TDim+1)>& rRightHandSideVector,
+        const ConditionDataStruct& rDataStruct );
+
+    /**
+     * @brief Computes the left-hand side of the Navier slip contribution as e.g. described in BEHR2004
+     * The (Navier) slip length is read as a nodal variable.
+     * If a smaller value is set, tangential velocities lead to a higher tangential traction.
+     * Though only tangential velocities should appear, a tangetial projection is added.
+     * (Reference BEHR2004: https://onlinelibrary.wiley.com/doi/abs/10.1002/fld.663)
+     * @param rLeftHandSideMatrix reference to the LHS matrix
+     * @param rDataStruct reference to a struct to hand over data
+     */
+    virtual void ComputeGaussPointNavierSlipLHSContribution(
+        BoundedMatrix<double, TNumNodes*(TDim+1),TNumNodes*(TDim+1)>& rLeftHandSideMatrix,
+        const ConditionDataStruct& rDataStruct);
+
     ///@}
     ///@name Protected  Access
     ///@{
@@ -408,33 +434,6 @@ private:
      */
     void ComputeGaussPointBehrSlipRHSContribution(  array_1d<double,TNumNodes*(TDim+1)>& rRightHandSideVector,
                                                     const ConditionDataStruct& rDataStruct );
-
-
-
-    /**
-     * @brief Computes the right-hand side of the Navier slip contribution as e.g. described in BEHR2004
-     * The (Navier) slip length is read as a nodal variable.
-     * If a smaller value is set, tangential velocities lead to a higher tangential traction.
-     * Though only tangential velocities should appear, a tangetial projection is added.
-     * (Reference BEHR2004: https://onlinelibrary.wiley.com/doi/abs/10.1002/fld.663)
-     * @param rRightHandSideVector reference to the RHS vector
-     * @param rDataStruct reference to a struct to hand over data
-     */
-    void ComputeGaussPointNavierSlipRHSContribution(    array_1d<double,TNumNodes*(TDim+1)>& rRightHandSideVector,
-                                                        const ConditionDataStruct& rDataStruct );
-
-
-    /**
-     * @brief Computes the left-hand side of the Navier slip contribution as e.g. described in BEHR2004
-     * The (Navier) slip length is read as a nodal variable.
-     * If a smaller value is set, tangential velocities lead to a higher tangential traction.
-     * Though only tangential velocities should appear, a tangetial projection is added.
-     * (Reference BEHR2004: https://onlinelibrary.wiley.com/doi/abs/10.1002/fld.663)
-     * @param rLeftHandSideMatrix reference to the LHS matrix
-     * @param rDataStruct reference to a struct to hand over data
-     */
-    void ComputeGaussPointNavierSlipLHSContribution(    BoundedMatrix<double,TNumNodes*(TDim+1),TNumNodes*(TDim+1)>& rLeftHandSideMatrix,
-                                                        const ConditionDataStruct& rDataStruct );
 
     ///@}
     ///@name Private  Access

--- a/applications/FluidDynamicsApplication/custom_conditions/two_fluid_navier_stokes_wall_condition.cpp
+++ b/applications/FluidDynamicsApplication/custom_conditions/two_fluid_navier_stokes_wall_condition.cpp
@@ -1,0 +1,150 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+// System includes
+
+
+// External includes
+
+
+// Project includes
+#include "includes/checks.h"
+
+// Application includes
+#include "two_fluid_navier_stokes_wall_condition.h"
+
+
+namespace Kratos
+{
+
+template<unsigned int TDim, unsigned int TNumNodes>
+int TwoFluidNavierStokesWallCondition<TDim,TNumNodes>::Check(const ProcessInfo& rCurrentProcessInfo)
+{
+    KRATOS_TRY;
+
+    int check = BaseType::Check(rCurrentProcessInfo);
+    if (check != 0) {
+        return check;
+    } else {
+        // Checks on nodes        
+        const auto& r_geom = BaseType::GetGeometry();
+        for (const auto& r_node : r_geom) {
+            if(r_node.SolutionStepsDataHas(DYNAMIC_VISCOSITY) == false){
+                KRATOS_ERROR << "missing DYNAMIC_VISCOSITY variable on solution step data for node " << r_node.Id();
+            }
+        }
+
+        return check;
+    }
+
+    KRATOS_CATCH("");
+}
+
+template<unsigned int TDim, unsigned int TNumNodes>
+void TwoFluidNavierStokesWallCondition<TDim,TNumNodes>::ComputeGaussPointNavierSlipRHSContribution(
+    array_1d<double,TNumNodes*(TDim+1)>& rRightHandSideVector,
+    const ConditionDataStruct& rDataStruct )
+{
+    KRATOS_TRY
+
+    const auto& r_geom = this->GetGeometry();
+    const double zero_tol = 1.0e-12;
+    array_1d<double,3> nodal_normal;
+    BoundedMatrix<double, TNumNodes, TNumNodes> nodal_projection_matrix;
+    for (unsigned int i_node = 0; i_node < TNumNodes; i_node++){
+        // Finding the nodal tangential projection matrix (I - n x n)
+        nodal_normal = r_geom[i_node].FastGetSolutionStepValue(NORMAL);
+        const double norm = norm_2(nodal_normal);
+        if (norm > zero_tol) {
+            nodal_normal /= norm;
+        }
+        FluidElementUtilities<3>::SetTangentialProjectionMatrix(nodal_normal, nodal_projection_matrix);
+
+        // Finding the coefficent to relate velocity to drag
+        const double viscosity = r_geom[i_node].GetSolutionStepValue(DYNAMIC_VISCOSITY);
+        const double navier_slip_length = r_geom[i_node].GetValue(SLIP_LENGTH);
+        KRATOS_ERROR_IF_NOT( navier_slip_length > 0.0 ) << "Negative or zero slip length was defined" << std::endl;
+        const double nodal_beta = viscosity / navier_slip_length;
+
+        const array_1d<double, TNumNodes> N = rDataStruct.N;
+        const double wGauss = rDataStruct.wGauss;
+        Vector interpolated_velocity = ZeroVector(TNumNodes);
+        for( unsigned int comp = 0; comp < TNumNodes; comp++){
+            for (unsigned int i = 0; i < TNumNodes; i++){
+                // necessary because VELOCITY with 3 entries even in 2D case
+                interpolated_velocity[i] -= N[comp] * r_geom[comp].FastGetSolutionStepValue(VELOCITY)[i];
+            }
+        }
+        // Application of the nodal projection matrix
+        const array_1d<double,TNumNodes> nodal_entry_rhs = prod( nodal_projection_matrix, (wGauss * N[i_node] * nodal_beta * interpolated_velocity) );
+        for (unsigned int entry = 0; entry < TNumNodes; entry++){
+            rRightHandSideVector( i_node*(TNumNodes+1) + entry ) += nodal_entry_rhs[entry];
+        }
+    }
+
+    KRATOS_CATCH("")
+}
+
+
+template<unsigned int TDim, unsigned int TNumNodes>
+void TwoFluidNavierStokesWallCondition<TDim,TNumNodes>::ComputeGaussPointNavierSlipLHSContribution(
+    BoundedMatrix<double,TNumNodes*(TDim+1),TNumNodes*(TDim+1)>& rLeftHandSideMatrix,
+    const ConditionDataStruct& rDataStruct )
+{
+    KRATOS_TRY
+
+    const GeometryType& r_geom = this->GetGeometry();
+
+    array_1d<double, TNumNodes> N = rDataStruct.N;
+    const double wGauss = rDataStruct.wGauss;
+
+    for(unsigned int inode = 0; inode < TNumNodes; inode++){
+
+        // finding the nodal projection matrix nodal_projection_matrix = ( [I] - (na)(na) )
+        BoundedMatrix<double, TNumNodes, TNumNodes> nodal_projection_matrix;
+        array_1d<double,3> nodal_normal = r_geom[inode].FastGetSolutionStepValue(NORMAL);
+        double sum_of_squares = 0.0;
+        for (unsigned int j = 0; j < 3; j++){
+            sum_of_squares += nodal_normal[j] * nodal_normal[j];
+        }
+        nodal_normal /= sqrt(sum_of_squares);
+        FluidElementUtilities<3>::SetTangentialProjectionMatrix( nodal_normal, nodal_projection_matrix );
+
+        // finding the coefficent to relate velocity to drag
+        const double viscosity = r_geom[inode].GetSolutionStepValue(DYNAMIC_VISCOSITY);
+        const double navier_slip_length = r_geom[inode].GetValue(SLIP_LENGTH);
+        KRATOS_ERROR_IF_NOT( navier_slip_length > 0.0 ) << "Negative or zero slip length was defined" << std::endl;
+        const double nodal_beta = viscosity / navier_slip_length;
+
+        for(unsigned int jnode = 0; jnode < TNumNodes; jnode++){
+
+            const BoundedMatrix<double, TNumNodes, TNumNodes> nodal_lhs_contribution = wGauss * nodal_beta * N[inode] * N[jnode] * nodal_projection_matrix;
+
+            for( unsigned int i = 0; i < TNumNodes; i++){
+                for( unsigned int j = 0; j < TNumNodes; j++){
+
+                    const unsigned int istart = inode * (TNumNodes+1);
+                    const unsigned int jstart = jnode * (TNumNodes+1);
+                    rLeftHandSideMatrix(istart + i, jstart + j) += nodal_lhs_contribution(i,j);
+                }
+            }
+        }
+    }
+
+    KRATOS_CATCH("")
+}
+
+
+template class TwoFluidNavierStokesWallCondition<2,2>;
+template class TwoFluidNavierStokesWallCondition<3,3>;
+
+} // namespace Kratos

--- a/applications/FluidDynamicsApplication/custom_conditions/two_fluid_navier_stokes_wall_condition.h
+++ b/applications/FluidDynamicsApplication/custom_conditions/two_fluid_navier_stokes_wall_condition.h
@@ -1,0 +1,416 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ \.
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Ruben Zorrilla
+//
+
+#ifndef KRATOS_TWO_FLUIDS_NAVIER_STOKES_WALL_CONDITION_H
+#define KRATOS_TWO_FLUIDS_NAVIER_STOKES_WALL_CONDITION_H
+
+// System includes
+#include <string>
+#include <iostream>
+
+
+// External includes
+
+
+// Project includes
+// #include "includes/define.h"
+// #include "includes/condition.h"
+// #include "includes/model_part.h"
+// #include "includes/serializer.h"
+// #include "includes/process_info.h"
+
+// Application includes
+#include "custom_conditions/navier_stokes_wall_condition.h"
+
+namespace Kratos
+{
+///@addtogroup FluidDynamicsApplication
+///@{
+
+///@name Kratos Globals
+///@{
+
+
+///@}
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name  Enum's
+///@{
+
+
+///@}
+///@name  Functions
+///@{
+
+
+///@}
+///@name Kratos Classes
+///@{
+
+/// Implements a wall condition for the Navier-Stokes monolithic formulation.
+/**
+  It is intended to be used in combination with ASGS Navier-Stokes symbolic elements or their
+  derived classes and the ResidualBasedIncrementalUpdateStaticSchemeSlip time scheme, which supports
+  slip conditions.
+  @see NavierStokes,EmbeddedNavierStokes,ResidualBasedIncrementalUpdateStaticSchemeSlip
+ */
+template< unsigned int TDim, unsigned int TNumNodes>
+class KRATOS_API(FLUID_DYNAMICS_APPLICATION) TwoFluidNavierStokesWallCondition : public NavierStokesWallCondition<TDim, TNumNodes>
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of TwoFluidNavierStokesWallCondition
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(TwoFluidNavierStokesWallCondition);
+
+    typedef NavierStokesWallCondition<TDim, TNumNodes> BaseType;
+
+    typedef typename BaseType::ConditionDataStruct ConditionDataStruct;
+
+    typedef Node<3> NodeType;
+
+    typedef Properties PropertiesType;
+
+    typedef Geometry<NodeType> GeometryType;
+
+    typedef Geometry<NodeType>::PointsArrayType NodesArrayType;
+
+    typedef Vector VectorType;
+
+    typedef Matrix MatrixType;
+
+    typedef std::size_t IndexType;
+
+    typedef std::vector<std::size_t> EquationIdVectorType;
+
+    typedef std::vector< Dof<double>::Pointer > DofsVectorType;
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    /** Admits an Id as a parameter.
+      @param NewId Index for the new         // Struct to pass around the data
+        ElementDataStruct data;
+        this->FillElementData(data, rCurrentProcessInfo);condition
+      */
+    TwoFluidNavierStokesWallCondition(IndexType NewId = 0)
+        : NavierStokesWallCondition<TDim, TNumNodes>(NewId)
+    {
+    }
+
+    /// Constructor using an array of nodes
+    /**
+     @param NewId Index of the new condition
+     @param ThisNodes An array containing the nodes of the new condition
+     */
+    TwoFluidNavierStokesWallCondition(
+        IndexType NewId,
+        const NodesArrayType& ThisNodes)
+        : NavierStokesWallCondition<TDim, TNumNodes>(NewId, ThisNodes)
+    {
+    }
+
+    /// Constructor using Geometry
+    /**
+     @param NewId Index of the new condition
+     @param pGeometry Pointer to a geometry object
+     */
+    TwoFluidNavierStokesWallCondition(
+        IndexType NewId,
+        GeometryType::Pointer pGeometry)
+        : NavierStokesWallCondition<TDim, TNumNodes>(NewId, pGeometry)
+    {
+    }
+
+    /// Constructor using Properties
+    /**
+     @param NewId Index of the new element
+     @param pGeometry Pointer to a geometry object
+     @param pProperties Pointer to the element's properties
+     */
+    TwoFluidNavierStokesWallCondition(
+        IndexType NewId,
+        GeometryType::Pointer pGeometry,
+        PropertiesType::Pointer pProperties)
+        : NavierStokesWallCondition<TDim, TNumNodes>(NewId, pGeometry, pProperties)
+    {
+    }
+
+    /// Copy constructor.
+    TwoFluidNavierStokesWallCondition(TwoFluidNavierStokesWallCondition const& rOther):
+        NavierStokesWallCondition<TDim, TNumNodes>(rOther)
+    {
+    }
+
+    /// Destructor.
+    ~TwoFluidNavierStokesWallCondition() override {}
+
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+    /// Assignment operator
+    TwoFluidNavierStokesWallCondition & operator=(TwoFluidNavierStokesWallCondition const& rOther)
+    {
+        Condition::operator=(rOther);
+        return *this;
+    }
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    /// Create a new TwoFluidNavierStokesWallCondition object.
+    /**
+      @param NewId Index of the new condition
+      @param ThisNodes An array containing the nodes of the new condition
+      @param pProperties Pointer to the element's properties
+      */
+    Condition::Pointer Create(
+        IndexType NewId,
+        NodesArrayType const& ThisNodes,
+        PropertiesType::Pointer pProperties) const override
+    {
+        return Kratos::make_intrusive<TwoFluidNavierStokesWallCondition>(NewId, BaseType::GetGeometry().Create(ThisNodes), pProperties);
+    }
+
+    /// Create a new TwoFluidNavierStokesWallCondition object.
+    /**
+      @param NewId Index of the new condition
+      @param pGeom A pointer to the condition's geometry
+      @param pProperties Pointer to the element's properties
+      */
+    Condition::Pointer Create(
+        IndexType NewId,
+        GeometryType::Pointer pGeom,
+        PropertiesType::Pointer pProperties) const override
+    {
+        return Kratos::make_intrusive< TwoFluidNavierStokesWallCondition >(NewId, pGeom, pProperties);
+    }
+
+    /**
+     * Clones the selected element variables, creating a new one
+     * @param NewId the ID of the new element
+     * @param ThisNodes the nodes of the new element
+     * @return a Pointer to the new element
+     */
+    Condition::Pointer Clone(
+        IndexType NewId,
+        NodesArrayType const& rThisNodes) const override
+    {
+        Condition::Pointer pNewCondition = Create(NewId, BaseType::GetGeometry().Create( rThisNodes ), BaseType::pGetProperties() );
+
+        pNewCondition->SetData(this->GetData());
+        pNewCondition->SetFlags(this->GetFlags());
+
+        return pNewCondition;
+    }
+
+    /**
+     * @brief Condition check
+     * Condition check. Derived from the base Navier-Stokes condition to check if the viscosity is a nodal variable
+     * @param rCurrentProcessInfo Reference to the ProcessInfo container
+     * @return int 0 if successful
+     */
+    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    std::string Info() const override
+    {
+        std::stringstream buffer;
+        buffer << "TwoFluidNavierStokesWallCondition" << TDim << "D";
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    void PrintInfo(std::ostream& rOStream) const override
+    {
+        rOStream << "TwoFluidNavierStokesWallCondition";
+    }
+
+    /// Print object's data.
+    void PrintData(std::ostream& rOStream) const override {}
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+    /**
+     * @brief Computes the right-hand side of the Navier slip contribution as e.g. described in BEHR2004
+     * The (Navier) slip length is read as a nodal variable.
+     * If a smaller value is set, tangential velocities lead to a higher tangential traction.
+     * Though only tangential velocities should appear, a tangetial projection is added.
+     * (Reference BEHR2004: https://onlinelibrary.wiley.com/doi/abs/10.1002/fld.663)
+     * @param rRightHandSideVector reference to the RHS vector
+     * @param rDataStruct reference to a struct to hand over data
+     */
+    void ComputeGaussPointNavierSlipRHSContribution(
+        array_1d<double,TNumNodes*(TDim+1)>& rRightHandSideVector,
+        const ConditionDataStruct& rDataStruct) override;
+
+    /**
+     * @brief Computes the left-hand side of the Navier slip contribution as e.g. described in BEHR2004
+     * The (Navier) slip length is read as a nodal variable.
+     * If a smaller value is set, tangential velocities lead to a higher tangential traction.
+     * Though only tangential velocities should appear, a tangetial projection is added.
+     * (Reference BEHR2004: https://onlinelibrary.wiley.com/doi/abs/10.1002/fld.663)
+     * @param rLeftHandSideMatrix reference to the LHS matrix
+     * @param rDataStruct reference to a struct to hand over data
+     */
+    void ComputeGaussPointNavierSlipLHSContribution(
+        BoundedMatrix<double,TNumNodes*(TDim+1),TNumNodes*(TDim+1)>& rLeftHandSideMatrix,
+        const ConditionDataStruct& rDataStruct ) override;
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Serialization
+    ///@{
+
+    friend class Serializer;
+
+    void save(Serializer& rSerializer) const override
+    {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS(rSerializer, Condition );
+    }
+
+    void load(Serializer& rSerializer) override
+    {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS(rSerializer, Condition );
+    }
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+
+    ///@}
+}; // Class TwoFluidNavierStokesWallCondition
+
+///@}
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+/// input stream function
+template< unsigned int TDim, unsigned int TNumNodes >
+inline std::istream& operator >> (std::istream& rIStream, TwoFluidNavierStokesWallCondition<TDim,TNumNodes>& rThis)
+{
+    return rIStream;
+}
+
+/// output stream function
+template< unsigned int TDim, unsigned int TNumNodes >
+inline std::ostream& operator << (std::ostream& rOStream, const TwoFluidNavierStokesWallCondition<TDim,TNumNodes>& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+
+///@}
+///@} addtogroup block
+}  // namespace Kratos.
+
+#endif // KRATOS_TWO_FLUIDS_NAVIER_STOKES_WALL_CONDITION_H

--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.cpp
@@ -115,6 +115,8 @@ KratosFluidDynamicsApplication::KratosFluidDynamicsApplication():
     // Two-Fluid Navier-Stokes symbolic elements
     mTwoFluidNavierStokes2D3N(0, Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mTwoFluidNavierStokes3D4N(0, Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+    mTwoFluidNavierStokesWallCondition2D(0, Element::GeometryType::Pointer(new Line2D2<Node<3>>(Element::GeometryType::PointsArrayType(2)))),
+    mTwoFluidNavierStokesWallCondition3D(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3>>(Element::GeometryType::PointsArrayType(3)))),
     mVMSAdjointElement2D(0,Element::GeometryType::Pointer(new Triangle2D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
     mVMSAdjointElement3D(0,Element::GeometryType::Pointer(new Tetrahedra3D4<Node<3> >(Element::GeometryType::PointsArrayType(4))))
 
@@ -292,6 +294,8 @@ void KratosFluidDynamicsApplication::Register() {
     KRATOS_REGISTER_CONDITION("MonolithicWallCondition3D", mMonolithicWallCondition3D);
     KRATOS_REGISTER_CONDITION("NavierStokesWallCondition2D2N", mNavierStokesWallCondition2D);
     KRATOS_REGISTER_CONDITION("NavierStokesWallCondition3D3N", mNavierStokesWallCondition3D);
+    KRATOS_REGISTER_CONDITION("TwoFluidNavierStokesWallCondition2D2N", mTwoFluidNavierStokesWallCondition2D);
+    KRATOS_REGISTER_CONDITION("TwoFluidNavierStokesWallCondition3D3N", mTwoFluidNavierStokesWallCondition3D);
     KRATOS_REGISTER_CONDITION("EmbeddedAusasNavierStokesWallCondition2D2N", mEmbeddedAusasNavierStokesWallCondition2D);
     KRATOS_REGISTER_CONDITION("EmbeddedAusasNavierStokesWallCondition3D3N", mEmbeddedAusasNavierStokesWallCondition3D);
     KRATOS_REGISTER_CONDITION("StokesWallCondition3D", mStokesWallCondition3D);

--- a/applications/FluidDynamicsApplication/fluid_dynamics_application.h
+++ b/applications/FluidDynamicsApplication/fluid_dynamics_application.h
@@ -56,6 +56,7 @@
 #include "custom_conditions/wall_condition_discontinuous.h"
 #include "custom_conditions/monolithic_wall_condition.h"
 #include "custom_conditions/stokes_wall_condition.h"
+#include "custom_conditions/two_fluid_navier_stokes_wall_condition.h"
 #include "custom_conditions/fs_periodic_condition.h"
 #include "custom_conditions/navier_stokes_wall_condition.h"
 #include "custom_conditions/embedded_ausas_navier_stokes_wall_condition.h"
@@ -383,6 +384,8 @@ private:
     /// Two Fluid Navier-Stokes symbolic element
     const TwoFluidNavierStokes< TwoFluidNavierStokesData<2, 3> > mTwoFluidNavierStokes2D3N;
     const TwoFluidNavierStokes< TwoFluidNavierStokesData<3, 4> > mTwoFluidNavierStokes3D4N;
+    const TwoFluidNavierStokesWallCondition<2, 2> mTwoFluidNavierStokesWallCondition2D;
+    const TwoFluidNavierStokesWallCondition<3, 3> mTwoFluidNavierStokesWallCondition3D;
 
     const VMSAdjointElement<2> mVMSAdjointElement2D;
     const VMSAdjointElement<3> mVMSAdjointElement3D;

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_two_fluids_solver.py
@@ -82,7 +82,7 @@ class NavierStokesTwoFluidsSolver(FluidSolver):
         super(NavierStokesTwoFluidsSolver,self).__init__(model,custom_settings)
 
         self.element_name = "TwoFluidNavierStokes"
-        self.condition_name = "NavierStokesWallCondition"
+        self.condition_name = "TwoFluidNavierStokesWallCondition"
         self.element_integrates_in_time = True
         self.element_has_nodal_properties = True
 


### PR DESCRIPTION
I've created a new condition for the two fluid elements that derives from the standard Navier-Stokes one.

The point is that the Navier-slip contribution requires the viscosity to be stored in the nodes in the two-fluids case while in the single fluid one this can be stored in the element properties. As it is right now, the Navier-Stokes element throws segfault when using it in combination with slip conditions. 

This change avoids the useless memory consumption in the single fluid case and allows to use it with slip (and Navier-slip) walls.

@mrhashemi and @ddiezrod I think that this may be also useful in case we need to do some 2-fluids specific wall implementation.
@sunethwarna I will create a new PR to make the `assign_neighbours_to_conditions` by default as we discussed some days ago. This is also required to add the Behr contribution to the Navier-Stokes wall condition.