### PR TITLE
[Core] add len to matrix in python

### DIFF
--- a/kratos/python/add_matrix_to_python.cpp
+++ b/kratos/python/add_matrix_to_python.cpp
@@ -41,6 +41,7 @@ namespace Python
         binder.def("Resize", [](TMatrixType& self, const typename TMatrixType::size_type new_size1, const typename TMatrixType::size_type new_size2)
                             {if(self.size1() != new_size1 || self.size2() != new_size2)
                                 self.resize(new_size1, new_size2, false);} );
+        binder.def("__len__", [](const TMatrixType& self){return self.size1() * self.size2();} );
         binder.def("__setitem__", [](TMatrixType& self, const std::pair<int,int> index, const  typename TMatrixType::value_type value)
                                     {
                                         const int index_i = index.first;

--- a/kratos/tests/test_matrix_interface.py
+++ b/kratos/tests/test_matrix_interface.py
@@ -6,6 +6,15 @@ import math
 
 class TestMatrixInterface(KratosUnittest.TestCase):
 
+    def test_len(self):
+        # creation
+        A = KM.Matrix(9, 8)
+        self.assertEqual(72, len(A))
+
+        # after resizing
+        A.Resize(5, 1)
+        self.assertEqual(5, len(A))
+
     def test_copy(self):
         A = KM.Matrix(2,3)
         A.fill(1.0)


### PR DESCRIPTION
**Description**
Support the len() method for Matrix in Python

**Changelog**
- added len() method for Matrix in core
- added python unit tests to cover len()

**Additional info**
Add any other relevant information here.
