### PR TITLE
[Core][ParUtils] fix compilation when shared memory parallelization is disabled

### DIFF
--- a/kratos/utilities/parallel_utilities.h
+++ b/kratos/utilities/parallel_utilities.h
@@ -25,7 +25,9 @@
 #include <thread>
 
 // External includes
+#ifdef KRATOS_SMP_OPENMP
 #include <omp.h>
+#endif
 
 // Project includes
 #include "includes/define.h"
@@ -35,6 +37,16 @@
 
 namespace Kratos
 {
+
+// this is temporary until it is available directly from Kratos
+// only necessary to compile when shared memory parallelization is disabled
+#ifdef KRATOS_SMP_NONE
+namespace {
+int omp_get_max_threads() {return 1;}
+}
+#endif
+
+
 ///@addtogroup KratosCore
 
 //***********************************************************************************


### PR DESCRIPTION
**Description**
Compiling Kratos without shared memory parallelization is currently broken because of the use of `omp_get_max_threads` e.g. here:
https://github.com/KratosMultiphysics/Kratos/blob/187d90eb929c73da8644b4a26fbaa2c6360e8409/kratos/utilities/parallel_utilities.h#L61-L63

This PR adds a function that mimics it in case shared memory parallelization is disabled.
This is TEMPORARY until we have a Kratos native solution for this (I have some draft for this)