### PR TITLE
[Core] Timers - use labels with full path

### DIFF
--- a/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
+++ b/kratos/solving_strategies/builder_and_solvers/residualbased_block_builder_and_solver.h
@@ -1398,6 +1398,7 @@ protected:
     virtual void ConstructMasterSlaveConstraintsStructure(ModelPart& rModelPart)
     {
         if (rModelPart.MasterSlaveConstraints().size() > 0) {
+            Timer::Start("ConstraintsRelationMatrixStructure");
             const ProcessInfo& r_current_process_info = rModelPart.GetProcessInfo();
 
             // Vector containing the localization in the system of the different terms

--- a/kratos/utilities/timer.cpp
+++ b/kratos/utilities/timer.cpp
@@ -109,8 +109,10 @@ Timer::Timer(){}
 void Timer::Start(std::string const& rIntervalName)
 {
     const auto it_internal_name = msInternalNameDatabase.find(rIntervalName);
+    GetLabelsStackInstance().push_back(rIntervalName);
     if(it_internal_name == msInternalNameDatabase.end()) {
-        const std::string internal_name = GetInternalName(rIntervalName);
+        auto full_name = CreateFullLabel();
+        const std::string internal_name = GetInternalName(full_name);
         msInternalNameDatabase.insert(std::pair<std::string, std::string>(rIntervalName, internal_name));
         msTimeTable[internal_name].SetStartTime(GetTime());
         ++msCounter;
@@ -122,6 +124,7 @@ void Timer::Start(std::string const& rIntervalName)
 
 void Timer::Stop(std::string const& rIntervalName)
 {
+    GetLabelsStackInstance().pop_back();
     const double stop_time = GetTime();
     const std::string& r_name = msInternalNameDatabase[rIntervalName];
     ContainerType::iterator it_time_data = msTimeTable.find(r_name);

--- a/kratos/utilities/timer.h
+++ b/kratos/utilities/timer.h
@@ -352,6 +352,21 @@ private:
      */
     static std::string GetInternalName(const std::string& rName);
 
+    static std::vector<std::string>& GetLabelsStackInstance()
+    {
+      static std::vector<std::string> instance;
+      return instance;
+    }
+
+    static std::string CreateFullLabel(){
+        auto& labels_stack = GetLabelsStackInstance();
+        std::string result;
+        for(auto& label : labels_stack){
+        result += "/" + label;
+        }
+        return result;
+    }
+
     ///@}
     ///@name Private Operations
     ///@{

--- a/kratos/utilities/timer.h
+++ b/kratos/utilities/timer.h
@@ -359,10 +359,10 @@ private:
     }
 
     static std::string CreateFullLabel(){
-        auto& labels_stack = GetLabelsStackInstance();
+        const auto& r_labels_stack = GetLabelsStackInstance();
         std::string result;
-        for(auto& label : labels_stack){
-        result += "/" + label;
+        for(const auto& r_label : r_labels_stack){
+        result += "/" + r_label;
         }
         return result;
     }


### PR DESCRIPTION
**Description**
This is an alternative to what is implemented in https://github.com/KratosMultiphysics/Kratos/pull/6824. The point is that labels contain the full path, so you can see easily the nested structure.

e.g with new format.:
![image](https://user-images.githubusercontent.com/25667299/90779660-627ab180-e2fe-11ea-910e-82f6abdb3de6.png)


**Changelog**
Use labels with full nested path in timers.
