### PR TITLE
[dem] Linker error solved.

### DIFF
--- a/applications/DEMApplication/custom_constitutive/DEM_D_Linear_viscous_Coulomb_CL.cpp
+++ b/applications/DEMApplication/custom_constitutive/DEM_D_Linear_viscous_Coulomb_CL.cpp
@@ -217,88 +217,6 @@ namespace Kratos {
         CalculateInelasticViscodampingEnergyFEM(inelastic_viscodamping_energy, ViscoDampingLocalContactForce, LocalDeltDisp);
     }
 
-    template<class NeighbourClassType>
-
-    void DEM_D_Linear_viscous_Coulomb::CalculateTangentialForceWithNeighbour(const double normal_contact_force,
-                                                                             const double OldLocalElasticContactForce[3],
-                                                                             double LocalElasticContactForce[3],
-                                                                             double ViscoDampingLocalContactForce[3],
-                                                                             const double LocalDeltDisp[3],
-                                                                             bool& sliding,
-                                                                             SphericParticle* const element,
-                                                                             NeighbourClassType* const neighbour,
-                                                                             double indentation,
-                                                                             double previous_indentation,
-                                                                             double& AuxElasticShearForce,
-                                                                             double& MaximumAdmisibleShearForce) {
-
-        LocalElasticContactForce[0] = OldLocalElasticContactForce[0] - mKt * LocalDeltDisp[0];
-        LocalElasticContactForce[1] = OldLocalElasticContactForce[1] - mKt * LocalDeltDisp[1];
-
-        AuxElasticShearForce = sqrt(LocalElasticContactForce[0] * LocalElasticContactForce[0] + LocalElasticContactForce[1] * LocalElasticContactForce[1]);
-
-        const double my_tg_of_static_friction_angle        = element->GetTgOfStaticFrictionAngle();
-        const double neighbour_tg_of_static_friction_angle = neighbour->GetProperties()[STATIC_FRICTION];
-        const double equiv_tg_of_static_fri_ang            = 0.5 * (my_tg_of_static_friction_angle + neighbour_tg_of_static_friction_angle);
-
-        const double my_tg_of_dynamic_friction_angle        = element->GetTgOfDynamicFrictionAngle();
-        const double neighbour_tg_of_dynamic_friction_angle = neighbour->GetProperties()[DYNAMIC_FRICTION];
-        const double equiv_tg_of_dynamic_fri_ang            = 0.5 * (my_tg_of_dynamic_friction_angle + neighbour_tg_of_dynamic_friction_angle);
-
-        if(equiv_tg_of_static_fri_ang < 0.0 || equiv_tg_of_dynamic_fri_ang < 0.0) {
-            KRATOS_ERROR << "The averaged friction is negative for one contact of element with Id: "<< element->Id()<<std::endl;
-        }
-
-        MaximumAdmisibleShearForce = normal_contact_force * equiv_tg_of_static_fri_ang;
-        if (AuxElasticShearForce > MaximumAdmisibleShearForce) MaximumAdmisibleShearForce = normal_contact_force * equiv_tg_of_dynamic_fri_ang;
-
-        const double tangential_contact_force_0 = LocalElasticContactForce[0] + ViscoDampingLocalContactForce[0];
-        const double tangential_contact_force_1 = LocalElasticContactForce[1] + ViscoDampingLocalContactForce[1];
-
-        const double ActualTotalShearForce = sqrt(tangential_contact_force_0 * tangential_contact_force_0 + tangential_contact_force_1 * tangential_contact_force_1);
-
-        if (ActualTotalShearForce > MaximumAdmisibleShearForce) {
-
-            const double ActualElasticShearForce = sqrt(LocalElasticContactForce[0] * LocalElasticContactForce[0] + LocalElasticContactForce[1] * LocalElasticContactForce[1]);
-
-            const double dot_product = LocalElasticContactForce[0] * ViscoDampingLocalContactForce[0] + LocalElasticContactForce[1] * ViscoDampingLocalContactForce[1];
-            const double ViscoDampingLocalContactForceModule = sqrt(ViscoDampingLocalContactForce[0] * ViscoDampingLocalContactForce[0] +\
-                                                                    ViscoDampingLocalContactForce[1] * ViscoDampingLocalContactForce[1]);
-
-            if (dot_product >= 0.0) {
-
-                if (ActualElasticShearForce > MaximumAdmisibleShearForce) {
-                    const double fraction = MaximumAdmisibleShearForce / ActualElasticShearForce;
-                    LocalElasticContactForce[0]      = LocalElasticContactForce[0] * fraction;
-                    LocalElasticContactForce[1]      = LocalElasticContactForce[1] * fraction;
-                    ViscoDampingLocalContactForce[0] = 0.0;
-                    ViscoDampingLocalContactForce[1] = 0.0;
-                }
-                else {
-                    const double ActualViscousShearForce = MaximumAdmisibleShearForce - ActualElasticShearForce;
-                    const double fraction = ActualViscousShearForce / ViscoDampingLocalContactForceModule;
-                    ViscoDampingLocalContactForce[0] *= fraction;
-                    ViscoDampingLocalContactForce[1] *= fraction;
-                }
-            }
-            else {
-                if (ViscoDampingLocalContactForceModule >= ActualElasticShearForce) {
-                    const double fraction = (MaximumAdmisibleShearForce + ActualElasticShearForce) / ViscoDampingLocalContactForceModule;
-                    ViscoDampingLocalContactForce[0] *= fraction;
-                    ViscoDampingLocalContactForce[1] *= fraction;
-                }
-                else {
-                    const double fraction = MaximumAdmisibleShearForce / ActualElasticShearForce;
-                    LocalElasticContactForce[0]      = LocalElasticContactForce[0] * fraction;
-                    LocalElasticContactForce[1]      = LocalElasticContactForce[1] * fraction;
-                    ViscoDampingLocalContactForce[0] = 0.0;
-                    ViscoDampingLocalContactForce[1] = 0.0;
-                }
-            }
-            sliding = true;
-        }
-    }
-
     void DEM_D_Linear_viscous_Coulomb::CalculateViscoDampingForceWithFEM(double LocalRelVel[3],
                                                                          double ViscoDampingLocalContactForce[3],
                                                                          SphericParticle* const element,
@@ -313,6 +231,18 @@ namespace Kratos {
         ViscoDampingLocalContactForce[1] = - tangential_damping_coefficient * LocalRelVel[1];
         ViscoDampingLocalContactForce[2] = - normal_damping_coefficient     * LocalRelVel[2];
 
+    }
+
+    double DEM_D_Linear_viscous_Coulomb::GetTgOfDynamicFrictionAngleOfElement(SphericParticle* element){
+        return element->GetTgOfDynamicFrictionAngle();
+    }
+
+    double DEM_D_Linear_viscous_Coulomb::GetTgOfStaticFrictionAngleOfElement(SphericParticle* element){
+        return element->GetTgOfStaticFrictionAngle();
+    }
+
+    std::size_t DEM_D_Linear_viscous_Coulomb::GetElementId(SphericParticle* element){
+        return element->Id();
     }
 
     double DEM_D_Linear_viscous_Coulomb::CalculateNormalForce(const double indentation) {

--- a/applications/DEMApplication/custom_constitutive/DEM_D_Linear_viscous_Coulomb_CL.h
+++ b/applications/DEMApplication/custom_constitutive/DEM_D_Linear_viscous_Coulomb_CL.h
@@ -152,9 +152,6 @@ namespace Kratos {
                 sliding = true;
             }
         }
-        double GetTgOfDynamicFrictionAngleOfElement(SphericParticle* element);
-        double GetTgOfStaticFrictionAngleOfElement(SphericParticle* element);
-        std::size_t GetElementId(SphericParticle* element);
 
         void CalculateViscoDampingForce(double LocalRelVel[3],
                                         double ViscoDampingLocalContactForce[3],
@@ -189,6 +186,11 @@ namespace Kratos {
         void CalculateInelasticViscodampingEnergyFEM(double& inelastic_viscodamping_energy,
                                                      double ViscoDampingLocalContactForce[3],
                                                      double LocalDeltDisp[3]);
+
+    protected:
+        double GetTgOfDynamicFrictionAngleOfElement(SphericParticle* element);
+        double GetTgOfStaticFrictionAngleOfElement(SphericParticle* element);
+        std::size_t GetElementId(SphericParticle* element);
 
     private:
 


### PR DESCRIPTION
**Description**
This linker error was appearing only for some versions of gcc, and only in Release mode (at least it was detected in these cases only).
The linker was complaining about an `undefined reference` to a templated method of a non-templated class.
I moved the method to the header file. 
Due to recursive declarations (bad design led to this situation) not everything could be in the header file, and I encapsulated three small sentences in methods that were kept in the cpp file.
Eventually we will have to redesing the DEM App to avoid these recursive declarations... This is just a patch.

**Changelog**
- Templated method moved to header file