### PR TITLE
[PotentialFlow] Making Process Info const 2 out of 2

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.cpp
@@ -53,7 +53,7 @@ void AdjointPotentialWallCondition<TPrimalCondition>::Initialize()
 }
 
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void AdjointPotentialWallCondition<TPrimalCondition>::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     mpPrimalCondition->Data() = this->Data();
     mpPrimalCondition->Set(Flags(*this));
@@ -93,7 +93,7 @@ void AdjointPotentialWallCondition<TPrimalCondition>::GetValuesVector(Vector& rV
 
 template <class TPrimalCondition>
 void AdjointPotentialWallCondition<TPrimalCondition>::CalculateLeftHandSide(MatrixType &rLeftHandSideMatrix,
-                            ProcessInfo &rCurrentProcessInfo)
+                            const ProcessInfo& rCurrentProcessInfo)
 {
     VectorType RHS;
     this->CalculateLocalSystem(rLeftHandSideMatrix, RHS, rCurrentProcessInfo);
@@ -123,7 +123,7 @@ void AdjointPotentialWallCondition<TPrimalCondition>::CalculateSensitivityMatrix
 template <class TPrimalCondition>
 void AdjointPotentialWallCondition<TPrimalCondition>::CalculateLocalSystem(MatrixType &rLeftHandSideMatrix,
                             VectorType &rRightHandSideVector,
-                            ProcessInfo &rCurrentProcessInfo)
+                            const ProcessInfo &rCurrentProcessInfo)
 {
     if (rLeftHandSideMatrix.size1() != TNumNodes)
         rLeftHandSideMatrix.resize(TNumNodes, TNumNodes, false);
@@ -164,7 +164,7 @@ int AdjointPotentialWallCondition<TPrimalCondition>::Check(const ProcessInfo& rC
 
 template <class TPrimalCondition>
 void AdjointPotentialWallCondition<TPrimalCondition>::EquationIdVector(EquationIdVectorType& rResult,
-                                ProcessInfo& rCurrentProcessInfo)
+                                const ProcessInfo& rCurrentProcessInfo) const
 {
     if (rResult.size() != TNumNodes)
         rResult.resize(TNumNodes, false);
@@ -191,7 +191,7 @@ void AdjointPotentialWallCondition<TPrimalCondition>::EquationIdVector(EquationI
 
 template <class TPrimalCondition>
 void AdjointPotentialWallCondition<TPrimalCondition>::GetDofList(DofsVectorType& ConditionDofList,
-                        ProcessInfo& CurrentProcessInfo)
+                        const ProcessInfo& CurrentProcessInfo) const
 {
     if (ConditionDofList.size() != TNumNodes)
     ConditionDofList.resize(TNumNodes);
@@ -217,7 +217,7 @@ void AdjointPotentialWallCondition<TPrimalCondition>::GetDofList(DofsVectorType&
 }
 
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void AdjointPotentialWallCondition<TPrimalCondition>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     mpPrimalCondition -> FinalizeSolutionStep(rCurrentProcessInfo);
 }

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.cpp
@@ -47,9 +47,9 @@ Condition::Pointer AdjointPotentialWallCondition<TPrimalCondition>::Clone(IndexT
 }
 
 template <class TPrimalCondition>
-void AdjointPotentialWallCondition<TPrimalCondition>::Initialize()
+void AdjointPotentialWallCondition<TPrimalCondition>::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
-    mpPrimalCondition->Initialize();
+    mpPrimalCondition->Initialize(rCurrentProcessInfo);
 }
 
 template <class TPrimalCondition>

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.h
@@ -78,22 +78,22 @@ public:
     // Find the condition's parent element.
     void Initialize() override;
 
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 
     void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                               ProcessInfo& rCurrentProcessInfo) override;
+                               const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
     void EquationIdVector(EquationIdVectorType& rResult,
-                          ProcessInfo& rCurrentProcessInfo) override;
+                          const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& ConditionDofList, ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& ConditionDofList, const ProcessInfo& CurrentProcessInfo) const override;
 
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetValuesVector(Vector& rValues, int Step=0)  override;
 

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/adjoint_potential_wall_condition.h
@@ -76,7 +76,7 @@ public:
     Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override;
 
     // Find the condition's parent element.
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.cpp
@@ -50,7 +50,7 @@ Condition::Pointer PotentialWallCondition<TDim, TNumNodes>::Clone(IndexType NewI
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-void PotentialWallCondition<TDim, TNumNodes>::Initialize()
+void PotentialWallCondition<TDim, TNumNodes>::Initialize(const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY;
 

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.cpp
@@ -75,7 +75,7 @@ void PotentialWallCondition<TDim, TNumNodes>::Initialize()
 
 template <unsigned int TDim, unsigned int TNumNodes>
 void PotentialWallCondition<TDim, TNumNodes>::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                                                    ProcessInfo& rCurrentProcessInfo)
+                                                                    const ProcessInfo& rCurrentProcessInfo)
 {
     if (rLeftHandSideMatrix.size1() != TNumNodes)
         rLeftHandSideMatrix.resize(TNumNodes, TNumNodes, false);
@@ -84,7 +84,7 @@ void PotentialWallCondition<TDim, TNumNodes>::CalculateLeftHandSide(MatrixType& 
 
 template <unsigned int TDim, unsigned int TNumNodes>
 void PotentialWallCondition<TDim, TNumNodes>::CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                                                    ProcessInfo& rCurrentProcessInfo)
+                                                                    const ProcessInfo& rCurrentProcessInfo)
 {
     if (rRightHandSideVector.size() != TNumNodes)
         rRightHandSideVector.resize(TNumNodes, false);
@@ -107,7 +107,7 @@ void PotentialWallCondition<TDim, TNumNodes>::CalculateRightHandSide(VectorType&
 
 template <unsigned int TDim, unsigned int TNumNodes>
 void PotentialWallCondition<TDim, TNumNodes>::CalculateLocalSystem(
-    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     if (rLeftHandSideMatrix.size1() != TNumNodes)
         rLeftHandSideMatrix.resize(TNumNodes, TNumNodes, false);
@@ -154,7 +154,7 @@ int PotentialWallCondition<TDim, TNumNodes>::Check(const ProcessInfo& rCurrentPr
 
 template <unsigned int TDim, unsigned int TNumNodes>
 void PotentialWallCondition<TDim, TNumNodes>::EquationIdVector(EquationIdVectorType& rResult,
-                                                               ProcessInfo& rCurrentProcessInfo)
+                                                               const ProcessInfo& rCurrentProcessInfo) const
 {
     if (rResult.size() != TNumNodes)
         rResult.resize(TNumNodes, false);
@@ -165,7 +165,7 @@ void PotentialWallCondition<TDim, TNumNodes>::EquationIdVector(EquationIdVectorT
 
 template <unsigned int TDim, unsigned int TNumNodes>
 void PotentialWallCondition<TDim, TNumNodes>::GetDofList(DofsVectorType& ConditionDofList,
-                                                         ProcessInfo& CurrentProcessInfo)
+                                                         const ProcessInfo& CurrentProcessInfo) const
 {
     if (ConditionDofList.size() != TNumNodes)
         ConditionDofList.resize(TNumNodes);
@@ -175,7 +175,7 @@ void PotentialWallCondition<TDim, TNumNodes>::GetDofList(DofsVectorType& Conditi
 }
 
 template <unsigned int TDim, unsigned int TNumNodes>
-void PotentialWallCondition<TDim, TNumNodes>::FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
+void PotentialWallCondition<TDim, TNumNodes>::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
     // Get parent element
     GlobalPointer<Element> pElem = pGetElement();

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
@@ -185,7 +185,7 @@ public:
     Condition::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override;
 
     // Find the condition's parent element.
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
                                const ProcessInfo& rCurrentProcessInfo) override;

--- a/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_conditions/potential_wall_condition.h
@@ -188,21 +188,21 @@ public:
     void Initialize() override;
 
     void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                               ProcessInfo& rCurrentProcessInfo) override;
+                               const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                               ProcessInfo& rCurrentProcessInfo) override;
+                               const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
     void EquationIdVector(EquationIdVectorType& rResult,
-                          ProcessInfo& rCurrentProcessInfo) override;
+                          const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& ConditionDofList, ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& ConditionDofList, const ProcessInfo& CurrentProcessInfo) const override;
 
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
     ///@}
     ///@name Access

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_analytical_incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_analytical_incompressible_potential_flow_element.cpp
@@ -48,10 +48,9 @@ namespace Kratos
     {
         KRATOS_TRY;
 
-        ProcessInfo process_info = rCurrentProcessInfo;
         Vector RHS;
         auto pPrimalElement = this->pGetPrimalElement();
-        pPrimalElement->CalculateRightHandSide(RHS, process_info);
+        pPrimalElement->CalculateRightHandSide(RHS, rCurrentProcessInfo);
 
         if (rOutput.size1() != NumNodes)
             rOutput.resize(Dim*NumNodes, RHS.size(), false);

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.cpp
@@ -33,7 +33,7 @@ namespace Kratos
     }
 
     template <class TPrimalElement>
-    void AdjointBasePotentialFlowElement<TPrimalElement>::InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+    void AdjointBasePotentialFlowElement<TPrimalElement>::InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
     {
         auto adjoint_geometry_data = this->GetGeometry().GetData();
         mpPrimalElement->GetGeometry().SetData(adjoint_geometry_data);
@@ -42,7 +42,7 @@ namespace Kratos
     }
 
     template <class TPrimalElement>
-    void AdjointBasePotentialFlowElement<TPrimalElement>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+    void AdjointBasePotentialFlowElement<TPrimalElement>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
     {
 
     }
@@ -50,7 +50,7 @@ namespace Kratos
     template <class TPrimalElement>
     void AdjointBasePotentialFlowElement<TPrimalElement>::CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo)
+                                      const ProcessInfo& rCurrentProcessInfo)
     {
         mpPrimalElement->CalculateLocalSystem(rLeftHandSideMatrix,
                                               rRightHandSideVector,
@@ -59,7 +59,7 @@ namespace Kratos
 
     template <class TPrimalElement>
     void AdjointBasePotentialFlowElement<TPrimalElement>::CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                       ProcessInfo& rCurrentProcessInfo)
+                                       const ProcessInfo& rCurrentProcessInfo)
     {
         MatrixType tmp;
         mpPrimalElement->CalculateLeftHandSide(tmp, rCurrentProcessInfo);
@@ -68,7 +68,7 @@ namespace Kratos
 
     template <class TPrimalElement>
     void AdjointBasePotentialFlowElement<TPrimalElement>::CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo)
+                                        const ProcessInfo& rCurrentProcessInfo)
     {
         mpPrimalElement->CalculateRightHandSide(rRightHandSideVector,
                                                 rCurrentProcessInfo);
@@ -151,7 +151,7 @@ namespace Kratos
     }
 
     template <class TPrimalElement>
-    void AdjointBasePotentialFlowElement<TPrimalElement>::EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+    void AdjointBasePotentialFlowElement<TPrimalElement>::EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
     {
         const AdjointBasePotentialFlowElement& r_this = *this;
         const int wake = r_this.GetValue(WAKE);
@@ -206,7 +206,7 @@ namespace Kratos
     }
 
     template <class TPrimalElement>
-    void AdjointBasePotentialFlowElement<TPrimalElement>::GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& CurrentProcessInfo)
+    void AdjointBasePotentialFlowElement<TPrimalElement>::GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& CurrentProcessInfo) const
     {
         const AdjointBasePotentialFlowElement& r_this = *this;
         const int wake = r_this.GetValue(WAKE);

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.cpp
@@ -27,9 +27,9 @@ namespace Kratos
     }
 
     template <class TPrimalElement>
-    void AdjointBasePotentialFlowElement<TPrimalElement>::Initialize()
+    void AdjointBasePotentialFlowElement<TPrimalElement>::Initialize(const ProcessInfo& rCurrentProcessInfo)
     {
-        mpPrimalElement->Initialize();
+        mpPrimalElement->Initialize(rCurrentProcessInfo);
     }
 
     template <class TPrimalElement>

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.h
@@ -92,7 +92,7 @@ public:
 
     IntegrationMethod GetIntegrationMethod() const override;
 
-    void Initialize() override;
+    void Initialize(const ProcessInfo& rCurrentProcessInfo) override;
 
     void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_base_potential_flow_element.h
@@ -94,19 +94,19 @@ public:
 
     void Initialize() override;
 
-    void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
-                                      ProcessInfo& rCurrentProcessInfo) override;
+                                      const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                       ProcessInfo& rCurrentProcessInfo) override;
+                                       const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                        ProcessInfo& rCurrentProcessInfo) override;
+                                        const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
             std::vector<double>& rValues,
@@ -126,9 +126,9 @@ public:
                                             Matrix& rOutput,
                                             const ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& CurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& CurrentProcessInfo) const override;
 
     int Check(const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_finite_difference_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/adjoint_finite_difference_potential_flow_element.cpp
@@ -52,7 +52,6 @@ namespace Kratos
     {
         KRATOS_TRY;
         const double delta = this->GetPerturbationSize();
-        ProcessInfo process_info = rCurrentProcessInfo;
 
         Vector RHS;
         Vector RHS_perturbed;
@@ -60,7 +59,7 @@ namespace Kratos
         auto pPrimalElement = this->pGetPrimalElement();
         const auto& r_geometry = this->GetGeometry();
 
-        pPrimalElement->CalculateRightHandSide(RHS, process_info);
+        pPrimalElement->CalculateRightHandSide(RHS, rCurrentProcessInfo);
 
         if (rOutput.size1() != NumNodes)
             rOutput.resize(Dim*NumNodes, RHS.size(), false);
@@ -72,7 +71,7 @@ namespace Kratos
                     pPrimalElement->GetGeometry()[i_node].Coordinates()[i_dim] += delta;
 
                     // compute LHS after perturbation
-                    pPrimalElement->CalculateRightHandSide(RHS_perturbed, process_info);
+                    pPrimalElement->CalculateRightHandSide(RHS_perturbed, rCurrentProcessInfo);
 
                     //compute derivative of RHS w.r.t. design variable with finite differences
                     for(unsigned int i = 0; i < RHS.size(); ++i)
@@ -116,12 +115,11 @@ namespace Kratos
         if (is_embedded && this->Is(ACTIVE)){
 
             const double delta = this->GetPerturbationSize();
-            ProcessInfo process_info = rCurrentProcessInfo;
             const auto& r_geometry = this->GetGeometry();
             Vector RHS;
             Vector RHS_perturbed;
 
-            pPrimalElement->CalculateRightHandSide(RHS, process_info);
+            pPrimalElement->CalculateRightHandSide(RHS, rCurrentProcessInfo);
 
             for(unsigned int i_node = 0; i_node<NumNodes; i_node++){
                 // Apply F.D in all cut nodes that are not trailing edge nodes.
@@ -129,7 +127,7 @@ namespace Kratos
                     // Perturbate distance
                     pPrimalElement->GetGeometry()[i_node].GetSolutionStepValue(GEOMETRY_DISTANCE) = distances[i_node]+delta;
                     // Compute perturbated RHS
-                    pPrimalElement->CalculateRightHandSide(RHS_perturbed, process_info);
+                    pPrimalElement->CalculateRightHandSide(RHS_perturbed, rCurrentProcessInfo);
                     // Recover distance value
                     pPrimalElement->GetGeometry()[i_node].GetSolutionStepValue(GEOMETRY_DISTANCE) = distances[i_node];
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.cpp
@@ -53,7 +53,7 @@ Element::Pointer CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::Cl
 
 template <int Dim, int NumNodes>
 void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
-    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     CalculateRightHandSide(rRightHandSideVector,rCurrentProcessInfo);
     CalculateLeftHandSide(rLeftHandSideMatrix,rCurrentProcessInfo);
@@ -61,7 +61,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocal
 
 template <int Dim, int NumNodes>
 void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRightHandSide(
-    VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     const CompressiblePerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -74,7 +74,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRight
 
 template <int Dim, int NumNodes>
 void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftHandSide(
-    MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     const CompressiblePerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -87,7 +87,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftH
 
 template <int Dim, int NumNodes>
 void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::EquationIdVector(
-    EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+    EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 {
     const CompressiblePerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -115,7 +115,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::EquationIdVect
 
 template <int Dim, int NumNodes>
 void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofList(DofsVectorType& rElementalDofList,
-                                                                 ProcessInfo& CurrentProcessInfo)
+                                                                 const ProcessInfo& CurrentProcessInfo) const
 {
     const CompressiblePerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -142,7 +142,7 @@ void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofList(Dof
 }
 
 template <int Dim, int NumNodes>
-void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void CompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     bool active = true;
     if ((this)->IsDefined(ACTIVE))

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_perturbation_potential_flow_element.h
@@ -152,19 +152,19 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                               ProcessInfo& rCurrentProcessInfo) override;
+                               const ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     ///@}
     ///@name Access

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.cpp
@@ -53,7 +53,7 @@ Element::Pointer CompressiblePotentialFlowElement<Dim, NumNodes>::Clone(
 
 template <int Dim, int NumNodes>
 void CompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
-    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     const CompressiblePotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -68,7 +68,7 @@ void CompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
 
 template <int Dim, int NumNodes>
 void CompressiblePotentialFlowElement<Dim, NumNodes>::CalculateRightHandSide(
-    VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     // TODO: improve speed
     Matrix tmp;
@@ -77,7 +77,7 @@ void CompressiblePotentialFlowElement<Dim, NumNodes>::CalculateRightHandSide(
 
 template <int Dim, int NumNodes>
 void CompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLeftHandSide(
-    MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     // TODO: improve speed
     VectorType tmp;
@@ -86,7 +86,7 @@ void CompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLeftHandSide(
 
 template <int Dim, int NumNodes>
 void CompressiblePotentialFlowElement<Dim, NumNodes>::EquationIdVector(
-    EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+    EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 {
     const CompressiblePotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -114,7 +114,7 @@ void CompressiblePotentialFlowElement<Dim, NumNodes>::EquationIdVector(
 
 template <int Dim, int NumNodes>
 void CompressiblePotentialFlowElement<Dim, NumNodes>::GetDofList(DofsVectorType& rElementalDofList,
-                                                                 ProcessInfo& CurrentProcessInfo)
+                                                                 const ProcessInfo& CurrentProcessInfo) const
 {
     const CompressiblePotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -141,7 +141,7 @@ void CompressiblePotentialFlowElement<Dim, NumNodes>::GetDofList(DofsVectorType&
 }
 
 template <int Dim, int NumNodes>
-void CompressiblePotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void CompressiblePotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     bool active = true;
     if ((this)->IsDefined(ACTIVE))

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/compressible_potential_flow_element.h
@@ -152,19 +152,19 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                               ProcessInfo& rCurrentProcessInfo) override;
+                               const ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     ///@}
     ///@name Access

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.cpp
@@ -50,7 +50,7 @@ Element::Pointer EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::Clone(
 
 template <int Dim, int NumNodes>
 void EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
-    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     const EmbeddedCompressiblePotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -71,7 +71,7 @@ void EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSyst
 
 template <int Dim, int NumNodes>
 void EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::CalculateEmbeddedLocalSystem(
-    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     if (rLeftHandSideMatrix.size1() != NumNodes || rLeftHandSideMatrix.size2() != NumNodes)
         rLeftHandSideMatrix.resize(NumNodes, NumNodes, false);

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.h
@@ -113,7 +113,7 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
     int Check(const ProcessInfo& rCurrentProcessInfo) override;
     /// Turn back information as a string.
@@ -134,7 +134,7 @@ private:
 
     void CalculateEmbeddedLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo);
+                              const ProcessInfo& rCurrentProcessInfo);
     friend class Serializer;
 
     void save(Serializer& rSerializer) const override;

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
@@ -51,7 +51,7 @@ Element::Pointer EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Clon
 
 template <int Dim, int NumNodes>
 void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
-    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     const EmbeddedIncompressiblePotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -77,7 +77,7 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSy
 
 template <int Dim, int NumNodes>
 void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateEmbeddedLocalSystem(
-    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     if (rLeftHandSideMatrix.size1() != NumNodes || rLeftHandSideMatrix.size2() != NumNodes)
         rLeftHandSideMatrix.resize(NumNodes, NumNodes, false);
@@ -115,7 +115,7 @@ void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateEmbedde
 
 template <int Dim, int NumNodes>
 void EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::AddPotentialGradientStabilizationTerm(
-    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     array_1d<double, NumNodes> potential;
     potential = PotentialFlowUtilities::GetPotentialOnNormalElement<Dim, NumNodes>(*this);

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.h
@@ -113,7 +113,7 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
     int Check(const ProcessInfo& rCurrentProcessInfo) override;
     /// Turn back information as a string.
@@ -134,11 +134,11 @@ private:
 
     void CalculateEmbeddedLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo);
+                              const ProcessInfo& rCurrentProcessInfo);
 
     void AddPotentialGradientStabilizationTerm(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo);
+                              const ProcessInfo& rCurrentProcessInfo);
     friend class Serializer;
 
     void save(Serializer& rSerializer) const override;

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.cpp
@@ -53,7 +53,7 @@ Element::Pointer IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::
 
 template <int Dim, int NumNodes>
 void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
-    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     CalculateRightHandSide(rRightHandSideVector,rCurrentProcessInfo);
     CalculateLeftHandSide(rLeftHandSideMatrix,rCurrentProcessInfo);
@@ -61,7 +61,7 @@ void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLoc
 
 template <int Dim, int NumNodes>
 void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRightHandSide(
-    VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     const IncompressiblePerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -74,7 +74,7 @@ void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateRig
 
 template <int Dim, int NumNodes>
 void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLeftHandSide(
-    MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     const IncompressiblePerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -87,7 +87,7 @@ void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::CalculateLef
 
 template <int Dim, int NumNodes>
 void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::EquationIdVector(
-    EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+    EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 {
     const IncompressiblePerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -115,7 +115,7 @@ void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::EquationIdVe
 
 template <int Dim, int NumNodes>
 void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofList(DofsVectorType& rElementalDofList,
-                                                                   ProcessInfo& CurrentProcessInfo)
+                                                                   const ProcessInfo& CurrentProcessInfo) const
 {
     const IncompressiblePerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -142,7 +142,7 @@ void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::GetDofList(D
 }
 
 template <int Dim, int NumNodes>
-void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void IncompressiblePerturbationPotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     bool active = true;
     if ((this)->IsDefined(ACTIVE))

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_perturbation_potential_flow_element.h
@@ -123,19 +123,19 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     ///@}
     ///@name Access

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.cpp
@@ -53,7 +53,7 @@ Element::Pointer IncompressiblePotentialFlowElement<Dim, NumNodes>::Clone(
 
 template <int Dim, int NumNodes>
 void IncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
-    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     const IncompressiblePotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -66,7 +66,7 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLocalSystem(
 
 template <int Dim, int NumNodes>
 void IncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateRightHandSide(
-    VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
+    VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
 {
     // TODO: improve speed
     Matrix tmp;
@@ -75,7 +75,7 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateRightHandSide(
 
 template <int Dim, int NumNodes>
 void IncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLeftHandSide(
-    MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo)
+    MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     // TODO: improve speed
     VectorType tmp;
@@ -84,7 +84,7 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::CalculateLeftHandSide(
 
 template <int Dim, int NumNodes>
 void IncompressiblePotentialFlowElement<Dim, NumNodes>::EquationIdVector(
-    EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo)
+    EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const
 {
     const IncompressiblePotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -112,7 +112,7 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::EquationIdVector(
 
 template <int Dim, int NumNodes>
 void IncompressiblePotentialFlowElement<Dim, NumNodes>::GetDofList(DofsVectorType& rElementalDofList,
-                                                                   ProcessInfo& CurrentProcessInfo)
+                                                                   const ProcessInfo& rCurrentProcessInfo) const
 {
     const IncompressiblePotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -139,7 +139,7 @@ void IncompressiblePotentialFlowElement<Dim, NumNodes>::GetDofList(DofsVectorTyp
 }
 
 template <int Dim, int NumNodes>
-void IncompressiblePotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void IncompressiblePotentialFlowElement<Dim, NumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     bool active = true;
     if ((this)->IsDefined(ACTIVE))

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/incompressible_potential_flow_element.h
@@ -123,19 +123,19 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                                ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& CurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& CurrentProcessInfo) const override;
 
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     ///@}
     ///@name Access

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.cpp
@@ -67,7 +67,7 @@ template <int TDim, int TNumNodes>
 void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateLocalSystem(
     MatrixType& rLeftHandSideMatrix,
     VectorType& rRightHandSideVector,
-    ProcessInfo& rCurrentProcessInfo)
+    const ProcessInfo& rCurrentProcessInfo)
 {
     CalculateRightHandSide(rRightHandSideVector,rCurrentProcessInfo);
     CalculateLeftHandSide(rLeftHandSideMatrix,rCurrentProcessInfo);
@@ -76,7 +76,7 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateLocalS
 template <int TDim, int TNumNodes>
 void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateRightHandSide(
     VectorType& rRightHandSideVector,
-    ProcessInfo& rCurrentProcessInfo)
+    const ProcessInfo& rCurrentProcessInfo)
 {
     const TransonicPerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -92,7 +92,7 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateRightH
 template <int TDim, int TNumNodes>
 void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateLeftHandSide(
     MatrixType& rLeftHandSideMatrix,
-    ProcessInfo& rCurrentProcessInfo)
+    const ProcessInfo& rCurrentProcessInfo)
 {
     const TransonicPerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -125,7 +125,7 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::CalculateLeftHa
 template <int TDim, int TNumNodes>
 void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::EquationIdVector(
     EquationIdVectorType& rResult,
-    ProcessInfo& CurrentProcessInfo)
+    const ProcessInfo& CurrentProcessInfo) const
 {
     const TransonicPerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -157,7 +157,7 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::EquationIdVecto
 
 template <int TDim, int TNumNodes>
 void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::GetDofList(DofsVectorType& rElementalDofList,
-                                                                 ProcessInfo& CurrentProcessInfo)
+                                                                 const ProcessInfo& CurrentProcessInfo) const
 {
     const TransonicPerturbationPotentialFlowElement& r_this = *this;
     const int wake = r_this.GetValue(WAKE);
@@ -193,7 +193,7 @@ void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::GetDofList(Dofs
 }
 
 template <int TDim, int TNumNodes>
-void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
+void TransonicPerturbationPotentialFlowElement<TDim, TNumNodes>::FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
 {
     const bool active = Is(ACTIVE);
 
@@ -1086,13 +1086,12 @@ array_1d<size_t, TNumNodes> TransonicPerturbationPotentialFlowElement<TDim, TNum
     const ProcessInfo& rCurrentProcessInfo)
 {
     array_1d<size_t, TNumNodes> upwind_node_key;
-    auto current_process_info = rCurrentProcessInfo;
     EquationIdVectorType upwind_element_ids, current_element_ids;
 
     upwind_node_key.clear();
 
-    pGetUpwindElement()->EquationIdVector(upwind_element_ids, current_process_info);
-    this->EquationIdVector(current_element_ids, current_process_info);
+    pGetUpwindElement()->EquationIdVector(upwind_element_ids, rCurrentProcessInfo);
+    this->EquationIdVector(current_element_ids, rCurrentProcessInfo);
 
     for (int i = 0; i < TNumNodes; i++) {
         auto current_id = std::find(current_element_ids.begin(), current_element_ids.end(),

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/transonic_perturbation_potential_flow_element.h
@@ -155,21 +155,21 @@ public:
 
     void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                               VectorType& rRightHandSideVector,
-                              ProcessInfo& rCurrentProcessInfo) override;
+                              const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateRightHandSide(VectorType& rRightHandSideVector,
-                                ProcessInfo& rCurrentProcessInfo) override;
+                                const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
-                               ProcessInfo& rCurrentProcessInfo) override;
+                               const ProcessInfo& rCurrentProcessInfo) override;
 
     void EquationIdVector(EquationIdVectorType& rResult,
-                          ProcessInfo& CurrentProcessInfo) override;
+                          const ProcessInfo& CurrentProcessInfo) const override;
 
     void GetDofList(DofsVectorType& rElementalDofList,
-                    ProcessInfo& rCurrentProcessInfo) override;
+                    const ProcessInfo& rCurrentProcessInfo) const override;
 
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
     ///@}
     ///@name Access


### PR DESCRIPTION
**Description**
Following https://github.com/KratosMultiphysics/Kratos/pull/7366, making `ProcessInfo` const in all `Element`s and `Condition`s of the Potential Flow App. 
