### PR TITLE
[Core] adding ScopeLock

### DIFF
--- a/kratos/CMakeLists.txt
+++ b/kratos/CMakeLists.txt
@@ -111,6 +111,7 @@ set( KRATOS_CORE_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/result_dabatase.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/geometry_utilities.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/utilities/normal_calculation_utils.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/utilities/scope_lock.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/tetrahedra_ball.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/tetrahedra_edge_shell.cpp;
     ${CMAKE_CURRENT_SOURCE_DIR}/modeler/cad_io_modeler.cpp;

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -22,6 +22,7 @@
 #include "includes/parallel_environment.h"
 #include "input_output/logger.h"
 #include "utilities/openmp_utils.h"
+#include "utilities/scope_lock.h"
 
 namespace Kratos {
 Kernel::Kernel(bool IsDistributedRun) : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(
@@ -38,6 +39,8 @@ Kernel::Kernel(bool IsDistributedRun) : mpKratosCoreApplication(Kratos::make_sha
     if (!IsImported("KratosMultiphysics")) {
         this->ImportApplication(mpKratosCoreApplication);
     }
+
+    ScopeLock::InitializeLock();
 }
 
 std::unordered_set<std::string> &Kernel::GetApplicationsList() {

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -40,7 +40,9 @@ Kernel::Kernel(bool IsDistributedRun) : mpKratosCoreApplication(Kratos::make_sha
         this->ImportApplication(mpKratosCoreApplication);
     }
 
-    ScopeLock::InitializeLock();
+    if (!ScopeLock::IsInitialized()) {
+        ScopeLock::Initialize();
+    }
 }
 
 std::unordered_set<std::string> &Kernel::GetApplicationsList() {

--- a/kratos/sources/kernel.cpp
+++ b/kratos/sources/kernel.cpp
@@ -22,7 +22,6 @@
 #include "includes/parallel_environment.h"
 #include "input_output/logger.h"
 #include "utilities/openmp_utils.h"
-#include "utilities/scope_lock.h"
 
 namespace Kratos {
 Kernel::Kernel(bool IsDistributedRun) : mpKratosCoreApplication(Kratos::make_shared<KratosApplication>(
@@ -38,10 +37,6 @@ Kernel::Kernel(bool IsDistributedRun) : mpKratosCoreApplication(Kratos::make_sha
 
     if (!IsImported("KratosMultiphysics")) {
         this->ImportApplication(mpKratosCoreApplication);
-    }
-
-    if (!ScopeLock::IsInitialized()) {
-        ScopeLock::Initialize();
     }
 }
 

--- a/kratos/utilities/auxiliar_model_part_utilities.cpp
+++ b/kratos/utilities/auxiliar_model_part_utilities.cpp
@@ -19,6 +19,7 @@
 // Project includes
 #include "includes/key_hash.h"
 #include "utilities/auxiliar_model_part_utilities.h"
+#include "utilities/scope_lock.h"
 
 namespace Kratos
 {
@@ -83,8 +84,8 @@ void AuxiliarModelPartUtilities::EnsureModelPartOwnsProperties(const bool Remove
         }
 
         // Combine buffers together
-        #pragma omp critical
         {
+            ScopeLock lock;
             list_of_properties.insert(buffer_list_of_properties.begin(),buffer_list_of_properties.end());
         }
     }

--- a/kratos/utilities/scope_lock.cpp
+++ b/kratos/utilities/scope_lock.cpp
@@ -17,7 +17,6 @@
 // External includes
 
 // Project includes
-#include "includes/define.h"
 #include "utilities/scope_lock.h"
 
 
@@ -25,30 +24,14 @@ namespace Kratos {
 
 ScopeLock::ScopeLock()
 {
-    KRATOS_ERROR_IF_NOT(ScopeLock::mIsInitialized) << "ScopeLock is not initialized!" << std::endl;
-    mpLock->SetLock();
+    mLock.SetLock();
 }
 
 ScopeLock::~ScopeLock()
 {
-    mpLock->UnSetLock();
+    mLock.UnSetLock();
 }
 
-bool ScopeLock::IsInitialized()
-{
-    return mIsInitialized;
-}
-
-void ScopeLock::Initialize()
-{
-    KRATOS_ERROR_IF(ScopeLock::mIsInitialized) << "ScopeLock was already initialized!" << std::endl;
-
-    static LockObject static_lock;
-    mpLock = &static_lock;
-    mIsInitialized = true;
-}
-
-LockObject* ScopeLock::mpLock = nullptr;
-bool ScopeLock::mIsInitialized = false;
+LockObject ScopeLock::mLock;
 
 }  // namespace Kratos.

--- a/kratos/utilities/scope_lock.cpp
+++ b/kratos/utilities/scope_lock.cpp
@@ -1,0 +1,49 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher, https://github.com/philbucher
+//                   Suneth Warnakulasuriya, https://github.com/sunethwarna
+//
+
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/define.h"
+#include "utilities/scope_lock.h"
+
+
+namespace Kratos {
+
+ScopeLock::ScopeLock()
+{
+    KRATOS_ERROR_IF_NOT(ScopeLock::mIsInitialized) << "ScopeLock is not initialized!" << std::endl;
+    mpLock->SetLock();
+}
+
+ScopeLock::~ScopeLock()
+{
+    mpLock->UnSetLock();
+}
+
+void ScopeLock::InitializeLock()
+{
+    KRATOS_ERROR_IF(ScopeLock::mIsInitialized) << "ScopeLock was already initialized!" << std::endl;
+
+    static LockObject static_lock;
+    mpLock = &static_lock;
+    mIsInitialized = true;
+}
+
+LockObject* ScopeLock::mpLock = nullptr;
+bool ScopeLock::mIsInitialized = false;
+
+}  // namespace Kratos.

--- a/kratos/utilities/scope_lock.cpp
+++ b/kratos/utilities/scope_lock.cpp
@@ -34,7 +34,12 @@ ScopeLock::~ScopeLock()
     mpLock->UnSetLock();
 }
 
-void ScopeLock::InitializeLock()
+bool ScopeLock::IsInitialized()
+{
+    return mIsInitialized;
+}
+
+void ScopeLock::Initialize()
 {
     KRATOS_ERROR_IF(ScopeLock::mIsInitialized) << "ScopeLock was already initialized!" << std::endl;
 

--- a/kratos/utilities/scope_lock.h
+++ b/kratos/utilities/scope_lock.h
@@ -1,0 +1,78 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Philipp Bucher, https://github.com/philbucher
+//                   Suneth Warnakulasuriya, https://github.com/sunethwarna
+//
+
+
+#if !defined(KRATOS_SCOPE_LOCK_H_INCLUDED)
+#define KRATOS_SCOPE_LOCK_H_INCLUDED
+
+
+// System includes
+
+// External includes
+
+// Project includes
+#include "includes/lock_object.h"
+
+
+namespace Kratos
+{
+///@addtogroup KratosCore
+///@{
+
+///@name Kratos Classes
+///@{
+
+/// Class for locking a scope.
+/** This class is used for locking a scope, i.e. to make this scope act as a critical section.
+*/
+class KRATOS_API(KRATOS_CORE) ScopeLock
+{
+public:
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    ScopeLock();
+
+    /// Destructor.
+    ~ScopeLock();
+
+    ScopeLock(const ScopeLock&) = delete;
+    ScopeLock& operator=(const ScopeLock&) = delete;
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    static void InitializeLock();
+
+    ///@}
+
+private:
+    ///@name Member Variables
+    ///@{
+
+    static LockObject* mpLock;
+    static bool mIsInitialized;
+
+    ///@}
+
+}; // Class ScopeLock
+
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_SCOPE_LOCK_H_INCLUDED defined

--- a/kratos/utilities/scope_lock.h
+++ b/kratos/utilities/scope_lock.h
@@ -21,6 +21,7 @@
 // External includes
 
 // Project includes
+#include "includes/define.h"
 #include "includes/lock_object.h"
 
 
@@ -54,18 +55,13 @@ public:
     ///@name Operations
     ///@{
 
-    static bool IsInitialized();
-
-    static void Initialize();
-
     ///@}
 
 private:
     ///@name Member Variables
     ///@{
 
-    static LockObject* mpLock;
-    static bool mIsInitialized;
+    static LockObject mLock;
 
     ///@}
 

--- a/kratos/utilities/scope_lock.h
+++ b/kratos/utilities/scope_lock.h
@@ -54,7 +54,9 @@ public:
     ///@name Operations
     ///@{
 
-    static void InitializeLock();
+    static bool IsInitialized();
+
+    static void Initialize();
 
     ///@}
 


### PR DESCRIPTION
**Description**
This PR adds the `ScopeLock` which can be used for critical sections (and for porting the `omp critical` sections to be C++11 threads compatible)
The ScopeLock internally uses the `LockObject`

I was discussing with @sunethwarna how to port the omp-critical sections and we came up with a "scoped lock"

usage is the following:
~~~cpp
// some code running in shared mem parallel ...
{ // opening the scope that is critical
    ScopeLock lock; // creating the object will lock (aka calling LockObject.SetLock())
    // .. doing whatever needs to be done
} // at the end of the scope the lock will be destroyed. 
// Destroying the lock will automatically unlock the underlying "actual" lock
// (aka calling LockObject.UnSetLock())
~~~
I added one example of how this would be used, see the changes

One "issue" is that in order to only create & destroy the actual lock which afaik is expensive, the Kernel initializes this lock