### PR TITLE
Revert "Revert "add function AddColors to the communicator""

### DIFF
--- a/kratos/includes/communicator.h
+++ b/kratos/includes/communicator.h
@@ -216,6 +216,8 @@ public:
 
     void SetNumberOfColors(SizeType NewNumberOfColors);
 
+    void AddColors(SizeType NumberOfAddedColors);
+
     NeighbourIndicesContainerType& NeighbourIndices();
 
     NeighbourIndicesContainerType const& NeighbourIndices() const;

--- a/kratos/sources/communicator.cpp
+++ b/kratos/sources/communicator.cpp
@@ -133,6 +133,22 @@ void Communicator::SetNumberOfColors(SizeType NewNumberOfColors)
     }
 }
 
+void Communicator::AddColors(SizeType NumberOfAddedColors)
+{
+    if (NumberOfAddedColors < 1)
+        return;
+
+    mNumberOfColors += NumberOfAddedColors;
+    MeshType mesh;
+
+    for (IndexType i = 0; i < NumberOfAddedColors; i++)
+    {
+        mLocalMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+        mGhostMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+        mInterfaceMeshes.push_back(Kratos::make_shared<MeshType>(mesh.Clone()));
+    }
+}
+
 Communicator::NeighbourIndicesContainerType& Communicator::NeighbourIndices()
 {
     return mNeighbourIndices;


### PR DESCRIPTION
This reverts commit 28ea97aaa1488fc95f038b7deeae947dc2bd9ed7.

For some reason the last commit merges in #7192 is a revert of the AddColors method, making imposssible to compile due to the existance of the communicator test