### PR TITLE
[MeshingApplication] Proper skip of MMG tests if StructuralApp is not compiled

### DIFF
--- a/applications/MeshingApplication/tests/meshing_application_test_factory.py
+++ b/applications/MeshingApplication/tests/meshing_application_test_factory.py
@@ -3,10 +3,8 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 import KratosMultiphysics
 try:
   from KratosMultiphysics.StructuralMechanicsApplication.adaptative_remeshing_structural_mechanics_analysis import AdaptativeRemeshingStructuralMechanicsAnalysis
-  missing_external_structural_dependencies = False
 except ImportError as e:
-    missing_external_structural_dependencies = True
-
+    pass
 import os
 
 # Import KratosUnittest
@@ -14,6 +12,7 @@ import KratosMultiphysics.KratosUnittest as KratosUnittest
 
 # TODO: Add fluid counter part
 class MeshingStructuralMechanicsTestFactory(KratosUnittest.TestCase):
+    @KratosUnittest.skipIfApplicationsNotAvailable("StructuralMechanicsApplication")
     def setUp(self):
         # Within this location context:
         with KratosUnittest.WorkFolderScope(".", __file__):
@@ -31,12 +30,9 @@ class MeshingStructuralMechanicsTestFactory(KratosUnittest.TestCase):
                 KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.INFO)
 
             # Creating the test
-            if not missing_external_structural_dependencies:
-                model = KratosMultiphysics.Model()
-                self.test = AdaptativeRemeshingStructuralMechanicsAnalysis(model, ProjectParameters)
-                self.test.Initialize()
-            else:
-                pass
+            model = KratosMultiphysics.Model()
+            self.test = AdaptativeRemeshingStructuralMechanicsAnalysis(model, ProjectParameters)
+            self.test.Initialize()
 
     def modify_parameters(self, project_parameters):
         """This function can be used in derived classes to modify existing parameters


### PR DESCRIPTION
**Description**
Currently if the StructuralApp is not compiled in the system, the mmg tests using the StructuralApp fail instead of being skipped. Added the skip() functionality from the KratosUnitTest to avoid the errors and skip the tests. 

**Changelog**
- Added skipTestIfAppNotAvailable in strucutral-mmg tests.

**Additional info**
NIL
