### PR TITLE
[Ci] Docker: specify mmg install dir for 5.5.1

### DIFF
--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -67,7 +67,7 @@ ${KRATOS_CMAKE_OPTIONS_FLAGS} \
 -DBLAS_LIBRARIES="/usr/lib/x86_64-linux-gnu/blas/libblas.so.3" \
 -DLAPACK_LIBRARIES="/usr/lib/x86_64-linux-gnu/liblapack.so.3" \
 -DUSE_COTIRE=ON \
--DINCLUDE_MMG=ON                                    \
+-DINCLUDE_MMG=OFF                                    \
 -DMMG_ROOT="/usr/local/"                            \
 
 # Buid

--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -58,8 +58,9 @@ RUN apt-get update -y && apt-get upgrade -y && \
     # install MMG 5.5
     git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg_5_5_1 && \
     mkdir /tmp/mmg_5_5_1/build && \
+    mkdir /external_libraries/mmg/mmg_5_5_1 && \
     cd /tmp/mmg_5_5_1/build && \
-    cmake .. -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make install && \
     rm -r /tmp/mmg_5_5_1 && \
     cd / && \


### PR DESCRIPTION
**Description**
this should fix the CI

In the future we should not install external libs in the root but in their dedicated folders to avoid interaction issues