### PR TITLE
[Mapping] make import of python mappers possible

### DIFF
--- a/applications/MappingApplication/python_scripts/python_mapper_factory.py
+++ b/applications/MappingApplication/python_scripts/python_mapper_factory.py
@@ -8,6 +8,8 @@
 import KratosMultiphysics as KM
 from KratosMultiphysics.MappingApplication import MapperFactory
 
+from importlib import import_module
+
 def CreateMapper(model_part_origin, model_part_destination, mapper_settings):
     if not isinstance(mapper_settings, KM.Parameters):
         raise Exception("expected input shall be a Parameters object, encapsulating a json string")
@@ -17,6 +19,12 @@ def CreateMapper(model_part_origin, model_part_destination, mapper_settings):
     # use the MappingApp if it has the requested mapper
     if MapperFactory.HasMapper(mapper_type):
         return MapperFactory.CreateMapper(model_part_origin, model_part_destination, mapper_settings)
+    else:
+        try:
+            mapper_module = import_module(mapper_type)
+            return mapper_module.Create(model_part_origin, model_part_destination, mapper_settings)
+        except BaseException as e:
+            KM.Logger.PrintWarning("PythonMapperFactory", 'Creating a python based mapper failed with the following error:\n', e)
 
     list_avail_mappers = MapperFactory.GetRegisteredMapperNames()
 
@@ -36,6 +44,12 @@ def CreateMPIMapper(model_part_origin, model_part_destination, mapper_settings):
     # use the MappingApp if it has the requested mapper
     if MapperFactory.HasMPIMapper(mapper_type):
         return MapperFactory.CreateMPIMapper(model_part_origin, model_part_destination, mapper_settings)
+    else:
+        try:
+            mapper_module = import_module(mapper_type)
+            return mapper_module.Create(model_part_origin, model_part_destination, mapper_settings)
+        except BaseException as e:
+            KM.Logger.PrintWarning("PythonMapperFactory", 'Creating a python based mapper failed with the following error:\n', e)
 
     list_avail_mappers = MapperFactory.GetRegisteredMPIMapperNames()
 


### PR DESCRIPTION
**Description**
Minor improvement to make import of python based mappers (like in #7452) possible

FYI this is how it can now be used from CoSim:
~~~json
"type" : "kratos_mapping",
"mapper_settings" : {
    "mapper_type"     : "KratosMultiphysics.MappingApplication.empire_mortar_mapper",
    "path_mapper_lib" : "/home/philippb/software/empire/EMPIRE-Core/lib/libEMPIRE_MapperLib.so"
}
~~~