### PR TITLE
[MPM] update static mpm to use fastest available solver

### DIFF
--- a/applications/ParticleMechanicsApplication/python_scripts/mpm_static_solver.py
+++ b/applications/ParticleMechanicsApplication/python_scripts/mpm_static_solver.py
@@ -6,6 +6,8 @@ import KratosMultiphysics
 # Importing the base class
 from KratosMultiphysics.ParticleMechanicsApplication.mpm_solver import MPMSolver
 
+from KratosMultiphysics import python_linear_solver_factory as linear_solver_factory
+
 def CreateSolver(model, custom_settings):
     return MPMStaticSolver(model, custom_settings)
 
@@ -15,6 +17,18 @@ class MPMStaticSolver(MPMSolver):
         # Construct the base solver.
         super(MPMStaticSolver, self).__init__(model, custom_settings)
         KratosMultiphysics.Logger.PrintInfo("::[MPMStaticSolver]:: ", "Construction is finished.")
+
+
+    @classmethod
+    def GetDefaultSettings(cls):
+        this_defaults = KratosMultiphysics.Parameters("""
+        {
+            "linear_solver_settings"             : {
+            }
+        }""")
+        this_defaults.AddMissingParameters(super(MPMStaticSolver, cls).GetDefaultSettings())
+        return this_defaults
+
 
     def _CreateSolutionScheme(self):
         return KratosMultiphysics.ResidualBasedIncrementalUpdateStaticScheme()


### PR DESCRIPTION
**Description**
The mpm static solver py is derived from the general (transient) implicit mpm solver py, which has amgcl in its default parameters as the linear solver. This causes problems for trivial static point load examples. This PR sets the static solver py default parameters to have a blank linear solver, which later defaults to the fastest available. 

Please note that the user can still specify and use the solver they use in the project parameters.
