### PR TITLE
[Core] Define projection geometry threshold

### DIFF
--- a/applications/CableNetApplication/custom_geometries/line_3d_n.h
+++ b/applications/CableNetApplication/custom_geometries/line_3d_n.h
@@ -350,12 +350,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         KRATOS_ERROR << "'IsInside' not available for arbitrarty noded line" << std::endl;

--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -77,7 +77,7 @@ public:
     ///@{
 
     /// constructor for untrimmed surface
-    BrepCurveOnSurface( 
+    BrepCurveOnSurface(
         typename NurbsSurfaceType::Pointer pSurface,
         typename NurbsCurveType::Pointer pCurve,
         bool SameCurveDirection = true)
@@ -279,13 +279,15 @@ public:
     * @param rPoint The point to be checked if is inside o note in global coordinates
     * @param rResult The local coordinates of the point
     * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
-    * @return True if the point is inside, false otherwise
+    * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
+     * @return True if the point is inside, false otherwise
     */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
-    ) const override
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
+        ) const override
     {
         KRATOS_ERROR << "IsInside is not yet implemented within the BrepCurveOnSurface";
     }

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -1643,12 +1643,14 @@ public:
     *        external point.
     * @param rResult the local coordinates of the point.
     * @param Tolerance the tolerance to the boundary.
-    * @return true if the point is inside, false otherwise
+    * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
+     * @return True if the point is inside, false otherwise
     */
     virtual bool IsInside(
         const CoordinatesArrayType& rPointGlobalCoordinates,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const
     {
         PointLocalCoordinates(

--- a/kratos/geometries/hexahedra_3d_20.h
+++ b/kratos/geometries/hexahedra_3d_20.h
@@ -464,12 +464,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/hexahedra_3d_27.h
+++ b/kratos/geometries/hexahedra_3d_27.h
@@ -486,12 +486,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/hexahedra_3d_8.h
+++ b/kratos/geometries/hexahedra_3d_8.h
@@ -466,12 +466,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/hexahedra_interface_3d_8.h
+++ b/kratos/geometries/hexahedra_interface_3d_8.h
@@ -665,12 +665,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/line_2d_2.h
+++ b/kratos/geometries/line_2d_2.h
@@ -901,12 +901,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 1.0e-6
         ) const override
     {
         // We compute the distance, if it is not in the pane we
@@ -916,7 +918,7 @@ public:
 
         // We check if we are on the plane
         if (std::abs(distance) > std::numeric_limits<double>::epsilon()) {
-            if (std::abs(distance) > 1.0e-6 * Length()) {
+            if (std::abs(distance) > ProjectionThreshold * Length()) {
                 KRATOS_WARNING_FIRST_N("Line2D2", 10) << "The point of coordinates X: " << rPoint[0] << "\tY: " << rPoint[1] << " it is in a distance: " << std::abs(distance) << std::endl;
                 return false;
             }

--- a/kratos/geometries/line_2d_3.h
+++ b/kratos/geometries/line_2d_3.h
@@ -375,12 +375,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/line_3d_2.h
+++ b/kratos/geometries/line_3d_2.h
@@ -744,12 +744,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/line_3d_3.h
+++ b/kratos/geometries/line_3d_3.h
@@ -371,12 +371,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/prism_3d_15.h
+++ b/kratos/geometries/prism_3d_15.h
@@ -524,12 +524,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/prism_3d_6.h
+++ b/kratos/geometries/prism_3d_6.h
@@ -470,12 +470,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/prism_interface_3d_6.h
+++ b/kratos/geometries/prism_interface_3d_6.h
@@ -465,12 +465,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/quadrilateral_2d_4.h
+++ b/kratos/geometries/quadrilateral_2d_4.h
@@ -467,12 +467,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/quadrilateral_2d_8.h
+++ b/kratos/geometries/quadrilateral_2d_8.h
@@ -418,12 +418,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/quadrilateral_2d_9.h
+++ b/kratos/geometries/quadrilateral_2d_9.h
@@ -437,12 +437,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/quadrilateral_3d_4.h
+++ b/kratos/geometries/quadrilateral_3d_4.h
@@ -522,12 +522,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         PointLocalCoordinatesImplementation( rResult, rPoint, true );

--- a/kratos/geometries/quadrilateral_3d_8.h
+++ b/kratos/geometries/quadrilateral_3d_8.h
@@ -427,12 +427,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/quadrilateral_3d_9.h
+++ b/kratos/geometries/quadrilateral_3d_9.h
@@ -437,12 +437,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/quadrilateral_interface_2d_4.h
+++ b/kratos/geometries/quadrilateral_interface_2d_4.h
@@ -461,12 +461,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/quadrilateral_interface_3d_4.h
+++ b/kratos/geometries/quadrilateral_interface_3d_4.h
@@ -475,12 +475,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/tetrahedra_3d_10.h
+++ b/kratos/geometries/tetrahedra_3d_10.h
@@ -413,12 +413,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/tetrahedra_3d_4.h
+++ b/kratos/geometries/tetrahedra_3d_4.h
@@ -1024,12 +1024,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/triangle_2d_3.h
+++ b/kratos/geometries/triangle_2d_3.h
@@ -712,12 +712,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/triangle_2d_6.h
+++ b/kratos/geometries/triangle_2d_6.h
@@ -464,12 +464,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         ) const override
     {
         this->PointLocalCoordinates( rResult, rPoint );

--- a/kratos/geometries/triangle_3d_3.h
+++ b/kratos/geometries/triangle_3d_3.h
@@ -879,12 +879,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 1.0e-6
         ) const override
     {
         // We compute the normal to check the normal distances between the point and the triangles, so we can discard that is on the triangle
@@ -899,7 +901,7 @@ public:
 
         // We check if we are on the plane
         if (std::abs(distance) > std::numeric_limits<double>::epsilon()) {
-            if (std::abs(distance) > 1.0e-6 * Length()) {
+            if (std::abs(distance) >  ProjectionThreshold * Length()) {
                 KRATOS_WARNING_FIRST_N("Triangle3D3", 10) << "The " << rPoint << " is in a distance: " << std::abs(distance) << std::endl;
                 return false;
             }

--- a/kratos/geometries/triangle_3d_6.h
+++ b/kratos/geometries/triangle_3d_6.h
@@ -472,12 +472,14 @@ public:
      * @param rPoint The point to be checked if is inside o note in global coordinates
      * @param rResult The local coordinates of the point
      * @param Tolerance The  tolerance that will be considered to check if the point is inside or not
+     * @param ProjectionThreshold If we allow a certain gap between the point and the geometry, projecting the point
      * @return True if the point is inside, false otherwise
      */
     bool IsInside(
         const CoordinatesArrayType& rPoint,
         CoordinatesArrayType& rResult,
-        const double Tolerance = std::numeric_limits<double>::epsilon()
+        const double Tolerance = std::numeric_limits<double>::epsilon(),
+        const double ProjectionThreshold = 0.0
         )const  override
     {
         this->PointLocalCoordinates( rResult, rPoint );


### PR DESCRIPTION
**Description**
Fixes #7337. This PR adds to the IsInside method a projection threshold. In order to not consider projection at all must be defined as 0.0. Is defined 0.0 by default except for the geometries already considering projection, in order to not break current tests/implementations.

**Changelog**
- Added ProjectionThreshold to IsInside method in geometries

