### PR TITLE
[Core] expose transpose matrix to python and add test

### DIFF
--- a/kratos/python/add_matrix_to_python.cpp
+++ b/kratos/python/add_matrix_to_python.cpp
@@ -97,6 +97,7 @@ namespace Python
         matrix_binder.def(py::init<const DenseMatrix<double>::size_type, const DenseMatrix<double>::size_type, const DenseMatrix<double>::value_type >());
         matrix_binder.def("fill", [](DenseMatrix<double>& self, const typename DenseMatrix<double>::value_type value) { noalias(self) = DenseMatrix<double>(self.size1(),self.size2(),value); });
         matrix_binder.def("fill_identity", [](DenseMatrix<double>& self) { noalias(self) = IdentityMatrix(self.size1()); });
+        matrix_binder.def("transpose", [](DenseMatrix<double>& self) { return Matrix(trans(self)); });
       #endif // KRATOS_USE_AMATRIX
         matrix_binder.def(py::init<const DenseMatrix<double>& >());
         matrix_binder.def("__mul__", [](const DenseMatrix<double>& m1, const Vector& v){ return Vector(prod(m1,v));}, py::is_operator());

--- a/kratos/tests/test_matrix_interface.py
+++ b/kratos/tests/test_matrix_interface.py
@@ -101,5 +101,17 @@ class TestMatrixInterface(KratosUnittest.TestCase):
         A *= 2.0
         self.assertMatrixAlmostEqual(C, A)
 
+    def test_matrix_transpose(self):
+        A = KM.Matrix(2,3)
+        B = KM.Matrix(3,2)
+        for i in range(A.Size1()):
+            for j in range(A.Size2()):
+                A[i,j] = i
+        B = A.transpose()
+
+        for i in range(A.Size1()):
+            for j in range(A.Size2()):
+                self.assertEqual(A[i,j], B[j,i])
+
 if __name__ == '__main__':
     KratosUnittest.main()


### PR DESCRIPTION
Hi,

this PR should expose the transpose function for a matrix to python.
A corresponding python test is added, too.