### PR TITLE
[Core] LevelSet - fix segmentation fault in destructor

### DIFF
--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -166,7 +166,7 @@ public:
     /// Destructor.
     ~LevelSetConvectionProcess() override
     {
-        mrModel.DeleteModelPart("DistanceConvectionPart");
+        mrModel.DeleteModelPart(mAuxModelPartName);
     }
 
     ///@}
@@ -328,6 +328,8 @@ protected:
 
     typename SolvingStrategyType::UniquePointer mpSolvingStrategy;
 
+    std::string mAuxModelPartName;
+
     ///@}
     ///@name Protected Operators
     ///@{
@@ -355,10 +357,12 @@ protected:
 
         KRATOS_TRY
 
-        if(mrModel.HasModelPart("DistanceConvectionPart"))
-            mrModel.DeleteModelPart("DistanceConvectionPart");
+        mAuxModelPartName = rBaseModelPart.Name() + "_DistanceConvectionPart";
 
-        mpDistanceModelPart= &(mrModel.CreateModelPart("DistanceConvectionPart"));
+        if(mrModel.HasModelPart(mAuxModelPartName))
+            mrModel.DeleteModelPart(mAuxModelPartName);
+
+        mpDistanceModelPart= &(mrModel.CreateModelPart(mAuxModelPartName));
 
 
         // Check buffer size

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -96,7 +96,8 @@ public:
           mrModel(rBaseModelPart.GetModel()),
           mrLevelSetVar(rLevelSetVar),
           mMaxAllowedCFL(max_cfl),
-          mMaxSubsteps(max_substeps)
+          mMaxSubsteps(max_substeps),
+          mAuxModelPartName(rBaseModelPart.Name() + "_DistanceConvectionPart")
     {
         KRATOS_TRY
 
@@ -348,7 +349,8 @@ protected:
           mrModel(rBaseModelPart.GetModel()),
           mrLevelSetVar(rLevelSetVar),
           mMaxAllowedCFL(MaxCFL),
-          mMaxSubsteps(MaxSubSteps)
+          mMaxSubsteps(MaxSubSteps),
+          mAuxModelPartName(rBaseModelPart.Name() + "_DistanceConvectionPart")
     {
         mDistancePartIsInitialized = false;
     }
@@ -356,8 +358,6 @@ protected:
     virtual void ReGenerateConvectionModelPart(ModelPart& rBaseModelPart){
 
         KRATOS_TRY
-
-        mAuxModelPartName = rBaseModelPart.Name() + "_DistanceConvectionPart";
 
         if(mrModel.HasModelPart(mAuxModelPartName))
             mrModel.DeleteModelPart(mAuxModelPartName);

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -93,6 +93,7 @@ public:
         const double cross_wind_stabilization_factor = 0.7,
         const unsigned int max_substeps = 0)
         : mrBaseModelPart(rBaseModelPart),
+          mrModel(rBaseModelPart.GetModel()),
           mrLevelSetVar(rLevelSetVar),
           mMaxAllowedCFL(max_cfl),
           mMaxSubsteps(max_substeps)
@@ -165,7 +166,7 @@ public:
     /// Destructor.
     ~LevelSetConvectionProcess() override
     {
-        mrBaseModelPart.GetModel().DeleteModelPart("DistanceConvectionPart");
+        mrModel.DeleteModelPart("DistanceConvectionPart");
     }
 
     ///@}
@@ -310,6 +311,8 @@ protected:
 
     ModelPart& mrBaseModelPart;
 
+    Model& mrModel;
+
     ModelPart* mpDistanceModelPart;
 
     Variable<double>& mrLevelSetVar;
@@ -340,6 +343,7 @@ protected:
         const double MaxCFL = 1.0,
         const unsigned int MaxSubSteps = 0)
         : mrBaseModelPart(rBaseModelPart),
+          mrModel(rBaseModelPart.GetModel()),
           mrLevelSetVar(rLevelSetVar),
           mMaxAllowedCFL(MaxCFL),
           mMaxSubsteps(MaxSubSteps)
@@ -351,12 +355,10 @@ protected:
 
         KRATOS_TRY
 
-        Model& current_model = rBaseModelPart.GetModel();
+        if(mrModel.HasModelPart("DistanceConvectionPart"))
+            mrModel.DeleteModelPart("DistanceConvectionPart");
 
-        if(current_model.HasModelPart("DistanceConvectionPart"))
-            current_model.DeleteModelPart("DistanceConvectionPart");
-
-        mpDistanceModelPart= &(current_model.CreateModelPart("DistanceConvectionPart"));
+        mpDistanceModelPart= &(mrModel.CreateModelPart("DistanceConvectionPart"));
 
 
         // Check buffer size

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -359,8 +359,9 @@ protected:
 
         KRATOS_TRY
 
-        if(mrModel.HasModelPart(mAuxModelPartName))
+        if (mrModel.HasModelPart(mAuxModelPartName)) {
             mrModel.DeleteModelPart(mAuxModelPartName);
+        }
 
         mpDistanceModelPart= &(mrModel.CreateModelPart(mAuxModelPartName));
 
@@ -572,5 +573,4 @@ inline std::ostream& operator << (
 }  // namespace Kratos.
 
 #endif // KRATOS_LEVELSET_CONVECTION_PROCESS_INCLUDED  defined
-
 


### PR DESCRIPTION
**Description**
This is the same error that happened in variational redistance. There is no guarantee that the mrBaseModelPart still exists when destructor is called. For some reason, I only get the error in mpi.

Adding a reference to the model and using it to remove the model part makes sure you do not get this seg fault. 

**Changelog**
-Using model to destroy model part in level set destructor.

**Additional info**
This should avoid errors in Molding too @KratosMultiphysics/altair 
