### PR TITLE
Fluid/ConDiff missing inits in python process

### DIFF
--- a/applications/ConvectionDiffusionApplication/python_scripts/check_and_prepare_model_process_convection_diffusion.py
+++ b/applications/ConvectionDiffusionApplication/python_scripts/check_and_prepare_model_process_convection_diffusion.py
@@ -1,10 +1,5 @@
-from __future__ import print_function, absolute_import, division  # makes KratosMultiphysics backward compatible with python 2.6 and 2.7
-
 # Importing the Kratos Library
 import KratosMultiphysics
-
-# Import applications
-import KratosMultiphysics.ConvectionDiffusionApplication as ConvectionDiffusionApplication
 
 def Factory(settings, Model):
     if(type(settings) != KratosMultiphysics.Parameters):
@@ -20,6 +15,7 @@ class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
     Conditions are added from the processes sub model parts.
     """
     def __init__(self, main_model_part, Parameters):
+        KratosMultiphysics.Process.__init__(self)
         self.main_model_part = main_model_part
 
         self.computing_model_part_name  = Parameters["computing_model_part_name"].GetString()

--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -1,5 +1,4 @@
 import KratosMultiphysics
-import KratosMultiphysics.FluidDynamicsApplication
 
 def Factory(settings, Model):
     if(type(settings) != KratosMultiphysics.Parameters):

--- a/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
+++ b/applications/FluidDynamicsApplication/python_scripts/check_and_prepare_model_process_fluid.py
@@ -9,6 +9,7 @@ def Factory(settings, Model):
 ## All the processes python should be derived from "Process"
 class CheckAndPrepareModelProcess(KratosMultiphysics.Process):
     def __init__(self, main_model_part, Parameters ):
+        KratosMultiphysics.Process.__init__(self)
         self.main_model_part = main_model_part
 
         default_parameters = KratosMultiphysics.Parameters(r'''{


### PR DESCRIPTION
**Description**
Not sure why this was not crashing before, guess we were lucky
This is part of #7648, where this throws a proper error message now

Btw this is not really a process, probably could be refactored into a standalone utility (it takes a modelpart and not a model :sweat_smile:) => in any case separate PR

I also cleaned unused imports and python2 stuff