### PR TITLE
Adding GetIterationsNumber to linear solver

### DIFF
--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -132,8 +132,8 @@ public:
     /// DofArray type
     typedef ModelPart::DofsArrayType DofsArrayType;
 
-    /// The index type definition
-    typedef std::size_t IndexType;
+    /// The index type definition to be consistent
+    typedef typename TSparseSpaceType::IndexType IndexType;
 
     /// The size type definition
     typedef std::size_t SizeType;
@@ -489,9 +489,9 @@ public:
      * @brief This method returns the current iteration number
      * @return mIterationsNumber The current iteration number
      */
-    unsigned int GetIterationsNumber() override
+    IndexType GetIterationsNumber() override
     {
-        return static_cast<unsigned int>( mIterationsNumber );
+        return mIterationsNumber;
     }
 
     /**

--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -489,7 +489,7 @@ public:
      * @brief This method returns the current iteration number
      * @return mIterationsNumber The current iteration number
      */
-    virtual unsigned int GetIterationsNumber() override
+    unsigned int GetIterationsNumber() override
     {
         return static_cast<unsigned int>( mIterationsNumber );
     }

--- a/kratos/linear_solvers/amgcl_solver.h
+++ b/kratos/linear_solvers/amgcl_solver.h
@@ -489,9 +489,9 @@ public:
      * @brief This method returns the current iteration number
      * @return mIterationsNumber The current iteration number
      */
-    virtual IndexType GetIterationsNumber()
+    virtual unsigned int GetIterationsNumber() override
     {
-        return mIterationsNumber;
+        return static_cast<unsigned int>( mIterationsNumber );
     }
 
     /**

--- a/kratos/linear_solvers/iterative_solver.h
+++ b/kratos/linear_solvers/iterative_solver.h
@@ -83,6 +83,9 @@ public:
 
     typedef  TPreconditionerType PreconditionerType;
 
+    /// The index type definition to be consistent
+    typedef typename TSparseSpaceType::IndexType IndexType;
+
     ///@}
     ///@name Life Cycle
     ///@{
@@ -284,7 +287,7 @@ public:
         mMaxIterationsNumber = NewMaxIterationsNumber;
     }
 
-    virtual unsigned int GetMaxIterationsNumber()
+    virtual IndexType GetMaxIterationsNumber()
     {
         return mMaxIterationsNumber;
     }
@@ -294,7 +297,7 @@ public:
         mIterationsNumber = NewIterationNumber;
     }
 
-    unsigned int GetIterationsNumber() override
+    IndexType GetIterationsNumber() override
     {
         return mIterationsNumber;
     }
@@ -397,7 +400,7 @@ protected:
 
     double mFirstResidualNorm;
 
-    unsigned int mIterationsNumber;
+    IndexType mIterationsNumber;
 
     double mBNorm;
 
@@ -454,7 +457,7 @@ private:
 
     double mTolerance;
 
-    unsigned int mMaxIterationsNumber;
+    IndexType mMaxIterationsNumber;
 
     ///@}
     ///@name Private Operators

--- a/kratos/linear_solvers/iterative_solver.h
+++ b/kratos/linear_solvers/iterative_solver.h
@@ -294,7 +294,7 @@ public:
         mIterationsNumber = NewIterationNumber;
     }
 
-    virtual unsigned int GetIterationsNumber()
+    virtual unsigned int GetIterationsNumber() override
     {
         return mIterationsNumber;
     }

--- a/kratos/linear_solvers/iterative_solver.h
+++ b/kratos/linear_solvers/iterative_solver.h
@@ -294,7 +294,7 @@ public:
         mIterationsNumber = NewIterationNumber;
     }
 
-    virtual unsigned int GetIterationsNumber() override
+    unsigned int GetIterationsNumber() override
     {
         return mIterationsNumber;
     }

--- a/kratos/linear_solvers/linear_solver.h
+++ b/kratos/linear_solvers/linear_solver.h
@@ -82,7 +82,10 @@ public:
 
     typedef typename TDenseSpaceType::VectorType DenseVectorType;
 
-    typedef std::size_t  SizeType;
+    typedef std::size_t SizeType;
+
+    /// The index type definition to be consistent
+    typedef typename TSparseSpaceType::IndexType IndexType;
 
     ///@}
     ///@name Life Cycle
@@ -273,7 +276,7 @@ public:
         return 0;
     }
 
-    virtual unsigned int GetIterationsNumber()
+    virtual IndexType GetIterationsNumber()
     {
         KRATOS_WARNING("LinearSolver") << "Accessed base function \"GetIterationsNumber\", returning 0 !" << std::endl ;
 

--- a/kratos/linear_solvers/linear_solver.h
+++ b/kratos/linear_solvers/linear_solver.h
@@ -275,7 +275,7 @@ public:
 
     virtual unsigned int GetIterationsNumber()
     {
-        std::cout << "WARNING: Accessed base function Kratos::LinearSolver::GetIterationsNumber(). Iterations number is only defined for AMGCL and IterativeSolver." << std::endl;
+        KRATOS_WARNING("LinearSolver") << "WARNING: Accessed base function Kratos::LinearSolver::GetTolerance(), returning 0 !" << std::endl;
         return 0;
     }
 

--- a/kratos/linear_solvers/linear_solver.h
+++ b/kratos/linear_solvers/linear_solver.h
@@ -260,7 +260,7 @@ public:
      */
     virtual void SetTolerance(double NewTolerance)
     {
-        KRATOS_WARNING("LinearSolver") << "WARNING: Accessed base function Kratos::LinearSolver::SetTolerance(double). This does nothing !" << std::endl;
+        KRATOS_WARNING("LinearSolver") << "Accessed base function Kratos::LinearSolver::SetTolerance(double). This does nothing !" << std::endl;
     }
     
     /**
@@ -269,13 +269,13 @@ public:
      */
     virtual double GetTolerance()
     {
-        KRATOS_WARNING("LinearSolver") << "WARNING: Accessed base function Kratos::LinearSolver::GetTolerance(). No tolerance defined, returning 0 !" << std::endl ;
+        KRATOS_WARNING("LinearSolver") << "Accessed base function Kratos::LinearSolver::GetTolerance(). No tolerance defined, returning 0 !" << std::endl ;
         return 0;
     }
 
     virtual unsigned int GetIterationsNumber()
     {
-        KRATOS_WARNING("LinearSolver") << "WARNING: Accessed base function Kratos::LinearSolver::GetTolerance(), returning 0 !" << std::endl;
+        KRATOS_WARNING("LinearSolver") << "Accessed base function Kratos::LinearSolver::GetTolerance(), returning 0 !" << std::endl;
         return 0;
     }
 

--- a/kratos/linear_solvers/linear_solver.h
+++ b/kratos/linear_solvers/linear_solver.h
@@ -260,22 +260,23 @@ public:
      */
     virtual void SetTolerance(double NewTolerance)
     {
-        KRATOS_WARNING("LinearSolver") << "Accessed base function Kratos::LinearSolver::SetTolerance(double). This does nothing !" << std::endl;
+        KRATOS_WARNING("LinearSolver") << "Accessed base function \"SetTolerance\". This does nothing !" << std::endl;
     }
-    
+
     /**
      * @brief This method allows to get the tolerance in the linear solver
      * @return The tolerance
      */
     virtual double GetTolerance()
     {
-        KRATOS_WARNING("LinearSolver") << "Accessed base function Kratos::LinearSolver::GetTolerance(). No tolerance defined, returning 0 !" << std::endl ;
+        KRATOS_WARNING("LinearSolver") << "Accessed base function \"GetTolerance\". No tolerance defined, returning 0 !" << std::endl ;
         return 0;
     }
 
     virtual unsigned int GetIterationsNumber()
     {
-        KRATOS_WARNING("LinearSolver") << "Accessed base function Kratos::LinearSolver::GetTolerance(), returning 0 !" << std::endl;
+        KRATOS_WARNING("LinearSolver") << "Accessed base function \"GetIterationsNumber\", returning 0 !" << std::endl ;
+
         return 0;
     }
 

--- a/kratos/linear_solvers/linear_solver.h
+++ b/kratos/linear_solvers/linear_solver.h
@@ -273,6 +273,12 @@ public:
         return 0;
     }
 
+    virtual unsigned int GetIterationsNumber()
+    {
+        std::cout << "WARNING: Accessed base function Kratos::LinearSolver::GetIterationsNumber(). Iterations number is only defined for AMGCL and IterativeSolver." << std::endl;
+        return 0;
+    }
+
     ///@}
     ///@name Inquiry
     ///@{

--- a/kratos/linear_solvers/scaling_solver.h
+++ b/kratos/linear_solvers/scaling_solver.h
@@ -260,7 +260,7 @@ public:
     ///@name Access
     ///@{
 
-    virtual unsigned int GetIterationsNumber() override
+    unsigned int GetIterationsNumber() override
     {
         return mpLinearSolver->GetIterationsNumber();
     }

--- a/kratos/linear_solvers/scaling_solver.h
+++ b/kratos/linear_solvers/scaling_solver.h
@@ -260,6 +260,11 @@ public:
     ///@name Access
     ///@{
 
+    virtual unsigned int GetIterationsNumber() override
+    {
+        return mpLinearSolver->GetIterationsNumber();
+    }
+
 
     ///@}
     ///@name Inquiry

--- a/kratos/linear_solvers/scaling_solver.h
+++ b/kratos/linear_solvers/scaling_solver.h
@@ -84,6 +84,9 @@ public:
     /// The definition of the linear solver factory type
     typedef LinearSolverFactory<TSparseSpaceType,TDenseSpaceType> LinearSolverFactoryType;
 
+    /// The index type definition to be consistent
+    typedef typename TSparseSpaceType::IndexType IndexType;
+
     ///@}
     ///@name Life Cycle
     ///@{
@@ -260,7 +263,7 @@ public:
     ///@name Access
     ///@{
 
-    unsigned int GetIterationsNumber() override
+    IndexType GetIterationsNumber() override
     {
         return mpLinearSolver->GetIterationsNumber();
     }

--- a/kratos/python/add_amgcl_solver_to_python.cpp
+++ b/kratos/python/add_amgcl_solver_to_python.cpp
@@ -78,7 +78,6 @@ void  AddAMGCLSolverToPython(pybind11::module& m)
     .def(py::init<>())
     .def(py::init<Parameters>())
     .def( "GetResidualNorm",&AMGCLSolverType::GetResidualNorm)
-    .def( "GetIterationsNumber",&AMGCLSolverType::GetIterationsNumber)
     ;
 
 

--- a/kratos/python/add_linear_solvers_to_python.cpp
+++ b/kratos/python/add_linear_solvers_to_python.cpp
@@ -147,6 +147,7 @@ void  AddLinearSolversToPython(pybind11::module& m)
     py::class_<IterativeSolverType, IterativeSolverType::Pointer, LinearSolverType>(m,"IterativeSolver")
     .def(py::init< >() )
     .def("__str__", PrintObject<IterativeSolverType>)
+    .def("GetIterationsNumber",&IterativeSolverType::GetIterationsNumber)
     ;
 
     py::class_<CGSolverType, CGSolverType::Pointer,IterativeSolverType>(m,"CGSolver")

--- a/kratos/python/add_linear_solvers_to_python.cpp
+++ b/kratos/python/add_linear_solvers_to_python.cpp
@@ -125,6 +125,7 @@ void  AddLinearSolversToPython(pybind11::module& m)
     .def("Solve",pointer_to_solve_eigen)
     .def("Clear",&LinearSolverType::Clear)
     .def("__str__", PrintObject<LinearSolverType>)
+    .def( "GetIterationsNumber",&LinearSolverType::GetIterationsNumber)
     ;
 
     py::class_<ComplexLinearSolverType, ComplexLinearSolverType::Pointer>(m,"ComplexLinearSolver")
@@ -147,7 +148,6 @@ void  AddLinearSolversToPython(pybind11::module& m)
     py::class_<IterativeSolverType, IterativeSolverType::Pointer, LinearSolverType>(m,"IterativeSolver")
     .def(py::init< >() )
     .def("__str__", PrintObject<IterativeSolverType>)
-    .def("GetIterationsNumber",&IterativeSolverType::GetIterationsNumber)
     ;
 
     py::class_<CGSolverType, CGSolverType::Pointer,IterativeSolverType>(m,"CGSolver")
@@ -179,7 +179,6 @@ void  AddLinearSolversToPython(pybind11::module& m)
     .def(py::init<LinearSolverType::Pointer>())
     .def(py::init<LinearSolverType::Pointer, bool >())
     .def(py::init<Parameters >())
-    .def("GetIterationsNumber",&ScalingSolverType::GetIterationsNumber)
     ;
 
     py::class_<PowerIterationEigenvalueSolverType, PowerIterationEigenvalueSolverType::Pointer, LinearSolverType>(m,"PowerIterationEigenvalueSolver")

--- a/kratos/python/add_linear_solvers_to_python.cpp
+++ b/kratos/python/add_linear_solvers_to_python.cpp
@@ -178,6 +178,7 @@ void  AddLinearSolversToPython(pybind11::module& m)
     .def(py::init<LinearSolverType::Pointer>())
     .def(py::init<LinearSolverType::Pointer, bool >())
     .def(py::init<Parameters >())
+    .def("GetIterationsNumber",&ScalingSolverType::GetIterationsNumber)
     ;
 
     py::class_<PowerIterationEigenvalueSolverType, PowerIterationEigenvalueSolverType::Pointer, LinearSolverType>(m,"PowerIterationEigenvalueSolver")


### PR DESCRIPTION
**Description**
Access to the iterations number of the iterative solvers

Please mark the PR with appropriate tags: 
- FastPR

**Changelog**
Please summarize the changes in one list to generate the changelog:
- GetIterationsNumber() is added to the corresponding classes.

**Additional info**
This functionality was not added to python in the current version and also was missing for scaling solver.
