### PR TITLE
[CI] adding -Wparentheses to Clang error flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         elif [ ${{ matrix.compiler }} = clang ]; then
           export CC=clang-9
           export CXX=clang++-9
-          export KRATOS_CMAKE_CXX_FLAGS="-Werror=delete-non-abstract-non-virtual-dtor -Werror=extra-tokens -Werror=defaulted-function-deleted -Werror=potentially-evaluated-expression -Werror=instantiation-after-specialization -Werror=undefined-var-template -Werror=unused-lambda-capture -Werror=unused-const-variable"
+          export KRATOS_CMAKE_CXX_FLAGS="-Werror=delete-non-abstract-non-virtual-dtor -Werror=extra-tokens -Werror=defaulted-function-deleted -Werror=potentially-evaluated-expression -Werror=instantiation-after-specialization -Werror=undefined-var-template -Werror=unused-lambda-capture -Werror=unused-const-variable -Werror=parentheses"
         else
           echo 'Unsupported compiler: ${{ matrix.compiler }}'
           exit 1

--- a/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
@@ -588,14 +588,14 @@ namespace MPMSearchElementUtility
     inline bool IntersectionCheckWithBoundingBox(const GeometryType& rGeom, const array_1d<double, 3>& rCoord, const double SideHalfLength)
     {
         const double z_coord = (rGeom.WorkingSpaceDimension() == 3) ? SideHalfLength : 0.0;
-        const Point point_low(rCoord[0] - SideHalfLength, rCoord[1] - SideHalfLength, rCoord[2] - z_coord;
-        const Point point_high(rCoord[0] + SideHalfLength, rCoord[1] + SideHalfLength, rCoord[2] + z_coord;
+        const Point point_low(rCoord[0] - SideHalfLength, rCoord[1] - SideHalfLength, rCoord[2] - z_coord);
+        const Point point_high(rCoord[0] + SideHalfLength, rCoord[1] + SideHalfLength, rCoord[2] + z_coord);
         NodeType ele_point_low, ele_point_high;
 
         const double dimension_45_degree_factor = (rGeom.WorkingSpaceDimension() == 3) ? 1.7321 : 1.414214;
         double center_to_center = norm_2(rGeom.Center() - rCoord);
         rGeom.BoundingBox(ele_point_low, ele_point_high);
-        double maximum_contact_range = (dimension_45_degree_factor * SideHalfLength +
+        double maximum_contact_range = dimension_45_degree_factor * SideHalfLength +
             norm_2(ele_point_high - ele_point_low);
         if (center_to_center <= maximum_contact_range) return true;
         return false;

--- a/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
@@ -587,12 +587,12 @@ namespace MPMSearchElementUtility
 
     inline bool IntersectionCheckWithBoundingBox(const GeometryType& rGeom, const array_1d<double, 3>& rCoord, const double SideHalfLength)
     {
-        const double z_coord = (rGeom.WorkingSpaceDimension() == 3) ? SideHalfLength : 0.0);
+        const double z_coord = (rGeom.WorkingSpaceDimension() == 3) ? SideHalfLength : 0.0;
         const Point point_low(rCoord[0] - SideHalfLength, rCoord[1] - SideHalfLength, rCoord[2] - z_coord;
         const Point point_high(rCoord[0] + SideHalfLength, rCoord[1] + SideHalfLength, rCoord[2] + z_coord;
         NodeType ele_point_low, ele_point_high;
 
-        const double dimension_45_degree_factor = (rGeom.WorkingSpaceDimension() == 3) ? 1.7321 : 1.414214);
+        const double dimension_45_degree_factor = (rGeom.WorkingSpaceDimension() == 3) ? 1.7321 : 1.414214;
         double center_to_center = norm_2(rGeom.Center() - rCoord);
         rGeom.BoundingBox(ele_point_low, ele_point_high);
         double maximum_contact_range = (dimension_45_degree_factor * SideHalfLength +

--- a/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
+++ b/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h
@@ -587,16 +587,15 @@ namespace MPMSearchElementUtility
 
     inline bool IntersectionCheckWithBoundingBox(const GeometryType& rGeom, const array_1d<double, 3>& rCoord, const double SideHalfLength)
     {
-        const Point point_low(rCoord[0] - SideHalfLength, rCoord[1] - SideHalfLength,
-            rCoord[2] - (rGeom.WorkingSpaceDimension() == 3) ? SideHalfLength : 0.0);
-        const Point point_high(rCoord[0] + SideHalfLength, rCoord[1] + SideHalfLength,
-            rCoord[2] + (rGeom.WorkingSpaceDimension() == 3) ? 1.0 : 0.0 * SideHalfLength);
+        const double z_coord = (rGeom.WorkingSpaceDimension() == 3) ? SideHalfLength : 0.0);
+        const Point point_low(rCoord[0] - SideHalfLength, rCoord[1] - SideHalfLength, rCoord[2] - z_coord;
+        const Point point_high(rCoord[0] + SideHalfLength, rCoord[1] + SideHalfLength, rCoord[2] + z_coord;
         NodeType ele_point_low, ele_point_high;
 
-
+        const double dimension_45_degree_factor = (rGeom.WorkingSpaceDimension() == 3) ? 1.7321 : 1.414214);
         double center_to_center = norm_2(rGeom.Center() - rCoord);
         rGeom.BoundingBox(ele_point_low, ele_point_high);
-        double maximum_contact_range = ((rGeom.WorkingSpaceDimension() == 3) ? 1.7321 : 1.414214 )* SideHalfLength +
+        double maximum_contact_range = (dimension_45_degree_factor * SideHalfLength +
             norm_2(ele_point_high - ele_point_low);
         if (center_to_center <= maximum_contact_range) return true;
         return false;


### PR DESCRIPTION
**Description**
As title says

@KratosMultiphysics/mpm I think this might be a bug, can you please take a look?

~~~
In file included from /home/philippb/software/Kratos_master/applications/ParticleMechanicsApplication/custom_python/add_custom_utilities_to_python.cpp:25:
/home/philippb/software/Kratos_master/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h:591:62: warning: operator '?:' has lower precedence than '-'; '-' will be evaluated first [-Wparentheses]
            rCoord[2] - (rGeom.WorkingSpaceDimension() == 3) ? SideHalfLength : 0.0);
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/home/philippb/software/Kratos_master/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h:591:62: note: place parentheses around the '-' expression to silence this warning
            rCoord[2] - (rGeom.WorkingSpaceDimension() == 3) ? SideHalfLength : 0.0);
                                                             ^
            (                                               )
/home/philippb/software/Kratos_master/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h:591:62: note: place parentheses around the '?:' expression to evaluate it first
            rCoord[2] - (rGeom.WorkingSpaceDimension() == 3) ? SideHalfLength : 0.0);
                                                             ^
                        (                                                          )
/home/philippb/software/Kratos_master/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h:593:62: warning: operator '?:' has lower precedence than '+'; '+' will be evaluated first [-Wparentheses]
            rCoord[2] + (rGeom.WorkingSpaceDimension() == 3) ? 1.0 : 0.0 * SideHalfLength);
            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^
/home/philippb/software/Kratos_master/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h:593:62: note: place parentheses around the '+' expression to silence this warning
            rCoord[2] + (rGeom.WorkingSpaceDimension() == 3) ? 1.0 : 0.0 * SideHalfLength);
                                                             ^
            (                                               )
/home/philippb/software/Kratos_master/applications/ParticleMechanicsApplication/custom_utilities/mpm_search_element_utility.h:593:62: note: place parentheses around the '?:' expression to evaluate it first
            rCoord[2] + (rGeom.WorkingSpaceDimension() == 3) ? 1.0 : 0.0 * SideHalfLength);
~~~