### PR TITLE
[structural] remove deprecated ctor in formfinding strategy

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/StructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -55,7 +55,6 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
 
     // Base types
     typedef LinearSolver<SparseSpaceType, LocalSpaceType > LinearSolverType;
-    typedef LinearSolverType::Pointer LinearSolverPointer;
     typedef SolvingStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType > BaseSolvingStrategyType;
 //     typedef BaseSolvingStrategyType::Pointer BaseSolvingStrategyPointer;
     typedef ConvergenceCriteria< SparseSpaceType, LocalSpaceType > ConvergenceCriteriaType;
@@ -111,7 +110,7 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
         .def("GetSolutionFoundFlag", &PrebucklingStrategyType::GetSolutionFoundFlag)
         ;
     py::class_< FormfindingStrategyType,typename FormfindingStrategyType::Pointer, ResidualBasedNewtonRaphsonStrategyType >(m,"FormfindingStrategy")
-        .def(py::init < ModelPart&, BaseSchemeType::Pointer, LinearSolverPointer, ConvergenceCriteriaPointer, BuilderAndSolverPointer, ModelPart&, bool, const std::string&, Parameters, int, bool, bool, bool>())
+        .def(py::init < ModelPart&, BaseSchemeType::Pointer, ConvergenceCriteriaPointer, BuilderAndSolverPointer, ModelPart&, bool, const std::string&, Parameters, int, bool, bool, bool>())
         .def_static("WriteFormFoundMdpa", &FormfindingStrategyType::WriteFormFoundMdpa)
         ;
 

--- a/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/formfinding_strategy.hpp
+++ b/applications/StructuralMechanicsApplication/custom_strategies/custom_strategies/formfinding_strategy.hpp
@@ -64,7 +64,6 @@ public:
     FormfindingStrategy(
         ModelPart& model_part,
         typename TSchemeType::Pointer pScheme,
-        typename TLinearSolver::Pointer pNewLinearSolver,
         typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
         typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
         ModelPart& rFormFindingModelPart,
@@ -77,7 +76,7 @@ public:
         bool MoveMeshFlag = false
     )
     : ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(model_part, pScheme,
-        pNewLinearSolver,pNewConvergenceCriteria,pNewBuilderAndSolver,MaxIterations,CalculateReactions,ReformDofSetAtEachStep,
+        pNewConvergenceCriteria,pNewBuilderAndSolver,MaxIterations,CalculateReactions,ReformDofSetAtEachStep,
         MoveMeshFlag),
         mProjectionSettings(ProjectionSetting),
         mrFormFindingModelPart(rFormFindingModelPart),

--- a/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_formfinding_solver.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/structural_mechanics_formfinding_solver.py
@@ -58,7 +58,6 @@ class FormfindingMechanicalSolver(MechanicalSolver):
     def _create_mechanical_solution_strategy(self):
         computing_model_part = self.GetComputingModelPart()
         mechanical_scheme = self.get_solution_scheme()
-        linear_solver = self.get_linear_solver()
         mechanical_convergence_criterion = self.get_convergence_criterion()
         builder_and_solver = self.get_builder_and_solver()
 
@@ -70,7 +69,6 @@ class FormfindingMechanicalSolver(MechanicalSolver):
         return StructuralMechanicsApplication.FormfindingStrategy(
                                                                 computing_model_part,
                                                                 mechanical_scheme,
-                                                                linear_solver,
                                                                 mechanical_convergence_criterion,
                                                                 builder_and_solver,
                                                                 formfinding_model_part,

--- a/applications/StructuralMechanicsApplication/tests/test_patch_test_formfinding_trusses.py
+++ b/applications/StructuralMechanicsApplication/tests/test_patch_test_formfinding_trusses.py
@@ -100,7 +100,6 @@ class TestPatchTestFormfinding(KratosUnittest.TestCase):
         }""")
         strategy = StructuralMechanicsApplication.FormfindingStrategy(mp,
                                                         scheme,
-                                                        linear_solver,
                                                         convergence_criterion,
                                                         builder_and_solver,
                                                         mp,


### PR DESCRIPTION
Thanks to Philipp's support I finally had time to face this overwhelming task. 

This PR removes the deprecated ctor in the structural formfinding strategy