### PR TITLE
making more robust the selection of pairs in rve periodicity utility

### DIFF
--- a/applications/StructuralMechanicsApplication/custom_utilities/rve_periodicity_utility.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/rve_periodicity_utility.cpp
@@ -26,7 +26,7 @@ void RVEPeriodicityUtility::AssignPeriodicity(
     ModelPart& rSlaveModelPart,
     const Matrix& rStrainTensor,
     const Vector& rDirection,
-    const double search_tolerance
+    const double SearchTolerance
     )
 {
     KRATOS_ERROR_IF(rMasterModelPart.NumberOfConditions() == 0) << "the master is expected to have conditions and it is empty" << std::endl;
@@ -49,7 +49,7 @@ void RVEPeriodicityUtility::AssignPeriodicity(
         array_1d<double, 3> transformed_slave_coordinates = it_node->GetInitialPosition() - rDirection;
 
         // Finding the host element for this node
-        const bool is_found = bin_based_point_locator.FindPointOnMeshSimplified(transformed_slave_coordinates, N, p_host_cond, max_search_results, search_tolerance);
+        const bool is_found = bin_based_point_locator.FindPointOnMeshSimplified(transformed_slave_coordinates, N, p_host_cond, max_search_results, SearchTolerance);
         if (is_found) {
             const auto& r_geometry = p_host_cond->GetGeometry();
 
@@ -266,5 +266,4 @@ void RVEPeriodicityUtility::Finalize(const Variable<array_1d<double, 3>>& rVaria
 }
 
 }  // namespace Kratos.
-
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/rve_periodicity_utility.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/rve_periodicity_utility.cpp
@@ -29,7 +29,7 @@ void RVEPeriodicityUtility::AssignPeriodicity(
     const double SearchTolerance
     )
 {
-    KRATOS_ERROR_IF(rMasterModelPart.NumberOfConditions() == 0) << "the master is expected to have conditions and it is empty" << std::endl;
+    KRATOS_ERROR_IF(rMasterModelPart.NumberOfConditions() == 0) << "The master is expected to have conditions and it is empty" << std::endl;
 
     const Vector translation = prod(rStrainTensor, rDirection);
 

--- a/applications/StructuralMechanicsApplication/custom_utilities/rve_periodicity_utility.cpp
+++ b/applications/StructuralMechanicsApplication/custom_utilities/rve_periodicity_utility.cpp
@@ -83,12 +83,10 @@ void RVEPeriodicityUtility::AssignPeriodicity(
             T = translation;
 
             //brute force search amongst all nodes to find the closest
-            for(auto& rMasterNode : rMasterModelPart.Nodes())
-            {
+            for(auto& rMasterNode : rMasterModelPart.Nodes()) {
                 array_1d<double,3> distance_vector = rMasterNode.GetInitialPosition() - transformed_slave_coordinates;
                 double d = norm_2(distance_vector);
-                if(d < node_distance)
-                {
+                if(d < node_distance) {
                     node_distance = d;
                     closest_node_id = rMasterNode.Id();
                 }
@@ -266,4 +264,3 @@ void RVEPeriodicityUtility::Finalize(const Variable<array_1d<double, 3>>& rVaria
 }
 
 }  // namespace Kratos.
-

--- a/applications/StructuralMechanicsApplication/custom_utilities/rve_periodicity_utility.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/rve_periodicity_utility.h
@@ -103,7 +103,9 @@ class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) RVEPeriodicityUtility
     void AssignPeriodicity(ModelPart& rMasterModelPart,
                            ModelPart& rSlaveModelPart,
                            const Matrix& rStrainTensor,
-                           const Vector& rDirection);
+                           const Vector& rDirection,
+                           const double search_tolerance=1e-6
+                           );
 
     /** this function finalizes the computation of the pairings. It can be called ONLY ONCE
      * @param rVariable is the value to which the pairing condition will be applied (needs to be a Variable with components)

--- a/applications/StructuralMechanicsApplication/custom_utilities/rve_periodicity_utility.h
+++ b/applications/StructuralMechanicsApplication/custom_utilities/rve_periodicity_utility.h
@@ -104,7 +104,7 @@ class KRATOS_API(STRUCTURAL_MECHANICS_APPLICATION) RVEPeriodicityUtility
                            ModelPart& rSlaveModelPart,
                            const Matrix& rStrainTensor,
                            const Vector& rDirection,
-                           const double search_tolerance=1e-6
+                           const double SearchTolerance=1e-6
                            );
 
     /** this function finalizes the computation of the pairings. It can be called ONLY ONCE

--- a/applications/StructuralMechanicsApplication/python_scripts/rve_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/rve_analysis.py
@@ -1,6 +1,8 @@
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication
 from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
+
+# Importing other libraries
 import math
 
 class RVEAnalysis(StructuralMechanicsAnalysis):

--- a/applications/StructuralMechanicsApplication/python_scripts/rve_analysis.py
+++ b/applications/StructuralMechanicsApplication/python_scripts/rve_analysis.py
@@ -1,7 +1,7 @@
 import KratosMultiphysics
 import KratosMultiphysics.StructuralMechanicsApplication
 from KratosMultiphysics.StructuralMechanicsApplication.structural_mechanics_analysis import StructuralMechanicsAnalysis
-
+import math
 
 class RVEAnalysis(StructuralMechanicsAnalysis):
     def __init__(self, model, project_parameters):
@@ -21,6 +21,9 @@ class RVEAnalysis(StructuralMechanicsAnalysis):
 
         # Pseudo time to be used for output
         self.time = 0.0
+
+        self.populate_search_eps = 1e-4 ##tolerance in finding which conditions belong to the surface (will be multiplied by the lenght of the diagonal)
+        self.geometrical_search_tolerance = 1e-4 #tolerance to be used in the search of the condition it falls into
 
         super().__init__(model, project_parameters)
 
@@ -142,7 +145,9 @@ class RVEAnalysis(StructuralMechanicsAnalysis):
 
     def _ConstructFaceModelParts(self, min_corner, max_corner, mp):
 
-        eps = 0.0001*(max_corner[0] - min_corner[0])/mp.NumberOfNodes()
+        diag_vect = max_corner - min_corner
+        diag_lenght = math.sqrt(diag_vect[0]**2+diag_vect[1]**2+diag_vect[2]**2 )
+        eps = self.populate_search_eps*diag_lenght
 
         KratosMultiphysics.VariableUtils().SetFlag(KratosMultiphysics.SLAVE, False, mp.Nodes)
         KratosMultiphysics.VariableUtils().SetFlag(KratosMultiphysics.MASTER, False, mp.Nodes)
@@ -324,9 +329,10 @@ class RVEAnalysis(StructuralMechanicsAnalysis):
         periodicity_utility = KratosMultiphysics.StructuralMechanicsApplication.RVEPeriodicityUtility(self._GetSolver().GetComputingModelPart())
 
         # assign periodicity to faces
-        periodicity_utility.AssignPeriodicity(self.min_x_face, self.max_x_face, strain, KratosMultiphysics.Vector([dx, 0.0, 0.0]))
-        periodicity_utility.AssignPeriodicity(self.min_y_face, self.max_y_face, strain, KratosMultiphysics.Vector([0.0, dy, 0.0]))
-        periodicity_utility.AssignPeriodicity(self.min_z_face, self.max_z_face, strain, KratosMultiphysics.Vector([0.0, 0.0, dz]))
+        search_tolerance = self.geometrical_search_tolerance
+        periodicity_utility.AssignPeriodicity(self.min_x_face, self.max_x_face, strain, KratosMultiphysics.Vector([dx, 0.0, 0.0]),search_tolerance)
+        periodicity_utility.AssignPeriodicity(self.min_y_face, self.max_y_face, strain, KratosMultiphysics.Vector([0.0, dy, 0.0]),search_tolerance)
+        periodicity_utility.AssignPeriodicity(self.min_z_face, self.max_z_face, strain, KratosMultiphysics.Vector([0.0, 0.0, dz]),search_tolerance)
 
         periodicity_utility.Finalize(KratosMultiphysics.DISPLACEMENT)
 


### PR DESCRIPTION
**Description**
this minor PR makes more robust the selection of periodicity condition by adding a fallback to the closest node
Also changes the way a tolerane is computed to give the user control and to make it more robust

Please mark the PR with appropriate tags: 
- StructuralMechanicsApplication

**Changelog**
Two changes are made:
1- the tolerance employed in selecting contions is made user-controllable and more inclusive
2- a fallback to the closest node is introduced so to avoid random failures
