### PR TITLE
[Core] fix timers - 2nd try

### DIFF
--- a/kratos/utilities/timer.cpp
+++ b/kratos/utilities/timer.cpp
@@ -113,19 +113,11 @@ void Timer::Start(std::string const& rIntervalName)
         const std::string internal_name = GetInternalName(rIntervalName);
         msInternalNameDatabase.insert(std::pair<std::string, std::string>(rIntervalName, internal_name));
         msTimeTable[internal_name].SetStartTime(GetTime());
-        
-        const std::string& r_name = msInternalNameDatabase[rIntervalName];
-        ContainerType::iterator it_time_data = msTimeTable.find(r_name);
-        it_time_data->second.SetStartTime(GetTime());        
-        
         ++msCounter;
     }
-    else
-    {
-        const std::string& r_name = msInternalNameDatabase[rIntervalName];
-        ContainerType::iterator it_time_data = msTimeTable.find(r_name);
-        it_time_data->second.SetStartTime(GetTime());
-    }
+    const std::string& r_name = msInternalNameDatabase[rIntervalName];
+    ContainerType::iterator it_time_data = msTimeTable.find(r_name);
+    it_time_data->second.SetStartTime(GetTime());
 }
 
 void Timer::Stop(std::string const& rIntervalName)

--- a/kratos/utilities/timer.cpp
+++ b/kratos/utilities/timer.cpp
@@ -33,8 +33,9 @@ void Timer::TimerData::PrintData(
             rOStream.precision(6);
             rOStream
             << std::setw(4)
-            << std::defaultfloat
+            << std::setiosflags(std::ios::fixed)
             << mRepeatNumber
+            << std::resetiosflags(std::ios::fixed)
             << "\t\t"
             << std::setiosflags(std::ios::scientific)
             << std::setprecision(4)
@@ -64,9 +65,10 @@ void Timer::TimerData::PrintData(
             rOStream.precision(6);
             rOStream
             << std::setw(4)
-            << std::defaultfloat
+            << std::setiosflags(std::ios::fixed)
             << mRepeatNumber
             << "\t\t"
+            << std::resetiosflags(std::ios::fixed)
             << std::setiosflags(std::ios::scientific)
             << std::setprecision(4)
             << std::uppercase
@@ -90,8 +92,9 @@ void Timer::TimerData::PrintData(
             << std::uppercase
             << std::setw(4)
             << mTotalElapsedTime/static_cast<double>(mRepeatNumber)
+            << std::resetiosflags(std::ios::scientific)
             << "     \t"
-            << std::fixed
+            << std::setiosflags(std::ios::fixed)
             << std::setprecision(3)
             << std::uppercase
             << std::setw(3)
@@ -261,4 +264,3 @@ bool Timer::msPrintIntervalInformation = true;
 const std::chrono::steady_clock::time_point Timer::mStartTime = std::chrono::steady_clock::now();
 
 } /// namespace Kratos
-

--- a/kratos/utilities/timer.cpp
+++ b/kratos/utilities/timer.cpp
@@ -113,7 +113,18 @@ void Timer::Start(std::string const& rIntervalName)
         const std::string internal_name = GetInternalName(rIntervalName);
         msInternalNameDatabase.insert(std::pair<std::string, std::string>(rIntervalName, internal_name));
         msTimeTable[internal_name].SetStartTime(GetTime());
+        
+        const std::string& r_name = msInternalNameDatabase[rIntervalName];
+        ContainerType::iterator it_time_data = msTimeTable.find(r_name);
+        it_time_data->second.SetStartTime(GetTime());        
+        
         ++msCounter;
+    }
+    else
+    {
+        const std::string& r_name = msInternalNameDatabase[rIntervalName];
+        ContainerType::iterator it_time_data = msTimeTable.find(r_name);
+        it_time_data->second.SetStartTime(GetTime());
     }
 }
 


### PR DESCRIPTION
**Description**
It seems std::defaultfloat is not available in centos7. This should work. Also, I forgot to bring one change made by @vdivine that we never pushed back to github. Maybe he can comment on that. It is needed to correctly compute times.
