### PR TITLE
Adding Apps to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,3 +10,4 @@
 # Applications
 /applications/TrilinosApplication/              @KratosMultiphysics/technical-committee
 /applications/MetisApplication/                 @KratosMultiphysics/technical-committee
+/applications/StructuralMechanicsApplication/   @KratosMultiphysics/structural-mechanics

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,9 +12,13 @@
 /applications/MetisApplication/                        @KratosMultiphysics/technical-committee
 /applications/StructuralMechanicsApplication/          @KratosMultiphysics/structural-mechanics
 /applications/ContactStructuralMechanicsApplication/   @KratosMultiphysics/structural-mechanics
+/applications/FluidDynamicsApplication/                @KratosMultiphysics/fluid-maintainers
+/applications/ConvectionDiffusionApplication           @KratosMultiphysics/fluid-maintainers
 /applications/MappingApplication/                      @KratosMultiphysics/cosimulation
 /applications/CoSimulationApplication/                 @KratosMultiphysics/cosimulation
 /applications/MeshMovingApplication/                   @KratosMultiphysics/meshmoving
 /applications/DEMApplication/                          @KratosMultiphysics/dem
 /applications/SwimmingDEMApplication/                  @KratosMultiphysics/dem
 /applications/ShapeOptimizationApplication/            @KratosMultiphysics/optimization
+/applications/CompressiblePotentialFlowApplication/    @KratosMultiphysics/potential-flow-team
+/applications/ChimeraApplication/                      @KratosMultiphysics/chimera

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@
 /scripts/             @KratosMultiphysics/technical-committee
 
 # Applications
-/applications/TrilinosApplication/              @KratosMultiphysics/technical-committee
-/applications/MetisApplication/                 @KratosMultiphysics/technical-committee
-/applications/StructuralMechanicsApplication/   @KratosMultiphysics/structural-mechanics
+/applications/TrilinosApplication/                     @KratosMultiphysics/technical-committee
+/applications/MetisApplication/                        @KratosMultiphysics/technical-committee
+/applications/StructuralMechanicsApplication/          @KratosMultiphysics/structural-mechanics
+/applications/ContactStructuralMechanicsApplication/   @KratosMultiphysics/structural-mechanics

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,3 +17,4 @@
 /applications/MeshMovingApplication/                   @KratosMultiphysics/meshmoving
 /applications/DEMApplication/                          @KratosMultiphysics/dem
 /applications/SwimmingDEMApplication/                  @KratosMultiphysics/dem
+/applications/ShapeOptimizationApplication/            @KratosMultiphysics/optimization

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,3 +12,6 @@
 /applications/MetisApplication/                        @KratosMultiphysics/technical-committee
 /applications/StructuralMechanicsApplication/          @KratosMultiphysics/structural-mechanics
 /applications/ContactStructuralMechanicsApplication/   @KratosMultiphysics/structural-mechanics
+/applications/MappingApplication/                      @KratosMultiphysics/cosimulation
+/applications/CoSimulationApplication/                 @KratosMultiphysics/cosimulation
+/applications/MeshMovingApplication/                   @KratosMultiphysics/meshmoving

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -22,3 +22,4 @@
 /applications/ShapeOptimizationApplication/            @KratosMultiphysics/optimization
 /applications/CompressiblePotentialFlowApplication/    @KratosMultiphysics/potential-flow-team
 /applications/ChimeraApplication/                      @KratosMultiphysics/chimera
+/applications/IgaApplication/                          @KratosMultiphysics/nurbs-breps

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,3 +15,5 @@
 /applications/MappingApplication/                      @KratosMultiphysics/cosimulation
 /applications/CoSimulationApplication/                 @KratosMultiphysics/cosimulation
 /applications/MeshMovingApplication/                   @KratosMultiphysics/meshmoving
+/applications/DEMApplication/                          @KratosMultiphysics/dem
+/applications/SwimmingDEMApplication/                  @KratosMultiphysics/dem


### PR DESCRIPTION
**Description**
This PR adds the StructuralMechanicsApplication to the Codeowners

The @KratosMultiphysics/technical-committee has decided **NOT** to enable the "require review from code owners" to not further increase the bureaucracy. 
![image](https://user-images.githubusercontent.com/25484702/88634911-47c66b80-d0b7-11ea-8595-6ff06e492bd6.png)

=> this means that we use codeowners only as notification tool in case sth changes

**Other applications are welcome to be added** (with teams, not individual developers) @KratosMultiphysics/all 

please read the [Github docs](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) for more information