### PR TITLE
[dem] The assert methods from Unittest are being used when possible (instead of our own asserts)

### DIFF
--- a/applications/DEMApplication/tests/test_DEM_2D.py
+++ b/applications/DEMApplication/tests/test_DEM_2D.py
@@ -14,7 +14,7 @@ this_working_dir_backup = os.getcwd()
 def GetFilePath(fileName):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
-class DEM2DTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage):
+class DEM2DTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     @classmethod
     def GetMainPath(self):
@@ -30,26 +30,13 @@ class DEM2DTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEM
             normal_impact_vel = node.GetSolutionStepValue(Kratos.VELOCITY_X)
             if node.Id == 1:
                 if self.time > 0.2:
-                    expected_value = 6.076801447242313
-                    self.CheckValueOfVelocity(normal_impact_vel, expected_value, tolerance)
+                    self.assertAlmostEqual(normal_impact_vel, 6.076801447242313, delta=tolerance)
             if node.Id == 2:
                 if self.time > 0.2:
-                    expected_value = 8.604163136887411
-                    self.CheckValueOfVelocity(normal_impact_vel, expected_value, tolerance)
+                    self.assertAlmostEqual(normal_impact_vel, 8.604163136887411, delta=tolerance)
             if node.Id == 3:
                 if self.time > 0.2:
-                    expected_value = 10.016439272775422
-                    self.CheckValueOfVelocity(normal_impact_vel, expected_value, tolerance)
-
-    @classmethod
-    def CheckValueOfVelocity(self, normal_impact_vel, expected_value, tolerance):
-        if normal_impact_vel > expected_value + tolerance or normal_impact_vel < expected_value - tolerance:
-            raise ValueError('Incorrect value for NORMAL_IMPACT_VELOCITY: expected value was '+ str(expected_value) + ' but received ' + str(normal_impact_vel))
-
-    def Finalize(self):
-        super(DEM2DTestSolution, self).Finalize()
-
-
+                    self.assertAlmostEqual(normal_impact_vel, 10.016439272775422, delta=tolerance)
 
 class TestDEM2D(KratosUnittest.TestCase):
 

--- a/applications/DEMApplication/tests/test_DEM_2D_contact.py
+++ b/applications/DEMApplication/tests/test_DEM_2D_contact.py
@@ -15,7 +15,7 @@ this_working_dir_backup = os.getcwd()
 def GetFilePath(fileName):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
-class DEM2D_ContactTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage):
+class DEM2D_ContactTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     @classmethod
     def GetMainPath(self):
@@ -33,30 +33,15 @@ class DEM2D_ContactTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_s
             if node.Id == 13:
                 if self.time > 0.3:
                     expected_value = 45126
-                    self.CheckPressure(dem_pressure, expected_value, tolerance)
+                    self.assertAlmostEqual(dem_pressure, expected_value, delta=tolerance)
                     expected_value = -23141
-                    self.CheckContactF(contact_force, expected_value, tolerance)
+                    self.assertAlmostEqual(contact_force, expected_value, delta=tolerance)
             if node.Id == 22:
                 if self.time > 0.3:
                     expected_value = 26712
-                    self.CheckPressure(dem_pressure, expected_value, tolerance)
+                    self.assertAlmostEqual(dem_pressure, expected_value, delta=tolerance)
                     expected_value = -13698
-                    self.CheckContactF(contact_force, expected_value, tolerance)
-
-
-    @classmethod
-    def CheckPressure(self, dem_pressure, expected_value, tolerance):
-        if expected_value > dem_pressure*tolerance or expected_value < dem_pressure/tolerance:
-            raise ValueError('Incorrect value for DEM_PRESSURE: expected value was '+ str(expected_value) + ' but received ' + str(dem_pressure))
-
-    @classmethod
-    def CheckContactF(self, contact_force, expected_value, tolerance):
-        if abs(expected_value) > abs(contact_force*tolerance) or abs(expected_value) < abs(contact_force/tolerance):
-            raise ValueError('Incorrect value for CONTACT_FORCES_X: expected value was '+ str(expected_value) + ' but received ' + str(contact_force))
-
-    def Finalize(self):
-        super(DEM2D_ContactTestSolution, self).Finalize()
-
+                    self.assertAlmostEqual(contact_force, expected_value, delta=tolerance)
 
 
 class TestDEM2DContact(KratosUnittest.TestCase):

--- a/applications/DEMApplication/tests/test_DEM_2D_control_module.py
+++ b/applications/DEMApplication/tests/test_DEM_2D_control_module.py
@@ -15,7 +15,7 @@ this_working_dir_backup = os.getcwd()
 def GetFilePath(fileName):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
-class DEM2D_ControlModuleTestSolution(DEMAnalysisStage):
+class DEM2D_ControlModuleTestSolution(DEMAnalysisStage, KratosUnittest.TestCase):
 
     def GetMainPath(self):
         return os.path.join(os.path.dirname(os.path.realpath(__file__)), "DEM2D_control_module_tests_files")
@@ -58,22 +58,13 @@ class DEM2D_ControlModuleTestSolution(DEMAnalysisStage):
             if node.Id == 5:
                 node_force_x = node.GetSolutionStepValue(DEM.CONTACT_FORCES_X)
                 expected_value = 316.79
-                self.CheckForceX(node_force_x, expected_value, tolerance)
+                self.assertAlmostEqual(node_force_x, expected_value, delta=tolerance)
             elif node.Id == 6:
                 node_force_y = node.GetSolutionStepValue(DEM.CONTACT_FORCES_Y)
                 expected_value = 150.1
-                self.CheckForceY(node_force_y, expected_value, tolerance)
+                self.assertAlmostEqual(node_force_y, expected_value, delta=tolerance)
 
         super(DEM2D_ControlModuleTestSolution, self).Finalize()
-
-    def CheckForceX(self, force, expected_value, tolerance):
-        if abs(expected_value) > abs(force*tolerance) or abs(expected_value) < abs(force/tolerance):
-            raise ValueError('Incorrect value for CONTACT_FORCES_X: expected value was '+ str(expected_value) + ' but received ' + str(force))
-
-    def CheckForceY(self, force, expected_value, tolerance):
-        if abs(expected_value) > abs(force*tolerance) or abs(expected_value) < abs(force/tolerance):
-            raise ValueError('Incorrect value for CONTACT_FORCES_Y: expected value was '+ str(expected_value) + ' but received ' + str(force))
-
 
 class TestDEM2DControlModule(KratosUnittest.TestCase):
 

--- a/applications/DEMApplication/tests/test_DEM_2D_inlet.py
+++ b/applications/DEMApplication/tests/test_DEM_2D_inlet.py
@@ -15,7 +15,7 @@ this_working_dir_backup = os.getcwd()
 def GetFilePath(fileName):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
-class DEM2D_InletTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage):
+class DEM2D_InletTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     @classmethod
     def GetMainPath(self):
@@ -34,26 +34,8 @@ class DEM2D_InletTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_sta
                 if self.time >= 1.15:
                     print(node_vel)
                     print(node_force)
-                    expected_value = 0.380489240
-                    self.CheckVel(node_vel, expected_value, tolerance)
-                    expected_value = -120983.1002
-                    self.CheckForce(node_force, expected_value, tolerance)
-
-
-    @classmethod
-    def CheckVel(self, vel, expected_value, tolerance):
-        if abs(expected_value) > abs(vel*tolerance) or abs(expected_value) < abs(vel/tolerance):
-            raise ValueError('Incorrect value for VELOCITY_Y: expected value was '+ str(expected_value) + ' but received ' + str(vel))
-
-    @classmethod
-    def CheckForce(self, force, expected_value, tolerance):
-        if abs(expected_value) > abs(force*tolerance) or abs(expected_value) < abs(force/tolerance):
-            raise ValueError('Incorrect value for TOTAL_FORCES_Y: expected value was '+ str(expected_value) + ' but received ' + str(force))
-
-    def Finalize(self):
-        super(DEM2D_InletTestSolution, self).Finalize()
-
-
+                    self.assertAlmostEqual(node_vel, 0.380489240, delta=tolerance)
+                    self.assertAlmostEqual(node_force, -120983.1002, delta=tolerance)
 
 class TestDEM2DInlet(KratosUnittest.TestCase):
 

--- a/applications/DEMApplication/tests/test_DEM_2D_restitution.py
+++ b/applications/DEMApplication/tests/test_DEM_2D_restitution.py
@@ -14,7 +14,7 @@ this_working_dir_backup = os.getcwd()
 def GetFilePath(fileName):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
-class DEM2D_RestitutionTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage):
+class DEM2D_RestitutionTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     def Initialize(self):
         super(DEM2D_RestitutionTestSolution, self).Initialize()
@@ -28,11 +28,6 @@ class DEM2D_RestitutionTestSolution(KratosMultiphysics.DEMApplication.DEM_analys
     def GetProblemNameWithPath(self):
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
 
-    @classmethod
-    def CheckRestitution(self, reference, restitution_coefficient, tolerance):
-        if not (reference < restitution_coefficient*tolerance and reference > restitution_coefficient/tolerance):
-            raise ValueError('Incorrect value for COEFFICIENT_OF_RESTITUTION: expected value was '+ str(reference) + ' but received ' + str(restitution_coefficient))
-
     def Finalize(self):
         tolerance = 1.0+1.0e-4
         for node in self.spheres_model_part.Nodes:
@@ -44,9 +39,8 @@ class DEM2D_RestitutionTestSolution(KratosMultiphysics.DEMApplication.DEM_analys
             Logger.PrintInfo("ref:", self.coeff)
             Logger.PrintInfo("upper bound:", restitution_coefficient*tolerance)
             Logger.PrintInfo("lower bound:", restitution_coefficient/tolerance)
-            self.CheckRestitution(self.coeff, restitution_coefficient, tolerance)
+            self.assertAlmostEqual(self.coeff, restitution_coefficient, delta=tolerance)
         super(DEM2D_RestitutionTestSolution, self).Finalize()
-
 
     def ReadModelParts(self, max_node_Id=0, max_elem_Id=0, max_cond_Id=0):
         properties = KratosMultiphysics.Properties(0)

--- a/applications/DEMApplication/tests/test_DEM_3D_contact.py
+++ b/applications/DEMApplication/tests/test_DEM_3D_contact.py
@@ -15,7 +15,7 @@ this_working_dir_backup = os.getcwd()
 def GetFilePath(fileName):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
-class DEM3D_ContactTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage):
+class DEM3D_ContactTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     @classmethod
     def GetMainPath(self):
@@ -32,33 +32,12 @@ class DEM3D_ContactTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_s
             contact_force = node.GetSolutionStepValue(DEM.CONTACT_FORCES_Z)
             if node.Id == 9:
                 if self.time > 0.35:
-                    expected_value = 1621
-                    self.CheckPressure(dem_pressure, expected_value, tolerance)
-                    expected_value = -6484
-                    self.CheckContactF(contact_force, expected_value, tolerance)
+                    self.assertAlmostEqual(dem_pressure, 1621, delta=tolerance)
+                    self.assertAlmostEqual(contact_force, -6484, delta=tolerance)
             if node.Id == 13:
                 if self.time > 0.35:
-                    expected_value = 841
-                    self.CheckPressure(dem_pressure, expected_value, tolerance)
-                    expected_value = -3366
-                    self.CheckContactF(contact_force, expected_value, tolerance)
-
-
-
-    @classmethod
-    def CheckPressure(self, dem_pressure, expected_value, tolerance):
-        if expected_value > dem_pressure*tolerance or expected_value < dem_pressure/tolerance:
-            raise ValueError('Incorrect value for DEM_PRESSURE: expected value was '+ str(expected_value) + ' but received ' + str(dem_pressure))
-
-    @classmethod
-    def CheckContactF(self, contact_force, expected_value, tolerance):
-        if abs(expected_value) > abs(contact_force*tolerance) or abs(expected_value) < abs(contact_force/tolerance):
-            raise ValueError('Incorrect value for CONTACT_FORCES_X: expected value was '+ str(expected_value) + ' but received ' + str(contact_force))
-
-    def Finalize(self):
-        super(DEM3D_ContactTestSolution, self).Finalize()
-
-
+                    self.assertAlmostEqual(dem_pressure, 841, delta=tolerance)
+                    self.assertAlmostEqual(contact_force, -3366, delta=tolerance)
 
 class TestDEM3DContact(KratosUnittest.TestCase):
 

--- a/applications/DEMApplication/tests/test_DEM_3D_continuum.py
+++ b/applications/DEMApplication/tests/test_DEM_3D_continuum.py
@@ -32,17 +32,16 @@ class DEM3D_ContinuumTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis
     def CheckValues(self, x_vel, z_vel, x_force, z_force, dem_pressure, z_elastic, shear, x_tangential):
         tol = 1.0000+1.0e-3
         #DEM reference values
-        x_vel_ref           =0.02043790
-        z_vel_ref           =-0.8771226
-        x_force_ref         =-25240.795
-        z_force_ref         =1963237.70
+        x_vel_ref = 0.02043790
+        z_vel_ref = -0.8771226
+        x_force_ref = -25240.795
+        z_force_ref = 1963237.70
 
         #FEM reference values
-        dem_pressure_ref    =21558.5
-        z_elastic_ref       =-273320
-        shear_ref           =271.471
-        x_tangential_ref    =4524.52
-
+        dem_pressure_ref = 21558.5
+        z_elastic_ref = -273320
+        shear_ref = 271.471
+        x_tangential_ref = 4524.52
 
         if not (abs(x_vel_ref) < abs(x_vel*tol) and abs(x_vel_ref) > abs(x_vel/tol)):
             raise ValueError('Incorrect value for VELOCITY_X: expected value was '+ str(x_vel_ref) + ' but received ' + str(x_vel))
@@ -67,9 +66,6 @@ class DEM3D_ContinuumTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis
 
         if not (abs(x_tangential_ref) < abs(x_tangential*tol) and abs(x_tangential_ref) > abs(x_tangential/tol)):
             raise ValueError('Incorrect value for TANGENTIAL_ELASTIC_FORCE_Z: expected value was '+ str(x_tangential_ref) + ' but received ' + str(x_tangential))
-
-
-
 
     def Finalize(self):
         for node in self.spheres_model_part.Nodes:

--- a/applications/DEMApplication/tests/test_DEM_3D_restitution.py
+++ b/applications/DEMApplication/tests/test_DEM_3D_restitution.py
@@ -15,7 +15,7 @@ this_working_dir_backup = os.getcwd()
 def GetFilePath(fileName):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
-class DEM3D_RestitutionTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage):
+class DEM3D_RestitutionTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     def Initialize(self):
         super(DEM3D_RestitutionTestSolution, self).Initialize()
@@ -29,11 +29,6 @@ class DEM3D_RestitutionTestSolution(KratosMultiphysics.DEMApplication.DEM_analys
     def GetProblemNameWithPath(self):
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
 
-    @classmethod
-    def CheckRestitution(self, reference, restitution_coefficient, tolerance):
-        if not (reference < abs(restitution_coefficient*tolerance) and reference > abs(restitution_coefficient/tolerance)):
-            raise ValueError('Incorrect value for COEFFICIENT_OF_RESTITUTION: expected value was '+ str(reference) + ' but received ' + str(restitution_coefficient))
-
     def Finalize(self):
         tolerance = 1.0001
         for node in self.spheres_model_part.Nodes:
@@ -45,7 +40,7 @@ class DEM3D_RestitutionTestSolution(KratosMultiphysics.DEMApplication.DEM_analys
             Logger.PrintInfo("ref:",self.coeff)
             Logger.PrintInfo("upper bound:",restitution_coefficient*tolerance)
             Logger.PrintInfo("lower bound:",restitution_coefficient/tolerance)
-            self.CheckRestitution(self.coeff, restitution_coefficient, tolerance)
+            self.assertAlmostEqual(self.coeff, restitution_coefficient, delta=tolerance)
         super(DEM3D_RestitutionTestSolution, self).Finalize()
 
 

--- a/applications/DEMApplication/tests/test_analytics.py
+++ b/applications/DEMApplication/tests/test_analytics.py
@@ -16,7 +16,7 @@ def GetFilePath(fileName):
 
 
 
-class AnalyticsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage):
+class AnalyticsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     @classmethod
     def GetMainPath(self):
@@ -34,33 +34,19 @@ class AnalyticsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage
             if node.Id == 1:
                 if self.time > 0.099:
                     expected_value = 11.07179
-                    self.CheckValueOfNormalImpactVelocity(normal_impact_vel, expected_value, tolerance)
+                    self.assertAlmostEqual(normal_impact_vel, expected_value, delta=tolerance)
                     expected_value = 6.941702
-                    self.CheckValueOfFaceNormalImpactVelocity(face_normal_impact_vel, expected_value, tolerance)
+                    self.assertAlmostEqual(face_normal_impact_vel, expected_value, delta=tolerance)
             if node.Id == 2:
                 if self.time > 0.099:
                     expected_value = 16.29633
-                    self.CheckValueOfNormalImpactVelocity(normal_impact_vel, expected_value, tolerance)
+                    self.assertAlmostEqual(normal_impact_vel, expected_value, delta=tolerance)
             if node.Id == 3:
                 if self.time > 0.099:
                     expected_value = 16.29633
-                    self.CheckValueOfNormalImpactVelocity(normal_impact_vel, expected_value, tolerance)
+                    self.assertAlmostEqual(normal_impact_vel, expected_value, delta=tolerance)
 
-    @classmethod
-    def CheckValueOfNormalImpactVelocity(self, normal_impact_vel, expected_value, tolerance):
-        if normal_impact_vel > expected_value + tolerance or normal_impact_vel < expected_value - tolerance:
-            raise ValueError('Incorrect value for NORMAL_IMPACT_VELOCITY: expected value was '+ str(expected_value) + ' but received ' + str(normal_impact_vel))
-
-    @classmethod
-    def CheckValueOfFaceNormalImpactVelocity(self, face_normal_impact_vel, expected_value, tolerance):
-        if face_normal_impact_vel > expected_value + tolerance or face_normal_impact_vel < expected_value - tolerance:
-            raise ValueError('Incorrect value for FACE_NORMAL_IMPACT_VELOCITY: expected value was '+ str(expected_value) + ' but received ' + str(face_normal_impact_vel))
-
-    def Finalize(self):
-        super(AnalyticsTestSolution, self).Finalize()
-
-
-class GhostsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage):
+class GhostsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     @classmethod
     def GetMainPath(self):
@@ -70,14 +56,14 @@ class GhostsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DE
         return os.path.join(self.main_path, self.DEM_parameters["problem_name"].GetString())
 
     def RunAnalytics(self, time, is_time_to_print=True):
-            self.MakeAnalyticsMeasurements()
-            if is_time_to_print:
-                self.FaceAnalyzerClass.CreateNewFile()
-                for sp in (sp for sp in self.rigid_face_model_part.SubModelParts if sp[DEM.IS_GHOST]):
-                    self.face_watcher_analysers[sp.Name].UpdateDataFiles(time)
-                    self.CheckTotalNumberOfCrossingParticles()
+        self.MakeAnalyticsMeasurements()
+        if is_time_to_print:
+            self.FaceAnalyzerClass.CreateNewFile()
+            for sp in (sp for sp in self.rigid_face_model_part.SubModelParts if sp[DEM.IS_GHOST]):
+                self.face_watcher_analysers[sp.Name].UpdateDataFiles(time)
+                self.CheckTotalNumberOfCrossingParticles()
 
-            self.FaceAnalyzerClass.RemoveOldFile()
+        self.FaceAnalyzerClass.RemoveOldFile()
 
     def CheckTotalNumberOfCrossingParticles(self):
         import h5py
@@ -86,16 +72,9 @@ class GhostsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DE
             input_data = h5py.File(self.main_path+'/flux_data.hdf5','r')
             n_accum_h5 = input_data.get('1/n_accum')
 
-            if n_accum_h5[-1] != -4:
-                print(n_accum_h5[-1])
-                raise ValueError('The total value of crossing particles was not the expected!')
+            self.assertEqual(n_accum_h5[-1], -4)
 
-    def Finalize(self):
-        super(GhostsTestSolution, self).Finalize()
-
-
-
-class MultiGhostsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage):
+class MultiGhostsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     @classmethod
     def GetMainPath(self):
@@ -123,13 +102,7 @@ class MultiGhostsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_sta
             input_data = h5py.File(self.main_path+'/flux_data.hdf5','r')
             n_accum_h5 = input_data.get('2/n_accum')
 
-            if n_accum_h5[-1] != -4:
-                print(n_accum_h5[-1])
-                raise ValueError('The total value of crossing particles was not the expected!')
-
-    def Finalize(self):
-        super(MultiGhostsTestSolution, self).Finalize()
-
+            self.assertEqual(n_accum_h5[-1], -4)
 
 class TestAnalytics(KratosUnittest.TestCase):
 

--- a/applications/DEMApplication/tests/test_glued_particles.py
+++ b/applications/DEMApplication/tests/test_glued_particles.py
@@ -14,7 +14,7 @@ this_working_dir_backup = os.getcwd()
 def GetFilePath(fileName):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
-class GluedParticlesTestSolution(DEM_analysis_stage.DEMAnalysisStage):
+class GluedParticlesTestSolution(DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     @classmethod
     def GetMainPath(self):
@@ -30,27 +30,17 @@ class GluedParticlesTestSolution(DEM_analysis_stage.DEMAnalysisStage):
             angular_velocity = node.GetSolutionStepValue(Kratos.ANGULAR_VELOCITY)
             if node.Id == 1:
                 if self.time > 0.01:
-                    self.CheckValue("Angular Velocity at time "+ str(self.time), angular_velocity[0], 2.0, tolerance)
+                    self.assertAlmostEqual(angular_velocity[0], 2.0, delta=tolerance)
 
                 if self.time > 0.499999 and self.time < 0.5000001:
-                    self.CheckValue("X Coordinate at time 0.5", node.X, -1.0, tolerance)
-                    self.CheckValue("Y Coordinate at time 0.5", node.Y, 0.6634116060768411, tolerance)
-                    self.CheckValue("Z Coordinate at time 0.5", node.Z, 0.21612092234725555, tolerance)
+                    self.assertAlmostEqual(node.X, -1.0, delta=tolerance)
+                    self.assertAlmostEqual(node.Y, 0.6634116060768411, delta=tolerance)
+                    self.assertAlmostEqual(node.Z, 0.21612092234725555, delta=tolerance)
 
                 if self.time > 0.999999 and self.time < 1.0000001:
-                    self.CheckValue("X Coordinate at time 1.0", node.X, -1.0, tolerance)
-                    self.CheckValue("Y Coordinate at time 1.0", node.Y, 0.6362810292697275, tolerance)
-                    self.CheckValue("Z Coordinate at time 1.0", node.Z, -0.16645873461885752, tolerance)
-
-    @classmethod
-    def CheckValue(self, explaining_string, value, expected_value, tolerance):
-        if value > expected_value + tolerance or value < expected_value - tolerance:
-            raise ValueError('Incorrect value for ' + explaining_string +': expected value was '+ str(expected_value) + ' but received ' + str(value))
-
-    def Finalize(self):
-        super(GluedParticlesTestSolution, self).Finalize()
-        #self.procedures.RemoveFoldersWithResults(self.main_path, self.problem_name)
-
+                    self.assertAlmostEqual(node.X, -1.0, tolerance)
+                    self.assertAlmostEqual(node.Y, 0.6362810292697275, delta=tolerance)
+                    self.assertAlmostEqual(node.Z, -0.16645873461885752, delta=tolerance)
 
 class TestGluedParticles(KratosUnittest.TestCase):
 

--- a/applications/DEMApplication/tests/test_kinematic_constraints.py
+++ b/applications/DEMApplication/tests/test_kinematic_constraints.py
@@ -13,7 +13,7 @@ this_working_dir_backup = os.getcwd()
 def GetFilePath(fileName):
     return os.path.join(os.path.dirname(os.path.realpath(__file__)), fileName)
 
-class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage):
+class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_analysis_stage.DEMAnalysisStage, KratosUnittest.TestCase):
 
     @classmethod
     def GetMainPath(self):
@@ -73,19 +73,11 @@ class KinematicConstraintsTestSolution(KratosMultiphysics.DEMApplication.DEM_ana
                     expected_value = 0.2192
                     self.CheckValueOfAngularVelocity(angular_velocity, 2, expected_value, tolerance)
 
-    @classmethod
     def CheckValueOfVelocity(self, velocity, component, expected_value, tolerance):
-        if velocity[component] > expected_value + tolerance or velocity[component] < expected_value - tolerance:
-            raise ValueError('Incorrect value for VELOCITY ' + str(component) + ': expected value was '+ str(expected_value) + ' but received ' + str(velocity))
+        self.assertAlmostEqual(velocity[component], expected_value, delta=tolerance)
 
-    @classmethod
     def CheckValueOfAngularVelocity(self, angular_velocity, component, expected_value, tolerance):
-        if angular_velocity[component] > expected_value + tolerance or angular_velocity[component] < expected_value - tolerance:
-            raise ValueError('Incorrect value for ANGULAR_VELOCITY ' + str(component) + ': expected value was '+ str(expected_value) + ' but received ' + str(angular_velocity))
-
-    def Finalize(self):
-        super(KinematicConstraintsTestSolution, self).Finalize()
-
+        self.assertAlmostEqual(angular_velocity[component], expected_value, delta=tolerance)
 
 class TestKinematicConstraints(KratosUnittest.TestCase):
 


### PR DESCRIPTION
**Description**
Several checks which were using our own verification functions are now using the Unittest `assert` methods.
It required  to make this analysis stage derive from the DEM Stage (it was already) AND the Unittest.TestCase (new).

**Changelog**
- Assert methods changed
- Removed custom assert methods
- Removed some other useless methods (Finalize method overriding but just calling `super`) 
