### PR TITLE
[StructuralMechanicsApplication] Clean up legacy python

### DIFF
--- a/applications/StructuralMechanicsApplication/StructuralMechanicsApplication.py
+++ b/applications/StructuralMechanicsApplication/StructuralMechanicsApplication.py
@@ -1,6 +1,3 @@
-# makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-from __future__ import print_function, absolute_import, division
-
 # Application dependent names and paths
 from KratosMultiphysics import _ImportApplication
 from KratosStructuralMechanicsApplication import *

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_analysis.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing Kratos
 import KratosMultiphysics as KM
 import KratosMultiphysics.StructuralMechanicsApplication as SMA

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_implicit_dynamic_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_static_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_utilities.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/adaptative_remeshing_structural_mechanics_utilities.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/automatic_rayleigh_parameters_computation_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/automatic_rayleigh_parameters_computation_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 from KratosMultiphysics import eigen_solver_factory

--- a/applications/StructuralMechanicsApplication/python_scripts/auxiliar_methods_adaptative_solvers.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/auxiliar_methods_adaptative_solvers.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/check_and_prepare_model_process_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/check_and_prepare_model_process_structural.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/StructuralMechanicsApplication/python_scripts/check_eigenvalues_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/check_eigenvalues_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 # Import KratosUnittest

--- a/applications/StructuralMechanicsApplication/python_scripts/convergence_criteria_factory.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/convergence_criteria_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/displacement_control_with_direction_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/displacement_control_with_direction_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/eigen_solution_input_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/eigen_solution_input_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/eigen_solution_output_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/eigen_solution_output_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/element_sensitivity_domain_integration_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 # Importing the Kratos Library
 import KratosMultiphysics
 import sys

--- a/applications/StructuralMechanicsApplication/python_scripts/impose_rigid_movement_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/impose_rigid_movement_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/python_scripts/kratos_main_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/kratos_main_structural.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics
 from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
 

--- a/applications/StructuralMechanicsApplication/python_scripts/postprocess_eigenvalues_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/postprocess_eigenvalues_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 import KratosMultiphysics.kratos_utilities as kratos_utils

--- a/applications/StructuralMechanicsApplication/python_scripts/project_vector_on_surface_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/project_vector_on_surface_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_adaptative_remeshing_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_adaptative_remeshing_structural.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 import KratosMultiphysics
 from importlib import import_module
 

--- a/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/python_solvers_wrapper_structural.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing Kratos
 import KratosMultiphysics
 import KratosMultiphysics.kratos_utilities as kratos_utils

--- a/applications/StructuralMechanicsApplication/python_scripts/rve_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/rve_analysis.py
@@ -1,6 +1,3 @@
-# makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication
 from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis

--- a/applications/StructuralMechanicsApplication/python_scripts/simplified_nodal_contact_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/simplified_nodal_contact_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/sprism_process.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/sprism_process.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_adjoint_static_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_analysis.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing Kratos
 import KratosMultiphysics
 from KratosMultiphysics.StructuralMechanicsApplication import python_solvers_wrapper_structural as structural_solvers

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_custom_scipy_base_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_custom_scipy_base_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_eigensolver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_explicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_explicit_dynamic_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_formfinding_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_formfinding_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_harmonic_analysis_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_harmonic_analysis_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_implicit_dynamic_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_prebuckling_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_prebuckling_analysis.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing Kratos
 import KratosMultiphysics
 # Importing the base class

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_prebuckling_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_prebuckling_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_static_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response.py
@@ -1,6 +1,3 @@
-"""This module contains the available structural response functions and their base class"""
-from __future__ import print_function, absolute_import, division
-
 # importing the Kratos Library
 import KratosMultiphysics
 from KratosMultiphysics import Parameters, Logger

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_response_function_factory.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_response_function_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 # importing the Kratos Library
 from KratosMultiphysics.StructuralMechanicsApplication import structural_response
 

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_convergence_criteria_factory.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_convergence_criteria_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_implicit_dynamic_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_static_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/trilinos_structural_mechanics_static_solver.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_test_factory.py
+++ b/applications/StructuralMechanicsApplication/tests/adjoint_sensitivity_analysis_test_factory.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import os
 
 #import kratos core and applications

--- a/applications/StructuralMechanicsApplication/tests/structural_mechanics_test_factory_mpi.py
+++ b/applications/StructuralMechanicsApplication/tests/structural_mechanics_test_factory_mpi.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/StructuralMechanicsApplication/tests/test_adjoint_loading_conditions.py
+++ b/applications/StructuralMechanicsApplication/tests/test_adjoint_loading_conditions.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/applications/StructuralMechanicsApplication/tests/test_axis_projection.py
+++ b/applications/StructuralMechanicsApplication/tests/test_axis_projection.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_compute_center_of_gravity.py
+++ b/applications/StructuralMechanicsApplication/tests/test_compute_center_of_gravity.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_compute_mass_moment_of_inertia.py
+++ b/applications/StructuralMechanicsApplication/tests/test_compute_mass_moment_of_inertia.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_constitutive_law.py
+++ b/applications/StructuralMechanicsApplication/tests/test_constitutive_law.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_cook_membrane.py
+++ b/applications/StructuralMechanicsApplication/tests/test_cook_membrane.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_cr_beam_adjoint_element_3d2n.py
+++ b/applications/StructuralMechanicsApplication/tests/test_cr_beam_adjoint_element_3d2n.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_dynamic_schemes.py
+++ b/applications/StructuralMechanicsApplication/tests/test_dynamic_schemes.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
+++ b/applications/StructuralMechanicsApplication/tests/test_harmonic_analysis.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_linear_thin_shell_adjoint_element_3d3n.py
+++ b/applications/StructuralMechanicsApplication/tests/test_linear_thin_shell_adjoint_element_3d3n.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_loading_conditions_line.py
+++ b/applications/StructuralMechanicsApplication/tests/test_loading_conditions_line.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_loading_conditions_point.py
+++ b/applications/StructuralMechanicsApplication/tests/test_loading_conditions_point.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
@@ -6,7 +5,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 
 class TestLoadingConditionsPoint(KratosUnittest.TestCase):
-            
+
     def _execute_point_load_condition_test(self, current_model, Dimension):
         mp = current_model.CreateModelPart("solid_part")
         mp.SetBufferSize(2)
@@ -128,7 +127,7 @@ class TestLoadingConditionsPoint(KratosUnittest.TestCase):
     def test_PointMomentCondition3D1N(self):
         current_model = KratosMultiphysics.Model()
         self._execute_point_moment_condition_test(current_model)
-    
+
 
 if __name__ == '__main__':
     KratosUnittest.main()

--- a/applications/StructuralMechanicsApplication/tests/test_loading_conditions_surface.py
+++ b/applications/StructuralMechanicsApplication/tests/test_loading_conditions_surface.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
@@ -7,7 +6,7 @@ import math
 
 
 class TestLoadingConditionsSurface(KratosUnittest.TestCase):
-        
+
     def _SimplestSurfaceLoadCondition3D4N(self, prefix = ""):
         current_model = KratosMultiphysics.Model()
         mp = current_model.CreateModelPart("solid_part")

--- a/applications/StructuralMechanicsApplication/tests/test_local_axis_visualization.py
+++ b/applications/StructuralMechanicsApplication/tests/test_local_axis_visualization.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_mass_calculation.py
+++ b/applications/StructuralMechanicsApplication/tests/test_mass_calculation.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_multipoint_contstraints.py
+++ b/applications/StructuralMechanicsApplication/tests/test_multipoint_contstraints.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication
@@ -8,7 +7,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 class TestMultipointConstraints(KratosUnittest.TestCase):
     def setUp(self):
         pass
-    
+
     def _add_variables(self, mp):
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.REACTION)
@@ -264,7 +263,7 @@ class TestMultipointConstraints(KratosUnittest.TestCase):
         cm = KratosMultiphysics.StructuralMechanicsApplication.ApplyMultipointConstraintsProcess(
             mp)
         self._apply_mpc_constraints(mp, cm)
-        # Solving the system of equations        
+        # Solving the system of equations
         self._setup_solver(mp)
 
         while (time <= end_time):

--- a/applications/StructuralMechanicsApplication/tests/test_nodal_damping.py
+++ b/applications/StructuralMechanicsApplication/tests/test_nodal_damping.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_cr_beam.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_cr_beam.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_formfinding_trusses.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_formfinding_trusses.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_large_strain.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_large_strain.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_membrane.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_membrane.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_shells.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_shells.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
@@ -161,9 +160,9 @@ class TestPatchTestShells(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
-                                displacement_results, 
-                                rotation_results, 
+                                element_name,
+                                displacement_results,
+                                rotation_results,
                                 False) # Do PostProcessing for GiD?
 
 
@@ -174,9 +173,9 @@ class TestPatchTestShells(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
-                                displacement_results, 
-                                rotation_results, 
+                                element_name,
+                                displacement_results,
+                                rotation_results,
                                 False) # Do PostProcessing for GiD?
 
 
@@ -187,9 +186,9 @@ class TestPatchTestShells(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
-                                displacement_results, 
-                                rotation_results, 
+                                element_name,
+                                displacement_results,
+                                rotation_results,
                                 False) # Do PostProcessing for GiD?
 
 
@@ -200,9 +199,9 @@ class TestPatchTestShells(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
-                                displacement_results, 
-                                rotation_results, 
+                                element_name,
+                                displacement_results,
+                                rotation_results,
                                 False) # Do PostProcessing for GiD?
 
 

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_shells_orthotropic.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_shells_orthotropic.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 from KratosMultiphysics import *
 
@@ -218,8 +217,8 @@ class TestPatchTestShellsOrthotropic(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
-                                displacement_results, 
+                                element_name,
+                                displacement_results,
                                 rotation_results,
                                 shell_stress_top_surface_results,
                                 shell_stress_bottom_surface_results,
@@ -237,8 +236,8 @@ class TestPatchTestShellsOrthotropic(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
-                                displacement_results, 
+                                element_name,
+                                displacement_results,
                                 rotation_results,
                                 shell_stress_top_surface_results,
                                 shell_stress_bottom_surface_results,
@@ -256,9 +255,9 @@ class TestPatchTestShellsOrthotropic(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
-                                displacement_results, 
-                                rotation_results, 
+                                element_name,
+                                displacement_results,
+                                rotation_results,
                                 shell_stress_top_surface_results,
                                 shell_stress_bottom_surface_results,
                                 tsai_wu_result,
@@ -275,8 +274,8 @@ class TestPatchTestShellsOrthotropic(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
-                                displacement_results, 
+                                element_name,
+                                displacement_results,
                                 rotation_results,
                                 shell_stress_top_surface_results,
                                 shell_stress_bottom_surface_results,

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_shells_stress.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_shells_stress.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
@@ -8,7 +7,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 class TestPatchTestShellsStressRec(KratosUnittest.TestCase):
     def setUp(self):
         pass
-        
+
     def _add_variables(self,mp):
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.DISPLACEMENT)
         mp.AddNodalSolutionStepVariable(KratosMultiphysics.ROTATION)
@@ -194,7 +193,7 @@ class TestPatchTestShellsStressRec(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
+                                element_name,
                                 displacement_results,
                                 rotation_results,
                                 shell_stress_middle_surface_results,
@@ -215,7 +214,7 @@ class TestPatchTestShellsStressRec(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
+                                element_name,
                                 displacement_results,
                                 rotation_results,
                                 shell_stress_middle_surface_results,
@@ -236,7 +235,7 @@ class TestPatchTestShellsStressRec(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
+                                element_name,
                                 displacement_results,
                                 rotation_results,
                                 shell_stress_middle_surface_results,
@@ -257,7 +256,7 @@ class TestPatchTestShellsStressRec(KratosUnittest.TestCase):
 
         current_model = KratosMultiphysics.Model()
         self.execute_shell_test(current_model,
-                                element_name, 
+                                element_name,
                                 displacement_results,
                                 rotation_results,
                                 shell_stress_middle_surface_results,

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_small_displacement_mixed_volumetric_strain.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_small_displacement_mixed_volumetric_strain.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain_bbar.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_small_strain_bbar.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_truss.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_truss.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_perfect_plasticity_implementation_verification.py
+++ b/applications/StructuralMechanicsApplication/tests/test_perfect_plasticity_implementation_verification.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_postprocess_eigenvalues_process.py
+++ b/applications/StructuralMechanicsApplication/tests/test_postprocess_eigenvalues_process.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_quadratic_elements.py
+++ b/applications/StructuralMechanicsApplication/tests/test_quadratic_elements.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication

--- a/applications/StructuralMechanicsApplication/tests/test_rve_analytic.py
+++ b/applications/StructuralMechanicsApplication/tests/test_rve_analytic.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division
-
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication
 import KratosMultiphysics.KratosUnittest as KratosUnittest

--- a/applications/StructuralMechanicsApplication/tests/test_truss_adjoint_element_3d2n.py
+++ b/applications/StructuralMechanicsApplication/tests/test_truss_adjoint_element_3d2n.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division
 import KratosMultiphysics
 
 import KratosMultiphysics.StructuralMechanicsApplication as StructuralMechanicsApplication


### PR DESCRIPTION
**Description**
Clean up lgeacy python code 

**Changelog**
- Removes `from __future__ import print_function, absolute_import, division`



