### PR TITLE
[Core] delete Variable assignment operator

### DIFF
--- a/kratos/containers/variable.h
+++ b/kratos/containers/variable.h
@@ -168,15 +168,9 @@ public:
     ///@{
 
     /**
-     * @brief Assignment operator.
-     * @param rOtherVariable The old variable to be assigned
+     * @brief Assignment operator, deleted to avoid misuse which can lead to memory problems
      */
-    VariableType& operator=(const VariableType& rOtherVariable)
-    {
-        VariableData::operator=(rOtherVariable);
-        mZero = rOtherVariable.mZero;
-        return *this;
-    }
+    VariableType& operator=(const VariableType& rOtherVariable) = delete;
 
     ///@}
     ///@name Operations
@@ -551,9 +545,6 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }
 ///@}
 
-
 }  // namespace Kratos.
 
 #endif // KRATOS_VARIABLE_H_INCLUDED  defined
-
-

--- a/kratos/solving_strategies/schemes/residual_based_pseudo_static_displacement_scheme.h
+++ b/kratos/solving_strategies/schemes/residual_based_pseudo_static_displacement_scheme.h
@@ -89,7 +89,7 @@ public:
      */
     explicit ResidualBasedPseudoStaticDisplacementScheme()
         : DerivedBaseType(0.0),
-          mRayleighBeta(NODAL_MAUX)
+          mpRayleighBeta(&NODAL_MAUX)
     {
     }
 
@@ -98,8 +98,7 @@ public:
      * @param ThisParameters Parameters with the Rayleigh variable
      */
     explicit ResidualBasedPseudoStaticDisplacementScheme(Parameters ThisParameters)
-        : DerivedBaseType(0.0),
-          mRayleighBeta(NODAL_MAUX)
+        : DerivedBaseType(0.0)
     {
         // Validate default parameters
         Parameters default_parameters = Parameters(R"(
@@ -109,7 +108,7 @@ public:
         })" );
         ThisParameters.ValidateAndAssignDefaults(default_parameters);
 
-        mRayleighBeta = KratosComponents<Variable<double>>::Get(ThisParameters["rayleigh_beta_variable"].GetString());
+        mpRayleighBeta = &KratosComponents<Variable<double>>::Get(ThisParameters["rayleigh_beta_variable"].GetString());
     }
 
     /**
@@ -117,7 +116,7 @@ public:
      */
     explicit ResidualBasedPseudoStaticDisplacementScheme(const Variable<double>& RayleighBetaVariable)
         :DerivedBaseType(0.0),
-        mRayleighBeta(RayleighBetaVariable)
+        mpRayleighBeta(&RayleighBetaVariable)
     {
     }
 
@@ -125,7 +124,7 @@ public:
      */
     explicit ResidualBasedPseudoStaticDisplacementScheme(ResidualBasedPseudoStaticDisplacementScheme& rOther)
         :DerivedBaseType(rOther),
-        mRayleighBeta(rOther.mRayleighBeta)
+        mpRayleighBeta(rOther.mpRayleighBeta)
     {
     }
 
@@ -344,7 +343,7 @@ public:
     /// Print object's data.
     void PrintData(std::ostream& rOStream) const override
     {
-        rOStream << Info() << ". Considering the following damping variable " << mRayleighBeta;
+        rOStream << Info() << ". Considering the following damping variable " << *mpRayleighBeta;
     }
 
     ///@}
@@ -386,7 +385,7 @@ protected:
         if (rD.size1() != 0 && TDenseSpace::TwoNorm(rD) > ZeroTolerance) // if D matrix declared
             noalias(rLHSContribution) += rD * DerivedBaseType::mBossak.c1;
         else if (rM.size1() != 0) {
-            const double beta = rCurrentProcessInfo[mRayleighBeta];
+            const double beta = rCurrentProcessInfo[*mpRayleighBeta];
             noalias(rLHSContribution) += rM * beta * DerivedBaseType::mBossak.c1;
         }
     }
@@ -414,7 +413,7 @@ protected:
             rElement.GetFirstDerivativesVector(DerivedBaseType::mVector.v[this_thread], 0);
             noalias(rRHSContribution) -= prod(rD, DerivedBaseType::mVector.v[this_thread]);
         } else if (rM.size1() != 0) {
-            const double beta = rCurrentProcessInfo[mRayleighBeta];
+            const double beta = rCurrentProcessInfo[*mpRayleighBeta];
             rElement.GetFirstDerivativesVector(DerivedBaseType::mVector.v[this_thread], 0);
             noalias(rRHSContribution) -= beta * prod(rM, DerivedBaseType::mVector.v[this_thread]);
         }
@@ -444,7 +443,7 @@ protected:
             rCondition.GetFirstDerivativesVector(DerivedBaseType::mVector.v[this_thread], 0);
             noalias(rRHSContribution) -= prod(rD, DerivedBaseType::mVector.v[this_thread]);
         } else if (rM.size1() != 0) {
-            const double beta = rCurrentProcessInfo[mRayleighBeta];
+            const double beta = rCurrentProcessInfo[*mpRayleighBeta];
             rCondition.GetFirstDerivativesVector(DerivedBaseType::mVector.v[this_thread], 0);
             noalias(rRHSContribution) -= beta * prod(rM, DerivedBaseType::mVector.v[this_thread]);
         }
@@ -469,7 +468,7 @@ private:
     ///@name Member Variables
     ///@{
 
-    Variable<double> mRayleighBeta; /// The Rayleigh Beta variable
+    const Variable<double>* mpRayleighBeta = nullptr; /// The Rayleigh Beta variable
 
     ///@}
     ///@name Private Operators


### PR DESCRIPTION
**Description**
This PR delete the assignment operator of `Variable`, which should help mitigate the memory problems we have with Variables =>  #3789 

Only minor updates should be necessary because we did already a large effort in cleaning (I found one in the core which was also discovered by @loumalouomega)
@loumalouomega you didn't make a separate commit for the fix, you mind pushing it here? I don't wanna meddle with https://github.com/KratosMultiphysics/Kratos/pull/7290/commits/fabb23002537fed5d40800f721ea50280741d9a3