### PR TITLE
Fixing sdem tests problems

### DIFF
--- a/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_solver.py
+++ b/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_solver.py
@@ -119,7 +119,7 @@ class SwimmingDEMSolver(PythonSolver):
 
         }""")
 
-        default_settings.AddMissingParameters(super(SwimmingDEMSolver, cls).GetDefaultParameters())
+        default_settings.AddMissingParameters(super().GetDefaultParameters())
         return default_settings
 
     def _ValidateSettings(self, project_parameters):

--- a/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_solver.py
+++ b/applications/SwimmingDEMApplication/python_scripts/swimming_DEM_solver.py
@@ -14,6 +14,114 @@ def Say(*args):
     Logger.Flush()
 
 class SwimmingDEMSolver(PythonSolver):
+
+    @classmethod
+    def GetDefaultParameters(cls):
+        # default settings string in json format
+        default_settings = Parameters("""{
+        "echo_level" : 1,
+
+        "gravity_parameters" : {
+            "modulus" : 9.81,
+            "direction" : [0.0, 0.0, -1.0]
+        },
+
+        "time_stepping" : {
+            "automatic_time_step" : true,
+            "time_step" : 0.001
+        },
+
+        "problem_data"  : {
+            "problem_name"  : "",
+            "echo_level" : 1,
+            "start_time" : 0.0,
+            "end_time"   : 1,
+            "parallel_type": "OpenMP",
+            "number_of_threads": 1
+        },
+
+        "ElementType" : "SwimmingDEMElement",
+        "body_force_per_unit_mass_variable_name" : "BODY_FORCE",
+        "do_print_results_option" : true,
+        "output_interval" : 0.5,
+
+        "processes" : {},
+
+        "coupling" : {
+            "coupling_level_type" : 1,
+            "coupling_weighing_type" : 2,
+            "coupling_weighing_type_comment" : "{fluid_to_DEM, DEM_to_fluid, fluid_fraction} = {lin, lin, imposed} (-1), {lin, const, const} (0), {lin, lin, const} (1), {lin, lin, lin} (2), averaging method (3)",
+            "interaction_start_time" : 0.0,
+
+            "forward_coupling" : {},
+
+            "backward_coupling" : {}
+        },
+
+        "frame_of_reference" : {},
+
+        "non_newtonian_fluid" : {},
+
+        "similarity" : {},
+
+        "stationarity" : {},
+
+        "debug_tool_cycle" : 10,
+        "debug_tool_cycle_comment" : " number of 'ticks' per debug computations cycle",
+        "print_debug_info_option" : false,
+        "print_debug_info_option_comment" : " print a summary of global physical measures",
+        "do_process_analytic_data" : true,
+        "fluid_domain_volume" : 1.0,
+        "fluid_domain_volume_comment" : "write down the volume you know it has, if available",
+
+        "full_particle_history_watcher" : "Empty",
+
+
+        "gradient_calculation_type" : 1,
+        "gradient_calculation_type_comment" : "(Not calculated (0), volume-weighed average(1), Superconvergent recovery(2))",
+        "material_acceleration_calculation_type" : 1,
+        "laplacian_calculation_type" : 0,
+        "laplacian_calculation_type_comment" : "(Not calculated (0), Finite element projection (1), Superconvergent recovery(2))",
+        "vorticity_calculation_type" : 5,
+        "store_full_gradient_option" : false,
+        "add_each_hydro_force_option" : true,
+        "add_each_hydro_force_option_comment" : " add each of the hydrodynamic forces (drag, lift and virtual mass)",
+        "pressure_grad_recovery_type" : 0,
+        "recovery_echo_level" : 1,
+        "store_fluid_pressure_option" : false,
+
+        "print_distance_option" : false,
+        "print_steps_per_plot_step" : 1,
+        "print_particles_results_option" : false,
+        "make_results_directories_option" : true,
+        "make_results_directories_option_comment": "results are written into a folder (../results) inside the problem folder",
+        "print_particles_results_cycle" : 1,
+        "print_particles_results_cycle_comment" : " number of 'ticks' per printing cycle",
+
+        "drag_modifier_type" : 2,
+        "drag_modifier_type_comment" : " Hayder (2), Chien (3)",
+
+        "json_output_process" : [],
+        "sdem_output_processes" : {},
+        "properties": [{}],
+
+        "fluid_parameters" : {},
+
+        "custom_fluid" : {},
+
+        "dem_parameters" : {},
+
+        "custom_dem" : {},
+
+        "dem_nodal_results" : {},
+
+        "fluid_nodal_results" : {}
+
+        }""")
+
+        default_settings.AddMissingParameters(super(SwimmingDEMSolver, cls).GetDefaultParameters())
+        return default_settings
+
     def _ValidateSettings(self, project_parameters):
 
         default_processes_settings = Parameters("""{

--- a/applications/SwimmingDEMApplication/tests/NightTests.py
+++ b/applications/SwimmingDEMApplication/tests/NightTests.py
@@ -20,6 +20,11 @@ try:
 except ImportError:
      interpolation_imports_available = False
 
+try:
+     import FluidDEMTestFactory as FDEMTF
+     fluid_DEM_coupling_imports_available = True
+except ImportError:
+     fluid_DEM_coupling_imports_available = False     
 # List of tests that are available
 available_tests = []
 
@@ -63,6 +68,12 @@ if interpolation_imports_available:
 
      available_tests += [test_class for test_class in InterpolationTF.TestFactory.__subclasses__()]
 
+if fluid_DEM_coupling_imports_available:
+     class fluid_dem_coupling_one_way_test(FDEMTF.TestFactory):
+          file_name = "fluid_dem_tests/settling_cube"
+          file_parameters = "fluid_dem_tests/ProjectParameters.json"
+
+     available_tests += [test_class for test_class in FDEMTF.TestFactory.__subclasses__()]
 
 def SetTestSuite(suites):
     night_suite = suites['nightly']
@@ -79,5 +90,5 @@ def AssembleTestSuites():
     return suites
 
 if __name__ == '__main__':
-    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.DETAIL)
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
     KratosUnittest.runTests(AssembleTestSuites())

--- a/applications/SwimmingDEMApplication/tests/NightTests.py
+++ b/applications/SwimmingDEMApplication/tests/NightTests.py
@@ -24,7 +24,7 @@ try:
      import FluidDEMTestFactory as FDEMTF
      fluid_DEM_coupling_imports_available = True
 except ImportError:
-     fluid_DEM_coupling_imports_available = False     
+     fluid_DEM_coupling_imports_available = False
 # List of tests that are available
 available_tests = []
 

--- a/applications/SwimmingDEMApplication/tests/SmallTests.py
+++ b/applications/SwimmingDEMApplication/tests/SmallTests.py
@@ -26,6 +26,6 @@ def AssembleTestSuites():
     return suites
 
 if __name__ == '__main__':
-    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.DETAIL)
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
     KratosUnittest.runTests(AssembleTestSuites())
 

--- a/applications/SwimmingDEMApplication/tests/ValidationTests.py
+++ b/applications/SwimmingDEMApplication/tests/ValidationTests.py
@@ -12,10 +12,6 @@ import SPFEMTestFactory as SPFEMTF
 # Import KratosUnittest
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 
-class fluid_dem_coupling_one_way_test(FDEMTF.TestFactory):
-     file_name = "fluid_dem_tests/settling_cube"
-     file_parameters = "fluid_dem_tests/ProjectParameters.json"
-
 class sdem_pfem_coupling_one_way_test(SPFEMTF.TestFactory):
      file_name = "PFEM-DEM_tests/sdem_pfem_coupling_one_way_test"
      file_parameters = "PFEM-DEM_tests/ProjectParameters.json"
@@ -40,5 +36,5 @@ def AssembleTestSuites():
     return suites
 
 if __name__ == '__main__':
-    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.DETAIL)
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
     KratosUnittest.runTests(AssembleTestSuites())

--- a/applications/SwimmingDEMApplication/tests/ValidationTests.py
+++ b/applications/SwimmingDEMApplication/tests/ValidationTests.py
@@ -6,7 +6,6 @@ import KratosMultiphysics.DEMApplication
 import KratosMultiphysics.SwimmingDEMApplication
 
 # Import TestFactory
-import FluidDEMTestFactory as FDEMTF
 import SPFEMTestFactory as SPFEMTF
 
 # Import KratosUnittest

--- a/applications/SwimmingDEMApplication/tests/fluid_dem_tests/ProjectParameters.json
+++ b/applications/SwimmingDEMApplication/tests/fluid_dem_tests/ProjectParameters.json
@@ -11,7 +11,7 @@
     "parallel_type" : "OpenMP",
     "echo_level" : 1,
     "start_time" : 0.0,
-    "end_time" : 0.3
+    "end_time" : 0.024
 },
 
 "do_print_results_option" : false,
@@ -23,6 +23,7 @@
     "coupling_weighing_type" : 1,
     "coupling_weighing_type_comment" : "{fluid_to_DEM, DEM_to_fluid, fluid_fraction} = {lin, lin, imposed} (-1), {lin, const, const} (0), {lin, lin, const} (1), {lin, lin, lin} (2), averaging method (3)",
     "interaction_start_time" : 0.01,
+    "min_fluid_fraction_projected" : 0.0,
     "forward_coupling" : {
         "time_averaging_type" : 0
     },
@@ -100,7 +101,7 @@
         "parallel_type" : "OpenMP",
         "echo_level" : 0,
         "start_time" : 0.0,
-        "end_time" : 1.0
+        "end_time" : 0.012
     },
 
     "solver_settings" : {
@@ -121,7 +122,7 @@
         "linear_solver_settings" : {
             "solver_type" : "amgcl",
             "max_iteration" : 200,
-            "tolerance" : 1e-7,
+            "tolerance" : 0.1,
             "provide_coordinates" : false,
             "smoother_type" : "ilu0",
             "krylov_type" : "gmres",

--- a/applications/SwimmingDEMApplication/tests/test_SwimmingDEMApplication.py
+++ b/applications/SwimmingDEMApplication/tests/test_SwimmingDEMApplication.py
@@ -1,5 +1,6 @@
 # import Kratos
 import KratosMultiphysics
+import KratosMultiphysics.FluidDynamicsApplication
 import KratosMultiphysics.DEMApplication
 import KratosMultiphysics.SwimmingDEMApplication
 

--- a/applications/SwimmingDEMApplication/tests/test_SwimmingDEMApplication.py
+++ b/applications/SwimmingDEMApplication/tests/test_SwimmingDEMApplication.py
@@ -34,7 +34,7 @@ def AssembleTestSuites():
     return suites
 
 if __name__ == '__main__':
-    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.DETAIL)
+    KratosMultiphysics.Logger.GetDefaultOutput().SetSeverity(KratosMultiphysics.Logger.Severity.WARNING)
     KratosUnittest.runTests(AssembleTestSuites())
 
 


### PR DESCRIPTION
**Description**
This PR fixes the problems with tests in _SwimmingDEMApplication_. After the update of the _python_solver.py_ the _ValidationParameters_ method can not be avoided so it is necessary to implement a _GetDefaultParameters()_ method in _swimming_DEM_solver.py_ to check that the parameters used are correct. Before this PR that method was not implemented so the tests in the _SwimmingDEMApplication_ did not work.

Please mark the PR with appropriate tags: 
- Applications

**Changelog**
Changes:
- Added  _GetDefaultParameters()_ in _swimming_DEM_solver.py_
- Added FluidDynamicsApplication import in _test_SwimmingDEMApplication.py_.
- Added fluid-dem one-way coupling to the night tests. 
- Changed the Severity to WARNING to reduce the information printed in console.
