### PR TITLE
[core] Add missing AssignSettings

### DIFF
--- a/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
+++ b/kratos/solving_strategies/strategies/residualbased_newton_raphson_strategy.h
@@ -375,7 +375,9 @@ class ResidualBasedNewtonRaphsonStrategy
           mKeepSystemConstantDuringIterations(false)
     {
         KRATOS_TRY
-
+        // Validate and assign defaults
+        Settings = this->ValidateAndAssignParameters(Settings, this->GetDefaultParameters());
+        this->AssignSettings(Settings);
         // Getting builder and solver
         auto p_builder_and_solver = GetBuilderAndSolver();
 


### PR DESCRIPTION
For some reason, these lines were lost in translation. For example, it was assigning uninitialized values of ComputeReactions