### PR TITLE
[Warning][Fluid][Fluid-related] Deprecated strategies constructors warning

### DIFF
--- a/applications/ChimeraApplication/custom_utilities/fractional_step_settings_for_chimera.h
+++ b/applications/ChimeraApplication/custom_utilities/fractional_step_settings_for_chimera.h
@@ -181,7 +181,12 @@ public:
 
             // Strategy
             BaseType::mStrategies[rStrategyLabel] = Kratos::make_shared< ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >>
-                                                                        (r_fs_velocity_model_part, p_scheme, pLinearSolver, p_build_and_solver, calculate_reactions, reform_dof_set, calculate_norm_dx_flag);
+                (r_fs_velocity_model_part,
+                p_scheme,
+                p_build_and_solver,
+                calculate_reactions,
+                reform_dof_set,
+                calculate_norm_dx_flag);
         }
         else if ( rStrategyLabel == BaseType::Pressure )
         {
@@ -194,8 +199,13 @@ public:
             p_build_and_solver->SetEchoLevel(strategy_echo_level);
 
             // Strategy
-            BaseType::mStrategies[rStrategyLabel] = Kratos::make_shared<ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >>
-                                                                        (r_fs_pressure_model_part, p_scheme, pLinearSolver, p_build_and_solver, calculate_reactions, reform_dof_set, calculate_norm_dx_flag);
+            BaseType::mStrategies[rStrategyLabel] = Kratos::make_shared<ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >>(
+                r_fs_pressure_model_part,
+                p_scheme,
+                p_build_and_solver,
+                calculate_reactions,
+                reform_dof_set,
+                calculate_norm_dx_flag);
         }
         else
         {

--- a/applications/ConvectionDiffusionApplication/custom_strategies/strategies/residualbased_convdiff_strategy.h
+++ b/applications/ConvectionDiffusionApplication/custom_strategies/strategies/residualbased_convdiff_strategy.h
@@ -166,7 +166,13 @@ public:
         typedef typename BuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>::Pointer BuilderSolverTypePointer;
 
         BuilderSolverTypePointer componentwise_build = BuilderSolverTypePointer(new	ResidualBasedEliminationBuilderAndSolverComponentwise<TSparseSpace,TDenseSpace,TLinearSolver,Variable<double> > (pNewLinearSolver,rUnknownVar) );
-        mstep1 = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,  TDenseSpace, TLinearSolver > 				(model_part,pscheme,pNewLinearSolver,componentwise_build,CalculateReactions,ReformDofAtEachIteration,CalculateNormDxFlag)  );
+        mstep1 = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace,  TDenseSpace, TLinearSolver >(
+            model_part,
+            pscheme,
+            componentwise_build,
+            CalculateReactions,
+            ReformDofAtEachIteration,
+            CalculateNormDxFlag));
         mstep1->SetEchoLevel(2);
         Check();
         KRATOS_CATCH("")
@@ -479,4 +485,3 @@ private:
 }  /* namespace Kratos.*/
 
 #endif /* KRATOS_RESIDUALBASED_CONVECTION_DIFFUSION_STRATEGY  defined */
-

--- a/applications/ConvectionDiffusionApplication/custom_strategies/strategies/residualbased_convdiff_strategy_nonlinear.h
+++ b/applications/ConvectionDiffusionApplication/custom_strategies/strategies/residualbased_convdiff_strategy_nonlinear.h
@@ -1,6 +1,6 @@
-// KRATOS ___ ___  _  ___   __   ___ ___ ___ ___ 
+// KRATOS ___ ___  _  ___   __   ___ ___ ___ ___
 //       / __/ _ \| \| \ \ / /__|   \_ _| __| __|
-//      | (_| (_) | .` |\ V /___| |) | || _|| _| 
+//      | (_| (_) | .` |\ V /___| |) | || _|| _|
 //       \___\___/|_|\_| \_/    |___/___|_| |_|  APPLICATION
 //
 //  License: BSD License
@@ -167,7 +167,13 @@ public:
         typedef typename BuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>::Pointer BuilderSolverTypePointer;
 
         BuilderSolverTypePointer componentwise_build = BuilderSolverTypePointer(new ResidualBasedEliminationBuilderAndSolverComponentwise<TSparseSpace, TDenseSpace, TLinearSolver, Variable<double> > (pNewLinearSolver, rUnknownVar));
-        mstep1 = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (model_part, pscheme, pNewLinearSolver, componentwise_build, CalculateReactions, ReformDofAtEachIteration, CalculateNormDxFlag));
+        mstep1 = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (
+            model_part,
+            pscheme,
+            componentwise_build,
+            CalculateReactions,
+            ReformDofAtEachIteration,
+            CalculateNormDxFlag));
         mstep1->SetEchoLevel(2);
 
         Check();
@@ -549,4 +555,3 @@ private:
 } /* namespace Kratos.*/
 
 #endif /* KRATOS_RESIDUALBASED_CONVECTION_DIFFUSION_STRATEGY_NONLINEAR  defined */
-

--- a/applications/ConvectionDiffusionApplication/custom_strategies/strategies/residualbased_eulerian_convdiff_strategy.h
+++ b/applications/ConvectionDiffusionApplication/custom_strategies/strategies/residualbased_eulerian_convdiff_strategy.h
@@ -173,8 +173,13 @@ public:
         //mstep1 = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,  TDenseSpace, TLinearSolver > 				(*mpConvectionModelPart,pscheme,pNewLinearSolver,componentwise_build,CalculateReactions,ReformDofAtEachIteration,CalculateNormDxFlag)  );
 
         BuilderSolverTypePointer pBuilderSolver = BuilderSolverTypePointer(new ResidualBasedBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>(pNewLinearSolver) );
-        mstep1 = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(*mpConvectionModelPart,pscheme,pNewLinearSolver,pBuilderSolver,CalculateReactions,ReformDofAtEachIteration,CalculateNormDxFlag) );
-
+        mstep1 = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(
+            *mpConvectionModelPart,
+            pscheme,
+            pBuilderSolver,
+            CalculateReactions,
+            ReformDofAtEachIteration,
+            CalculateNormDxFlag));
 
         mstep1->SetEchoLevel(2);
 

--- a/applications/ConvectionDiffusionApplication/custom_strategies/strategies/residualbased_semi_eulerian_convdiff_strategy.h
+++ b/applications/ConvectionDiffusionApplication/custom_strategies/strategies/residualbased_semi_eulerian_convdiff_strategy.h
@@ -159,7 +159,13 @@ public:
         //mstep1 = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,  TDenseSpace, TLinearSolver > 				(*mpConvectionModelPart,pscheme,pNewLinearSolver,componentwise_build,CalculateReactions,ReformDofAtEachIteration,CalculateNormDxFlag)  );
 
         BuilderSolverTypePointer pBuilderSolver = BuilderSolverTypePointer(new ResidualBasedBlockBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>(pNewLinearSolver) );
-        mstep1 = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(*mpConvectionModelPart,pscheme,pNewLinearSolver,pBuilderSolver,CalculateReactions,ReformDofAtEachIteration,CalculateNormDxFlag) );
+        mstep1 = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,TDenseSpace,TLinearSolver >(
+            *mpConvectionModelPart,
+            pscheme,
+            pBuilderSolver,
+            CalculateReactions,
+            ReformDofAtEachIteration,
+            CalculateNormDxFlag) );
 
 
         mstep1->SetEchoLevel(2);
@@ -511,4 +517,3 @@ private:
 }  /* namespace Kratos.*/
 
 #endif /* KRATOS_RESIDUALBASED_SEMI_EULERIAN_CONVECTION_DIFFUSION_STRATEGY  defined */
-

--- a/applications/ConvectionDiffusionApplication/python_scripts/adjoint_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/adjoint_diffusion_solver.py
@@ -177,7 +177,6 @@ class AdjointDiffusionSolver(PythonSolver):
 
         self.solver = kratos.ResidualBasedLinearStrategy(self.model_part,
                                                          self.time_scheme,
-                                                         self.linear_solver,
                                                          builder_and_solver,
                                                          False,
                                                          False,
@@ -253,7 +252,3 @@ class AdjointDiffusionSolver(PythonSolver):
 
         ## Call the replace elements and conditions process
         kratos.ReplaceElementsAndConditionsProcess(self.model_part, self.settings["element_replace_settings"]).Execute()
-
-
-
-

--- a/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/convection_diffusion_solver.py
@@ -103,7 +103,6 @@ class ConvectionDiffusionSolver(object):
             self.strategy = ResidualBasedLinearStrategy(
                 self.model_part,
                 scheme,
-                self.linear_solver,
                 builder_and_solver,
                 self.calculate_reactions,
                 self.reform_dofs_at_each_step,

--- a/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.cpp
@@ -49,7 +49,7 @@ DistanceSmoothingProcess<TDim, TSparseSpace, TDenseSpace, TLinearSolver>::Distan
 
     auto p_builder_solver = Kratos::make_shared<ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver> >(plinear_solver);
 
-    CreateSolutionStrategy(plinear_solver, p_builder_solver);
+    CreateSolutionStrategy(p_builder_solver);
 }
 
 template< unsigned int TDim, class TSparseSpace, class TDenseSpace, class TLinearSolver>
@@ -163,9 +163,7 @@ void DistanceSmoothingProcess<TDim, TSparseSpace, TDenseSpace, TLinearSolver>::C
 }
 
 template< unsigned int TDim, class TSparseSpace, class TDenseSpace, class TLinearSolver>
-void DistanceSmoothingProcess<TDim, TSparseSpace, TDenseSpace, TLinearSolver>::CreateSolutionStrategy(
-    typename TLinearSolver::Pointer pLinearSolver,
-    BuilderSolverPointerType pBuilderAndSolver)
+void DistanceSmoothingProcess<TDim, TSparseSpace, TDenseSpace, TLinearSolver>::CreateSolutionStrategy(BuilderSolverPointerType pBuilderAndSolver)
 {
     // Generate a linear solver strategy
     auto p_scheme = Kratos::make_shared< ResidualBasedIncrementalUpdateStaticScheme< TSparseSpace,TDenseSpace > >();
@@ -179,7 +177,6 @@ void DistanceSmoothingProcess<TDim, TSparseSpace, TDenseSpace, TLinearSolver>::C
     mp_solving_strategy = Kratos::make_unique<ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver> >(
         r_smoothing_model_part,
         p_scheme,
-        pLinearSolver,
         pBuilderAndSolver,
         CalculateReactions,
         ReformDofAtEachIteration,

--- a/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/distance_smoothing_process.h
@@ -155,9 +155,12 @@ private:
     ///@name Private Operations
     ///@{
 
-    void CreateSolutionStrategy(
-        typename TLinearSolver::Pointer pLinearSolver,
-        BuilderSolverPointerType pBuilderAndSolver);
+    /**
+     * @brief Create a Solution Strategy object
+     * This method creates the linear solution strategy
+     * @param pBuilderAndSolver Builder and solver pointer
+     */
+    void CreateSolutionStrategy(BuilderSolverPointerType pBuilderAndSolver);
 
     /**
      * @brief Initialize the process

--- a/applications/FluidDynamicsApplication/custom_processes/stokes_initialization_process.h
+++ b/applications/FluidDynamicsApplication/custom_processes/stokes_initialization_process.h
@@ -124,15 +124,14 @@ public:
         bool ReformDofSetFlag = false;
         bool CalculateNormDxFlag = false;
         bool MoveMeshFlag = false;
-        mpSolutionStrategy = StrategyPointerType( 
-            new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(r_stokes_part,
-                                                                                                                            pScheme,
-                                                                                                                            mpLinearSolver,
-                                                                                                                            pBuildAndSolver,
-                                                                                                                            ReactionFlag,
-                                                                                                                            ReformDofSetFlag,
-                                                                                                                            CalculateNormDxFlag,
-                                                                                                                            MoveMeshFlag) );
+        mpSolutionStrategy = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(
+            r_stokes_part,
+            pScheme,
+            pBuildAndSolver,
+            ReactionFlag,
+            ReformDofSetFlag,
+            CalculateNormDxFlag,
+            MoveMeshFlag) );
         mpSolutionStrategy->SetEchoLevel(0);
         mpSolutionStrategy->Check();
 
@@ -186,8 +185,8 @@ public:
 
     void SetConditions(ModelPart& rStokesPart, ModelPart::ConditionsContainerType::Pointer pConditions)
     {
-        
-        ModelPart& r_stokes_part = mrReferenceModelPart.GetModel().GetModelPart("StokesModelPart");    
+
+        ModelPart& r_stokes_part = mrReferenceModelPart.GetModel().GetModelPart("StokesModelPart");
         rStokesPart.SetConditions(pConditions);
         r_stokes_part.GetCommunicator().LocalMesh().SetConditions(pConditions);
     }

--- a/applications/FluidDynamicsApplication/custom_utilities/fractional_step_settings.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fractional_step_settings.h
@@ -147,8 +147,13 @@ public:
             }
 
             // Strategy
-            BaseType::mStrategies[rStrategyLabel] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >
-                                                                        (rModelPart, pScheme, pLinearSolver, pBuildAndSolver, CalculateReactions, ReformDofSet, CalculateNormDxFlag));
+            BaseType::mStrategies[rStrategyLabel] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >(
+                rModelPart,
+                pScheme,
+                pBuildAndSolver,
+                CalculateReactions,
+                ReformDofSet,
+                CalculateNormDxFlag));
 
         }
         else if ( rStrategyLabel == BaseType::Pressure )
@@ -158,8 +163,13 @@ public:
             SchemePointerType pScheme = SchemePointerType(new ResidualBasedIncrementalUpdateStaticScheme< TSparseSpace, TDenseSpace > ());
 
             // Strategy
-            BaseType::mStrategies[rStrategyLabel] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >
-                                                                        (rModelPart, pScheme, pLinearSolver, pBuildAndSolver, CalculateReactions, ReformDofSet, CalculateNormDxFlag));
+            BaseType::mStrategies[rStrategyLabel] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >(
+                rModelPart,
+                pScheme,
+                pBuildAndSolver,
+                CalculateReactions,
+                ReformDofSet,
+                CalculateNormDxFlag));
         }
         else
         {

--- a/applications/FluidDynamicsApplication/custom_utilities/fractional_step_settings_periodic.h
+++ b/applications/FluidDynamicsApplication/custom_utilities/fractional_step_settings_periodic.h
@@ -145,8 +145,13 @@ public:
             }
 
             // Strategy
-            BaseType::mStrategies[rStrategyLabel] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >
-                                                                        (rModelPart, pScheme, pLinearSolver, pBuildAndSolver, CalculateReactions, ReformDofSet, CalculateNormDxFlag));
+            BaseType::mStrategies[rStrategyLabel] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >(
+                rModelPart,
+                pScheme,
+                pBuildAndSolver,
+                CalculateReactions,
+                ReformDofSet,
+                CalculateNormDxFlag));
 
         }
         else if ( rStrategyLabel == BaseType::Pressure )
@@ -157,8 +162,13 @@ public:
             SchemePointerType pScheme = SchemePointerType(new ResidualBasedIncrementalUpdateStaticScheme< TSparseSpace, TDenseSpace > ());
 
             // Strategy
-            BaseType::mStrategies[rStrategyLabel] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >
-                                                                        (rModelPart, pScheme, pLinearSolver, pBuildAndSolver, CalculateReactions, ReformDofSet, CalculateNormDxFlag));
+            BaseType::mStrategies[rStrategyLabel] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver >(
+                rModelPart,
+                pScheme,
+                pBuildAndSolver,
+                CalculateReactions,
+                ReformDofSet,
+                CalculateNormDxFlag));
         }
         else
         {

--- a/applications/FluidDynamicsApplication/python_scripts/adjoint_vmsmonolithic_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/adjoint_vmsmonolithic_solver.py
@@ -118,7 +118,6 @@ class AdjointVMSMonolithicSolver(AdjointFluidSolver):
     def _CreateSolutionStrategy(self):
         computing_model_part = self.GetComputingModelPart()
         time_scheme = self._GetScheme()
-        linear_solver = self._GetLinearSolver()
         builder_and_solver = self._GetBuilderAndSolver()
         calculate_reaction_flag = False
         reform_dof_set_at_each_step = False
@@ -127,7 +126,6 @@ class AdjointVMSMonolithicSolver(AdjointFluidSolver):
         return KratosMultiphysics.ResidualBasedLinearStrategy(
             computing_model_part,
             time_scheme,
-            linear_solver,
             builder_and_solver,
             calculate_reaction_flag,
             reform_dof_set_at_each_step,

--- a/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
+++ b/applications/FluidDynamicsApplication/python_scripts/fluid_solver.py
@@ -385,13 +385,11 @@ class FluidSolver(PythonSolver):
     def _CreateLinearStrategy(self):
         computing_model_part = self.GetComputingModelPart()
         time_scheme = self._GetScheme()
-        linear_solver = self._GetLinearSolver()
         builder_and_solver = self._GetBuilderAndSolver()
         calculate_norm_dx = False
         return KratosMultiphysics.ResidualBasedLinearStrategy(
             computing_model_part,
             time_scheme,
-            linear_solver,
             builder_and_solver,
             self.settings["compute_reactions"].GetBool(),
             self.settings["reform_dofs_at_each_step"].GetBool(),
@@ -401,13 +399,11 @@ class FluidSolver(PythonSolver):
     def _CreateNewtonRaphsonStrategy(self):
         computing_model_part = self.GetComputingModelPart()
         time_scheme = self._GetScheme()
-        linear_solver = self._GetLinearSolver()
         convergence_criterion = self._GetConvergenceCriterion()
         builder_and_solver = self._GetBuilderAndSolver()
         return KratosMultiphysics.ResidualBasedNewtonRaphsonStrategy(
             computing_model_part,
             time_scheme,
-            linear_solver,
             convergence_criterion,
             builder_and_solver,
             self.settings["maximum_iterations"].GetInt(),

--- a/applications/FluidDynamicsApplication/trilinos_extension/custom_processes/trilinos_stokes_initialization_process.h
+++ b/applications/FluidDynamicsApplication/trilinos_extension/custom_processes/trilinos_stokes_initialization_process.h
@@ -130,9 +130,9 @@ public:
 
         // Builder and solver
         int guess_row_size;
-        if(BaseDomainSize == 2) 
+        if(BaseDomainSize == 2)
             guess_row_size = 15;
-        else 
+        else
             guess_row_size = 40;
 
         auto pBuildAndSolver = Kratos::make_shared<TrilinosBlockBuilderAndSolverPeriodic<TSparseSpace,TDenseSpace,TLinearSolver> >(
@@ -151,7 +151,6 @@ public:
         pSolutionStrategy = Kratos::make_shared< ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver> >(
             rStokesModelPart,
             pScheme,
-            pBaseLinearSolver,
             pBuildAndSolver,
             ReactionFlag,
             ReformDofSetFlag,

--- a/applications/FluidDynamicsApplication/trilinos_extension/custom_utilities/trilinos_fractional_step_settings.h
+++ b/applications/FluidDynamicsApplication/trilinos_extension/custom_utilities/trilinos_fractional_step_settings.h
@@ -144,7 +144,13 @@ public:
             }
 
             // Strategy
-            this->mStrategies[BaseType::Velocity] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (rModelPart, pScheme, pLinearSolver, pBuildAndSolver, CalculateReactions, ReformDofSet, CalculateNormDxFlag));
+            this->mStrategies[BaseType::Velocity] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (
+                rModelPart,
+                pScheme,
+                pBuildAndSolver,
+                CalculateReactions,
+                ReformDofSet,
+                CalculateNormDxFlag));
 
         }
         else if ( rStrategyLabel == BaseType::Pressure )
@@ -154,7 +160,13 @@ public:
             SchemePointerType pScheme = SchemePointerType(new ResidualBasedIncrementalUpdateStaticScheme< TSparseSpace, TDenseSpace > ());
 
             // Strategy
-            this->mStrategies[BaseType::Pressure] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (rModelPart, pScheme, pLinearSolver, pBuildAndSolver, CalculateReactions, ReformDofSet, CalculateNormDxFlag));
+            this->mStrategies[BaseType::Pressure] = StrategyPointerType(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > (
+                rModelPart,
+                pScheme,
+                pBuildAndSolver,
+                CalculateReactions,
+                ReformDofSet,
+                CalculateNormDxFlag));
         }
         else
         {

--- a/applications/FluidDynamicsApplication/trilinos_extension/custom_utilities/trilinos_fractional_step_settings_periodic.h
+++ b/applications/FluidDynamicsApplication/trilinos_extension/custom_utilities/trilinos_fractional_step_settings_periodic.h
@@ -156,7 +156,13 @@ public:
             SchemePointerType pScheme = Kratos::make_shared< ResidualBasedIncrementalUpdateStaticScheme< TSparseSpace, TDenseSpace > >();
 
             // Strategy
-            this->mStrategies[BaseType::Pressure] = Kratos::make_shared< ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > >(rModelPart, pScheme, pLinearSolver, pBuildAndSolver, CalculateReactions, ReformDofSet, CalculateNormDxFlag);
+            this->mStrategies[BaseType::Pressure] = Kratos::make_shared< ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver > >(
+                rModelPart,
+                pScheme,
+                pBuildAndSolver,
+                CalculateReactions,
+                ReformDofSet,
+                CalculateNormDxFlag);
         }
         else
         {

--- a/applications/MeshMovingApplication/custom_strategies/strategies/laplacian_meshmoving_strategy.h
+++ b/applications/MeshMovingApplication/custom_strategies/strategies/laplacian_meshmoving_strategy.h
@@ -117,30 +117,33 @@ public:
             TSparseSpace, TDenseSpace, TLinearSolver, VarComponent>(
             pNewLinearSolver, MESH_DISPLACEMENT_Z));
 
-    mstrategy_x = typename BaseType::Pointer(
-        new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace,
-                                        TLinearSolver>(
-            *mpmesh_model_part, pscheme, pNewLinearSolver,
-            mpbuilder_and_solver_x, ComputeReactions,
-            mreform_dof_set_at_each_step, calculate_norm_dx_flag));
+    mstrategy_x = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace,TLinearSolver>(
+        *mpmesh_model_part,
+        pscheme,
+        mpbuilder_and_solver_x,
+        ComputeReactions,
+        mreform_dof_set_at_each_step,
+        calculate_norm_dx_flag));
 
     mstrategy_x->SetEchoLevel(mecho_level);
 
-    mstrategy_y = typename BaseType::Pointer(
-        new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace,
-                                        TLinearSolver>(
-            *mpmesh_model_part, pscheme, pNewLinearSolver,
-            mpbuilder_and_solver_y, ComputeReactions,
-            mreform_dof_set_at_each_step, calculate_norm_dx_flag));
+    mstrategy_y = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace,TLinearSolver>(
+        *mpmesh_model_part,
+        pscheme,
+        mpbuilder_and_solver_y,
+        ComputeReactions,
+        mreform_dof_set_at_each_step,
+        calculate_norm_dx_flag));
 
     mstrategy_y->SetEchoLevel(mecho_level);
 
-    mstrategy_z = typename BaseType::Pointer(
-        new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace,
-                                        TLinearSolver>(
-            *mpmesh_model_part, pscheme, pNewLinearSolver,
-            mpbuilder_and_solver_z, ComputeReactions,
-            mreform_dof_set_at_each_step, calculate_norm_dx_flag));
+    mstrategy_z = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace,TLinearSolver>(
+        *mpmesh_model_part,
+        pscheme,
+        mpbuilder_and_solver_z,
+        ComputeReactions,
+        mreform_dof_set_at_each_step,
+        calculate_norm_dx_flag));
 
     mstrategy_z->SetEchoLevel(mecho_level);
 

--- a/applications/MeshMovingApplication/custom_strategies/strategies/structural_meshmoving_strategy.h
+++ b/applications/MeshMovingApplication/custom_strategies/strategies/structural_meshmoving_strategy.h
@@ -108,12 +108,13 @@ public:
                                                TLinearSolver>(
             pNewLinearSolver));
 
-    mstrategy = typename BaseType::Pointer(
-        new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace,
-                                        TLinearSolver>(
-            *mpmesh_model_part, pscheme, pNewLinearSolver, mpbulider_and_solver,
-            mcompute_reactions, mreform_dof_set_at_each_step,
-            calculate_norm_dx_flag));
+    mstrategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace,TLinearSolver>(
+        *mpmesh_model_part,
+        pscheme,
+        mpbulider_and_solver,
+        mcompute_reactions,
+        mreform_dof_set_at_each_step,
+        calculate_norm_dx_flag));
 
     mstrategy->SetEchoLevel(mecho_level);
 

--- a/applications/MeshMovingApplication/custom_utilities/fixed_mesh_ale_utilities.cpp
+++ b/applications/MeshMovingApplication/custom_utilities/fixed_mesh_ale_utilities.cpp
@@ -305,7 +305,6 @@ namespace Kratos
         mpMeshMovingStrategy = Kratos::make_shared<StrategyType>(
             mrVirtualModelPart,
             p_scheme,
-            mpLinearSolver,
             p_builder_and_solver,
             compute_reactions,
             reform_dof_set_at_each_step,

--- a/applications/TrilinosApplication/custom_processes/trilinos_levelset_convection_process.h
+++ b/applications/TrilinosApplication/custom_processes/trilinos_levelset_convection_process.h
@@ -155,7 +155,6 @@ public:
         (this->mpSolvingStrategy) = Kratos::make_unique< ResidualBasedLinearStrategy<TSparseSpace,TDenseSpace,TLinearSolver > >(
             *BaseType::mpDistanceModelPart,
             p_scheme,
-            pLinearSolver,
             p_builder_and_solver,
             calculate_reactions,
             reform_dof_at_each_iteration,
@@ -372,5 +371,3 @@ template< unsigned int TDim, class TSparseSpace, class TDenseSpace, class TLinea
 }  // namespace Kratos.
 
 #endif // KRATOS_TRILINOS_LEVELSET_CONVECTION_PROCESS_INCLUDED  defined
-
-

--- a/applications/TrilinosApplication/custom_strategies/strategies/trilinos_fractionalstep_configuration.h
+++ b/applications/TrilinosApplication/custom_strategies/strategies/trilinos_fractionalstep_configuration.h
@@ -130,7 +130,13 @@ public:
         BuilderSolverTypePointer vel_build =
             BuilderSolverTypePointer(
                 new TrilinosResidualBasedEliminationBuilderAndSolverComponentwiseSplit<TSparseSpace,TDenseSpace,TLinearSolver,VarComponent>(Comm,guess_row_size,pNewVelocityLinearSolver,this->mDomainSize,FRACT_VEL_X,FRACT_VEL_Y,FRACT_VEL_Z) );
-        this->mpfracvel_strategy = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,  TDenseSpace, TLinearSolver >(model_part,pscheme,pNewVelocityLinearSolver,vel_build,CalculateReactions,ReformDofAtEachIteration,CalculateNormDxFlag)  );
+        this->mpfracvel_strategy = typename BaseType::Pointer( new ResidualBasedLinearStrategy<TSparseSpace,  TDenseSpace, TLinearSolver >(
+            model_part,
+            pscheme,
+            vel_build,
+            CalculateReactions,
+            ReformDofAtEachIteration,
+            CalculateNormDxFlag));
         this->mpfracvel_strategy->SetEchoLevel(1);
 
 // 			BuilderSolverTypePointer vel_y_build	= BuilderSolverTypePointer(	new TrilinosResidualBasedEliminationBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>(Comm,guess_row_size,pNewVelocityLinearSolver) );
@@ -157,7 +163,13 @@ public:
 //				this->mppressurestep->SetEchoLevel(1);
 
             BuilderSolverTypePointer pressure_builderandsolver = BuilderSolverTypePointer(	new TrilinosResidualBasedEliminationBuilderAndSolver<TSparseSpace,TDenseSpace,TLinearSolver>(Comm,guess_row_size,pNewPressureLinearSolver) );
-            this->mppressurestep = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace,  TDenseSpace, TLinearSolver >(model_part,pscheme,pNewVelocityLinearSolver,pressure_builderandsolver,CalculateReactions,ReformDofAtEachIteration,CalculateNormDxFlag)  );
+            this->mppressurestep = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace,  TDenseSpace, TLinearSolver >(
+                model_part,
+                pscheme,
+                pressure_builderandsolver,
+                CalculateReactions,
+                ReformDofAtEachIteration,
+                CalculateNormDxFlag));
             this->mppressurestep->SetEchoLevel(1);
 
         }

--- a/applications/TrilinosApplication/custom_strategies/strategies/trilinos_laplacian_meshmoving_strategy.h
+++ b/applications/TrilinosApplication/custom_strategies/strategies/trilinos_laplacian_meshmoving_strategy.h
@@ -129,9 +129,13 @@ public:
             new TrilinosBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver>(
                 Communicator, guess_row_size, pNewLinearSolver));
 
-        mstrategy = typename BaseType::Pointer(
-            new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(
-                *mpmesh_model_part, pscheme, pNewLinearSolver, aux_var_build, m_compute_reactions, m_reform_dof_set_at_each_step, calculate_norm_dx_flag));
+        mstrategy = typename BaseType::Pointer(new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(
+            *mpmesh_model_part,
+            pscheme,
+            aux_var_build,
+            m_compute_reactions,
+            m_reform_dof_set_at_each_step,
+            calculate_norm_dx_flag));
 
         mstrategy->SetEchoLevel(m_echo_level);
 

--- a/applications/TrilinosApplication/custom_strategies/strategies/trilinos_structural_meshmoving_strategy.h
+++ b/applications/TrilinosApplication/custom_strategies/strategies/trilinos_structural_meshmoving_strategy.h
@@ -129,7 +129,6 @@ public:
             new ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(
                 *mpmesh_model_part,
                 pscheme,
-                pNewLinearSolver,
                 builderSolver,
                 m_compute_reactions,
                 m_reform_dof_set_at_each_step,

--- a/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
+++ b/kratos/processes/calculate_embedded_nodal_variable_from_skin_process.h
@@ -599,7 +599,6 @@ protected:
         mpSolvingStrategy = Kratos::make_unique<ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver>>(
             r_aux_model_part,
             p_scheme,
-            mpLinearSolver,
             p_builder_and_solver,
             calculate_reactions,
             reform_dof_at_each_iteration,

--- a/kratos/processes/levelset_convection_process.h
+++ b/kratos/processes/levelset_convection_process.h
@@ -148,7 +148,6 @@ public:
         mpSolvingStrategy = Kratos::make_unique< ResidualBasedLinearStrategy<TSparseSpace,TDenseSpace,TLinearSolver > >(
             *mpDistanceModelPart,
             pscheme,
-            plinear_solver,
             pBuilderSolver,
             CalculateReactions,
             ReformDofAtEachIteration,
@@ -573,4 +572,3 @@ inline std::ostream& operator << (
 }  // namespace Kratos.
 
 #endif // KRATOS_LEVELSET_CONVECTION_PROCESS_INCLUDED  defined
-

--- a/kratos/processes/variational_distance_calculation_process.h
+++ b/kratos/processes/variational_distance_calculation_process.h
@@ -143,7 +143,7 @@ public:
 
         auto p_builder_solver = Kratos::make_shared<ResidualBasedBlockBuilderAndSolver<TSparseSpace, TDenseSpace, TLinearSolver> >(pLinearSolver);
 
-        InitializeSolutionStrategy(pLinearSolver, p_builder_solver);
+        InitializeSolutionStrategy(p_builder_solver);
 
         KRATOS_CATCH("")
     }
@@ -179,7 +179,7 @@ public:
         // Generate an auxilary model part and populate it by elements of type DistanceCalculationElementSimplex
         ReGenerateDistanceModelPart(rBaseModelPart);
 
-        InitializeSolutionStrategy(pLinearSolver, pBuilderAndSolver);
+        InitializeSolutionStrategy(pBuilderAndSolver);
 
         KRATOS_CATCH("")
     }
@@ -447,9 +447,7 @@ protected:
         VariableUtils().CheckVariableExists<Variable<double > >(FLAG_VARIABLE, mrBaseModelPart.Nodes());
     }
 
-    void InitializeSolutionStrategy(
-        typename TLinearSolver::Pointer pLinearSolver,
-        BuilderSolverPointerType pBuilderAndSolver)
+    void InitializeSolutionStrategy(BuilderSolverPointerType pBuilderAndSolver)
     {
         // Generate a linear strategy
         auto p_scheme = Kratos::make_shared< ResidualBasedIncrementalUpdateStaticScheme< TSparseSpace,TDenseSpace > >();
@@ -463,7 +461,6 @@ protected:
         mpSolvingStrategy = Kratos::make_unique<ResidualBasedLinearStrategy<TSparseSpace, TDenseSpace, TLinearSolver> >(
             r_distance_model_part,
             p_scheme,
-            pLinearSolver,
             pBuilderAndSolver,
             CalculateReactions,
             ReformDofAtEachIteration,


### PR DESCRIPTION
**Description**
Remove the deprecated strategies constructors usages in the `FluidDynamicsApplication` and other fluid-related places.

Please mark the PR with appropriate tags: 
- Applications
- Cleanup
- Warning
- Deprecated

**Changelog**
Remove the linear solver & builder and solver constructors usages.