### PR TITLE
[Core][VtkOutput] move parameters to top of file and switch to binary format by default

### DIFF
--- a/applications/ShapeOptimizationApplication/python_scripts/design_logger_vtk.py
+++ b/applications/ShapeOptimizationApplication/python_scripts/design_logger_vtk.py
@@ -30,6 +30,7 @@ class DesignLoggerVTK( DesignLogger ):
             "name"       : "vtk",
             "vtk_parameters" : {
                 "model_part_name"        : "PLEASE_SPECIFY_MODEL_PART_NAME",
+                "file_format"            : "binary",
                 "output_sub_model_parts" : false,
                 "folder_name"            : "Optimization_Results"
             }

--- a/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/parameters.json
+++ b/applications/ShapeOptimizationApplication/tests/opt_process_vertex_morphing_test/parameters.json
@@ -52,7 +52,10 @@
                 "CONTROL_POINT_CHANGE"
             ],
             "output_format" : {
-                "name": "vtk"
+                "name": "vtk",
+                "vtk_parameters" : {
+                    "file_format" : "ascii"
+                }
             }
         }
     }

--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -25,6 +25,39 @@
 
 namespace Kratos
 {
+
+Parameters VtkOutput::GetDefaultParameters()
+{
+    // IMPORTANT: when "output_control_type" is "time", then paraview will not be able to group them
+    Parameters default_parameters = Parameters(R"(
+    {
+        "model_part_name"                             : "PLEASE_SPECIFY_MODEL_PART_NAME",
+        "file_format"                                 : "ascii",
+        "output_precision"                            : 7,
+        "output_control_type"                         : "step",
+        "output_interval"                             : 1.0,
+        "output_sub_model_parts"                      : false,
+        "folder_name"                                 : "VTK_Output",
+        "custom_name_prefix"                          : "",
+        "custom_name_postfix"                         : "",
+        "save_output_files_in_folder"                 : true,
+        "write_deformed_configuration"                : false,
+        "write_ids"                                   : false,
+        "nodal_solution_step_data_variables"          : [],
+        "nodal_data_value_variables"                  : [],
+        "nodal_flags"                                 : [],
+        "element_data_value_variables"                : [],
+        "element_flags"                               : [],
+        "condition_data_value_variables"              : [],
+        "condition_flags"                             : [],
+        "gauss_point_variables_extrapolated_to_nodes" : [],
+        "gauss_point_variables_in_elements"           : []
+    })" );
+
+    return default_parameters;
+}
+
+
 VtkOutput::VtkOutput(
     ModelPart& rModelPart,
     Parameters ThisParameters
@@ -1053,40 +1086,6 @@ void VtkOutput::WriteModelPartWithoutNodesToFile(ModelPart& rModelPart, const st
 
     // Deletin auxiliar modek part
     r_model.DeleteModelPart("AUXILIAR_" + r_name_model_part);
-}
-
-/***********************************************************************************/
-/***********************************************************************************/
-
-Parameters VtkOutput::GetDefaultParameters()
-{
-    // IMPORTANT: when "output_control_type" is "time", then paraview will not be able to group them
-    Parameters default_parameters = Parameters(R"(
-    {
-        "model_part_name"                             : "PLEASE_SPECIFY_MODEL_PART_NAME",
-        "file_format"                                 : "ascii",
-        "output_precision"                            : 7,
-        "output_control_type"                         : "step",
-        "output_interval"                             : 1.0,
-        "output_sub_model_parts"                      : false,
-        "folder_name"                                 : "VTK_Output",
-        "custom_name_prefix"                          : "",
-        "custom_name_postfix"                         : "",
-        "save_output_files_in_folder"                 : true,
-        "write_deformed_configuration"                : false,
-        "write_ids"                                   : false,
-        "nodal_solution_step_data_variables"          : [],
-        "nodal_data_value_variables"                  : [],
-        "nodal_flags"                                 : [],
-        "element_data_value_variables"                : [],
-        "element_flags"                               : [],
-        "condition_data_value_variables"              : [],
-        "condition_flags"                             : [],
-        "gauss_point_variables_extrapolated_to_nodes" : [],
-        "gauss_point_variables_in_elements"           : []
-    })" );
-
-    return default_parameters;
 }
 
 } // namespace Kratos

--- a/kratos/input_output/vtk_output.cpp
+++ b/kratos/input_output/vtk_output.cpp
@@ -32,7 +32,7 @@ Parameters VtkOutput::GetDefaultParameters()
     Parameters default_parameters = Parameters(R"(
     {
         "model_part_name"                             : "PLEASE_SPECIFY_MODEL_PART_NAME",
-        "file_format"                                 : "ascii",
+        "file_format"                                 : "binary",
         "output_precision"                            : 7,
         "output_control_type"                         : "step",
         "output_interval"                             : 1.0,


### PR DESCRIPTION
**Description**
Whenever I search sth in the defaults of the vtk output it is annoying to scroll down to the end of the long file.
With this change the default parameters are easily visible