### PR TITLE
[Core] Timers - use full label in find

### DIFF
--- a/kratos/utilities/timer.cpp
+++ b/kratos/utilities/timer.cpp
@@ -108,25 +108,26 @@ Timer::Timer(){}
 
 void Timer::Start(std::string const& rIntervalName)
 {
-    const auto it_internal_name = msInternalNameDatabase.find(rIntervalName);
     GetLabelsStackInstance().push_back(rIntervalName);
+    auto full_name = CreateFullLabel();
+    const auto it_internal_name = msInternalNameDatabase.find(full_name);
     if(it_internal_name == msInternalNameDatabase.end()) {
-        auto full_name = CreateFullLabel();
         const std::string internal_name = GetInternalName(full_name);
-        msInternalNameDatabase.insert(std::pair<std::string, std::string>(rIntervalName, internal_name));
+        msInternalNameDatabase.insert(std::pair<std::string, std::string>(full_name, internal_name));
         msTimeTable[internal_name].SetStartTime(GetTime());
         ++msCounter;
     }
-    const std::string& r_name = msInternalNameDatabase[rIntervalName];
+    const std::string& r_name = msInternalNameDatabase[full_name];
     ContainerType::iterator it_time_data = msTimeTable.find(r_name);
     it_time_data->second.SetStartTime(GetTime());
 }
 
 void Timer::Stop(std::string const& rIntervalName)
 {
+    auto full_name = CreateFullLabel();
     GetLabelsStackInstance().pop_back();
     const double stop_time = GetTime();
-    const std::string& r_name = msInternalNameDatabase[rIntervalName];
+    const std::string& r_name = msInternalNameDatabase[full_name];
     ContainerType::iterator it_time_data = msTimeTable.find(r_name);
 
     if(it_time_data == msTimeTable.end())


### PR DESCRIPTION
**Description**
This is an error fix from my previous PR. Internal database should use the "full label" as for example "Solve" could be called from two different solvers and you want to have that information separated.

**Changelog**
Use full label to store internal database in timers.