### PR TITLE
[CoSim] using python mapper factory

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/data_transfer_operators/kratos_mapping.py
+++ b/applications/CoSimulationApplication/python_scripts/data_transfer_operators/kratos_mapping.py
@@ -4,6 +4,7 @@ from KratosMultiphysics.CoSimulationApplication.base_classes.co_simulation_data_
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 import KratosMultiphysics.MappingApplication as KratosMapping
+from KratosMultiphysics.MappingApplication import python_mapper_factory
 
 # CoSimulation imports
 import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
@@ -52,9 +53,9 @@ class KratosMappingDataTransferOperator(CoSimulationDataTransferOperator):
             self.__mappers[inverse_identifier_tuple].InverseMap(variable_destination, variable_origin, mapper_flags)
         else:
             if model_part_origin.IsDistributed() or model_part_destination.IsDistributed():
-                mapper_create_fct = KratosMapping.MapperFactory.CreateMPIMapper
+                mapper_create_fct = python_mapper_factory.CreateMPIMapper
             else:
-                mapper_create_fct = KratosMapping.MapperFactory.CreateMapper
+                mapper_create_fct = python_mapper_factory.CreateMapper
 
             if self.echo_level > 0:
                 info_msg  = "Creating Mapper:\n"

--- a/applications/MappingApplication/python_scripts/python_mapper_factory.py
+++ b/applications/MappingApplication/python_scripts/python_mapper_factory.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Python factory for all the currently available Mappers in Kratos
 # The intention is to give the users a unique place to create Mappers
 # The goal is to implement the Mappers from the other Apps also in the
@@ -10,54 +8,39 @@ from __future__ import print_function, absolute_import, division  # makes Kratos
 import KratosMultiphysics as KM
 from KratosMultiphysics.MappingApplication import MapperFactory
 
-from importlib import import_module
-
-available_mappers = {
-    "empire_nearest_neighbor" : "empire_mapper_wrapper",
-    "empire_nearest_element"  : "empire_mapper_wrapper",
-    "empire_barycentric"      : "empire_mapper_wrapper",
-    "empire_dual_mortar"      : "empire_mapper_wrapper",
-    "empire_mortar"           : "empire_mapper_wrapper"
-}
-
 def CreateMapper(model_part_origin, model_part_destination, mapper_settings):
     if not isinstance(mapper_settings, KM.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
 
     mapper_type = mapper_settings["mapper_type"].GetString()
 
-    is_distributed = model_part_origin.IsDistributed() or model_part_destination.IsDistributed()
-
-    if is_distributed:
-        list_avail_mappers = MapperFactory.GetRegisteredMPIMapperNames()
-        dist_info = "MPI"
-    else:
-        list_avail_mappers = MapperFactory.GetRegisteredMapperNames()
-        dist_info = "serial (non-MPI)"
-
     # use the MappingApp if it has the requested mapper
-    if is_distributed:
-        if MapperFactory.HasMPIMapper(mapper_type):
-            return MapperFactory.CreateMPIMapper(model_part_origin, model_part_destination, mapper_settings)
-    elif MapperFactory.HasMapper(mapper_type):
+    if MapperFactory.HasMapper(mapper_type):
         return MapperFactory.CreateMapper(model_part_origin, model_part_destination, mapper_settings)
 
-    if mapper_type in available_mappers:
-        mapper_module_name = available_mappers[mapper_type]
+    list_avail_mappers = MapperFactory.GetRegisteredMapperNames()
 
-        if mapper_type.startswith("empire"):
-            raw_mapper_name = mapper_type[7:]
-            if raw_mapper_name in list_avail_mappers:
-                info_msg  = "Using a mapper from Empire ({}), even though the same mapper is available in Kratos\n".format(raw_mapper_name)
-                info_msg += "Consider switching for improved performance, less overead and native MPI support"
-                KM.Logger.PrintInfo("Python-Mapper-Factory", info_msg)
+    err_msg  = 'The requested mapper "{}" is not available in serial (non-MPI)\n'.format(mapper_type)
+    err_msg += 'The following mappers are available:'
+    for avail_mapper in list_avail_mappers:
+        err_msg += '\n\t{}'.format(avail_mapper)
+    raise Exception(err_msg)
 
-        return import_module("KratosMultiphysics.MappingApplication." + mapper_module_name).CreateMapper(model_part_origin, model_part_destination, mapper_settings)
-    else:
-        list_avail_mappers.extend(available_mappers.keys())
 
-        err_msg  = 'The requested mapper "{}" is not available in {}\n'.format(mapper_type, dist_info)
-        err_msg += 'The following mappers are available:'
-        for avail_mapper in list_avail_mappers:
-            err_msg += '\n\t{}'.format(avail_mapper)
-        raise Exception(err_msg)
+def CreateMPIMapper(model_part_origin, model_part_destination, mapper_settings):
+    if not isinstance(mapper_settings, KM.Parameters):
+        raise Exception("expected input shall be a Parameters object, encapsulating a json string")
+
+    mapper_type = mapper_settings["mapper_type"].GetString()
+
+    # use the MappingApp if it has the requested mapper
+    if MapperFactory.HasMPIMapper(mapper_type):
+        return MapperFactory.CreateMPIMapper(model_part_origin, model_part_destination, mapper_settings)
+
+    list_avail_mappers = MapperFactory.GetRegisteredMPIMapperNames()
+
+    err_msg  = 'The requested mapper "{}" is not available in MPI\n'.format(mapper_type)
+    err_msg += 'The following mappers are available:'
+    for avail_mapper in list_avail_mappers:
+        err_msg += '\n\t{}'.format(avail_mapper)
+    raise Exception(err_msg)


### PR DESCRIPTION
**Description**
Now instead of using the C++ mapper factory I want to use the python one. The reason for this is that then we can also use python based mappers in CoSimulation (I am currently finishing up the Empire mapper wrapper)

**Changelog**
- Use `python_mapper_factory` in data transfer operator `KratosMapping`
- Clean and simplify `python_mapper_factory`