### PR TITLE
[CI] Adding MPI meshing python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,20 @@ jobs:
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
         mpiexec -np 2 python3 applications/MeshingApplication/tests/test_MeshingApplication_mpi.py --using-mpi
 
+    - name: Running MPI Python MeshingApplication (3 Cores)
+      run: |
+        . /opt/intel/mkl/bin/mklvars.sh
+        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
+        mpiexec -np 3 python3 applications/MeshingApplication/tests/test_MeshingApplication_mpi.py --using-mpi
+
+    - name: Running MPI Python MeshingApplication (4 Cores)
+      run: |
+        . /opt/intel/mkl/bin/mklvars.sh
+        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
+        mpiexec -np 4 python3 applications/MeshingApplication/tests/test_MeshingApplication_mpi.py --using-mpi
+
   windows:
     runs-on: windows-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,13 @@ jobs:
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
         mpiexec --oversubscribe -np 4 python3 applications/ParticleMechanicsApplication/tests/test_ParticleMechanicsApplication_mpi.py --using-mpi
 
+    - name: Running MPI Python MeshingApplication (2 Cores)
+      run: |
+        . /opt/intel/mkl/bin/mklvars.sh
+        export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
+        export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
+        mpiexec -np 2 python3 applications/MeshingApplication/tests/test_MeshingApplication_mpi.py --using-mpi
+
   windows:
     runs-on: windows-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,14 +231,14 @@ jobs:
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
-        mpiexec -np 3 python3 applications/MeshingApplication/tests/test_MeshingApplication_mpi.py --using-mpi
+        mpiexec --oversubscribe  -np 3 python3 applications/MeshingApplication/tests/test_MeshingApplication_mpi.py --using-mpi
 
     - name: Running MPI Python MeshingApplication (4 Cores)
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
         export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}/libs
-        mpiexec -np 4 python3 applications/MeshingApplication/tests/test_MeshingApplication_mpi.py --using-mpi
+        mpiexec --oversubscribe  -np 4 python3 applications/MeshingApplication/tests/test_MeshingApplication_mpi.py --using-mpi
 
   windows:
     runs-on: windows-latest

--- a/applications/MeshingApplication/tests/test_MeshingApplication_mpi.py
+++ b/applications/MeshingApplication/tests/test_MeshingApplication_mpi.py
@@ -1,0 +1,48 @@
+# import Kratos
+import KratosMultiphysics
+
+# Import Kratos "wrapper" for unittests
+import KratosMultiphysics.KratosUnittest as KratosUnittest
+
+try:
+    import KratosMultiphysics.mpi as KratosMPI
+    import KratosMultiphysics.MetisApplication as MetisApplication
+    import KratosMultiphysics.TrilinosApplication as TrilinosApplication
+except ImportError:
+    raise Exception("KratosMPI could not be imported!")
+
+if KratosMultiphysics.ParallelEnvironment.GetDefaultSize() != 2:
+    raise Exception("The MPI tests currently support only being run with 2 processors!")
+
+# Import the tests or test_classes to create the suits
+
+def AssembleTestSuites():
+    ''' Populates the test suites to run.
+    Populates the test suites to run. At least, it should pupulate the suites:
+    "small", "nighlty" and "all"
+    Return
+    ------
+    suites: A dictionary of suites
+        The set of suites with its test_cases added.
+    '''
+    suites = KratosUnittest.KratosSuites
+
+    ### Small MPI tests ########################################################
+    smallMPISuite = suites['mpi_small']
+
+    ### Nightly MPI tests ######################################################
+    nightlyMPISuite = suites['mpi_nightly']
+    nightlyMPISuite.addTests(smallMPISuite)
+
+    ### Full MPI set ###########################################################
+    allMPISuite = suites['mpi_all']
+    allMPISuite.addTests(nightlyMPISuite) # already contains the smallMPISuite
+
+    allSuite = suites['all']
+    allSuite.addTests(allMPISuite)
+
+    return suites
+
+
+if __name__ == '__main__':
+    KratosUnittest.runTests(AssembleTestSuites())

--- a/applications/MeshingApplication/tests/test_MeshingApplication_mpi.py
+++ b/applications/MeshingApplication/tests/test_MeshingApplication_mpi.py
@@ -1,18 +1,11 @@
-# import Kratos
-import KratosMultiphysics
+# Importing the Kratos Library
+import KratosMultiphysics as KM
+
+if not KM.IsDistributedRun():
+    raise Exception("This test script can only be executed in MPI!")
 
 # Import Kratos "wrapper" for unittests
 import KratosMultiphysics.KratosUnittest as KratosUnittest
-
-try:
-    import KratosMultiphysics.mpi as KratosMPI
-    import KratosMultiphysics.MetisApplication as MetisApplication
-    import KratosMultiphysics.TrilinosApplication as TrilinosApplication
-except ImportError:
-    raise Exception("KratosMPI could not be imported!")
-
-if KratosMultiphysics.ParallelEnvironment.GetDefaultSize() != 2:
-    raise Exception("The MPI tests currently support only being run with 2 processors!")
 
 # Import the tests or test_classes to create the suits
 


### PR DESCRIPTION
**Description**
This adds the MPI meshing app suite to the CI.

It is currently empty, PR #7570  will add the first test.


**Changelog**
Please summarize the changes in one list to generate the changelog:
E.g.
- Created MPI test suite
- Added to CI
