### PR TITLE
[SwimmingDEM] missing imports in init

### DIFF
--- a/applications/SwimmingDEMApplication/SwimmingDEMApplication.py
+++ b/applications/SwimmingDEMApplication/SwimmingDEMApplication.py
@@ -1,7 +1,10 @@
-from __future__ import print_function, absolute_import, division #makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-from KratosSwimmingDEMApplication import *
-
 from KratosMultiphysics import _ImportApplication
+
+# import the applications the SwimmingDEMApplication depends on
+import KratosMultiphysics.FluidDynamicsApplication
+import KratosMultiphysics.DEMApplication
+
+from KratosSwimmingDEMApplication import *
 application = KratosSwimmingDEMApplication()
 application_name = "KratosSwimmingDEMApplication"
 


### PR DESCRIPTION
**Description**
In #7553 I noticed that this was missing.

**Changelog**
Adding the imports of the Applications the SwimmingDEM depends on (aka links against) to avoid potential nasty problems with undefined symbols etc that we had in the past (e.g. #5373)
