### PR TITLE
[HDF5] Remove deprecation warning for "from collections import Mapping"

### DIFF
--- a/applications/HDF5Application/python_scripts/core/utils.py
+++ b/applications/HDF5Application/python_scripts/core/utils.py
@@ -7,7 +7,7 @@ license: HDF5Application/license.txt
 __all__ = ['ParametersWrapper']
 
 
-from collections import Mapping
+from collections.abc import Mapping
 
 
 import KratosMultiphysics


### PR DESCRIPTION
**Description**
As in the title.

**Changelog**
- Removed deprecation warning
