### PR TITLE
[ShallowWater] Removing variable_component includes

### DIFF
--- a/applications/ShallowWaterApplication/shallow_water_application_variables.h
+++ b/applications/ShallowWaterApplication/shallow_water_application_variables.h
@@ -19,10 +19,9 @@
 // External includes
 
 // Project includes
+#include "containers/variable.h"
 #include "includes/define.h"
 #include "includes/element.h"
-#include "containers/variable_component.h"
-#include "containers/vector_component_adaptor.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
**Description**
title says it all

Please mark the PR with appropriate tags: 
- Cleanup

**Changelog**
- The include is removed from `shallow_water_application_variables.h`
