### PR TITLE
[Core][ModelPartIO] adding Vector in DivideElementalDataBlock

### DIFF
--- a/kratos/sources/model_part_io.cpp
+++ b/kratos/sources/model_part_io.cpp
@@ -3691,6 +3691,10 @@ void ModelPartIO::DivideElementalDataBlock(OutputFilesContainerType& OutputFiles
     {
         DivideVectorialVariableData(OutputFiles, ElementsAllPartitions, "ElementalData");
     }
+    else if(KratosComponents<Variable<Vector> >::Has(variable_name))
+    {
+        DivideVectorialVariableData(OutputFiles, ElementsAllPartitions, "ElementalData");
+    }
     else if(KratosComponents<Variable<Matrix> >::Has(variable_name))
     {
         DivideVectorialVariableData(OutputFiles, ElementsAllPartitions, "ElementalData");


### PR DESCRIPTION
**Description**
For some reason `Vector` was not in the list of variables in `DivideElementalDataBlock`, even though all other variable types are

With this change also models with Elements having ElementalData of type `Vector` can be partitioned. I can hardly believe I am the first one doing this :D