### PR TITLE
[MLMC] Update xMC library

### DIFF
--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_amc_Kratos_poisson_2d.json
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_amc_Kratos_poisson_2d.json
@@ -23,7 +23,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 3
+        "eventGroupSize": 3
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1]],
@@ -63,13 +63,13 @@
         "parameters": null,
         "printToFile": false,
         "problemId": "poisson_2d",
-        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_poisson_square_2d_finer.json",
+        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_finer.json",
         "refinementParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_refinement.json",
         "refinementStrategy": "stochastic_adaptive_refinement",
         "outputBatchSize" : 1,
         "taskAllAtOnce": false
     },
-    "monoCriteriaInpuctDict" :{
+    "monoCriteriaInpuctDictionary" :{
         "statisticalError": {
             "criteria": "xmc.methodDefs_monoCriterion.criterionFunctions.isLowerThanOrEqualTo",
             "tolerance": [0.15],

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mc_Kratos_asynchronous_poisson_2d.json
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mc_Kratos_asynchronous_poisson_2d.json
@@ -24,7 +24,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 5
+        "eventGroupSize": 5
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1]],
@@ -65,13 +65,13 @@
         "parameters": null,
         "printToFile": false,
         "problemId": "poisson_2d",
-        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_poisson_square_2d_finer.json",
+        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_finer.json",
         "refinementParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_refinement.json",
         "refinementStrategy": "stochastic_adaptive_refinement",
         "outputBatchSize" : 1,
         "taskAllAtOnce": true
     },
-    "monoCriteriaInpuctDict" :{
+    "monoCriteriaInpuctDictionary" :{
         "statisticalError": {
             "criteria": "xmc.methodDefs_monoCriterion.criterionFunctions.isLowerThanOrEqualTo",
             "tolerance": [0.15],

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mc_Kratos_asynchronous_poisson_2d_with_combined_power_sums.json
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mc_Kratos_asynchronous_poisson_2d_with_combined_power_sums.json
@@ -24,7 +24,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 3
+        "eventGroupSize": 3
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1]],
@@ -65,13 +65,13 @@
         "parameters": null,
         "printToFile": false,
         "problemId": "poisson_2d",
-        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_poisson_square_2d_finer.json",
+        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_finer.json",
         "refinementParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_refinement.json",
         "refinementStrategy": "stochastic_adaptive_refinement",
         "outputBatchSize": 2,
         "taskAllAtOnce": false
     },
-    "monoCriteriaInpuctDict" :{
+    "monoCriteriaInpuctDictionary" :{
         "statisticalError": {
             "criteria": "xmc.methodDefs_monoCriterion.criterionFunctions.isLowerThanOrEqualTo",
             "tolerance": [0.15],

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mc_Kratos_poisson_2d.json
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mc_Kratos_poisson_2d.json
@@ -24,7 +24,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 3
+        "eventGroupSize": 3
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1]],
@@ -64,13 +64,13 @@
         "parameters": null,
         "printToFile": false,
         "problemId": "poisson_2d",
-        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_poisson_square_2d_finer.json",
+        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_finer.json",
         "refinementParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_refinement.json",
         "refinementStrategy": "stochastic_adaptive_refinement",
         "outputBatchSize": 1,
         "taskAllAtOnce": false
     },
-    "monoCriteriaInpuctDict" :{
+    "monoCriteriaInpuctDictionary" :{
         "statisticalError": {
             "criteria": "xmc.methodDefs_monoCriterion.criterionFunctions.isLowerThanOrEqualTo",
             "tolerance": [0.15],

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mc_Kratos_poisson_2d_with_combined_power_sums.json
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mc_Kratos_poisson_2d_with_combined_power_sums.json
@@ -24,7 +24,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 3
+        "eventGroupSize": 3
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1]],
@@ -64,13 +64,13 @@
         "parameters": null,
         "printToFile": false,
         "problemId": "poisson_2d",
-        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_poisson_square_2d_finer.json",
+        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_finer.json",
         "refinementParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_refinement.json",
         "refinementStrategy": "stochastic_adaptive_refinement",
         "outputBatchSize" : 3,
         "taskAllAtOnce": false
     },
-    "monoCriteriaInpuctDict" :{
+    "monoCriteriaInpuctDictionary" :{
         "statisticalError": {
             "criteria": "xmc.methodDefs_monoCriterion.criterionFunctions.isLowerThanOrEqualTo",
             "tolerance": [0.15],

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mlmc_Kratos_asynchronous_poisson_2d.json
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mlmc_Kratos_asynchronous_poisson_2d.json
@@ -24,7 +24,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 5
+        "eventGroupSize": 5
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1,2]],
@@ -65,13 +65,13 @@
         "parameters": null,
         "printToFile": false,
         "problemId": "poisson_2d",
-        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_poisson_square_2d_finer.json",
+        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_finer.json",
         "refinementParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_refinement.json",
         "refinementStrategy": "stochastic_adaptive_refinement",
         "outputBatchSize": 1,
         "taskAllAtOnce": true
     },
-    "monoCriteriaInpuctDict" :{
+    "monoCriteriaInpuctDictionary" :{
         "statisticalError": {
             "criteria": "xmc.methodDefs_monoCriterion.criterionFunctions.isLowerThanOrEqualTo",
             "tolerance": [0.15],

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mlmc_Kratos_asynchronous_poisson_2d_with_combined_power_sums.json
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mlmc_Kratos_asynchronous_poisson_2d_with_combined_power_sums.json
@@ -24,7 +24,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 2
+        "eventGroupSize": 2
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1,2]],
@@ -65,13 +65,13 @@
         "parameters": null,
         "printToFile": false,
         "problemId": "poisson_2d",
-        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_poisson_square_2d_finer.json",
+        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_finer.json",
         "refinementParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_refinement.json",
         "refinementStrategy": "stochastic_adaptive_refinement",
         "outputBatchSize": 2,
         "taskAllAtOnce": true
     },
-    "monoCriteriaInpuctDict" :{
+    "monoCriteriaInpuctDictionary" :{
         "statisticalError": {
             "criteria": "xmc.methodDefs_monoCriterion.criterionFunctions.isLowerThanOrEqualTo",
             "tolerance": [0.15],

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mlmc_Kratos_poisson_2d.json
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mlmc_Kratos_poisson_2d.json
@@ -24,7 +24,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 3
+        "eventGroupSize": 3
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1,2]],
@@ -65,13 +65,13 @@
         "parameters": null,
         "printToFile": false,
         "problemId": "poisson_2d",
-        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_poisson_square_2d_finer.json",
+        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_finer.json",
         "refinementParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_refinement.json",
         "refinementStrategy": "stochastic_adaptive_refinement",
         "outputBatchSize" : 1,
         "taskAllAtOnce": false
     },
-    "monoCriteriaInpuctDict" :{
+    "monoCriteriaInpuctDictionary" :{
         "statisticalError": {
             "criteria": "xmc.methodDefs_monoCriterion.criterionFunctions.isLowerThanOrEqualTo",
             "tolerance": [0.15],

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mlmc_Kratos_poisson_2d_with_combined_power_sums.json
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/parameters/parameters_xmc_test_mlmc_Kratos_poisson_2d_with_combined_power_sums.json
@@ -24,7 +24,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 2
+        "eventGroupSize": 2
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1,2]],
@@ -65,13 +65,13 @@
         "parameters": null,
         "printToFile": false,
         "problemId": "poisson_2d",
-        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_poisson_square_2d_finer.json",
+        "projectParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_finer.json",
         "refinementParametersPath": "../xmc/classDefs_solverWrapper/problemDefs_KratosMultiphysics/poisson_2d/problem_settings/parameters_refinement.json",
         "refinementStrategy": "stochastic_adaptive_refinement",
         "outputBatchSize" : 2,
         "taskAllAtOnce": false
     },
-    "monoCriteriaInpuctDict" :{
+    "monoCriteriaInpuctDictionary" :{
         "statisticalError": {
             "criteria": "xmc.methodDefs_monoCriterion.criterionFunctions.isLowerThanOrEqualTo",
             "tolerance": [0.15],

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/run_mc_Kratos.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/run_mc_Kratos.py
@@ -45,11 +45,11 @@ if __name__ == "__main__":
     # MonoCriterion
     criteriaArray = []
     criteriaInputs = []
-    for monoCriterion in (parameters["monoCriteriaInpuctDict"]):
+    for monoCriterion in (parameters["monoCriteriaInpuctDictionary"]):
         criteriaArray.append(xmc.monoCriterion.MonoCriterion(\
-            parameters["monoCriteriaInpuctDict"][monoCriterion]["criteria"],\
-            parameters["monoCriteriaInpuctDict"][monoCriterion]["tolerance"]))
-        criteriaInputs.append([parameters["monoCriteriaInpuctDict"][monoCriterion]["input"]])
+            parameters["monoCriteriaInpuctDictionary"][monoCriterion]["criteria"],\
+            parameters["monoCriteriaInpuctDictionary"][monoCriterion]["tolerance"]))
+        criteriaInputs.append([parameters["monoCriteriaInpuctDictionary"][monoCriterion]["input"]])
 
     # MultiCriterion
     multiCriterionInputDictionary=parameters["multiCriterionInputDictionary"]

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/run_mlmc_Kratos.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/examples/run_mlmc_Kratos.py
@@ -45,11 +45,11 @@ if __name__ == "__main__":
     # MonoCriterion
     criteriaArray = []
     criteriaInputs = []
-    for monoCriterion in (parameters["monoCriteriaInpuctDict"]):
+    for monoCriterion in (parameters["monoCriteriaInpuctDictionary"]):
         criteriaArray.append(xmc.monoCriterion.MonoCriterion(\
-            parameters["monoCriteriaInpuctDict"][monoCriterion]["criteria"],\
-            parameters["monoCriteriaInpuctDict"][monoCriterion]["tolerance"]))
-        criteriaInputs.append([parameters["monoCriteriaInpuctDict"][monoCriterion]["input"]])
+            parameters["monoCriteriaInpuctDictionary"][monoCriterion]["criteria"],\
+            parameters["monoCriteriaInpuctDictionary"][monoCriterion]["tolerance"]))
+        criteriaInputs.append([parameters["monoCriteriaInpuctDictionary"][monoCriterion]["input"]])
 
     # MultiCriterion
     multiCriterionInputDictionary=parameters["multiCriterionInputDictionary"]

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/methodDefs_randomGeneratorWrapper/generator.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/methodDefs_randomGeneratorWrapper/generator.py
@@ -77,3 +77,9 @@ def returnUniformAndTwoNormal(*args):
     two normal random variables
     """
     return [int(np.random.uniform(args[0],args[1])),np.random.normal(args[2], args[3], 1),np.random.normal(args[4], args[5], 1)]
+
+def returnIntegerUniform(*args):
+    """
+    Return one integer uniformly distributed random variable
+    """
+    return [int(np.random.uniform(args[0],args[1]))]

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/methodDefs_randomGeneratorWrapper/generator.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/methodDefs_randomGeneratorWrapper/generator.py
@@ -11,7 +11,7 @@ def normal(mean : float, deviation : float, shape : tuple = None):
     - deviation: float, standard deviation of the normal distribution.
     - shape (optional): tuple, shape of the desired output. If omitted, the output is a float.
 
-    Output: float if shape is omitted. Otherwise, nested list of required shape, whose every element is a float. 
+    Output: float if shape is omitted. Otherwise, nested list of required shape, whose every element is a float.
     These floats are drawn independantly from the normal distribution specified by the input arguments.
 
     Note: differences with returnStandardNormal.
@@ -27,7 +27,7 @@ def normal(mean : float, deviation : float, shape : tuple = None):
     if isinstance(sample,np.ndarray):
         sample = sample.astype(float).tolist()
     return sample
-        
+
 
 def returnStandardNormal(*args):
     """
@@ -70,6 +70,13 @@ def returnRayleighAndUniform(*args):
     rayleigh_rv = np.random.rayleigh(args[0],size=1)[0]
     uniform_rv = np.random.uniform(args[1], args[2], 1)
     return [rayleigh_rv, uniform_rv]
+
+def returnUniformAndNormal(*args):
+    """
+    Return one integer uniformly distributed random variable and
+    one normal random variable
+    """
+    return [int(np.random.uniform(args[0],args[1])),np.random.normal(args[2], args[3], 1)]
 
 def returnUniformAndTwoNormal(*args):
     """

--- a/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/monteCarloIndex.py
+++ b/applications/MultilevelMonteCarloApplication/external_libraries/XMC/xmc/monteCarloIndex.py
@@ -84,7 +84,7 @@ class MonteCarloIndex():
         Returns the requested moment estimation of the cost.
         The input arguments are passed to the cost estimator's relevant method.
         """
-        
+
         return self.costEstimator.value(*costEstimatorValueArguments)
 
     def newSample(self):
@@ -93,7 +93,7 @@ class MonteCarloIndex():
 
         See the documentation of SampleGenerator.generate for the data structure.
         """
-        
+
         sample = self.sampler.generate()
         return sample
 
@@ -101,14 +101,14 @@ class MonteCarloIndex():
         """
         Returns the dimension of the Monte Carlo index set.
         """
-        
+
         return len(self.indexValue)
 
     def solverIndices(self):
         """
         Compute list of indices of correlated solvers.
         """
-        
+
         diff_tuple = []
         hypercube_vertices = 2**self.indexSetDimension()
         for _ in range(self.indexSetDimension()):
@@ -124,7 +124,7 @@ class MonteCarloIndex():
         """
         Add newsamples to stored samples. This is an internal method with no check on whether sample storage is enabled; be careful when using it.
         """
-        
+
         # TODO replace self.samples with self.data
         self.samples.append(newSamples)
 
@@ -135,7 +135,7 @@ class MonteCarloIndex():
         each sample and the associated cost with newSample and pass them
         to the update methods of qoiEstimator and costEstimator.
         """
-        
+
         # Compute number of new samples based on areSamplesRecycled
         # TODO Minimum number of new samples hard coded here to 6, since
         # program not planned for moment > 4 estimation. Accept/infer this
@@ -180,15 +180,15 @@ class MonteCarloIndex():
         # (s: solver, o: output); idem for S_i2.
 
         # If solver outputs are split, (i.e. MonteCarloIndex.areSamplesSplit()),
-        # S_ij is of length len(MonteCarloIndex.sampleSplitSizes()) 
+        # S_ij is of length len(MonteCarloIndex.sampleSplitSizes())
         # and S_ijk is of length MonteCarloIndex.sampleSplitSizes()[k].
         # Example, for any event i. If MonteCarloIndex.numberOfSolvers() == 2 and
         # MonteCarloIndex.sampleSplitSizes() == [3, 2]:
         # S_i1 == [ S_(1,1), S_(1,2) ] == [ [s1_o1, s1_o2, s1_o3], [s1_o4, s1_o5] ]
         #      == [future, future] if parallel
-        # (s: solver, o: output); idem for solver S_i2.       
+        # (s: solver, o: output); idem for solver S_i2.
 
-        
+
         ### Estimator update
 
         # Get the multi-indices to the subsets of estimators, samples and times
@@ -361,7 +361,7 @@ class MonteCarloIndex():
         """
         Returns the numberofsolvers in the sample generator<
         """
-        
+
         return len(self.sampler.solvers)
 
     def sampleDimension(self, *args) -> int:
@@ -375,7 +375,7 @@ class MonteCarloIndex():
         Output argument:
         - sample dimension: integer. See SampleGenerator.sampleDimension
         """
-        
+
         return self.sampler.sampleDimension(*args)
 
     def sampleSplitSizes(self, *args):
@@ -386,7 +386,7 @@ class MonteCarloIndex():
 
         Output argument: list of integers, or None. If list, it is [len(subSample) for subSample in sample], where sample is the output from a single solver (after processing).
         """
-        
+
         return self.sampler.sampleSplitSizes(*args)
 
     def areSamplesSplit(self, *args) -> bool:
@@ -398,5 +398,5 @@ class MonteCarloIndex():
 
         Output argument: boolean, True is samples are split and False otherwise.
         """
-        
+
         return self.sampler.areSamplesSplit(*args)

--- a/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mc_Kratos_asynchronous_poisson_2d.json
+++ b/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mc_Kratos_asynchronous_poisson_2d.json
@@ -27,7 +27,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 5
+        "eventGroupSize": 5
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1]],

--- a/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mc_Kratos_asynchronous_poisson_2d_with_10_combined_power_sums.json
+++ b/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mc_Kratos_asynchronous_poisson_2d_with_10_combined_power_sums.json
@@ -27,7 +27,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 2
+        "eventGroupSize": 2
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1]],

--- a/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mc_Kratos_asynchronous_poisson_2d_with_combined_power_sums.json
+++ b/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mc_Kratos_asynchronous_poisson_2d_with_combined_power_sums.json
@@ -27,7 +27,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 2
+        "eventGroupSize": 2
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1]],

--- a/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mc_Kratos_poisson_2d.json
+++ b/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mc_Kratos_poisson_2d.json
@@ -27,7 +27,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 3
+        "eventGroupSize": 3
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1]],

--- a/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mc_Kratos_poisson_2d_with_combined_power_sums.json
+++ b/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mc_Kratos_poisson_2d_with_combined_power_sums.json
@@ -27,7 +27,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 3
+        "eventGroupSize": 3
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1]],

--- a/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mlmc_Kratos_asynchronous_poisson_2d.json
+++ b/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mlmc_Kratos_asynchronous_poisson_2d.json
@@ -27,7 +27,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 5
+        "eventGroupSize": 5
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1,2]],

--- a/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mlmc_Kratos_asynchronous_poisson_2d_with_combined_power_sums.json
+++ b/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mlmc_Kratos_asynchronous_poisson_2d_with_combined_power_sums.json
@@ -27,7 +27,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 2
+        "eventGroupSize": 2
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1,2]],

--- a/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mlmc_Kratos_poisson_2d.json
+++ b/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mlmc_Kratos_poisson_2d.json
@@ -27,7 +27,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 3
+        "eventGroupSize": 3
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1,2]],

--- a/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mlmc_Kratos_poisson_2d_with_combined_power_sums.json
+++ b/applications/MultilevelMonteCarloApplication/tests/parameters/parameters_xmc_test_mlmc_Kratos_poisson_2d_with_combined_power_sums.json
@@ -27,7 +27,7 @@
         "indexValue": null,
         "qoiEstimator": ["xmc.momentEstimator.MomentEstimator"],
         "sampler": "xmc.sampleGenerator.SampleGenerator",
-        "estimatorBatchSize": 2
+        "eventGroupSize": 2
     },
     "monteCarloSamplerInputDictionary": {
         "assemblersForError": [[1,2]],

--- a/applications/MultilevelMonteCarloApplication/tests/poisson_square_2d/multilevel_monte_carlo_main.py
+++ b/applications/MultilevelMonteCarloApplication/tests/poisson_square_2d/multilevel_monte_carlo_main.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/MultilevelMonteCarloApplication/tests/poisson_square_2d/simulation_definition.py
+++ b/applications/MultilevelMonteCarloApplication/tests/poisson_square_2d/simulation_definition.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/MultilevelMonteCarloApplication/tests/poisson_square_2d_xmc/simulation_definition.py
+++ b/applications/MultilevelMonteCarloApplication/tests/poisson_square_2d_xmc/simulation_definition.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
 

--- a/applications/MultilevelMonteCarloApplication/tests/test_multilevel_montecarlo.py
+++ b/applications/MultilevelMonteCarloApplication/tests/test_multilevel_montecarlo.py
@@ -1,18 +1,12 @@
 from KratosMultiphysics import *
 from KratosMultiphysics.MultilevelMonteCarloApplication import *
 
-try:
-    import KratosMultiphysics.ConvectionDiffusionApplication
-    have_convection_diffusion_application = True
-except ImportError:
-    have_convection_diffusion_application = False
-
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 import KratosMultiphysics.kratos_utilities as kratos_utilities
 
 import os
 
-@KratosUnittest.skipUnless(have_convection_diffusion_application,"Missing required application: ConvectionDiffusionApplication")
+@KratosUnittest.skipIfApplicationsNotAvailable("ConvectionDiffusionApplication")
 class KratosMultilevelMonteCarloGeneralTestsAuxiliary(KratosUnittest.TestCase):
 
     def MonteCarloTest(self):


### PR DESCRIPTION
**Description**
Update xMC library to commit e1200a8df93e37d232bbb293201d1bdf6d71605b.

Please mark the PR with appropriate tags: 
- External library.

**Changelog**

- The deprecated `estimatorBatchSize` is replaced with `eventGroupSize`.
- Some json name inconsistencies are fixed.
- `python2` dependencies in tests are removed.

**Additional info**
None.