### PR TITLE
[Core][VTK-Output] move folder creation to C++

### DIFF
--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -20,6 +20,7 @@
 // Project includes
 #include "vtk_output.h"
 #include "containers/model.h"
+#include "includes/kratos_filesystem.h"
 #include "processes/fast_transfer_between_model_parts_process.h"
 
 namespace Kratos
@@ -155,18 +156,11 @@ void VtkOutput::WriteModelPartToFile(const ModelPart& rModelPart, const bool IsS
 
 std::string VtkOutput::GetOutputFileName(const ModelPart& rModelPart, const bool IsSubModelPart, const std::string& rOutputFilename)
 {
-    // Putting everything together
     std::string output_file_name = "";
-    if (mOutputSettings["save_output_files_in_folder"].GetBool()) {
-        output_file_name = mOutputSettings["folder_name"].GetString() + "/";
-    }
 
-    if (rOutputFilename != "")
-    {
-        output_file_name += rOutputFilename + ".vtk";
-    }
-    else
-    {
+    if (rOutputFilename != "") { // user specified file name externally
+        output_file_name = rOutputFilename;
+    } else {
         const int rank = rModelPart.GetCommunicator().MyPID();
         std::string model_part_name;
 
@@ -193,10 +187,22 @@ std::string VtkOutput::GetOutputFileName(const ModelPart& rModelPart, const bool
                 << "are: \"step\", \"time\"" << std::endl;
         }
 
-
         const std::string& r_custom_name_prefix = mOutputSettings["custom_name_prefix"].GetString();
         const std::string& r_custom_name_postfix = mOutputSettings["custom_name_postfix"].GetString();
-        output_file_name += r_custom_name_prefix + model_part_name + r_custom_name_postfix + "_" + std::to_string(rank) + "_" + label + ".vtk";
+        output_file_name += r_custom_name_prefix + model_part_name + r_custom_name_postfix + "_" + std::to_string(rank) + "_" + label;
+    }
+
+    output_file_name += ".vtk";
+
+    if (mOutputSettings["save_output_files_in_folder"].GetBool()) {
+        const std::string folder_name = mOutputSettings["folder_name"].GetString();
+
+        // create folder if it doesn't exist before
+        if (!Kratos::filesystem::is_directory(folder_name)) {
+            Kratos::filesystem::create_directories(folder_name);
+        }
+
+        output_file_name = Kratos::FilesystemExtensions::JoinPaths({folder_name, output_file_name});
     }
 
     return output_file_name;

--- a/kratos/python_scripts/vtk_output_process.py
+++ b/kratos/python_scripts/vtk_output_process.py
@@ -1,7 +1,6 @@
 import KratosMultiphysics
 import KratosMultiphysics.kratos_utilities as kratos_utils
 from  KratosMultiphysics.deprecation_management import DeprecationManager
-import os
 
 def Factory(settings, model):
     if not isinstance(settings, KratosMultiphysics.Parameters):
@@ -32,8 +31,6 @@ class VtkOutputProcess(KratosMultiphysics.Process):
                 folder_name = settings["folder_name"].GetString()
                 if not self.model_part.ProcessInfo[KratosMultiphysics.IS_RESTARTED]:
                     kratos_utils.DeleteDirectoryIfExisting(folder_name)
-                if not os.path.isdir(folder_name):
-                    os.makedirs(folder_name)
             self.model_part.GetCommunicator().GetDataCommunicator().Barrier()
 
         self.output_interval = settings["output_interval"].GetDouble()


### PR DESCRIPTION
**Description**
Until now if the VTK-Ouput was used without the python layer it wouldn't work if output in folder was requested.
This properly implements the folder creation in C++ with `Kratos::filesystem` so that it also works in C++

**Changelog**
Please summarize the changes in one list to generate the changelog:
- Move folder creation from python to C++

**Additional info**
Implements #6244
