### PR TITLE
Fix windows compilation

### DIFF
--- a/kratos/includes/kratos_components.h
+++ b/kratos/includes/kratos_components.h
@@ -24,9 +24,10 @@
 
 // Project includes
 #include "includes/define.h"
-#include "containers/flags.h"
-#include "utilities/quaternion.h"
 #include "includes/data_communicator.h"
+#include "containers/flags.h"
+#include "containers/variable.h"
+#include "utilities/quaternion.h"
 
 namespace Kratos
 {


### PR DESCRIPTION
**Description**
Fixes #7579

I believe that #7511 removed access to `variable.h` from `kratos_components.h` which was granted via `vector_component_adaptor.h`. CI would pass because of cotire unifying the sources.

@peterjwilson could you confirm it works with this fix?

~~Also, no idea why this is compiling in linux. It should not, or at least it should be dangerous. I assume the code is created at link time because `Kratos::KratosCommponents<Variable<Flags>>` is a template and it has no visibility problems as in windows?, but no idea. (@pooyan-dadvand help?, just for curiosity)~~
**Edit**: It worked in linux because of the forward declaration of the serializer...

**Changelog**
- Adding missing include
