### PR TITLE
[Fluid] Remove useless nodal material properties

### DIFF
--- a/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.cpp
+++ b/applications/FluidDynamicsApplication/custom_conditions/navier_stokes_wall_condition.cpp
@@ -81,6 +81,12 @@ void NavierStokesWallCondition<TDim,TNumNodes>::CalculateLocalSystem(MatrixType&
     if (rRightHandSideVector.size() != MatrixSize)
         rRightHandSideVector.resize(MatrixSize, false); //false says not to preserve existing storage!!
 
+    // Check that parents have been computed
+    // These are required to retrieve the material properties and the viscous stress
+    auto& parentElement = this->GetValue(NEIGHBOUR_ELEMENTS);
+    KRATOS_ERROR_IF(parentElement.size() > 1) << "A condition was assigned more than one parent element." << std::endl;
+    KRATOS_ERROR_IF(parentElement.size() == 0) << "A condition was NOT assigned a parent element. Please execute the check_and_prepare_model_process_fluid process." << std::endl;
+
     // Struct to pass around the data
     ConditionDataStruct data;
     // Allocate memory needed
@@ -111,12 +117,6 @@ void NavierStokesWallCondition<TDim,TNumNodes>::CalculateLocalSystem(MatrixType&
 
     if ( this->Is(SLIP) ){
         // finding parent element to retrieve viscous stresses which are later stored in "data"
-        GlobalPointersVector<Element> parentElement = this->GetValue( NEIGHBOUR_ELEMENTS );
-        KRATOS_ERROR_IF( parentElement.size() > 1 ) << "A condition was assigned more than one parent element." << std::endl;
-        KRATOS_ERROR_IF( parentElement.size() == 0 ) << "A condition was NOT assigned a parent element. "
-        << "This leads to errors for the slip condition [BEHR2004] "
-        << "Please execute the check_and_prepare_model_process_fluid process." << std::endl;
-
         Element& parent = parentElement[0];
         data.ViscousStress = ZeroVector( 3*(TDim-1) );
         parent.Calculate(FLUID_STRESS, data.ViscousStress, rCurrentProcessInfo);
@@ -394,20 +394,22 @@ void NavierStokesWallCondition<TDim,TNumNodes>::ComputeRHSNeumannContribution(ar
 
 
 template<unsigned int TDim, unsigned int TNumNodes>
-void NavierStokesWallCondition<TDim,TNumNodes>::ComputeRHSOutletInflowContribution(array_1d<double,TNumNodes*(TDim+1)>& rhs_gauss,
-                                                                                   const ConditionDataStruct& data)
+void NavierStokesWallCondition<TDim,TNumNodes>::ComputeRHSOutletInflowContribution(
+    array_1d<double,TNumNodes*(TDim+1)>& rhs_gauss,
+    const ConditionDataStruct& data)
 {
     const unsigned int LocalSize = TDim+1;
     const GeometryType& rGeom = this->GetGeometry();
 
+    // Get DENSITY from parent element properties
+    auto & r_neighbours = this->GetValue(NEIGHBOUR_ELEMENTS);
+    const double rho = r_neighbours[0].GetProperties().GetValue(DENSITY);
+
     // Compute Gauss pt. density, velocity norm and velocity projection
-    double rhoGauss = 0.0;
     array_1d<double, 3> vGauss = ZeroVector(3);
     for (unsigned int i=0; i<TNumNodes; ++i)
     {
-        const double& rRho = rGeom[i].FastGetSolutionStepValue(DENSITY);
         const array_1d<double, 3>& rVelNode = rGeom[i].FastGetSolutionStepValue(VELOCITY);
-        rhoGauss += data.N[i]*rRho;
         vGauss += data.N[i]*rVelNode;
     }
 
@@ -424,7 +426,7 @@ void NavierStokesWallCondition<TDim,TNumNodes>::ComputeRHSOutletInflowContributi
         unsigned int row = i*LocalSize;
         for (unsigned int d=0; d<TDim; ++d)
         {
-            rhs_gauss[row+d] += data.wGauss*data.N[i]*0.5*rhoGauss*vGaussSquaredNorm*S_0*data.Normal[d];
+            rhs_gauss[row+d] += data.wGauss*data.N[i]*0.5*rho*vGaussSquaredNorm*S_0*data.Normal[d];
         }
     }
 }

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla
 //
@@ -124,10 +124,10 @@ void EmbeddedAusasNavierStokes<3>::ComputeGaussPointLHSContribution(
     constexpr unsigned int dim = 3;
     constexpr unsigned int nnodes = 4;
 
-    const double rho = data.rho;                            // Density
-    const double mu = data.mu;                              // Dynamic viscosity
-    const double h = data.h;                                // Characteristic element size
-    const double c = data.c;                                // Wave velocity
+    const double rho = data.rho; // Density
+    const double mu = data.mu;   // Dynamic viscosity
+    const double h = data.h;     // Characteristic element size
+    const double c = data.c;     // Wave velocity
 
     const double& dt = data.dt;
     const double& bdf0 = data.bdf0;
@@ -756,10 +756,10 @@ void EmbeddedAusasNavierStokes<2>::ComputeGaussPointLHSContribution(
     constexpr unsigned int dim = 2;
     constexpr unsigned int nnodes = 3;
 
-    const double rho = data.rho;        // Density
-    const double mu = data.mu;          // Dynamic viscosity
-    const double h = data.h;                                // Characteristic element size
-    const double c = data.c;                                // Wave velocity
+    const double rho = data.rho; // Density
+    const double mu = data.mu;   // Dynamic viscosity
+    const double h = data.h;     // Characteristic element size
+    const double c = data.c;     // Wave velocity
 
     const double& dt = data.dt;
     const double& bdf0 = data.bdf0;
@@ -1008,10 +1008,10 @@ void EmbeddedAusasNavierStokes<3>::ComputeGaussPointRHSContribution(
     constexpr int nnodes = 4;
     constexpr int strain_size = 6;
 
-    const double rho = data.rho;        // Density
-    const double mu = data.mu;          // Dynamic viscosity
-    const double h = data.h;                                // Characteristic element size
-    const double c = data.c;                                // Wave velocity
+    const double rho = data.rho; // Density
+    const double mu = data.mu;   // Dynamic viscosity
+    const double h = data.h;     // Characteristic element size
+    const double c = data.c;     // Wave velocity
 
     const double& dt = data.dt;
     const double& bdf0 = data.bdf0;
@@ -1113,10 +1113,10 @@ void EmbeddedAusasNavierStokes<2>::ComputeGaussPointRHSContribution(
     constexpr int nnodes = 3;
     constexpr int strain_size = 3;
 
-    const double rho = data.rho;        // Density
-    const double mu = data.mu;          // Dynamic viscosity
-    const double h = data.h;                                // Characteristic element size
-    const double c = data.c;                                // Wave velocity
+    const double rho = data.rho; // Density
+    const double mu = data.mu;   // Dynamic viscosity
+    const double h = data.h;     // Characteristic element size
+    const double c = data.c;     // Wave velocity
 
     const double& dt = data.dt;
     const double& bdf0 = data.bdf0;

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.cpp
@@ -124,8 +124,8 @@ void EmbeddedAusasNavierStokes<3>::ComputeGaussPointLHSContribution(
     constexpr unsigned int dim = 3;
     constexpr unsigned int nnodes = 4;
 
-    const double rho = inner_prod(data.N, data.rho);        // Density
-    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double rho = data.rho;                            // Density
+    const double mu = data.mu;                              // Dynamic viscosity
     const double h = data.h;                                // Characteristic element size
     const double c = data.c;                                // Wave velocity
 
@@ -756,8 +756,8 @@ void EmbeddedAusasNavierStokes<2>::ComputeGaussPointLHSContribution(
     constexpr unsigned int dim = 2;
     constexpr unsigned int nnodes = 3;
 
-    const double rho = inner_prod(data.N, data.rho);        // Density
-    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double rho = data.rho;        // Density
+    const double mu = data.mu;          // Dynamic viscosity
     const double h = data.h;                                // Characteristic element size
     const double c = data.c;                                // Wave velocity
 
@@ -1008,8 +1008,8 @@ void EmbeddedAusasNavierStokes<3>::ComputeGaussPointRHSContribution(
     constexpr int nnodes = 4;
     constexpr int strain_size = 6;
 
-    const double rho = inner_prod(data.N, data.rho);        // Density
-    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double rho = data.rho;        // Density
+    const double mu = data.mu;          // Dynamic viscosity
     const double h = data.h;                                // Characteristic element size
     const double c = data.c;                                // Wave velocity
 
@@ -1113,8 +1113,8 @@ void EmbeddedAusasNavierStokes<2>::ComputeGaussPointRHSContribution(
     constexpr int nnodes = 3;
     constexpr int strain_size = 3;
 
-    const double rho = inner_prod(data.N, data.rho);        // Density
-    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double rho = data.rho;        // Density
+    const double mu = data.mu;          // Dynamic viscosity
     const double h = data.h;                                // Characteristic element size
     const double c = data.c;                                // Wave velocity
 

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
@@ -76,7 +76,7 @@ public:
     struct EmbeddedAusasElementDataStruct {
 
         BoundedMatrix<double, TNumNodes, TDim> v, vn, vnn, vmesh, f;
-        array_1d<double,TNumNodes> p, pn, pnn, rho, mu;
+        array_1d<double,TNumNodes> p, pn, pnn;
 
         array_1d<double, TNumNodes>                 N;        // Shape functions values on Gauss pt. container
         BoundedMatrix<double, TNumNodes, TDim>     DN_DX;    // Shape functions gradients values on Gauss pt. container
@@ -93,6 +93,8 @@ public:
         double volume;        // In 2D: element area. In 3D: element volume
         double dt;            // Time increment
         double dyn_tau;       // Dynamic tau considered in ASGS stabilization coefficients
+        double mu;            // Dynamic viscosity
+        double rho;           // Density
 
         // No splitted elements geometry data containers
         VectorType                      w_gauss;       // No splitted element Gauss pts. weights values
@@ -480,6 +482,11 @@ protected:
 
         rData.c = rCurrentProcessInfo[SOUND_VELOCITY];      // Wave velocity
 
+        // Material properties
+        const auto& r_prop = GetProperties();
+        rData.rho = r_prop.GetValue(DENSITY);
+        rData.mu = r_prop.GetValue(DYNAMIC_VISCOSITY);
+
         for (unsigned int i = 0; i < TNumNodes; i++) {
 
             const array_1d<double,3>& body_force = r_geom[i].FastGetSolutionStepValue(BODY_FORCE);
@@ -499,8 +506,6 @@ protected:
             rData.p[i] = r_geom[i].FastGetSolutionStepValue(PRESSURE);
             rData.pn[i] = r_geom[i].FastGetSolutionStepValue(PRESSURE,1);
             rData.pnn[i] = r_geom[i].FastGetSolutionStepValue(PRESSURE,2);
-            rData.rho[i] = r_geom[i].FastGetSolutionStepValue(DENSITY);
-            rData.mu[i] = r_geom[i].FastGetSolutionStepValue(DYNAMIC_VISCOSITY);
         }
 
         // Getting the nodal distances vector
@@ -1107,26 +1112,18 @@ protected:
         }
 
         // Compute the element average values
-        double avg_rho = 0.0;
-        double avg_visc = 0.0;
         array_1d<double, TDim> avg_vel = ZeroVector(TDim);
-
         for (unsigned int i_node = 0; i_node < TNumNodes; ++i_node) {
-            avg_rho += rData.rho(i_node);
-            avg_visc += rData.mu(i_node);
             avg_vel += row(rData.v, i_node);
         }
-
-        avg_rho /= TNumNodes;
-        avg_visc /= TNumNodes;
         avg_vel /= TNumNodes;
 
         const double v_norm = norm_2(avg_vel);
 
         // Compute the penalty constant
-        const double pen_cons = avg_rho*std::pow(rData.h, TDim)/rData.dt +
-                                avg_visc*std::pow(rData.h,TDim-2) +
-                                avg_rho*v_norm*std::pow(rData.h, TDim-1);
+        const double pen_cons = rData.rho*std::pow(rData.h, TDim)/rData.dt +
+                                rData.mu*std::pow(rData.h,TDim-2) +
+                                rData.rho*v_norm*std::pow(rData.h, TDim-1);
 
         // Return the penalty coefficient
         const double K = rCurrentProcessInfo[PENALTY_COEFFICIENT];

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_navier_stokes.h
@@ -598,26 +598,18 @@ protected:
         }
 
         // Compute the element average values
-        double avg_rho = 0.0;
-        double avg_visc = 0.0;
         array_1d<double, TDim> avg_vel = ZeroVector(TDim);
-
         for (unsigned int i_node = 0; i_node < TNumNodes; ++i_node) {
-            avg_rho += rData.rho(i_node);
-            avg_visc += rData.mu(i_node);
             avg_vel += row(rData.v, i_node);
         }
-
-        avg_rho /= TNumNodes;
-        avg_visc /= TNumNodes;
         avg_vel /= TNumNodes;
 
         const double v_norm = norm_2(avg_vel);
 
         // Compute the penalty constant
-        const double pen_cons = avg_rho*std::pow(rData.h, TDim)/rData.dt +
-                                avg_rho*avg_visc*std::pow(rData.h,TDim-2) +
-                                avg_rho*v_norm*std::pow(rData.h, TDim-1);
+        const double pen_cons = rData.rho*std::pow(rData.h, TDim)/rData.dt +
+                                rData.rho*rData.mu*std::pow(rData.h,TDim-2) +
+                                rData.rho*v_norm*std::pow(rData.h, TDim-1);
 
         // Return the penalty coefficient
         const double K = rCurrentProcessInfo[PENALTY_COEFFICIENT];
@@ -877,16 +869,9 @@ protected:
         }
         v_norm = std::sqrt(v_norm);
 
-        // Compute the element average density
-        double avg_rho = 0.0;
-        for (unsigned int j=0; j<TNumNodes; ++j) {
-            avg_rho += rData.rho(j);
-        }
-        avg_rho /= TNumNodes;
-
         // Compute the Nitsche coefficient (considering the Winter stabilization term)
         const double penalty = 1.0/rCurrentProcessInfo[PENALTY_COEFFICIENT];
-        const double cons_coef = (eff_mu + eff_mu + avg_rho*v_norm*rData.h + avg_rho*rData.h*rData.h/rData.dt)/(rData.h*penalty);
+        const double cons_coef = (eff_mu + eff_mu + rData.rho*v_norm*rData.h + rData.rho*rData.h*rData.h/rData.dt)/(rData.h*penalty);
 
         // Declare auxiliar arrays
         BoundedMatrix<double, MatrixSize, MatrixSize> auxLeftHandSideMatrix = ZeroMatrix(MatrixSize, MatrixSize);

--- a/applications/FluidDynamicsApplication/custom_elements/navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/navier_stokes.cpp
@@ -4,8 +4,8 @@
 //   _|\_\_|  \__,_|\__|\___/ ____/
 //                   Multi-Physics
 //
-//  License:		 BSD License
-//					 Kratos default license: kratos/license.txt
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
 //
 //  Main authors:    Ruben Zorrilla
 //
@@ -124,10 +124,10 @@ void NavierStokes<3>::ComputeGaussPointLHSContribution(
     constexpr int dim = 3;
     constexpr int nnodes = 4;
 
-    const double rho = data.rho;                            // Density
-    const double mu = data.mu;                              // Dynamic viscosity
-    const double h = data.h;                                // Characteristic element size
-    const double c = data.c;                                // Wave velocity
+    const double rho = data.rho; // Density
+    const double mu = data.mu;   // Dynamic viscosity
+    const double h = data.h;     // Characteristic element size
+    const double c = data.c;     // Wave velocity
 
     const double& dt = data.dt;
     const double& bdf0 = data.bdf0;
@@ -755,10 +755,10 @@ void NavierStokes<2>::ComputeGaussPointLHSContribution(
     constexpr int dim = 2;
     constexpr int nnodes = 3;
 
-    const double rho = data.rho;        // Density
-    const double mu = data.mu;          // Dynamic viscosity
-    const double h = data.h;                                // Characteristic element size
-    const double c = data.c;                                // Wave velocity
+    const double rho = data.rho; // Density
+    const double mu = data.mu;   // Dynamic viscosity
+    const double h = data.h;     // Characteristic element size
+    const double c = data.c;     // Wave velocity
 
     const double& dt = data.dt;
     const double& bdf0 = data.bdf0;
@@ -1006,10 +1006,10 @@ void NavierStokes<3>::ComputeGaussPointRHSContribution(
     constexpr int nnodes = 4;
     constexpr int strain_size = 6;
 
-    const double rho = data.rho;        // Density
-    const double mu = data.mu;          // Dynamic viscosity
-    const double h = data.h;                                // Characteristic element size
-    const double c = data.c;                                // Wave velocity
+    const double rho = data.rho; // Density
+    const double mu = data.mu;   // Dynamic viscosity
+    const double h = data.h;     // Characteristic element size
+    const double c = data.c;     // Wave velocity
 
     const double& dt = data.dt;
     const double& bdf0 = data.bdf0;
@@ -1109,10 +1109,10 @@ void NavierStokes<2>::ComputeGaussPointRHSContribution(
     constexpr int nnodes = 3;
     constexpr int strain_size = 3;
 
-    const double rho = data.rho;        // Density
-    const double mu = data.mu;          // Dynamic viscosity
-    const double h = data.h;                                // Characteristic element size
-    const double c = data.c;                                // Wave velocity
+    const double rho = data.rho; // Density
+    const double mu = data.mu;   // Dynamic viscosity
+    const double h = data.h;     // Characteristic element size
+    const double c = data.c;     // Wave velocity
 
     const double& dt = data.dt;
     const double& bdf0 = data.bdf0;
@@ -1188,10 +1188,9 @@ double NavierStokes<3>::SubscaleErrorEstimate(const ElementDataStruct& data)
     constexpr int dim = 3;
     constexpr int nnodes = 4;
 
-    const double rho = data.rho;        // Density
-    const double mu = data.mu;          // Dynamic viscosity
-    const double h = data.h;                                // Characteristic element size
-    // const double c = data.c;                                // Wave velocity
+    const double rho = data.rho; // Density
+    const double mu = data.mu;   // Dynamic viscosity
+    const double h = data.h;     // Characteristic element size
 
     const double& dt = data.dt;
     const double& bdf0 = data.bdf0;
@@ -1244,9 +1243,9 @@ double NavierStokes<2>::SubscaleErrorEstimate(const ElementDataStruct& data)
     constexpr int dim = 2;
     constexpr int nnodes = 3;
 
-    const double rho = data.rho;        // Density
-    const double mu = data.mu;          // Dynamic viscosity
-    const double h = data.h;                                // Characteristic element size
+    const double rho = data.rho; // Density
+    const double mu = data.mu;   // Dynamic viscosity
+    const double h = data.h;     // Characteristic element size
 
     const double& dt = data.dt;
     const double& bdf0 = data.bdf0;

--- a/applications/FluidDynamicsApplication/custom_elements/navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/navier_stokes.cpp
@@ -124,8 +124,8 @@ void NavierStokes<3>::ComputeGaussPointLHSContribution(
     constexpr int dim = 3;
     constexpr int nnodes = 4;
 
-    const double rho = inner_prod(data.N, data.rho);        // Density
-    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double rho = data.rho;                            // Density
+    const double mu = data.mu;                              // Dynamic viscosity
     const double h = data.h;                                // Characteristic element size
     const double c = data.c;                                // Wave velocity
 
@@ -755,8 +755,8 @@ void NavierStokes<2>::ComputeGaussPointLHSContribution(
     constexpr int dim = 2;
     constexpr int nnodes = 3;
 
-    const double rho = inner_prod(data.N, data.rho);        // Density
-    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double rho = data.rho;        // Density
+    const double mu = data.mu;          // Dynamic viscosity
     const double h = data.h;                                // Characteristic element size
     const double c = data.c;                                // Wave velocity
 
@@ -1006,8 +1006,8 @@ void NavierStokes<3>::ComputeGaussPointRHSContribution(
     constexpr int nnodes = 4;
     constexpr int strain_size = 6;
 
-    const double rho = inner_prod(data.N, data.rho);        // Density
-    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double rho = data.rho;        // Density
+    const double mu = data.mu;          // Dynamic viscosity
     const double h = data.h;                                // Characteristic element size
     const double c = data.c;                                // Wave velocity
 
@@ -1109,8 +1109,8 @@ void NavierStokes<2>::ComputeGaussPointRHSContribution(
     constexpr int nnodes = 3;
     constexpr int strain_size = 3;
 
-    const double rho = inner_prod(data.N, data.rho);        // Density
-    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double rho = data.rho;        // Density
+    const double mu = data.mu;          // Dynamic viscosity
     const double h = data.h;                                // Characteristic element size
     const double c = data.c;                                // Wave velocity
 
@@ -1188,8 +1188,8 @@ double NavierStokes<3>::SubscaleErrorEstimate(const ElementDataStruct& data)
     constexpr int dim = 3;
     constexpr int nnodes = 4;
 
-    const double rho = inner_prod(data.N, data.rho);        // Density
-    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double rho = data.rho;        // Density
+    const double mu = data.mu;          // Dynamic viscosity
     const double h = data.h;                                // Characteristic element size
     // const double c = data.c;                                // Wave velocity
 
@@ -1244,8 +1244,8 @@ double NavierStokes<2>::SubscaleErrorEstimate(const ElementDataStruct& data)
     constexpr int dim = 2;
     constexpr int nnodes = 3;
 
-    const double rho = inner_prod(data.N, data.rho);        // Density
-    const double mu = inner_prod(data.N, data.mu);          // Dynamic viscosity
+    const double rho = data.rho;        // Density
+    const double mu = data.mu;          // Dynamic viscosity
     const double h = data.h;                                // Characteristic element size
 
     const double& dt = data.dt;

--- a/applications/FluidDynamicsApplication/custom_elements/navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/navier_stokes.h
@@ -71,7 +71,7 @@ public:
     struct ElementDataStruct
     {
         BoundedMatrix<double, TNumNodes, TDim> v, vn, vnn, vmesh, f;
-        array_1d<double,TNumNodes> p, pn, pnn, rho, mu;
+        array_1d<double,TNumNodes> p, pn, pnn;
 
         BoundedMatrix<double, TNumNodes, TDim > DN_DX;
         array_1d<double, TNumNodes > N;
@@ -88,6 +88,8 @@ public:
         double volume;        // In 2D: element area. In 3D: element volume
         double dt;            // Time increment
         double dyn_tau;       // Dynamic tau considered in ASGS stabilization coefficients
+        double mu;            // Dynamic viscosity
+        double rho;           // Density
     };
 
     ///@}
@@ -403,6 +405,11 @@ protected:
 
         rData.c = rCurrentProcessInfo[SOUND_VELOCITY];           // Wave velocity
 
+        // Material properties
+        const auto& r_prop = GetProperties();
+        rData.rho = r_prop.GetValue(DENSITY);
+        rData.mu = r_prop.GetValue(DYNAMIC_VISCOSITY);
+
         for (unsigned int i = 0; i < TNumNodes; i++)
         {
 
@@ -424,8 +431,6 @@ protected:
             rData.p[i] = this->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE);
             rData.pn[i] = this->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE,1);
             rData.pnn[i] = this->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE,2);
-            rData.rho[i] = this->GetGeometry()[i].FastGetSolutionStepValue(DENSITY);
-            rData.mu[i] = this->GetGeometry()[i].FastGetSolutionStepValue(DYNAMIC_VISCOSITY);
         }
 
     }

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
@@ -248,21 +248,9 @@ class FluidSolver(PythonSolver):
         return materials_imported
 
     def _SetNodalProperties(self):
-        # Get density and dynamic viscostity from the properties of the first element
-        for el in self.main_model_part.Elements:
-            rho = el.Properties.GetValue(KratosMultiphysics.DENSITY)
-            if rho <= 0.0:
-                raise Exception("DENSITY set to {0} in Properties {1}, positive number expected.".format(rho,el.Properties.Id))
-            dyn_viscosity = el.Properties.GetValue(KratosMultiphysics.DYNAMIC_VISCOSITY)
-            if dyn_viscosity <= 0.0:
-                raise Exception("DYNAMIC_VISCOSITY set to {0} in Properties {1}, positive number expected.".format(dyn_viscosity,el.Properties.Id))
-            kin_viscosity = dyn_viscosity / rho
-            break
-        else:
-            raise Exception("No fluid elements found in the main model part.")
-        # Transfer the obtained properties to the nodes
-        KratosMultiphysics.VariableUtils().SetVariable(KratosMultiphysics.DENSITY, rho, self.main_model_part.Nodes)
-        KratosMultiphysics.VariableUtils().SetVariable(KratosMultiphysics.VISCOSITY, kin_viscosity, self.main_model_part.Nodes)
+        err_msg = "Calling base FluidSolver \'_SetNodalProperties\' method.\n"
+        err_msg += "This must be implemented in the derived solver in accordance with the element formulation."
+        raise Exception(err_msg)
 
     # TODO: I THINK THIS SHOULD BE MOVED TO THE BASE PYTHON SOLVER
     def is_restarted(self):

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -304,8 +304,6 @@ class NavierStokesEmbeddedMonolithicSolver(FluidSolver):
         KratosMultiphysics.Logger.PrintInfo(self.__class__.__name__, "Construction of NavierStokesEmbeddedMonolithicSolver finished.")
 
     def AddVariables(self):
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DENSITY) # TODO: Remove this once the "old" embedded elements get the density from the properties (or once we delete them)
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DYNAMIC_VISCOSITY) # TODO: Remove this once the "old" embedded elements get the density from the properties (or once we delete them)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PRESSURE)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VELOCITY)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.ACCELERATION)
@@ -460,20 +458,8 @@ class NavierStokesEmbeddedMonolithicSolver(FluidSolver):
         return materials_imported
 
     def _SetNodalProperties(self):
-        # Get density and dynamic viscostity from the properties of the first element
-        for el in self.main_model_part.Elements:
-            rho = el.Properties.GetValue(KratosMultiphysics.DENSITY)
-            if rho <= 0.0:
-                raise Exception("DENSITY set to {0} in Properties {1}, positive number expected.".format(rho,el.Properties.Id))
-            dyn_viscosity = el.Properties.GetValue(KratosMultiphysics.DYNAMIC_VISCOSITY)
-            if dyn_viscosity <= 0.0:
-                raise Exception("DYNAMIC_VISCOSITY set to {0} in Properties {1}, positive number expected.".format(dyn_viscosity,el.Properties.Id))
-            break
-        else:
-            raise Exception("No fluid elements found in the main model part.")
-        # Transfer the obtained properties to the nodes
-        KratosMultiphysics.VariableUtils().SetVariable(KratosMultiphysics.DENSITY, rho, self.main_model_part.Nodes)
-        KratosMultiphysics.VariableUtils().SetVariable(KratosMultiphysics.DYNAMIC_VISCOSITY, dyn_viscosity, self.main_model_part.Nodes)
+        # This is required to avoid the base solver to set the DENSITY and DYNAMIC_VISCOSITY in the nodes
+        pass
 
     def __SetEmbeddedFormulation(self):
         # Set the SLIP elemental flag

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -246,7 +246,7 @@ class NavierStokesEmbeddedMonolithicSolver(FluidSolver):
             "volume_model_part_name" : "volume_model_part",
             "skin_parts": [""],
             "no_skin_parts":[""],
-            "assign_neighbour_elements_to_conditions": false,
+            "assign_neighbour_elements_to_conditions": true,
             "time_stepping"                : {
                 "automatic_time_step" : true,
                 "CFL_number"          : 1,
@@ -456,10 +456,6 @@ class NavierStokesEmbeddedMonolithicSolver(FluidSolver):
             self.main_model_part.ProcessInfo[KratosMultiphysics.SOUND_VELOCITY] = default_sound_velocity
 
         return materials_imported
-
-    def _SetNodalProperties(self):
-        # This is required to avoid the base solver to set the DENSITY and DYNAMIC_VISCOSITY in the nodes
-        pass
 
     def __SetEmbeddedFormulation(self):
         # Set the SLIP elemental flag

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_embedded_solver.py
@@ -51,7 +51,7 @@ class EmbeddedFormulation(object):
         self.condition_name = "NavierStokesWallCondition"
         self.level_set_type = formulation_settings["level_set_type"].GetString()
         self.element_integrates_in_time = True
-        self.element_has_nodal_properties = True
+        self.element_has_nodal_properties = False
 
         self.process_info_data[KratosMultiphysics.DYNAMIC_TAU] = formulation_settings["dynamic_tau"].GetDouble()
         self.process_info_data[KratosCFD.PENALTY_COEFFICIENT] = formulation_settings["penalty_coefficient"].GetDouble()
@@ -94,7 +94,7 @@ class EmbeddedFormulation(object):
         self.condition_name = "EmbeddedAusasNavierStokesWallCondition"
         self.level_set_type = formulation_settings["level_set_type"].GetString()
         self.element_integrates_in_time = True
-        self.element_has_nodal_properties = True
+        self.element_has_nodal_properties = False
 
         self.process_info_data[KratosMultiphysics.DYNAMIC_TAU] = formulation_settings["dynamic_tau"].GetDouble()
         self.process_info_data[KratosCFD.PENALTY_COEFFICIENT] = formulation_settings["penalty_coefficient"].GetDouble()

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
@@ -221,3 +221,20 @@ class NavierStokesSolverFractionalStep(FluidSolver):
                 self.settings["compute_reactions"].GetBool())
 
         return solution_strategy
+
+    def _SetNodalProperties(self):
+        # Get density and dynamic viscostity from the properties of the first element
+        for el in self.main_model_part.Elements:
+            rho = el.Properties.GetValue(KratosMultiphysics.DENSITY)
+            if rho <= 0.0:
+                raise Exception("DENSITY set to {0} in Properties {1}, positive number expected.".format(rho,el.Properties.Id))
+            dyn_viscosity = el.Properties.GetValue(KratosMultiphysics.DYNAMIC_VISCOSITY)
+            if dyn_viscosity <= 0.0:
+                raise Exception("DYNAMIC_VISCOSITY set to {0} in Properties {1}, positive number expected.".format(dyn_viscosity,el.Properties.Id))
+            kin_viscosity = dyn_viscosity / rho
+            break
+        else:
+            raise Exception("No fluid elements found in the main model part.")
+        # Transfer the obtained properties to the nodes
+        KratosMultiphysics.VariableUtils().SetVariable(KratosMultiphysics.DENSITY, rho, self.main_model_part.Nodes)
+        KratosMultiphysics.VariableUtils().SetVariable(KratosMultiphysics.VISCOSITY, kin_viscosity, self.main_model_part.Nodes)

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
@@ -288,8 +288,6 @@ class NavierStokesSolverMonolithic(FluidSolver):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.PRESSURE)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.IS_STRUCTURE)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VISCOSITY)
-        self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DENSITY)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.BODY_FORCE)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_AREA)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NODAL_H)
@@ -301,6 +299,11 @@ class NavierStokesSolverMonolithic(FluidSolver):
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.NORMAL)
         self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.Y_WALL)
         self.main_model_part.AddNodalSolutionStepVariable(KratosCFD.Q_VALUE)
+
+        # Adding variables required for the nodal material properties
+        if self.element_has_nodal_properties:
+            self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.DENSITY)
+            self.main_model_part.AddNodalSolutionStepVariable(KratosMultiphysics.VISCOSITY)
 
         # Adding variables required for the turbulence modelling
         if hasattr(self, "_turbulence_model_solver"):

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
@@ -373,3 +373,20 @@ class NavierStokesSolverMonolithic(FluidSolver):
         self.settings["time_stepping"]["automatic_time_step"].SetBool(False)
         if self.settings["formulation"].Has("dynamic_tau"):
             self.settings["formulation"]["dynamic_tau"].SetDouble(0.0)
+
+    def _SetNodalProperties(self):
+        # Get density and dynamic viscostity from the properties of the first element
+        for el in self.main_model_part.Elements:
+            rho = el.Properties.GetValue(KratosMultiphysics.DENSITY)
+            if rho <= 0.0:
+                raise Exception("DENSITY set to {0} in Properties {1}, positive number expected.".format(rho,el.Properties.Id))
+            dyn_viscosity = el.Properties.GetValue(KratosMultiphysics.DYNAMIC_VISCOSITY)
+            if dyn_viscosity <= 0.0:
+                raise Exception("DYNAMIC_VISCOSITY set to {0} in Properties {1}, positive number expected.".format(dyn_viscosity,el.Properties.Id))
+            kin_viscosity = dyn_viscosity / rho
+            break
+        else:
+            raise Exception("No fluid elements found in the main model part.")
+        # Transfer the obtained properties to the nodes
+        KratosMultiphysics.VariableUtils().SetVariable(KratosMultiphysics.DENSITY, rho, self.main_model_part.Nodes)
+        KratosMultiphysics.VariableUtils().SetVariable(KratosMultiphysics.VISCOSITY, kin_viscosity, self.main_model_part.Nodes)

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_ausas_navier_stokes_wall_condition.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_ausas_navier_stokes_wall_condition.cpp
@@ -45,8 +45,6 @@ namespace Kratos {
 			// Variables addition
 			modelPart.AddNodalSolutionStepVariable(DISTANCE);
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
-			modelPart.AddNodalSolutionStepVariable(DENSITY);
-			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_TAU);
 			modelPart.AddNodalSolutionStepVariable(SOUND_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
@@ -89,12 +87,6 @@ namespace Kratos {
 			vel_original(0,0) = 0.0; vel_original(0,1) = 0.1;
 			vel_original(1,0) = 0.1; vel_original(1,1) = 0.2;
 			vel_original(2,0) = 0.2; vel_original(2,1) = 0.3;
-
-			// Set the nodal DENSITY and DYNAMIC_VISCOSITY values
-			for (NodeIteratorType it_node=modelPart.NodesBegin(); it_node<modelPart.NodesEnd(); ++it_node){
-				it_node->FastGetSolutionStepValue(DENSITY) = pProp->GetValue(DENSITY);
-				it_node->FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = pProp->GetValue(DYNAMIC_VISCOSITY);
-			}
 
 			Geometry<Node<3>> &r_geometry = pElement->GetGeometry();
 
@@ -152,9 +144,7 @@ namespace Kratos {
 
 			// Variables addition
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
-			modelPart.AddNodalSolutionStepVariable(DENSITY);
 			modelPart.AddNodalSolutionStepVariable(REACTION);
-			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_TAU);
 			modelPart.AddNodalSolutionStepVariable(SOUND_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
@@ -201,12 +191,6 @@ namespace Kratos {
 			vel_original(1,0) = 0.1; vel_original(1,1) = 0.2; vel_original(1,2) = 0.3;
 			vel_original(2,0) = 0.2; vel_original(2,1) = 0.3; vel_original(2,2) = 0.4;
 			vel_original(3,0) = 0.3; vel_original(3,1) = 0.4; vel_original(3,2) = 0.5;
-
-			// Set the nodal DENSITY and DYNAMIC_VISCOSITY values
-			for (NodeIteratorType it_node=modelPart.NodesBegin(); it_node<modelPart.NodesEnd(); ++it_node){
-                it_node->FastGetSolutionStepValue(DENSITY) = pProp->GetValue(DENSITY);
-                it_node->FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = pProp->GetValue(DYNAMIC_VISCOSITY);
-            }
 
 			Geometry<Node<3>> &r_geometry = pElement->GetGeometry();
 

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element.cpp
@@ -32,8 +32,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     ModelPart& model_part = model.CreateModelPart("Main",3);
 
     // Variables addition
-    model_part.AddNodalSolutionStepVariable(DENSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
-    model_part.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
     model_part.AddNodalSolutionStepVariable(REACTION);
     model_part.AddNodalSolutionStepVariable(BODY_FORCE);
     model_part.AddNodalSolutionStepVariable(DYNAMIC_TAU);
@@ -44,7 +42,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     model_part.AddNodalSolutionStepVariable(DISTANCE);
     model_part.AddNodalSolutionStepVariable(ACCELERATION);
     model_part.AddNodalSolutionStepVariable(EXTERNAL_PRESSURE);
-    model_part.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
     model_part.AddNodalSolutionStepVariable(REACTION_WATER_PRESSURE);
 
     // For VMS comparison
@@ -106,8 +103,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElement2D3N, FluidDynamicsApplicationFastSuite
     Element::Pointer p_element = model_part.pGetElement(1);
 
     for(unsigned int i=0; i<3; i++){
-        p_element->GetGeometry()[i].FastGetSolutionStepValue(DENSITY) = p_properties->GetValue(DENSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
-        p_element->GetGeometry()[i].FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = p_properties->GetValue(DYNAMIC_VISCOSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
         p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE)    = 0.0;
         p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 1) = 0.0;
         p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 2) = 0.0;

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element_discontinuous.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_fluid_element_discontinuous.cpp
@@ -32,8 +32,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElementDiscontinuous2D3N, FluidDynamicsApplica
     ModelPart& model_part = model.CreateModelPart("Main",3);
 
     // Variables addition
-    model_part.AddNodalSolutionStepVariable(DENSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
-    model_part.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
     model_part.AddNodalSolutionStepVariable(REACTION);
     model_part.AddNodalSolutionStepVariable(BODY_FORCE);
     model_part.AddNodalSolutionStepVariable(DYNAMIC_TAU);
@@ -44,7 +42,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElementDiscontinuous2D3N, FluidDynamicsApplica
     model_part.AddNodalSolutionStepVariable(DISTANCE);
     model_part.AddNodalSolutionStepVariable(ACCELERATION);
     model_part.AddNodalSolutionStepVariable(EXTERNAL_PRESSURE);
-    model_part.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
     model_part.AddNodalSolutionStepVariable(REACTION_WATER_PRESSURE);
 
     // For VMS comparison
@@ -101,8 +98,6 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedElementDiscontinuous2D3N, FluidDynamicsApplica
     Element::Pointer p_element = model_part.pGetElement(1);
 
     for(unsigned int i=0; i<3; i++){
-        p_element->GetGeometry()[i].FastGetSolutionStepValue(DENSITY) = p_properties->GetValue(DENSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
-        p_element->GetGeometry()[i].FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = p_properties->GetValue(DYNAMIC_VISCOSITY); // TODO: To be removed once the element migration is finally finished (the old embedded elements still use nodal density and viscosity)
         p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE)    = 0.0;
         p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 1) = 0.0;
         p_element->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE, 2) = 0.0;

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_navier_stokes_element.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_embedded_navier_stokes_element.cpp
@@ -44,8 +44,6 @@ namespace Kratos {
 			modelPart.AddNodalSolutionStepVariable(DISTANCE);
 			modelPart.AddNodalSolutionStepVariable(REACTION);
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
-			modelPart.AddNodalSolutionStepVariable(DENSITY);
-			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_TAU);
 			modelPart.AddNodalSolutionStepVariable(SOUND_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
@@ -85,12 +83,6 @@ namespace Kratos {
 			vel_original(0,0) = 0.0; vel_original(0,1) = 0.1;
 			vel_original(1,0) = 0.1; vel_original(1,1) = 0.2;
 			vel_original(2,0) = 0.2; vel_original(2,1) = 0.3;
-
-			// Set the nodal DENSITY and DYNAMIC_VISCOSITY values
-			for (NodeIteratorType it_node=modelPart.NodesBegin(); it_node<modelPart.NodesEnd(); ++it_node){
-				it_node->FastGetSolutionStepValue(DENSITY) = pElemProp->GetValue(DENSITY);
-				it_node->FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = pElemProp->GetValue(DYNAMIC_VISCOSITY);
-			}
 
 			array_1d<double, 3> embedded_vel;
 			embedded_vel(0) = 1.0;
@@ -144,8 +136,6 @@ namespace Kratos {
 
 			// Variables addition
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
-			modelPart.AddNodalSolutionStepVariable(DENSITY);
-			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_TAU);
 			modelPart.AddNodalSolutionStepVariable(SOUND_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
@@ -187,12 +177,6 @@ namespace Kratos {
 			vel_original(1,0) = 0.1; vel_original(1,1) = 0.2; vel_original(1,2) = 0.3;
 			vel_original(2,0) = 0.2; vel_original(2,1) = 0.3; vel_original(2,2) = 0.4;
 			vel_original(3,0) = 0.3; vel_original(3,1) = 0.4; vel_original(3,2) = 0.5;
-
-			// Set the nodal DENSITY and DYNAMIC_VISCOSITY values
-			for (NodeIteratorType it_node=modelPart.NodesBegin(); it_node<modelPart.NodesEnd(); ++it_node){
-				it_node->FastGetSolutionStepValue(DENSITY) = pElemProp->GetValue(DENSITY);
-				it_node->FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = pElemProp->GetValue(DYNAMIC_VISCOSITY);
-			}
 
 			array_1d<double, 3> embedded_vel;
 			embedded_vel(0) = 1.0;

--- a/applications/FluidDynamicsApplication/tests/cpp_tests/test_navier_stokes_symbolic_element.cpp
+++ b/applications/FluidDynamicsApplication/tests/cpp_tests/test_navier_stokes_symbolic_element.cpp
@@ -41,8 +41,6 @@ namespace Kratos {
 
 			// Variables addition
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
-			modelPart.AddNodalSolutionStepVariable(DENSITY);
-			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_TAU);
 			modelPart.AddNodalSolutionStepVariable(SOUND_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
@@ -86,12 +84,6 @@ namespace Kratos {
 			perturbation_matrix(0,0) = 1.0; perturbation_matrix(0,1) = 0.1;
 			perturbation_matrix(1,0) = 0.1; perturbation_matrix(1,1) = 0.2;
 			perturbation_matrix(2,0) = 0.2; perturbation_matrix(2,1) = 0.3;
-
-			// Set the nodal DENSITY and DYNAMIC_VISCOSITY values
-			for (NodeIteratorType it_node=modelPart.NodesBegin(); it_node<modelPart.NodesEnd(); ++it_node){
-				it_node->FastGetSolutionStepValue(DENSITY) = pElemProp->GetValue(DENSITY);
-				it_node->FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = pElemProp->GetValue(DYNAMIC_VISCOSITY);
-			}
 
 			for(unsigned int i=0; i<3; i++){
 				pElement->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE)    = 0.0;
@@ -171,8 +163,6 @@ namespace Kratos {
 
 			// Variables addition
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
-			modelPart.AddNodalSolutionStepVariable(DENSITY);
-			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_TAU);
 			modelPart.AddNodalSolutionStepVariable(SOUND_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
@@ -217,8 +207,6 @@ namespace Kratos {
 			for (NodeIteratorType it_node=modelPart.NodesBegin(); it_node<modelPart.NodesEnd(); ++it_node){
 				it_node->FastGetSolutionStepValue(PRESSURE) = pressure_value;
 				it_node->FastGetSolutionStepValue(VELOCITY) = velocity_values;
-				it_node->FastGetSolutionStepValue(DENSITY) = pElemProp->GetValue(DENSITY);
-				it_node->FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = pElemProp->GetValue(DYNAMIC_VISCOSITY);
 			}
 
 			// Compute RHS and LHS
@@ -272,8 +260,6 @@ namespace Kratos {
 
 			// Variables addition
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
-			modelPart.AddNodalSolutionStepVariable(DENSITY);
-			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_TAU);
 			modelPart.AddNodalSolutionStepVariable(SOUND_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
@@ -320,12 +306,6 @@ namespace Kratos {
 			perturbation_matrix(1,0) = 0.1; perturbation_matrix(1,1) = 0.2; perturbation_matrix(1,2) = 0.6;
 			perturbation_matrix(2,0) = 0.2; perturbation_matrix(2,1) = 0.3; perturbation_matrix(2,2) = 0.7;
 			perturbation_matrix(3,0) = 0.3; perturbation_matrix(3,1) = 0.4; perturbation_matrix(3,2) = 0.8;
-
-			// Set the nodal DENSITY and DYNAMIC_VISCOSITY values
-			for (NodeIteratorType it_node=modelPart.NodesBegin(); it_node<modelPart.NodesEnd(); ++it_node){
-				it_node->FastGetSolutionStepValue(DENSITY) = pElemProp->GetValue(DENSITY);
-				it_node->FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = pElemProp->GetValue(DYNAMIC_VISCOSITY);
-			}
 
 			for(unsigned int i=0; i<4; i++){
 				pElement->GetGeometry()[i].FastGetSolutionStepValue(PRESSURE)    = 0.0;
@@ -402,8 +382,6 @@ namespace Kratos {
 
 			// Variables addition
 			modelPart.AddNodalSolutionStepVariable(BODY_FORCE);
-			modelPart.AddNodalSolutionStepVariable(DENSITY);
-			modelPart.AddNodalSolutionStepVariable(DYNAMIC_VISCOSITY);
 			modelPart.AddNodalSolutionStepVariable(DYNAMIC_TAU);
 			modelPart.AddNodalSolutionStepVariable(SOUND_VELOCITY);
 			modelPart.AddNodalSolutionStepVariable(PRESSURE);
@@ -449,8 +427,6 @@ namespace Kratos {
 			for (NodeIteratorType it_node=modelPart.NodesBegin(); it_node<modelPart.NodesEnd(); ++it_node){
 				it_node->FastGetSolutionStepValue(PRESSURE) = pressure_value;
 				it_node->FastGetSolutionStepValue(VELOCITY) = velocity_values;
-				it_node->FastGetSolutionStepValue(DENSITY) = pElemProp->GetValue(DENSITY);
-				it_node->FastGetSolutionStepValue(DYNAMIC_VISCOSITY) = pElemProp->GetValue(DYNAMIC_VISCOSITY);
 			}
 
 			// Compute RHS and LHS


### PR DESCRIPTION
This PR removes the nodal material properties (`DENSITY` and `VISCOSITY`) in those elements that do not require them. This implies saving the memory corresponding to 4 or 6 (depending on the buffer size) doubles per node.

The old VMS, the fractional-step and the VMS adjoint ones keep the nodal values.