### PR TITLE
[Core][Logger] Replace GetMessage with GetLoggerMessage to avoid conflict

### DIFF
--- a/kratos/input_output/logger.h
+++ b/kratos/input_output/logger.h
@@ -124,7 +124,7 @@ namespace Kratos
       ///@{
 
     std::string const& GetCurrentMessage() {
-      return mCurrentMessage.GetMessage();
+      return mCurrentMessage.GetLoggerMessage();
         }
 
       ///@}

--- a/kratos/input_output/logger_message.h
+++ b/kratos/input_output/logger_message.h
@@ -186,7 +186,7 @@ public:
   mMessage = TheMessage;
   }
 
-  std::string const& GetMessage() const {
+  std::string const& GetLoggerMessage() const {
   return mMessage;
   }
 

--- a/kratos/input_output/logger_output.cpp
+++ b/kratos/input_output/logger_output.cpp
@@ -82,9 +82,9 @@ namespace Kratos
                 r_stream << "Rank " << TheMessage.GetSourceRank() << ": ";
 
             if(TheMessage.GetLabel().size())
-                r_stream << TheMessage.GetLabel() << ": " << TheMessage.GetMessage();
+                r_stream << TheMessage.GetLabel() << ": " << TheMessage.GetLoggerMessage();
             else
-                r_stream << TheMessage.GetMessage();
+                r_stream << TheMessage.GetLoggerMessage();
 
             ResetMessageColor(message_severity);
         }

--- a/kratos/input_output/logger_table_output.cpp
+++ b/kratos/input_output/logger_table_output.cpp
@@ -77,7 +77,7 @@ namespace Kratos
 
     if (column_index >= 0) { // The label found in columns
       MoveCursorToColumn(column_index);
-      auto message = TheMessage.GetMessage();
+      auto message = TheMessage.GetLoggerMessage();
       message.erase(message.find_last_not_of(" \n\t") + 1);
       this->GetStream()  << std::left << std::setw(mColumnsWidth[column_index]) << message;
     }

--- a/kratos/tests/cpp_tests/input_output/test_logger.cpp
+++ b/kratos/tests/cpp_tests/input_output/test_logger.cpp
@@ -28,7 +28,7 @@ namespace Kratos {
             message << "Test message with number " << 12 << 'e' << "00";
 
             KRATOS_CHECK_C_STRING_EQUAL(message.GetLabel().c_str(), "label");
-            if (DataCommunicator::GetDefault().Rank() == 0) KRATOS_CHECK_C_STRING_EQUAL(message.GetMessage().c_str(), "Test message with number 12e00");
+            if (DataCommunicator::GetDefault().Rank() == 0) KRATOS_CHECK_C_STRING_EQUAL(message.GetLoggerMessage().c_str(), "Test message with number 12e00");
             KRATOS_CHECK_EQUAL(message.GetSeverity(), LoggerMessage::Severity::INFO);
             KRATOS_CHECK_EQUAL(message.GetCategory(), LoggerMessage::Category::STATUS);
             KRATOS_CHECK_EQUAL(message.GetLocation().GetFileName(), "Unknown");
@@ -39,7 +39,7 @@ namespace Kratos {
                 << LoggerMessage::Category::CRITICAL
                 << KRATOS_CODE_LOCATION << std::endl;
 
-            KRATOS_CHECK_C_STRING_EQUAL(message.GetMessage().c_str(), "Test message with number 12e00\n");
+            KRATOS_CHECK_C_STRING_EQUAL(message.GetLoggerMessage().c_str(), "Test message with number 12e00\n");
             KRATOS_CHECK_EQUAL(message.GetSeverity(), LoggerMessage::Severity::DETAIL);
             KRATOS_CHECK_EQUAL(message.GetCategory(), LoggerMessage::Category::CRITICAL);
             KRATOS_CHECK_NOT_EQUAL(message.GetLocation().GetFileName().find("test_logger.cpp"), std::string::npos);


### PR DESCRIPTION
**Description**

Avoids conflict with Win32 GetMessage function: https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getmessage. Part of #7026

**Changelog**
- Replace GetMessage with GetLoggerMessage 
