### PR TITLE
Warding low performance macros

### DIFF
--- a/kratos/input_output/logger.h
+++ b/kratos/input_output/logger.h
@@ -247,8 +247,13 @@ namespace Kratos
 
 #define KRATOS_INFO(label) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::INFO
 #define KRATOS_INFO_IF(label, conditional) if(conditional) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::INFO
-#define KRATOS_INFO_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == 0) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::INFO
-#define KRATOS_INFO_FIRST_N(label, logger_count) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES < logger_count) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::INFO
+#ifdef KRATOS_DEBUG
+  #define KRATOS_INFO_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == 0) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::INFO
+  #define KRATOS_INFO_FIRST_N(label, logger_count) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES < logger_count) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::INFO
+#else
+  #define KRATOS_INFO_ONCE(label) if(false) KRATOS_INFO(label)
+  #define KRATOS_INFO_FIRST_N(label, logger_count) if(false) KRATOS_INFO(label)
+#endif
 
 #define KRATOS_INFO_ALL_RANKS(label) KRATOS_INFO(label) << Kratos::Logger::DistributedFilter::FromAllRanks()
 #define KRATOS_INFO_IF_ALL_RANKS(label, conditional) KRATOS_INFO_IF(label, conditional) << Kratos::Logger::DistributedFilter::FromAllRanks()
@@ -257,8 +262,13 @@ namespace Kratos
 
 #define KRATOS_WARNING(label) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::WARNING
 #define KRATOS_WARNING_IF(label, conditional) if(conditional) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::WARNING
-#define KRATOS_WARNING_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == 0) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::WARNING
-#define KRATOS_WARNING_FIRST_N(label, logger_count) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES < logger_count) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::WARNING
+#ifdef KRATOS_DEBUG
+  #define KRATOS_WARNING_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == 0) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::WARNING
+  #define KRATOS_WARNING_FIRST_N(label, logger_count) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES < logger_count) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::WARNING
+#else
+  #define KRATOS_WARNING_ONCE(label) if(false) KRATOS_WARNING(label)
+  #define KRATOS_WARNING_FIRST_N(label, logger_count) if(false) KRATOS_WARNING(label)
+#endif
 
 #define KRATOS_WARNING_ALL_RANKS(label) KRATOS_WARNING(label) << Kratos::Logger::DistributedFilter::FromAllRanks()
 #define KRATOS_WARNING_IF_ALL_RANKS(label, conditional) KRATOS_WARNING_IF(label, conditional) << Kratos::Logger::DistributedFilter::FromAllRanks()
@@ -267,8 +277,13 @@ namespace Kratos
 
 #define KRATOS_DETAIL(label) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::DETAIL
 #define KRATOS_DETAIL_IF(label, conditional) if(conditional) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::DETAIL
-#define KRATOS_DETAIL_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == 0) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::DETAIL
-#define KRATOS_DETAIL_FIRST_N(label, logger_count) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES < logger_count) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::DETAIL
+#ifdef KRATOS_DEBUG
+  #define KRATOS_DETAIL_ONCE(label) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES == 0) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::DETAIL
+  #define KRATOS_DETAIL_FIRST_N(label, logger_count) static int KRATOS_LOG_OCCURRENCES = -1; if (++KRATOS_LOG_OCCURRENCES < logger_count) Kratos::Logger(label) << KRATOS_CODE_LOCATION << Kratos::Logger::Severity::DETAIL
+#else
+  #define KRATOS_DETAIL_ONCE(label) if(false) KRATOS_DETAIL(label)
+  #define KRATOS_DETAIL_FIRST_N(label, logger_count) if(false) KRATOS_DETAIL(label)
+#endif
 
 #define KRATOS_DETAIL_ALL_RANKS(label) KRATOS_DETAIL(label) << Kratos::Logger::DistributedFilter::FromAllRanks()
 #define KRATOS_DETAIL_IF_ALL_RANKS(label, conditional) KRATOS_DETAIL_IF(label, conditional) << Kratos::Logger::DistributedFilter::FromAllRanks()

--- a/kratos/tests/cpp_tests/input_output/test_logger.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_logger.cpp
@@ -441,7 +441,6 @@ namespace Kratos {
             Logger::AddOutput(p_output);
 
             const DataCommunicator& r_comm = DataCommunicator::GetDefault();
-            int rank = r_comm.Rank();
 
             for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_INFO_ONCE_ALL_RANKS("TestInfo") << "Test info message - " << i;
@@ -449,7 +448,7 @@ namespace Kratos {
 
             std::stringstream out;
 #ifdef KRATOS_DEBUG
-            out << "Rank " << rank << ": TestInfo: Test info message - 0";
+            out << "Rank " << r_comm.Rank() << ": TestInfo: Test info message - 0";
 #else
             out << "";
 #endif
@@ -464,7 +463,6 @@ namespace Kratos {
             Logger::AddOutput(p_output);
 
             const DataCommunicator& r_comm = DataCommunicator::GetDefault();
-            int rank = r_comm.Rank();
 
             for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_INFO_FIRST_N_ALL_RANKS("TestInfo", 4) << ".";
@@ -472,6 +470,7 @@ namespace Kratos {
 
             std::stringstream out;
 #ifdef KRATOS_DEBUG
+            int rank = r_comm.Rank();
             for(std::size_t i = 0; i < 4; i++) {
                 out << "Rank " << rank << ": TestInfo: .";
             }

--- a/kratos/tests/cpp_tests/input_output/test_logger.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_logger.cpp
@@ -129,7 +129,12 @@ namespace Kratos {
                 KRATOS_INFO_ONCE("TestInfo") << "Test info message - " << i;
             }
 
+#ifdef KRATOS_DEBUG
             std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestInfo: Test info message - 0" : "";
+#else
+            std::string expected_output = "";
+#endif
+
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -143,7 +148,11 @@ namespace Kratos {
                 KRATOS_INFO_FIRST_N("TestInfo", 4) << ".";
             }
 
+#ifdef KRATOS_DEBUG
             std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestInfo: .TestInfo: .TestInfo: .TestInfo: ." : "";
+#else
+            std::string expected_output = "";
+#endif
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -182,7 +191,12 @@ namespace Kratos {
                 KRATOS_WARNING_ONCE("TestWarning") << "Test warning message - " << i;
             }
 
+#ifdef KRATOS_DEBUG
             std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: Test warning message - 0" : "";
+#else
+            std::string expected_output = "";
+#endif  
+
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -196,7 +210,12 @@ namespace Kratos {
                 KRATOS_WARNING_FIRST_N("TestWarning", 4) << ".";
             }
 
+#ifdef KRATOS_DEBUG
             std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "[WARNING] TestWarning: .[WARNING] TestWarning: .[WARNING] TestWarning: .[WARNING] TestWarning: ." : "";
+#else
+            std::string expected_output = "";
+#endif            
+            
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -238,7 +257,11 @@ namespace Kratos {
                 KRATOS_DETAIL_ONCE("TestDetail") << "Test detail message - " << i;
             }
 
+#ifdef KRATOS_DEBUG
             std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestDetail: Test detail message - 0" : "";
+#else
+            std::string expected_output = "";
+#endif
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -253,7 +276,11 @@ namespace Kratos {
                 KRATOS_DETAIL_FIRST_N("TestDetail", 4) << ".";
             }
 
+#ifdef KRATOS_DEBUG
             std::string expected_output = DataCommunicator::GetDefault().Rank() == 0 ? "TestDetail: .TestDetail: .TestDetail: .TestDetail: ." : "";
+#else
+            std::string expected_output = "";
+#endif
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), expected_output.c_str());
         }
 
@@ -419,8 +446,13 @@ namespace Kratos {
             for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_INFO_ONCE_ALL_RANKS("TestInfo") << "Test info message - " << i;
             }
+
             std::stringstream out;
+#ifdef KRATOS_DEBUG
             out << "Rank " << rank << ": TestInfo: Test info message - 0";
+#else
+            out << "";
+#endif
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), out.str().c_str());
         }
@@ -439,9 +471,13 @@ namespace Kratos {
             }
 
             std::stringstream out;
+#ifdef KRATOS_DEBUG
             for(std::size_t i = 0; i < 4; i++) {
                 out << "Rank " << rank << ": TestInfo: .";
             }
+#else
+            out << "";
+#endif
 
             KRATOS_CHECK_C_STRING_EQUAL(buffer.str().c_str(), out.str().c_str());
         }

--- a/kratos/tests/cpp_tests/input_output/test_logger.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_logger.cpp
@@ -440,15 +440,13 @@ namespace Kratos {
             LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
             Logger::AddOutput(p_output);
 
-            const DataCommunicator& r_comm = DataCommunicator::GetDefault();
-
             for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_INFO_ONCE_ALL_RANKS("TestInfo") << "Test info message - " << i;
             }
 
             std::stringstream out;
 #ifdef KRATOS_DEBUG
-            out << "Rank " << r_comm.Rank() << ": TestInfo: Test info message - 0";
+            out << "Rank " << DataCommunicator::GetDefault().Rank() << ": TestInfo: Test info message - 0";
 #else
             out << "";
 #endif
@@ -462,15 +460,13 @@ namespace Kratos {
             LoggerOutput::Pointer p_output(new LoggerOutput(buffer));
             Logger::AddOutput(p_output);
 
-            const DataCommunicator& r_comm = DataCommunicator::GetDefault();
-
             for(std::size_t i = 0; i < 10; i++) {
                 KRATOS_INFO_FIRST_N_ALL_RANKS("TestInfo", 4) << ".";
             }
 
             std::stringstream out;
 #ifdef KRATOS_DEBUG
-            int rank = r_comm.Rank();
+            int rank = DataCommunicator::GetDefault().Rank();
             for(std::size_t i = 0; i < 4; i++) {
                 out << "Rank " << rank << ": TestInfo: .";
             }


### PR DESCRIPTION
**Description**
This PR disables `KRATOS_X_ONCE` and `KRATOS_X_FIRST_N` macros usable in release due to its performance hit.
Macros remain enabled in other builds. They behave like the `KRATOS_TRACE` now.

It does not break current code and Wiki has been updated with the changes.

**Changelog**
- Disabling counter macros in Release

**Additional info**
See #7401
