### PR TITLE
[StatApp] Remove VariableComponent header files

### DIFF
--- a/applications/StatisticsApplication/statistics_application_variables.h
+++ b/applications/StatisticsApplication/statistics_application_variables.h
@@ -20,8 +20,6 @@
 // Project includes
 #include "containers/variable.h"
 #include "includes/define.h"
-#include "containers/variable_component.h"
-#include "containers/vector_component_adaptor.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
**Description**
Removes `VariableComponent` uses in StatisticsApplication

**Changelog**
- Removes `VariableComponent` header file
