### PR TITLE
[MeshingApplication] Remove legacy python support

### DIFF
--- a/applications/MeshingApplication/MeshingApplication.py
+++ b/applications/MeshingApplication/MeshingApplication.py
@@ -1,6 +1,3 @@
-# makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-from __future__ import print_function, absolute_import, division
-
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
 from KratosMeshingApplication import *

--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics as KratosMultiphysics
 import KratosMultiphysics.MeshingApplication as MeshingApplication

--- a/applications/MeshingApplication/python_scripts/multiscale_refining_process.py
+++ b/applications/MeshingApplication/python_scripts/multiscale_refining_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics as KratosMultiphysics
 import KratosMultiphysics.MeshingApplication as MeshingApplication
@@ -28,7 +27,7 @@ class MultiscaleRefiningProcess(KratosMultiphysics.Process):
                     "variable_threshold"              : 1e-3,
                     "increase_threshold"              : true,
                     "only_refine_wet_domain"          : true
-                }   
+                }
             },
             "variables_to_apply_fixity"       : [],
             "variables_to_set_at_interface"   : [],

--- a/applications/MeshingApplication/tests/meshing_application_test_factory.py
+++ b/applications/MeshingApplication/tests/meshing_application_test_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics
 try:
   from KratosMultiphysics.StructuralMechanicsApplication.adaptative_remeshing_structural_mechanics_analysis import AdaptativeRemeshingStructuralMechanicsAnalysis

--- a/applications/MeshingApplication/tests/test_refine.py
+++ b/applications/MeshingApplication/tests/test_refine.py
@@ -1,6 +1,4 @@
-﻿from __future__ import print_function, absolute_import, division
-
-import KratosMultiphysics.KratosUnittest as KratosUnittest
+﻿import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics
 import KratosMultiphysics.MeshingApplication
 import math
@@ -16,13 +14,13 @@ class TestRedistance(KratosUnittest.TestCase):
         for elem in Elements:
             vol += elem.GetArea()
         return vol
-    
+
     def _ComputeSurfaceArea(self,Conditions):
         area = 0.0
         for cond in Conditions:
             area += cond.GetArea()
-        return area       
-        
+        return area
+
     def test_refine_all(self):
         current_model = KratosMultiphysics.Model()
         model_part = current_model.CreateModelPart("Main")
@@ -32,19 +30,19 @@ class TestRedistance(KratosUnittest.TestCase):
 
         #IMPORTANT! must compute the neighbours first!!
         KratosMultiphysics.FindNodalNeighboursProcess(model_part).Execute()
-        
+
         original_vol = self._ComputeVolume(model_part.Elements)
         #original_surface = self._ComputeSurfaceArea(model_part.Conditions)
-        
+
         for elem in model_part.Elements:
             elem.SetValue(KratosMultiphysics.SPLIT_ELEMENT,True)
-            
+
         refiner = KratosMultiphysics.MeshingApplication.LocalRefineTetrahedraMesh(model_part)
-        
+
         refine_on_reference = False
         interpolate_internal_variables = True
         refiner.LocalRefineMesh( refine_on_reference, interpolate_internal_variables)
-        
+
         refined_vol = self._ComputeVolume(model_part.Elements)
         refined_surface = self._ComputeSurfaceArea(model_part.Conditions)
 
@@ -53,7 +51,7 @@ class TestRedistance(KratosUnittest.TestCase):
         #self.assertAlmostEqual(refined_surface, original_surface, 9)
         self.assertEqual(len(model_part.Elements), 1992)
         self.assertEqual(len(model_part.Nodes), 482)
-        
+
     def test_refine_half(self):
         current_model = KratosMultiphysics.Model()
         model_part = current_model.CreateModelPart("Main")
@@ -61,23 +59,23 @@ class TestRedistance(KratosUnittest.TestCase):
         KratosMultiphysics.ModelPartIO(GetFilePath("coarse_sphere")).ReadModelPart(model_part)
         model_part.SetBufferSize(2)
         print(model_part)
-        
+
         original_vol = self._ComputeVolume(model_part.Elements)
         #original_surface = self._ComputeSurfaceArea(model_part.Conditions)
-        
+
         for elem in model_part.Elements:
             if(elem.Id % 2 == 0):
                 elem.SetValue(KratosMultiphysics.SPLIT_ELEMENT,True)
-            
+
         #IMPORTANT! must compute the neighbours first!!
         KratosMultiphysics.FindNodalNeighboursProcess(model_part).Execute()
-        
+
         refiner = KratosMultiphysics.MeshingApplication.LocalRefineTetrahedraMesh(model_part)
-        
+
         refine_on_reference = False
         interpolate_internal_variables = True
         refiner.LocalRefineMesh( refine_on_reference, interpolate_internal_variables)
-        
+
         refined_vol = self._ComputeVolume(model_part.Elements)
         refined_surface = self._ComputeSurfaceArea(model_part.Conditions)
 
@@ -86,7 +84,7 @@ class TestRedistance(KratosUnittest.TestCase):
         #self.assertAlmostEqual(refined_surface, original_surface, 9)
         self.assertEqual(len(model_part.Elements), 2010)
         self.assertEqual(len(model_part.Nodes), 462)
-                         
+
     def test_refine_half_and_improve(self):
         current_model = KratosMultiphysics.Model()
         model_part = current_model.CreateModelPart("Main")
@@ -94,25 +92,25 @@ class TestRedistance(KratosUnittest.TestCase):
         KratosMultiphysics.ModelPartIO(GetFilePath("coarse_sphere")).ReadModelPart(model_part)
         model_part.SetBufferSize(2)
         print(model_part)
-        
+
         original_vol = self._ComputeVolume(model_part.Elements)
         #original_surface = self._ComputeSurfaceArea(model_part.Conditions)
-        
+
         for elem in model_part.Elements:
             if(elem.Id % 2 == 0):
                 elem.SetValue(KratosMultiphysics.SPLIT_ELEMENT,True)
-            
+
         #IMPORTANT! must compute the neighbours first!!
         KratosMultiphysics.FindNodalNeighboursProcess(model_part).Execute()
-        
+
         refiner = KratosMultiphysics.MeshingApplication.LocalRefineTetrahedraMesh(model_part)
-        
+
         refine_on_reference = False
         interpolate_internal_variables = True
         refiner.LocalRefineMesh( refine_on_reference, interpolate_internal_variables)
 
         KratosMultiphysics.FindNodalNeighboursProcess(model_part).Execute()
-        
+
         reconnector = KratosMultiphysics.MeshingApplication.TetrahedraReconnectUtility(model_part)
         simIter = 2
         iterations = 2
@@ -131,7 +129,7 @@ class TestRedistance(KratosUnittest.TestCase):
         reconnector.OptimizeQuality(model_part, simIter, iterations, ProcessByNode, ProcessByFace, ProcessByEdge, saveToFile, removeFreeVertexes, evaluateInParallel, reInsertNodes, debugMode,minAngle)
         meshIsValid = reconnector.EvaluateQuality()
         reconnector.FinalizeOptimization(removeFreeVertexes)
-                        
+
         refined_vol = self._ComputeVolume(model_part.Elements)
         refined_surface = self._ComputeSurfaceArea(model_part.Conditions)
 

--- a/applications/MeshingApplication/tests/test_remesh_rectangle.py
+++ b/applications/MeshingApplication/tests/test_remesh_rectangle.py
@@ -1,7 +1,4 @@
-
-# We import the libraies
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
+# We import the libraries
 import KratosMultiphysics
 import KratosMultiphysics.MeshingApplication as MeshingApplication
 

--- a/applications/MeshingApplication/tests/test_remesh_sphere.py
+++ b/applications/MeshingApplication/tests/test_remesh_sphere.py
@@ -1,7 +1,4 @@
-
-# We import the libraies
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
+# We import the libraries
 import KratosMultiphysics
 import KratosMultiphysics.MeshingApplication as MeshingApplication
 


### PR DESCRIPTION
This PR removes from __future__ import print_function, absolute_import, division # makes KratosMultiphysics backward compatible with python 2.6 and 2.7 that now that the python2 support is dropped is not needed anymore