### PR TITLE
[Core][Breps] Update parents of quadrature point geometries from brep geometries

### DIFF
--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -318,6 +318,10 @@ public:
     {
         mpCurveOnSurface->CreateIntegrationPoints(rIntegrationPoints,
             mCurveNurbsInterval.GetT0(), mCurveNurbsInterval.GetT1());
+
+        for (IndexType i = 0; i < rResultGeometries.size(); ++i) {
+            rResultGeometries(i)->SetGeometryParent(this);
+        }
     }
 
     ///@}

--- a/kratos/geometries/brep_curve_on_surface.h
+++ b/kratos/geometries/brep_curve_on_surface.h
@@ -318,10 +318,6 @@ public:
     {
         mpCurveOnSurface->CreateIntegrationPoints(rIntegrationPoints,
             mCurveNurbsInterval.GetT0(), mCurveNurbsInterval.GetT1());
-
-        for (IndexType i = 0; i < rResultGeometries.size(); ++i) {
-            rResultGeometries(i)->SetGeometryParent(this);
-        }
     }
 
     ///@}
@@ -345,6 +341,10 @@ public:
     {
         mpCurveOnSurface->CreateQuadraturePointGeometries(
             rResultGeometries, NumberOfShapeFunctionDerivatives);
+
+        for (IndexType i = 0; i < rResultGeometries.size(); ++i) {
+            rResultGeometries(i)->SetGeometryParent(this);
+        }
     }
 
     ///@}

--- a/kratos/geometries/brep_surface.h
+++ b/kratos/geometries/brep_surface.h
@@ -369,6 +369,10 @@ public:
     {
         mpNurbsSurface->CreateQuadraturePointGeometries(
             rResultGeometries, NumberOfShapeFunctionDerivatives);
+
+        for (IndexType i = 0; i < rResultGeometries.size(); ++i) {
+            rResultGeometries(i)->SetGeometryParent(this);
+        }
     }
 
     ///@}


### PR DESCRIPTION
**Description**
This updates that Brep Geometries will now be the parents of quadrature point geometries. It is possible to get to the Nurbs from the Brep but not in the other way. Furthermore, this is required for correct post processing.