### PR TITLE
[README] Add citation section

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [CI-link]: https://github.com/KratosMultiphysics/Kratos/actions?query=workflow%3ACI
 
 [DOI-image]: https://zenodo.org/badge/DOI/10.5281/zenodo.3870709.svg
-[DOI]: https://doi.org/10.5281/zenodo.3870709
+[DOI]: https://doi.org/10.5281/zenodo.3234644
 
 _KRATOS Multiphysics_ ("Kratos") is a framework for building parallel, multi-disciplinary simulation software, aiming at modularity, extensibility, and high performance. Kratos is written in C++, and counts with an extensive Python interface. More in [Overview](https://github.com/KratosMultiphysics/Kratos/wiki/Overview)
 

--- a/README.md
+++ b/README.md
@@ -90,3 +90,9 @@ In Kratos Core:
 In applications
 - [Trilinos](https://trilinos.org/) for MPI linear algebra and solvers used in trilinos application
 - [METIS](http://glaros.dtc.umn.edu/gkhome/views/metis) for partitioning in metis application
+
+# How to cite Kratos?
+Please, use the following references when citing Kratos in your work.
+- Dadvand, P., Rossi, R. & Oñate, E. An Object-oriented Environment for Developing Finite Element Codes for Multi-disciplinary Applications. Arch Computat Methods Eng 17, 253–297 (2010). https://doi.org/10.1007/s11831-010-9045-2
+- Dadvand, P., Rossi, R., Gil, M., Martorell, X., Cotela, J., Juanpere, E., Idelsohn, S., Oñate, E. (2013). Migration of a generic multi-physics framework to HPC environments. Computers & Fluids. 80. 301–309. 10.1016/j.compfluid.2012.02.004.
+- Vicente Mataix Ferrándiz, Philipp Bucher, Riccardo Rossi, Jordi Cotela, Josep Maria, Rubén Zorrilla, … Riccardo Tosi. (2020, May 29). KratosMultiphysics (Version 8.0). Zenodo. https://doi.org/10.5281/zenodo.3234644

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@
 [CI-image]: https://github.com/KratosMultiphysics/Kratos/workflows/CI/badge.svg
 [CI-link]: https://github.com/KratosMultiphysics/Kratos/actions?query=workflow%3ACI
 
-[DOI-image]: https://zenodo.org/badge/DOI/10.5281/zenodo.3870709.svg
+[DOI-image]: https://zenodo.org/badge/DOI/10.5281/zenodo.3234644.svg
+
 [DOI]: https://doi.org/10.5281/zenodo.3234644
 
 _KRATOS Multiphysics_ ("Kratos") is a framework for building parallel, multi-disciplinary simulation software, aiming at modularity, extensibility, and high performance. Kratos is written in C++, and counts with an extensive Python interface. More in [Overview](https://github.com/KratosMultiphysics/Kratos/wiki/Overview)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <p align=center><img height="72.125%" width="72.125%" src="https://raw.githubusercontent.com/KratosMultiphysics/Documentation/master/Wiki_files/Home/kratos.png"></p>
 
-[![Release][release-image]][releases] [![License][license-image]][license] [![Github CI][CI-image]][CI-link]
+[![Release][release-image]][releases] [![License][license-image]][license] [![Github CI][CI-image]][CI-link][![DOI][DOI-image]][DOI]
 
 [release-image]: https://img.shields.io/badge/release-8.0-green.svg?style=flat
 [releases]: https://github.com/KratosMultiphysics/Kratos/releases
@@ -10,6 +10,9 @@
 
 [CI-image]: https://github.com/KratosMultiphysics/Kratos/workflows/CI/badge.svg
 [CI-link]: https://github.com/KratosMultiphysics/Kratos/actions?query=workflow%3ACI
+
+[DOI-image]: https://zenodo.org/badge/DOI/10.5281/zenodo.3870709.svg
+[DOI]: https://doi.org/10.5281/zenodo.3870709
 
 _KRATOS Multiphysics_ ("Kratos") is a framework for building parallel, multi-disciplinary simulation software, aiming at modularity, extensibility, and high performance. Kratos is written in C++, and counts with an extensive Python interface. More in [Overview](https://github.com/KratosMultiphysics/Kratos/wiki/Overview)
 

--- a/README.md
+++ b/README.md
@@ -95,4 +95,4 @@ In applications
 Please, use the following references when citing Kratos in your work.
 - Dadvand, P., Rossi, R. & Oñate, E. An Object-oriented Environment for Developing Finite Element Codes for Multi-disciplinary Applications. Arch Computat Methods Eng 17, 253–297 (2010). https://doi.org/10.1007/s11831-010-9045-2
 - Dadvand, P., Rossi, R., Gil, M., Martorell, X., Cotela, J., Juanpere, E., Idelsohn, S., Oñate, E. (2013). Migration of a generic multi-physics framework to HPC environments. Computers & Fluids. 80. 301–309. 10.1016/j.compfluid.2012.02.004.
-- Vicente Mataix Ferrándiz, Philipp Bucher, Riccardo Rossi, Jordi Cotela, Josep Maria, Rubén Zorrilla, … Riccardo Tosi. (2020, May 29). KratosMultiphysics (Version 8.0). Zenodo. https://doi.org/10.5281/zenodo.3234644
+- Mataix Ferrándiz, V., Bucher, P., Rossi, R., Cotela, J., Carbonell, J. M., Zorrilla, R., … Tosi, R. (2020, May 29). KratosMultiphysics (Version 8.0). Zenodo. https://doi.org/10.5281/zenodo.3234644


### PR DESCRIPTION
**Description**
This PR adds a new section to the README.

Please mark the PR with appropriate tags: 
- Documentation.

**Changelog**
Adding three references to the readme for citing Kratos.

Please note that in the [Zenodo web-page](https://zenodo.org/record/3870709#.XxW-f-exVPY), it is written that

> Cite all versions? You can cite all versions by using the DOI 10.5281/zenodo.3234644. This DOI represents all versions, and will always resolve to the latest one.

I have copy-pasted the references as the journals and Zenodo suggest, and some name are not being written in the reference.

**Additional info**
None.
