### PR TITLE
[Fluid] Default assign_neigbours

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_vmsmonolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_vmsmonolithic_solver.py
@@ -48,7 +48,7 @@ class AdjointVMSMonolithicSolver(AdjointFluidSolver):
                 "time_step"           : -0.1
             },
             "consider_periodic_conditions": false,
-            "assign_neighbour_elements_to_conditions": false
+            "assign_neighbour_elements_to_conditions": true
         }""")
 
         default_settings.AddMissingParameters(super(AdjointVMSMonolithicSolver, cls).GetDefaultSettings())

--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -14,7 +14,7 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
         default_parameters = KratosMultiphysics.Parameters(r'''{
             "volume_model_part_name" : "",
             "skin_parts" : [],
-            "assign_neighbour_elements_to_conditions" : false
+            "assign_neighbour_elements_to_conditions" : true
         }''')
         Parameters.ValidateAndAssignDefaults(default_parameters)
         if Parameters["volume_model_part_name"].GetString() == "":

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
@@ -211,11 +211,7 @@ class FluidSolver(PythonSolver):
         prepare_model_part_settings = KratosMultiphysics.Parameters("{}")
         prepare_model_part_settings.AddValue("volume_model_part_name",self.settings["volume_model_part_name"])
         prepare_model_part_settings.AddValue("skin_parts",self.settings["skin_parts"])
-        if (self.settings.Has("assign_neighbour_elements_to_conditions")):
-            prepare_model_part_settings.AddValue("assign_neighbour_elements_to_conditions",self.settings["assign_neighbour_elements_to_conditions"])
-        else:
-            warn_msg = "\"assign_neighbour_elements_to_conditions\" should be added to defaults of " + self.__class__.__name__
-            KratosMultiphysics.Logger.PrintWarning('\n\x1b[1;31mDEPRECATION-WARNING\x1b[0m', warn_msg)
+        prepare_model_part_settings.AddValue("assign_neighbour_elements_to_conditions",self.settings["assign_neighbour_elements_to_conditions"])
 
         check_and_prepare_model_process_fluid.CheckAndPrepareModelProcess(self.main_model_part, prepare_model_part_settings).Execute()
 

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_compressible_solver.py
@@ -46,7 +46,7 @@ class NavierStokesCompressibleSolver(FluidSolver):
             },
             "volume_model_part_name" : "volume_model_part",
             "skin_parts": [""],
-            "assign_neighbour_elements_to_conditions": false,
+            "assign_neighbour_elements_to_conditions": true,
             "no_skin_parts":[""],
             "time_stepping"                : {
                 "automatic_time_step" : true,

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_fractionalstep.py
@@ -69,7 +69,7 @@ class NavierStokesSolverFractionalStep(FluidSolver):
             },
             "volume_model_part_name" : "volume_model_part",
             "skin_parts":[""],
-            "assign_neighbour_elements_to_conditions": false,
+            "assign_neighbour_elements_to_conditions": true,
             "no_skin_parts":[""],
             "time_stepping"                : {
                 "automatic_time_step" : false,

--- a/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
+++ b/applications/FluidDynamicsApplication/python_scripts/navier_stokes_solver_vmsmonolithic.py
@@ -180,7 +180,7 @@ class NavierStokesSolverMonolithic(FluidSolver):
             },
             "volume_model_part_name" : "volume_model_part",
             "skin_parts": [""],
-            "assign_neighbour_elements_to_conditions": false,
+            "assign_neighbour_elements_to_conditions": true,
             "no_skin_parts":[""],
             "time_stepping"                : {
                 "automatic_time_step" : false,

--- a/applications/FluidDynamicsApplication/python_scripts/trilinos_adjoint_vmsmonolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/trilinos_adjoint_vmsmonolithic_solver.py
@@ -53,7 +53,7 @@ class AdjointVMSMonolithicMPISolver(AdjointVMSMonolithicSolver):
                 "time_step"           : -0.1
             },
             "consider_periodic_conditions": false,
-            "assign_neighbour_elements_to_conditions": false
+            "assign_neighbour_elements_to_conditions": true
         }""")
 
         default_settings.AddMissingParameters(super(AdjointVMSMonolithicMPISolver, cls).GetDefaultSettings())


### PR DESCRIPTION
**Description**
Default calculation of neighbour elements

Please mark the PR with appropriate tags: 
- Behavior change
- Applications
- FastPR

**Changelog**
After this PR the default behavior of the check and prepare will be to assign the parent elements to the conditions. This will avoid unexpected memory errors when this is required to calculate the conditions contribution. The option to deactivate this to save memory is left to the user (note that the increment in the total simulation time is negligible as this is executed once).

I took the chance to remove the corresponding deprecation warning.
