### PR TITLE
[ShapeOpt]  add possibility to recalculate damping weights in every iteration

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
@@ -94,7 +94,9 @@ class ModelPartController:
         self.mesh_controller.UpdateMeshAccordingInputVariable(InputVariable)
 
         if self.model_settings["damping"]["recalculate_damping"].GetBool():
-            self.damping_utility = None
+            self.damping_utility = KSO.DampingUtilities(
+                self.design_surface, self.damping_regions, self.model_settings["damping"]
+            )
 
     # --------------------------------------------------------------------------
     def SetMeshToReferenceMesh(self):
@@ -123,10 +125,6 @@ class ModelPartController:
     # --------------------------------------------------------------------------
     def DampNodalVariableIfSpecified(self, variable):
         if self.model_settings["damping"]["apply_damping"].GetBool():
-            if not self.damping_utility:
-                self.damping_utility = KSO.DampingUtilities(
-                    self.design_surface, self.damping_regions, self.model_settings["damping"]
-                )
             self.damping_utility.DampNodalVariable(variable)
 
     # --------------------------------------------------------------------------

--- a/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
@@ -36,6 +36,7 @@ class ModelPartController:
             "design_surface_sub_model_part_name" : "DESIGN_SURFACE_NAME",
             "damping" : {
                 "apply_damping"      : false,
+                "recalculate_damping": false,
                 "max_neighbor_nodes" : 10000,
                 "damping_regions"    : []
             },
@@ -74,7 +75,10 @@ class ModelPartController:
 
         if self.model_settings["damping"]["apply_damping"].GetBool():
             self.__IdentifyDampingRegions()
-            self.damping_utility = KSO.DampingUtilities(self.design_surface, self.damping_regions, self.model_settings["damping"])
+            if not self.model_settings["damping"]["recalculate_damping"].GetBool():
+                self.damping_utility = KSO.DampingUtilities(
+                    self.design_surface, self.damping_regions, self.model_settings["damping"]
+                )
 
     # --------------------------------------------------------------------------
     def SetMinimalBufferSize(self, buffer_size):
@@ -89,6 +93,11 @@ class ModelPartController:
     # --------------------------------------------------------------------------
     def UpdateMeshAccordingInputVariable(self, InputVariable):
         self.mesh_controller.UpdateMeshAccordingInputVariable(InputVariable)
+
+        if self.model_settings["damping"]["recalculate_damping"].GetBool():
+            self.damping_utility = KSO.DampingUtilities(
+                self.design_surface, self.damping_regions, self.model_settings["damping"]
+            )
 
     # --------------------------------------------------------------------------
     def SetMeshToReferenceMesh(self):

--- a/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/model_part_controller_factory.py
@@ -75,10 +75,9 @@ class ModelPartController:
 
         if self.model_settings["damping"]["apply_damping"].GetBool():
             self.__IdentifyDampingRegions()
-            if not self.model_settings["damping"]["recalculate_damping"].GetBool():
-                self.damping_utility = KSO.DampingUtilities(
-                    self.design_surface, self.damping_regions, self.model_settings["damping"]
-                )
+            self.damping_utility = KSO.DampingUtilities(
+                self.design_surface, self.damping_regions, self.model_settings["damping"]
+            )
 
     # --------------------------------------------------------------------------
     def SetMinimalBufferSize(self, buffer_size):
@@ -95,9 +94,7 @@ class ModelPartController:
         self.mesh_controller.UpdateMeshAccordingInputVariable(InputVariable)
 
         if self.model_settings["damping"]["recalculate_damping"].GetBool():
-            self.damping_utility = KSO.DampingUtilities(
-                self.design_surface, self.damping_regions, self.model_settings["damping"]
-            )
+            self.damping_utility = None
 
     # --------------------------------------------------------------------------
     def SetMeshToReferenceMesh(self):
@@ -126,6 +123,10 @@ class ModelPartController:
     # --------------------------------------------------------------------------
     def DampNodalVariableIfSpecified(self, variable):
         if self.model_settings["damping"]["apply_damping"].GetBool():
+            if not self.damping_utility:
+                self.damping_utility = KSO.DampingUtilities(
+                    self.design_surface, self.damping_regions, self.model_settings["damping"]
+                )
             self.damping_utility.DampNodalVariable(variable)
 
     # --------------------------------------------------------------------------


### PR DESCRIPTION
**Description**
Damping weights can now be recalculated in every iteration after updating the shape.

Please mark the PR with appropriate tags: 
- Feature

**Changelog**
- [ShapeOpt] Damping weights can now be recalculated in every iteration after updating the shape.