### PR TITLE
[FastPR][Core] Explicit time dependent BCs bugfix

### DIFF
--- a/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta_4.h
+++ b/kratos/solving_strategies/strategies/explicit_solving_strategy_runge_kutta_4.h
@@ -236,7 +236,7 @@ protected:
                 double& r_u_0 = it_dof->GetSolutionStepValue(0);
                 const double& r_u_1 = it_dof->GetSolutionStepValue(1);
                 if (it_dof->IsFixed()) {
-                    u_n(i_dof) = r_u_1;
+                    u_n(i_dof) = r_u_0;
                 }
                 r_u_0 = r_u_1;
             }


### PR DESCRIPTION
**Description**
Explicit time dependent BCs hotfix.

Please mark the PR with appropriate tags: 
- FastPR
- BugFix
- KratosCore

**Changelog**
Get the fixed DOFs values from the buffer position 0 (before these were took from 1 so the increment to be applied in the BC imposition was always 0).
