### PR TITLE
[Core] Expose GetModelPart of SolvingStrategy

### DIFF
--- a/kratos/python/add_strategies_to_python.cpp
+++ b/kratos/python/add_strategies_to_python.cpp
@@ -572,7 +572,7 @@ namespace Kratos
                     .def("GetSystemMatrix", &BaseSolvingStrategyType::GetSystemMatrix, py::return_value_policy::reference_internal)
                     .def("GetSystemVector", &BaseSolvingStrategyType::GetSystemVector, py::return_value_policy::reference_internal)
                     .def("GetSolutionVector", &BaseSolvingStrategyType::GetSolutionVector, py::return_value_policy::reference_internal)
-                    .def("GetModelPart", &BaseSolvingStrategyType::GetModelPart )
+                    .def("GetModelPart", &BaseSolvingStrategyType::GetModelPart, py::return_value_policy::reference )
                     .def("Info", &BaseSolvingStrategyType::Info)
                     ;
 

--- a/kratos/python/add_strategies_to_python.cpp
+++ b/kratos/python/add_strategies_to_python.cpp
@@ -572,7 +572,7 @@ namespace Kratos
                     .def("GetSystemMatrix", &BaseSolvingStrategyType::GetSystemMatrix, py::return_value_policy::reference_internal)
                     .def("GetSystemVector", &BaseSolvingStrategyType::GetSystemVector, py::return_value_policy::reference_internal)
                     .def("GetSolutionVector", &BaseSolvingStrategyType::GetSolutionVector, py::return_value_policy::reference_internal)
-                    .def("GetModelPart", &BaseSolvingStrategyType::GetModelPart, py::return_value_policy::reference )
+                    .def("GetModelPart", &BaseSolvingStrategyType::GetModelPart)
                     .def("Info", &BaseSolvingStrategyType::Info)
                     ;
 

--- a/kratos/python/add_strategies_to_python.cpp
+++ b/kratos/python/add_strategies_to_python.cpp
@@ -572,7 +572,7 @@ namespace Kratos
                     .def("GetSystemMatrix", &BaseSolvingStrategyType::GetSystemMatrix, py::return_value_policy::reference_internal)
                     .def("GetSystemVector", &BaseSolvingStrategyType::GetSystemVector, py::return_value_policy::reference_internal)
                     .def("GetSolutionVector", &BaseSolvingStrategyType::GetSolutionVector, py::return_value_policy::reference_internal)
-                    //.def("GetModelPart", &BaseSolvingStrategyType::GetModelPart )
+                    .def("GetModelPart", &BaseSolvingStrategyType::GetModelPart )
                     .def("Info", &BaseSolvingStrategyType::Info)
                     ;
 


### PR DESCRIPTION
**Description**
This PR exposes previously unexposed (commented out) `GetModelPart` method of `SolvingStrategy` again to python. I am not sure the reasoning behind removing the exposure. The reference of the `ModelPart` in `SolvingStrategy` is exposed to python.

**Changelog**
- Exposing `GetModelPart` in `SolvingStrategy`
