### PR TITLE
MassConservationCheckProcess Correction

### DIFF
--- a/applications/FluidDynamicsApplication/custom_processes/mass_conservation_check_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/mass_conservation_check_process.cpp
@@ -200,8 +200,16 @@ void MassConservationCheckProcess::ComputeVolumesAndInterface( double& positiveV
             Vector Distance( rGeom.PointsNumber(), 0.0 );
             for (unsigned int i = 0; i < rGeom.PointsNumber(); i++){
                 // Control mechanism to avoid 0.0 ( is necessary because "distance_modification" possibly not yet executed )
-                if ( rGeom[i].FastGetSolutionStepValue(DISTANCE) == 0.0 ){
-                    it_elem->GetGeometry().GetPoint(i).FastGetSolutionStepValue(DISTANCE) = 1.0e-7;
+                const double dist = rGeom[i].FastGetSolutionStepValue(DISTANCE);
+                if ( std::abs(dist) < 1.0e-15 ){
+                    if (dist > 0.0){
+                        it_elem->GetGeometry().GetPoint(i).FastGetSolutionStepValue(DISTANCE) =
+                        1.0e-6*it_elem->GetGeometry().GetPoint(i).GetValue(NODAL_H);
+                    }
+                    else{
+                        it_elem->GetGeometry().GetPoint(i).FastGetSolutionStepValue(DISTANCE) =
+                        -1.0e-6*it_elem->GetGeometry().GetPoint(i).GetValue(NODAL_H);
+                    }
                 }
                 Distance[i] = rGeom[i].FastGetSolutionStepValue(DISTANCE);
             }

--- a/applications/FluidDynamicsApplication/custom_processes/mass_conservation_check_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/mass_conservation_check_process.cpp
@@ -169,7 +169,7 @@ void MassConservationCheckProcess::ComputeVolumesAndInterface( double& positiveV
         Matrix shape_functions;
         GeometryType::ShapeFunctionsGradientsType shape_derivatives;
 
-        const auto rGeom = it_elem->GetGeometry();
+        auto& rGeom = it_elem->GetGeometry();
         unsigned int pt_count_pos = 0;
         unsigned int pt_count_neg = 0;
 
@@ -202,8 +202,8 @@ void MassConservationCheckProcess::ComputeVolumesAndInterface( double& positiveV
                 // Control mechanism to avoid 0.0 ( is necessary because "distance_modification" possibly not yet executed )
                 double& r_dist = rGeom[i].FastGetSolutionStepValue(DISTANCE);
                 if (std::abs(r_dist) < 1.0e-12) {
-                    const double aux_dist = 1.0e-6* rGeom[i].GetValue(NODAL_H)
-                    if (dist > 0.0) {
+                    const double aux_dist = 1.0e-6* rGeom[i].GetValue(NODAL_H);
+                    if (r_dist > 0.0) {
                         #pragma omp critical
                         r_dist = aux_dist;
                     } else {

--- a/applications/FluidDynamicsApplication/custom_processes/mass_conservation_check_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/mass_conservation_check_process.cpp
@@ -203,10 +203,12 @@ void MassConservationCheckProcess::ComputeVolumesAndInterface( double& positiveV
                 const double dist = rGeom[i].FastGetSolutionStepValue(DISTANCE);
                 if ( std::abs(dist) < 1.0e-15 ){
                     if (dist > 0.0){
+                        #pragma omp critical
                         it_elem->GetGeometry().GetPoint(i).FastGetSolutionStepValue(DISTANCE) =
                         1.0e-6*it_elem->GetGeometry().GetPoint(i).GetValue(NODAL_H);
                     }
                     else{
+                        #pragma omp critical
                         it_elem->GetGeometry().GetPoint(i).FastGetSolutionStepValue(DISTANCE) =
                         -1.0e-6*it_elem->GetGeometry().GetPoint(i).GetValue(NODAL_H);
                     }

--- a/applications/FluidDynamicsApplication/custom_processes/mass_conservation_check_process.cpp
+++ b/applications/FluidDynamicsApplication/custom_processes/mass_conservation_check_process.cpp
@@ -200,17 +200,15 @@ void MassConservationCheckProcess::ComputeVolumesAndInterface( double& positiveV
             Vector Distance( rGeom.PointsNumber(), 0.0 );
             for (unsigned int i = 0; i < rGeom.PointsNumber(); i++){
                 // Control mechanism to avoid 0.0 ( is necessary because "distance_modification" possibly not yet executed )
-                const double dist = rGeom[i].FastGetSolutionStepValue(DISTANCE);
-                if ( std::abs(dist) < 1.0e-15 ){
-                    if (dist > 0.0){
+                double& r_dist = rGeom[i].FastGetSolutionStepValue(DISTANCE);
+                if (std::abs(r_dist) < 1.0e-12) {
+                    const double aux_dist = 1.0e-6* rGeom[i].GetValue(NODAL_H)
+                    if (dist > 0.0) {
                         #pragma omp critical
-                        it_elem->GetGeometry().GetPoint(i).FastGetSolutionStepValue(DISTANCE) =
-                        1.0e-6*it_elem->GetGeometry().GetPoint(i).GetValue(NODAL_H);
-                    }
-                    else{
+                        r_dist = aux_dist;
+                    } else {
                         #pragma omp critical
-                        it_elem->GetGeometry().GetPoint(i).FastGetSolutionStepValue(DISTANCE) =
-                        -1.0e-6*it_elem->GetGeometry().GetPoint(i).GetValue(NODAL_H);
+                        r_dist = -aux_dist;
                     }
                 }
                 Distance[i] = rGeom[i].FastGetSolutionStepValue(DISTANCE);


### PR DESCRIPTION
**Description**
MassConservationCheckProcess may lead to unresolved Jacobian matrix within ComputeFaceValuesOnOneSide. The solution is to slightly modify the distance in a way that the interface does not coincide with any node. However, the correction needs to be consistent with the implemented definition of the cut element. 

Anyway, I am not sure if "#pragma omp critical" is needed.
