### PR TITLE
[Core] Minor change to kratos/CMakeLists.txt 

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -221,8 +221,8 @@ target_compile_definitions(KratosCore PRIVATE
 
 if (${AMGCL_GPGPU} MATCHES ON)
     add_subdirectory(
-        ${CMAKE_SOURCE_DIR}/external_libraries/vexcl
-        ${CMAKE_BINARY_DIR}/external_libraries/vexcl)
+        ${KRATOS_SOURCE_DIR}/external_libraries/vexcl
+        ${KRATOS_BINARY_DIR}/external_libraries/vexcl)
 
     if ("${AMGCL_GPGPU_BACKEND}" STREQUAL "OpenCL" AND TARGET VexCL::OpenCL)
         target_link_libraries(KratosCore PUBLIC VexCL::OpenCL)


### PR DESCRIPTION

**Description**
This PR is to fix a compilation error when building kratos as a submodule and having vexcl enabled.

If the root project (which has kratos as its submodule) has CMAKE_SOURCE_DIR defined, then it gets propagated here and cmake searches wrong sub-directory for vexcl and throws an error complaining that it can't find vexcl.

**Changelog**
- replaced CMAKE_SOURCE_DIR with KRATOS_SOURCE_DIR
- replaced CMAKE_BINARY_DIR with KRATOS_BINARY_DIR

