### PR TITLE
[PotentialFlow] Using LinearSolversApp in tests

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_adjoint_analytical_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_adjoint_analytical_parameters.json
@@ -29,7 +29,7 @@
             },
         "echo_level"                   : 0,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu"
+            "solver_type"         : "LinearSolversApplication.sparse_lu"
         }
     },
     "processes" : {

--- a/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_adjoint_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_adjoint_parameters.json
@@ -30,7 +30,7 @@
             },
         "echo_level"                   : 0,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu"
+            "solver_type"         : "LinearSolversApplication.sparse_lu"
         },
         "reference_chord": 1.0
     },

--- a/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_primal_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_adjoint_test/naca0012_small_sensitivities_primal_parameters.json
@@ -20,7 +20,7 @@
         "skin_parts"             : ["PotentialWallCondition2D_Far_field_Auto1","Body2D_Body"],
         "no_skin_parts"          : [],
         "linear_solver_settings"  : {
-            "solver_type"             : "ExternalSolversApplication.super_lu",
+            "solver_type"             : "LinearSolversApplication.sparse_lu",
             "verbosity"               : 0
         },
         "reference_chord": 1.0

--- a/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_compressible_test/naca0012_small_compressible_parameters.json
+++ b/applications/CompressiblePotentialFlowApplication/tests/naca0012_small_compressible_test/naca0012_small_compressible_parameters.json
@@ -22,7 +22,7 @@
         "relative_tolerance": 1e-12,
         "absolute_tolerance": 1e-12,
         "linear_solver_settings"  : {
-                "solver_type"             : "ExternalSolversApplication.super_lu",
+                "solver_type"             : "LinearSolversApplication.sparse_lu",
                 "verbosity"               : 0
         },
         "volume_model_part_name" : "Parts_Parts_Auto1",

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -36,7 +36,7 @@ class PotentialFlowTests(UnitTest.TestCase):
         # Set to true to get post-process files for the test
         self.print_output = False
 
-    @UnitTest.skipIfApplicationsNotAvailable("ExternalSolversApplication", "HDF5Application")
+    @UnitTest.skipIfApplicationsNotAvailable("HDF5Application")
     def test_Naca0012SmallAdjoint(self):
         file_name = "naca0012_small_sensitivities"
         settings_file_name_primal = file_name + "_primal_parameters.json"
@@ -58,7 +58,7 @@ class PotentialFlowTests(UnitTest.TestCase):
                 if file_name.endswith(".h5"):
                     kratos_utilities.DeleteFileIfExisting(file_name)
 
-    @UnitTest.skipIfApplicationsNotAvailable("ExternalSolversApplication", "LinearSolversApplication")
+    @UnitTest.skipIfApplicationsNotAvailable("LinearSolversApplication")
     def test_Naca0012SmallCompressible(self):
         file_name = "naca0012_small_compressible"
         settings_file_name = file_name + "_parameters.json"

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 import KratosMultiphysics.CompressiblePotentialFlowApplication as CPFApp
@@ -15,10 +13,6 @@ from KratosMultiphysics.KratosUnittest import isclose as t_isclose
 import os
 
 # Check other applications dependency
-hdf5_is_available = kratos_utilities.CheckIfApplicationsAvailable("HDF5Application")
-eigensolver_is_available = kratos_utilities.CheckIfApplicationsAvailable("EigenSolversApplication")
-externalsolvers_is_available = kratos_utilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
-meshing_is_available = kratos_utilities.CheckIfApplicationsAvailable("MeshingApplication")
 try:
     import stl
     numpy_stl_is_available = True
@@ -26,6 +20,7 @@ except:
     numpy_stl_is_available = False
 
 class WorkFolderScope:
+    # TODO use KratosUnittest.WorkFolderScope
     def __init__(self, work_folder):
         self.currentPath = os.getcwd()
         self.scope = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)),work_folder))
@@ -42,11 +37,8 @@ class PotentialFlowTests(UnitTest.TestCase):
         # Set to true to get post-process files for the test
         self.print_output = False
 
+    @UnitTest.skipIfApplicationsNotAvailable("ExternalSolversApplication", "HDF5Application")
     def test_Naca0012SmallAdjoint(self):
-        if not externalsolvers_is_available:
-            self.skipTest("Missing required application: ExternalSolversApplication")
-        if not hdf5_is_available:
-            self.skipTest("Missing required application: HDF5Application")
         file_name = "naca0012_small_sensitivities"
         settings_file_name_primal = file_name + "_primal_parameters.json"
         settings_file_name_adjoint = file_name + "_adjoint_parameters.json"
@@ -67,11 +59,8 @@ class PotentialFlowTests(UnitTest.TestCase):
                 if file_name.endswith(".h5"):
                     kratos_utilities.DeleteFileIfExisting(file_name)
 
+    @UnitTest.skipIfApplicationsNotAvailable("ExternalSolversApplication", "LinearSolversApplication")
     def test_Naca0012SmallCompressible(self):
-        if not externalsolvers_is_available:
-            self.skipTest("Missing required application: ExternalSolversApplication")
-        if not eigensolver_is_available:
-            self.skipTest("Missing required application: EigenSolversApplication")
         file_name = "naca0012_small_compressible"
         settings_file_name = file_name + "_parameters.json"
         work_folder = "naca0012_small_compressible_test"
@@ -87,9 +76,8 @@ class PotentialFlowTests(UnitTest.TestCase):
                 if file_name.endswith(".time"):
                     kratos_utilities.DeleteFileIfExisting(file_name)
 
+    @UnitTest.skipIfApplicationsNotAvailable("LinearSolversApplication")
     def test_Naca0012SmallTransonic(self):
-        if not eigensolver_is_available:
-            self.skipTest("Missing required application: EigenSolversApplication")
         file_name = "naca0012_small_transonic"
         settings_file_name = file_name + "_parameters.json"
         work_folder = "naca0012_small_transonic_test"
@@ -103,9 +91,8 @@ class PotentialFlowTests(UnitTest.TestCase):
 
         kratos_utilities.DeleteTimeFiles(work_folder)
 
+    @UnitTest.skipIfApplicationsNotAvailable("LinearSolversApplication")
     def test_Naca0012SmallPerturbationCompressible(self):
-        if not eigensolver_is_available:
-            self.skipTest("Missing required application: EigenSolversApplication")
         file_name = "naca0012_small_perturbation_compressible"
         settings_file_name = file_name + "_parameters.json"
         work_folder = "naca0012_small_perturbation_compressible_test"
@@ -121,20 +108,16 @@ class PotentialFlowTests(UnitTest.TestCase):
                 if file_name.endswith(".time"):
                     kratos_utilities.DeleteFileIfExisting(file_name)
 
+    @UnitTest.skipIfApplicationsNotAvailable("MeshingApplication")
     def test_EmbeddedCircleNoWake(self):
-        if not meshing_is_available:
-            self.skipTest("Missing required application: MeshingApplication")
         settings_file_name = "embedded_circle_no_wake_parameters.json"
         work_folder = "embedded_test"
 
         with WorkFolderScope(work_folder):
             self._runTest(settings_file_name)
 
+    @UnitTest.skipIfApplicationsNotAvailable("HDF5Application", "MeshingApplication")
     def test_EmbeddedCircle(self):
-        if not hdf5_is_available:
-            self.skipTest("Missing required application: HDF5Application")
-        if not meshing_is_available:
-            self.skipTest("Missing required application: MeshingApplication")
         settings_file_name = "embedded_circle_parameters.json"
         settings_adjoint_file_name = "embedded_circle_adjoint_parameters.json"
         settings_penalty_file_name = "embedded_circle_penalty_parameters.json"
@@ -220,6 +203,7 @@ class PotentialFlowTests(UnitTest.TestCase):
         self._validateIdList(solution_element_id_list, reference_element_id_list)
 
     def _validateIdList(self, solution_element_id_list, reference_element_id_list):
+        # TODO replace with unittest.assertListEqual or KratosUnitTest.assertVectorAlmostEqual
         if(abs(len(reference_element_id_list) - len(solution_element_id_list)) > 0.1):
             raise Exception('Lists have different lengths', ' reference_element_id_list = ',
                             reference_element_id_list, ' solution_element_id_list = ', solution_element_id_list)
@@ -309,6 +293,7 @@ class PotentialFlowTests(UnitTest.TestCase):
         self.main_model_part = model.GetModelPart(settings["solver_settings"]["model_part_name"].GetString())
 
     def _check_results(self, result, reference, rel_tol, abs_tol):
+        # TODO add message directly to t_isclose
         isclosethis = t_isclose(result, reference, rel_tol, abs_tol)
 
         full_msg =  "Failed with following parameters:\n"

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -36,7 +36,7 @@ class PotentialFlowTests(UnitTest.TestCase):
         # Set to true to get post-process files for the test
         self.print_output = False
 
-    @UnitTest.skipIfApplicationsNotAvailable("HDF5Application")
+    @UnitTest.skipIfApplicationsNotAvailable("LinearSolversApplication", "HDF5Application")
     def test_Naca0012SmallAdjoint(self):
         file_name = "naca0012_small_sensitivities"
         settings_file_name_primal = file_name + "_primal_parameters.json"

--- a/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
+++ b/applications/CompressiblePotentialFlowApplication/tests/potential_flow_test_factory.py
@@ -12,7 +12,6 @@ from KratosMultiphysics.KratosUnittest import isclose as t_isclose
 
 import os
 
-# Check other applications dependency
 try:
     import stl
     numpy_stl_is_available = True


### PR DESCRIPTION
Following #7204, removes dependency on the ExternalSolversApplication.