### PR TITLE
[LinearSolversApp][MKL] adding options from Intel Link Advisor

### DIFF
--- a/applications/LinearSolversApplication/CMakeLists.txt
+++ b/applications/LinearSolversApplication/CMakeLists.txt
@@ -31,9 +31,23 @@ if( USE_EIGEN_MKL MATCHES ON )
 
         link_directories("$ENV{MKLROOT}/lib")
 
-        if( NOT MSVC )
-            set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -L$ENV{MKLROOT}/lib/intel64 -Wl,--no-as-needed -lpthread -lm -ldl" )
+        # Setting the options from the MKL Link Line Advisor
+        if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+            if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+                set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -L$ENV{MKLROOT}/lib/intel64 -Wl,--no-as-needed -lpthread -lm -ldl" )
+            elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
+                set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -L$ENV{MKLROOT}/lib/intel64 -Wl,--no-as-needed -lpthread -ldl" )
+            endif()
+        elseif (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+            if (${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
+                set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -L${MKLROOT}/lib -Wl,-rpath,${MKLROOT}/lib -lmkl_rt -lpthread -lm -ldl" )
+            elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+                set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -m64 -L${MKLROOT}/lib -Wl,-rpath,${MKLROOT}/lib -lmkl_rt -lpthread -lm -ldl" )
+            elseif (${CMAKE_CXX_COMPILER_ID} MATCHES "Intel")
+                set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -L${MKLROOT}/lib -Wl,-rpath,${MKLROOT}/lib -lmkl_rt -lpthread -lm -ldl" )
+            endif()
         endif()
+
     elseif( DEFINED ENV{CONDA_PREFIX} )
         message("-- Found Conda environment: $ENV{CONDA_PREFIX}")
 


### PR DESCRIPTION
**Description**
Together with @oberbichler we implemented the compiler options from the Intel Link Advisor for the compilers that are available there.
esp for the Intel compiler on Linux it wasn't fully working, now it is resolved

should also help with #7458, I will also test it more in the future.

Here is the options used in the link advisor
![image](https://user-images.githubusercontent.com/25484702/93214031-ed679400-f764-11ea-91bc-0f1b968f241e.png)

For the record: the link advisor also wants to add `-lm ` for the intel compiler but then it complains with the following warning which is why I didn't add it
`icpc: warning #10315: specifying -lm before files may supersede the Intel(R) math library and affect performance`