### PR TITLE
[ContactStructuralMechanicsApplication] Remove legacy python support

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/ContactStructuralMechanicsApplication.py
+++ b/applications/ContactStructuralMechanicsApplication/ContactStructuralMechanicsApplication.py
@@ -1,6 +1,3 @@
-# makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-from __future__ import print_function, absolute_import, division
-
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
 from KratosContactStructuralMechanicsApplication import *

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_analysis.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_analysis.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing Kratos
 import KratosMultiphysics as KM
 import KratosMultiphysics.StructuralMechanicsApplication as SMA

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_implicit_dynamic_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_static_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_static_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_utilities.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/adaptative_remeshing_contact_structural_mechanics_utilities.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/alm_contact_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/auxiliar_methods_solvers.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/auxiliar_methods_solvers.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 import KratosMultiphysics.ContactStructuralMechanicsApplication as CSMA

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/basic_mapping_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/basic_mapping_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_convergence_criteria_factory.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_convergence_criteria_factory.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KM backward compatible with python 2.6 and 2.7
 #import kratos core and applications
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_remesh_mmg_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_remesh_mmg_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_explicit_dynamic_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_explicit_dynamic_solver.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KM backward compatible with python 2.6 and 2.7
 #import kratos core and applications
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_implicit_dynamic_solver.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KM backward compatible with python 2.6 and 2.7
 #import kratos core and applications
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_static_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_static_solver.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KM backward compatible with python 2.6 and 2.7
 #import kratos core and applications
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/explicit_penalty_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/explicit_penalty_contact_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mesh_tying_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_structural_mechanics_implicit_dynamic_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_structural_mechanics_static_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_structural_mechanics_static_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/penalty_contact_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/penalty_contact_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/python_solvers_wrapper_adaptative_remeshing_contact_structural.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/python_solvers_wrapper_adaptative_remeshing_contact_structural.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics
 from importlib import import_module
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/replace_properties_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/replace_properties_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 
@@ -58,7 +56,7 @@ class ReplacePropertiesProcess(KratosMultiphysics.Process):
 
         # If we reinitialize entities
         self.reinitialize_entities = settings["reinitialize_entities"].GetBool()
-        
+
         # Materials filename
         self.materials_filename = settings["materials_filename"].GetString()
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/search_base_process.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/search_base_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/ContactStructuralMechanicsApplication/tests/contact_structural_mechanics_test_factory.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/contact_structural_mechanics_test_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/ContactStructuralMechanicsApplication/tests/test_check_normals_process.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/test_check_normals_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KM backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics as KM
 import KratosMultiphysics.ContactStructuralMechanicsApplication as CSMA
 

--- a/applications/ContactStructuralMechanicsApplication/tests/test_double_curvature_integration.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/test_double_curvature_integration.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics
 import KratosMultiphysics.ContactStructuralMechanicsApplication as ContactStructuralMechanicsApplication
 

--- a/applications/ContactStructuralMechanicsApplication/tests/test_dynamic_search.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/test_dynamic_search.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KM backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics as KM
 import KratosMultiphysics.ContactStructuralMechanicsApplication as CSMA
 

--- a/applications/ContactStructuralMechanicsApplication/tests/test_process_factory.py
+++ b/applications/ContactStructuralMechanicsApplication/tests/test_process_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics
 import KratosMultiphysics.ContactStructuralMechanicsApplication as ContactStructuralMechanicsApplication
 


### PR DESCRIPTION
This PR removes `from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7`  that now that the python2 support is dropped is not needed anymore