### PR TITLE
Core/change for out of kratos dir build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -475,8 +475,8 @@ install(CODE "message(STATUS \"Deleting: ${CMAKE_INSTALL_PREFIX}/libs\")")
 install(CODE "file(REMOVE_RECURSE \"${CMAKE_INSTALL_PREFIX}/libs\")")
 
 # Install core files for the KratosMultiphysics python module
-install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/__init__.py" DESTINATION KratosMultiphysics )
-install(FILES "${CMAKE_SOURCE_DIR}/kratos/python_interface/kratos_globals.py" DESTINATION KratosMultiphysics )
+install(FILES "${KRATOS_SOURCE_DIR}/kratos/python_interface/__init__.py" DESTINATION KratosMultiphysics )
+install(FILES "${KRATOS_SOURCE_DIR}/kratos/python_interface/kratos_globals.py" DESTINATION KratosMultiphysics )
 
 # Install the libraries in the libs folder
 install(FILES ${Boost_LIBRARIES} DESTINATION libs)


### PR DESCRIPTION
**Description**

Whenever CMake source directory is not the same as the Kratos source directory, I get the error during installation.  The change would avoid the problem.

-----------------------------------------------------------------------
@KratosMultiphysics/technical-committee  @KratosMultiphysics/altair 