### PR TITLE
[Core] Remove legacy python from python interface

### DIFF
--- a/kratos/python_interface/__init__.py
+++ b/kratos/python_interface/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 import os
 import sys
 from . import kratos_globals

--- a/kratos/python_interface/kratos_globals.py
+++ b/kratos/python_interface/kratos_globals.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 class KratosGlobalsImpl(object):
 
     def __init__(self, ThisKernel, ApplicationsRoot):


### PR DESCRIPTION
**Description**
Removing `from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7` from __init__.py and kratos_globals.pỳ

**Changelog**
- Removing `from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7` from __init__.py and kratos_globals.pỳ
