### PR TITLE
[LinSolversApp] fixing feast compileation for older versions of MKL

### DIFF
--- a/applications/LinearSolversApplication/custom_python/add_custom_solvers_to_python.h
+++ b/applications/LinearSolversApplication/custom_python/add_custom_solvers_to_python.h
@@ -20,7 +20,9 @@
 //MKL implements some of FEAST's function. This define excludes the definitions of MKL's FEAST
 //functions in mkl/include/mkl_solvers_ee.h. Otherwise, some functions are defined multiple times
 #if defined USE_EIGEN_FEAST
+// defining both as MKL uses either, depending on the version
 #define _MKL_SOLVERS_EE_H
+#define __MKL_SOLVERS_EE_H
 #endif
 
 namespace Kratos {


### PR DESCRIPTION
**Description**
Fixing the compilation of feast when using an older (I use 2018 which is not that old really) versions of MKL
for some reason MKL switched from using `__MKL_SOLVERS_EE_H` to `_MKL_SOLVERS_EE_H`, not sure why. Solution I came up with is to define both in order to be on the safe side.
I hope this doesn't affect other things. 
Any opinions/suggestions?

This was [first discovered by @manuelmessmer](https://github.com/KratosMultiphysics/Kratos/pull/7131#issuecomment-657426258)
