### PR TITLE
[MPM] fix search parallel loop

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
@@ -169,7 +169,7 @@ namespace MPMSearchElementUtility
         std::vector<typename Element::Pointer>& rMissingElements,
         const double Tolerance)
     {
-        #pragma omp for
+        #pragma omp parallel for
         for (int i = 0; i < static_cast<int>(rMPMModelPart.Elements().size()); ++i) {
             auto element_itr = (rMPMModelPart.ElementsBegin() + i);
             array_1d<double, 3> local_coordinates;
@@ -207,7 +207,7 @@ namespace MPMSearchElementUtility
         std::vector<typename Condition::Pointer>& rMissingConditions,
         const double Tolerance)
     {
-        #pragma omp for
+        #pragma omp parallel for
         for (int i = 0; i < static_cast<int>(rMPMModelPart.Conditions().size()); ++i) {
             auto condition_itr = rMPMModelPart.Conditions().begin() + i;
 


### PR DESCRIPTION
**Description**
Fixes the parallel loop for element and condition search. 

`#pragma omp parallel` spawns a group of threads, while `#pragma omp` for divides loop iterations between the spawned threads. You can do both things at once with the fused `#pragma omp parallel for` directive.


**Changelog**
- Change `#pragma omp for` to `#pragma omp parallel for`