### PR TITLE
[Core] Variables list visitor

### DIFF
--- a/kratos/containers/variable.h
+++ b/kratos/containers/variable.h
@@ -299,6 +299,10 @@ public:
         rSerializer.load("Data",*static_cast<TDataType* >(pData));
     }
 
+    virtual void AcceptVisitor(VariablesListVisitorBase& TheVisitor) const override {
+        TheVisitor.Visit(*this);
+    }
+
     /**
      * @brief This method returns the variable type
      * @return The type of the variable

--- a/kratos/containers/variable_data.cpp
+++ b/kratos/containers/variable_data.cpp
@@ -91,6 +91,10 @@ namespace Kratos
     {
     }
 
+    void VariableData::AcceptVisitor(VariablesListVisitorBase& TheVisitor) const {
+        KRATOS_ERROR << "Variables should define the AcceptVisitor method" << std::endl;
+    }
+
     /// NOTE: This function is for internal use and not
     /// to change arbitrary any variable's key
     void VariableData::SetKey(KeyType NewKey)

--- a/kratos/containers/variable_data.h
+++ b/kratos/containers/variable_data.h
@@ -31,6 +31,8 @@
 #include "includes/define.h"
 #include "utilities/counter.h"
 #include "includes/serializer.h"
+#include "containers/variables_list_visitor_base.h"
+
 
 
 namespace Kratos
@@ -172,6 +174,8 @@ public:
      * @param pData A pointer to the data to be loaded
      */
     virtual void Load(Serializer& rSerializer, void* pData) const;
+
+    virtual void AcceptVisitor(VariablesListVisitorBase& TheVisitor) const;
 
     ///@}
     ///@name Access

--- a/kratos/containers/variables_list.cpp
+++ b/kratos/containers/variables_list.cpp
@@ -22,6 +22,13 @@
 
 namespace Kratos
 {
+    void VariablesList::ApplyVisitor(VariablesListVisitorBase& TheVisitor){
+        for (auto p_variable : mVariables)
+        {
+            p_variable->AcceptVisitor(TheVisitor);
+        }
+    }
+
     void VariablesList::save(Serializer& rSerializer) const
     {
         std::size_t size = mVariables.size();

--- a/kratos/containers/variables_list.cpp
+++ b/kratos/containers/variables_list.cpp
@@ -83,7 +83,28 @@ namespace Kratos
         }
 
     }
-
+    void VariablesList::AddVariable(const std::string& rVarName)
+    {
+        //ugly but needed: here we need to get the component type by checking the Kratos components
+        if(KratosComponents<Variable<bool>>::Has(rVarName))
+            Add(KratosComponents<Variable<bool>>::Get(rVarName));
+        else if(KratosComponents<Variable<int>>::Has(rVarName))
+            Add(KratosComponents<Variable<int>>::Get(rVarName));
+        else if(KratosComponents<Variable<unsigned int>>::Has(rVarName))
+            Add(KratosComponents<Variable<unsigned int>>::Get(rVarName));
+        else if(KratosComponents<Variable<double>>::Has(rVarName))
+            Add(KratosComponents<Variable<double>>::Get(rVarName));
+        else if(KratosComponents<Variable<array_1d<double,3>>>::Has(rVarName))
+            Add(KratosComponents<Variable<array_1d<double,3>>>::Get(rVarName));
+        else if(KratosComponents<Variable<Vector>>::Has(rVarName))
+            Add(KratosComponents<Variable<Vector>>::Get(rVarName));
+        else if(KratosComponents<Variable<Matrix>>::Has(rVarName))
+            Add(KratosComponents<Variable<Matrix>>::Get(rVarName));
+        else
+        {
+            KRATOS_ERROR << "variable " << rVarName << " not found as recognized variable type" << std::endl;
+        }
+    }
     
 }  // namespace Kratos.
 

--- a/kratos/containers/variables_list.h
+++ b/kratos/containers/variables_list.h
@@ -284,6 +284,13 @@ namespace Kratos
 			mDataSize += static_cast<SizeType>(((block_size - 1) + ThisVariable.Size()) / block_size);
 		}
 
+		/// Adding variable by its name. 
+		/** Please note that this one is not very fast as it should search in the components. 
+		 *  So please use it when other methods cannot be used.
+		**/
+		void AddVariable(const std::string& rVarName);
+
+
 		int AddDof(VariableData const* pThisDofVariable){
 			
 			for(std::size_t dof_index = 0 ; dof_index < mDofVariables.size() ; dof_index++){

--- a/kratos/containers/variables_list.h
+++ b/kratos/containers/variables_list.h
@@ -30,6 +30,7 @@
 // Project includes
 #include "includes/define.h"
 #include "containers/variable.h"
+// #include "containers/variables_list_visitor.h"
 
 #ifdef KRATOS_DEBUG
 #include "utilities/openmp_utils.h"
@@ -38,6 +39,7 @@
 
 namespace Kratos
 {
+	class VariablesListVisitorBase;
 
 	///@name Kratos Classes
 	///@{
@@ -352,6 +354,13 @@ namespace Kratos
 			return GetPosition(pThisVariable->SourceKey());
 		}
 
+		void ApplyVisitor(VariablesListVisitorBase& TheVisitor);
+
+		// template<typename TFunctionType>
+		// void ApplyVisitorFunction(TFunctionType&& TheFunction){
+		// 	ApplyVisitor(VariablesListVisitor<TFunctionType>(TheFunction));
+
+		// }
 
 		///@}
 		///@name Access

--- a/kratos/containers/variables_list_visitor.h
+++ b/kratos/containers/variables_list_visitor.h
@@ -1,0 +1,248 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+
+
+#if !defined(KRATOS_VARIABLES_LIST_VISITOR_H_INCLUDED )
+#define  KRATOS_VARIABLES_LIST_VISITOR_H_INCLUDED
+
+
+// System includes
+#include <string>
+#include <iostream>
+
+
+// External includes
+
+
+// Project includes
+#include "includes/define.h"
+#include "includes/ublas_interface.h"
+#include "containers/variable.h"
+
+
+namespace Kratos
+{
+///@addtogroup ApplicationNameApplication
+///@{
+
+///@name Kratos Globals
+///@{
+
+///@}
+///@name Type Definitions
+///@{
+
+///@}
+///@name  Enum's
+///@{
+
+///@}
+///@name  Functions
+///@{
+
+///@}
+///@name Kratos Classes
+///@{
+
+/// Short class definition.
+/** Detail class definition.
+*/
+template<typename TFunctionType>
+class VariablesListVisitor : public VariablesListVisitorBase
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of VariablesListVisitor
+    KRATOS_CLASS_POINTER_DEFINITION(VariablesListVisitor);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    VariablesListVisitor(TFunctionType&& TheFunction)
+        : mFunction(std::move(TheFunction)) {}
+
+    /// Destructor.
+    virtual ~VariablesListVisitor(){}
+
+    ///@}
+    ///@name Operators
+    ///@{
+
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    virtual void Visit(Variable<bool> const& TheVariable) override {mFunction(TheVariable);}
+    virtual void Visit(Variable<int> const& TheVariable) override {mFunction(TheVariable);}
+    virtual void Visit(Variable<unsigned int> const& TheVariable) override {mFunction(TheVariable);}
+    virtual void Visit(Variable<double> const& TheVariable) override {mFunction(TheVariable);}
+    virtual void Visit(Variable<array_1d<double,3>> const& TheVariable) override {mFunction(TheVariable);}
+    virtual void Visit(Variable<Vector> const& TheVariable) override {mFunction(TheVariable);}
+    virtual void Visit(Variable<Matrix> const& TheVariable) override {mFunction(TheVariable);}
+    
+    virtual void Visit(VariableData const& TheVariable) override { // Fallback method
+        KRATOS_ERROR << "The variable " << TheVariable << " type is not supported by the variables list visitor." << std::endl;
+    } 
+
+    ///@}
+    ///@name Access
+    ///@{
+
+
+    ///@}
+    ///@name Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    virtual std::string Info() const override
+    {
+std::stringstream buffer;
+    buffer << "VariablesListVisitor" ;
+    return buffer.str();
+    }
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream& rOStream) const override {rOStream << "VariablesListVisitor";}
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const override {}
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+protected:
+    ///@name Protected static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operators
+    ///@{
+
+
+    ///@}
+    ///@name Protected Operations
+    ///@{
+
+
+    ///@}
+    ///@name Protected  Access
+    ///@{
+
+
+    ///@}
+    ///@name Protected Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Protected LifeCycle
+    ///@{
+
+
+    ///@}
+
+private:
+    ///@name Static Member Variables
+    ///@{
+
+
+    ///@}
+    ///@name Member Variables
+    ///@{
+
+        TFunctionType mFunction;
+
+
+    ///@}
+    ///@name Private Operators
+    ///@{
+
+
+    ///@}
+    ///@name Private Operations
+    ///@{
+
+
+    ///@}
+    ///@name Private  Access
+    ///@{
+
+
+    ///@}
+    ///@name Private Inquiry
+    ///@{
+
+
+    ///@}
+    ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    VariablesListVisitor& operator=(VariablesListVisitor const& rOther) = delete;
+
+    /// Copy constructor.
+    VariablesListVisitor(VariablesListVisitor const& rOther) = delete;
+
+    ///@}
+
+}; // Class VariablesListVisitor
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+/// output stream function
+template<typename TFunctionType>
+inline std::ostream& operator << (std::ostream& rOStream,
+                const VariablesListVisitor<TFunctionType>& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_VARIABLES_LIST_VISITOR_H_INCLUDED  defined
+
+

--- a/kratos/containers/variables_list_visitor.h
+++ b/kratos/containers/variables_list_visitor.h
@@ -115,9 +115,9 @@ public:
     /// Turn back information as a string.
     virtual std::string Info() const override
     {
-std::stringstream buffer;
-    buffer << "VariablesListVisitor" ;
-    return buffer.str();
+        std::stringstream buffer;
+        buffer << "VariablesListVisitor" ;
+        return buffer.str();
     }
 
     /// Print information about this object.
@@ -244,5 +244,4 @@ inline std::ostream& operator << (std::ostream& rOStream,
 }  // namespace Kratos.
 
 #endif // KRATOS_VARIABLES_LIST_VISITOR_H_INCLUDED  defined
-
 

--- a/kratos/containers/variables_list_visitor_base.h
+++ b/kratos/containers/variables_list_visitor_base.h
@@ -1,0 +1,149 @@
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
+//    . \  |   (   | |   (   |\__ `
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
+//
+//  License:		 BSD License
+//					 Kratos default license: kratos/license.txt
+//
+//  Main authors:    Pooyan Dadvand
+//
+
+
+#if !defined(KRATOS_VARIABLES_LIST_VISITOR_BASE_H_INCLUDED )
+#define  KRATOS_VARIABLES_LIST_VISITOR_BASE_H_INCLUDED
+
+
+// System includes
+#include <string>
+#include <iostream>
+
+
+// Project includes
+#include "includes/define.h"
+#include "includes/ublas_interface.h"
+
+
+namespace Kratos
+{
+
+template<class TDataType> class Variable; 
+
+///@addtogroup ApplicationNameApplication
+///@{
+
+///@name Kratos Classes
+///@{
+
+/// Short class definition.
+/** Detail class definition.
+*/
+class VariablesListVisitorBase
+{
+public:
+    ///@name Type Definitions
+    ///@{
+
+    /// Pointer definition of VariablesListVisitorBase
+    KRATOS_CLASS_POINTER_DEFINITION(VariablesListVisitorBase);
+
+    ///@}
+    ///@name Life Cycle
+    ///@{
+
+    /// Default constructor.
+    VariablesListVisitorBase(){}
+
+    /// Destructor.
+    virtual ~VariablesListVisitorBase(){}
+
+    ///@}
+    ///@name Operations
+    ///@{
+
+    virtual void Visit(Variable<bool> const& TheVariable) = 0;
+    virtual void Visit(Variable<int> const& TheVariable) = 0;
+    virtual void Visit(Variable<unsigned int> const& TheVariable) = 0;
+    virtual void Visit(Variable<double> const& TheVariable) = 0;
+    virtual void Visit(Variable<array_1d<double,3>> const& TheVariable) = 0;
+    virtual void Visit(Variable<Vector> const& TheVariable) = 0;
+    virtual void Visit(Variable<Matrix> const& TheVariable) = 0;
+    
+    virtual void Visit(VariableData const& TheVariable) = 0; // Fallback method
+
+    template<typename TVariablesContainerType> 
+    void VisitVariables(TVariablesContainerType const& Variables){
+        for (auto p_variable : Variables) {
+            p_variable->AcceptVisitor(*this);
+        }
+    }
+
+    ///@}
+    ///@name Input and output
+    ///@{
+
+    /// Turn back information as a string.
+    virtual std::string Info() const
+    {
+        std::stringstream buffer;
+        buffer << "VariablesListVisitorBase" ;
+        return buffer.str();
+    }
+
+    /// Print information about this object.
+    virtual void PrintInfo(std::ostream& rOStream) const {rOStream << "VariablesListVisitorBase";}
+
+    /// Print object's data.
+    virtual void PrintData(std::ostream& rOStream) const {}
+
+    ///@}
+    ///@name Friends
+    ///@{
+
+
+    ///@}
+
+private:
+     ///@name Un accessible methods
+    ///@{
+
+    /// Assignment operator.
+    VariablesListVisitorBase& operator=(VariablesListVisitorBase const& rOther) = delete;
+
+    /// Copy constructor.
+    VariablesListVisitorBase(VariablesListVisitorBase const& rOther) = delete;
+
+    ///@}
+
+}; // Class VariablesListVisitorBase
+
+///@}
+
+///@name Type Definitions
+///@{
+
+
+///@}
+///@name Input and output
+///@{
+
+/// output stream function
+inline std::ostream& operator << (std::ostream& rOStream,
+                const VariablesListVisitorBase& rThis)
+{
+    rThis.PrintInfo(rOStream);
+    rOStream << std::endl;
+    rThis.PrintData(rOStream);
+
+    return rOStream;
+}
+///@}
+
+///@} addtogroup block
+
+}  // namespace Kratos.
+
+#endif // KRATOS_VARIABLES_LIST_VISITOR_BASE_H_INCLUDED  defined
+
+

--- a/kratos/containers/variables_list_visitor_base.h
+++ b/kratos/containers/variables_list_visitor_base.h
@@ -62,15 +62,45 @@ public:
     ///@name Operations
     ///@{
 
-    virtual void Visit(Variable<bool> const& TheVariable) = 0;
-    virtual void Visit(Variable<int> const& TheVariable) = 0;
-    virtual void Visit(Variable<unsigned int> const& TheVariable) = 0;
-    virtual void Visit(Variable<double> const& TheVariable) = 0;
-    virtual void Visit(Variable<array_1d<double,3>> const& TheVariable) = 0;
-    virtual void Visit(Variable<Vector> const& TheVariable) = 0;
-    virtual void Visit(Variable<Matrix> const& TheVariable) = 0;
-    
-    virtual void Visit(VariableData const& TheVariable) = 0; // Fallback method
+    /// The visit class is called for each variable in the given variables list.
+    virtual void Visit(Variable<bool> const& TheVariable){
+        ThrowError("bool");
+   }
+
+    /// The visit class is called for each variable in the given variables list.
+    virtual void Visit(Variable<int> const& TheVariable){
+        ThrowError("integer");
+    }
+
+    /// The visit class is called for each variable in the given variables list.
+    virtual void Visit(Variable<unsigned int> const& TheVariable){
+        ThrowError("unsigned integer");
+    }
+
+    /// The visit class is called for each variable in the given variables list.
+    virtual void Visit(Variable<double> const& TheVariable){
+        ThrowError("double");
+    }
+
+    /// The visit class is called for each variable in the given variables list.
+    virtual void Visit(Variable<array_1d<double,3>> const& TheVariable){
+        ThrowError("array_1d3");
+    }
+
+    /// The visit class is called for each variable in the given variables list.
+    virtual void Visit(Variable<Vector> const& TheVariable){
+        ThrowError("Vector");
+    }
+
+    /// The visit class is called for each variable in the given variables list.
+    virtual void Visit(Variable<Matrix> const& TheVariable){
+        ThrowError("Matrix");
+    }
+
+    virtual void Visit(VariableData const& TheVariable){ // Fallback method
+        KRATOS_ERROR << "Unsupported variable type. The supported varibles types to visits are" 
+        << "boo, int, unsinged int, array_1d<double,3>, Vector, and Matrix." << std::endl;
+    }
 
     template<typename TVariablesContainerType> 
     void VisitVariables(TVariablesContainerType const& Variables){
@@ -105,6 +135,12 @@ public:
     ///@}
 
 private:
+
+    void ThrowError(std::string VariableType){
+         KRATOS_ERROR << "Calling the base class visit method for the " << VariableType << 
+         " variable. The main cause of this error is that the visitor class does not support " << VariableType  << std::endl;
+    }
+
      ///@name Un accessible methods
     ///@{
 

--- a/kratos/tests/cpp_tests/containers/test_variables_list.cpp
+++ b/kratos/tests/cpp_tests/containers/test_variables_list.cpp
@@ -68,8 +68,8 @@ KRATOS_TEST_CASE_IN_SUITE(VariablesListGetDofInfo, KratosCoreFastSuite) {
             template<typename TVariableType> 
             void operator()(TVariableType const& TheVariable) const
             {
-                for (auto &node : mrModelPart.Nodes()) {
-                    auto& r_value = node.FastGetSolutionStepValue(TheVariable);
+                for (auto& r_node : mrModelPart.Nodes()) {
+                    auto& r_value = r_node.FastGetSolutionStepValue(TheVariable);
                     r_value = 1.0;    
                 }                     
             }
@@ -77,8 +77,8 @@ KRATOS_TEST_CASE_IN_SUITE(VariablesListGetDofInfo, KratosCoreFastSuite) {
             template<typename TDataType> 
             void operator()(Variable<array_1d<TDataType,3>> const& TheVariable) const 
             {
-                for (auto &node : mrModelPart.Nodes()) {
-                    auto& r_value = node.FastGetSolutionStepValue(TheVariable);
+                for (auto& r_node : mrModelPart.Nodes()) {
+                    auto& r_value = r_node.FastGetSolutionStepValue(TheVariable);
                     r_value = ScalarVector(3,-1.0);    
                 }                     
             }

--- a/kratos/tests/cpp_tests/containers/test_variables_list.cpp
+++ b/kratos/tests/cpp_tests/containers/test_variables_list.cpp
@@ -66,18 +66,18 @@ KRATOS_TEST_CASE_IN_SUITE(VariablesListGetDofInfo, KratosCoreFastSuite) {
             SetModelPartVariableToOne(ModelPart& TheModelPart) : mrModelPart(TheModelPart){}
 
             template<typename TVariableType> 
-            void operator()(TVariableType const& TheVariable) const {
+            void operator()(TVariableType const& TheVariable) const
+            {
                 for (auto &node : mrModelPart.Nodes())
-                {
                     auto& r_value = node.FastGetSolutionStepValue(TheVariable);
                     r_value = 1.0;    
                 }                     
             }
 
             template<typename TDataType> 
-            void operator()(Variable<array_1d<TDataType,3>> const& TheVariable) const {
-                for (auto &node : mrModelPart.Nodes())
-                {
+            void operator()(Variable<array_1d<TDataType,3>> const& TheVariable) const 
+            {
+                for (auto &node : mrModelPart.Nodes()) {
                     auto& r_value = node.FastGetSolutionStepValue(TheVariable);
                     r_value = ScalarVector(3,-1.0);    
                 }                     

--- a/kratos/tests/cpp_tests/containers/test_variables_list.cpp
+++ b/kratos/tests/cpp_tests/containers/test_variables_list.cpp
@@ -18,9 +18,10 @@
 // External includes
 
 // Project includes
-#include "containers/variables_list_data_value_container.h"
-#include "includes/variables.h"
+#include "containers/model.h"
 #include "testing/testing.h"
+#include "containers/variables_list_visitor.h"
+
 
 namespace Kratos {
 namespace Testing {
@@ -56,6 +57,67 @@ KRATOS_TEST_CASE_IN_SUITE(VariablesListGetDofInfo, KratosCoreFastSuite) {
     KRATOS_CHECK_EQUAL(variables_list.GetDofVariable(dof_index), DISPLACEMENT_Y);
     KRATOS_CHECK_EQUAL(variables_list.pGetDofReaction(dof_index), &REACTION_Y);
 
+}
+
+
+    class SetModelPartVariableToOne{
+            ModelPart& mrModelPart;
+        public:
+            SetModelPartVariableToOne(ModelPart& TheModelPart) : mrModelPart(TheModelPart){}
+
+            template<typename TVariableType> 
+            void operator()(TVariableType const& TheVariable) const {
+                for (auto &node : mrModelPart.Nodes())
+                {
+                    auto& r_value = node.FastGetSolutionStepValue(TheVariable);
+                    r_value = 1.0;    
+                }                     
+            }
+
+            template<typename TDataType> 
+            void operator()(Variable<array_1d<TDataType,3>> const& TheVariable) const {
+                for (auto &node : mrModelPart.Nodes())
+                {
+                    auto& r_value = node.FastGetSolutionStepValue(TheVariable);
+                    r_value = ScalarVector(3,-1.0);    
+                }                     
+            }
+
+            void operator()(Variable<Vector> const& TheVaraible) const {} // Skip it for Vector
+
+            void operator()(Variable<Matrix> const& TheVaraible) const {} // Skip it for Matrix
+    };  
+
+KRATOS_TEST_CASE_IN_SUITE(VariablesListApplyVisitor, KratosCoreFastSuite)
+{
+    Model current_model;
+    ModelPart &model_part = current_model.CreateModelPart("test");
+    model_part.AddNodalSolutionStepVariable(TEMPERATURE);  //not to have an empty var list
+    model_part.AddNodalSolutionStepVariable(DISPLACEMENT); //not to have an empty var list
+    model_part.AddNodalSolutionStepVariable(VELOCITY);     //not to have an empty var list
+
+    model_part.CreateNewNode(1, 1.0, 2.0, 3.0);
+    model_part.CreateNewNode(2, 1.0, 2.0, 3.0);
+    model_part.CreateNewNode(3, 1.0, 2.0, 3.0);
+
+    //now create a container of pointers to variables of type VariablesData*
+    std::vector<VariableData*> variables{&TEMPERATURE, &VELOCITY, &DISPLACEMENT_X, &DISPLACEMENT_Z};
+
+   VariablesListVisitor<SetModelPartVariableToOne> the_visitor(model_part);
+
+   the_visitor.VisitVariables(variables);
+
+    for (auto& rNode : model_part.Nodes())
+    {
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(TEMPERATURE), 1.0);
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(DISPLACEMENT_X), 1.0);
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(DISPLACEMENT_Y), 0.0); //NOT SET!!
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(DISPLACEMENT_Z), 1.0);
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(VELOCITY_X), -1.0);
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(VELOCITY_Y), -1.0); 
+        KRATOS_CHECK_EQUAL(rNode.FastGetSolutionStepValue(VELOCITY_Z), -1.0);
+
+    }
 }
 
 }

--- a/kratos/tests/cpp_tests/containers/test_variables_list.cpp
+++ b/kratos/tests/cpp_tests/containers/test_variables_list.cpp
@@ -68,7 +68,7 @@ KRATOS_TEST_CASE_IN_SUITE(VariablesListGetDofInfo, KratosCoreFastSuite) {
             template<typename TVariableType> 
             void operator()(TVariableType const& TheVariable) const
             {
-                for (auto &node : mrModelPart.Nodes())
+                for (auto &node : mrModelPart.Nodes()) {
                     auto& r_value = node.FastGetSolutionStepValue(TheVariable);
                     r_value = 1.0;    
                 }                     

--- a/kratos/tests/cpp_tests/containers/test_variables_list.cpp
+++ b/kratos/tests/cpp_tests/containers/test_variables_list.cpp
@@ -83,9 +83,9 @@ KRATOS_TEST_CASE_IN_SUITE(VariablesListGetDofInfo, KratosCoreFastSuite) {
                 }                     
             }
 
-            void operator()(Variable<Vector> const& TheVaraible) const {} // Skip it for Vector
+            void operator()(Variable<Vector> const& TheVariable) const {} // Skip it for Vector
 
-            void operator()(Variable<Matrix> const& TheVaraible) const {} // Skip it for Matrix
+            void operator()(Variable<Matrix> const& TheVariable) const {} // Skip it for Matrix
     };  
 
 KRATOS_TEST_CASE_IN_SUITE(VariablesListApplyVisitor, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/containers/test_variables_list.cpp
+++ b/kratos/tests/cpp_tests/containers/test_variables_list.cpp
@@ -83,9 +83,9 @@ KRATOS_TEST_CASE_IN_SUITE(VariablesListGetDofInfo, KratosCoreFastSuite) {
                 }                     
             }
 
-            void operator()(Variable<Vector> const& TheVariable) const {} // Skip it for Vector
+            void operator()(Variable<Vector> const& TheVariable) const {} // Skip it for Vector without sending error
 
-            void operator()(Variable<Matrix> const& TheVariable) const {} // Skip it for Matrix
+            void operator()(Variable<Matrix> const& TheVariable) const {} // Skip it for Matrix without sending error
     };  
 
 KRATOS_TEST_CASE_IN_SUITE(VariablesListApplyVisitor, KratosCoreFastSuite)
@@ -101,7 +101,7 @@ KRATOS_TEST_CASE_IN_SUITE(VariablesListApplyVisitor, KratosCoreFastSuite)
     model_part.CreateNewNode(3, 1.0, 2.0, 3.0);
 
     //now create a container of pointers to variables of type VariablesData*
-    std::vector<VariableData*> variables{&TEMPERATURE, &VELOCITY, &DISPLACEMENT_X, &DISPLACEMENT_Z};
+   VariablesList::VariablesContainerType variables{&TEMPERATURE, &VELOCITY, &DISPLACEMENT_X, &DISPLACEMENT_Z};
 
    VariablesListVisitor<SetModelPartVariableToOne> the_visitor(model_part);
 


### PR DESCRIPTION
**Description**
This PR is an alternative implementation of the #5091 proposed by @RiccardoRossi. In this implementation I have tried to avoid the template recursion and std::variant used in the other one in favor of having standard (AKA classical) hierarchical implementation of the visitor. The idea is to avoid the compilation time and reduce the complexity of the code and its compiler errors.

The approach will work with any container of pointers to the variables and can be extended by some helper visitors to be more practical.

Of course, there is no free launch, and the drawback of this approach is that if we want to extend it to a new type, this should be reflected all of the visitors which are not using the template provided here. Meanwhile, in the template implementation, this may also happen if the new template function does not support the new type.

**Changelog**
The changes are in VariableData and Variable. There is an optional change in VariablesLIst in using the visitor but can be undoned