### PR TITLE
[Core][BugFix] Strange fix for relase builds [#7551]

### DIFF
--- a/kratos/utilities/coordinate_transformation_utilities.h
+++ b/kratos/utilities/coordinate_transformation_utilities.h
@@ -322,7 +322,7 @@ public:
         rOutput(0, 1) = unit_normal_derivative[1];
         rOutput(0, 2) = unit_normal_derivative[2];
 
-        array_1d<double, 3> rT1 = ZeroVector(3);
+        array_1d<double, 3> rT1(3, 0.0);
         rT1[0] = 1.0;
         double dot = unit_normal[0];
         double dot_derivative = unit_normal_derivative[0];

--- a/kratos/utilities/coordinate_transformation_utilities.h
+++ b/kratos/utilities/coordinate_transformation_utilities.h
@@ -322,7 +322,7 @@ public:
         rOutput(0, 1) = unit_normal_derivative[1];
         rOutput(0, 2) = unit_normal_derivative[2];
 
-        array_1d<double, 3> rT1(0.0);
+        array_1d<double, 3> rT1 = ZeroVector(3);
         rT1[0] = 1.0;
         double dot = unit_normal[0];
         double dot_derivative = unit_normal_derivative[0];


### PR DESCRIPTION
**Description**
So I have a strange situation the fix is suggested in this PR for #7551 . :)

The situation is regarding the following block:
https://github.com/KratosMultiphysics/Kratos/blob/f0fc380274674d9421aeca58b4d165f9d5313a07/kratos/utilities/coordinate_transformation_utilities.h#L325-L338

In here, if I put  `KRATOS_WATCH(rT1)` after line 338, then in relase this PR fix is not required and all the tests are also passing. 

Without putting `KRATOS_WATCH(rT1)` after line 338, I tried the following
1. Removed `noalias`
2. Removed `-=` and use the expanded version
3. Removed array multiplication and used component wise substraction and multiplication

Above nothing worked. Then I changed line 325 to as suggested in this PR and then it works. 
`array_1d<double, 3> rT1(0.0);` line also should initialize array_1d<double, 3> variable with `0.0` ryt? I don't understand why it doesn't work in release mode. (Everythin works without this PR's fix in FullDebug)

My intention of using `array_1d<double, 3> rT1(0.0);` is to avoid copy and assignment operation.

**Changelog**
- BugFix for failing `TestCoordinateTransformationUtilitiesCoarseSphere` test
