### PR TITLE
[PotentialFlow] Making Process Info const 1 out of 2

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_perturbation_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_perturbation_potential_element.cpp
@@ -72,7 +72,8 @@ KRATOS_TEST_CASE_IN_SUITE(CompressiblePerturbationPotentialFlowElementRHS, Compr
     // Compute RHS
     Vector RHS = ZeroVector(3);
 
-    pElement->CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
 
     std::vector<double> reference{146.2643261263345,-122.1426284341492,-24.12169769218525};
 
@@ -94,7 +95,8 @@ KRATOS_TEST_CASE_IN_SUITE(CompressiblePerturbationPotentialFlowElementLHS, Compr
     // Compute LHS
     Matrix LHS = ZeroMatrix(3, 3);
 
-    pElement->CalculateLeftHandSide(LHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
 
     std::array<double, 9> reference{ 0.06114278464441542,-0.1306215050744058, 0.06947872042999037,
                                      -0.1306215050744058, 0.6710758508914103,-0.5404543458170046,
@@ -126,7 +128,8 @@ KRATOS_TEST_CASE_IN_SUITE(PingCompressiblePerturbationPotentialFlowElementLHS, C
     Matrix LHS_analytical = ZeroMatrix(number_of_nodes, number_of_nodes);
 
     // Compute original RHS and LHS
-    pElement->CalculateLocalSystem(LHS_original, RHS_original, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS_original, RHS_original, r_current_process_info);
 
     double delta = 1e-3;
     for(unsigned int i = 0; i < number_of_nodes; i++){
@@ -136,7 +139,7 @@ KRATOS_TEST_CASE_IN_SUITE(PingCompressiblePerturbationPotentialFlowElementLHS, C
         Vector RHS_pinged = ZeroVector(number_of_nodes);
         Matrix LHS_pinged = ZeroMatrix(number_of_nodes, number_of_nodes);
         // Compute pinged LHS and RHS
-        pElement->CalculateLocalSystem(LHS_pinged, RHS_pinged, model_part.GetProcessInfo());
+        pElement->CalculateLocalSystem(LHS_pinged, RHS_pinged, r_current_process_info);
 
         for(unsigned int k = 0; k < number_of_nodes; k++){
             // Compute the finite difference estimate of the sensitivity
@@ -200,7 +203,8 @@ KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementRHS, C
     // Compute RHS and LHS
     Vector RHS = ZeroVector(6);
 
-    pElement->CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
 
     std::vector<double> reference{146.2643261263345,-0,-0,-0,-122.1426284341492,-24.12169769218525};
 
@@ -224,7 +228,8 @@ KRATOS_TEST_CASE_IN_SUITE(WakeCompressiblePerturbationPotentialFlowElementLHS, C
     // Compute LHS
     Matrix LHS = ZeroMatrix(6, 6);
 
-    pElement->CalculateLeftHandSide(LHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
 
     // Check the LHS values
     std::array<double,36> reference{0.06114278464441542,-0.1306215050744058,0.06947872042999037,0,0,0,

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_compressible_potential_element.cpp
@@ -100,7 +100,8 @@ KRATOS_TEST_CASE_IN_SUITE(CompressiblePotentialFlowElementRHS, CompressiblePoten
     Vector RHS = ZeroVector(3);
     Matrix LHS = ZeroMatrix(3, 3);
 
-    pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS, RHS, r_current_process_info);
 
     std::vector<double> reference({0.615561780, 0.0, -0.615561780});
 
@@ -132,7 +133,8 @@ KRATOS_TEST_CASE_IN_SUITE(CompressiblePotentialFlowElementLHS, CompressiblePoten
     Vector RHS = ZeroVector(3);
     Matrix LHS = ZeroMatrix(3, 3);
 
-    pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS, RHS, r_current_process_info);
 
     std::array<double, 9> reference{0.615556466, -0.615561780, 5.314318652e-06, -0.615561780, 1.231123561, -0.615561780, 5.314318652e-06, -0.615561780, 0.615556466};
 
@@ -164,7 +166,8 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedCompressiblePotentialFlowElementCalculateLocal
     Vector RHS = ZeroVector(3);
     Matrix LHS = ZeroMatrix(3, 3);
 
-    pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS, RHS, r_current_process_info);
 
     std::vector<double> reference{0.125625, 0.0, -0.125625};
 
@@ -191,7 +194,8 @@ KRATOS_TEST_CASE_IN_SUITE(EmbeddedCompressiblePotentialFlowElementCalculateLocal
     Vector RHS = ZeroVector(3);
     Matrix LHS = ZeroMatrix(3, 3);
 
-    pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS, RHS, r_current_process_info);
 
     std::array<double, 9> reference_array{0.251249, -0.25125, 1.08455e-06, -0.25125, 0.502499, -0.25125, 1.08455e-06, -0.25125, 0.251249};
     // Copying to a 3x3 matrix to check against LHS
@@ -247,7 +251,8 @@ KRATOS_TEST_CASE_IN_SUITE(CompressiblePotentialFlowElementRHSWake, CompressibleP
     Vector RHS = ZeroVector(6);
     Matrix LHS = ZeroMatrix(6, 6);
 
-    pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS, RHS, r_current_process_info);
 
     std::array<double, 6> reference{0.615561780, 0.0, 0.0, 0.0, 0.0, -0.615561780};
 
@@ -298,7 +303,8 @@ KRATOS_TEST_CASE_IN_SUITE(CompressiblePotentialFlowElementLHSWake, CompressibleP
     Vector RHS = ZeroVector(6);
     Matrix LHS = ZeroMatrix(6, 6);
 
-    pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS, RHS, r_current_process_info);
 
     // Check the RHS values (the RHS is computed as the LHS x previous_solution,
     // hence, it is assumed that if the RHS is correct, the LHS is correct as well)
@@ -331,14 +337,15 @@ KRATOS_TEST_CASE_IN_SUITE(CompressiblePotentialFlowElementEquationIdVector, Comp
     }
 
     Element::DofsVectorType ElementalDofList;
-    pElement->GetDofList(ElementalDofList, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->GetDofList(ElementalDofList, r_current_process_info);
 
     for (int i = 0; i < 3; i++) {
         ElementalDofList[i]->SetEquationId(i);
     }
 
     Element::EquationIdVectorType EquationIdVector;
-    pElement->EquationIdVector(EquationIdVector, model_part.GetProcessInfo());
+    pElement->EquationIdVector(EquationIdVector, r_current_process_info);
 
     // Check the EquationIdVector values
     for (unsigned int i = 0; i < EquationIdVector.size(); i++) {
@@ -369,14 +376,15 @@ KRATOS_TEST_CASE_IN_SUITE(CompressiblePotentialFlowElementEquationIdVectorWake, 
     }
 
     Element::DofsVectorType ElementalDofList;
-    pElement->GetDofList(ElementalDofList, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->GetDofList(ElementalDofList, r_current_process_info);
 
     for (int i = 0; i < 6; i++) {
         ElementalDofList[i]->SetEquationId(i);
     }
 
     Element::EquationIdVectorType EquationIdVector;
-    pElement->EquationIdVector(EquationIdVector, model_part.GetProcessInfo());
+    pElement->EquationIdVector(EquationIdVector, r_current_process_info);
 
     // Check the EquationIdVector values
     for (unsigned int i = 0; i < EquationIdVector.size(); i++) {

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_incompressible_perturbation_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_incompressible_perturbation_potential_element.cpp
@@ -101,7 +101,8 @@ namespace Kratos {
       // Compute RHS
       Vector RHS = ZeroVector(3);
 
-      pElement->CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->CalculateRightHandSide(RHS, r_current_process_info);
 
       // Check the RHS values
       std::vector<double> reference{5.5, -5, -0.5};
@@ -125,7 +126,8 @@ namespace Kratos {
       // Compute LHS
       Matrix LHS = ZeroMatrix(3,3);
 
-      pElement->CalculateLeftHandSide(LHS, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->CalculateLeftHandSide(LHS, r_current_process_info);
 
       // Check the LHS values
       std::array<double, 9> reference{0.5, -0.5, 0, -0.5, 1, -0.5, 0.0, -0.5, 0.5};
@@ -155,7 +157,8 @@ namespace Kratos {
       // Compute RHS
       Vector RHS = ZeroVector(6);
 
-      pElement->CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->CalculateRightHandSide(RHS, r_current_process_info);
 
       // Check the RHS values
       std::vector<double> reference{5.5, 0.0, 0.0, 0.0, -5, -0.5};
@@ -181,7 +184,8 @@ namespace Kratos {
       // Compute LHS
       Matrix LHS = ZeroMatrix(6,6);
 
-      pElement->CalculateLeftHandSide(LHS, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->CalculateLeftHandSide(LHS, r_current_process_info);
 
       // Check the LHS values
       std::array<double, 36> reference
@@ -213,13 +217,14 @@ namespace Kratos {
         pElement->GetGeometry()[i].AddDof(VELOCITY_POTENTIAL);
 
       Element::DofsVectorType ElementalDofList;
-      pElement->GetDofList(ElementalDofList, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->GetDofList(ElementalDofList, r_current_process_info);
 
       for (int i = 0; i < 3; i++)
         ElementalDofList[i]->SetEquationId(i);
 
       Element::EquationIdVectorType EquationIdVector;
-      pElement->EquationIdVector(EquationIdVector, model_part.GetProcessInfo());
+      pElement->EquationIdVector(EquationIdVector, r_current_process_info);
 
       // Check the EquationIdVector values
       for (unsigned int i = 0; i < EquationIdVector.size(); i++) {
@@ -249,13 +254,14 @@ namespace Kratos {
       }
 
       Element::DofsVectorType ElementalDofList;
-      pElement->GetDofList(ElementalDofList, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->GetDofList(ElementalDofList, r_current_process_info);
 
       for (int i = 0; i < 6; i++)
         ElementalDofList[i]->SetEquationId(i);
 
       Element::EquationIdVectorType EquationIdVector;
-      pElement->EquationIdVector(EquationIdVector, model_part.GetProcessInfo());
+      pElement->EquationIdVector(EquationIdVector, r_current_process_info);
 
       //Check the EquationIdVector values
       for (unsigned int i = 0; i < EquationIdVector.size(); i++) {

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_incompressible_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_incompressible_potential_element.cpp
@@ -130,7 +130,8 @@ namespace Kratos {
       Vector RHS = ZeroVector(3);
       Matrix LHS = ZeroMatrix(3, 3);
 
-      pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->CalculateLocalSystem(LHS, RHS, r_current_process_info);
 
       // Check the RHS values (the RHS is computed as the LHS x previous_solution,
       // hence, it is assumed that if the RHS is correct, the LHS is correct as well)
@@ -160,7 +161,8 @@ namespace Kratos {
       Vector RHS = ZeroVector(6);
       Matrix LHS = ZeroMatrix(6, 6);
 
-      pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->CalculateLocalSystem(LHS, RHS, r_current_process_info);
 
       // Check the RHS values (the RHS is computed as the LHS x previous_solution,
       // hence, it is assumed that if the RHS is correct, the LHS is correct as well)
@@ -195,7 +197,8 @@ namespace Kratos {
       Vector RHS = ZeroVector(3);
       Matrix LHS = ZeroMatrix(3, 3);
 
-      pElement->CalculateLocalSystem(LHS, RHS, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->CalculateLocalSystem(LHS, RHS, r_current_process_info);
 
       // Check the RHS values (the RHS is computed as the LHS x previous_solution,
       // hence, it is assumed that if the RHS is correct, the LHS is correct as well)
@@ -223,13 +226,14 @@ namespace Kratos {
         pElement->GetGeometry()[i].AddDof(VELOCITY_POTENTIAL);
 
       Element::DofsVectorType ElementalDofList;
-      pElement->GetDofList(ElementalDofList, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->GetDofList(ElementalDofList, r_current_process_info);
 
       for (int i = 0; i < 3; i++)
         ElementalDofList[i]->SetEquationId(i);
 
       Element::EquationIdVectorType EquationIdVector;
-      pElement->EquationIdVector(EquationIdVector, model_part.GetProcessInfo());
+      pElement->EquationIdVector(EquationIdVector, r_current_process_info);
 
       // Check the EquationIdVector values
       for (unsigned int i = 0; i < EquationIdVector.size(); i++) {
@@ -259,13 +263,14 @@ namespace Kratos {
       }
 
       Element::DofsVectorType ElementalDofList;
-      pElement->GetDofList(ElementalDofList, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      pElement->GetDofList(ElementalDofList, r_current_process_info);
 
       for (int i = 0; i < 6; i++)
         ElementalDofList[i]->SetEquationId(i);
 
       Element::EquationIdVectorType EquationIdVector;
-      pElement->EquationIdVector(EquationIdVector, model_part.GetProcessInfo());
+      pElement->EquationIdVector(EquationIdVector, r_current_process_info);
 
       //Check the EquationIdVector values
       for (unsigned int i = 0; i < EquationIdVector.size(); i++) {
@@ -486,7 +491,8 @@ namespace Kratos {
 
       AssignPotentialsToNormalElement(pElement);
 
-      double pressure_coefficient = PotentialFlowUtilities::ComputeIncompressiblePressureCoefficient<2,3>(*pElement, model_part.GetProcessInfo());
+      const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+      double pressure_coefficient = PotentialFlowUtilities::ComputeIncompressiblePressureCoefficient<2,3>(*pElement, r_current_process_info);
 
       KRATOS_CHECK_NEAR(pressure_coefficient, 0.98, 1e-7);
     }

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_potential_flow_utilities.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_potential_flow_utilities.cpp
@@ -93,7 +93,8 @@ KRATOS_TEST_CASE_IN_SUITE(ComputePerturbedVelocity, CompressiblePotentialApplica
 
     AssignPerturbationPotentialsToElement(*pElement);
 
-    array_1d<double, 2> perturbed_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<2,3>(*pElement, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    array_1d<double, 2> perturbed_velocity = PotentialFlowUtilities::ComputePerturbedVelocity<2,3>(*pElement, r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(perturbed_velocity[0], 303.0, 1e-15);
     KRATOS_CHECK_RELATIVE_NEAR(perturbed_velocity[1], 50.0, 1e-15);
@@ -107,7 +108,8 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeVelocityMagnitude, CompressiblePotentialApplica
     AssignFreeStreamValues(model_part);
 
     // velocity corresponding to squared mach number of 3.0
-    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(3.0, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(3.0, r_current_process_info);
 
     const double reference_velocity_squared = 232356.0;
 
@@ -124,7 +126,8 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeMaximumVelocitySquared, CompressiblePotentialAp
     const double reference_max_velocity_squared = 232356.0;
 
     // Max local Mach number = sqrt(3.0), from MACH_SQUARED_LIMIT
-    const double max_velocity_squared = PotentialFlowUtilities::ComputeMaximumVelocitySquared<2, 3>(model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double max_velocity_squared = PotentialFlowUtilities::ComputeMaximumVelocitySquared<2, 3>(r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(max_velocity_squared, reference_max_velocity_squared, 1e-15);
 }
@@ -138,9 +141,10 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeLocalSpeedOfSound, CompressiblePotentialApplica
     Element::Pointer pElement = model_part.pGetElement(1);
 
     AssignPotentialsToElement(*pElement);
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     const double local_speed_of_sound =
         PotentialFlowUtilities::ComputeLocalSpeedOfSound<2, 3>(
-            *pElement, model_part.GetProcessInfo());
+            *pElement, r_current_process_info);
     KRATOS_CHECK_NEAR(local_speed_of_sound, 333.801138, 1e-6);
 }
 
@@ -154,12 +158,13 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeLocalSpeedofSoundSquared, CompressiblePotential
     const double local_mach_number_squared = 3.0;
 
     // velocity corresponding to mach number 3.0
-    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, r_current_process_info);
 
     array_1d<double, 2> velocity(2, 0.0);
     velocity[0] = std::sqrt(local_velocity_squared);
 
-    const double local_speed_sound_squared = PotentialFlowUtilities::ComputeLocalSpeedofSoundSquared<2,3>(velocity, model_part.GetProcessInfo());
+    const double local_speed_sound_squared = PotentialFlowUtilities::ComputeLocalSpeedofSoundSquared<2,3>(velocity, r_current_process_info);
 
     const double reference_local_speed_sound_squared = 77452.0;
 
@@ -175,9 +180,10 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeLocalMachNumber, CompressiblePotentialApplicati
     Element::Pointer pElement = model_part.pGetElement(1);
 
     AssignPotentialsToElement(*pElement);
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     const double local_mach_number =
         PotentialFlowUtilities::ComputeLocalMachNumber<2, 3>(
-            *pElement, model_part.GetProcessInfo());
+            *pElement, r_current_process_info);
     KRATOS_CHECK_NEAR(local_mach_number, 0.748948914, 1e-6);
 }
 
@@ -191,13 +197,14 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeLocalMachNumberSquared, CompressiblePotentialAp
     const double reference_local_mach_squared = 3.0;
 
     // velocity corresponding to mach number 3.0
-    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(reference_local_mach_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(reference_local_mach_squared, r_current_process_info);
 
     array_1d<double, 2> velocity(2, 0.0);
     velocity[0] = std::sqrt(local_velocity_squared);
 
     // computes mach number with clamping
-    const double local_mach_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<2, 3>(velocity, model_part.GetProcessInfo());
+    const double local_mach_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<2, 3>(velocity, r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(local_mach_squared, reference_local_mach_squared, 1e-15);
 }
@@ -212,16 +219,17 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeDerivativeLocalMachSquaredWRTVelocitySquaredTra
     const double local_mach_number_squared = 1.0;
 
     // velocity corresponding to mach number 1.0
-    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, r_current_process_info);
 
     array_1d<double, 2> velocity(2, 0.0);
     velocity[0] = std::sqrt(local_velocity_squared);
 
     // performs clamping on mach number
-    const double local_mach_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<2, 3>(velocity, model_part.GetProcessInfo());
+    const double local_mach_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<2, 3>(velocity, r_current_process_info);
 
     const double mach_derivative = PotentialFlowUtilities::ComputeDerivativeLocalMachSquaredWRTVelocitySquared<2, 3>(velocity,
-                local_mach_squared, model_part.GetProcessInfo());
+                local_mach_squared, r_current_process_info);
 
     const double reference_derivative = 1.1620100191086091883e-05;
 
@@ -238,16 +246,17 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeDerivativeLocalMachSquaredWRTVelocitySquaredSup
     const double local_mach_number_squared = 3.0;
 
     // velocity corresponding to mach number 3.0
-    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, r_current_process_info);
 
     array_1d<double, 2> velocity(2, 0.0);
     velocity[0] = std::sqrt(local_velocity_squared);
 
     // performs clamping on mach number
-    const double local_mach_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<2, 3>(velocity, model_part.GetProcessInfo());
+    const double local_mach_squared = PotentialFlowUtilities::ComputeLocalMachNumberSquared<2, 3>(velocity, r_current_process_info);
 
     const double mach_derivative = PotentialFlowUtilities::ComputeDerivativeLocalMachSquaredWRTVelocitySquared<2, 3>(velocity,
-                local_mach_squared, model_part.GetProcessInfo());
+                local_mach_squared, r_current_process_info);
 
     const double reference_derivative = 2.0657955895264163348e-05;
 
@@ -263,9 +272,10 @@ KRATOS_TEST_CASE_IN_SUITE(ComputePerturbationIncompressiblePressureCoefficient, 
     Element::Pointer pElement = model_part.pGetElement(1);
 
     AssignPerturbationPotentialsToElement(*pElement);
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     const double pressure_coefficient =
         PotentialFlowUtilities::ComputePerturbationIncompressiblePressureCoefficient<2, 3>(
-            *pElement, model_part.GetProcessInfo());
+            *pElement, r_current_process_info);
 
     KRATOS_CHECK_NEAR(pressure_coefficient, -1.266171664744329, 1e-15);
 }
@@ -279,9 +289,10 @@ KRATOS_TEST_CASE_IN_SUITE(ComputePerturbationCompressiblePressureCoefficient, Co
     Element::Pointer pElement = model_part.pGetElement(1);
 
     AssignPerturbationPotentialsToElement(*pElement);
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     const double pressure_coefficient =
         PotentialFlowUtilities::ComputePerturbationCompressiblePressureCoefficient<2, 3>(
-            *pElement, model_part.GetProcessInfo());
+            *pElement, r_current_process_info);
 
     KRATOS_CHECK_NEAR(pressure_coefficient, -1.128385779511008, 1e-15);
 }
@@ -295,9 +306,10 @@ KRATOS_TEST_CASE_IN_SUITE(ComputePerturbationLocalSpeedOfSound, CompressiblePote
     Element::Pointer pElement = model_part.pGetElement(1);
 
     AssignPerturbationPotentialsToElement(*pElement);
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     const double local_speed_of_sound =
         PotentialFlowUtilities::ComputePerturbationLocalSpeedOfSound<2, 3>(
-            *pElement, model_part.GetProcessInfo());
+            *pElement, r_current_process_info);
 
     KRATOS_CHECK_NEAR(local_speed_of_sound, 324.1317633309022, 1e-13);
 }
@@ -311,9 +323,10 @@ KRATOS_TEST_CASE_IN_SUITE(ComputePerturbationLocalMachNumber, CompressiblePotent
     Element::Pointer pElement = model_part.pGetElement(1);
 
     AssignPerturbationPotentialsToElement(*pElement);
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     const double local_mach_number =
         PotentialFlowUtilities::ComputePerturbationLocalMachNumber<2, 3>(
-            *pElement, model_part.GetProcessInfo());
+            *pElement, r_current_process_info);
 
     KRATOS_CHECK_NEAR(local_mach_number, 0.9474471158469713, 1e-16);
 }
@@ -327,7 +340,8 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindFactor, CompressiblePotentialApplicationF
 
     const double local_mach_squared = 3.0;
 
-    const double upwind_factor = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(local_mach_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double upwind_factor = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(local_mach_squared, r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(upwind_factor, 0.6733, 1e-15);
 }
@@ -342,7 +356,8 @@ KRATOS_TEST_CASE_IN_SUITE(SelectMaxUpwindFactor, CompressiblePotentialApplicatio
     const double local_mach_number_squared = 3.0;
 
     // velocity corresponding to mach number sqrt(3.0)
-    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, r_current_process_info);
 
     array_1d<double, 2> current_velocity(2, 0.0);
     current_velocity[0] = std::sqrt(local_velocity_squared);
@@ -350,13 +365,13 @@ KRATOS_TEST_CASE_IN_SUITE(SelectMaxUpwindFactor, CompressiblePotentialApplicatio
     const double upwind_mach_number_squared = 0.7 * 0.7;
 
     // velocity corresponding to mach number 0.7
-    const double upwind_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(upwind_mach_number_squared, model_part.GetProcessInfo());
+    const double upwind_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(upwind_mach_number_squared, r_current_process_info);
 
     array_1d<double, 2> upwind_velocity(2, 0.0);
     upwind_velocity[0] = std::sqrt(upwind_velocity_squared);
 
     // find max of current element upwind factor, upwind element upwind factor, and 0
-    const double upwind_factor = PotentialFlowUtilities::SelectMaxUpwindFactor<2, 3>(current_velocity, upwind_velocity, model_part.GetProcessInfo());
+    const double upwind_factor = PotentialFlowUtilities::SelectMaxUpwindFactor<2, 3>(current_velocity, upwind_velocity, r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(upwind_factor, 0.6733, 1e-15);
 }
@@ -370,8 +385,9 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindFactorCase0, CompressiblePotentialApplica
 
     array_1d<double, 3> upwind_factor_options(3, 0.0);
 
-    upwind_factor_options[1] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(0.35, model_part.GetProcessInfo());
-    upwind_factor_options[2] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(0.49, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    upwind_factor_options[1] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(0.35, r_current_process_info);
+    upwind_factor_options[2] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(0.49, r_current_process_info);
 
     const auto upwind_factor_case = PotentialFlowUtilities::ComputeUpwindFactorCase<2,3>(upwind_factor_options);
 
@@ -387,8 +403,9 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindFactorCase1, CompressiblePotentialApplica
 
     array_1d<double, 3> upwind_factor_options(3, 0.0);
 
-    upwind_factor_options[1] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(3.0, model_part.GetProcessInfo());
-    upwind_factor_options[2] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(0.49, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    upwind_factor_options[1] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(3.0, r_current_process_info);
+    upwind_factor_options[2] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(0.49, r_current_process_info);
 
     const auto upwind_factor_case = PotentialFlowUtilities::ComputeUpwindFactorCase<2,3>(upwind_factor_options);
 
@@ -404,8 +421,9 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindFactorCase2, CompressiblePotentialApplica
 
     array_1d<double, 3> upwind_factor_options(3, 0.0);
 
-    upwind_factor_options[1] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(1.3, model_part.GetProcessInfo());
-    upwind_factor_options[2] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(3.0, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    upwind_factor_options[1] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(1.3, r_current_process_info);
+    upwind_factor_options[2] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(3.0, r_current_process_info);
 
     const auto upwind_factor_case = PotentialFlowUtilities::ComputeUpwindFactorCase<2,3>(upwind_factor_options);
 
@@ -421,8 +439,9 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindFactorCaseSubsonicElement, CompressiblePo
 
     array_1d<double, 3> upwind_factor_options(3, 0.0);
 
-    upwind_factor_options[1] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(0.49, model_part.GetProcessInfo());
-    upwind_factor_options[2] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(3.0, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    upwind_factor_options[1] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(0.49, r_current_process_info);
+    upwind_factor_options[2] = PotentialFlowUtilities::ComputeUpwindFactor<2, 3>(3.0, r_current_process_info);
 
     const auto upwind_factor_case = PotentialFlowUtilities::ComputeUpwindFactorCase<2,3>(upwind_factor_options);
 
@@ -438,8 +457,9 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindFactorDerivativeWRTMachSquared, Compressi
 
     const double local_mach_number_squared = 3.0;
 
-    const double upwind_factor_derivative = PotentialFlowUtilities::ComputeUpwindFactorDerivativeWRTMachSquared<2,3>(local_mach_number_squared,model_part.GetProcessInfo());
-    
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double upwind_factor_derivative = PotentialFlowUtilities::ComputeUpwindFactorDerivativeWRTMachSquared<2,3>(local_mach_number_squared,r_current_process_info);
+
     KRATOS_CHECK_RELATIVE_NEAR(upwind_factor_derivative, 0.1089, 1e-15);
 }
 
@@ -453,13 +473,14 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindFactorDerivativeWRTVelocitySquared, Compr
     const double local_mach_number_squared = 3.0;
 
     // velocity corresponding to mach number sqrt(3.0)
-    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, r_current_process_info);
 
     array_1d<double, 2> current_velocity(2, 0.0);
     current_velocity[0] = std::sqrt(local_velocity_squared);
 
-    const double upwind_factor_derivative = PotentialFlowUtilities::ComputeUpwindFactorDerivativeWRTVelocitySquared<2,3>(current_velocity, model_part.GetProcessInfo());
-    
+    const double upwind_factor_derivative = PotentialFlowUtilities::ComputeUpwindFactorDerivativeWRTVelocitySquared<2,3>(current_velocity, r_current_process_info);
+
     const double mach_derivative_ref = 2.0657955895264163348e-05;
     const double upwind_factor_ref = 0.1089;
 
@@ -475,7 +496,8 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeDensity, CompressiblePotentialApplicationFastSu
 
     const double local_mach_number_squared = 3.0;
 
-    const double density = PotentialFlowUtilities::ComputeDensity<2, 3>(local_mach_number_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double density = PotentialFlowUtilities::ComputeDensity<2, 3>(local_mach_number_squared, r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(density, 0.450114595263459, 1e-15);
 }
@@ -490,7 +512,8 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindedDensity, CompressiblePotentialApplicati
     const double local_mach_number_squared = 3.0;
 
     // velocity corresponding to mach number sqrt(3.0)
-    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, r_current_process_info);
 
     array_1d<double, 2> current_velocity(2, 0.0);
     current_velocity[0] = std::sqrt(local_velocity_squared);
@@ -498,12 +521,12 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindedDensity, CompressiblePotentialApplicati
     const double upwind_mach_number_squared = 0.7 * 0.7;
 
     // velocity corresponding to mach number 0.7
-    const double upwind_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(upwind_mach_number_squared, model_part.GetProcessInfo());
+    const double upwind_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(upwind_mach_number_squared, r_current_process_info);
 
     array_1d<double, 2> upwind_velocity(2, 0.0);
     upwind_velocity[0] = std::sqrt(upwind_velocity_squared);
 
-    const double upwinded_density = PotentialFlowUtilities::ComputeUpwindedDensity<2,3>(current_velocity, upwind_velocity, model_part.GetProcessInfo());
+    const double upwinded_density = PotentialFlowUtilities::ComputeUpwindedDensity<2,3>(current_velocity, upwind_velocity, r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(upwinded_density, 0.92388212928098, 1e-15);
 }
@@ -517,7 +540,8 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeDensityDerivativeWRTVelocitySquared, Compressib
 
     const double local_mach_number_squared = 3.0;
 
-    const double density_derivative = PotentialFlowUtilities::ComputeDensityDerivativeWRTVelocitySquared<2,3>(local_mach_number_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double density_derivative = PotentialFlowUtilities::ComputeDensityDerivativeWRTVelocitySquared<2,3>(local_mach_number_squared, r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(density_derivative, -2.905764830239754E-06, 1e-15);
 }
@@ -532,7 +556,8 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindedDensityDerivativeWRTVelocitySquaredSupe
     const double local_mach_number_squared = 3.0;
 
     // velocity corresponding to mach number sqrt(3.0)
-    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double local_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(local_mach_number_squared, r_current_process_info);
 
     array_1d<double, 2> current_velocity(2, 0.0);
     current_velocity[0] = std::sqrt(local_velocity_squared);
@@ -556,8 +581,9 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindedDensityDerivativeWRTVelocitySquaredSupe
 
     const double upwind_mach_number_squared = 3.0;
 
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     const double density_derivative_deaccel = PotentialFlowUtilities::ComputeUpwindedDensityDerivativeWRTVelocitySquaredSupersonicDeaccelerating<2,3>(
-        local_mach_number_squared, upwind_mach_number_squared, model_part.GetProcessInfo());
+        local_mach_number_squared, upwind_mach_number_squared, r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(density_derivative_deaccel, -1.3584190201217436E-06, 1e-15);
 }
@@ -573,8 +599,9 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindedDensityDerivativeWRTUpwindVelocitySquar
 
     const double upwind_mach_number_squared = 0.7 * 0.7;
 
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
     const double density_derivative_accel = PotentialFlowUtilities::ComputeUpwindedDensityDerivativeWRTUpwindVelocitySquaredSupersonicAccelerating<2,3>(
-        local_mach_number_squared, upwind_mach_number_squared, model_part.GetProcessInfo());
+        local_mach_number_squared, upwind_mach_number_squared, r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(density_derivative_accel, -3.441482308103857E-06, 1e-15);
 }
@@ -591,13 +618,14 @@ KRATOS_TEST_CASE_IN_SUITE(ComputeUpwindedDensityDerivativeWRTUpwindVelocitySquar
     const double upwind_mach_number_squared = 3.0;
 
     // velocity corresponding to mach number sqrt(3.0)
-    const double upwind_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(upwind_mach_number_squared, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    const double upwind_velocity_squared = PotentialFlowUtilities::ComputeVelocityMagnitude<2, 3>(upwind_mach_number_squared, r_current_process_info);
 
     array_1d<double, 2> upwind_velocity(2, 0.0);
     upwind_velocity[0] = std::sqrt(upwind_velocity_squared);
 
     const double density_derivative_deaccel = PotentialFlowUtilities::ComputeUpwindedDensityDerivativeWRTUpwindVelocitySquaredSupersonicDeaccelerating<2,3>(
-        upwind_velocity, local_mach_number_squared, upwind_mach_number_squared, model_part.GetProcessInfo());
+        upwind_velocity, local_mach_number_squared, upwind_mach_number_squared, r_current_process_info);
 
     KRATOS_CHECK_RELATIVE_NEAR(density_derivative_deaccel, -2.7838255012122669E-06, 1e-15);
 }

--- a/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_transonic_perturbation_potential_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/tests/cpp_tests/test_transonic_perturbation_potential_element.cpp
@@ -95,7 +95,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowElementRHS, Compress
     // Compute RHS
     Vector RHS = ZeroVector(4);
 
-    pElement->CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
 
     std::vector<double> reference{146.2643261263345,-122.1426284341492,-24.12169769218525};
 
@@ -111,14 +112,15 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowInletElementRHS, Com
 
     GenerateTransonicPerturbationElement(model_part);
     Element::Pointer pElement = model_part.pGetElement(1);
-    pElement->Initialize(model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->Initialize(r_current_process_info);
 
     AssignPotentialsToNormalTransonicPerturbationElement(pElement);
 
     // Compute RHS
     Vector RHS = ZeroVector(3);
 
-    pElement->CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
 
     std::vector<double> reference{146.2643261263345,-122.1426284341492,-24.12169769218525};
 
@@ -142,7 +144,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowElementLHS, Compress
     // Compute LHS
     Matrix LHS = ZeroMatrix(4, 4);
 
-    pElement->CalculateLeftHandSide(LHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
 
     std::array<double, 16> reference{ 0.061142784644415527,-0.1306215050744058, 0.06947872042999037, 0.0,
                                      -0.1306215050744058, 0.6710758508914103,-0.5404543458170046, 0.0,
@@ -172,7 +175,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowSupersonicElementLHS
     FindNodalNeighboursProcess find_nodal_neighbours_process(model_part);
     find_nodal_neighbours_process.Execute();
 
-    pElement->Initialize(model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->Initialize(r_current_process_info);
     pUpwindElement->SetFlags(INLET);
 
     std::array<double, 3> high_potential{1.0, 200.0, 100.0};  // node id order 23 74 55
@@ -187,10 +191,10 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowSupersonicElementLHS
     }
 
     Element::DofsVectorType CurrentElementalDofList;
-    pElement->GetDofList(CurrentElementalDofList, model_part.GetProcessInfo());
+    pElement->GetDofList(CurrentElementalDofList, r_current_process_info);
 
     Element::DofsVectorType UpwindElementalDofList;
-    pUpwindElement->GetDofList(UpwindElementalDofList, model_part.GetProcessInfo());
+    pUpwindElement->GetDofList(UpwindElementalDofList, r_current_process_info);
 
     std::vector<int> current_ids{23, 74, 55};
     std::vector<int> upwind_ids{23, 55, 67};
@@ -198,11 +202,11 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowSupersonicElementLHS
         CurrentElementalDofList[i]->SetEquationId(current_ids[i]);
         UpwindElementalDofList[2]->SetEquationId(upwind_ids[i]);
     }
-    
+
     // // Compute LHS
     Matrix LHS = ZeroMatrix(4, 4);
 
-    pElement->CalculateLeftHandSide(LHS, model_part.GetProcessInfo());
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
 
     std::array<double, 16> reference{ 0.37708651121240516,-0.54915594944726343,0.17743192602659938,-0.0053624877917411414,
                                      -0.35664864389216139,1.0308840557120569,-0.68092794767744869,0.0066925358575532206,
@@ -232,7 +236,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowSupersonicDecelerati
     FindNodalNeighboursProcess find_nodal_neighbours_process(model_part);
     find_nodal_neighbours_process.Execute();
 
-    pElement->Initialize(model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->Initialize(r_current_process_info);
     pUpwindElement->SetFlags(INLET);
 
     std::array<double, 3> high_potential{10.0, 200.0, 350.0};  // node id order 23 74 55
@@ -248,10 +253,10 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowSupersonicDecelerati
     }
 
     Element::DofsVectorType CurrentElementalDofList;
-    pElement->GetDofList(CurrentElementalDofList, model_part.GetProcessInfo());
+    pElement->GetDofList(CurrentElementalDofList, r_current_process_info);
 
     Element::DofsVectorType UpwindElementalDofList;
-    pUpwindElement->GetDofList(UpwindElementalDofList, model_part.GetProcessInfo());
+    pUpwindElement->GetDofList(UpwindElementalDofList, r_current_process_info);
 
     std::vector<int> current_ids{23, 74, 55};
     std::vector<int> upwind_ids{23, 55, 67};
@@ -259,11 +264,11 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowSupersonicDecelerati
         CurrentElementalDofList[i]->SetEquationId(current_ids[i]);
         UpwindElementalDofList[2]->SetEquationId(upwind_ids[i]);
     }
-    
+
     // // Compute LHS
     Matrix LHS = ZeroMatrix(4, 4);
 
-    pElement->CalculateLeftHandSide(LHS, model_part.GetProcessInfo());
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
 
     std::array<double, 16> reference{ -0.054669771246690091,-0.14888540383260493,0.40255671949894734,-0.19900154441965234,
                                       -0.083557300280464597,0.51822478070562072,-0.55794161182804491,0.12327413140288881,
@@ -299,17 +304,18 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowSupersonicElementRHS
     AssignPerturbationPotentialsToTransonicElement(*pElement, high_potential);
     // mach number 0.3999
     AssignPerturbationPotentialsToTransonicElement(*pUpwindElement, low_potential);
-    
+
 
     for (auto& r_node : model_part.Nodes()){
         r_node.AddDof(VELOCITY_POTENTIAL);
     }
 
     Element::DofsVectorType CurrentElementalDofList;
-    pElement->GetDofList(CurrentElementalDofList, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->GetDofList(CurrentElementalDofList, r_current_process_info);
 
     Element::DofsVectorType UpwindElementalDofList;
-    pUpwindElement->GetDofList(UpwindElementalDofList, model_part.GetProcessInfo());
+    pUpwindElement->GetDofList(UpwindElementalDofList, r_current_process_info);
 
     std::vector<int> current_ids{23, 74, 55};
     std::vector<int> upwind_ids{23, 55, 67};
@@ -318,13 +324,13 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowSupersonicElementRHS
         UpwindElementalDofList[i]->SetEquationId(upwind_ids[i]);
     }
 
-    pElement->Initialize(model_part.GetProcessInfo());
+    pElement->Initialize(r_current_process_info);
     pUpwindElement->SetFlags(INLET);
-    
+
     // Compute RHS
     Vector RHS = ZeroVector(4);
 
-    pElement->CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
 
     std::vector<double> reference{185.25633340652948,-231.20512387394589,45.948790467416408,0.0};
 
@@ -340,7 +346,8 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowInletElementLHS, Com
 
     GenerateTransonicPerturbationElement(model_part);
     Element::Pointer pElement = model_part.pGetElement(1);
-    pElement->Initialize(model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->Initialize(r_current_process_info);
 
     pElement->SetFlags(INLET);
 
@@ -349,7 +356,7 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowInletElementLHS, Com
     // Compute LHS
     Matrix LHS = ZeroMatrix(4, 4);
 
-    pElement->CalculateLeftHandSide(LHS, model_part.GetProcessInfo());
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
 
     std::array<double, 9> reference{ 0.061142784644415527,-0.1306215050744058, 0.06947872042999037,
                                      -0.1306215050744058, 0.67107585089141042,-0.5404543458170046,
@@ -383,7 +390,8 @@ KRATOS_TEST_CASE_IN_SUITE(PingTransonicPerturbationPotentialFlowElementLHS, Comp
     Matrix LHS_analytical = ZeroMatrix(number_of_nodes, number_of_nodes);
 
     // Compute original RHS and LHS
-    pElement->CalculateLocalSystem(LHS_original, RHS_original, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLocalSystem(LHS_original, RHS_original, r_current_process_info);
 
     double delta = 1e-3;
     for(unsigned int i = 0; i < number_of_nodes; i++){
@@ -393,7 +401,7 @@ KRATOS_TEST_CASE_IN_SUITE(PingTransonicPerturbationPotentialFlowElementLHS, Comp
         Vector RHS_pinged = ZeroVector(number_of_nodes);
         Matrix LHS_pinged = ZeroMatrix(number_of_nodes, number_of_nodes);
         // Compute pinged LHS and RHS
-        pElement->CalculateLocalSystem(LHS_pinged, RHS_pinged, model_part.GetProcessInfo());
+        pElement->CalculateLocalSystem(LHS_pinged, RHS_pinged, r_current_process_info);
 
         for(unsigned int k = 0; k < number_of_nodes; k++){
             // Compute the finite difference estimate of the sensitivity
@@ -430,7 +438,8 @@ KRATOS_TEST_CASE_IN_SUITE(PingTransonicPerturbationPotentialFlowSupersonicElemen
     FindNodalNeighboursProcess find_nodal_neighbours_process(model_part);
     find_nodal_neighbours_process.Execute();
 
-    pElement->Initialize(model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->Initialize(r_current_process_info);
     pUpwindElement->SetFlags(INLET);
 
     std::array<double, 3> high_potential{1.0, 200.0, 100.0};  // node id order 23 74 55
@@ -445,10 +454,10 @@ KRATOS_TEST_CASE_IN_SUITE(PingTransonicPerturbationPotentialFlowSupersonicElemen
     }
 
     Element::DofsVectorType CurrentElementalDofList;
-    pElement->GetDofList(CurrentElementalDofList, model_part.GetProcessInfo());
+    pElement->GetDofList(CurrentElementalDofList, r_current_process_info);
 
     Element::DofsVectorType UpwindElementalDofList;
-    pUpwindElement->GetDofList(UpwindElementalDofList, model_part.GetProcessInfo());
+    pUpwindElement->GetDofList(UpwindElementalDofList, r_current_process_info);
 
     std::vector<int> current_ids{23, 74, 55}; // 1 2 3
     std::vector<int> upwind_ids{23, 55, 67};  // 1 3 4
@@ -463,7 +472,7 @@ KRATOS_TEST_CASE_IN_SUITE(PingTransonicPerturbationPotentialFlowSupersonicElemen
     Matrix LHS_analytical = ZeroMatrix(number_of_nodes + 1, number_of_nodes + 1);
 
     // Compute original RHS and LHS
-    pElement->CalculateLocalSystem(LHS_original, RHS_original, model_part.GetProcessInfo());
+    pElement->CalculateLocalSystem(LHS_original, RHS_original, r_current_process_info);
 
     double delta = 1e-3;
     for(unsigned int i = 0; i < 4; i++){
@@ -478,7 +487,7 @@ KRATOS_TEST_CASE_IN_SUITE(PingTransonicPerturbationPotentialFlowSupersonicElemen
         Vector RHS_pinged = ZeroVector(number_of_nodes + 1);
         Matrix LHS_pinged = ZeroMatrix(number_of_nodes + 1, number_of_nodes + 1);
         // Compute pinged LHS and RHS
-        pElement->CalculateLocalSystem(LHS_pinged, RHS_pinged, model_part.GetProcessInfo());
+        pElement->CalculateLocalSystem(LHS_pinged, RHS_pinged, r_current_process_info);
 
         for(unsigned int k = 0; k < number_of_nodes + 1; k++){
             // Compute the finite difference estimate of the sensitivity
@@ -514,14 +523,15 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowElementEquationId, C
     find_nodal_neighbours_process.Execute();
 
     Element::Pointer pCurrentElement = model_part.pGetElement(1);
-    pCurrentElement->Initialize(model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pCurrentElement->Initialize(r_current_process_info);
 
     for (auto& r_node : model_part.Nodes()){
         r_node.AddDof(VELOCITY_POTENTIAL);
     }
 
     Element::DofsVectorType CurrentElementalDofList;
-    pCurrentElement->GetDofList(CurrentElementalDofList, model_part.GetProcessInfo());
+    pCurrentElement->GetDofList(CurrentElementalDofList, r_current_process_info);
 
     std::vector<int> ids{23, 74, 55};
     for (int i = 0; i < 3; i++) {
@@ -530,17 +540,17 @@ KRATOS_TEST_CASE_IN_SUITE(TransonicPerturbationPotentialFlowElementEquationId, C
 
     // upwind element equation id
     Element::Pointer pUpwindElement = model_part.pGetElement(2);
-    
+
     pUpwindElement->GetGeometry()[2].AddDof(VELOCITY_POTENTIAL);
-    
+
     Element::DofsVectorType UpwindElementalDofList;
-    pUpwindElement->GetDofList(UpwindElementalDofList, model_part.GetProcessInfo());
-    
+    pUpwindElement->GetDofList(UpwindElementalDofList, r_current_process_info);
+
     UpwindElementalDofList[2]->SetEquationId(67);
 
     // make and check equation ids
     Element::EquationIdVectorType EquationIdVector;
-    pCurrentElement->EquationIdVector(EquationIdVector, model_part.GetProcessInfo());
+    pCurrentElement->EquationIdVector(EquationIdVector, r_current_process_info);
 
     std::vector<double> reference{23.0, 74.0, 55.0, 67.0};
     KRATOS_CHECK_VECTOR_NEAR(EquationIdVector, reference, 1e-15);
@@ -590,7 +600,8 @@ KRATOS_TEST_CASE_IN_SUITE(WakeTransonicPerturbationPotentialFlowElementRHS, Comp
     // Compute RHS and LHS
     Vector RHS = ZeroVector(6);
 
-    pElement->CalculateRightHandSide(RHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateRightHandSide(RHS, r_current_process_info);
 
     std::vector<double> reference{146.2643261263345,-0,-0,-0,-122.1426284341492,-24.12169769218525};
 
@@ -614,7 +625,8 @@ KRATOS_TEST_CASE_IN_SUITE(WakeTransonicPerturbationPotentialFlowElementLHS, Comp
     // Compute LHS
     Matrix LHS = ZeroMatrix(6, 6);
 
-    pElement->CalculateLeftHandSide(LHS, model_part.GetProcessInfo());
+    const ProcessInfo& r_current_process_info = model_part.GetProcessInfo();
+    pElement->CalculateLeftHandSide(LHS, r_current_process_info);
 
     // Check the LHS values
     std::array<double,36> reference{0.061142784644415527,-0.1306215050744058,0.06947872042999037,0,0,0,


### PR DESCRIPTION
**Description**
Following https://github.com/KratosMultiphysics/Kratos/pull/6580 the `ProcessInfo` is made const in the cpp tests of the PotentialFlowApp. In the next PR the `Element`s and `Condition`s will be updated. 

**Changelog**
- Making Process Info const in all cpp tests
