### PR TITLE
[Contact] Removing deprecated warnings in tests

### DIFF
--- a/applications/ContactStructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
+++ b/applications/ContactStructuralMechanicsApplication/custom_python/add_custom_strategies_to_python.cpp
@@ -123,6 +123,9 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
     py::class_< ResidualBasedNewtonRaphsonContactStrategyType,
         typename ResidualBasedNewtonRaphsonContactStrategyType::Pointer,
         BaseSolvingStrategyType  >  (m, "ResidualBasedNewtonRaphsonContactStrategy")
+        .def(py::init < ModelPart&, BaseSchemeType::Pointer, ConvergenceCriteriaType::Pointer, BuilderAndSolverType::Pointer, unsigned int, bool, bool, bool, Parameters >())
+        .def(py::init < ModelPart&, BaseSchemeType::Pointer, ConvergenceCriteriaType::Pointer, BuilderAndSolverType::Pointer, unsigned int, bool, bool, bool, Parameters, ProcessesListType>())
+        .def(py::init < ModelPart&, BaseSchemeType::Pointer, ConvergenceCriteriaType::Pointer, BuilderAndSolverType::Pointer, unsigned int, bool, bool, bool, Parameters, ProcessesListType, ProcessesListType>())
         .def(py::init < ModelPart&, BaseSchemeType::Pointer, LinearSolverType::Pointer, ConvergenceCriteriaType::Pointer, unsigned int, bool, bool, bool, Parameters >())
         .def(py::init < ModelPart&, BaseSchemeType::Pointer, LinearSolverType::Pointer, ConvergenceCriteriaType::Pointer, unsigned int, bool, bool, bool, Parameters, ProcessesListType>())
         .def(py::init < ModelPart&, BaseSchemeType::Pointer, LinearSolverType::Pointer, ConvergenceCriteriaType::Pointer, unsigned int, bool, bool, bool, Parameters, ProcessesListType, ProcessesListType>())
@@ -147,8 +150,9 @@ void  AddCustomStrategiesToPython(pybind11::module& m)
         .def("GetKeepSystemConstantDuringIterations", &LineSearchContactStrategy< SparseSpaceType, LocalSpaceType, LinearSolverType >::GetKeepSystemConstantDuringIterations)
         ;
 
-    // Residual Based Newton Raphson Contact Strategy
+    // Residual Based Newton Raphson MPC Contact Strategy
     py::class_< ResidualBasedNewtonRaphsonMPCContactStrategyType, typename ResidualBasedNewtonRaphsonMPCContactStrategyType::Pointer, BaseSolvingStrategyType  >  (m, "ResidualBasedNewtonRaphsonMPCContactStrategy")
+        .def(py::init < ModelPart&, BaseSchemeType::Pointer, ConvergenceCriteriaType::Pointer, BuilderAndSolverType::Pointer, unsigned int, bool, bool, bool, Parameters >())
         .def(py::init < ModelPart&, BaseSchemeType::Pointer, LinearSolverType::Pointer, ConvergenceCriteriaType::Pointer, unsigned int, bool, bool, bool, Parameters >())
         .def(py::init < ModelPart&, BaseSchemeType::Pointer, LinearSolverType::Pointer, ConvergenceCriteriaType::Pointer, BuilderAndSolverType::Pointer, unsigned int, bool, bool, bool, Parameters >())
         .def("SetMaxIterationNumber", &ResidualBasedNewtonRaphsonMPCContactStrategyType::SetMaxIterationNumber)

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_contact_strategy.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_contact_strategy.h
@@ -117,20 +117,18 @@ public:
     /**
      * @brief Default constructor
      * @param rModelPart The model part of the problem
-     * @param p_scheme The integration scheme
-     * @param pNewLinearSolver The linear solver employed
+     * @param pScheme The integration scheme
      * @param pNewConvergenceCriteria The convergence criteria employed
      * @param MaxIterations The maximum number of iterations
      * @param CalculateReactions The flag for the reaction calculation
      * @param ReformDofSetAtEachStep The flag that allows to compute the modification of the DOF
      * @param MoveMeshFlag The flag that allows to move the mesh
      */
-
     ResidualBasedNewtonRaphsonContactStrategy(
         ModelPart& rModelPart,
-        typename TSchemeType::Pointer p_scheme,
-        typename TLinearSolver::Pointer pNewLinearSolver,
+        typename TSchemeType::Pointer pScheme,
         typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
+        typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
         IndexType MaxIterations = 30,
         bool CalculateReactions = false,
         bool ReformDofSetAtEachStep = false,
@@ -138,8 +136,8 @@ public:
         Parameters ThisParameters =  Parameters(R"({})"),
         ProcessesListType pMyProcesses = nullptr,
         ProcessesListType pPostProcesses = nullptr
-    )
-        : ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, p_scheme, pNewLinearSolver, pNewConvergenceCriteria, MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag),
+        )
+        : ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pNewConvergenceCriteria, pNewBuilderAndSolver, MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag ),
         mThisParameters(ThisParameters),
         mpMyProcesses(pMyProcesses),
         mpPostProcesses(pPostProcesses)
@@ -157,7 +155,7 @@ public:
     /**
      * @brief Default constructor
      * @param rModelPart The model part of the problem
-     * @param p_scheme The integration scheme
+     * @param pScheme The integration scheme
      * @param pNewLinearSolver The linear solver employed
      * @param pNewConvergenceCriteria The convergence criteria employed
      * @param MaxIterations The maximum number of iterations
@@ -165,10 +163,48 @@ public:
      * @param ReformDofSetAtEachStep The flag that allows to compute the modification of the DOF
      * @param MoveMeshFlag The flag that allows to move the mesh
      */
-
     ResidualBasedNewtonRaphsonContactStrategy(
         ModelPart& rModelPart,
-        typename TSchemeType::Pointer p_scheme,
+        typename TSchemeType::Pointer pScheme,
+        typename TLinearSolver::Pointer pNewLinearSolver,
+        typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
+        IndexType MaxIterations = 30,
+        bool CalculateReactions = false,
+        bool ReformDofSetAtEachStep = false,
+        bool MoveMeshFlag = false,
+        Parameters ThisParameters =  Parameters(R"({})"),
+        ProcessesListType pMyProcesses = nullptr,
+        ProcessesListType pPostProcesses = nullptr
+    )
+        : ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pNewLinearSolver, pNewConvergenceCriteria, MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag),
+        mThisParameters(ThisParameters),
+        mpMyProcesses(pMyProcesses),
+        mpPostProcesses(pPostProcesses)
+    {
+        KRATOS_TRY;
+
+        mConvergenceCriteriaEchoLevel = pNewConvergenceCriteria->GetEchoLevel();
+
+        Parameters default_parameters = GetDefaultParameters();
+        mThisParameters.ValidateAndAssignDefaults(default_parameters);
+
+        KRATOS_CATCH("");
+    }
+
+    /**
+     * @brief Default constructor
+     * @param rModelPart The model part of the problem
+     * @param pScheme The integration scheme
+     * @param pNewLinearSolver The linear solver employed
+     * @param pNewConvergenceCriteria The convergence criteria employed
+     * @param MaxIterations The maximum number of iterations
+     * @param CalculateReactions The flag for the reaction calculation
+     * @param ReformDofSetAtEachStep The flag that allows to compute the modification of the DOF
+     * @param MoveMeshFlag The flag that allows to move the mesh
+     */
+    ResidualBasedNewtonRaphsonContactStrategy(
+        ModelPart& rModelPart,
+        typename TSchemeType::Pointer pScheme,
         typename TLinearSolver::Pointer pNewLinearSolver,
         typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
         typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
@@ -180,7 +216,7 @@ public:
         ProcessesListType pMyProcesses = nullptr,
         ProcessesListType pPostProcesses = nullptr
         )
-        : ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, p_scheme, pNewLinearSolver, pNewConvergenceCriteria, pNewBuilderAndSolver, MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag ),
+        : ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pNewLinearSolver, pNewConvergenceCriteria, pNewBuilderAndSolver, MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag ),
         mThisParameters(ThisParameters),
         mpMyProcesses(pMyProcesses),
         mpPostProcesses(pPostProcesses)
@@ -198,7 +234,6 @@ public:
     /**
      * Destructor.
      */
-
     ~ResidualBasedNewtonRaphsonContactStrategy() override
     = default;
 

--- a/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_mpc_contact_strategy.h
+++ b/applications/ContactStructuralMechanicsApplication/custom_strategies/custom_strategies/residualbased_newton_raphson_mpc_contact_strategy.h
@@ -126,6 +126,41 @@ public:
      * @brief Default constructor
      * @param rModelPart The model part of the problem
      * @param pScheme The integration scheme
+     * @param pNewConvergenceCriteria The convergence criteria employed
+     * @param MaxIterations The maximum number of iterations
+     * @param CalculateReactions The flag for the reaction calculation
+     * @param ReformDofSetAtEachStep The flag that allows to compute the modification of the DOF
+     * @param MoveMeshFlag The flag that allows to move the mesh
+     */
+    ResidualBasedNewtonRaphsonMPCContactStrategy(
+        ModelPart& rModelPart,
+        typename TSchemeType::Pointer pScheme,
+        typename TConvergenceCriteriaType::Pointer pNewConvergenceCriteria,
+        typename TBuilderAndSolverType::Pointer pNewBuilderAndSolver,
+        IndexType MaxIterations = 30,
+        bool CalculateReactions = false,
+        bool ReformDofSetAtEachStep = false,
+        bool MoveMeshFlag = false,
+        Parameters ThisParameters =  Parameters(R"({})")
+        )
+        : ResidualBasedNewtonRaphsonStrategy<TSparseSpace, TDenseSpace, TLinearSolver>(rModelPart, pScheme, pNewConvergenceCriteria, pNewBuilderAndSolver, MaxIterations, CalculateReactions, ReformDofSetAtEachStep, MoveMeshFlag ),
+        mThisParameters(ThisParameters)
+    {
+        KRATOS_TRY;
+
+        // We create the contact criteria
+        mpMPCContactCriteria = Kratos::make_shared<TMPCContactCriteriaType>();
+
+        Parameters default_parameters = GetDefaultParameters();
+        mThisParameters.ValidateAndAssignDefaults(default_parameters);
+
+        KRATOS_CATCH("");
+    }
+
+    /**
+     * @brief Default constructor
+     * @param rModelPart The model part of the problem
+     * @param pScheme The integration scheme
      * @param pNewLinearSolver The linear solver employed
      * @param pNewConvergenceCriteria The convergence criteria employed
      * @param MaxIterations The maximum number of iterations
@@ -198,7 +233,6 @@ public:
     /**
      * Destructor.
      */
-
     ~ResidualBasedNewtonRaphsonMPCContactStrategy() override
     = default;
 

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/auxiliar_methods_solvers.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/auxiliar_methods_solvers.py
@@ -312,7 +312,7 @@ def  AuxiliarLineSearch(computing_model_part, mechanical_scheme, linear_solver, 
                                             newton_parameters
                                             )
 
-def  AuxiliarNewton(computing_model_part, mechanical_scheme, linear_solver, mechanical_convergence_criterion, builder_and_solver, settings, contact_settings, processes_list, post_process):
+def  AuxiliarNewton(computing_model_part, mechanical_scheme, mechanical_convergence_criterion, builder_and_solver, settings, contact_settings, processes_list, post_process):
     newton_parameters = KM.Parameters("""{}""")
     newton_parameters.AddValue("adaptative_strategy", contact_settings["adaptative_strategy"])
     newton_parameters.AddValue("split_factor", contact_settings["split_factor"])
@@ -320,7 +320,6 @@ def  AuxiliarNewton(computing_model_part, mechanical_scheme, linear_solver, mech
     newton_parameters.AddValue("inner_loop_iterations", contact_settings["inner_loop_iterations"])
     return CSMA.ResidualBasedNewtonRaphsonContactStrategy(computing_model_part,
                                                             mechanical_scheme,
-                                                            linear_solver,
                                                             mechanical_convergence_criterion,
                                                             builder_and_solver,
                                                             settings["max_iteration"].GetInt(),
@@ -332,14 +331,13 @@ def  AuxiliarNewton(computing_model_part, mechanical_scheme, linear_solver, mech
                                                             post_process
                                                             )
 
-def  AuxiliarMPCNewton(computing_model_part, mechanical_scheme, linear_solver, mechanical_convergence_criterion, builder_and_solver, settings, contact_settings):
+def  AuxiliarMPCNewton(computing_model_part, mechanical_scheme, mechanical_convergence_criterion, builder_and_solver, settings, contact_settings):
     newton_parameters = KM.Parameters("""{}""")
     newton_parameters.AddValue("inner_loop_iterations", contact_settings["inner_loop_iterations"])
     newton_parameters.AddValue("update_each_nl_iteration", contact_settings["update_each_nl_iteration"])
     newton_parameters.AddValue("enforce_ntn", contact_settings["enforce_ntn"])
     return CSMA.ResidualBasedNewtonRaphsonMPCContactStrategy(computing_model_part,
                                                                 mechanical_scheme,
-                                                                linear_solver,
                                                                 mechanical_convergence_criterion,
                                                                 builder_and_solver,
                                                                 settings["max_iteration"].GetInt(),

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_implicit_dynamic_solver.py
@@ -177,10 +177,9 @@ class ContactImplicitMechanicalSolver(structural_mechanics_implicit_dynamic_solv
     def _create_contact_newton_raphson_strategy(self):
         computing_model_part = self.GetComputingModelPart()
         self.mechanical_scheme = self.get_solution_scheme()
-        self.linear_solver = self.get_linear_solver()
         self.mechanical_convergence_criterion = self.get_convergence_criterion()
         self.builder_and_solver = self.get_builder_and_solver()
-        return auxiliar_methods_solvers.AuxiliarNewton(computing_model_part, self.mechanical_scheme, self.linear_solver, self.mechanical_convergence_criterion, self.builder_and_solver, self.settings, self.contact_settings, self.processes_list, self.post_process)
+        return auxiliar_methods_solvers.AuxiliarNewton(computing_model_part, self.mechanical_scheme, self.mechanical_convergence_criterion, self.builder_and_solver, self.settings, self.contact_settings, self.processes_list, self.post_process)
 
     @classmethod
     def GetDefaultParameters(cls):

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_static_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/contact_structural_mechanics_static_solver.py
@@ -177,10 +177,9 @@ class ContactStaticMechanicalSolver(structural_mechanics_static_solver.StaticMec
     def _create_contact_newton_raphson_strategy(self):
         computing_model_part = self.GetComputingModelPart()
         self.mechanical_scheme = self.get_solution_scheme()
-        self.linear_solver = self.get_linear_solver()
         self.mechanical_convergence_criterion = self.get_convergence_criterion()
         self.builder_and_solver = self.get_builder_and_solver()
-        return auxiliar_methods_solvers.AuxiliarNewton(computing_model_part, self.mechanical_scheme, self.linear_solver, self.mechanical_convergence_criterion, self.builder_and_solver, self.settings, self.contact_settings, self.processes_list, self.post_process)
+        return auxiliar_methods_solvers.AuxiliarNewton(computing_model_part, self.mechanical_scheme, self.mechanical_convergence_criterion, self.builder_and_solver, self.settings, self.contact_settings, self.processes_list, self.post_process)
 
     @classmethod
     def GetDefaultParameters(cls):

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_structural_mechanics_implicit_dynamic_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_structural_mechanics_implicit_dynamic_solver.py
@@ -90,10 +90,9 @@ class MPCContactImplicitMechanicalSolver(structural_mechanics_implicit_dynamic_s
     def _create_contact_newton_raphson_strategy(self):
         computing_model_part = self.GetComputingModelPart()
         self.mechanical_scheme = self.get_solution_scheme()
-        self.linear_solver = self.get_linear_solver()
         self.mechanical_convergence_criterion = self.get_convergence_criterion()
         self.builder_and_solver = self.get_builder_and_solver()
-        return auxiliar_methods_solvers.AuxiliarMPCNewton(computing_model_part, self.mechanical_scheme, self.linear_solver, self.mechanical_convergence_criterion, self.builder_and_solver, self.settings, self.mpc_contact_settings)
+        return auxiliar_methods_solvers.AuxiliarMPCNewton(computing_model_part, self.mechanical_scheme, self.mechanical_convergence_criterion, self.builder_and_solver, self.settings, self.mpc_contact_settings)
 
     @classmethod
     def GetDefaultParameters(cls):

--- a/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_structural_mechanics_static_solver.py
+++ b/applications/ContactStructuralMechanicsApplication/python_scripts/mpc_contact_structural_mechanics_static_solver.py
@@ -90,10 +90,9 @@ class MPCContactStaticSolver(structural_mechanics_static_solver.StaticMechanical
     def _create_contact_newton_raphson_strategy(self):
         computing_model_part = self.GetComputingModelPart()
         self.mechanical_scheme = self.get_solution_scheme()
-        self.linear_solver = self.get_linear_solver()
         self.mechanical_convergence_criterion = self.get_convergence_criterion()
         self.builder_and_solver = self.get_builder_and_solver()
-        return auxiliar_methods_solvers.AuxiliarMPCNewton(computing_model_part, self.mechanical_scheme, self.linear_solver, self.mechanical_convergence_criterion, self.builder_and_solver, self.settings, self.mpc_contact_settings)
+        return auxiliar_methods_solvers.AuxiliarMPCNewton(computing_model_part, self.mechanical_scheme, self.mechanical_convergence_criterion, self.builder_and_solver, self.settings, self.mpc_contact_settings)
 
     @classmethod
     def GetDefaultParameters(cls):

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictional_contact_test_2D/mesh_moving_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictional_contact_test_2D/mesh_moving_matching_test_parameters.json
@@ -27,7 +27,6 @@
         "time_stepping"                      : {
             "time_step" : 0.05
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/contact_patch_complex_geom_slope_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/contact_patch_complex_geom_slope_test_parameters.json
@@ -27,7 +27,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : false,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hertz_simple_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hertz_simple_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 0.5005
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hertz_sphere_plate_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hertz_sphere_plate_test_parameters.json
@@ -27,7 +27,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hyper_simple_patch_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hyper_simple_patch_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "clear_storage"                      : true,
         "line_search"                        : false,
         "compute_reactions"                  : false,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hyper_simple_patch_test_with_elimination_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hyper_simple_patch_test_with_elimination_parameters.json
@@ -27,7 +27,9 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : false,
+        "builder_and_solver_settings" : {
+            "use_block_builder" : false
+        },
         "clear_storage"                      : true,
         "line_search"                        : false,
         "compute_reactions"                  : false,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hyper_simple_patch_test_with_elimination_with_constraints_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hyper_simple_patch_test_with_elimination_with_constraints_parameters.json
@@ -27,7 +27,9 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : false,
+        "builder_and_solver_settings" : {
+            "use_block_builder" : false
+        },
         "clear_storage"                      : true,
         "line_search"                        : false,
         "compute_reactions"                  : false,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hyper_simple_slope_patch_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hyper_simple_slope_patch_test_parameters.json
@@ -27,7 +27,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "clear_storage"                      : true,
         "line_search"                        : false,
         "compute_reactions"                  : false,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hyper_simple_triangle_patch_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/hyper_simple_triangle_patch_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "clear_storage"                      : true,
         "line_search"                        : false,
         "compute_reactions"                  : false,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/ironing_die_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/ironing_die_test_parameters.json
@@ -28,7 +28,6 @@
         "time_stepping"                      : {
             "time_step" : 0.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/ironing_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/ironing_test_parameters.json
@@ -27,7 +27,6 @@
         "time_stepping"                      : {
             "time_step" : 0.0025
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/mesh_moving_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/mesh_moving_matching_test_parameters.json
@@ -27,7 +27,6 @@
         "time_stepping"                      : {
             "time_step" : 0.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/simple_patch_notmatching_a_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/simple_patch_notmatching_a_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/simple_patch_notmatching_b_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/simple_patch_notmatching_b_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/simple_patch_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/simple_patch_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "clear_storage"                      : true,
         "line_search"                        : false,
         "compute_reactions"                  : false,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/simple_slope_patch_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/simple_slope_patch_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "clear_storage"                      : true,
         "line_search"                        : false,
         "compute_reactions"                  : false,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/taylor_patch_dynamic_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/taylor_patch_dynamic_test_parameters.json
@@ -31,7 +31,6 @@
         "time_stepping"                      : {
             "time_step" : 0.11
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"	         : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/taylor_patch_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_2D/taylor_patch_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_patch_complex_geom_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_patch_complex_geom_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_patch_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_patch_matching_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_patch_nonmatching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_patch_nonmatching_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_adaptative_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_adaptative_test_parameters.json
@@ -29,7 +29,6 @@
         "time_stepping"                      : {
             "time_step" : 1.3
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : false,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_quadtri_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_quadtri_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_slope_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_slope_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_test_parameters.json
@@ -29,7 +29,6 @@
         "time_stepping"                      : {
             "time_step" : 0.5
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_triquad_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_triquad_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_multi_contact_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/ALM_frictionless_contact_test_3D/3D_multi_contact_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.3
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : false,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/3D_contact_simplest_patch_matching_quadtri_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/3D_contact_simplest_patch_matching_quadtri_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/3D_contact_simplest_patch_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/3D_contact_simplest_patch_matching_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/3D_contact_simplest_patch_matching_triquad_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/3D_contact_simplest_patch_matching_triquad_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/hyper_simple_slope_patch_test_2D_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/hyper_simple_slope_patch_test_2D_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "clear_storage"                      : true,
         "line_search"                        : false,
         "compute_reactions"                  : false,

--- a/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/simple_patch_test_2D_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/simple_patch_test_2D_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "clear_storage"                      : true,
         "line_search"                        : false,
         "compute_reactions"                  : false,

--- a/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/simple_patch_test_3D_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mesh_tying_test/simple_patch_test_3D_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/2D_contact_simplest_patch_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/2D_contact_simplest_patch_matching_test_parameters.json
@@ -22,7 +22,6 @@
         "material_import_settings" :{
             "materials_filename": "mpc_contact_tests/2D_contact_simplest_patch_matching_test_materials.json"
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/2D_contact_simplest_with_friction_patch_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/2D_contact_simplest_with_friction_patch_matching_test_parameters.json
@@ -22,7 +22,6 @@
         "material_import_settings" :{
             "materials_filename": "mpc_contact_tests/2D_contact_simplest_patch_matching_test_materials.json"
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/3D_contact_patch_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/3D_contact_patch_matching_test_parameters.json
@@ -22,7 +22,6 @@
         "material_import_settings" :{
             "materials_filename": "mpc_contact_tests/3D_contact_patch_matching_test_materials.json"
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"	         : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/3D_contact_simplest_patch_matching_slope_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/3D_contact_simplest_patch_matching_slope_test_parameters.json
@@ -22,7 +22,6 @@
         "material_import_settings" :{
             "materials_filename": "mpc_contact_tests/3D_contact_simplest_patch_matching_slope_test_materials.json"
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"	         : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/3D_contact_simplest_patch_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/3D_contact_simplest_patch_matching_test_parameters.json
@@ -22,7 +22,6 @@
         "material_import_settings" :{
             "materials_filename": "mpc_contact_tests/3D_contact_simplest_patch_matching_test_materials.json"
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/3D_contact_simplest_with_friction_patch_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/3D_contact_simplest_with_friction_patch_matching_test_parameters.json
@@ -22,7 +22,6 @@
         "material_import_settings" :{
             "materials_filename": "mpc_contact_tests/3D_contact_simplest_patch_matching_test_materials.json"
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/beam_contact_static_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/beam_contact_static_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 0.01
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/beam_contact_static_with_friction_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/beam_contact_static_with_friction_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 0.01
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/beam_contact_static_with_tying_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/mpc_contact_tests/beam_contact_static_with_tying_test_parameters.json
@@ -22,7 +22,6 @@
         "time_stepping"                      : {
             "time_step" : 0.01
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,

--- a/applications/ContactStructuralMechanicsApplication/tests/penalty_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_test_parameters.json
+++ b/applications/ContactStructuralMechanicsApplication/tests/penalty_frictionless_contact_test_3D/3D_contact_simplest_patch_matching_test_parameters.json
@@ -26,7 +26,6 @@
         "time_stepping"                      : {
             "time_step" : 1.0
         },
-        "block_builder"                      : true,
         "line_search"                        : false,
         "clear_storage"                      : true,
         "reform_dofs_at_each_step"           : true,


### PR DESCRIPTION
**Description**
This removes the deprecated warnings in contact tests, making the output as follows:

![imagen](https://user-images.githubusercontent.com/19991680/96749277-e9194100-13ca-11eb-81a2-63b810de0e90.png)
![imagen](https://user-images.githubusercontent.com/19991680/96749327-f7675d00-13ca-11eb-95a6-ab5723ebdc78.png)

**Changelog**
- Update custom strategies constructors
- Update tests parameters
- Update solvers
