### PR TITLE
[MeshingApplication][MMG]  Adding Windows configure file to compile mmg and updating readme

### DIFF
--- a/applications/MeshingApplication/custom_external_libraries/mmg/README.md
+++ b/applications/MeshingApplication/custom_external_libraries/mmg/README.md
@@ -18,6 +18,20 @@ or:
 Add the following to the main Kratos configure.sh: 
 
 	-DINCLUDE_MMG=ON                                                                  \
+	-DMMG_ROOT="path/to/mmg/"
+
+
+## Error 1: Kratos cannot find the MMG libraries automatically
+Double-check where and how the MMG libraries were compiled on your system. If MMG libraries were not written in the format "libmmg" or "libmmg3d", you can specify the correct prefix with the following configuration:
+
+	-DINCLUDE_MMG=ON                                                                  \
+	-DMMG_ROOT="path/to/mmg/"	 						  \
+	-DMMG_LIBRARY_PREFIX=""
+	
+
+## Error 2: Kratos cannot find the MMG libraries automatically even if I specify the correct prefix
+If any of the MMG libraries cannot be found, you can explicitily set them in the Kratos configure: 
+
 	-DMMG_INCLUDE_DIR="installation_directory/mmg/include/"\
 	-DMMG2D_INCLUDE_DIR="installation_directory/mmg/include/mmg/mmg2d/"\
 	-DMMG3D_INCLUDE_DIR="installation_directory/mmg/include/mmg/mmg3d/"\
@@ -26,4 +40,3 @@ Add the following to the main Kratos configure.sh:
 	-DMMG2D_LIBRARY="installation_directory/mmg/lib/libmmg2d.a" \
 	-DMMG3D_LIBRARY="installation_directoryl_libraries/mmg/lib/libmmg3d.a" \
 	-DMMGS_LIBRARY="installation_directory/mmg/lib/libmmgs.a"   \
-

--- a/applications/MeshingApplication/custom_external_libraries/mmg/README.md
+++ b/applications/MeshingApplication/custom_external_libraries/mmg/README.md
@@ -30,7 +30,7 @@ Double-check where and how the MMG libraries were compiled on your system. If MM
 	
 
 ## Error 2: Kratos cannot find the MMG libraries automatically even if I specify the correct prefix
-If any of the MMG libraries cannot be found, you can explicitily set them in the Kratos configure: 
+If any of the MMG libraries cannot be found, you can explicitly set them in the Kratos configure: 
 
 	-DMMG_INCLUDE_DIR="installation_directory/mmg/include/"\
 	-DMMG2D_INCLUDE_DIR="installation_directory/mmg/include/mmg/mmg2d/"\

--- a/applications/MeshingApplication/custom_external_libraries/mmg/build/configure.bat
+++ b/applications/MeshingApplication/custom_external_libraries/mmg/build/configure.bat
@@ -1,0 +1,19 @@
+del CMakeCache.txt
+
+cls
+
+cmake .. -G"Visual Studio 16 2019" -A x64   ^
+-DCMAKE_BUILD_TYPE=Release                  ^
+-DCMAKE_CXX_FLAGS="-O3"                     ^
+-DCMAKE_C_FLAGS="-O3"                       ^
+-DUSE_SCOTCH=OFF                            ^
+-DLIBMMG_SHARED=OFF                         ^
+-DLIBMMG_STATIC=ON                          ^
+-DLIBMMGS_SHARED=OFF                        ^
+-DLIBMMGS_STATIC=ON                         ^
+-DLIBMMG2D_SHARED=OFF                       ^
+-DLIBMMG2D_STATIC=ON                        ^
+-DLIBMMG3D_SHARED=OFF                       ^
+-DLIBMMG3D_STATIC=ON                                   
+
+cmake --build . --target install -- /property:configuration=Release /p:Platform=x64


### PR DESCRIPTION
Adding the Windows-equivalent [configure.sh](https://github.com/KratosMultiphysics/Kratos/blob/master/applications/MeshingApplication/custom_external_libraries/mmg/build/configure.sh) that we have in the repo to build MMG with Linux.

These files are used[ in the Wiki instructions to install MMG](https://github.com/KratosMultiphysics/Kratos/wiki/%5BUtilities%5D-MMG-Process).

I also updated the README in this folder and will update the Kratos Wiki accordingly after this is merged. 