### PR TITLE
[ConvDiff] Take into account custom buffer size

### DIFF
--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_base_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_base_solver.py
@@ -83,6 +83,8 @@ class ConvectionDiffusionBaseSolver(PythonSolver):
 
         # Set default buffer size
         self.min_buffer_size = 1
+        if custom_settings.Has("buffer_size"):
+            self.custom_buffer_size = custom_settings["buffer_size"].GetInt()
 
         if model_part_name == "":
             raise Exception('Please specify a model_part name!')
@@ -479,6 +481,7 @@ class ConvectionDiffusionBaseSolver(PythonSolver):
         required_buffer_size = self.GetMinimumBufferSize()
         current_buffer_size = self.main_model_part.GetBufferSize()
         buffer_size = max(current_buffer_size, required_buffer_size)
+        buffer_size = max(buffer_size,self.custom_buffer_size)
         self.main_model_part.SetBufferSize(buffer_size)
         # Cycle the buffer. This sets all historical nodal solution step data to
         # the current value and initializes the time stepping in the process info.


### PR DESCRIPTION
**Description**
Take into account user-defined `buffer_size`.

Please mark the PR with appropriate tags: 
- Applications, Python, BugFix

**Changelog**
I noticed the user-defined `buffer_size` was not taken into account when setting the `buffer_size` in the model part.

**Additional info**
I don't know if this behavior is the expected one. In this case, we should remove the `buffer_size` entry from the default_settings I guess.
I thought it was easier to open a PR with the change than an issue. If you think opening an issue is better, let me know and I will do.
I assign the contributors of this file, please add whoever you think may be needed.
