### PR TITLE
[CodeOwners] detect changes in root-files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # see https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-/                     @KratosMultiphysics/technical-committee
+/*                    @KratosMultiphysics/technical-committee
 /kratos/              @KratosMultiphysics/technical-committee
 /.github/             @KratosMultiphysics/technical-committee
 /cmake_modules/       @KratosMultiphysics/technical-committee


### PR DESCRIPTION
**Description**
It seems like changes to files in the root dir are not detected (see e.g. #7262)
This PR should fix this

**Additional info**
see the [github documentation](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners#example-of-a-codeowners-file)
~~~
# The `docs/*` pattern will match files like
# `docs/getting-started.md` but not further nested files like
# `docs/build-app/troubleshooting.md`.
docs/*  docs@example.com
~~~
