### PR TITLE
[Core] serializer quadrature point geometry

### DIFF
--- a/kratos/geometries/quadrature_point_geometry.h
+++ b/kratos/geometries/quadrature_point_geometry.h
@@ -70,7 +70,7 @@ public:
     /// using base class functions
     using BaseType::Jacobian;
     using BaseType::DeterminantOfJacobian;
-    using BaseType::ShapeFunctionsValues; 
+    using BaseType::ShapeFunctionsValues;
     using BaseType::ShapeFunctionsLocalGradients;
     using BaseType::InverseOfJacobian;
 
@@ -115,7 +115,7 @@ public:
     /// Constructor with points and geometry shape function container
     QuadraturePointGeometry(
         const PointsArrayType& ThisPoints,
-        GeometryShapeFunctionContainerType& ThisGeometryShapeFunctionContainer)
+        const GeometryShapeFunctionContainerType& ThisGeometryShapeFunctionContainer)
         : BaseType(ThisPoints, &mGeometryData)
         , mGeometryData(
             &msGeometryDimension,
@@ -126,7 +126,7 @@ public:
     /// Constructor with points, geometry shape function container, parent
     QuadraturePointGeometry(
         const PointsArrayType& ThisPoints,
-        GeometryShapeFunctionContainerType& ThisGeometryShapeFunctionContainer,
+        const GeometryShapeFunctionContainerType& ThisGeometryShapeFunctionContainer,
         GeometryType* pGeometryParent)
         : BaseType(ThisPoints, &mGeometryData)
         , mGeometryData(
@@ -463,22 +463,31 @@ private:
     void save( Serializer& rSerializer ) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
-        rSerializer.save("pGeometryParent", mpGeometryParent);
-        rSerializer.save("GeometryData", mGeometryData);
+
+        rSerializer.save("IntegrationPoints", mGeometryData.IntegrationPoints());
+        rSerializer.save("ShapeFunctionsValues", mGeometryData.ShapeFunctionsValues());
+        rSerializer.save("ShapeFunctionsLocalGradients", mGeometryData.ShapeFunctionsLocalGradients());
     }
 
     void load( Serializer& rSerializer ) override
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
-        rSerializer.load("pGeometryParent", mpGeometryParent);
 
-        GeometryDimension local(3, 3, 3);
-        GeometryDimension *temp = &local;
-        rSerializer.load("pGeometryDimension", temp);
+        IntegrationPointsContainerType integration_points;
+        ShapeFunctionsValuesContainerType shape_functions_values;
+        ShapeFunctionsLocalGradientsContainerType shape_functions_local_gradients;
 
-        rSerializer.load("GeometryData", mGeometryData);
+        rSerializer.load("IntegrationPoints", integration_points[GeometryData::GI_GAUSS_1]);
+        rSerializer.load("ShapeFunctionsValues", shape_functions_values[GeometryData::GI_GAUSS_1]);
+        rSerializer.load("ShapeFunctionsLocalGradients", shape_functions_local_gradients[GeometryData::GI_GAUSS_1]);
 
-        mGeometryData.SetGeometryDimension(&msGeometryDimension);
+        mGeometryData.SetGeometryShapeFunctionContainer(GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(
+            GeometryData::GI_GAUSS_1,
+            integration_points,
+            shape_functions_values,
+            shape_functions_local_gradients));
+
+
     }
 
     ///@}

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -417,15 +417,17 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
     const Hexahedra3D20<NodeType> mHexahedra3D20Prototype = Hexahedra3D20<NodeType>( GeometryType::PointsArrayType(20));
     const Hexahedra3D27<NodeType> mHexahedra3D27Prototype = Hexahedra3D27<NodeType>( GeometryType::PointsArrayType(27));
     //QuadraturePointGeometries:
-    const QuadraturePointGeometry<Node<3>,1> mQuadraturePointGeometry1DinWorkingSpace1D = QuadraturePointGeometry<Node<3>,1>(GeometryType::PointsArrayType(),
+    const QuadraturePointGeometry<Node<3>,1> mQuadraturePointGeometryPoint1D = QuadraturePointGeometry<Node<3>,1>(GeometryType::PointsArrayType(),
         GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
-    const QuadraturePointGeometry<Node<3>,2,1> mQuadraturePointGeometry1DinWorkingSpace2D = QuadraturePointGeometry<Node<3>,2,1>(GeometryType::PointsArrayType(),
+    const QuadraturePointGeometry<Node<3>,2,1> mQuadraturePointGeometryPoint2D = QuadraturePointGeometry<Node<3>,2,1>(GeometryType::PointsArrayType(),
         GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
-    const QuadraturePointGeometry<Node<3>,2> mQuadraturePointGeometry2DinWorkingSpace2D = QuadraturePointGeometry<Node<3>,2>(GeometryType::PointsArrayType(),
+    const QuadraturePointGeometry<Node<3>,3,1> mQuadraturePointGeometryPoint3D = QuadraturePointGeometry<Node<3>,3,1>(GeometryType::PointsArrayType(),
         GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
-    const QuadraturePointGeometry<Node<3>,3,2> mQuadraturePointGeometry2DinWorkingSpace3D = QuadraturePointGeometry<Node<3>,3,2>(GeometryType::PointsArrayType(),
+    const QuadraturePointGeometry<Node<3>,2> mQuadraturePointGeometrySurface2D = QuadraturePointGeometry<Node<3>,2>(GeometryType::PointsArrayType(),
         GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
-    const QuadraturePointGeometry<Node<3>,3> mQuadraturePointGeometry3DinWorkingSpace3D = QuadraturePointGeometry<Node<3>,3>(GeometryType::PointsArrayType(),
+    const QuadraturePointGeometry<Node<3>,3,2> mQuadraturePointGeometrySurface3D = QuadraturePointGeometry<Node<3>,3,2>(GeometryType::PointsArrayType(),
+        GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
+    const QuadraturePointGeometry<Node<3>,3> mQuadraturePointGeometrySolid3D = QuadraturePointGeometry<Node<3>,3>(GeometryType::PointsArrayType(),
         GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
 
     // General conditions must be defined

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -427,7 +427,7 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
         GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
     const QuadraturePointGeometry<Node<3>,3,2> mQuadraturePointGeometrySurface3D = QuadraturePointGeometry<Node<3>,3,2>(GeometryType::PointsArrayType(),
         GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
-    const QuadraturePointGeometry<Node<3>,3> mQuadraturePointGeometrySolid3D = QuadraturePointGeometry<Node<3>,3>(GeometryType::PointsArrayType(),
+    const QuadraturePointGeometry<Node<3>,3> mQuadraturePointGeometryVolume3D = QuadraturePointGeometry<Node<3>,3>(GeometryType::PointsArrayType(),
         GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
 
     // General conditions must be defined

--- a/kratos/includes/kratos_application.h
+++ b/kratos/includes/kratos_application.h
@@ -416,6 +416,17 @@ class KRATOS_API(KRATOS_CORE) KratosApplication {
     const Hexahedra3D8<NodeType> mHexahedra3D8Prototype = Hexahedra3D8<NodeType>( GeometryType::PointsArrayType(8));
     const Hexahedra3D20<NodeType> mHexahedra3D20Prototype = Hexahedra3D20<NodeType>( GeometryType::PointsArrayType(20));
     const Hexahedra3D27<NodeType> mHexahedra3D27Prototype = Hexahedra3D27<NodeType>( GeometryType::PointsArrayType(27));
+    //QuadraturePointGeometries:
+    const QuadraturePointGeometry<Node<3>,1> mQuadraturePointGeometry1DinWorkingSpace1D = QuadraturePointGeometry<Node<3>,1>(GeometryType::PointsArrayType(),
+        GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
+    const QuadraturePointGeometry<Node<3>,2,1> mQuadraturePointGeometry1DinWorkingSpace2D = QuadraturePointGeometry<Node<3>,2,1>(GeometryType::PointsArrayType(),
+        GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
+    const QuadraturePointGeometry<Node<3>,2> mQuadraturePointGeometry2DinWorkingSpace2D = QuadraturePointGeometry<Node<3>,2>(GeometryType::PointsArrayType(),
+        GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
+    const QuadraturePointGeometry<Node<3>,3,2> mQuadraturePointGeometry2DinWorkingSpace3D = QuadraturePointGeometry<Node<3>,3,2>(GeometryType::PointsArrayType(),
+        GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
+    const QuadraturePointGeometry<Node<3>,3> mQuadraturePointGeometry3DinWorkingSpace3D = QuadraturePointGeometry<Node<3>,3>(GeometryType::PointsArrayType(),
+        GeometryShapeFunctionContainer<GeometryData::IntegrationMethod>(GeometryData::GI_GAUSS_1, IntegrationPoint<3>(), Matrix(), Matrix()));
 
     // General conditions must be defined
 

--- a/kratos/integration/integration_point.h
+++ b/kratos/integration/integration_point.h
@@ -308,6 +308,25 @@ private:
     TWeightType mWeight;
 
     ///@}
+    ///@name Serialization
+    ///@{
+
+    friend class Serializer;
+
+    void save( Serializer& rSerializer ) const override
+    {
+        KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, BaseType );
+        rSerializer.save("Weight", mWeight);
+
+    }
+
+    void load( Serializer& rSerializer ) override
+    {
+        KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, BaseType );
+        rSerializer.load("Weight", mWeight);
+    }
+
+    ///@}
     ///@name Private Operators
     ///@{
 

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -181,7 +181,7 @@ void KratosApplication::RegisterKratosCore() {
     //Register general geometries:
     // Point register:
     Serializer::Register("Point", mPointPrototype);
-    
+
     // Register + KratosComponents
     KRATOS_REGISTER_GEOMETRY("Point2D", mPoint2DPrototype);
     KRATOS_REGISTER_GEOMETRY("Point3D", mPoint3DPrototype);
@@ -207,6 +207,11 @@ void KratosApplication::RegisterKratosCore() {
     KRATOS_REGISTER_GEOMETRY("Hexahedra3D8", mHexahedra3D8Prototype);
     KRATOS_REGISTER_GEOMETRY("Hexahedra3D20", mHexahedra3D20Prototype);
     KRATOS_REGISTER_GEOMETRY("Hexahedra3D27", mHexahedra3D27Prototype);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometry1DinWorkingSpace1D", mQuadraturePointGeometry1DinWorkingSpace1D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometry1DinWorkingSpace2D", mQuadraturePointGeometry1DinWorkingSpace2D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometry2DinWorkingSpace2D", mQuadraturePointGeometry2DinWorkingSpace2D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometry2DinWorkingSpace3D", mQuadraturePointGeometry2DinWorkingSpace3D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometry3DinWorkingSpace3D", mQuadraturePointGeometry3DinWorkingSpace3D);
 
     // Register flags:
     KRATOS_REGISTER_FLAG(STRUCTURE);

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -207,11 +207,12 @@ void KratosApplication::RegisterKratosCore() {
     KRATOS_REGISTER_GEOMETRY("Hexahedra3D8", mHexahedra3D8Prototype);
     KRATOS_REGISTER_GEOMETRY("Hexahedra3D20", mHexahedra3D20Prototype);
     KRATOS_REGISTER_GEOMETRY("Hexahedra3D27", mHexahedra3D27Prototype);
-    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometry1DinWorkingSpace1D", mQuadraturePointGeometry1DinWorkingSpace1D);
-    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometry1DinWorkingSpace2D", mQuadraturePointGeometry1DinWorkingSpace2D);
-    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometry2DinWorkingSpace2D", mQuadraturePointGeometry2DinWorkingSpace2D);
-    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometry2DinWorkingSpace3D", mQuadraturePointGeometry2DinWorkingSpace3D);
-    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometry3DinWorkingSpace3D", mQuadraturePointGeometry3DinWorkingSpace3D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometryPoint1D", mQuadraturePointGeometryPoint1D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometryPoint2D", mQuadraturePointGeometryPoint2D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometryPoint3D", mQuadraturePointGeometryPoint3D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometrySurface2D", mQuadraturePointGeometrySurface2D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometrySurface3D", mQuadraturePointGeometrySurface3D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometrySolid3D", mQuadraturePointGeometrySolid3D);
 
     // Register flags:
     KRATOS_REGISTER_FLAG(STRUCTURE);

--- a/kratos/sources/kratos_application.cpp
+++ b/kratos/sources/kratos_application.cpp
@@ -212,7 +212,7 @@ void KratosApplication::RegisterKratosCore() {
     KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometryPoint3D", mQuadraturePointGeometryPoint3D);
     KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometrySurface2D", mQuadraturePointGeometrySurface2D);
     KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometrySurface3D", mQuadraturePointGeometrySurface3D);
-    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometrySolid3D", mQuadraturePointGeometrySolid3D);
+    KRATOS_REGISTER_GEOMETRY("QuadraturePointGeometryVolume3D", mQuadraturePointGeometryVolume3D);
 
     // Register flags:
     KRATOS_REGISTER_FLAG(STRUCTURE);

--- a/kratos/tests/cpp_tests/sources/test_serializer_geometry_data.cpp
+++ b/kratos/tests/cpp_tests/sources/test_serializer_geometry_data.cpp
@@ -161,7 +161,7 @@ namespace Kratos {
             serializer.load("qp", quadrature_loaded);
 
             // Check coordinates
-            for(unsigned int i; i < 3; ++i){
+            for(unsigned int i = 0; i < 3; ++i){
                 KRATOS_CHECK_NEAR((*quadrature_saved)[i].X(), (*quadrature_loaded)[i].X(), 1e-6);
                 KRATOS_CHECK_NEAR((*quadrature_saved)[i].Y(), (*quadrature_loaded)[i].Y(), 1e-6);
                 KRATOS_CHECK_NEAR((*quadrature_saved)[i].Z(), (*quadrature_loaded)[i].Z(), 1e-6);

--- a/kratos/tests/cpp_tests/sources/test_serializer_geometry_data.cpp
+++ b/kratos/tests/cpp_tests/sources/test_serializer_geometry_data.cpp
@@ -72,7 +72,7 @@ namespace Kratos {
                 );
         }
 
-        Geometry<Node<3>>::Pointer GenerateQuadraturePoint2(ModelPart& rModelPart) {
+        Geometry<Node<3>>::Pointer GenerateQuadraturePoint2DTest(ModelPart& rModelPart) {
             auto triangle = GeneratePointsTriangle2D3TestQP(rModelPart);
 
             auto integration_points = triangle->IntegrationPoints();
@@ -97,6 +97,22 @@ namespace Kratos {
                     triangle->Points(),
                     data_container,
                     triangle.get()));
+
+            return p_this_quadrature_point;
+        }
+
+        Geometry<Node<3>>::Pointer GenerateQuadraturePoint2DTestLoad() {
+
+            GeometryShapeFunctionContainer<GeometryData::IntegrationMethod> data_container(
+                GeometryData::GI_GAUSS_1,
+                IntegrationPoint<3>(),
+                Matrix(),
+                Matrix());
+
+            Geometry<Node<3>>::Pointer p_this_quadrature_point(
+                Kratos::make_shared<QuadraturePointGeometry<Node<3>, 2>>(
+                    GeometryType::PointsArrayType(3),
+                    data_container));
 
             return p_this_quadrature_point;
         }
@@ -128,6 +144,54 @@ namespace Kratos {
             KRATOS_CHECK_EQUAL(line_saved->GetDefaultIntegrationMethod(), line_loaded->GetDefaultIntegrationMethod());
 
             KRATOS_CHECK_EQUAL(&(line_saved->GetGeometryData()), &(line_loaded->GetGeometryData()));
+        }
+
+        KRATOS_TEST_CASE_IN_SUITE(SerializerQuadraturePoint, KratosCoreFastSuite)
+        {
+            Model model;
+            auto& mp = model.CreateModelPart("SerializerQuadraturePoint");
+
+            StreamSerializer serializer;
+
+            auto quadrature_saved = GenerateQuadraturePoint2DTest(mp);
+
+            auto quadrature_loaded = GenerateQuadraturePoint2DTestLoad(); // Empty quadrature point geometry
+
+            serializer.save("qp", quadrature_saved);
+            serializer.load("qp", quadrature_loaded);
+
+            // Check coordinates
+            for(unsigned int i; i < 3; ++i){
+                KRATOS_CHECK_NEAR((*quadrature_saved)[i].X(), (*quadrature_loaded)[i].X(), 1e-6);
+                KRATOS_CHECK_NEAR((*quadrature_saved)[i].Y(), (*quadrature_loaded)[i].Y(), 1e-6);
+                KRATOS_CHECK_NEAR((*quadrature_saved)[i].Z(), (*quadrature_loaded)[i].Z(), 1e-6);
+            }
+            // Check size and dimension
+            KRATOS_CHECK_EQUAL(quadrature_saved->size(), quadrature_loaded->size());
+            KRATOS_CHECK_EQUAL(quadrature_saved->WorkingSpaceDimension(), quadrature_loaded->WorkingSpaceDimension());
+            KRATOS_CHECK_EQUAL(quadrature_saved->GetDefaultIntegrationMethod(), quadrature_loaded->GetDefaultIntegrationMethod());
+
+            // Check integration point
+            IntegrationPoint<3> point_loaded = quadrature_loaded->GetGeometryData().IntegrationPoints()[0];
+            IntegrationPoint<3> point_saved = quadrature_saved->GetGeometryData().IntegrationPoints()[0];
+            KRATOS_CHECK_NEAR(point_saved.X(), point_loaded.X(), 1e-6);
+            KRATOS_CHECK_NEAR(point_saved.Y(), point_loaded.Y(), 1e-6);
+            KRATOS_CHECK_NEAR(point_saved.Z(), point_loaded.Z(), 1e-6);
+            KRATOS_CHECK_NEAR(point_saved.Weight(), point_loaded.Weight(),1e-6);
+
+            // Check shape functions values
+            KRATOS_CHECK_MATRIX_NEAR(quadrature_saved->ShapeFunctionsValues(),
+                                     quadrature_loaded->ShapeFunctionsValues(), 1e-6);
+
+            // Check shape functions local gradients
+            KRATOS_CHECK_EQUAL(quadrature_loaded->GetGeometryData().ShapeFunctionsLocalGradients().size(),1);
+            KRATOS_CHECK_MATRIX_NEAR(quadrature_saved->GetGeometryData().ShapeFunctionsLocalGradients()[0],
+                                     quadrature_loaded->GetGeometryData().ShapeFunctionsLocalGradients()[0], 1e-6);
+
+            // Check Dimensions of geometry data
+            KRATOS_CHECK_EQUAL(quadrature_saved->GetGeometryData().Dimension(), quadrature_loaded->GetGeometryData().Dimension());
+            KRATOS_CHECK_EQUAL(quadrature_saved->GetGeometryData().WorkingSpaceDimension(), quadrature_loaded->GetGeometryData().WorkingSpaceDimension());
+            KRATOS_CHECK_EQUAL(quadrature_saved->GetGeometryData().LocalSpaceDimension(), quadrature_loaded->GetGeometryData().LocalSpaceDimension());
         }
     } // namespace Testing
 }  // namespace Kratos.


### PR DESCRIPTION
**Description**
This PR shall enable the serialization of the quadrature point geometry, which was not working until now.
@KratosMultiphysics/mpm this is required to send and recieve MPM particle elements (which hold a quadrature point geometry) during a MPM-MPI execution. The respective PR will follow.
@tteschemacher could you also please have a look, because I think you (at least partly) implemented the quadrature point geometry?

**Changelog**
- Necessary changes to serialize quadrature point geometry.
- Adding test case.
- Adding some const's to the quadrature point geometry constructors
