### PR TITLE
[CI] adding timeouts to MPI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         python3 kratos/python_scripts/run_tests.py -l small -c python3
 
     - name: Running MPICore C++ tests (2 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -80,6 +81,7 @@ jobs:
         mpiexec -np 2 python3 kratos/python_scripts/run_cpp_mpi_tests.py --using-mpi
 
     - name: Running MPICore C++ tests (3 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -87,6 +89,7 @@ jobs:
         mpiexec --oversubscribe -np 3 python3 kratos/python_scripts/run_cpp_mpi_tests.py --using-mpi
 
     - name: Running MPICore C++ tests (4 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -94,6 +97,7 @@ jobs:
         mpiexec --oversubscribe -np 4 python3 kratos/python_scripts/run_cpp_mpi_tests.py --using-mpi
 
     - name: Running MPICore Python tests (2 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -101,6 +105,7 @@ jobs:
         mpiexec -np 2 python3 kratos/mpi/tests/test_KratosMPICore.py --using-mpi
 
     - name: Running MPICore Python tests (3 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -108,6 +113,7 @@ jobs:
         mpiexec --oversubscribe -np 3 python3 kratos/mpi/tests/test_KratosMPICore.py --using-mpi
 
     - name: Running MPICore Python tests (4 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -115,6 +121,7 @@ jobs:
         mpiexec --oversubscribe -np 4 python3 kratos/mpi/tests/test_KratosMPICore.py --using-mpi
 
     - name: Running MPI Python TrilinosApplication (2 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -122,6 +129,7 @@ jobs:
         mpiexec -np 2 python3 applications/TrilinosApplication/tests/test_TrilinosApplication_mpi.py --using-mpi
 
     - name: Running MPI Python TrilinosApplication (3 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -129,6 +137,7 @@ jobs:
         mpiexec --oversubscribe -np 3 python3 applications/TrilinosApplication/tests/test_TrilinosApplication_mpi.py --using-mpi
 
     - name: Running MPI Python TrilinosApplication (4 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -136,6 +145,7 @@ jobs:
         mpiexec --oversubscribe -np 4 python3 applications/TrilinosApplication/tests/test_TrilinosApplication_mpi.py --using-mpi
 
     - name: Running MPI Python CoSimulationApplication (2 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -143,6 +153,7 @@ jobs:
         mpiexec -np 2 python3 applications/CoSimulationApplication/tests/test_CoSimulationApplication_mpi.py --using-mpi
 
     - name: Running MPI Python CoSimulationApplication (3 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -150,6 +161,7 @@ jobs:
         mpiexec --oversubscribe -np 3 python3 applications/CoSimulationApplication/tests/test_CoSimulationApplication_mpi.py --using-mpi
 
     - name: Running MPI Python CoSimulationApplication (4 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -157,6 +169,7 @@ jobs:
         mpiexec --oversubscribe -np 4 python3 applications/CoSimulationApplication/tests/test_CoSimulationApplication_mpi.py --using-mpi
 
     - name: Running MPI Python MappingApplication (2 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -164,6 +177,7 @@ jobs:
         mpiexec -np 2 python3 applications/MappingApplication/tests/test_MappingApplication_mpi.py --using-mpi
 
     - name: Running MPI Python MappingApplication (3 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -171,6 +185,7 @@ jobs:
         mpiexec --oversubscribe -np 3 python3 applications/MappingApplication/tests/test_MappingApplication_mpi.py --using-mpi
 
     - name: Running MPI Python MappingApplication (4 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -178,6 +193,7 @@ jobs:
         mpiexec --oversubscribe -np 4 python3 applications/MappingApplication/tests/test_MappingApplication_mpi.py --using-mpi
 
     - name: Running MPI Python StructuralMechanicsApplication (2 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -185,6 +201,7 @@ jobs:
         mpiexec -np 2 python3 applications/StructuralMechanicsApplication/tests/test_StructuralMechanicsApplication_mpi.py --using-mpi
 
     - name: Running MPI Python FluidDynamicsApplication (2 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -192,6 +209,7 @@ jobs:
         mpiexec -np 2 python3 applications/FluidDynamicsApplication/tests/test_FluidDynamicsApplication_mpi.py --using-mpi
 
     - name: Running MPI Python RANSApplication (2 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -199,6 +217,7 @@ jobs:
         mpiexec -np 2 python3 applications/RANSApplication/tests/test_RANSApplication_mpi.py --using-mpi
 
     - name: Running MPI Python ParticleMechanicsApplication (2 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -206,6 +225,7 @@ jobs:
         mpiexec -np 2 python3 applications/ParticleMechanicsApplication/tests/test_ParticleMechanicsApplication_mpi.py --using-mpi
 
     - name: Running MPI Python ParticleMechanicsApplication (3 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -213,6 +233,7 @@ jobs:
         mpiexec --oversubscribe -np 3 python3 applications/ParticleMechanicsApplication/tests/test_ParticleMechanicsApplication_mpi.py --using-mpi
 
     - name: Running MPI Python ParticleMechanicsApplication (4 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -220,6 +241,7 @@ jobs:
         mpiexec --oversubscribe -np 4 python3 applications/ParticleMechanicsApplication/tests/test_ParticleMechanicsApplication_mpi.py --using-mpi
 
     - name: Running MPI Python MeshingApplication (2 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -227,6 +249,7 @@ jobs:
         mpiexec -np 2 python3 applications/MeshingApplication/tests/test_MeshingApplication_mpi.py --using-mpi
 
     - name: Running MPI Python MeshingApplication (3 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}
@@ -234,6 +257,7 @@ jobs:
         mpiexec --oversubscribe  -np 3 python3 applications/MeshingApplication/tests/test_MeshingApplication_mpi.py --using-mpi
 
     - name: Running MPI Python MeshingApplication (4 Cores)
+      timeout-minutes : 10
       run: |
         . /opt/intel/mkl/bin/mklvars.sh
         export PYTHONPATH=${PYTHONPATH}:${GITHUB_WORKSPACE}/bin/${{ matrix.build-type }}


### PR DESCRIPTION
**Description**
Since MPI has the nice feature of hanging indefinite in case sth is not working, I think it makes sense to add at least some timeouts

Note that this is a **temporary** solution until I had time to finish the testing script for the MPI tests
(in our standard test script the time is already limited)
