### PR TITLE
Add conformity check to mapper

### DIFF
--- a/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
+++ b/applications/MappingApplication/custom_mappers/interpolative_mapper_base.h
@@ -183,6 +183,11 @@ public:
     ///@name Inquiry
     ///@{
 
+    int AreMeshesConforming() const override
+    {
+        return mpIntefaceCommunicator->AreMeshesConforming();
+    }
+
     ///@}
     ///@name Input and output
     ///@{

--- a/applications/MappingApplication/custom_mappers/mapper.h
+++ b/applications/MappingApplication/custom_mappers/mapper.h
@@ -165,8 +165,6 @@ public:
     /**
     * @brief Quering for mesh conformity
     * returns 1 if all the nodes are conform and 0 otherwise
-    * pure virtual, has to be implemented in every derived mapper,
-    * @see MapperFactory
     */
     virtual int AreMeshesConforming() const
     {

--- a/applications/MappingApplication/custom_mappers/mapper.h
+++ b/applications/MappingApplication/custom_mappers/mapper.h
@@ -168,7 +168,10 @@ public:
     * pure virtual, has to be implemented in every derived mapper,
     * @see MapperFactory
     */
-    virtual int AreMeshesConforming() const = 0;
+    virtual int AreMeshesConforming() const
+    {
+        KRATOS_ERROR << "This mapper doesn't implement \"AreMeshesConforming\"!" << std::endl;
+    };
 
     ///@}
     ///@name Input and output

--- a/applications/MappingApplication/custom_mappers/mapper.h
+++ b/applications/MappingApplication/custom_mappers/mapper.h
@@ -159,6 +159,18 @@ public:
     virtual TMappingMatrixType* pGetMappingMatrix() = 0;
 
     ///@}
+    ///@name Inquiry
+    ///@{
+
+    /**
+    * @brief Quering for mesh conformity
+    * returns 1 if all the nodes are conform and 0 otherwise
+    * pure virtual, has to be implemented in every derived mapper,
+    * @see MapperFactory
+    */
+    virtual int AreMeshesConforming() const = 0;
+
+    ///@}
     ///@name Input and output
     ///@{
 

--- a/applications/MappingApplication/custom_python/add_custom_mappers_to_python.cpp
+++ b/applications/MappingApplication/custom_python/add_custom_mappers_to_python.cpp
@@ -139,22 +139,24 @@ void ExposeMapperToPython(pybind11::module& m, const std::string& rName)
     // Exposing the base class of the Mappers to Python, but without constructor
     const auto mapper
         = py::class_< MapperType, typename MapperType::Pointer >(m, rName.c_str())
-            .def("UpdateInterface",  UpdateInterfaceWithoutArgs<TSparseSpace, TDenseSpace>)
-            .def("UpdateInterface",  UpdateInterfaceWithOptions<TSparseSpace, TDenseSpace>)
-            .def("UpdateInterface",  UpdateInterfaceWithSearchRadius<TSparseSpace, TDenseSpace>)
-            .def("UpdateInterface",  &MapperType::UpdateInterface) // with options & search-radius
+            .def("UpdateInterface",     UpdateInterfaceWithoutArgs<TSparseSpace, TDenseSpace>)
+            .def("UpdateInterface",     UpdateInterfaceWithOptions<TSparseSpace, TDenseSpace>)
+            .def("UpdateInterface",     UpdateInterfaceWithSearchRadius<TSparseSpace, TDenseSpace>)
+            .def("UpdateInterface",     &MapperType::UpdateInterface) // with options & search-radius
 
-            .def("Map",              MapWithoutOptionsScalar<TSparseSpace, TDenseSpace>)
-            .def("Map",              MapWithoutOptionsVector<TSparseSpace, TDenseSpace>)
-            .def("Map",              MapWithOptionsScalar<TSparseSpace, TDenseSpace>)
-            .def("Map",              MapWithOptionsVector<TSparseSpace, TDenseSpace>)
+            .def("Map",                 MapWithoutOptionsScalar<TSparseSpace, TDenseSpace>)
+            .def("Map",                 MapWithoutOptionsVector<TSparseSpace, TDenseSpace>)
+            .def("Map",                 MapWithOptionsScalar<TSparseSpace, TDenseSpace>)
+            .def("Map",                 MapWithOptionsVector<TSparseSpace, TDenseSpace>)
 
-            .def("InverseMap",       InverseMapWithoutOptionsScalar<TSparseSpace, TDenseSpace>)
-            .def("InverseMap",       InverseMapWithoutOptionsVector<TSparseSpace, TDenseSpace>)
-            .def("InverseMap",       InverseMapWithOptionsScalar<TSparseSpace, TDenseSpace>)
-            .def("InverseMap",       InverseMapWithOptionsVector<TSparseSpace, TDenseSpace>)
+            .def("InverseMap",          InverseMapWithoutOptionsScalar<TSparseSpace, TDenseSpace>)
+            .def("InverseMap",          InverseMapWithoutOptionsVector<TSparseSpace, TDenseSpace>)
+            .def("InverseMap",          InverseMapWithOptionsScalar<TSparseSpace, TDenseSpace>)
+            .def("InverseMap",          InverseMapWithOptionsVector<TSparseSpace, TDenseSpace>)
 
-            .def("__str__",          PrintObject<MapperType>)
+            .def("AreMeshesConforming", &MapperType::AreMeshesConforming)
+
+            .def("__str__",             PrintObject<MapperType>)
             ;
 
     // Adding the flags that can be used for mapping

--- a/applications/MappingApplication/custom_searching/interface_communicator.cpp
+++ b/applications/MappingApplication/custom_searching/interface_communicator.cpp
@@ -56,10 +56,15 @@ void InterfaceCommunicator::ExchangeInterfaceData(const Communicator& rComm,
     // radius was either computed or specified properly)
     // only if some points did not find a neighbor or dont have a valid
     // projection, more search iterations are necessary
+    mMeshesAreConforming = 1;
     ConductSearchIteration(rOptions, rpInterfaceInfo);
 
     while (++num_iteration <= max_search_iterations && !AllNeighborsFound(rComm)) {
         mSearchRadius *= increase_factor;
+
+        // If all neighbours were not found in the first iteration, the meshes are not conforming
+        // for the initial given search radius.
+        mMeshesAreConforming = 0;
 
         KRATOS_WARNING_IF("Mapper", mEchoLevel >= 1 && rComm.MyPID() == 0)
             << "search radius was increased, another search iteration is conducted\n"

--- a/applications/MappingApplication/custom_searching/interface_communicator.h
+++ b/applications/MappingApplication/custom_searching/interface_communicator.h
@@ -91,6 +91,14 @@ public:
                                const MapperInterfaceInfoUniquePointerType& rpRefInterfaceInfo);
 
     ///@}
+    ///@name Inquiry
+    ///@{
+
+    int AreMeshesConforming() {
+        return mMeshesAreConforming;
+    }
+
+    ///@}
     ///@name Input and output
     ///@{
 
@@ -129,6 +137,7 @@ protected:
     double mSearchRadius = -1.0;
 
     int mEchoLevel = 0;
+    int mMeshesAreConforming = 0;
 
     ///@}
     ///@name Protected Operations

--- a/applications/MappingApplication/custom_searching/mpi/interface_communicator_mpi.cpp
+++ b/applications/MappingApplication/custom_searching/mpi/interface_communicator_mpi.cpp
@@ -17,6 +17,7 @@
 
 // External includes
 #include "mpi.h"
+#include "includes/parallel_environment.h"
 
 // Project includes
 #include "interface_communicator_mpi.h"
@@ -128,6 +129,8 @@ void InterfaceCommunicatorMPI::FinalizeSearchIteration(const MapperInterfaceInfo
                                                                rpRefInterfaceInfo,
                                                                mCommRank,
                                                                mMapperInterfaceInfosContainer);
+
+    mMeshesAreConforming = ParallelEnvironment::GetDefaultDataCommunicator().MinAll(mMeshesAreConforming);
 
     AssignInterfaceInfos();
 

--- a/applications/MappingApplication/tests/basic_mapper_tests.py
+++ b/applications/MappingApplication/tests/basic_mapper_tests.py
@@ -210,17 +210,6 @@ class BasicMapperTests(mapper_test_case.MapperTestCase):
         self.assertEqual(is_conforming, True)
 
     def test_Is_not_conforming(self):
-        model = KM.Model()
-        model_part_origin_non_conform = model.CreateModelPart("non_conforming")
-        
-        KM.ModelPartIO(self.input_file_origin, KM.ModelPartIO.READ | KM.ModelPartIO.SKIP_TIMER).ReadModelPart(model_part_origin_non_conform)
-
-        if self.mapper_parameters.Has("interface_submodel_part_origin"):
-            interface_model_part_origin_non_conform = model_part_origin_non_conform.GetSubModelPart(
-                mapper_parameters["interface_submodel_part_origin"].GetString())
-        else:
-            interface_model_part_origin_non_conform = model_part_origin_non_conform
-
         non_conform_mapper = KratosMapping.MapperFactory.CreateMapper(
             self.model_part_origin, 
             self.model_part_destination, 

--- a/applications/MappingApplication/tests/basic_mapper_tests.py
+++ b/applications/MappingApplication/tests/basic_mapper_tests.py
@@ -214,8 +214,8 @@ class BasicMapperTests(mapper_test_case.MapperTestCase):
         non_conform_parameters.AddEmptyValue("search_radius").SetDouble(1e-6)
 
         non_conform_mapper = KratosMapping.MapperFactory.CreateMapper(
-            self.model_part_origin, 
-            self.model_part_destination, 
+            self.model_part_origin,
+            self.model_part_destination,
             non_conform_parameters
         )
 

--- a/applications/MappingApplication/tests/basic_mapper_tests.py
+++ b/applications/MappingApplication/tests/basic_mapper_tests.py
@@ -25,7 +25,7 @@ class BasicMapperTests(mapper_test_case.MapperTestCase):
         # TODO ATTENTION: currently the MapperFactory removes some keys, hence those checks have to be done beforehand => improve this!
 
         cls.mapper_type = mapper_parameters["mapper_type"].GetString()
-        cls.mapper_parameters = mapper_parameters
+        cls.mapper_parameters = mapper_parameters.Clone()
 
         if mapper_parameters.Has("interface_submodel_part_origin"):
             cls.interface_model_part_origin = cls.model_part_origin.GetSubModelPart(
@@ -210,13 +210,13 @@ class BasicMapperTests(mapper_test_case.MapperTestCase):
         self.assertEqual(is_conforming, True)
 
     def test_Is_not_conforming(self):
+        non_conform_parameters = self.mapper_parameters.Clone()
+        non_conform_parameters.AddEmptyValue("search_radius").SetDouble(1e-6)
+
         non_conform_mapper = KratosMapping.MapperFactory.CreateMapper(
             self.model_part_origin, 
             self.model_part_destination, 
-            KM.Parameters("""{
-                "mapper_type" : \"""" + self.mapper_type + """\",
-                "search_radius": 0.00001 }"""
-            )
+            non_conform_parameters
         )
 
         is_conforming = non_conform_mapper.AreMeshesConforming()

--- a/applications/MappingApplication/tests/basic_mapper_tests.py
+++ b/applications/MappingApplication/tests/basic_mapper_tests.py
@@ -213,7 +213,12 @@ class BasicMapperTests(mapper_test_case.MapperTestCase):
         non_conform_parameters = self.mapper_parameters.Clone()
         non_conform_parameters.AddEmptyValue("search_radius").SetDouble(1e-6)
 
-        non_conform_mapper = KratosMapping.MapperFactory.CreateMapper(
+        if data_comm.IsDistributed():
+            map_creator = KratosMapping.MapperFactory.CreateMPIMapper
+        else:
+            map_creator = KratosMapping.MapperFactory.CreateMapper
+
+        non_conform_mapper = map_creator(
             self.model_part_origin,
             self.model_part_destination,
             non_conform_parameters

--- a/applications/MappingApplication/tests/basic_mapper_tests.py
+++ b/applications/MappingApplication/tests/basic_mapper_tests.py
@@ -25,6 +25,7 @@ class BasicMapperTests(mapper_test_case.MapperTestCase):
         # TODO ATTENTION: currently the MapperFactory removes some keys, hence those checks have to be done beforehand => improve this!
 
         cls.mapper_type = mapper_parameters["mapper_type"].GetString()
+        cls.mapper_parameters = mapper_parameters
 
         if mapper_parameters.Has("interface_submodel_part_origin"):
             cls.interface_model_part_origin = cls.model_part_origin.GetSubModelPart(
@@ -203,6 +204,35 @@ class BasicMapperTests(mapper_test_case.MapperTestCase):
         self.assertAlmostEqual(sum_origin[0], sum_destination[0])
         self.assertAlmostEqual(sum_origin[1], sum_destination[1])
         self.assertAlmostEqual(sum_origin[2], sum_destination[2])
+
+    def test_Is_conforming(self):
+        is_conforming = self.mapper.AreMeshesConforming()
+        self.assertEqual(is_conforming, True)
+
+    def test_Is_not_conforming(self):
+        model = KM.Model()
+        model_part_origin_non_conform = model.CreateModelPart("non_conforming")
+        
+        KM.ModelPartIO(self.input_file_origin, KM.ModelPartIO.READ | KM.ModelPartIO.SKIP_TIMER).ReadModelPart(model_part_origin_non_conform)
+
+        if self.mapper_parameters.Has("interface_submodel_part_origin"):
+            interface_model_part_origin_non_conform = model_part_origin_non_conform.GetSubModelPart(
+                mapper_parameters["interface_submodel_part_origin"].GetString())
+        else:
+            interface_model_part_origin_non_conform = model_part_origin_non_conform
+
+        non_conform_mapper = KratosMapping.MapperFactory.CreateMapper(
+            self.model_part_origin, 
+            self.model_part_destination, 
+            KM.Parameters("""{
+                "mapper_type" : \"""" + self.mapper_type + """\",
+                "search_radius": 0.00001 }"""
+            )
+        )
+
+        is_conforming = non_conform_mapper.AreMeshesConforming()
+        self.assertEqual(is_conforming, False)
+
 
     # def test_UpdateInterface(self):
     #     pass


### PR DESCRIPTION
The conformity check. 

I am still making tests but I am pretty sure this does what @ddiezrod needs.

The idea is that instead of making an explicit check we reuse the results of the first iteration of the interface communicator, so the check itself comes at no extra cost.

I would like to discuss specially the changes in the `interface_communicator_mpi.cpp`. Since the conformity check is something global I would need to synch the values, which adds a new dependency to the mpi core in this file that was not there before.

The synch could be done outside the mapper, hence no need for the new dependency, but it would be less inctuitive for the final user.

Let me know what you think