### PR TITLE
[Core] Activate deprecation warnings => #7381

### DIFF
--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -273,7 +273,9 @@ public:
     virtual void EquationIdVector(EquationIdVectorType& rResult,
                                   const ProcessInfo& rCurrentProcessInfo) const
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         const_cast<Condition*>(this)->EquationIdVector(rResult, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rResult.size() != 0) {
         //     rResult.resize(0);
         // }
@@ -294,7 +296,9 @@ public:
     virtual void GetDofList(DofsVectorType& rElementalDofList,
                             const ProcessInfo& rCurrentProcessInfo) const
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         const_cast<Condition*>(this)->GetDofList(rElementalDofList, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rElementalDofList.size() != 0) {
         //     rElementalDofList.resize(0);
         // }
@@ -390,7 +394,9 @@ public:
      */
     virtual void Initialize(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         Initialize();
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"ProcessInfo\"")
@@ -427,7 +433,9 @@ public:
      */
     virtual void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         InitializeSolutionStep(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
@@ -439,7 +447,9 @@ public:
      */
     virtual void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         InitializeNonLinearIteration(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
@@ -451,7 +461,9 @@ public:
      */
     virtual void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         FinalizeNonLinearIteration(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
@@ -463,7 +475,9 @@ public:
      */
     virtual void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         FinalizeSolutionStep(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
@@ -489,7 +503,9 @@ public:
                                       VectorType& rRightHandSideVector,
                                       const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateLocalSystem(rLeftHandSideMatrix, rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -535,7 +551,9 @@ public:
     virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
                                        const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateLeftHandSide(rLeftHandSideMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -556,6 +574,7 @@ public:
      * @param rLeftHandSideMatrices container for the desired LHS output
      * @param rLHSVariables parameter describing the expected LHSs
      */
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void CalculateLeftHandSide(std::vector< MatrixType >& rLeftHandSideMatrices,
                     const std::vector< Variable< MatrixType > >& rLHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
@@ -574,7 +593,9 @@ public:
     virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
                                         const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateRightHandSide(rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rRightHandSideVector.size() != 0) {
         //     rRightHandSideVector.resize(0, false);
         // }
@@ -594,6 +615,7 @@ public:
      * @param rRightHandSideVectors container for the desired RHS output
      * @param rRHSVariables parameter describing the expected RHSs
      */
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void CalculateRightHandSide(std::vector< VectorType >& rRightHandSideVectors,
                     const std::vector< Variable< VectorType > >& rRHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
@@ -626,7 +648,9 @@ public:
                                                         VectorType& rRightHandSideVector,
                                                         const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateFirstDerivativesContributions(rLeftHandSideMatrix, rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -654,7 +678,9 @@ public:
     virtual void CalculateFirstDerivativesLHS(MatrixType& rLeftHandSideMatrix,
                                               const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateFirstDerivativesLHS(rLeftHandSideMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -677,8 +703,9 @@ public:
     virtual void CalculateFirstDerivativesRHS(VectorType& rRightHandSideVector,
                                               const ProcessInfo& rCurrentProcessInfo)
     {
-
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateFirstDerivativesRHS(rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
 
         // if (rRightHandSideVector.size() != 0) {
         //     rRightHandSideVector.resize(0, false);
@@ -715,7 +742,9 @@ public:
                                                          VectorType& rRightHandSideVector,
                                                          const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateSecondDerivativesContributions(rLeftHandSideMatrix, rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -744,7 +773,9 @@ public:
     virtual void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
                                                const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateSecondDerivativesLHS(rLeftHandSideMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -767,7 +798,9 @@ public:
     virtual void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
                                                const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateSecondDerivativesRHS(rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rRightHandSideVector.size() != 0) {
         //     rRightHandSideVector.resize(0, false);
         // }
@@ -795,7 +828,9 @@ public:
      */
     virtual void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateMassMatrix(rMassMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rMassMatrix.size1() != 0) {
         //     rMassMatrix.resize(0, 0, false);
         // }
@@ -816,7 +851,9 @@ public:
      */
     virtual void CalculateDampingMatrix(MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateDampingMatrix(rDampingMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rDampingMatrix.size1() != 0) {
         //     rDampingMatrix.resize(0, 0, false);
         // }
@@ -847,7 +884,9 @@ public:
      */
     virtual void AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         AddExplicitContribution(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddExplicitContribution(ProcessInfo& rCurrentProcessInfo)
@@ -984,49 +1023,63 @@ public:
                           std::vector<bool>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<int>& rVariable,
                           std::vector<int>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                           std::vector<double>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
                           std::vector< array_1d<double, 3 > >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
                           std::vector< array_1d<double, 6 > >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<Vector >& rVariable,
                           std::vector< Vector >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<Matrix >& rVariable,
                           std::vector< Matrix >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -1170,7 +1223,9 @@ public:
      */
     virtual void MassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         MassMatrix(rMassMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
 
         // if (rMassMatrix.size1() != 0) {
         //     rMassMatrix.resize(0, 0, false);
@@ -1192,7 +1247,9 @@ public:
     virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix,
                                double coeff, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         AddMassMatrix(rLeftHandSideMatrix, coeff, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix, double coeff, ProcessInfo& rCurrentProcessInfo)
@@ -1207,7 +1264,9 @@ public:
      */
     virtual void DampMatrix(MatrixType& rDampMatrix, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         DampMatrix(rDampMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rDampMatrix.size1() != 0) {
         //     rDampMatrix.resize(0, 0, false);
         // }
@@ -1226,7 +1285,9 @@ public:
     virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff,
                                   const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         AddInertiaForces(rRightHandSideVector, coeff, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff, ProcessInfo& rCurrentProcessInfo)
@@ -1243,7 +1304,9 @@ public:
     virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
             VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateLocalVelocityContribution(rDampingMatrix, rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rDampingMatrix.size1() != 0) {
         //     rDampingMatrix.resize(0, 0, false);
         // }

--- a/kratos/includes/condition.h
+++ b/kratos/includes/condition.h
@@ -278,7 +278,7 @@ public:
         //     rResult.resize(0);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void EquationIdVector(EquationIdVectorType& rResult,
                   ProcessInfo& rCurrentProcessInfo)
     {
@@ -299,7 +299,7 @@ public:
         //     rElementalDofList.resize(0);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void GetDofList(DofsVectorType& rConditionDofList,
                 ProcessInfo& rCurrentProcessInfo)
     {
@@ -335,7 +335,7 @@ public:
             values.resize(0, false);
         }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void GetValuesVector(Vector& values, int Step = 0)
     {
         const auto& r_const_this = *this;
@@ -351,7 +351,7 @@ public:
             values.resize(0, false);
         }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void GetFirstDerivativesVector(Vector& values, int Step = 0)
     {
         const auto& r_const_this = *this;
@@ -367,7 +367,7 @@ public:
             values.resize(0, false);
         }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void GetSecondDerivativesVector(Vector& values, int Step = 0)
     {
         const auto& r_const_this = *this;
@@ -393,7 +393,7 @@ public:
         Initialize();
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"ProcessInfo\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"ProcessInfo\"")
     virtual void Initialize()
     {
     }
@@ -429,7 +429,7 @@ public:
     {
         InitializeSolutionStep(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -441,7 +441,7 @@ public:
     {
         InitializeNonLinearIteration(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -453,7 +453,7 @@ public:
     {
         FinalizeNonLinearIteration(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -465,7 +465,7 @@ public:
     {
         FinalizeSolutionStep(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -498,7 +498,7 @@ public:
         // }
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                       VectorType& rRightHandSideVector,
                       ProcessInfo& rCurrentProcessInfo)
@@ -541,7 +541,7 @@ public:
         // }
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
                        ProcessInfo& rCurrentProcessInfo)
     {
@@ -579,7 +579,7 @@ public:
         //     rRightHandSideVector.resize(0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
                     ProcessInfo& rCurrentProcessInfo)
     {
@@ -634,7 +634,7 @@ public:
         //     rRightHandSideVector.resize(0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateFirstDerivativesContributions(MatrixType& rLeftHandSideMatrix,
                             VectorType& rRightHandSideVector,
                             ProcessInfo& rCurrentProcessInfo)
@@ -659,7 +659,7 @@ public:
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateFirstDerivativesLHS(MatrixType& rLeftHandSideMatrix,
                           ProcessInfo& rCurrentProcessInfo)
     {
@@ -684,7 +684,7 @@ public:
         //     rRightHandSideVector.resize(0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateFirstDerivativesRHS(VectorType& rRightHandSideVector,
                           ProcessInfo& rCurrentProcessInfo)
     {
@@ -723,7 +723,7 @@ public:
         //     rRightHandSideVector.resize(0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
                              VectorType& rRightHandSideVector,
                              ProcessInfo& rCurrentProcessInfo)
@@ -749,7 +749,7 @@ public:
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
                            ProcessInfo& rCurrentProcessInfo)
     {
@@ -772,7 +772,7 @@ public:
         //     rRightHandSideVector.resize(0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
                            ProcessInfo& rCurrentProcessInfo)
     {
@@ -800,7 +800,7 @@ public:
         //     rMassMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rMassMatrix.size1() != 0)
@@ -821,7 +821,7 @@ public:
         //     rDampingMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateDampingMatrix(MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampingMatrix.size1() != 0)
@@ -849,7 +849,7 @@ public:
     {
         AddExplicitContribution(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddExplicitContribution(ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -871,7 +871,7 @@ public:
     {
         KRATOS_ERROR << "Base condition class is not able to assemble rRHS to the desired variable. destination variable is " << rDestinationVariable << std::endl;
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddExplicitContribution(
         const VectorType& rRHSVector,
         const Variable<VectorType>& rRHSVariable,
@@ -900,7 +900,7 @@ public:
     {
         KRATOS_ERROR << "Base condition class is not able to assemble rRHS to the desired variable. destination variable is " << rDestinationVariable << std::endl;
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddExplicitContribution(
         const VectorType& rRHSVector,
         const Variable<VectorType>& rRHSVariable,
@@ -929,7 +929,7 @@ public:
     {
         KRATOS_ERROR << "Base condition class is not able to assemble rLHS to the desired variable. destination variable is " << rDestinationVariable << std::endl;
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddExplicitContribution(
         const MatrixType& rLHSMatrix,
         const Variable<MatrixType>& rLHSVariable,
@@ -1080,49 +1080,49 @@ public:
 
     //GET ON INTEGRATION POINTS METHODS
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<bool>& rVariable,
                          std::vector<bool>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<int>& rVariable,
                          std::vector<int>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
                          std::vector<double>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
                          std::vector<array_1d<double, 3 > >& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
                          std::vector<array_1d<double, 6 > >& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
                          std::vector<Vector>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
                          std::vector<Matrix>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
@@ -1152,7 +1152,7 @@ public:
 
         KRATOS_CATCH("")
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual int Check(const ProcessInfo& rCurrentProcessInfo)
     {
         KRATOS_TRY
@@ -1176,7 +1176,7 @@ public:
         //     rMassMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void MassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rMassMatrix.size1() != 0)
@@ -1194,7 +1194,7 @@ public:
     {
         AddMassMatrix(rLeftHandSideMatrix, coeff, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix, double coeff, ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -1212,7 +1212,7 @@ public:
         //     rDampMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void DampMatrix(MatrixType& rDampMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampMatrix.size1() != 0)
@@ -1228,7 +1228,7 @@ public:
     {
         AddInertiaForces(rRightHandSideVector, coeff, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff, ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -1248,7 +1248,7 @@ public:
         //     rDampingMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampingMatrix.size1() != 0)

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -269,7 +269,9 @@ public:
     virtual void EquationIdVector(EquationIdVectorType& rResult,
                                   const ProcessInfo& rCurrentProcessInfo) const
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         const_cast<Element*>(this)->EquationIdVector(rResult, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rResult.size() != 0) {
         //     rResult.resize(0);
         // }
@@ -289,7 +291,9 @@ public:
     virtual void GetDofList(DofsVectorType& rElementalDofList,
                             const ProcessInfo& rCurrentProcessInfo) const
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         const_cast<Element*>(this)->GetDofList(rElementalDofList, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rElementalDofList.size() != 0) {
         //     rElementalDofList.resize(0);
         // }
@@ -384,7 +388,9 @@ public:
      */
     virtual void Initialize(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         Initialize();
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"ProcessInfo\"")
@@ -423,7 +429,9 @@ public:
      */
     virtual void InitializeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         InitializeSolutionStep(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
@@ -436,7 +444,9 @@ public:
      */
     virtual void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         InitializeNonLinearIteration(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
@@ -448,7 +458,9 @@ public:
      */
     virtual void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         FinalizeNonLinearIteration(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
@@ -461,7 +473,9 @@ public:
      */
     virtual void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         FinalizeSolutionStep(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
@@ -488,7 +502,9 @@ public:
                                       VectorType& rRightHandSideVector,
                                       const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateLocalSystem(rLeftHandSideMatrix, rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -540,7 +556,9 @@ public:
     virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
                                        const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateLeftHandSide(rLeftHandSideMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -561,6 +579,7 @@ public:
      * @param rLeftHandSideMatrices container for the desired LHS output
      * @param rLHSVariables parameter describing the expected LHSs
      */
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void CalculateLeftHandSide(std::vector< MatrixType >& rLeftHandSideMatrices,
                     const std::vector< Variable< MatrixType > >& rLHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
@@ -579,7 +598,9 @@ public:
     virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
                                         const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateRightHandSide(rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rRightHandSideVector.size() != 0) {
         //     rRightHandSideVector.resize(0, false);
         // }
@@ -599,6 +620,7 @@ public:
      * @param rRightHandSideVectors container for the desired RHS output
      * @param rRHSVariables parameter describing the expected RHSs
      */
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void CalculateRightHandSide(std::vector< VectorType >& rRightHandSideVectors,
                     const std::vector< Variable< VectorType > >& rRHSVariables,
                     ProcessInfo& rCurrentProcessInfo)
@@ -630,7 +652,9 @@ public:
                                                         VectorType& rRightHandSideVector,
                                                         const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateFirstDerivativesContributions(rLeftHandSideMatrix, rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -658,7 +682,9 @@ public:
     virtual void CalculateFirstDerivativesLHS(MatrixType& rLeftHandSideMatrix,
                                               const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateFirstDerivativesLHS(rLeftHandSideMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -682,7 +708,9 @@ public:
                                               const ProcessInfo& rCurrentProcessInfo)
     {
 
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateFirstDerivativesRHS(rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
 
         // if (rRightHandSideVector.size() != 0) {
         //     rRightHandSideVector.resize(0, false);
@@ -719,7 +747,9 @@ public:
                                                          VectorType& rRightHandSideVector,
                                                          const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateSecondDerivativesContributions(rLeftHandSideMatrix, rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -748,7 +778,9 @@ public:
     virtual void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
                                                const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateSecondDerivativesLHS(rLeftHandSideMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rLeftHandSideMatrix.size1() != 0) {
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
@@ -771,7 +803,9 @@ public:
     virtual void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
                                                const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateSecondDerivativesRHS(rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rRightHandSideVector.size() != 0) {
         //     rRightHandSideVector.resize(0, false);
         // }
@@ -800,7 +834,9 @@ public:
      */
     virtual void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateMassMatrix(rMassMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rMassMatrix.size1() != 0) {
         //     rMassMatrix.resize(0, 0, false);
         // }
@@ -821,7 +857,9 @@ public:
      */
     virtual void CalculateDampingMatrix(MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateDampingMatrix(rDampingMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rDampingMatrix.size1() != 0) {
         //     rDampingMatrix.resize(0, 0, false);
         // }
@@ -853,7 +891,9 @@ public:
      */
     virtual void AddExplicitContribution(const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         AddExplicitContribution(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddExplicitContribution(ProcessInfo& rCurrentProcessInfo)
@@ -990,56 +1030,72 @@ public:
                           std::vector<bool>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<int>& rVariable,
                           std::vector<int>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<double>& rVariable,
                           std::vector<double>& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
                           std::vector< array_1d<double, 3 > >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
                           std::vector< array_1d<double, 6 > >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<Vector >& rVariable,
                           std::vector< Vector >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<Matrix >& rVariable,
                           std::vector< Matrix >& rOutput,
                           const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     virtual void CalculateOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
                          std::vector<ConstitutiveLaw::Pointer>& rOutput,
                          const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->GetValueOnIntegrationPoints(rVariable, rOutput, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -1201,7 +1257,9 @@ public:
      */
     virtual void MassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         MassMatrix(rMassMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
 
         // if (rMassMatrix.size1() != 0) {
         //     rMassMatrix.resize(0, 0, false);
@@ -1223,7 +1281,9 @@ public:
     virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix,
                                double coeff, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         AddMassMatrix(rLeftHandSideMatrix, coeff, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix,
@@ -1239,7 +1299,9 @@ public:
      */
     virtual void DampMatrix(MatrixType& rDampMatrix, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         DampMatrix(rDampMatrix, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rDampMatrix.size1() != 0) {
         //     rDampMatrix.resize(0, 0, false);
         // }
@@ -1258,7 +1320,9 @@ public:
     virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff,
                                   const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         AddInertiaForces(rRightHandSideVector, coeff, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff,
@@ -1275,7 +1339,9 @@ public:
     virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
             VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         CalculateLocalVelocityContribution(rDampingMatrix, rRightHandSideVector, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // if (rDampingMatrix.size1() != 0) {
         //     rDampingMatrix.resize(0, 0, false);
         // }

--- a/kratos/includes/element.h
+++ b/kratos/includes/element.h
@@ -294,7 +294,7 @@ public:
         //     rElementalDofList.resize(0);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void GetDofList(DofsVectorType& rElementalDofList,
                             ProcessInfo& rCurrentProcessInfo)
     {
@@ -329,7 +329,7 @@ public:
             values.resize(0, false);
         }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void GetValuesVector(Vector& values, int Step = 0)
     {
         const auto& r_const_this = *this;
@@ -345,7 +345,7 @@ public:
             values.resize(0, false);
         }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void GetFirstDerivativesVector(Vector& values, int Step = 0)
     {
         const auto& r_const_this = *this;
@@ -361,7 +361,7 @@ public:
             values.resize(0, false);
         }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void GetSecondDerivativesVector(Vector& values, int Step = 0)
     {
         const auto& r_const_this = *this;
@@ -387,7 +387,7 @@ public:
         Initialize();
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"ProcessInfo\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"ProcessInfo\"")
     virtual void Initialize()
     {
     }
@@ -425,7 +425,7 @@ public:
     {
         InitializeSolutionStep(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void InitializeSolutionStep(ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -438,7 +438,7 @@ public:
     {
         InitializeNonLinearIteration(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -450,7 +450,7 @@ public:
     {
         FinalizeNonLinearIteration(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -463,7 +463,7 @@ public:
     {
         FinalizeSolutionStep(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -497,7 +497,7 @@ public:
         // }
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,
                                       VectorType& rRightHandSideVector,
                                       ProcessInfo& rCurrentProcessInfo)
@@ -546,7 +546,7 @@ public:
         // }
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,
                                        ProcessInfo& rCurrentProcessInfo)
     {
@@ -584,7 +584,7 @@ public:
         //     rRightHandSideVector.resize(0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateRightHandSide(VectorType& rRightHandSideVector,
                                         ProcessInfo& rCurrentProcessInfo)
     {
@@ -638,7 +638,7 @@ public:
         //     rRightHandSideVector.resize(0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateFirstDerivativesContributions(MatrixType& rLeftHandSideMatrix,
                             VectorType& rRightHandSideVector,
                             ProcessInfo& rCurrentProcessInfo)
@@ -663,7 +663,7 @@ public:
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateFirstDerivativesLHS(MatrixType& rLeftHandSideMatrix,
                           ProcessInfo& rCurrentProcessInfo)
     {
@@ -688,7 +688,7 @@ public:
         //     rRightHandSideVector.resize(0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateFirstDerivativesRHS(VectorType& rRightHandSideVector,
                           ProcessInfo& rCurrentProcessInfo)
     {
@@ -727,7 +727,7 @@ public:
         //     rRightHandSideVector.resize(0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateSecondDerivativesContributions(MatrixType& rLeftHandSideMatrix,
                              VectorType& rRightHandSideVector,
                              ProcessInfo& rCurrentProcessInfo)
@@ -753,7 +753,7 @@ public:
         //     rLeftHandSideMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateSecondDerivativesLHS(MatrixType& rLeftHandSideMatrix,
                            ProcessInfo& rCurrentProcessInfo)
     {
@@ -776,7 +776,7 @@ public:
         //     rRightHandSideVector.resize(0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateSecondDerivativesRHS(VectorType& rRightHandSideVector,
                            ProcessInfo& rCurrentProcessInfo)
     {
@@ -805,7 +805,7 @@ public:
         //     rMassMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rMassMatrix.size1() != 0)
@@ -826,7 +826,7 @@ public:
         //     rDampingMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateDampingMatrix(MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampingMatrix.size1() != 0)
@@ -855,7 +855,7 @@ public:
     {
         AddExplicitContribution(const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddExplicitContribution(ProcessInfo& rCurrentProcessInfo)
     {
     }
@@ -877,7 +877,7 @@ public:
     {
         KRATOS_ERROR << "Base element class is not able to assemble rRHS to the desired variable. destination variable is " << rDestinationVariable << std::endl;
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddExplicitContribution(
         const VectorType& rRHSVector,
         const Variable<VectorType>& rRHSVariable,
@@ -906,7 +906,7 @@ public:
     {
          KRATOS_ERROR << "Base element class is not able to assemble rRHS to the desired variable. destination variable is " << rDestinationVariable << std::endl;
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddExplicitContribution(
         const VectorType& rRHSVector,
         const Variable<VectorType>& rRHSVariable,
@@ -935,7 +935,7 @@ public:
     {
          KRATOS_ERROR << "Base element class is not able to assemble rLHS to the desired variable. destination variable is " << rDestinationVariable << std::endl;
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddExplicitContribution(
         const MatrixType& rLHSMatrix,
         const Variable<MatrixType>& rLHSVariable,
@@ -1103,56 +1103,56 @@ public:
 
     //GET ON INTEGRATION POINTS METHODS
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<bool>& rVariable,
                          std::vector<bool>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<int>& rVariable,
                          std::vector<int>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<double>& rVariable,
                          std::vector<double>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 3 > >& rVariable,
                          std::vector<array_1d<double, 3 > >& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<array_1d<double, 6 > >& rVariable,
                          std::vector<array_1d<double, 6 > >& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable,
                          std::vector<Vector>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable,
                          std::vector<Matrix>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
     {
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use \"CalculateOnIntegrationPoints\"")
     virtual void GetValueOnIntegrationPoints(const Variable<ConstitutiveLaw::Pointer>& rVariable,
                          std::vector<ConstitutiveLaw::Pointer>& rValues,
                          const ProcessInfo& rCurrentProcessInfo)
@@ -1183,7 +1183,7 @@ public:
         KRATOS_CATCH("")
     }
 
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual int Check(const ProcessInfo& rCurrentProcessInfo)
     {
         KRATOS_TRY
@@ -1207,7 +1207,7 @@ public:
         //     rMassMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void MassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rMassMatrix.size1() != 0)
@@ -1225,7 +1225,7 @@ public:
     {
         AddMassMatrix(rLeftHandSideMatrix, coeff, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddMassMatrix(MatrixType& rLeftHandSideMatrix,
                                double coeff, ProcessInfo& rCurrentProcessInfo)
     {
@@ -1244,7 +1244,7 @@ public:
         //     rDampMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void DampMatrix(MatrixType& rDampMatrix, ProcessInfo& rCurrentProcessInfo)
     {
         if (rDampMatrix.size1() != 0)
@@ -1260,7 +1260,7 @@ public:
     {
         AddInertiaForces(rRightHandSideVector, coeff, const_cast<ProcessInfo&>(rCurrentProcessInfo)); // TODO remove this after the transition period
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void AddInertiaForces(VectorType& rRightHandSideVector, double coeff,
                                   ProcessInfo& rCurrentProcessInfo)
     {
@@ -1280,7 +1280,7 @@ public:
         //     rDampingMatrix.resize(0, 0, false);
         // }
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please add the missing \"const\"")
     virtual void CalculateLocalVelocityContribution(MatrixType& rDampingMatrix,
             VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo)
     {

--- a/kratos/solving_strategies/schemes/scheme.h
+++ b/kratos/solving_strategies/schemes/scheme.h
@@ -631,7 +631,9 @@ public:
      */
     virtual void CleanMemory(Condition& rCondition)
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->CleanMemory(Condition::Pointer(&rCondition)); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // rCondition.CleanMemory();
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
@@ -714,6 +716,7 @@ public:
         const ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->CalculateSystemContributions(
             Element::Pointer(&rElement),
             LHS_Contribution,
@@ -721,6 +724,7 @@ public:
             rEquationIdVector,
             const_cast<ProcessInfo&>(rCurrentProcessInfo)
         ); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // rElement.CalculateLocalSystem(LHS_Contribution, RHS_Contribution, rCurrentProcessInfo);
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
@@ -732,7 +736,9 @@ public:
         ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         pCurrentElement->CalculateLocalSystem(LHS_Contribution, RHS_Contribution, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -751,6 +757,7 @@ public:
         const ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->Condition_CalculateSystemContributions(
             Condition::Pointer(&rCondition),
             LHS_Contribution,
@@ -758,6 +765,7 @@ public:
             rEquationIdVector,
             const_cast<ProcessInfo&>(rCurrentProcessInfo)
         ); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // rCondition.CalculateLocalSystem(LHS_Contribution, RHS_Contribution, rCurrentProcessInfo);
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
@@ -769,7 +777,9 @@ public:
         ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         pCurrentCondition->CalculateLocalSystem(LHS_Contribution, RHS_Contribution, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -786,12 +796,14 @@ public:
         const ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->Calculate_RHS_Contribution(
             Element::Pointer(&rElement),
             RHS_Contribution,
             rEquationIdVector,
             const_cast<ProcessInfo&>(rCurrentProcessInfo)
         ); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // rElement.CalculateRightHandSide(RHS_Contribution, rCurrentProcessInfo);
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
@@ -802,7 +814,9 @@ public:
         ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         pCurrentElement->CalculateRightHandSide(RHS_Contribution, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -819,12 +833,14 @@ public:
         const ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->Condition_Calculate_RHS_Contribution(
             Condition::Pointer(&rCondition),
             RHS_Contribution,
             rEquationIdVector,
             const_cast<ProcessInfo&>(rCurrentProcessInfo)
         ); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // rCondition.CalculateRightHandSide(RHS_Contribution, rCurrentProcessInfo);
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
@@ -835,7 +851,9 @@ public:
         ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         pCurrentCondition->CalculateRightHandSide(RHS_Contribution, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -852,12 +870,14 @@ public:
         const ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->Calculate_LHS_Contribution(
             Element::Pointer(&rElement),
             LHS_Contribution,
             rEquationIdVector,
             const_cast<ProcessInfo&>(rCurrentProcessInfo)
         ); // TODO remove this after the transition period and uncomment the following
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
         // rElement.CalculateLeftHandSide(LHS_Contribution, rCurrentProcessInfo);
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
@@ -868,7 +888,9 @@ public:
         ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         pCurrentElement->CalculateLeftHandSide(LHS_Contribution, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -885,13 +907,15 @@ public:
         const ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         this->Condition_Calculate_LHS_Contribution(
             Condition::Pointer(&rCondition),
             LHS_Contribution,
             rEquationIdVector,
             const_cast<ProcessInfo&>(rCurrentProcessInfo)
         ); // TODO remove this after the transition period and uncomment the following
-        // rrCondition.CalculateLeftHandSide(LHS_Contribution, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
+        // rCondition.CalculateLeftHandSide(LHS_Contribution, rCurrentProcessInfo);
     }
     KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void Condition_Calculate_LHS_Contribution(
@@ -901,7 +925,9 @@ public:
         ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         pCurrentCondition->CalculateLeftHandSide(LHS_Contribution, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -925,7 +951,9 @@ public:
         ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         (pCurrentElement)->EquationIdVector(EquationId, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -949,7 +977,9 @@ public:
         ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         (pCurrentCondition)->EquationIdVector(EquationId, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -973,7 +1003,9 @@ public:
         ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         pCurrentElement->GetDofList(ElementalDofList, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**
@@ -997,7 +1029,9 @@ public:
         ProcessInfo& rCurrentProcessInfo
         )
     {
+        KRATOS_START_IGNORING_DEPRECATED_FUNCTION_WARNING
         pCurrentCondition->GetDofList(ConditionDofList, rCurrentProcessInfo);
+        KRATOS_STOP_IGNORING_DEPRECATED_FUNCTION_WARNING
     }
 
     /**

--- a/kratos/solving_strategies/schemes/scheme.h
+++ b/kratos/solving_strategies/schemes/scheme.h
@@ -619,7 +619,7 @@ public:
         this->CleanMemory(Element::Pointer(&rElement)); // TODO remove this after the transition period and uncomment the following
         // rElement.CleanMemory();
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void CleanMemory(Element::Pointer rCurrentElement)
     {
         rCurrentElement->CleanMemory();
@@ -634,7 +634,7 @@ public:
         this->CleanMemory(Condition::Pointer(&rCondition)); // TODO remove this after the transition period and uncomment the following
         // rCondition.CleanMemory();
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void CleanMemory(Condition::Pointer rCurrentCondition)
     {
         rCurrentCondition->CleanMemory();
@@ -723,7 +723,7 @@ public:
         ); // TODO remove this after the transition period and uncomment the following
         // rElement.CalculateLocalSystem(LHS_Contribution, RHS_Contribution, rCurrentProcessInfo);
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void CalculateSystemContributions(
         Element::Pointer pCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
@@ -760,7 +760,7 @@ public:
         ); // TODO remove this after the transition period and uncomment the following
         // rCondition.CalculateLocalSystem(LHS_Contribution, RHS_Contribution, rCurrentProcessInfo);
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void Condition_CalculateSystemContributions(
         Condition::Pointer pCurrentCondition,
         LocalSystemMatrixType& LHS_Contribution,
@@ -794,7 +794,7 @@ public:
         ); // TODO remove this after the transition period and uncomment the following
         // rElement.CalculateRightHandSide(RHS_Contribution, rCurrentProcessInfo);
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void Calculate_RHS_Contribution(
         Element::Pointer pCurrentElement,
         LocalSystemVectorType& RHS_Contribution,
@@ -827,7 +827,7 @@ public:
         ); // TODO remove this after the transition period and uncomment the following
         // rCondition.CalculateRightHandSide(RHS_Contribution, rCurrentProcessInfo);
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void Condition_Calculate_RHS_Contribution(
         Condition::Pointer pCurrentCondition,
         LocalSystemVectorType& RHS_Contribution,
@@ -860,7 +860,7 @@ public:
         ); // TODO remove this after the transition period and uncomment the following
         // rElement.CalculateLeftHandSide(LHS_Contribution, rCurrentProcessInfo);
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void Calculate_LHS_Contribution(
         Element::Pointer pCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
@@ -893,7 +893,7 @@ public:
         ); // TODO remove this after the transition period and uncomment the following
         // rrCondition.CalculateLeftHandSide(LHS_Contribution, rCurrentProcessInfo);
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void Condition_Calculate_LHS_Contribution(
         Condition::Pointer pCurrentCondition,
         LocalSystemMatrixType& LHS_Contribution,
@@ -918,7 +918,7 @@ public:
     {
         rElement.EquationIdVector(rEquationId, rCurrentProcessInfo);
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void EquationId(
         Element::Pointer pCurrentElement,
         Element::EquationIdVectorType& EquationId,
@@ -942,7 +942,7 @@ public:
     {
         rCondition.EquationIdVector(rEquationId, rCurrentProcessInfo);
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void Condition_EquationId(
         Condition::Pointer pCurrentCondition,
         Element::EquationIdVectorType& EquationId,
@@ -966,7 +966,7 @@ public:
     {
         rElement.GetDofList(rDofList, rCurrentProcessInfo);
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void GetElementalDofList(
         Element::Pointer pCurrentElement,
         Element::DofsVectorType& ElementalDofList,
@@ -990,7 +990,7 @@ public:
     {
         rCondition.GetDofList(rDofList, rCurrentProcessInfo);
     }
-    // KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
+    KRATOS_DEPRECATED_MESSAGE("This is legacy version, please use the other overload of this function")
     virtual void GetConditionDofList(
         Condition::Pointer pCurrentCondition,
         Element::DofsVectorType& ConditionDofList,


### PR DESCRIPTION
**Description**
As announced in #7381 this PR activates the deprecation warnings in `Element`, `Condition` and `Scheme`. It will be merged this Friday, 30.10.
For details please see #7381 

I also disabled the "internal" deprecation warnings that come from calling the old methods for backward compatibility reasons.

@sunethwarna the sensitivity builder gives some warnings, can you please have a look?