### PR TITLE
[Core] Remove array_1d size_t Ctor

### DIFF
--- a/applications/MappingApplication/custom_searching/interface_communicator.cpp
+++ b/applications/MappingApplication/custom_searching/interface_communicator.cpp
@@ -255,7 +255,7 @@ void InterfaceCommunicator::ConductLocalSearch(const Communicator& rComm)
     if (num_interface_obj_bin > 0) { // this partition has a bin structure
         InterfaceObjectConfigure::ResultContainerType neighbor_results(num_interface_obj_bin);
         std::vector<double> neighbor_distances(num_interface_obj_bin);
-        auto interface_obj(Kratos::make_shared<InterfaceObject>(array_1d<double, 3>(0.0)));
+        auto interface_obj(Kratos::make_shared<InterfaceObject>(array_1d<double, 3>()));
 
         int sum_num_results = 0;
         int sum_num_searched_objects = 0;

--- a/applications/MappingApplication/mapping_application.cpp
+++ b/applications/MappingApplication/mapping_application.cpp
@@ -76,7 +76,7 @@ namespace Kratos
 
 KratosMappingApplication::KratosMappingApplication() :
     KratosApplication("MappingApplication"),
-    mInterfaceObject(array_1d<double, 3>(0.0)),
+    mInterfaceObject(array_1d<double, 3>()),
     mInterfaceNode(),
     mInterfaceGeometryObject()
 {}

--- a/kratos/containers/array_1d.h
+++ b/kratos/containers/array_1d.h
@@ -106,15 +106,6 @@ public:
         //sin esto no funciona en windows!!
         //std::fill (data().begin(), data().end(), value_type	());
     }
-    explicit BOOST_UBLAS_INLINE
-    array_1d (size_type array_size):
-        vector_expression<self_type> ()
-    {
-        //sin esto no funciona en windows!!
-        //std::fill (data().begin(), data().end(), value_type	());
-
-        /* 				std::fill (data().begin(), data().end(), value_type	()); */
-    }
 
     explicit BOOST_UBLAS_INLINE
     array_1d (size_type array_size, value_type v):

--- a/kratos/tests/cpp_tests/geometries/test_hexahedra_3d_8.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_hexahedra_3d_8.cpp
@@ -255,7 +255,7 @@ namespace Kratos {
 
   KRATOS_TEST_CASE_IN_SUITE(Hexahedra3D8ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
       auto geom = GenerateOriginCenterLen2Hexahedra3D8();
-      array_1d<double, 3> coord(3);
+      array_1d<double, 3> coord;
       coord[0] = 1.0 / 2.0;
       coord[1] = 1.0 / 4.0;
       coord[2] = 1.0 / 16.0;

--- a/kratos/tests/cpp_tests/geometries/test_line_2d_2.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_2d_2.cpp
@@ -329,7 +329,7 @@ namespace Testing {
 
     KRATOS_TEST_CASE_IN_SUITE(Line2D2ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
         auto geom = GeneratePointsDiagonalLine2D2();
-        array_1d<double, 3> coord(3);
+        array_1d<double, 3> coord;
         coord[0] = 2.0/3.0;
         coord[1] = 2.0/3.0;
         coord[2] = 0.0;

--- a/kratos/tests/cpp_tests/geometries/test_line_3d_2.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_line_3d_2.cpp
@@ -313,7 +313,7 @@ namespace Testing {
 
     KRATOS_TEST_CASE_IN_SUITE(Line3D2ShapeFunctionValue, KratosCoreGeometriesFastSuite) {
         Geometry<Point>::Pointer p_geom = GeneratePointsDiagonalLine3D2();
-        array_1d<double, 3> coord(3);
+        array_1d<double, 3> coord;
         coord[0] = 2.0/3.0;
         coord[1] = 2.0/3.0;
         coord[2] = 2.0/3.0;
@@ -329,7 +329,7 @@ namespace Testing {
 
     KRATOS_TEST_CASE_IN_SUITE(Line3D2ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
         Geometry<Point>::Pointer p_geom = GeneratePointsDiagonalLine3D2();
-        array_1d<double, 3> coord(3);
+        array_1d<double, 3> coord;
         coord[0] = 2.0/3.0;
         coord[1] = 2.0/3.0;
         coord[2] = 2.0/3.0;

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_curve.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_curve.cpp
@@ -184,9 +184,9 @@ typedef Node<3> NodeType;
         // Check length of 2D curve
         KRATOS_CHECK_NEAR(curve.Length(), 11.180339887498949, TOLERANCE);
 
-        array_1d<double, 3> parameter(0.0);
+        array_1d<double, 3> parameter;
         parameter[0] = 1.0;
-        array_1d<double, 3> result(0.0);
+        array_1d<double, 3> result;
 
         curve.GlobalCoordinates(result, parameter);
 
@@ -229,10 +229,10 @@ typedef Node<3> NodeType;
 
         // check point at t = 0
         {
-            array_1d<double, 3> parameter(0.0);
+            array_1d<double, 3> parameter;
             parameter[0] = 0.0;
 
-            array_1d<double, 3> result(0.0);
+            array_1d<double, 3> result;
             curve.GlobalCoordinates(result, parameter);
 
             KRATOS_CHECK_NEAR(result[0], 0, TOLERANCE);
@@ -242,7 +242,7 @@ typedef Node<3> NodeType;
 
         // check derivatives at t = 0
         {
-            array_1d<double, 3> parameter(0.0);
+            array_1d<double, 3> parameter;
             parameter[0] = 0.0;
 
             std::vector<array_1d<double, 3>> derivatives;
@@ -267,10 +267,10 @@ typedef Node<3> NodeType;
 
         // check point at t = 65.9462851997
         {
-            array_1d<double, 3> parameter(0.0);
+            array_1d<double, 3> parameter;
             parameter[0] = 65.9462851997;
 
-            array_1d<double, 3> result(0.0);
+            array_1d<double, 3> result;
             curve.GlobalCoordinates(result, parameter);
 
             KRATOS_CHECK_NEAR(result[0], 17.372881, TOLERANCE);
@@ -280,7 +280,7 @@ typedef Node<3> NodeType;
 
         // check derivatives at t = 65.9462851997
         {
-            array_1d<double, 3> parameter(0.0);
+            array_1d<double, 3> parameter;
             parameter[0] = 65.9462851997;
 
             std::vector<array_1d<double, 3>> derivatives;
@@ -305,10 +305,10 @@ typedef Node<3> NodeType;
 
         // check point at t = 125
         {
-            array_1d<double, 3> parameter(0.0);
+            array_1d<double, 3> parameter;
             parameter[0] = 125;
 
-            array_1d<double, 3> result(0.0);
+            array_1d<double, 3> result;
             curve.GlobalCoordinates(result, parameter);
 
             KRATOS_CHECK_NEAR(result[0], -15.801248, TOLERANCE);
@@ -318,7 +318,7 @@ typedef Node<3> NodeType;
 
         // check derivatives at t = 125
         {
-            array_1d<double, 3> parameter(0.0);
+            array_1d<double, 3> parameter;
             parameter[0] = 125;
 
             std::vector<array_1d<double, 3>> derivatives;
@@ -343,10 +343,10 @@ typedef Node<3> NodeType;
 
         // check point at t = 131.892570399495
         {
-            array_1d<double, 3> parameter(0.0);
+            array_1d<double, 3> parameter;
             parameter[0] = 131.892570399495;
 
-            array_1d<double, 3> result(0.0);
+            array_1d<double, 3> result;
             curve.GlobalCoordinates(result, parameter);
 
             KRATOS_CHECK_NEAR(result[0], -25, TOLERANCE);
@@ -356,7 +356,7 @@ typedef Node<3> NodeType;
 
         // check derivatives at t = 131.892570399495
         {
-            array_1d<double, 3> parameter(0.0);
+            array_1d<double, 3> parameter;
             parameter[0] = 131.892570399495;
 
             std::vector<array_1d<double, 3>> derivatives;

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_surface.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_surface.cpp
@@ -140,7 +140,7 @@ namespace Testing {
         knot_u[1] = 0.0;
         knot_u[2] = 10.0;
         knot_u[3] = 10.0;
-        Vector knot_v = ZeroVector(2); 
+        Vector knot_v = ZeroVector(2);
         knot_v[0] = 0.0;
         knot_v[1] = 5.0;
 
@@ -287,10 +287,10 @@ namespace Testing {
         KRATOS_CHECK_EQUAL(surface.NumberOfControlPointsV(), 3);
         KRATOS_CHECK_EQUAL(surface.PointsNumber(), 12);
 
-        array_1d<double, 3> parameter(0.0);
+        array_1d<double, 3> parameter;
         parameter[0] = 0.0;
         parameter[1] = 0.0;
-        array_1d<double, 3> result(0.0);
+        array_1d<double, 3> result;
 
         surface.GlobalCoordinates(result, parameter);
     }
@@ -313,10 +313,10 @@ namespace Testing {
         KRATOS_CHECK_EQUAL(surface.NumberOfControlPointsV(), 2);
         KRATOS_CHECK_EQUAL(surface.PointsNumber(), 10);
 
-        array_1d<double, 3> parameter(0.0);
+        array_1d<double, 3> parameter;
         parameter[0] = 10.0;
         parameter[1] = 3.5;
-        array_1d<double, 3> result(0.0);
+        array_1d<double, 3> result;
 
         surface.GlobalCoordinates(result, parameter);
         double length = sqrt(result[0] * result[0] + result[1] * result[1]);
@@ -325,8 +325,8 @@ namespace Testing {
 
         std::vector<array_1d<double, 3>> derivatives;
         surface.GlobalSpaceDerivatives(derivatives, parameter, 3);
-        array_1d<double, 3> cross(0.0);
-        array_1d<double, 3> colinear_vector(0.0);
+        array_1d<double, 3> cross;
+        array_1d<double, 3> colinear_vector;
         derivatives[0][2] = 0.0;
         MathUtils<double>::CrossProduct(cross, derivatives[1], derivatives[2]);
         MathUtils<double>::CrossProduct(colinear_vector, cross, derivatives[0]);
@@ -382,10 +382,10 @@ namespace Testing {
         KRATOS_CHECK_EQUAL(surface.NumberOfControlPointsV(), 2);
         KRATOS_CHECK_EQUAL(surface.PointsNumber(), 6);
 
-        array_1d<double, 3> parameter(0.0);
+        array_1d<double, 3> parameter;
         parameter[0] = 10.0;
         parameter[1] = 3.5;
-        array_1d<double, 3> result(0.0);
+        array_1d<double, 3> result;
 
         surface.GlobalCoordinates(result, parameter);
         KRATOS_CHECK_NEAR(result[0], 10.0, TOLERANCE);
@@ -497,10 +497,10 @@ namespace Testing {
         KRATOS_CHECK_EQUAL(surface.NumberOfControlPointsV(), 6);
         KRATOS_CHECK_EQUAL(surface.PointsNumber(), 36);
 
-        array_1d<double, 3> parameter(0.0);
+        array_1d<double, 3> parameter;
         parameter[0] = .25;
         parameter[1] = .75;
-        array_1d<double, 3> result(0.0);
+        array_1d<double, 3> result;
 
         surface.GlobalCoordinates(result, parameter);
         KRATOS_CHECK_NEAR(result[0], 0.027607103217140, TOLERANCE);

--- a/kratos/tests/cpp_tests/geometries/test_nurbs_surface_shape_functions.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_nurbs_surface_shape_functions.cpp
@@ -104,7 +104,7 @@ namespace Testing {
         weights[35] = 1.0;
 
         // Parameter on the surface where to compute the basis functions and their derivatives
-        array_1d<double, 3> parameter(0.0);
+        array_1d<double, 3> parameter;
         parameter[0] = .582;
         parameter[1] = .8972;
 

--- a/kratos/tests/cpp_tests/geometries/test_prism_3d_6.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_prism_3d_6.cpp
@@ -170,7 +170,7 @@ namespace Testing {
 
     KRATOS_TEST_CASE_IN_SUITE(Prism3D6ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
         auto geom = GenerateRegularPrism3D6();
-        array_1d<double, 3> coord(3);
+        array_1d<double, 3> coord;
         coord[0] = 1.0 / 2.0;
         coord[1] = 1.0 / 4.0;
         coord[2] = 1.0 / 16.0;

--- a/kratos/tests/cpp_tests/geometries/test_quadrilateral_2d_4.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_quadrilateral_2d_4.cpp
@@ -177,7 +177,7 @@ namespace Testing
 
     KRATOS_TEST_CASE_IN_SUITE(Quadrilateral2D4ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
       auto geom = GenerateRightQuadrilateral2D4<Node<3>>();
-      array_1d<double, 3> coord(3);
+      array_1d<double, 3> coord;
       coord[0] = 1.0 / 2.0;
       coord[1] = 1.0 / 4.0;
       coord[2] = 0.0;

--- a/kratos/tests/cpp_tests/geometries/test_quadrilateral_2d_8.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_quadrilateral_2d_8.cpp
@@ -123,7 +123,7 @@ namespace {
 
     KRATOS_TEST_CASE_IN_SUITE(Quadrilateral2D8ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
         auto geom = GenerateReferenceQuadrilateral2D8();
-        array_1d<double, 3> coord(3);
+        array_1d<double, 3> coord;
         coord[0] = 1.0 / 2.0;
         coord[1] = 1.0 / 8.0;
         coord[2] = 0.0;

--- a/kratos/tests/cpp_tests/geometries/test_quadrilateral_3d_4.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_quadrilateral_3d_4.cpp
@@ -207,7 +207,7 @@ namespace Testing
 
     KRATOS_TEST_CASE_IN_SUITE(Quadrilateral3D4ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
       auto geom = GenerateFlatQuadrilateral3D4<Node<3>>();
-      array_1d<double, 3> coord(3);
+      array_1d<double, 3> coord;
       coord[0] = 1.0 / 2.0;
       coord[1] = 1.0 / 4.0;
       coord[2] = 0.0;

--- a/kratos/tests/cpp_tests/geometries/test_tetrahedra_3d_10.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_tetrahedra_3d_10.cpp
@@ -145,7 +145,7 @@ namespace{
 
   KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D10ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
     auto geom = GenerateReferenceTetrahedra3D10();
-    array_1d<double, 3> coord(3);
+    array_1d<double, 3> coord;
     coord[0] = 1.0 / 2.0;
     coord[1] = 1.0 / 4.0;
     coord[2] = 1.0 / 16.0;

--- a/kratos/tests/cpp_tests/geometries/test_tetrahedra_3d_4.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_tetrahedra_3d_4.cpp
@@ -425,7 +425,7 @@ namespace Kratos {
 
       KRATOS_CHECK_NEAR(geomTriRect->Quality(criteria),  0.955316618, TOLERANCE);
     }
-    
+
      /** Checks if the max dihedral angle quality metric is correctly calculated.
      * - TriRectangular tetrahedra, which should return a sub-optimal score.
      */
@@ -457,7 +457,7 @@ namespace Kratos {
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       Vector dihedral_angles(6);
-      geomTriRect->ComputeDihedralAngles(dihedral_angles); 
+      geomTriRect->ComputeDihedralAngles(dihedral_angles);
 
       KRATOS_CHECK_NEAR(dihedral_angles[0],  Globals::Pi *0.5, TOLERANCE);
       KRATOS_CHECK_NEAR(dihedral_angles[1],  Globals::Pi *0.5, TOLERANCE);
@@ -476,7 +476,7 @@ namespace Kratos {
       auto geomTriRect = GenerateTriRectangularTetrahedra3D4();
 
       Vector solid_angles(6);
-      geomTriRect->ComputeSolidAngles(solid_angles); 
+      geomTriRect->ComputeSolidAngles(solid_angles);
 
       KRATOS_CHECK_NEAR(solid_angles[0],  Globals::Pi *0.5, TOLERANCE);
       KRATOS_CHECK_NEAR(solid_angles[1],  0.339836909, TOLERANCE);
@@ -603,7 +603,7 @@ namespace Kratos {
 
   KRATOS_TEST_CASE_IN_SUITE(Tetrahedra3D4ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
       auto geom = GenerateTriRectangularTetrahedra3D4();
-      array_1d<double, 3> coord(3);
+      array_1d<double, 3> coord;
       coord[0] = 1.0 / 2.0;
       coord[1] = 1.0 / 4.0;
       coord[2] = 1.0 / 16.0;

--- a/kratos/tests/cpp_tests/geometries/test_triangle_2d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_triangle_2d_3.cpp
@@ -112,7 +112,7 @@ namespace Testing {
       auto p_geom = GeneratePointsRightTriangle2D3();
 
       const auto& r_edges = p_geom->GenerateEdges();
-      
+
       KRATOS_CHECK_NEAR((r_edges[0])[0].X(), (p_geom->pGetPoint(1))->X(), TOLERANCE);
       KRATOS_CHECK_NEAR((r_edges[0])[0].Y(), (p_geom->pGetPoint(1))->Y(), TOLERANCE);
       KRATOS_CHECK_NEAR((r_edges[0])[0].Z(), (p_geom->pGetPoint(1))->Z(), TOLERANCE);
@@ -592,7 +592,7 @@ namespace Testing {
 
     KRATOS_TEST_CASE_IN_SUITE(Triangle2D3ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
       auto geom = GenerateNodesRightTriangle2D3();
-      array_1d<double, 3> coord(3);
+      array_1d<double, 3> coord;
       coord[0] = 1.0 / 2.0;
       coord[1] = 1.0 / 8.0;
       coord[2] = 0.0;

--- a/kratos/tests/cpp_tests/geometries/test_triangle_2d_6.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_triangle_2d_6.cpp
@@ -136,7 +136,7 @@ namespace {
 
     KRATOS_TEST_CASE_IN_SUITE(Triangle2D6ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
         auto geom = GenerateReferenceTriangle2D6();
-        array_1d<double, 3> coord(3);
+        array_1d<double, 3> coord;
         coord[0] = 1.0 / 2.0;
         coord[1] = 1.0 / 8.0;
         coord[2] = 0.0;

--- a/kratos/tests/cpp_tests/geometries/test_triangle_3d_3.cpp
+++ b/kratos/tests/cpp_tests/geometries/test_triangle_3d_3.cpp
@@ -93,7 +93,7 @@ namespace Testing
         auto p_geom = GenerateRightTriangle3D3<NodeType>();
 
         const auto& r_edges = p_geom->GenerateEdges();
-        
+
         KRATOS_CHECK_NEAR((r_edges[0])[0].X(), (p_geom->pGetPoint(1))->X(), TOLERANCE);
         KRATOS_CHECK_NEAR((r_edges[0])[0].Y(), (p_geom->pGetPoint(1))->Y(), TOLERANCE);
         KRATOS_CHECK_NEAR((r_edges[0])[0].Z(), (p_geom->pGetPoint(1))->Z(), TOLERANCE);
@@ -700,7 +700,7 @@ namespace Testing
 
     KRATOS_TEST_CASE_IN_SUITE(Triangle3D3ShapeFunctionsValues, KratosCoreGeometriesFastSuite) {
         auto geom = GenerateEquilateralTriangle3D3<NodeType>();
-        array_1d<double, 3> coord(3);
+        array_1d<double, 3> coord;
         coord[0] = 1.0 / 2.0;
         coord[1] = 1.0 / 8.0;
         coord[2] = 0.0;

--- a/kratos/utilities/coordinate_transformation_utilities.h
+++ b/kratos/utilities/coordinate_transformation_utilities.h
@@ -322,7 +322,7 @@ public:
         rOutput(0, 1) = unit_normal_derivative[1];
         rOutput(0, 2) = unit_normal_derivative[2];
 
-        array_1d<double, 3> rT1(0.0);
+        array_1d<double, 3> rT1 = ZeroVector(3);
         rT1[0] = 1.0;
         double dot = unit_normal[0];
         double dot_derivative = unit_normal_derivative[0];


### PR DESCRIPTION
**Description**
This removes the `std::size_t` Ctor from `array_1d` and all occurances of it.

**Changelog**
- Removes `array_1d::array_1d(std::size_t)` ctor
- Removes all occurances of that same ctor
