### PR TITLE
[Core] Adding missing separation includes

### DIFF
--- a/kratos/includes/checks.h
+++ b/kratos/includes/checks.h
@@ -11,9 +11,14 @@
 //
 //
 
+// System includes
 #include <cstring>
 #include <limits>
 #include <cmath> // std::abs for double
+
+// External includes
+
+// Project includes
 #include "includes/exception.h"
 
 #if !defined(KRATOS_CHECKS_H_INCLUDED )


### PR DESCRIPTION
**Description**
I found that check.h does not separate the includes

**Changelog**
- Adding separators
