### PR TITLE
[Core] Add Get ParentPath and FileName retrieval methods

### DIFF
--- a/kratos/includes/kratos_filesystem.h
+++ b/kratos/includes/kratos_filesystem.h
@@ -48,6 +48,10 @@ std::uintmax_t KRATOS_API(KRATOS_CORE) remove_all(const std::string& rPath);
 
 void KRATOS_API(KRATOS_CORE) rename(const std::string& rPathFrom, const std::string& rPathTo);
 
+std::string KRATOS_API(KRATOS_CORE) parent_path(const std::string& rPath);
+
+std::string KRATOS_API(KRATOS_CORE) filename(const std::string& rPath);
+
 } // namespace filesystem
 
 

--- a/kratos/sources/kratos_filesystem.cpp
+++ b/kratos/sources/kratos_filesystem.cpp
@@ -68,6 +68,16 @@ void rename(const std::string& rPathFrom, const std::string& rPathTo)
 {
     return ghc::filesystem::rename(rPathFrom, rPathTo);
 }
+    
+std::string parent_path(const std::string& rPath)
+{
+    return ghc::filesystem::path(rPath).parent_path();
+}
+
+std::string filename(const std::string& rPath)
+{
+    return ghc::filesystem::path(rPath).filename();
+}
 
 } // namespace filesystem
 

--- a/kratos/tests/cpp_tests/sources/test_filesystem.cpp
+++ b/kratos/tests/cpp_tests/sources/test_filesystem.cpp
@@ -49,6 +49,14 @@ KRATOS_TEST_CASE_IN_SUITE(FileSystemJoinPaths, KratosCoreFastSuite)
     std::vector<std::string> paths_2;
     KRATOS_CHECK_STRING_EQUAL(Kratos::FilesystemExtensions::JoinPaths(paths_2), "");
 }
+    
+KRATOS_TEST_CASE_IN_SUITE(FileSystemParentPathFilename, KratosCoreFastSuite)
+{
+    std::vector<std::string> paths_1 {"sl", "", "uom", "dssc"};
+    const std::string& path = Kratos::FilesystemExtensions::JoinPaths(paths_1);
+    KRATOS_CHECK_STRING_EQUAL(Kratos::filesystem::parent_path(path), "sl/uom");
+    KRATOS_CHECK_STRING_EQUAL(Kratos::filesystem::filename(path), "dssc");
+}
 
 KRATOS_TEST_CASE_IN_SUITE(FileSystemJoinEmptyPaths, KratosCoreFastSuite)
 {

--- a/kratos/tests/cpp_tests/sources/test_filesystem.cpp
+++ b/kratos/tests/cpp_tests/sources/test_filesystem.cpp
@@ -54,7 +54,10 @@ KRATOS_TEST_CASE_IN_SUITE(FileSystemParentPathFilename, KratosCoreFastSuite)
 {
     std::vector<std::string> paths_1 {"sl", "", "uom", "dssc"};
     const std::string& path = Kratos::FilesystemExtensions::JoinPaths(paths_1);
-    KRATOS_CHECK_STRING_EQUAL(Kratos::filesystem::parent_path(path), "sl/uom");
+    const auto& parent_path = Kratos::filesystem::parent_path(path);
+    const auto& parent_parent_path = Kratos::filesystem::parent_path(parent_path);
+    KRATOS_CHECK_STRING_EQUAL(parent_parent_path, "sl");
+    KRATOS_CHECK_STRING_EQUAL(Kratos::filesystem::filename(parent_path), "uom");
     KRATOS_CHECK_STRING_EQUAL(Kratos::filesystem::filename(path), "dssc");
 }
 


### PR DESCRIPTION
**Description**
As mentioned in the title. These are to be removed once migrating to use c++17 std::filesystem. 

**Changelog**
- Add `parent_path` method
- Add `filename` method
