### PR TITLE
[ShapeOpt] fix geometric response mp init

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/response_functions/packaging_response_base.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/response_functions/packaging_response_base.py
@@ -37,16 +37,16 @@ class PackagingResponseBase(ResponseFunctionInterface):
         self.response_settings = response_settings
         self.model = model
 
-        model_part_name = response_settings["model_part_name"].GetString()
+        self._model_part_name = response_settings["model_part_name"].GetString()
         input_type = response_settings["model_import_settings"]["input_type"].GetString()
         if input_type == "mdpa":
-            self.model_part = self.model.CreateModelPart(model_part_name)
+            self.model_part = self.model.CreateModelPart(self._model_part_name)
             domain_size = response_settings["domain_size"].GetInt()
             if domain_size not in [2, 3]:
                 raise Exception("PackagingResponseBase: Invalid 'domain_size': {}".format(domain_size))
             self.model_part.ProcessInfo.SetValue(KM.DOMAIN_SIZE, domain_size)
         elif input_type == "use_input_model_part":
-            self.model_part = self.model.GetModelPart(model_part_name)
+            self.model_part = None  # will be retrieved in Initialize()
         else:
             raise Exception("PackagingResponseBase: '{}' model part input type not implemented.".format(input_type))
 
@@ -79,6 +79,8 @@ class PackagingResponseBase(ResponseFunctionInterface):
             file_name = self.response_settings["model_import_settings"]["input_filename"].GetString()
             model_part_io = KM.ModelPartIO(file_name)
             model_part_io.ReadModelPart(self.model_part)
+        else:
+            self.model_part = self.model.GetModelPart(self._model_part_name)
 
     def InitializeSolutionStep(self):
         self.value = None

--- a/applications/ShapeOptimizationApplication/python_scripts/response_functions/surface_normal_shape_change.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/response_functions/surface_normal_shape_change.py
@@ -35,16 +35,16 @@ class SurfaceNormalShapeChange(ResponseFunctionInterface):
         self.response_settings = response_settings
         self.model = model
 
-        model_part_name = response_settings["model_part_name"].GetString()
+        self._model_part_name = response_settings["model_part_name"].GetString()
         input_type = response_settings["model_import_settings"]["input_type"].GetString()
         if input_type == "mdpa":
-            self.model_part = self.model.CreateModelPart(model_part_name)
+            self.model_part = self.model.CreateModelPart(self._model_part_name)
             domain_size = response_settings["domain_size"].GetInt()
             if domain_size not in [2, 3]:
                 raise Exception("SurfaceNormalShapeChange: Invalid 'domain_size': {}".format(domain_size))
             self.model_part.ProcessInfo.SetValue(KM.DOMAIN_SIZE, domain_size)
         elif input_type == "use_input_model_part":
-            self.model_part = self.model.GetModelPart(model_part_name)
+            self.model_part = None  # will be retrieved in Initialize()
         else:
             raise Exception("SurfaceNormalShapeChange: '{}' model part input type not implemented.".format(input_type))
 
@@ -61,7 +61,7 @@ class SurfaceNormalShapeChange(ResponseFunctionInterface):
     @classmethod
     def GetDefaultSettings(cls):
         this_defaults = KM.Parameters("""{
-            "response_type"         : "UNKNOWN_TYPE",
+            "response_type"         : "surface_normal_shape_change",
             "model_part_name"       : "UNKNOWN_NAME",
             "domain_size"           : 3,
             "model_import_settings" : {
@@ -77,6 +77,8 @@ class SurfaceNormalShapeChange(ResponseFunctionInterface):
             file_name = self.response_settings["model_import_settings"]["input_filename"].GetString()
             model_part_io = KM.ModelPartIO(file_name)
             model_part_io.ReadModelPart(self.model_part)
+        else:
+            self.model_part = self.model.GetModelPart(self._model_part_name)
 
     def InitializeSolutionStep(self):
         self.previous_value = self.value


### PR DESCRIPTION
**Description**
It was not possible to use a submodelpart for the geometric responses, because it was already expected to exist in the model, before the actual model part was imported. 
The retrieval of the (sub) model part for the response is now delayed and happens after the optimizer has imported all model parts including the sub model parts. 

**Changelog**
- responses can now use a submodelpart
