### PR TITLE
[Core][Apps] C++ classes derived settings

### DIFF
--- a/kratos/solving_strategies/strategies/line_search_strategy.h
+++ b/kratos/solving_strategies/strategies/line_search_strategy.h
@@ -135,9 +135,8 @@ public:
      * @param ThisParameters The configuration parameters
      */
     explicit LineSearchStrategy(ModelPart& rModelPart, Parameters ThisParameters)
-        : BaseType(rModelPart, ThisParameters)
-    {
-    }
+        : LineSearchStrategy(rModelPart, ThisParameters, LineSearchStrategy::StaticGetDefaultSettings())
+    { }
 
     /**
      * Default Constructor
@@ -247,6 +246,32 @@ public:
     {
     }
 
+    /**
+     * @brief This method returns the default settings
+     */
+    Parameters GetDefaultSettings() const override
+    {
+        return LineSearchStrategy::StaticGetDefaultSettings();
+    }
+
+    static Parameters StaticGetDefaultSettings()
+    {
+        std::cout << "LINE SEARCH STRATEGY GetDefaultSettings" << std::endl;
+
+        Parameters default_parameters(R"({
+            "max_line_search_iterations" : 5,
+            "first_alpha_value"          : 0.5,
+            "second_alpha_value"         : 1.0,
+            "min_alpha"                  : 0.1,
+            "max_alpha"                  : 2.0,
+            "line_search_tolerance"      : 0.5
+        })");
+
+        default_parameters.AddMissingParameters(BaseType::StaticGetDefaultSettings());
+
+        return default_parameters;
+    }
+
 
     ///@}
     ///@name Operators
@@ -269,7 +294,7 @@ public:
     {
         return Kratos::make_shared<ClassType>(rModelPart, ThisParameters);
     }
-    
+
     /**
      * @brief Returns the name of the class as used in the settings (snake_case format)
      * @return The name of the class
@@ -485,24 +510,6 @@ protected:
     }
 
     /**
-     * @brief This method returns the default settings
-     */
-    Parameters GetDefaultSettings() override
-    {
-        Parameters base_default_settings = BaseType::GetDefaultSettings();
-        Parameters default_settings(R"({
-            "max_line_search_iterations" : 5,
-            "first_alpha_value"          : 0.5,
-            "second_alpha_value"         : 1.0,
-            "min_alpha"                  : 0.1,
-            "max_alpha"                  : 2.0,
-            "line_search_tolerance"      : 0.5
-        })");
-        default_settings.AddMissingParameters(base_default_settings);
-        return default_settings;
-    }
-
-    /**
      * @brief This method assigns settings to member variables
      * @param Settings Parameters that are assigned to the member variables
      */
@@ -535,6 +542,20 @@ protected:
         DefaultSettings["reform_dofs_at_each_step"].SetBool(ReformDofSetAtEachStep);
         DefaultSettings["calculate_reactions"].SetBool(CalculateReactions);
     }
+
+
+    explicit LineSearchStrategy(ModelPart& rModelPart, Parameters ThisParameters, Parameters DefaultSettings)
+        : BaseType(rModelPart, ThisParameters, DefaultSettings)
+    {
+        // by this point the baseclass validated and assigned defaults
+        mMaxLineSearchIterations = ThisParameters["max_line_search_iterations"].GetInt();
+        mFirstAlphaValue = ThisParameters["first_alpha_value"].GetDouble();
+        mSecondAlphaValue = ThisParameters["second_alpha_value"].GetDouble();
+        mMinAlpha = ThisParameters["min_alpha"].GetDouble();
+        mMaxAlpha = ThisParameters["max_alpha"].GetDouble();
+        mLineSearchTolerance = ThisParameters["line_search_tolerance"].GetDouble();
+    }
+
 
 
 

--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -116,9 +116,9 @@ class ResidualBasedNewtonRaphsonStrategy
      * @param ThisParameters The configuration parameters
      */
     explicit ResidualBasedNewtonRaphsonStrategy(ModelPart& rModelPart, Parameters ThisParameters)
-        : BaseType(rModelPart, ThisParameters)
+        : ResidualBasedNewtonRaphsonStrategy(rModelPart, ThisParameters, ResidualBasedNewtonRaphsonStrategy::StaticGetDefaultSettings())
     {
-        KRATOS_ERROR << "IMPLEMENTATION PENDING IN CONSTRUCTOR WITH PARAMETERS" << std::endl;
+        std::cout << "Normal CTor of NR Strategy" << std::endl;
     }
 
     /**
@@ -432,6 +432,27 @@ class ResidualBasedNewtonRaphsonStrategy
         mpb.reset();
 
         Clear();
+    }
+
+    Parameters GetDefaultSettings() const override
+    {
+        return ResidualBasedNewtonRaphsonStrategy::StaticGetDefaultSettings();
+    }
+
+    static Parameters StaticGetDefaultSettings()
+    {
+        std::cout << "NR STRATEGY GetDefaultSettings" << std::endl;
+
+        Parameters default_parameters(R"({
+            "use_old_stiffness_in_first_iteration": false,
+            "max_iterations"           : 30,
+            "reform_dofs_at_each_step" : false,
+            "calculate_reactions"      : false
+        })");
+
+        default_parameters.AddMissingParameters(BaseType::StaticGetDefaultSettings());
+
+        return default_parameters;
     }
 
     /**
@@ -1196,7 +1217,7 @@ class ResidualBasedNewtonRaphsonStrategy
     ///@}
     ///@name Member Variables
     ///@{
-    
+
     typename TSchemeType::Pointer mpScheme = nullptr; /// The pointer to the time scheme employed
     typename TBuilderAndSolverType::Pointer mpBuilderAndSolver = nullptr; /// The pointer to the builder and solver employed
     typename TConvergenceCriteriaType::Pointer mpConvergenceCriteria = nullptr; /// The pointer to the convergence criteria employed
@@ -1307,20 +1328,6 @@ class ResidualBasedNewtonRaphsonStrategy
     }
 
     /**
-     * @brief This method returns the default settings
-     */
-    virtual Parameters GetDefaultSettings()
-    {
-        Parameters default_settings(R"({
-            "use_old_stiffness_in_first_iteration": false,
-            "max_iterations"           : 30,
-            "reform_dofs_at_each_step" : false,
-            "calculate_reactions"      : false
-        })");
-        return default_settings;
-    }
-
-    /**
      * @brief This method assigns settings to member variables
      * @param Settings Parameters that are assigned to the member variables
      */
@@ -1335,6 +1342,18 @@ class ResidualBasedNewtonRaphsonStrategy
     ///@}
     ///@name Private Operations
     ///@{
+
+    explicit ResidualBasedNewtonRaphsonStrategy(ModelPart& rModelPart, Parameters ThisParameters, Parameters DefaultSettings)
+        : BaseType(rModelPart, ThisParameters, DefaultSettings)
+    {
+        std::cout << "Protected CTor of NR Strategy" << std::endl;
+
+        // by this point the baseclass validated and assigned defaults
+        mMaxIterationNumber = ThisParameters["max_iterations"].GetInt();
+        mReformDofSetAtEachStep = ThisParameters["reform_dofs_at_each_step"].GetBool();
+        mCalculateReactionsFlag = ThisParameters["calculate_reactions"].GetBool();
+        mUseOldStiffnessInFirstIteration = ThisParameters["use_old_stiffness_in_first_iteration"].GetBool();
+    }
 
     ///@}
     ///@name Private  Access

--- a/kratos/solving_strategies/strategies/solving_strategy.h
+++ b/kratos/solving_strategies/strategies/solving_strategy.h
@@ -122,10 +122,9 @@ public:
      * @param ThisParameters The configuration parameters
      */
     explicit SolvingStrategy(ModelPart& rModelPart, Parameters ThisParameters)
-        : mpModelPart(&rModelPart)
+        : SolvingStrategy(rModelPart, ThisParameters, SolvingStrategy::StaticGetDefaultSettings())
     {
-        const bool move_mesh_flag = ThisParameters.Has("move_mesh_flag") ? ThisParameters["move_mesh_flag"].GetBool() : false;
-        SetMoveMeshFlag(move_mesh_flag);
+        std::cout << "Normal CTor of Solving Strategy" << std::endl;
     }
 
     /**
@@ -144,6 +143,22 @@ public:
     /** Destructor.
      */
     virtual ~SolvingStrategy(){}
+
+    virtual Parameters GetDefaultSettings() const
+    {
+        return SolvingStrategy::StaticGetDefaultSettings();
+    }
+
+    static Parameters StaticGetDefaultSettings()
+    {
+        std::cout << "SOLVING STRATEGY GetDefaultSettings" << std::endl;
+
+        const Parameters default_parameters(R"({
+            "move_mesh_flag" : false
+        })");
+
+        return default_parameters;
+    }
 
     ///@}
     ///@name Operators
@@ -453,6 +468,17 @@ protected:
     ///@}
     ///@name Protected Operators
     ///@{
+
+    explicit SolvingStrategy(ModelPart& rModelPart, Parameters ThisParameters, Parameters DefaultSettings)
+        : mpModelPart(&rModelPart)
+    {
+        std::cout << "Protected CTor of Solving Strategy" << std::endl;
+
+        ThisParameters.ValidateAndAssignDefaults(DefaultSettings);
+
+        const bool move_mesh_flag = ThisParameters["move_mesh_flag"].GetBool();
+        SetMoveMeshFlag(move_mesh_flag);
+    }
 
 
     ///@}


### PR DESCRIPTION
**Description**
This PR introduces the recursive validation for the `SolvingStrategy`. It works the same as the python version that I added in #4736.
After this PR is through the same mechanism can and should be used for the other classes with `Parameters` constructors

The mechanism is a bit more complicated than in python bcs of how the classes are instantiated. Basically I cannot call functions of derived classes in the base-constructor

In a nutshell the mechanism works in the following way:
~~~c++
class Base
{
public:
    // regular CTor that gets called from outside
    class Base(params) : Base(params, Base::Defaults()) { }

    static Parameters Defaults()
    {
        // defaults = ...
        return defaults;
    }

protected:
    // protected CTor, called from regular CTor AND derived classes
    Base(params, defaults)
    {
        params.ValidateAndAssignDefaults(defaults)
        // assign settings of base class
    }
};

class Derived : Base
{
public:
    // regular CTor that gets called from outside
    class Derived(params) : Derived(params, Derived::Defaults()) { }

    static Parameters Defaults()
    {
        // defaults = ...
        defaults.AddMissingParameters(Base::Defaults());
        return defaults;
    }

protected:
    // protected CTor, called from regular CTor AND derived classes
    Derived(params, defaults) : Base(params, defaults)
    {
        // assign settings of this class
        // ...
    }
};
~~~


**Additional info**
necessary for #5939
