### PR TITLE
[Discussion][Core] Adding Common Reducer

### DIFF
--- a/kratos/utilities/reduction_utilities.h
+++ b/kratos/utilities/reduction_utilities.h
@@ -80,9 +80,10 @@ public:
     /// THREADSAFE (needs some sort of lock guard) reduction, to be used to sync threads
     void ThreadSafeReduce(const Reducer<TDataType>& rOther)
     {
+        const TDataType& r_other_value = rOther.GetValue();
 #pragma omp critical
         {
-            mF(mReducedValue, rOther.GetValue());
+            mF(mReducedValue, r_other_value);
         }
     }
 

--- a/kratos/utilities/reduction_utilities.h
+++ b/kratos/utilities/reduction_utilities.h
@@ -68,6 +68,9 @@ public:
         return mReducedValue;
     }
 
+    /// Destructor. Do nothing!!!
+    virtual ~Reducer() {}
+
     /// NON-THREADSAFE (fast) value of reduction, to be used within a single thread
     void LocalReduce(const TDataType& value)
     {

--- a/kratos/utilities/reduction_utilities.h
+++ b/kratos/utilities/reduction_utilities.h
@@ -51,6 +51,7 @@ public:
     {
     }
 
+    /// Custom constructor with initialization
     Reducer(const TDataType& rInitialValue,
             std::function<void(TDataType&, const TDataType&)>&& f)
         : mReducedValue(rInitialValue),
@@ -60,8 +61,10 @@ public:
     }
 
     /// access to reduced value
-    TDataType GetValue() const
+    virtual TDataType GetValue() const
     {
+        // this method is made virtual so, if required they can perform some thread independent
+        // work here such as sorting, so we can optimize global sorting when we have locally thread sorted lists.
         return mReducedValue;
     }
 


### PR DESCRIPTION
**Description**
This PR show cases one of the ways to have a common Reducer, which can be used to create CustomReducers like in the following situation
https://github.com/KratosMultiphysics/Kratos/blob/76f7c206b1bd4bb8461c0769a9a0afb6ca432ae5/kratos/processes/find_global_nodal_neighbours_for_entities_process.cpp#L301-L328

Then above code can be simplified with the commn reducer introduced in this PR as following
```c++
    class GlobalPointerAdder : Reducer<GlobalPointersVector<NodeType>>
    {
    public:
        typedef GlobalPointersVector<NodeType> value_type;
        GlobalPointerAdder(): Reducer<GlobalPointersVector<NodeType>>([](value_type& rReducedVector, const value_type& rVector) {
            for (auto& r_gp : rVector.GetContainer()) {
                rReducedVector.push_back(r_gp);
            }
        })
        {
        }
    };
```

Advantages of this is:
1. There will be much less `#pragma omp critical` sections propagating through Kratos
2. Easy to write own custom reducers
3. Less code duplication.

**Changelog**
- Added `Reducer` to reduction utiltiies
- Changed `MaxReduction` to use `Reducer`
- Changed `MinRedcution` to use `Reducer`