### PR TITLE
[MeshingApplication] Saving new mesh in a .mdpa file after the simulation run in mmg_process

### DIFF
--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -437,16 +437,8 @@ class MmgProcess(KratosMultiphysics.Process):
             for sub_model_part_name in sub_model_part_names_to_remove:
                 if self.main_model_part.HasSubModelPart(sub_model_part_name):
                     self.main_model_part.RemoveSubModelPart(sub_model_part_name)
-            if self.output_final_mesh:
-                KratosMultiphysics.ModelPartIO(output_mesh_file_name, KratosMultiphysics.IO.WRITE | KratosMultiphysics.IO.MESH_ONLY).WriteModelPart(self.main_model_part)
-
-    def _compute_average_quantity(self):
-        """ This method is executed in order to compute the average of a generic quantity, between consecutives time steps
-        
-        Keyword arguments:
-        self -- It signifies an instance of a class.
-        """
-        pass
+        if self.output_final_mesh:
+            KratosMultiphysics.ModelPartIO(output_mesh_file_name, KratosMultiphysics.IO.WRITE | KratosMultiphysics.IO.MESH_ONLY).WriteModelPart(self.main_model_part)
 
     def ExecuteFinalizeSolutionStep(self):
         """ This method is executed in order to finalize the current step
@@ -454,10 +446,6 @@ class MmgProcess(KratosMultiphysics.Process):
         Keyword arguments:
         self -- It signifies an instance of a class.
         """
-        self.average_remeshing = self.settings["remesh_post_process"].GetBool()
-        if self.average_remeshing:
-            self._compute_average_quantity()
-
         if self.strategy == "superconvergent_patch_recovery" or self.strategy == "SPR":
             current_time = self.main_model_part.ProcessInfo[KratosMultiphysics.TIME]
             if self.interval.IsInInterval(current_time):

--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -432,10 +432,10 @@ class MmgProcess(KratosMultiphysics.Process):
         output_mesh_file_name = self.settings["output_mesh_file_name"].GetString()
         sub_model_part_names_to_remove = self.settings["sub_model_part_names_to_remove"].GetStringArray()
         if self.remesh_at_finalize:
-            self._ExecuteRefinement()
             for sub_model_part_name in sub_model_part_names_to_remove:
                 if self.main_model_part.HasSubModelPart(sub_model_part_name):
                     self.main_model_part.RemoveSubModelPart(sub_model_part_name)
+            self._ExecuteRefinement()
         if self.output_final_mesh:
             KratosMultiphysics.ModelPartIO(output_mesh_file_name, KratosMultiphysics.IO.WRITE | KratosMultiphysics.IO.MESH_ONLY).WriteModelPart(self.main_model_part)
 

--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -155,8 +155,11 @@ class MmgProcess(KratosMultiphysics.Process):
             "save_external_files"              : false,
             "save_colors_files"                : false,
             "save_mdpa_file"                   : false,
+            "remesh_at_finalize"               : true,
             "remesh_post_process"              : true,
-            "output_file_name"                 : "final_refined_mesh",
+            "output_final_mesh"                : true,
+            "sub_model_part_names_to_remove"   : [],
+            "output_mesh_file_name"            : "final_refined_mesh",
             "max_number_of_searchs"            : 1000,
             "preserve_flags"                   : true,
             "interpolate_non_historical"       : true,
@@ -425,13 +428,17 @@ class MmgProcess(KratosMultiphysics.Process):
         Keyword arguments:
         self -- It signifies an instance of a class.
         """
-        self.average_remeshing = self.settings["remesh_post_process"].GetBool()
-        output_file_path = self.settings["output_file_name"].GetString()
-        if self.average_remeshing:
+        self.remesh_at_finalize = self.settings["remesh_at_finalize"].GetBool()
+        self.output_final_mesh = self.settings["output_final_mesh"].GetBool()
+        output_mesh_file_name = self.settings["output_mesh_file_name"].GetString()
+        sub_model_part_names_to_remove = self.settings["sub_model_part_names_to_remove"].GetStringArray()
+        if self.remesh_at_finalize:
             self._ExecuteRefinement()
-            if self.main_model_part.HasSubModelPart("fluid_computational_model_part"):
-                self.main_model_part.RemoveSubModelPart("fluid_computational_model_part")
-            KratosMultiphysics.ModelPartIO(output_file_path, KratosMultiphysics.IO.WRITE | KratosMultiphysics.IO.MESH_ONLY).WriteModelPart(self.main_model_part)
+            for sub_model_part_name in sub_model_part_names_to_remove:
+                if self.main_model_part.HasSubModelPart(sub_model_part_name):
+                    self.main_model_part.RemoveSubModelPart(sub_model_part_name)
+            if self.output_final_mesh:
+                KratosMultiphysics.ModelPartIO(output_mesh_file_name, KratosMultiphysics.IO.WRITE | KratosMultiphysics.IO.MESH_ONLY).WriteModelPart(self.main_model_part)
 
     def _compute_average_quantity(self):
         """ This method is executed in order to compute the average of a generic quantity, between consecutives time steps

--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -155,8 +155,8 @@ class MmgProcess(KratosMultiphysics.Process):
             "save_external_files"              : false,
             "save_colors_files"                : false,
             "save_mdpa_file"                   : false,
-            "remesh_at_finalize"               : true,
-            "output_final_mesh"                : true,
+            "remesh_at_finalize"               : false,
+            "output_final_mesh"                : false,
             "sub_model_part_names_to_remove"   : [],
             "output_mesh_file_name"            : "final_refined_mesh",
             "max_number_of_searchs"            : 1000,
@@ -427,16 +427,16 @@ class MmgProcess(KratosMultiphysics.Process):
         Keyword arguments:
         self -- It signifies an instance of a class.
         """
-        self.remesh_at_finalize = self.settings["remesh_at_finalize"].GetBool()
-        self.output_final_mesh = self.settings["output_final_mesh"].GetBool()
+        remesh_at_finalize = self.settings["remesh_at_finalize"].GetBool()
+        output_final_mesh = self.settings["output_final_mesh"].GetBool()
         output_mesh_file_name = self.settings["output_mesh_file_name"].GetString()
         sub_model_part_names_to_remove = self.settings["sub_model_part_names_to_remove"].GetStringArray()
-        if self.remesh_at_finalize:
+        if remesh_at_finalize:
             for sub_model_part_name in sub_model_part_names_to_remove:
                 if self.main_model_part.HasSubModelPart(sub_model_part_name):
                     self.main_model_part.RemoveSubModelPart(sub_model_part_name)
             self._ExecuteRefinement()
-        if self.output_final_mesh:
+        if output_final_mesh:
             KratosMultiphysics.ModelPartIO(output_mesh_file_name, KratosMultiphysics.IO.WRITE | KratosMultiphysics.IO.MESH_ONLY).WriteModelPart(self.main_model_part)
 
     def ExecuteFinalizeSolutionStep(self):

--- a/applications/MeshingApplication/python_scripts/mmg_process.py
+++ b/applications/MeshingApplication/python_scripts/mmg_process.py
@@ -156,7 +156,6 @@ class MmgProcess(KratosMultiphysics.Process):
             "save_colors_files"                : false,
             "save_mdpa_file"                   : false,
             "remesh_at_finalize"               : true,
-            "remesh_post_process"              : true,
             "output_final_mesh"                : true,
             "sub_model_part_names_to_remove"   : [],
             "output_mesh_file_name"            : "final_refined_mesh",


### PR DESCRIPTION
Implementation of the remeshing after the simulation.

**Description**
The implementation regards the generation of a new mesh after the whole simulation run. Then it will save the mesh in a .mdpa file.

Please mark the PR with appropriate tags: 
- Application, finalstep

- Added final remeshing to the ExecuteFinalize in the mmg_process
- Saving in .mdpa file the mesh
- Added the dummy function of the avarage computation 

**Additional info**
The flag for activating/deactivating the option is called "remesh_post_process" and the file name is called "output_file_name". Both of them are defined in the deafult parameters in the mmg_process.py script. 
