### PR TITLE
[Core] use OpenMPUtils in thread pools

### DIFF
--- a/kratos/includes/thread_fixed_size_memory_pool.h
+++ b/kratos/includes/thread_fixed_size_memory_pool.h
@@ -236,10 +236,10 @@ namespace Kratos
       ///@{
 
 		void AddChunk() {
-			if (mThreadNumber != static_cast<std::size_t>(GetThreadNumber()))
+			if (mThreadNumber != static_cast<std::size_t>(OpenMPUtils::ThisThread()))
                 KRATOS_ERROR;
 
-			KRATOS_DEBUG_CHECK_EQUAL(mThreadNumber, static_cast<std::size_t>(GetThreadNumber()));
+			KRATOS_DEBUG_CHECK_EQUAL(mThreadNumber, static_cast<std::size_t>(OpenMPUtils::ThisThread()));
 
             mChunks.emplace_back(mBlockSizeInBytes, mChunkSize);
             Chunk* p_available_chunk = &(mChunks.back());

--- a/kratos/tests/cpp_tests/sources/test_chunk.cpp
+++ b/kratos/tests/cpp_tests/sources/test_chunk.cpp
@@ -20,7 +20,6 @@
 // Project includes
 #include "testing/testing.h"
 #include "includes/chunk.h"
-#include "utilities/openmp_utils.h"
 
 
 
@@ -29,7 +28,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(ChunkInitialize, KratosCoreFastSuite)
 		{
-			int max_threads = LockObject::GetNumberOfThreads();
+			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
 
 			std::size_t block_size_in_bytes = 5; // the aligned block size is 8
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
@@ -49,7 +48,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(ChunkAllocateDeallocate, KratosCoreFastSuite)
 		{
-			int max_threads = LockObject::GetNumberOfThreads();
+			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
 			std::size_t block_size_in_bytes = 5;
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
 		  std::size_t chunk_size_in_bytes =  header_size + 1024;
@@ -74,7 +73,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(ChunkParallelAllocate, KratosCoreFastSuite)
 		{
-			int max_threads = LockObject::GetNumberOfThreads();
+			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
 			std::size_t block_size_in_bytes = 5;
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
 		  std::size_t chunk_size_in_bytes =  header_size + 1024;
@@ -114,7 +113,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(ChunkParallelAllocateDeallocate, EXCLUDED_KratosCoreFastSuite)
 		{
-			int max_threads = LockObject::GetNumberOfThreads();
+			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
 			std::size_t block_size_in_bytes = 5;
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
 		  std::size_t chunk_size_in_bytes =  header_size + 1024;

--- a/kratos/tests/cpp_tests/sources/test_memory_pool.cpp
+++ b/kratos/tests/cpp_tests/sources/test_memory_pool.cpp
@@ -26,7 +26,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(FixedSizeMemoryPoolConstruction, KratosCoreFastSuite)
 		{
-			int max_threads = LockObject::GetNumberOfThreads();
+			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
 			std::size_t block_size = 5;
 			std::size_t default_chunk_size = 1024 * 1024; // 1M
 			FixedSizeMemoryPool fixed_size_memory_pool(block_size);
@@ -38,7 +38,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(FixedSizeMemoryPoolAllocationDeallocation, KratosCoreFastSuite)
 		{
-			int max_threads = LockObject::GetNumberOfThreads();
+			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
 			std::size_t block_size = 15;
 			std::size_t default_chunk_size = 1024 * 1024; // 1M
 			std::size_t number_of_blocks = (default_chunk_size - 2 * max_threads * sizeof(Chunk::SizeType)) / 16;
@@ -69,7 +69,7 @@ namespace Kratos {
 
 		//KRATOS_TEST_CASE_IN_SUITE(FixedSizeMemoryPoolStressTest, KratosCoreStressSuite)
 		//{
-		//	int max_threads = LockObject::GetNumberOfThreads();
+		//	int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
 		//	std::size_t block_size = 64;
 		//	std::size_t default_chunk_size = 1024 * 1024;// 1M
 		//	std::size_t number_of_blocks = (default_chunk_size - 2 * max_threads * sizeof(Chunk::SizeType)) / 64;


### PR DESCRIPTION
**Description**
part of #7597

this is necessary as the changed functions are agreed to be removed from the `LockObject`
