### PR TITLE
[Core][Geometry] Add Assign and Calculate interfaces

### DIFF
--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -646,42 +646,42 @@ public:
     /// Set with bool
     virtual void Set(
         const Variable<bool>& rVariable,
-        bool& Output) {}
+        const bool Input) {}
 
     /// Set with int
     virtual void Set(
         const Variable<int>& rVariable,
-        int& Output) {}
+        const int Input) {}
 
     /// Set with double
     virtual void Set(
         const Variable<double>& rVariable,
-        double& Output) {}
+        const double Input) {}
 
     /// Set with array_1d<double, 2>
     virtual void Set(
         const Variable<array_1d<double, 2>>& rVariable,
-        array_1d<double, 2>& Output) {}
+        const array_1d<double, 2> Input) {}
 
     /// Set with array_1d<double, 3>
     virtual void Set(
         const Variable<array_1d<double, 3>>& rVariable,
-        array_1d<double, 3>& Output) {}
+        const array_1d<double, 3> Input) {}
 
     /// Set with array_1d<double, 6>
     virtual void Set(
         const Variable<array_1d<double, 6>>& rVariable,
-        array_1d<double, 6>& Output) {}
+        const array_1d<double, 6> Input) {}
 
     /// Set with Vector
     virtual void Set(
         const Variable<Vector>& rVariable,
-        Vector& Output) {}
+        const Vector Input) {}
 
     /// Set with Matrix
     virtual void Set(
         const Variable<Matrix>& rVariable,
-        Matrix& Output) {}
+        const Matrix Input) {}
 
     /* Calculate either provides get or calculates a certain value,
      * according to a variable.

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -661,27 +661,27 @@ public:
     /// Set with array_1d<double, 2>
     virtual void Set(
         const Variable<array_1d<double, 2>>& rVariable,
-        const array_1d<double, 2> Input) {}
+        const array_1d<double, 2>& rInput) {}
 
     /// Set with array_1d<double, 3>
     virtual void Set(
         const Variable<array_1d<double, 3>>& rVariable,
-        const array_1d<double, 3> Input) {}
+        const array_1d<double, 3>& rInput) {}
 
     /// Set with array_1d<double, 6>
     virtual void Set(
         const Variable<array_1d<double, 6>>& rVariable,
-        const array_1d<double, 6> Input) {}
+        const array_1d<double, 6>& rInput) {}
 
     /// Set with Vector
     virtual void Set(
         const Variable<Vector>& rVariable,
-        const Vector Input) {}
+        const Vector& rInput) {}
 
     /// Set with Matrix
     virtual void Set(
         const Variable<Matrix>& rVariable,
-        const Matrix Input) {}
+        const Matrix& rInput) {}
 
     /* Calculate either provides get or calculates a certain value,
      * according to a variable.

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -690,42 +690,42 @@ public:
     /// Calculate with bool
     virtual void Calculate(
         const Variable<bool>& rVariable,
-        bool& Output) {}
+        bool& rOutput) {}
 
     /// Calculate with int
     virtual void Calculate(
         const Variable<int>& rVariable,
-        int& Output) {}
+        int& rOutput) {}
 
     /// Calculate with double
     virtual void Calculate(
         const Variable<double>& rVariable,
-        double& Output) {}
+        double& rOutput) {}
 
     /// Calculate with array_1d<double, 2>
     virtual void Calculate(
         const Variable<array_1d<double, 2>>& rVariable,
-        array_1d<double, 2>& Output) {}
+        array_1d<double, 2>& rOutput) {}
 
     /// Calculate with array_1d<double, 3>
     virtual void Calculate(
         const Variable<array_1d<double, 3>>& rVariable,
-        array_1d<double, 3>& Output) {}
+        array_1d<double, 3>& rOutput) {}
 
     /// Calculate with array_1d<double, 6>
     virtual void Calculate(
         const Variable<array_1d<double, 6>>& rVariable,
-        array_1d<double, 6>& Output) {}
+        array_1d<double, 6>& rOutput) {}
 
     /// Calculate with Vector
     virtual void Calculate(
         const Variable<Vector>& rVariable,
-        Vector& Output) {}
+        Vector& rOutput) {}
 
     /// Calculate with Matrix
     virtual void Calculate(
         const Variable<Matrix>& rVariable,
-        Matrix& Output) {}
+        Matrix& rOutput) {}
 
     ///@}
     ///@name Inquiry

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -635,6 +635,99 @@ public:
     }
 
     ///@}
+    ///@name Dynamic access to internals
+    ///@{
+
+    /* Set s a certain value to the geometry,
+     * according to a variable.
+     * Allows dynamic interfaces with each respective geometry.
+     */
+
+    /// Set with bool
+    virtual void Set(
+        const Variable<bool>& rVariable,
+        double& Output) {}
+
+    /// Set with int
+    virtual void Set(
+        const Variable<int>& rVariable,
+        double& Output) {}
+
+    /// Set with double
+    virtual void Set(
+        const Variable<double>& rVariable,
+        double& Output) {}
+
+    /// Set with array_1d<double, 2>
+    virtual void Set(
+        const Variable<array_1d<double, 2>>& rVariable,
+        array_1d<double, 3 >& Output) {}
+
+    /// Set with array_1d<double, 3>
+    virtual void Set(
+        const Variable<array_1d<double, 3>>& rVariable,
+        array_1d<double, 3 >& Output) {}
+
+    /// Set with array_1d<double, 6>
+    virtual void Set(
+        const Variable<array_1d<double, 6>>& rVariable,
+        array_1d<double, 3 >& Output) {}
+
+    /// Set with Vector
+    virtual void Set(
+        const Variable<Vector >& rVariable,
+        Vector& Output) {}
+
+    /// Set with Matrix
+    virtual void Set(
+        const Variable<Matrix >& rVariable,
+        Matrix& Output) {}
+
+    /* Calculate either provides get or calculates a certain value,
+     * according to a variable.
+     */
+
+    /// Calculate with bool
+    virtual void Calculate(
+        const Variable<bool>& rVariable,
+        double& Output) {}
+
+    /// Calculate with int
+    virtual void Calculate(
+        const Variable<int>& rVariable,
+        double& Output) {}
+
+    /// Calculate with double
+    virtual void Calculate(
+        const Variable<double>& rVariable,
+        double& Output) {}
+
+    /// Calculate with array_1d<double, 2>
+    virtual void Calculate(
+        const Variable<array_1d<double, 2>>& rVariable,
+        array_1d<double, 3 >& Output) {}
+
+    /// Calculate with array_1d<double, 3>
+    virtual void Calculate(
+        const Variable<array_1d<double, 3>>& rVariable,
+        array_1d<double, 3 >& Output) {}
+
+    /// Calculate with array_1d<double, 6>
+    virtual void Calculate(
+        const Variable<array_1d<double, 6>>& rVariable,
+        array_1d<double, 3 >& Output) {}
+
+    /// Calculate with Vector
+    virtual void Calculate(
+        const Variable<Vector >& rVariable,
+        Vector& Output) {}
+
+    /// Calculate with Matrix
+    virtual void Calculate(
+        const Variable<Matrix >& rVariable,
+        Matrix& Output) {}
+
+    ///@}
     ///@name Inquiry
     ///@{
 

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -646,12 +646,12 @@ public:
     /// Set with bool
     virtual void Set(
         const Variable<bool>& rVariable,
-        double& Output) {}
+        bool& Output) {}
 
     /// Set with int
     virtual void Set(
         const Variable<int>& rVariable,
-        double& Output) {}
+        int& Output) {}
 
     /// Set with double
     virtual void Set(
@@ -661,26 +661,26 @@ public:
     /// Set with array_1d<double, 2>
     virtual void Set(
         const Variable<array_1d<double, 2>>& rVariable,
-        array_1d<double, 3 >& Output) {}
+        array_1d<double, 2>& Output) {}
 
     /// Set with array_1d<double, 3>
     virtual void Set(
         const Variable<array_1d<double, 3>>& rVariable,
-        array_1d<double, 3 >& Output) {}
+        array_1d<double, 3>& Output) {}
 
     /// Set with array_1d<double, 6>
     virtual void Set(
         const Variable<array_1d<double, 6>>& rVariable,
-        array_1d<double, 3 >& Output) {}
+        array_1d<double, 6>& Output) {}
 
     /// Set with Vector
     virtual void Set(
-        const Variable<Vector >& rVariable,
+        const Variable<Vector>& rVariable,
         Vector& Output) {}
 
     /// Set with Matrix
     virtual void Set(
-        const Variable<Matrix >& rVariable,
+        const Variable<Matrix>& rVariable,
         Matrix& Output) {}
 
     /* Calculate either provides get or calculates a certain value,
@@ -690,12 +690,12 @@ public:
     /// Calculate with bool
     virtual void Calculate(
         const Variable<bool>& rVariable,
-        double& Output) {}
+        bool& Output) {}
 
     /// Calculate with int
     virtual void Calculate(
         const Variable<int>& rVariable,
-        double& Output) {}
+        int& Output) {}
 
     /// Calculate with double
     virtual void Calculate(
@@ -705,26 +705,26 @@ public:
     /// Calculate with array_1d<double, 2>
     virtual void Calculate(
         const Variable<array_1d<double, 2>>& rVariable,
-        array_1d<double, 3 >& Output) {}
+        array_1d<double, 2>& Output) {}
 
     /// Calculate with array_1d<double, 3>
     virtual void Calculate(
         const Variable<array_1d<double, 3>>& rVariable,
-        array_1d<double, 3 >& Output) {}
+        array_1d<double, 3>& Output) {}
 
     /// Calculate with array_1d<double, 6>
     virtual void Calculate(
         const Variable<array_1d<double, 6>>& rVariable,
-        array_1d<double, 3 >& Output) {}
+        array_1d<double, 6>& Output) {}
 
     /// Calculate with Vector
     virtual void Calculate(
-        const Variable<Vector >& rVariable,
+        const Variable<Vector>& rVariable,
         Vector& Output) {}
 
     /// Calculate with Matrix
     virtual void Calculate(
-        const Variable<Matrix >& rVariable,
+        const Variable<Matrix>& rVariable,
         Matrix& Output) {}
 
     ///@}

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -638,52 +638,52 @@ public:
     ///@name Dynamic access to internals
     ///@{
 
-    /* Set s a certain value to the geometry,
+    /* Assigns a value to the geometry,
      * according to a variable.
      * Allows dynamic interfaces with each respective geometry.
      */
 
-    /// Set with bool
-    virtual void Set(
+    /// Assign with bool
+    virtual void Assign(
         const Variable<bool>& rVariable,
         const bool Input) {}
 
-    /// Set with int
-    virtual void Set(
+    /// Assign with int
+    virtual void Assign(
         const Variable<int>& rVariable,
         const int Input) {}
 
-    /// Set with double
-    virtual void Set(
+    /// Assign with double
+    virtual void Assign(
         const Variable<double>& rVariable,
         const double Input) {}
 
-    /// Set with array_1d<double, 2>
-    virtual void Set(
+    /// Assign with array_1d<double, 2>
+    virtual void Assign(
         const Variable<array_1d<double, 2>>& rVariable,
         const array_1d<double, 2>& rInput) {}
 
-    /// Set with array_1d<double, 3>
-    virtual void Set(
+    /// Assign with array_1d<double, 3>
+    virtual void Assign(
         const Variable<array_1d<double, 3>>& rVariable,
         const array_1d<double, 3>& rInput) {}
 
-    /// Set with array_1d<double, 6>
-    virtual void Set(
+    /// Assign with array_1d<double, 6>
+    virtual void Assign(
         const Variable<array_1d<double, 6>>& rVariable,
         const array_1d<double, 6>& rInput) {}
 
-    /// Set with Vector
-    virtual void Set(
+    /// Assign with Vector
+    virtual void Assign(
         const Variable<Vector>& rVariable,
         const Vector& rInput) {}
 
-    /// Set with Matrix
-    virtual void Set(
+    /// Assign with Matrix
+    virtual void Assign(
         const Variable<Matrix>& rVariable,
         const Matrix& rInput) {}
 
-    /* Calculate either provides get or calculates a certain value,
+    /* Calculate either provides, gets or calculates a certain value,
      * according to a variable.
      */
 

--- a/kratos/geometries/geometry.h
+++ b/kratos/geometries/geometry.h
@@ -690,42 +690,42 @@ public:
     /// Calculate with bool
     virtual void Calculate(
         const Variable<bool>& rVariable,
-        bool& rOutput) {}
+        bool& rOutput) const {}
 
     /// Calculate with int
     virtual void Calculate(
         const Variable<int>& rVariable,
-        int& rOutput) {}
+        int& rOutput) const {}
 
     /// Calculate with double
     virtual void Calculate(
         const Variable<double>& rVariable,
-        double& rOutput) {}
+        double& rOutput) const {}
 
     /// Calculate with array_1d<double, 2>
     virtual void Calculate(
         const Variable<array_1d<double, 2>>& rVariable,
-        array_1d<double, 2>& rOutput) {}
+        array_1d<double, 2>& rOutput) const {}
 
     /// Calculate with array_1d<double, 3>
     virtual void Calculate(
         const Variable<array_1d<double, 3>>& rVariable,
-        array_1d<double, 3>& rOutput) {}
+        array_1d<double, 3>& rOutput) const {}
 
     /// Calculate with array_1d<double, 6>
     virtual void Calculate(
         const Variable<array_1d<double, 6>>& rVariable,
-        array_1d<double, 6>& rOutput) {}
+        array_1d<double, 6>& rOutput) const {}
 
     /// Calculate with Vector
     virtual void Calculate(
         const Variable<Vector>& rVariable,
-        Vector& rOutput) {}
+        Vector& rOutput) const {}
 
     /// Calculate with Matrix
     virtual void Calculate(
         const Variable<Matrix>& rVariable,
-        Matrix& rOutput) {}
+        Matrix& rOutput) const {}
 
     ///@}
     ///@name Inquiry

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -87,6 +87,28 @@ namespace Python
         return(dummy.IsIdSelfAssigned());
     }
 
+    ///@}
+    ///@name Set and Calculate
+    ///@{
+
+    template< class TDataType >
+    pybind11::list Set(
+        GeometryType& dummy, const Variable<TDataType>& rVariable, TDataType Value)
+    {
+        dummy.Set(rVariable, Value);
+    }
+
+    template< class TDataType >
+    pybind11::list Calculate(
+        GeometryType& dummy, const Variable<TDataType>& rVariable)
+    {
+        TDataType Output;
+        dummy.Calculate(rVariable, Output);
+        return Output;
+    }
+
+    ///@}
+
 void  AddGeometriesToPython(pybind11::module& m)
 {
     namespace py = pybind11;
@@ -163,6 +185,24 @@ void  AddGeometriesToPython(pybind11::module& m)
     .def("Length",&GeometryType::Length)
     .def("Area",&GeometryType::Area)
     .def("Volume",&GeometryType::Volume)
+    // Calculate
+    .def("Set", Set<bool>)
+    .def("Set", Set<int>)
+    .def("Set", Set<double>)
+    .def("Set", Set<array_1d<double, 2>>)
+    .def("Set", Set<array_1d<double, 3>>)
+    .def("Set", Set<array_1d<double, 6>>)
+    .def("Set", Set<Vector>)
+    .def("Set", Set<Matrix>)
+    // Calculate
+    .def("Calculate", Calculate<bool>)
+    .def("Calculate", Calculate<int>)
+    .def("Calculate", Calculate<double>)
+    .def("Calculate", Calculate<array_1d<double, 2>>)
+    .def("Calculate", Calculate<array_1d<double, 3>>)
+    .def("Calculate", Calculate<array_1d<double, 6>>)
+    .def("Calculate", Calculate<Vector>)
+    .def("Calculate", Calculate<Matrix>)
     // Print
     .def("__str__", PrintObject<GeometryType>)
     // Access to nodes

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -185,7 +185,7 @@ void  AddGeometriesToPython(pybind11::module& m)
     .def("Length",&GeometryType::Length)
     .def("Area",&GeometryType::Area)
     .def("Volume",&GeometryType::Volume)
-    // Calculate
+    // Set
     .def("Set", Set<bool>)
     .def("Set", Set<int>)
     .def("Set", Set<double>)

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -92,14 +92,14 @@ namespace Python
     ///@{
 
     template< class TDataType >
-    pybind11::list Set(
+    void Set(
         GeometryType& dummy, const Variable<TDataType>& rVariable, TDataType Value)
     {
         dummy.Set(rVariable, Value);
     }
 
     template< class TDataType >
-    pybind11::list Calculate(
+    TDataType Calculate(
         GeometryType& dummy, const Variable<TDataType>& rVariable)
     {
         TDataType Output;

--- a/kratos/python/add_geometries_to_python.cpp
+++ b/kratos/python/add_geometries_to_python.cpp
@@ -92,10 +92,10 @@ namespace Python
     ///@{
 
     template< class TDataType >
-    void Set(
+    void Assign(
         GeometryType& dummy, const Variable<TDataType>& rVariable, TDataType Value)
     {
-        dummy.Set(rVariable, Value);
+        dummy.Assign(rVariable, Value);
     }
 
     template< class TDataType >
@@ -185,15 +185,15 @@ void  AddGeometriesToPython(pybind11::module& m)
     .def("Length",&GeometryType::Length)
     .def("Area",&GeometryType::Area)
     .def("Volume",&GeometryType::Volume)
-    // Set
-    .def("Set", Set<bool>)
-    .def("Set", Set<int>)
-    .def("Set", Set<double>)
-    .def("Set", Set<array_1d<double, 2>>)
-    .def("Set", Set<array_1d<double, 3>>)
-    .def("Set", Set<array_1d<double, 6>>)
-    .def("Set", Set<Vector>)
-    .def("Set", Set<Matrix>)
+    // Assign
+    .def("Assign", Assign<bool>)
+    .def("Assign", Assign<int>)
+    .def("Assign", Assign<double>)
+    .def("Assign", Assign<array_1d<double, 2>>)
+    .def("Assign", Assign<array_1d<double, 3>>)
+    .def("Assign", Assign<array_1d<double, 6>>)
+    .def("Assign", Assign<Vector>)
+    .def("Assign", Assign<Matrix>)
     // Calculate
     .def("Calculate", Calculate<bool>)
     .def("Calculate", Calculate<int>)


### PR DESCRIPTION
yo,

welcome back with a beautiful PR after the summer break.

**Description**
This PR adds the interfaces for Set and Calculate to the geometry. They are similar as the ones from Elements and Conditions. This allows dynamic interfaces, especially with more sophisticated geometries. Like this we do not have to add new interfaces, but can access to all internal variables and compute upon them.

Normally it would be Get and Set. However, to be consistent it is Calculate and Set.