### PR TITLE
[dem] [sdem] Python classes no longer derive from 'object'

### DIFF
--- a/applications/DEMApplication/python_scripts/DEM_analysis_stage.py
+++ b/applications/DEMApplication/python_scripts/DEM_analysis_stage.py
@@ -6,6 +6,8 @@ from KratosMultiphysics import *
 from KratosMultiphysics.DEMApplication import *
 from KratosMultiphysics.analysis_stage import AnalysisStage
 from KratosMultiphysics.DEMApplication.DEM_restart_utility import DEMRestartUtility
+import KratosMultiphysics.DEMApplication.dem_default_input_parameters
+from KratosMultiphysics.DEMApplication.analytic_tools import analytic_data_procedures
 
 from importlib import import_module
 
@@ -51,7 +53,6 @@ class DEMAnalysisStage(AnalysisStage):
 
     @classmethod
     def GetDefaultInputParameters(self):
-        import KratosMultiphysics.DEMApplication.dem_default_input_parameters
         return KratosMultiphysics.DEMApplication.dem_default_input_parameters.GetDefaultInputParameters()
 
     @classmethod
@@ -91,11 +92,7 @@ class DEMAnalysisStage(AnalysisStage):
         # Creating necessary directories:
         self.problem_name = self.GetProblemTypeFileName()
 
-        [self.post_path,
-        self.data_and_results,
-        self.graphs_path] = self.procedures.CreateDirectories(str(self.main_path),
-                                                              str(self.problem_name),
-                                                              do_print_results=self.do_print_results_option)[:-1]
+        [self.post_path, self.data_and_results, self.graphs_path] = self.procedures.CreateDirectories(str(self.main_path), str(self.problem_name), do_print_results=self.do_print_results_option)[:-1]
 
         # Prepare modelparts
         self.CreateModelParts()
@@ -140,13 +137,12 @@ class DEMAnalysisStage(AnalysisStage):
     def IsCountStep(self):
         self.step_count += 1
         if self.step_count == self.p_count:
-           self.p_count += self.p_frequency
-           return True
+            self.p_count += self.p_frequency
+            return True
 
         return False
 
     def SetAnalyticParticleWatcher(self):
-        from KratosMultiphysics.DEMApplication.analytic_tools import analytic_data_procedures
         self.particle_watcher = AnalyticParticleWatcher()
 
         # is this being used? TODO
@@ -241,10 +237,10 @@ class DEMAnalysisStage(AnalysisStage):
             return imported_module
 
         return SetSolverStrategy().ExplicitStrategy(self.all_model_parts,
-                                                     self.creator_destructor,
-                                                     self.dem_fem_search,
-                                                     self.DEM_parameters,
-                                                     self.procedures)
+                                                    self.creator_destructor,
+                                                    self.dem_fem_search,
+                                                    self.DEM_parameters,
+                                                    self.procedures)
 
     def AddVariables(self):
         self.procedures.AddAllVariablesInAllModelParts(self._GetSolver(), self.translational_scheme, self.rotational_scheme, self.all_model_parts, self.DEM_parameters)

--- a/applications/DEMApplication/python_scripts/DEM_material_test_script.py
+++ b/applications/DEMApplication/python_scripts/DEM_material_test_script.py
@@ -8,7 +8,7 @@ import weakref
 from KratosMultiphysics import *
 from KratosMultiphysics.DEMApplication import *
 
-class MaterialTest(object):
+class MaterialTest():
 
     def __init__(self, DEM_parameters, procedures, solver, graphs_path, post_path, spheres_model_part, rigid_face_model_part):
         self.parameters = DEM_parameters
@@ -849,7 +849,7 @@ class MaterialTest(object):
         ##savefig(savedname + '.eps')
         savefig(savedname + '.png')
 
-class PreUtils(object):
+class PreUtils():
 
     def __init__(self, spheres_model_part):
 

--- a/applications/DEMApplication/python_scripts/DEM_procedures.py
+++ b/applications/DEMApplication/python_scripts/DEM_procedures.py
@@ -46,7 +46,7 @@ def GetBoolParameterIfItExists(set_of_parameters, parameter_key):
     return False
 
 
-class MdpaCreator(object):
+class MdpaCreator():
 
     def __init__(self, path, DEM_parameters):
 
@@ -90,7 +90,7 @@ class MdpaCreator(object):
         mdpa.write('End NodalData' + '\n' + '\n')
 
 
-class SetOfModelParts(object):
+class SetOfModelParts():
     def __init__(self, model_parts_list):
         self.MaxNodeId = 0
         self.MaxElemId = 0
@@ -129,7 +129,7 @@ class SetOfModelParts(object):
         return self.model_parts[name]
 
     def Add(self, model_part, name=None):
-        if name != None:
+        if name is not None:
             self.model_parts[name] = model_part
         else:
             self.model_parts[model_part.Name] = model_part
@@ -137,7 +137,7 @@ class SetOfModelParts(object):
         self.mp_list.append(model_part)
 
 
-class GranulometryUtils(object):
+class GranulometryUtils():
 
     def __init__(self, domain_volume, model_part):
 
@@ -173,7 +173,7 @@ class GranulometryUtils(object):
         Logger.Print("spheres per area unit: ", self.spheres_per_area, label="")
 
 
-class PostUtils(object):
+class PostUtils():
 
     def __init__(self, DEM_parameters, spheres_model_part):
 
@@ -259,7 +259,7 @@ class PostUtils(object):
         PostUtilities().ComputeEulerAngles(spheres_model_part, cluster_model_part)
 
 
-class DEMEnergyCalculator(object):
+class DEMEnergyCalculator():
 
     def __init__(self, DEM_parameters, spheres_model_part, cluster_model_part, graphs_path, energy_plot):
 
@@ -330,7 +330,7 @@ class DEMEnergyCalculator(object):
             self.energy_plot.close
 
 
-class Procedures(object):
+class Procedures():
 
     def __init__(self, DEM_parameters):
 
@@ -387,7 +387,7 @@ class Procedures(object):
                 rotational_scheme = SymplecticEulerScheme()
             elif self.DEM_parameters["TranslationalIntegrationScheme"].GetString() == 'Taylor_Scheme':
                 rotational_scheme = TaylorScheme()
-            elif (self.DEM_parameters["TranslationalIntegrationScheme"].GetString() == 'Velocity_Verlet'):
+            elif self.DEM_parameters["TranslationalIntegrationScheme"].GetString() == 'Velocity_Verlet':
                 rotational_scheme = VelocityVerletScheme()
         elif self.DEM_parameters["RotationalIntegrationScheme"].GetString() == 'Runge_Kutta':
             rotational_scheme = RungeKuttaScheme()
@@ -548,7 +548,7 @@ class Procedures(object):
         model_part.AddNodalSolutionStepVariable(PARTICLE_DENSITY)
 
     def AddElasticFaceVariables(self, model_part, DEM_parameters): #Only used in CSM coupling
-        self.AddRigidFaceVariables(model_part,self.DEM_parameters)
+        self.AddRigidFaceVariables(model_part, self.DEM_parameters)
         model_part.AddNodalSolutionStepVariable(TOTAL_FORCES)
 
     @classmethod
@@ -798,7 +798,8 @@ class Procedures(object):
         if self.DEM_parameters["BoundingBoxOption"].GetBool():
             self.SetBoundingBox(all_model_parts.Get("SpheresPart"), all_model_parts.Get("ClusterPart"), all_model_parts.Get("RigidFacePart"), all_model_parts.Get("DEMInletPart"), creator_destructor)
             bounding_box_time_limits = [self.solver.bounding_box_start_time, self.solver.bounding_box_stop_time]
-            return bounding_box_time_limits
+
+        return bounding_box_time_limits
 
     def SetBoundingBox(self, spheres_model_part, clusters_model_part, rigid_faces_model_part, dem_inlet_model_part, creator_destructor):
 
@@ -837,8 +838,7 @@ class Procedures(object):
                 "ERROR: Input parameter of wrong type in file 'DEM_explicit_solver_var.py'.")
             a = str(expected_type)
             b = str(var)
-            self.KratosPrintWarning("The type expected was " +
-                             a + " but " + b + " was read.")
+            self.KratosPrintWarning("The type expected was " + a + " but " + b + " was read.")
             self.KratosPrintWarning(
                 "**************************************************************************")
             sys.exit()
@@ -856,7 +856,7 @@ class Procedures(object):
         Logger.Flush()
 
 
-class DEMFEMProcedures(object):
+class DEMFEMProcedures():
 
     def __init__(self, DEM_parameters, graphs_path, spheres_model_part, rigid_face_model_part):
 
@@ -963,58 +963,8 @@ class DEMFEMProcedures(object):
         self.domain_size = self.DEM_parameters["Dimension"].GetInt()
         evaluate_computation_of_fem_results()
 
-    def MoveAllMeshes(self, all_model_parts, time, dt): # TODO: deprecated
-        message = 'Warning!'
-        message += '\nFunction \'MoveAllMeshes\' is deprecated. It is called inside sphere_strategy.py'
-        message += '\nIt will be removed after 10/31/2019.\n'
-        Logger.PrintWarning("DEM_procedures.py", message)
-
-        spheres_model_part = all_model_parts.Get("SpheresPart")
-        dem_inlet_model_part = all_model_parts.Get("DEMInletPart")
-        rigid_face_model_part = all_model_parts.Get("RigidFacePart")
-
-        self.mesh_motion.MoveAllMeshes(spheres_model_part, time, dt)
-        self.mesh_motion.MoveAllMeshes(dem_inlet_model_part, time, dt)
-        self.mesh_motion.MoveAllMeshes(rigid_face_model_part, time, dt)
-
-    # def MoveAllMeshesUsingATable(self, model_part, time, dt):
-
-    #     self.mesh_motion.MoveAllMeshesUsingATable(model_part, time, dt)
-
-        # for smp in model_part.SubModelParts:
-
-        #     if not smp[TABLE_NUMBER]:
-        #         continue
-
-        #     Logger.Print("Info:", label="")
-        #     Logger.Print(smp[IDENTIFIER], label="")
-        #     Logger.Print(smp[TABLE_NUMBER], label="")
-
-        #     for node in smp.Nodes:
-
-        #         old_coords = Vector(3)
-        #         old_coords[0] = node.X
-        #         old_coords[1] = node.Y
-        #         old_coords[2] = node.Z
-
-        #         velocity = Vector(3)
-        #         velocity[0] = model_part.GetTable(smp[TABLE_NUMBER]).GetValue(time)
-        #         velocity[1] = 0.0
-        #         velocity[2] = 0.0
-        #         node.SetSolutionStepValue(VELOCITY, velocity)
-
-        #         node.X = old_coords[0] + velocity[0] * dt
-        #         node.Y = old_coords[1] + velocity[1] * dt
-        #         node.Z = old_coords[2] + velocity[2] * dt
-
-        #         displacement = Vector(3)
-        #         displacement[0] = node.X - node.X0
-        #         displacement[1] = node.Y - node.Y0
-        #         displacement[2] = node.Z - node.Z0
-        #         node.SetSolutionStepValue(DISPLACEMENT, displacement)
-
     @classmethod
-    def UpdateTimeInModelParts(self, all_model_parts, time, dt, step, is_time_to_print = False):
+    def UpdateTimeInModelParts(self, all_model_parts, time, dt, step, is_time_to_print=False):
 
         spheres_model_part = all_model_parts.Get("SpheresPart")
         cluster_model_part = all_model_parts.Get("ClusterPart")
@@ -1027,7 +977,7 @@ class DEMFEMProcedures(object):
         self.UpdateTimeInOneModelPart(rigid_face_model_part, time, dt, step, is_time_to_print)
 
     @classmethod
-    def UpdateTimeInOneModelPart(self, model_part, time, dt, step, is_time_to_print = False):
+    def UpdateTimeInOneModelPart(self, model_part, time, dt, step, is_time_to_print=False):
         model_part.ProcessInfo[TIME] = time
         model_part.ProcessInfo[DELTA_TIME] = dt
         model_part.ProcessInfo[TIME_STEPS] = step
@@ -1188,7 +1138,7 @@ class DEMFEMProcedures(object):
                         node.Fix(VELOCITY_Y)
 
 
-class Report(object):
+class Report():
 
     def __init__(self):
         pass
@@ -1249,12 +1199,12 @@ class Report(object):
         return report
 
 
-class PreUtils(object):
+class PreUtils():
 
     def __init__(self):
         pass
 
-class MaterialTest(object):
+class MaterialTest():
 
     def __init__(self):
         pass
@@ -1301,7 +1251,7 @@ class MaterialTest(object):
             self.script.GenerateGraphics()
 
 
-class MultifileList(object):
+class MultifileList():
 
     def __init__(self, post_path, name, step, which_folder):
         self.index = 0
@@ -1316,7 +1266,7 @@ class MultifileList(object):
         self.file = open(absolute_path_to_file, "w")
 
 
-class DEMIo(object):
+class DEMIo():
 
     def __init__(self, model, DEM_parameters, post_path, all_model_parts):
 
@@ -1457,9 +1407,9 @@ class DEMIo(object):
         )
         self.SetMultifileLists(self.multifiles)
 
-
+    @classmethod
     def KratosPrintInfo(self, message):
-        Logger.PrintInfo(message,label="DEM")
+        Logger.PrintInfo(message, label="DEM")
         Logger.Flush()
 
     @classmethod
@@ -1495,7 +1445,7 @@ class DEMIo(object):
         self.PushPrintVar(self.PostDisplacement, DISPLACEMENT, self.global_variables)
         self.PushPrintVar(self.PostVelocity, VELOCITY, self.global_variables)
         self.PushPrintVar(self.PostTotalForces, TOTAL_FORCES, self.global_variables)
-        self.PushPrintVar(self.PostAppliedForces, EXTERNAL_APPLIED_FORCE,  self.global_variables)
+        self.PushPrintVar(self.PostAppliedForces, EXTERNAL_APPLIED_FORCE, self.global_variables)
         self.PushPrintVar(self.PostAppliedForces, EXTERNAL_APPLIED_MOMENT, self.global_variables)
         if self.DEM_parameters["PostAngularVelocity"].GetBool():
             self.PushPrintVar(self.PostAngularVelocity, ANGULAR_VELOCITY, self.global_variables)
@@ -1512,7 +1462,7 @@ class DEMIo(object):
 
 
     def AddSpheresAndClustersVariables(self):  # variables common to spheres and clusters
-        self.PushPrintVar(self.PostRigidElementForces,  RIGID_ELEMENT_FORCE,     self.spheres_and_clusters_variables)
+        self.PushPrintVar(self.PostRigidElementForces, RIGID_ELEMENT_FORCE, self.spheres_and_clusters_variables)
 
     # variables common to spheres and clusters
     def AddSpheresNotInClusterAndClustersVariables(self):
@@ -1529,9 +1479,6 @@ class DEMIo(object):
         self.PushPrintVar(self.PostTangentialImpactVelocity, TANGENTIAL_IMPACT_VELOCITY, self.spheres_variables)
         self.PushPrintVar(self.PostFaceNormalImpactVelocity, FACE_NORMAL_IMPACT_VELOCITY, self.spheres_variables)
         self.PushPrintVar(self.PostFaceTangentialImpactVelocity, FACE_TANGENTIAL_IMPACT_VELOCITY, self.spheres_variables)
-        #self.PushPrintVar(self.PostLinearImpulse, LINEAR_IMPULSE, self.spheres_variables)
-        #self.PushPrintVar(1, DELTA_DISPLACEMENT, self.spheres_variables)  # Debugging
-        #self.PushPrintVar(1, PARTICLE_ROTATION_ANGLE, self.spheres_variables)  # Debugging
 
         if "PostRollingResistanceMoment" in self.DEM_parameters.keys():
             if self.DEM_parameters["RotationOption"].GetBool():
@@ -1588,11 +1535,6 @@ class DEMIo(object):
 
     def AddRigidBodyVariables(self):
         pass
-        #self.PushPrintVar(1,                         PARTICLE_MOMENT,              self.rigid_body_variables)
-        #self.PushPrintVar(1,                         DELTA_DISPLACEMENT,           self.rigid_body_variables)
-        #self.PushPrintVar(1,                         DELTA_ROTATION,               self.rigid_body_variables)
-        #self.PushPrintVar(1,                         EXTERNAL_APPLIED_FORCE,       self.rigid_body_variables)
-        #self.PushPrintVar(1,                         EXTERNAL_APPLIED_MOMENT,      self.rigid_body_variables)
 
     def AddContactVariables(self):
         # Contact Elements Variables
@@ -1795,13 +1737,6 @@ class DEMIo(object):
 
     def PrintResults(self, all_model_parts, creator_destructor, dem_fem_search, time, bounding_box_time_limits):
 
-        #TODO: move these definitions to the constructor! (__init__) moved!
-        # self.spheres_model_part = spheres_model_part = all_model_parts.Get("SpheresPart")
-        # self.cluster_model_part = cluster_model_part = all_model_parts.Get("ClusterPart")
-        # self.rigid_face_model_part = rigid_face_model_part = all_model_parts.Get("RigidFacePart")
-        # self.contact_model_part = contact_model_part = all_model_parts.Get("ContactPart")
-        # self.mapping_model_part = mapping_model_part = all_model_parts.Get("MappingPart")
-
         if self.filesystem == MultiFileFlag.MultipleFiles:
             self.InitializeResults(self.spheres_model_part,
                                    self.rigid_face_model_part,
@@ -1986,7 +1921,7 @@ class DEMIo(object):
 
 
 
-class ParallelUtils(object):
+class ParallelUtils():
 
     def __init__(self):
         pass

--- a/applications/DEMApplication/python_scripts/DEM_procedures_mpi.py
+++ b/applications/DEMApplication/python_scripts/DEM_procedures_mpi.py
@@ -19,23 +19,18 @@ class MdpaCreator(DEM_procedures.MdpaCreator):
     def __init__(self, path, DEM_parameters):
         super(MdpaCreator,self).__init__(path, DEM_parameters)
 
-
-class GranulometryUtils(DEM_procedures.GranulometryUtils):
-
-    def __init__(self, domain_volume, model_part):
-        super(GranulometryUtils,self).__init__(domain_volume, model_part)
-
+GranulometryUtils = DEM_procedures.GranulometryUtils
 
 class PostUtils(DEM_procedures.PostUtils):
 
     def __init__(self, DEM_parameters, balls_model_part):
-        super(PostUtils,self).__init__(DEM_parameters, balls_model_part)
+        super(PostUtils, self).__init__(DEM_parameters, balls_model_part)
 
 
 class Procedures(DEM_procedures.Procedures):
 
     def __init__(self, DEM_parameters):
-        super(Procedures,self).__init__(DEM_parameters)
+        super(Procedures, self).__init__(DEM_parameters)
 
     def Barrier(self):
         mpi.world.barrier()
@@ -44,13 +39,13 @@ class Procedures(DEM_procedures.Procedures):
         model_part.AddNodalSolutionStepVariable(PARTITION_INDEX)
         model_part.AddNodalSolutionStepVariable(PARTITION_MASK)
 
-    def CreateDirectories(self, main_path, problem_name, do_print_results=True):
+    def CreateDirectories(self, main_path, problem_name, run_code='', do_print_results=True):
 
-        root             = main_path + '/' + problem_name
-        post_path        = root + '_Post_Files'
+        root = main_path + '/' + problem_name
+        post_path = root + '_Post_Files'
         data_and_results = root + '_Results_and_Data'
-        graphs_path      = root + '_Graphs'
-        MPI_results      = root + '_MPI_results'
+        graphs_path = root + '_Graphs'
+        MPI_results = root + '_MPI_results'
 
         if mpi.rank == 0 and do_print_results:
             for directory in [post_path, data_and_results, graphs_path, MPI_results]:
@@ -62,7 +57,7 @@ class Procedures(DEM_procedures.Procedures):
         return [post_path, data_and_results, graphs_path, MPI_results]
 
     def PreProcessModel(self, DEM_parameters):
-        if (mpi.rank == 0):
+        if mpi.rank == 0:
             print("Creating MPIer...")
             #MPIClassObject = MPIer.MPIerClass(str(DEM_parameters["problem_name"].GetString()) + "DEM.mdpa")
             print("done.")
@@ -76,13 +71,13 @@ class Procedures(DEM_procedures.Procedures):
         return total_max
 
     def DeleteFiles(self):
-        if (mpi.rank == 0):
+        if mpi.rank == 0:
             files_to_delete_list = glob('*.time')
             for to_erase_file in files_to_delete_list:
                 os.remove(to_erase_file)
 
     def KratosPrintInfo(self, message):
-        if (mpi.rank == 0):
+        if mpi.rank == 0:
             Logger.Print(*args, label="DEM")
             Logger.Flush()
 
@@ -117,12 +112,12 @@ class MaterialTest(DEM_procedures.MaterialTest):
     def Initialize(self, DEM_parameters, procedures, solver, graphs_path, post_path, balls_model_part, rigid_face_model_part):
         self.TestType = DEM_parameters["TestType"].GetString()
 
-        if (self.TestType != "None"):
+        if self.TestType != "None":
             self.script = DEM_material_test_script.MaterialTest(DEM_parameters, procedures, solver, graphs_path, post_path, balls_model_part, rigid_face_model_part)
             self.script.Initialize()
 
 
-class MultifileList(object):
+class MultifileList():
 
     def __init__(self,name,step):
         self.index = 0

--- a/applications/DEMApplication/python_scripts/dem_vtk_output.py
+++ b/applications/DEMApplication/python_scripts/dem_vtk_output.py
@@ -7,7 +7,7 @@ import shutil
 from KratosMultiphysics import *
 from KratosMultiphysics.DEMApplication import *
 
-class VtkOutput(object):
+class VtkOutput():
     def __init__(self, main_path, problem_name, spheres_model_part, rigid_face_model_part):
         self.problem_name = problem_name
 

--- a/applications/DEMApplication/python_scripts/main_script.py
+++ b/applications/DEMApplication/python_scripts/main_script.py
@@ -22,7 +22,7 @@ else:
     Logger.PrintInfo("DEM", "Running under OpenMP........")
     import KratosMultiphysics.DEMApplication.DEM_procedures as DEM_procedures
 
-class Solution(object):
+class Solution():
 
     def GetParametersFileName(self):
         return "ProjectParametersDEM.json"

--- a/applications/DEMApplication/python_scripts/multiaxial_control_module_generalized_2d_utility.py
+++ b/applications/DEMApplication/python_scripts/multiaxial_control_module_generalized_2d_utility.py
@@ -2,7 +2,7 @@ import KratosMultiphysics
 import KratosMultiphysics.DEMApplication as Dem
 
 
-class MultiaxialControlModuleGeneralized2DUtility(object):
+class MultiaxialControlModuleGeneralized2DUtility():
     def __init__(self, Model, settings):
 
         #NOTE: Negative target_stress means compression

--- a/applications/DEMApplication/python_scripts/sphere_strategy.py
+++ b/applications/DEMApplication/python_scripts/sphere_strategy.py
@@ -6,7 +6,7 @@ import math
 import time
 import KratosMultiphysics.DEMApplication.cluster_file_reader as cluster_file_reader
 
-class ExplicitStrategy(object):
+class ExplicitStrategy():
 
     #def __init__(self, all_model_parts, creator_destructor, dem_fem_search, scheme, DEM_parameters, procedures):
     def __init__(self, all_model_parts, creator_destructor, dem_fem_search, DEM_parameters, procedures):

--- a/applications/DEMApplication/python_scripts/time_step_testing_stage.py
+++ b/applications/DEMApplication/python_scripts/time_step_testing_stage.py
@@ -3,7 +3,7 @@ from KratosMultiphysics.DEMApplication import *
 import KratosMultiphysics.DEMApplication.DEM_analysis_stage as DEM_analysis_stage
 
 
-class TimeStepTester(object):
+class TimeStepTester():
     def __init__(self):
         #self.schemes_list = ["Forward_Euler", "Taylor_Scheme", "Symplectic_Euler", "Velocity_Verlet"]
         self.schemes_list = ["Symplectic_Euler", "Velocity_Verlet"]

--- a/applications/DemStructuresCouplingApplication/python_scripts/control_module_fem_dem_utility.py
+++ b/applications/DemStructuresCouplingApplication/python_scripts/control_module_fem_dem_utility.py
@@ -2,7 +2,7 @@ import KratosMultiphysics
 import KratosMultiphysics.DemStructuresCouplingApplication as DemFem
 
 
-class ControlModuleFemDemUtility(object):
+class ControlModuleFemDemUtility():
     def __init__(self, Model, spheres_model_part, test_number):
 
         fem_main_model_part = Model["Structure"]

--- a/applications/DemStructuresCouplingApplication/python_scripts/dem_fem_coupling_algorithm.py
+++ b/applications/DemStructuresCouplingApplication/python_scripts/dem_fem_coupling_algorithm.py
@@ -15,7 +15,7 @@ import KratosMultiphysics.StructuralMechanicsApplication as Structural
 import KratosMultiphysics.DemStructuresCouplingApplication as DemFem
 from KratosMultiphysics.DemStructuresCouplingApplication import dem_structures_coupling_gid_output
 
-class Algorithm(object):
+class Algorithm():
 
     def __init__(self):
         self.model = Kratos.Model()

--- a/applications/DemStructuresCouplingApplication/python_scripts/sand_production_post_process_tool.py
+++ b/applications/DemStructuresCouplingApplication/python_scripts/sand_production_post_process_tool.py
@@ -10,7 +10,7 @@ import KratosMultiphysics.DemStructuresCouplingApplication as DemFem
 def Norm(vector):
     return np.sqrt(sum(v**2 for v in vector))
 
-class SandProductionPostProcessTool(object):
+class SandProductionPostProcessTool():
     def __init__(self, fem_model_part, dem_model_part, test_number):
 
         if not test_number:

--- a/applications/DemStructuresCouplingApplication/python_scripts/stress_failure_check_utility.py
+++ b/applications/DemStructuresCouplingApplication/python_scripts/stress_failure_check_utility.py
@@ -1,7 +1,7 @@
 import KratosMultiphysics
 import KratosMultiphysics.DemStructuresCouplingApplication as DemFem
 
-class StressFailureCheckUtility(object):
+class StressFailureCheckUtility():
     def __init__(self, model_part, test_number):
 
         if not test_number:

--- a/applications/SwimmingDEMApplication/python_scripts/custom_body_force/manufactured_solution.py
+++ b/applications/SwimmingDEMApplication/python_scripts/custom_body_force/manufactured_solution.py
@@ -3,7 +3,7 @@ import KratosMultiphysics
 def CreateManufacturedSolution(custom_settings):
     return ManufacturedSolution(custom_settings)
 
-class ManufacturedSolution(object):
+class ManufacturedSolution():
     def __init__(self, settings):
         '''
         This is a base class to build manufactured fluid solutions.
@@ -71,7 +71,7 @@ class ManufacturedSolution(object):
         """ Velocity
         """
         raise Exception("Method not implemented")
-    
+
     def u2(self, x1, x2, t):
         """ Velocity
         """
@@ -82,7 +82,7 @@ class ManufacturedSolution(object):
 
     def du1dt(self, x1, x2, t):
         raise Exception("Method not implemented")
-    
+
     def du2dt(self, x1, x2, t):
         raise Exception("Method not implemented")
 
@@ -117,13 +117,13 @@ class ManufacturedSolution(object):
         By default, pressure is 0
         '''
         return 0.0
-    
+
     def dp1(self, x1, x2, t):
         '''
         By default, pressure is 0
         '''
         return 0.0
-    
+
     def dp2(self, x1, x2, t):
         '''
         By default, pressure is 0

--- a/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_analysis.py
+++ b/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_analysis.py
@@ -28,7 +28,7 @@ def Say(*args):
 
 import KratosMultiphysics.DEMApplication.DEM_procedures as DP
 
-class SDEMLogger(object):
+class SDEMLogger():
     def __init__(self, do_print_file=False):
         self.terminal = sys.stdout
         self.console_output_file_name = 'console_output.txt'


### PR DESCRIPTION
**Description**
This was needed by Python2, but not anymore with just Python3 support.

**Changelog**

- 'object' removed as base classe from all places in DEM and SwimmingDEM and Coupled with Structures
- Also a few Pylint suggestions were addressed, just format.
