### PR TITLE
[Script][Core] Proper number of processors detected on MacOSX

### DIFF
--- a/scripts/standard_configure_mac.sh
+++ b/scripts/standard_configure_mac.sh
@@ -49,4 +49,4 @@ rm -rf "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}/CMakeFiles"
  -DUSE_EIGEN_MKL=OFF
 
 # Buid
-/Applications/CMake.app/Contents/bin/cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j$(nproc)
+/Applications/CMake.app/Contents/bin/cmake --build "${KRATOS_BUILD}/${KRATOS_BUILD_TYPE}" --target install -- -j$(sysctl -n hw.physicalcpu)


### PR DESCRIPTION
**Description**
proc does not exist in Mac, using proper one

**Changelog**
- Replace proc by proper Mac alternative
