### PR TITLE
[Dam] Warning removed (deprecated NR constructor)

### DIFF
--- a/applications/DamApplication/CMakeLists.txt
+++ b/applications/DamApplication/CMakeLists.txt
@@ -2,6 +2,10 @@ set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
 message("**** configuring KratosDamApplication ****")
 
+kratos_add_dependency(${KRATOS_SOURCE_DIR}/applications/ConvectionDiffusionApplication)
+kratos_add_dependency(${KRATOS_SOURCE_DIR}/applications/PoromechanicsApplication)
+kratos_add_dependency(${KRATOS_SOURCE_DIR}/applications/StructuralMechanicsApplication)
+
 ################### PYBIND11
 include(pybind11Tools)
 

--- a/applications/DamApplication/python_scripts/dam_MPI_thermo_mechanic_solver.py
+++ b/applications/DamApplication/python_scripts/dam_MPI_thermo_mechanic_solver.py
@@ -160,7 +160,6 @@ class DamMPIThermoMechanicSolver(dam_thermo_mechanic_solver.DamThermoMechanicSol
         # Solver creation (Note: this could be TrilinosResidualBasedLinearStrategy, but there is no such strategy)
         self.Thermal_Solver = TrilinosApplication.TrilinosNewtonRaphsonStrategy(self.thermal_computing_model_part,
                                                                        thermal_scheme,
-                                                                       self.thermal_linear_solver,
                                                                        convergence_criterion,
                                                                        thermal_builder_and_solver,
                                                                        self.settings["mechanical_solver_settings"]["max_iteration"].GetInt(),

--- a/applications/DamApplication/python_scripts/dam_mechanical_solver.py
+++ b/applications/DamApplication/python_scripts/dam_mechanical_solver.py
@@ -351,7 +351,6 @@ class DamMechanicalSolver(object):
                 self.strategy_params.AddValue("search_neighbours_step",self.settings["mechanical_solver_settings"]["search_neighbours_step"])
                 solver = KratosPoro.PoromechanicsNewtonRaphsonNonlocalStrategy(self.main_model_part,
                                                                                scheme,
-                                                                               self.linear_solver,
                                                                                convergence_criterion,
                                                                                builder_and_solver,
                                                                                self.strategy_params,
@@ -363,7 +362,6 @@ class DamMechanicalSolver(object):
                 self.main_model_part.ProcessInfo.SetValue(KratosPoro.IS_CONVERGED, True)
                 solver = KratosMultiphysics.ResidualBasedNewtonRaphsonStrategy(self.main_model_part,
                                                                                scheme,
-                                                                               self.linear_solver,
                                                                                convergence_criterion,
                                                                                builder_and_solver,
                                                                                max_iters,

--- a/applications/DamApplication/python_scripts/dam_selfweight_solver.py
+++ b/applications/DamApplication/python_scripts/dam_selfweight_solver.py
@@ -380,7 +380,6 @@ class DamSelfweightSolver(object):
                 self.strategy_params.AddValue("search_neighbours_step",self.settings["mechanical_solver_settings"]["search_neighbours_step"])
                 solver = KratosPoro.PoromechanicsNewtonRaphsonNonlocalStrategy(self.mechanical_computing_model_part,
                                                                                scheme,
-                                                                               self.mechanical_linear_solver,
                                                                                convergence_criterion,
                                                                                builder_and_solver,
                                                                                self.strategy_params,
@@ -392,7 +391,6 @@ class DamSelfweightSolver(object):
                 self.main_model_part.ProcessInfo.SetValue(KratosPoro.IS_CONVERGED, True)
                 solver = KratosMultiphysics.ResidualBasedNewtonRaphsonStrategy(self.mechanical_computing_model_part,
                                                                                     scheme,
-                                                                                    self.mechanical_linear_solver,
                                                                                     convergence_criterion,
                                                                                     builder_and_solver,
                                                                                     max_iters,

--- a/applications/DamApplication/python_scripts/dam_thermo_mechanic_solver.py
+++ b/applications/DamApplication/python_scripts/dam_thermo_mechanic_solver.py
@@ -233,7 +233,6 @@ class DamThermoMechanicSolver(object):
         # Solver creation
         self.Thermal_Solver = KratosMultiphysics.ResidualBasedLinearStrategy(self.thermal_computing_model_part,
                                                                              thermal_scheme,
-                                                                             self.thermal_linear_solver,
                                                                              thermal_builder_and_solver,
                                                                              self.settings["thermal_solver_settings"]["compute_reactions"].GetBool(),
                                                                              self.settings["thermal_solver_settings"]["reform_dofs_at_each_step"].GetBool(),
@@ -452,7 +451,6 @@ class DamThermoMechanicSolver(object):
                 self.strategy_params.AddValue("search_neighbours_step",self.settings["mechanical_solver_settings"]["search_neighbours_step"])
                 solver = KratosPoro.PoromechanicsNewtonRaphsonNonlocalStrategy(self.mechanical_computing_model_part,
                                                                                scheme,
-                                                                               self.mechanical_linear_solver,
                                                                                convergence_criterion,
                                                                                builder_and_solver,
                                                                                self.strategy_params,
@@ -464,7 +462,6 @@ class DamThermoMechanicSolver(object):
                 self.main_model_part.ProcessInfo.SetValue(KratosPoro.IS_CONVERGED, True)
                 solver = KratosMultiphysics.ResidualBasedNewtonRaphsonStrategy(self.mechanical_computing_model_part,
                                                                                     scheme,
-                                                                                    self.mechanical_linear_solver,
                                                                                     convergence_criterion,
                                                                                     builder_and_solver,
                                                                                     max_iters,


### PR DESCRIPTION
**Description**
As in #7620 the PR removes a deprecation warning from the Nethon-Raphson strategy (constructor with linear solver).

**Changelog**
- The NR and Arc-Length strategies from PoromechanicsApp and KratosMultiphyisics now use the core NR strategy without linear solver in the arguments
- Compilation dependencies of the DamApplication have also been added to simplify compilation
