### PR TITLE
[Core] Split modeler factory in h and cpp

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -114,6 +114,7 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/tetrahedra_ball.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/tetrahedra_edge_shell.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/cad_io_modeler.cpp;
+    ${CMAKE_CURRENT_SOURCE_DIR}/modeler/modeler_factory.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modified_shape_functions/modified_shape_functions.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modified_shape_functions/ausas_modified_shape_functions.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modified_shape_functions/triangle_2d_3_modified_shape_functions.cpp;

--- a/kratos/modeler/modeler_factory.cpp
+++ b/kratos/modeler/modeler_factory.cpp
@@ -1,0 +1,44 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:         BSD License
+//                   Kratos default license: kratos/license.txt
+//
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "modeler_factory.h"
+
+namespace Kratos
+{
+    ///@name Kratos Classes
+    ///@{
+
+        /// Checks if the modeler is registered
+    bool ModelerFactory::Has(const std::string& ModelerName)
+    {
+        return KratosComponents< Modeler >::Has(ModelerName);
+    }
+
+    /// Checks if the modeler is registered
+    typename Modeler::Pointer ModelerFactory::Create(
+        const std::string& ModelerName, Model& rModel, const Parameters ModelParameters)
+    {
+        KRATOS_ERROR_IF_NOT(Has(ModelerName))
+            << "Trying to construct a modeler: "
+            << ModelerName << "\" which does not exist.\n"
+            << "The available options (for currently loaded applications) are:\n"
+            << KratosComponents< Modeler >() << std::endl;
+
+        Modeler const& r_clone_modeler = KratosComponents< Modeler >::Get(ModelerName);
+        return r_clone_modeler.Create(rModel, ModelParameters);
+    }
+
+}  // namespace Kratos.
+

--- a/kratos/modeler/modeler_factory.h
+++ b/kratos/modeler/modeler_factory.h
@@ -31,24 +31,11 @@ namespace ModelerFactory
 {
 
     /// Checks if the modeler is registered
-    bool Has(const std::string& ModelerName)
-    {
-        return KratosComponents< Modeler >::Has(ModelerName);
-    }
+    bool KRATOS_API(KRATOS_CORE) Has(const std::string& ModelerName);
 
     /// Checks if the modeler is registered
-    typename Modeler::Pointer Create(
-        const std::string& ModelerName, Model& rModel, const Parameters ModelParameters)
-    {
-        KRATOS_ERROR_IF_NOT(Has(ModelerName))
-            << "Trying to construct a modeler: "
-            << ModelerName << "\" which does not exist.\n"
-            << "The available options (for currently loaded applications) are:\n"
-            << KratosComponents< Modeler >() << std::endl;
-
-        Modeler const& r_clone_modeler = KratosComponents< Modeler >::Get(ModelerName);
-        return r_clone_modeler.Create(rModel, ModelParameters);
-    }
+    typename Modeler::Pointer KRATOS_API(KRATOS_CORE) Create(
+        const std::string& ModelerName, Model& rModel, const Parameters ModelParameters);
 
 }
 


### PR DESCRIPTION
**Description**
In windows it had compilation errors without this change (e.g. in #6010 ). Besides, it doesn't change any behavior.

**Changelog**
Add modeler_factory.cpp