### PR TITLE
[dem] Removing useless conditions and renaming RigidEdge3D to RigidEdge2D

### DIFF
--- a/applications/DEMApplication/DEM_application.cpp
+++ b/applications/DEMApplication/DEM_application.cpp
@@ -450,33 +450,32 @@ KRATOS_CREATE_LOCAL_FLAG(DEMFlags, POLYHEDRON_SKIN, 18);
 //ELEMENTS
 
 KratosDEMApplication::KratosDEMApplication() : KratosApplication("DEMApplication"),
-      mCylinderParticle2D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mCylinderContinuumParticle2D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mNanoParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mAnalyticSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mSphericContinuumParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mPolyhedronSkinSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mIceContinuumParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mThermalSphericContinuumParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mThermalSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mSinteringSphericContinuumParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mBondingSphericContinuumParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mParticleContactElement(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
-      mSolidFace3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-      mSolidFace3D4N(0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
-      mRigidFace3D2N(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
-      mRigidFace3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-      mRigidFace3D4N(0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
-      mAnalyticRigidFace3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
-      mRigidEdge3D2N(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
-      mRigidEdge2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
-      mRigidBodyElement3D(0, Element::GeometryType::Pointer(new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mShipElement3D(0, Element::GeometryType::Pointer(new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mContactInfoSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mCluster3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mSingleSphereCluster3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
-      mMapCon3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))) {}
+    mCylinderParticle2D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mCylinderContinuumParticle2D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mNanoParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mAnalyticSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mSphericContinuumParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mPolyhedronSkinSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mIceContinuumParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mThermalSphericContinuumParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mThermalSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mSinteringSphericContinuumParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mBondingSphericContinuumParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mParticleContactElement(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
+    mSolidFace3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+    mSolidFace3D4N(0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+    mRigidFace3D2N(0, Element::GeometryType::Pointer(new Line3D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
+    mRigidFace3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+    mRigidFace3D4N(0, Element::GeometryType::Pointer(new Quadrilateral3D4<Node<3> >(Element::GeometryType::PointsArrayType(4)))),
+    mAnalyticRigidFace3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))),
+    mRigidEdge2D2N(0, Element::GeometryType::Pointer(new Line2D2<Node<3> >(Element::GeometryType::PointsArrayType(2)))),
+    mRigidBodyElement3D(0, Element::GeometryType::Pointer(new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mShipElement3D(0, Element::GeometryType::Pointer(new Point3D<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mContactInfoSphericParticle3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mCluster3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mSingleSphereCluster3D(0, Element::GeometryType::Pointer(new Sphere3D1<Node<3> >(Element::GeometryType::PointsArrayType(1)))),
+    mMapCon3D3N(0, Element::GeometryType::Pointer(new Triangle3D3<Node<3> >(Element::GeometryType::PointsArrayType(3)))) {}
 
 // Explicit instantiation of composed constitutive laws
 template class DEM_compound_constitutive_law<DEM_D_Hertz_viscous_Coulomb, DEM_D_JKR_Cohesive_Law>;
@@ -490,7 +489,7 @@ void KratosDEMApplication::Register() {
                     << "            | | | |  _| | |\\/| | |_) / _` |/ __| |/ /      \n"
                     << "            | |_| | |___| |  | |  __/ (_| | (__|   <       \n"
                     << "            |____/|_____|_|  |_|_|   \\__,_|\\___|_|\\_\\      \n"
-                    << "Importing DEMApplication... ";                    
+                    << "Importing DEMApplication... ";
 
     KRATOS_REGISTER_VARIABLE(CONTINUUM_INI_NEIGHBOUR_ELEMENTS)
     KRATOS_REGISTER_VARIABLE(NODE_TO_NEIGH_ELEMENT_POINTER)
@@ -890,8 +889,6 @@ void KratosDEMApplication::Register() {
     KRATOS_REGISTER_CONDITION("RigidFace3D4N", mRigidFace3D4N)
     KRATOS_REGISTER_CONDITION("AnalyticRigidFace3D", mAnalyticRigidFace3D3N)
     KRATOS_REGISTER_CONDITION("AnalyticRigidFace3D3N", mAnalyticRigidFace3D3N)
-    KRATOS_REGISTER_CONDITION("RigidEdge3D", mRigidEdge3D2N)
-    KRATOS_REGISTER_CONDITION("RigidEdge3D2N", mRigidEdge3D2N)
     KRATOS_REGISTER_CONDITION("RigidEdge2D2N", mRigidEdge2D2N)
 
     // SERIALIZER

--- a/applications/DEMApplication/DEM_application.h
+++ b/applications/DEMApplication/DEM_application.h
@@ -104,8 +104,7 @@ private:
     const RigidFace3D  mRigidFace3D3N;
     const RigidFace3D  mRigidFace3D4N;
     const AnalyticRigidFace3D  mAnalyticRigidFace3D3N;
-    const RigidEdge3D  mRigidEdge3D2N;
-    const RigidEdge3D  mRigidEdge2D2N;
+    const RigidEdge2D  mRigidEdge2D2N;
     const RigidBodyElement3D mRigidBodyElement3D;
     const ShipElement3D mShipElement3D;
     const ContactInfoSphericParticle mContactInfoSphericParticle3D;

--- a/applications/DEMApplication/custom_conditions/RigidEdge.cpp
+++ b/applications/DEMApplication/custom_conditions/RigidEdge.cpp
@@ -12,7 +12,7 @@ namespace Kratos
 	using namespace GeometryFunctions;
 //************************************************************************************
 //************************************************************************************
-RigidEdge3D::RigidEdge3D( IndexType NewId,
+RigidEdge2D::RigidEdge2D( IndexType NewId,
         GeometryType::Pointer pGeometry)
     : DEMWall( NewId, pGeometry )
 {
@@ -22,14 +22,14 @@ RigidEdge3D::RigidEdge3D( IndexType NewId,
 //************************************************************************************
 //**** life cycle ********************************************************************
 //************************************************************************************
-RigidEdge3D::RigidEdge3D( IndexType NewId, GeometryType::Pointer pGeometry,
+RigidEdge2D::RigidEdge2D( IndexType NewId, GeometryType::Pointer pGeometry,
         PropertiesType::Pointer pProperties
                                             )
     : DEMWall( NewId, pGeometry, pProperties )
 {
 }
 
-RigidEdge3D::RigidEdge3D( IndexType NewId, GeometryType::Pointer pGeometry,
+RigidEdge2D::RigidEdge2D( IndexType NewId, GeometryType::Pointer pGeometry,
         PropertiesType::Pointer pProperties,
         Condition::Pointer Master,
         Condition::Pointer Slave,
@@ -47,17 +47,17 @@ RigidEdge3D::RigidEdge3D( IndexType NewId, GeometryType::Pointer pGeometry,
 //********************************************************
 
 
-Condition::Pointer RigidEdge3D::Create( IndexType NewId,
+Condition::Pointer RigidEdge2D::Create( IndexType NewId,
         NodesArrayType const& ThisNodes,
         PropertiesType::Pointer pProperties) const
 {
-    return Condition::Pointer( new RigidEdge3D(NewId, GetGeometry().Create(ThisNodes),
+    return Condition::Pointer( new RigidEdge2D(NewId, GetGeometry().Create(ThisNodes),
                                pProperties));
 }
 /**
  * Destructor. Never to be called manually
  */
-RigidEdge3D::~RigidEdge3D()
+RigidEdge2D::~RigidEdge2D()
 {
 }
 
@@ -67,7 +67,7 @@ RigidEdge3D::~RigidEdge3D()
 * calculates only the RHS vector (certainly to be removed due to contact algorithm)
 */
 
-void RigidEdge3D::Initialize(const ProcessInfo& rCurrentProcessInfo) {
+void RigidEdge2D::Initialize(const ProcessInfo& rCurrentProcessInfo) {
 
     if (! rCurrentProcessInfo[IS_RESTARTED]){
         this->GetGeometry()[0].FastGetSolutionStepValue(NON_DIMENSIONAL_VOLUME_WEAR) = 0.0;
@@ -79,7 +79,7 @@ void RigidEdge3D::Initialize(const ProcessInfo& rCurrentProcessInfo) {
 }
 
 
-void RigidEdge3D::ComputeConditionRelativeData(int rigid_neighbour_index,
+void RigidEdge2D::ComputeConditionRelativeData(int rigid_neighbour_index,
                                                SphericParticle* const particle,
                                                double LocalCoordSystem[3][3],
                                                double& DistPToB,
@@ -145,7 +145,7 @@ void RigidEdge3D::ComputeConditionRelativeData(int rigid_neighbour_index,
     }
 }//ComputeConditionRelativeData
 
-void RigidEdge3D::CalculateNormal(array_1d<double, 3>& rnormal){
+void RigidEdge2D::CalculateNormal(array_1d<double, 3>& rnormal){
 
     double delta_x = GetGeometry()[1].X() - GetGeometry()[0].X();
     double delta_y = GetGeometry()[1].Y() - GetGeometry()[0].Y();
@@ -159,7 +159,7 @@ void RigidEdge3D::CalculateNormal(array_1d<double, 3>& rnormal){
 
 
 
-void RigidEdge3D::Calculate(const Variable<Vector >& rVariable, Vector& Output, const ProcessInfo& r_process_info)
+void RigidEdge2D::Calculate(const Variable<Vector >& rVariable, Vector& Output, const ProcessInfo& r_process_info)
 {
   if (rVariable == RIGID_FACE_COMPUTE_MOVEMENT)
   {
@@ -274,7 +274,7 @@ void RigidEdge3D::Calculate(const Variable<Vector >& rVariable, Vector& Output, 
 
 }
 
-void RigidEdge3D::FinalizeSolutionStep(ProcessInfo& r_process_info)
+void RigidEdge2D::FinalizeSolutionStep(ProcessInfo& r_process_info)
 {
 
 

--- a/applications/DEMApplication/custom_conditions/RigidEdge.h
+++ b/applications/DEMApplication/custom_conditions/RigidEdge.h
@@ -20,11 +20,11 @@
 namespace Kratos
 {
 
-class KRATOS_API(DEM_APPLICATION) RigidEdge3D : public DEMWall
+class KRATOS_API(DEM_APPLICATION) RigidEdge2D : public DEMWall
 {
 public:
-    // Counted pointer of RigidEdge3D
-    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(RigidEdge3D);
+    // Counted pointer of RigidEdge2D
+    KRATOS_CLASS_INTRUSIVE_POINTER_DEFINITION(RigidEdge2D);
 
 	typedef GlobalPointersVector<Element> ParticleWeakVectorType;
 	typedef ParticleWeakVectorType::ptr_iterator ParticleWeakIteratorType_ptr;
@@ -37,25 +37,23 @@ public:
     /**
      * Default constructor.
      */
-    RigidEdge3D( IndexType NewId, GeometryType::Pointer pGeometry);
+    RigidEdge2D( IndexType NewId, GeometryType::Pointer pGeometry);
 
-    RigidEdge3D( IndexType NewId, GeometryType::Pointer pGeometry,
-                           PropertiesType::Pointer pProperties
-                         );
+    RigidEdge2D( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties);
 
 
-    RigidEdge3D( IndexType NewId, GeometryType::Pointer pGeometry,
-                           PropertiesType::Pointer pProperties,
-                           Condition::Pointer Master,
-                           Condition::Pointer Slave,
-                           Point& MasterContactLocalPoint,
-                           Point& SlaveContactLocalPoint,
-                           int SlaveIntegrationPointIndex
-                         );
+    RigidEdge2D( IndexType NewId, GeometryType::Pointer pGeometry,
+                        PropertiesType::Pointer pProperties,
+                        Condition::Pointer Master,
+                        Condition::Pointer Slave,
+                        Point& MasterContactLocalPoint,
+                        Point& SlaveContactLocalPoint,
+                        int SlaveIntegrationPointIndex
+                        );
     /**
      * Destructor.
      */
-    virtual ~RigidEdge3D();
+    virtual ~RigidEdge2D();
 
 
     Condition::Pointer Create( IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
@@ -65,13 +63,13 @@ public:
     void Calculate(const Variable<Vector >& rVariable, Vector& Output, const ProcessInfo& r_process_info) override;
     void FinalizeSolutionStep(ProcessInfo& r_process_info) override;
     void ComputeConditionRelativeData(int rigid_neighbour_index,
-                                      SphericParticle* const particle,
-                                      double LocalCoordSystem[3][3],
-                                      double& DistPToB,
-                                      array_1d<double, 4>& Weight,
-                                      array_1d<double, 3>& edge_delta_disp_at_contact_point,
-                                      array_1d<double, 3>& edge_velocity_at_contact_point,
-                                      int& ContactType) override;
+                                    SphericParticle* const particle,
+                                    double LocalCoordSystem[3][3],
+                                    double& DistPToB,
+                                    array_1d<double, 4>& Weight,
+                                    array_1d<double, 3>& edge_delta_disp_at_contact_point,
+                                    array_1d<double, 3>& edge_velocity_at_contact_point,
+                                    int& ContactType) override;
 
     /**
      * Turn back information as a string.
@@ -102,7 +100,7 @@ private:
     friend class Serializer;
 
     // A private default constructor necessary for serialization
-    RigidEdge3D() {};
+    RigidEdge2D() {};
 
     virtual void save(Serializer& rSerializer) const override
     {

--- a/applications/DEMApplication/python_scripts/DEM_procedures.py
+++ b/applications/DEMApplication/python_scripts/DEM_procedures.py
@@ -1974,18 +1974,18 @@ class DEMIo(object):
 
         # BB Elements:
         props = Properties(10000)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 1, [node1.Id, node4.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 2, [node4.Id, node8.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 3, [node8.Id, node5.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 4, [node5.Id, node1.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 5, [node1.Id, node2.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 6, [node3.Id, node4.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 7, [node7.Id, node8.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 8, [node5.Id, node6.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 9, [node6.Id, node2.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 10, [node2.Id, node3.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 11, [node3.Id, node7.Id], props)
-        bounding_box_model_part.CreateNewCondition("RigidEdge3D", max_element_Id + 12, [node7.Id, node6.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 1, [node1.Id, node4.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 2, [node4.Id, node8.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 3, [node8.Id, node5.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 4, [node5.Id, node1.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 5, [node1.Id, node2.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 6, [node3.Id, node4.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 7, [node7.Id, node8.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 8, [node5.Id, node6.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 9, [node6.Id, node2.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 10, [node2.Id, node3.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 11, [node3.Id, node7.Id], props)
+        bounding_box_model_part.CreateNewCondition("RigidFace3D2N", max_element_Id + 12, [node7.Id, node6.Id], props)
 
 
 

--- a/applications/DemStructuresCouplingApplication/custom_utilities/dem_structures_coupling_utilities.h
+++ b/applications/DemStructuresCouplingApplication/custom_utilities/dem_structures_coupling_utilities.h
@@ -70,7 +70,7 @@ void TransferStructuresSkinToDem(ModelPart& r_source_model_part, ModelPart& r_de
         Geometry< Node<3> >::Pointer p_geometry =  it->pGetGeometry();
         Condition::Pointer cond;
         if (dimension == 2) {
-            cond = Condition::Pointer(new RigidEdge3D(id, p_geometry, props));
+            cond = Condition::Pointer(new RigidEdge2D(id, p_geometry, props));
         } else {
             cond = Condition::Pointer(new RigidFace3D(id, p_geometry, props));
         }


### PR DESCRIPTION
**Description**
As pointed out by @KlausBSautter, there were two Conditions that were not used anywhere, considering that RigidFace does the same job.
Solves #7480

**Changelog**
Removed RigidEdge3D
Removed RigidEdge3D2N
The remaining condition in 2D (RigidEdge2D2N) was using a C++ object called RigidEdge3D which was actually a 2D object always, especially now that everything in 3D is computed by RigidFace.
