### PR TITLE
[Trilinos] add dependency to MetisApplication

### DIFF
--- a/applications/TrilinosApplication/CMakeLists.txt
+++ b/applications/TrilinosApplication/CMakeLists.txt
@@ -4,9 +4,6 @@ message("**** configuring KratosTrilinosApplication ****")
 
 include(pybind11Tools)
 
-kratos_add_dependency(${KRATOS_SOURCE_DIR}/applications/MetisApplication)
-
-
 if(${TRILINOS_EXCLUDE_ML_SOLVER} MATCHES ON)
     add_definitions(-DTRILINOS_EXCLUDE_ML_SOLVER)
     message("**** WARNING: Manually disabled ML-Solver ****")

--- a/applications/TrilinosApplication/CMakeLists.txt
+++ b/applications/TrilinosApplication/CMakeLists.txt
@@ -4,6 +4,8 @@ message("**** configuring KratosTrilinosApplication ****")
 
 include(pybind11Tools)
 
+kratos_add_dependency(${KRATOS_SOURCE_DIR}/applications/MetisApplication)
+
 
 if(${TRILINOS_EXCLUDE_ML_SOLVER} MATCHES ON)
     add_definitions(-DTRILINOS_EXCLUDE_ML_SOLVER)

--- a/applications/TrilinosApplication/TrilinosApplication.py
+++ b/applications/TrilinosApplication/TrilinosApplication.py
@@ -1,6 +1,7 @@
 from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 from KratosMultiphysics import _ImportApplication
 import KratosMultiphysics.mpi # importing the MPI-Core, since the TrilinosApp directly links to it
+import KratosMultiphysics.MetisApplication # importing to avoid problems with loading the metis library
 from KratosTrilinosApplication import *
 application = KratosTrilinosApplication()
 application_name = "KratosTrilinosApplication"

--- a/applications/TrilinosApplication/TrilinosApplication.py
+++ b/applications/TrilinosApplication/TrilinosApplication.py
@@ -1,7 +1,9 @@
 from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 from KratosMultiphysics import _ImportApplication
+from KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable
 import KratosMultiphysics.mpi # importing the MPI-Core, since the TrilinosApp directly links to it
-import KratosMultiphysics.MetisApplication # importing to avoid problems with loading the metis library
+if CheckIfApplicationsAvailable("MetisApplication")
+    import KratosMultiphysics.MetisApplication # importing to avoid problems with loading the metis library
 from KratosTrilinosApplication import *
 application = KratosTrilinosApplication()
 application_name = "KratosTrilinosApplication"

--- a/applications/TrilinosApplication/TrilinosApplication.py
+++ b/applications/TrilinosApplication/TrilinosApplication.py
@@ -1,4 +1,3 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
 from KratosMultiphysics import _ImportApplication
 from KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable
 import KratosMultiphysics.mpi # importing the MPI-Core, since the TrilinosApp directly links to it

--- a/applications/TrilinosApplication/TrilinosApplication.py
+++ b/applications/TrilinosApplication/TrilinosApplication.py
@@ -1,7 +1,7 @@
 from KratosMultiphysics import _ImportApplication
 from KratosMultiphysics.kratos_utilities import CheckIfApplicationsAvailable
 import KratosMultiphysics.mpi # importing the MPI-Core, since the TrilinosApp directly links to it
-if CheckIfApplicationsAvailable("MetisApplication")
+if CheckIfApplicationsAvailable("MetisApplication"):
     import KratosMultiphysics.MetisApplication # importing to avoid problems with loading the metis library
 from KratosTrilinosApplication import *
 application = KratosTrilinosApplication()


### PR DESCRIPTION
**Description**
On some clusters it is necessary to import the MetisApp before the TrilinosApp otherwise it can crash badly

Even though this dependency is not strictly necessary it probably still makes sense to introduce it to avoid the problem mentioned above which can be difficult for less experiences users

Plus Trilinos (the library) internally uses Metis too, hence if one wants to use the TrilinosApp one anyway has to compile Metis

I.e. this PR adds the burden of compiling the MetisApp which is pretty simple (and done automatically thx to `kratos_add_dependency`)

following #6843 and #6892
