### PR TITLE
[Core] Filesystem::JoinPaths fix in case of empty path

### DIFF
--- a/kratos/sources/kratos_filesystem.cpp
+++ b/kratos/sources/kratos_filesystem.cpp
@@ -83,7 +83,7 @@ std::string JoinPaths(const std::vector<std::string>& rPaths)
     // first remove empty paths
     paths.erase(std::remove_if(paths.begin(), paths.end(),
                          [](const std::string& s)
-                         { std::cout << s << std::endl;return s.empty(); }), paths.end());
+                         { return s.empty(); }), paths.end());
 
     const std::size_t num_paths = paths.size();
 

--- a/kratos/sources/kratos_filesystem.cpp
+++ b/kratos/sources/kratos_filesystem.cpp
@@ -78,18 +78,21 @@ std::string CurrentWorkingDirectory()
 
 std::string JoinPaths(const std::vector<std::string>& rPaths)
 {
-    const std::size_t num_paths = rPaths.size();
+    auto paths(rPaths); // create local copy
+
+    // first remove empty paths
+    paths.erase(std::remove_if(paths.begin(), paths.end(),
+                         [](const std::string& s)
+                         { std::cout << s << std::endl;return s.empty(); }), paths.end());
+
+    const std::size_t num_paths = paths.size();
 
     if (num_paths == 0) { return ""; }
 
-    for (std::size_t i=0; i<num_paths; ++i) {
-        KRATOS_ERROR_IF(rPaths[i] == "") << "Path in position " << i << " is empty!" << std::endl;
-    }
-
-    std::string full_path = rPaths[0];
+    std::string full_path = paths[0];
     if (num_paths > 1) {
         for(std::size_t i=1; i<num_paths; ++i) {
-            full_path += "/" + rPaths[i]; // using portable separator "/"
+            full_path += "/" + paths[i]; // using portable separator "/"
         }
     }
 

--- a/kratos/sources/kratos_filesystem.cpp
+++ b/kratos/sources/kratos_filesystem.cpp
@@ -10,6 +10,9 @@
 //  Main authors:    Philipp Bucher (https://github.com/philbucher)
 //
 
+// System includes
+#include <algorithm>
+
 // External includes
 #include "ghc/filesystem.hpp" // TODO after moving to C++17 this can be removed since the functions can be used directly
 

--- a/kratos/sources/kratos_filesystem.cpp
+++ b/kratos/sources/kratos_filesystem.cpp
@@ -82,6 +82,10 @@ std::string JoinPaths(const std::vector<std::string>& rPaths)
 
     if (num_paths == 0) { return ""; }
 
+    for (std::size_t i=0; i<num_paths; ++i) {
+        KRATOS_ERROR_IF(rPaths[i] == "") << "Path in position " << i << " is empty!" << std::endl;
+    }
+
     std::string full_path = rPaths[0];
     if (num_paths > 1) {
         for(std::size_t i=1; i<num_paths; ++i) {

--- a/kratos/tests/cpp_tests/sources/test_filesystem.cpp
+++ b/kratos/tests/cpp_tests/sources/test_filesystem.cpp
@@ -50,6 +50,15 @@ KRATOS_TEST_CASE_IN_SUITE(FileSystemJoinPaths, KratosCoreFastSuite)
     KRATOS_CHECK_STRING_EQUAL(Kratos::FilesystemExtensions::JoinPaths(paths_2), "");
 }
 
+KRATOS_TEST_CASE_IN_SUITE(FileSystemJoinInvalidPaths, KratosCoreFastSuite)
+{
+    std::vector<std::string> paths_1 {"eee", "", "gt"};
+
+    KRATOS_CHECK_EXCEPTION_IS_THROWN(
+        Kratos::FilesystemExtensions::JoinPaths(paths_1),
+        "Path in position 1 is empty!");
+}
+
 KRATOS_TEST_CASE_IN_SUITE(FileSystemIsRegularFile, KratosCoreFastSuite)
 {
     const std::string file_name("dummy_file.txt");

--- a/kratos/tests/cpp_tests/sources/test_filesystem.cpp
+++ b/kratos/tests/cpp_tests/sources/test_filesystem.cpp
@@ -50,13 +50,11 @@ KRATOS_TEST_CASE_IN_SUITE(FileSystemJoinPaths, KratosCoreFastSuite)
     KRATOS_CHECK_STRING_EQUAL(Kratos::FilesystemExtensions::JoinPaths(paths_2), "");
 }
 
-KRATOS_TEST_CASE_IN_SUITE(FileSystemJoinInvalidPaths, KratosCoreFastSuite)
+KRATOS_TEST_CASE_IN_SUITE(FileSystemJoinEmptyPaths, KratosCoreFastSuite)
 {
-    std::vector<std::string> paths_1 {"eee", "", "gt"};
+    std::vector<std::string> paths {"eee", "", "gt"};
 
-    KRATOS_CHECK_EXCEPTION_IS_THROWN(
-        Kratos::FilesystemExtensions::JoinPaths(paths_1),
-        "Path in position 1 is empty!");
+    KRATOS_CHECK_STRING_EQUAL(Kratos::FilesystemExtensions::JoinPaths(paths), "eee/gt");
 }
 
 KRATOS_TEST_CASE_IN_SUITE(FileSystemIsRegularFile, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/sources/test_filesystem.cpp
+++ b/kratos/tests/cpp_tests/sources/test_filesystem.cpp
@@ -52,9 +52,11 @@ KRATOS_TEST_CASE_IN_SUITE(FileSystemJoinPaths, KratosCoreFastSuite)
 
 KRATOS_TEST_CASE_IN_SUITE(FileSystemJoinEmptyPaths, KratosCoreFastSuite)
 {
-    std::vector<std::string> paths {"eee", "", "gt"};
+    std::vector<std::string> paths_1 {"eee", "", "gt"};
+    KRATOS_CHECK_STRING_EQUAL(Kratos::FilesystemExtensions::JoinPaths(paths_1), "eee/gt");
 
-    KRATOS_CHECK_STRING_EQUAL(Kratos::FilesystemExtensions::JoinPaths(paths), "eee/gt");
+    std::vector<std::string> paths_2 {"", "", "gt"};
+    KRATOS_CHECK_STRING_EQUAL(Kratos::FilesystemExtensions::JoinPaths(paths_2), "gt");
 }
 
 KRATOS_TEST_CASE_IN_SUITE(FileSystemIsRegularFile, KratosCoreFastSuite)


### PR DESCRIPTION
**Description**
remove empty paths 
i.e. `std::vector<std::string> paths {"eee", "", "gt"}` will result in `"eee/gt"`instead of `"eee//gt"`

**Changelog**
fix function and add test

**Additional info**
same behavior as pythons `os.path.join` and `pathlib.Path :: /`
