### PR TITLE
[MPM] Fix neighbour search parallel

### DIFF
--- a/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
@@ -109,6 +109,7 @@ namespace MPMSearchElementUtility
             }
 
         }
+        #pragma omp critical
         rGeom.SetValue(GEOMETRY_NEIGHBOURS, geometry_neighbours);
     }
 


### PR DESCRIPTION
**Description**
Set omp critical when setting geometry neighbours to geoms, otherwise collisions can occur.

@VeronikaSinger this may also help fix some of your funny test errors :)