### PR TITLE
[Poro] Cleanup const processinfo

### DIFF
--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_condition.cpp
@@ -26,11 +26,11 @@ Condition::Pointer UPwCondition<TDim,TNumNodes>::Create(IndexType NewId,NodesArr
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<2,1>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<2,1>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = GetGeometry();
+    const GeometryType& rGeom = GetGeometry();
     const unsigned int condition_size = 2 + 1;
     unsigned int index = 0;
 
@@ -47,11 +47,11 @@ void UPwCondition<2,1>::GetDofList(DofsVectorType& rConditionDofList, const Proc
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<2,2>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<2,2>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = GetGeometry();
+    const GeometryType& rGeom = GetGeometry();
     const unsigned int condition_size = 2 * (2 + 1);
     unsigned int index = 0;
 
@@ -71,11 +71,11 @@ void UPwCondition<2,2>::GetDofList(DofsVectorType& rConditionDofList, const Proc
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,1>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,1>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = GetGeometry();
+    const GeometryType& rGeom = GetGeometry();
     const unsigned int condition_size = 3 + 1;
     unsigned int index = 0;
 
@@ -93,11 +93,11 @@ void UPwCondition<3,1>::GetDofList(DofsVectorType& rConditionDofList, const Proc
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,3>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,3>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = GetGeometry();
+    const GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 3 * (3 + 1);
     unsigned int index = 0;
 
@@ -118,11 +118,11 @@ void UPwCondition<3,3>::GetDofList(DofsVectorType& rConditionDofList, const Proc
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,4>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,4>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = GetGeometry();
+    const GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 4 * (3 + 1);
     unsigned int index = 0;
 
@@ -198,11 +198,11 @@ void UPwCondition<TDim,TNumNodes>::CalculateRightHandSide( VectorType& rRightHan
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<2,1>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<2,1>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = GetGeometry();
+    const GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 2 + 1;
     unsigned int index = 0;
 
@@ -219,11 +219,11 @@ void UPwCondition<2,1>::EquationIdVector(EquationIdVectorType& rResult,const Pro
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<2,2>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<2,2>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = GetGeometry();
+    const GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 2 * (2 + 1);
     unsigned int index = 0;
 
@@ -243,11 +243,11 @@ void UPwCondition<2,2>::EquationIdVector(EquationIdVectorType& rResult,const Pro
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,1>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,1>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = GetGeometry();
+    const GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 3 + 1;
     unsigned int index = 0;
 
@@ -265,11 +265,11 @@ void UPwCondition<3,1>::EquationIdVector(EquationIdVectorType& rResult,const Pro
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,3>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,3>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = GetGeometry();
+    const GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 3 * (3 + 1);
     unsigned int index = 0;
 
@@ -290,11 +290,11 @@ void UPwCondition<3,3>::EquationIdVector(EquationIdVectorType& rResult,const Pro
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,4>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,4>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = GetGeometry();
+    const GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 4 * (3 + 1);
     unsigned int index = 0;
 

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_condition.cpp
@@ -26,17 +26,17 @@ Condition::Pointer UPwCondition<TDim,TNumNodes>::Create(IndexType NewId,NodesArr
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<2,1>::GetDofList(DofsVectorType& rConditionDofList, ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<2,1>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
-    
+
     GeometryType& rGeom = GetGeometry();
     const unsigned int condition_size = 2 + 1;
     unsigned int index = 0;
-    
+
     if (rConditionDofList.size() != condition_size)
       rConditionDofList.resize( condition_size );
-    
+
     rConditionDofList[index++] = rGeom[0].pGetDof(DISPLACEMENT_X);
     rConditionDofList[index++] = rGeom[0].pGetDof(DISPLACEMENT_Y);
     rConditionDofList[index++] = rGeom[0].pGetDof(WATER_PRESSURE);
@@ -47,17 +47,17 @@ void UPwCondition<2,1>::GetDofList(DofsVectorType& rConditionDofList, ProcessInf
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<2,2>::GetDofList(DofsVectorType& rConditionDofList, ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<2,2>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
-    
+
     GeometryType& rGeom = GetGeometry();
     const unsigned int condition_size = 2 * (2 + 1);
     unsigned int index = 0;
-    
+
     if (rConditionDofList.size() != condition_size)
       rConditionDofList.resize( condition_size );
-    
+
     for (unsigned int i = 0; i < 2; i++)
     {
         rConditionDofList[index++] = rGeom[i].pGetDof(DISPLACEMENT_X);
@@ -71,17 +71,17 @@ void UPwCondition<2,2>::GetDofList(DofsVectorType& rConditionDofList, ProcessInf
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,1>::GetDofList(DofsVectorType& rConditionDofList, ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,1>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
-    
+
     GeometryType& rGeom = GetGeometry();
     const unsigned int condition_size = 3 + 1;
     unsigned int index = 0;
-    
+
     if (rConditionDofList.size() != condition_size)
       rConditionDofList.resize( condition_size );
-    
+
     rConditionDofList[index++] = rGeom[0].pGetDof(DISPLACEMENT_X);
     rConditionDofList[index++] = rGeom[0].pGetDof(DISPLACEMENT_Y);
     rConditionDofList[index++] = rGeom[0].pGetDof(DISPLACEMENT_Z);
@@ -93,17 +93,17 @@ void UPwCondition<3,1>::GetDofList(DofsVectorType& rConditionDofList, ProcessInf
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,3>::GetDofList(DofsVectorType& rConditionDofList, ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,3>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
-    
+
     GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 3 * (3 + 1);
     unsigned int index = 0;
-    
+
     if (rConditionDofList.size() != condition_size)
       rConditionDofList.resize( condition_size );
-    
+
     for (unsigned int i = 0; i < 3; i++)
     {
         rConditionDofList[index++] = rGeom[i].pGetDof(DISPLACEMENT_X);
@@ -118,17 +118,17 @@ void UPwCondition<3,3>::GetDofList(DofsVectorType& rConditionDofList, ProcessInf
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,4>::GetDofList(DofsVectorType& rConditionDofList, ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,4>::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
-    
+
     GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 4 * (3 + 1);
     unsigned int index = 0;
-    
+
     if (rConditionDofList.size() != condition_size)
       rConditionDofList.resize( condition_size );
-    
+
     for (unsigned int i = 0; i < 4; i++)
     {
         rConditionDofList[index++] = rGeom[i].pGetDof(DISPLACEMENT_X);
@@ -143,69 +143,69 @@ void UPwCondition<3,4>::GetDofList(DofsVectorType& rConditionDofList, ProcessInf
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwCondition<TDim,TNumNodes>::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void UPwCondition<TDim,TNumNodes>::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
     unsigned int condition_size = TNumNodes * (TDim + 1);
-    
+
     //Resetting the LHS
     if ( rLeftHandSideMatrix.size1() != condition_size )
         rLeftHandSideMatrix.resize( condition_size, condition_size, false );
     noalias( rLeftHandSideMatrix ) = ZeroMatrix( condition_size, condition_size );
-    
+
     //Resetting the RHS
     if ( rRightHandSideVector.size() != condition_size )
         rRightHandSideVector.resize( condition_size, false );
     noalias( rRightHandSideVector ) = ZeroVector( condition_size );
-    
+
     this->CalculateAll(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo);
-        
+
     KRATOS_CATCH( "" )
 }
 
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwCondition<TDim,TNumNodes>::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void UPwCondition<TDim,TNumNodes>::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY;
-    
+
     KRATOS_THROW_ERROR(std::logic_error,"UPwCondition::CalculateLeftHandSide not implemented","");
-    
+
     KRATOS_CATCH("");
 }
 
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwCondition<TDim,TNumNodes>::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void UPwCondition<TDim,TNumNodes>::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
-    
+
     unsigned int condition_size = TNumNodes * (TDim + 1);
-        
+
     //Resetting the RHS
     if ( rRightHandSideVector.size() != condition_size )
         rRightHandSideVector.resize( condition_size, false );
     noalias( rRightHandSideVector ) = ZeroVector( condition_size );
-    
+
     this->CalculateRHS(rRightHandSideVector, rCurrentProcessInfo);
-    
+
     KRATOS_CATCH( "" )
 }
 
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<2,1>::EquationIdVector(EquationIdVectorType& rResult,ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<2,1>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
-    
+
     GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 2 + 1;
     unsigned int index = 0;
-    
+
     if (rResult.size() != condition_size)
       rResult.resize( condition_size, false );
 
@@ -219,14 +219,14 @@ void UPwCondition<2,1>::EquationIdVector(EquationIdVectorType& rResult,ProcessIn
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<2,2>::EquationIdVector(EquationIdVectorType& rResult,ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<2,2>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
-    
+
     GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 2 * (2 + 1);
     unsigned int index = 0;
-    
+
     if (rResult.size() != condition_size)
       rResult.resize( condition_size, false );
 
@@ -243,14 +243,14 @@ void UPwCondition<2,2>::EquationIdVector(EquationIdVectorType& rResult,ProcessIn
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,1>::EquationIdVector(EquationIdVectorType& rResult,ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,1>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
-    
+
     GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 3 + 1;
     unsigned int index = 0;
-    
+
     if (rResult.size() != condition_size)
       rResult.resize( condition_size, false );
 
@@ -265,14 +265,14 @@ void UPwCondition<3,1>::EquationIdVector(EquationIdVectorType& rResult,ProcessIn
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,3>::EquationIdVector(EquationIdVectorType& rResult,ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,3>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
-    
+
     GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 3 * (3 + 1);
     unsigned int index = 0;
-    
+
     if (rResult.size() != condition_size)
       rResult.resize( condition_size, false );
 
@@ -290,14 +290,14 @@ void UPwCondition<3,3>::EquationIdVector(EquationIdVectorType& rResult,ProcessIn
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwCondition<3,4>::EquationIdVector(EquationIdVectorType& rResult,ProcessInfo& rCurrentProcessInfo)
+void UPwCondition<3,4>::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
-    
+
     GeometryType& rGeom = GetGeometry();
     unsigned int condition_size = 4 * (3 + 1);
     unsigned int index = 0;
-    
+
     if (rResult.size() != condition_size)
       rResult.resize( condition_size, false );
 
@@ -316,7 +316,7 @@ void UPwCondition<3,4>::EquationIdVector(EquationIdVectorType& rResult,ProcessIn
 
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwCondition<TDim,TNumNodes>::CalculateAll( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& CurrentProcessInfo )
-{    
+{
     this->CalculateRHS(rRightHandSideVector,CurrentProcessInfo);
 }
 
@@ -324,7 +324,7 @@ void UPwCondition<TDim,TNumNodes>::CalculateAll( MatrixType& rLeftHandSideMatrix
 
 template< unsigned int TDim, unsigned int TNumNodes >
 void UPwCondition<TDim,TNumNodes>::CalculateRHS( VectorType& rRightHandSideVector, const ProcessInfo& CurrentProcessInfo )
-{    
+{
     KRATOS_TRY
 
     KRATOS_THROW_ERROR( std::logic_error, "calling the default CalculateRHS method for a particular condition ... illegal operation!!", "" )

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_condition.hpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_condition.hpp
@@ -37,17 +37,17 @@ class KRATOS_API(POROMECHANICS_APPLICATION) UPwCondition : public Condition
 public:
 
     KRATOS_CLASS_POINTER_DEFINITION( UPwCondition );
-    
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     // Default constructor
     UPwCondition() : Condition() {}
-    
+
     // Constructor 1
     UPwCondition( IndexType NewId, GeometryType::Pointer pGeometry ) : Condition(NewId, pGeometry) {}
-    
+
     // Constructor 2
-    UPwCondition( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties ) : Condition(NewId, pGeometry, pProperties) 
+    UPwCondition( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties ) : Condition(NewId, pGeometry, pProperties)
     {
         mThisIntegrationMethod = this->GetIntegrationMethod();
     }
@@ -58,25 +58,25 @@ public:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     Condition::Pointer Create(IndexType NewId,NodesArrayType const& ThisNodes,PropertiesType::Pointer pProperties ) const override;
- 
-    void GetDofList(DofsVectorType& rConditionDofList,ProcessInfo& rCurrentProcessInfo ) override;
+
+    void GetDofList(DofsVectorType& rConditionDofList,const ProcessInfo& rCurrentProcessInfo ) override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,VectorType& rRightHandSideVector,ProcessInfo& rCurrentProcessInfo ) override;
-    
-    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,ProcessInfo& rCurrentProcessInfo ) override;
-    
-    void CalculateRightHandSide(VectorType& rRightHandSideVector,ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo ) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult,ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,const ProcessInfo& rCurrentProcessInfo ) override;
+
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo ) override;
+
+    void EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo ) override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-protected:   
-        
+protected:
+
     // Member Variables
-    
+
     GeometryData::IntegrationMethod mThisIntegrationMethod;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -88,11 +88,11 @@ protected:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 private:
-    
+
     // Serialization
-    
+
     friend class Serializer;
-    
+
     void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Condition )
@@ -102,9 +102,9 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Condition )
     }
-    
+
 }; // class UPwCondition.
 
 } // namespace Kratos.
 
-#endif // KRATOS_U_PW_CONDITION_H_INCLUDED defined 
+#endif // KRATOS_U_PW_CONDITION_H_INCLUDED defined

--- a/applications/PoromechanicsApplication/custom_conditions/U_Pw_condition.hpp
+++ b/applications/PoromechanicsApplication/custom_conditions/U_Pw_condition.hpp
@@ -59,7 +59,7 @@ public:
 
     Condition::Pointer Create(IndexType NewId,NodesArrayType const& ThisNodes,PropertiesType::Pointer pProperties ) const override;
 
-    void GetDofList(DofsVectorType& rConditionDofList,const ProcessInfo& rCurrentProcessInfo ) override;
+    void GetDofList(DofsVectorType& rConditionDofList,const ProcessInfo& rCurrentProcessInfo ) const override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -69,7 +69,7 @@ public:
 
     void CalculateRightHandSide(VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo ) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo ) override;
+    void EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo ) const override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
@@ -53,10 +53,10 @@ Condition::Pointer GeneralUPwDiffOrderCondition::Create(IndexType NewId,NodesArr
 void GeneralUPwDiffOrderCondition::Initialize()
 {
     KRATOS_TRY
-    
+
     const GeometryType& rGeom = GetGeometry();
     const SizeType NumUNodes = rGeom.PointsNumber();
-    
+
     switch(NumUNodes)
     {
         case 3: //2D L3P2
@@ -74,13 +74,13 @@ void GeneralUPwDiffOrderCondition::Initialize()
         default:
             KRATOS_THROW_ERROR(std::logic_error,"Unexpected geometry type for different order interpolation element","");
     }
-    
+
     KRATOS_CATCH( "" )
 }
 
 //----------------------------------------------------------------------------------------
 
-void GeneralUPwDiffOrderCondition::GetDofList(DofsVectorType& rConditionDofList, ProcessInfo& rCurrentProcessInfo)
+void GeneralUPwDiffOrderCondition::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -92,7 +92,7 @@ void GeneralUPwDiffOrderCondition::GetDofList(DofsVectorType& rConditionDofList,
 
     if(rConditionDofList.size() != ConditionSize)
         rConditionDofList.resize(ConditionSize);
-    
+
     SizeType Index = 0;
 /*
     for(SizeType i = 0; i < NumPNodes; i++)
@@ -103,7 +103,7 @@ void GeneralUPwDiffOrderCondition::GetDofList(DofsVectorType& rConditionDofList,
             rConditionDofList[Index++] = GetGeometry()[i].pGetDof( DISPLACEMENT_Z );
         rConditionDofList[Index++] = GetGeometry()[i].pGetDof( WATER_PRESSURE );
     }
-    
+
     for(SizeType i=NumPNodes; i<NumUNodes; i++)
     {
         rConditionDofList[Index++] = GetGeometry()[i].pGetDof( DISPLACEMENT_X );
@@ -123,13 +123,13 @@ void GeneralUPwDiffOrderCondition::GetDofList(DofsVectorType& rConditionDofList,
 
     for(SizeType i=0; i<NumPNodes; i++)
         rConditionDofList[Index++] = GetGeometry()[i].pGetDof( WATER_PRESSURE );
-        
+
     KRATOS_CATCH( "" )
 }
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-void GeneralUPwDiffOrderCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void GeneralUPwDiffOrderCondition::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -138,63 +138,63 @@ void GeneralUPwDiffOrderCondition::CalculateLocalSystem( MatrixType& rLeftHandSi
     const SizeType NumUNodes = rGeom.PointsNumber();
     const SizeType NumPNodes = mpPressureGeometry->PointsNumber();
     const SizeType ConditionSize = NumUNodes * Dim + NumPNodes;
-    
+
     //Resetting the LHS
     if ( rLeftHandSideMatrix.size1() != ConditionSize )
         rLeftHandSideMatrix.resize( ConditionSize, ConditionSize, false );
     noalias( rLeftHandSideMatrix ) = ZeroMatrix( ConditionSize, ConditionSize );
-    
+
     //Resetting the RHS
     if ( rRightHandSideVector.size() != ConditionSize )
         rRightHandSideVector.resize( ConditionSize, false );
     noalias( rRightHandSideVector ) = ZeroVector( ConditionSize );
-    
+
     //calculation flags
     bool CalculateLHSMatrixFlag = true;
     bool CalculateResidualVectorFlag = true;
-    
+
     CalculateAll(rLeftHandSideMatrix, rRightHandSideVector, rCurrentProcessInfo, CalculateLHSMatrixFlag, CalculateResidualVectorFlag);
-    
+
     KRATOS_CATCH( "" )
 }
 
 //----------------------------------------------------------------------------------------
 
-void GeneralUPwDiffOrderCondition::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void GeneralUPwDiffOrderCondition::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
-    
+
     KRATOS_THROW_ERROR(std::logic_error,"GeneralUPwDiffOrderCondition::CalculateLeftHandSide not implemented","");
-    
+
     KRATOS_CATCH( "" )
 }
 
 //----------------------------------------------------------------------------------------
 
-void GeneralUPwDiffOrderCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void GeneralUPwDiffOrderCondition::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     const GeometryType& rGeom = GetGeometry();
     const SizeType Dim = rGeom.WorkingSpaceDimension();
     const SizeType NumUNodes = rGeom.PointsNumber();
     const SizeType NumPNodes = mpPressureGeometry->PointsNumber();
     const SizeType ConditionSize = NumUNodes * Dim + NumPNodes;
-        
+
     //Resetting the RHS
     if ( rRightHandSideVector.size() != ConditionSize )
         rRightHandSideVector.resize( ConditionSize, false );
     noalias( rRightHandSideVector ) = ZeroVector( ConditionSize );
-    
+
     //calculation flags
     bool CalculateLHSMatrixFlag = false;
     bool CalculateResidualVectorFlag = true;
     MatrixType temp = Matrix();
-    
+
     CalculateAll(temp, rRightHandSideVector, rCurrentProcessInfo, CalculateLHSMatrixFlag, CalculateResidualVectorFlag);
 }
 
 //----------------------------------------------------------------------------------------
 
-void GeneralUPwDiffOrderCondition::EquationIdVector(EquationIdVectorType& rResult,ProcessInfo& rCurrentProcessInfo)
+void GeneralUPwDiffOrderCondition::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 
@@ -203,12 +203,12 @@ void GeneralUPwDiffOrderCondition::EquationIdVector(EquationIdVectorType& rResul
     const SizeType NumUNodes = rGeom.PointsNumber();
     const SizeType NumPNodes = mpPressureGeometry->PointsNumber();
     const SizeType ConditionSize = NumUNodes * Dim + NumPNodes;
-    
+
     if ( rResult.size() != ConditionSize )
         rResult.resize( ConditionSize, false );
-    
+
     SizeType Index = 0;
-    
+
     for ( SizeType i = 0; i < NumUNodes; i++ )
     {
         rResult[Index++] = GetGeometry()[i].GetDof( DISPLACEMENT_X ).EquationId();
@@ -225,15 +225,15 @@ void GeneralUPwDiffOrderCondition::EquationIdVector(EquationIdVectorType& rResul
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-void GeneralUPwDiffOrderCondition::CalculateAll(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo, 
+void GeneralUPwDiffOrderCondition::CalculateAll(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo,
                                         bool CalculateLHSMatrixFlag, bool CalculateResidualVectorFlag)
-{   
+{
     KRATOS_TRY
 
     //Definition of variables
     ConditionVariables Variables;
     this->InitializeConditionVariables(Variables,rCurrentProcessInfo);
-    
+
     //Loop over integration points
     const GeometryType::IntegrationPointsArrayType& integration_points = GetGeometry().IntegrationPoints( mThisIntegrationMethod );
 
@@ -241,22 +241,22 @@ void GeneralUPwDiffOrderCondition::CalculateAll(MatrixType& rLeftHandSideMatrix,
     {
         //compute element kinematics (Np)
         this->CalculateKinematics(Variables,PointNumber);
-        
+
         //Compute Condition Vector
         this->CalculateConditionVector(Variables,PointNumber);
-        
+
         //Calculating weighting coefficient for integration
         this->CalculateIntegrationCoefficient( Variables, PointNumber, integration_points[PointNumber].Weight() );
 
         //Contributions to the left hand side
         if ( CalculateLHSMatrixFlag )
             this->CalculateAndAddLHS(rLeftHandSideMatrix, Variables);
-        
+
         //Contributions to the right hand side
         if ( CalculateResidualVectorFlag )
             this->CalculateAndAddRHS(rRightHandSideVector, Variables);
     }
-    
+
     KRATOS_CATCH( "" )
 }
 
@@ -273,7 +273,7 @@ void GeneralUPwDiffOrderCondition::InitializeConditionVariables (ConditionVariab
 
     (rVariables.NuContainer).resize(NumGPoints,NumUNodes,false);
     rVariables.NuContainer = rGeom.ShapeFunctionsValues( mThisIntegrationMethod );
-    
+
     (rVariables.NpContainer).resize(NumGPoints,NumPNodes,false);
     rVariables.NpContainer = mpPressureGeometry->ShapeFunctionsValues( mThisIntegrationMethod );
 
@@ -324,7 +324,7 @@ void GeneralUPwDiffOrderCondition::CalculateIntegrationCoefficient(ConditionVari
 //----------------------------------------------------------------------------------------
 
 void GeneralUPwDiffOrderCondition::CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, ConditionVariables& rVariables)
-{    
+{
 
 }
 

--- a/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
+++ b/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.cpp
@@ -80,7 +80,7 @@ void GeneralUPwDiffOrderCondition::Initialize()
 
 //----------------------------------------------------------------------------------------
 
-void GeneralUPwDiffOrderCondition::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo)
+void GeneralUPwDiffOrderCondition::GetDofList(DofsVectorType& rConditionDofList, const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 
@@ -194,7 +194,7 @@ void GeneralUPwDiffOrderCondition::CalculateRightHandSide( VectorType& rRightHan
 
 //----------------------------------------------------------------------------------------
 
-void GeneralUPwDiffOrderCondition::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo)
+void GeneralUPwDiffOrderCondition::EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
+++ b/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
@@ -38,10 +38,10 @@ public:
 
     // Default constructor
     GeneralUPwDiffOrderCondition();
-    
+
     // Constructor 1
     GeneralUPwDiffOrderCondition( IndexType NewId, GeometryType::Pointer pGeometry );
-    
+
     // Constructor 2
     GeneralUPwDiffOrderCondition( IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties );
 
@@ -51,24 +51,24 @@ public:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     Condition::Pointer Create(IndexType NewId,NodesArrayType const& ThisNodes,PropertiesType::Pointer pProperties ) const override;
- 
+
     void Initialize() override;
- 
-    void GetDofList(DofsVectorType& rConditionDofList,ProcessInfo& rCurrentProcessInfo ) override;
+
+    void GetDofList(DofsVectorType& rConditionDofList,const ProcessInfo& rCurrentProcessInfo ) override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,VectorType& rRightHandSideVector,ProcessInfo& rCurrentProcessInfo ) override;
-    
-    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,ProcessInfo& rCurrentProcessInfo ) override;
-    
-    void CalculateRightHandSide(VectorType& rRightHandSideVector,ProcessInfo& rCurrentProcessInfo ) override;
-    
-    void EquationIdVector(EquationIdVectorType& rResult,ProcessInfo& rCurrentProcessInfo ) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo ) override;
+
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,const ProcessInfo& rCurrentProcessInfo ) override;
+
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo ) override;
+
+    void EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo ) override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-protected:   
+protected:
 
     struct ConditionVariables
     {
@@ -81,20 +81,20 @@ protected:
         Vector Nu; //Contains the displacement shape functions at every node
         Vector Np; //Contains the pressure shape functions at every node
         double IntegrationCoefficient;
-        
+
         //Imposed condition at all nodes
         Vector ConditionVector;
     };
-    
+
     // Member Variables
-    
+
     IntegrationMethod mThisIntegrationMethod;
-    
+
     Geometry< Node<3> >::Pointer mpPressureGeometry;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void CalculateAll(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo, 
+    void CalculateAll(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo,
                                 bool CalculateLHSMatrixFlag, bool CalculateResidualVectorFlag);
 
     void InitializeConditionVariables (ConditionVariables& rVariables, const ProcessInfo& rCurrentProcessInfo);
@@ -108,17 +108,17 @@ protected:
     void CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, ConditionVariables& rVariables);
 
     void CalculateAndAddRHS(VectorType& rRightHandSideVector, ConditionVariables& rVariables);
-    
+
     virtual void CalculateAndAddConditionForce(VectorType& rRightHandSideVector, ConditionVariables& rVariables);
-    
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 private:
-    
+
     // Serialization
-    
+
     friend class Serializer;
-    
+
     void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Condition )
@@ -128,9 +128,9 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Condition )
     }
-    
+
 }; // class GeneralUPwDiffOrderCondition.
 
 } // namespace Kratos.
 
-#endif // KRATOS_GENERAL_U_PW_DIFF_ORDER_CONDITION_H_INCLUDED defined 
+#endif // KRATOS_GENERAL_U_PW_DIFF_ORDER_CONDITION_H_INCLUDED defined

--- a/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
+++ b/applications/PoromechanicsApplication/custom_conditions/general_U_Pw_diff_order_condition.hpp
@@ -54,7 +54,7 @@ public:
 
     void Initialize() override;
 
-    void GetDofList(DofsVectorType& rConditionDofList,const ProcessInfo& rCurrentProcessInfo ) override;
+    void GetDofList(DofsVectorType& rConditionDofList,const ProcessInfo& rCurrentProcessInfo ) const override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -64,7 +64,7 @@ public:
 
     void CalculateRightHandSide(VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo ) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo ) override;
+    void EquationIdVector(EquationIdVectorType& rResult,const ProcessInfo& rCurrentProcessInfo ) const override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_element.cpp
@@ -155,7 +155,7 @@ void UPwElement<TDim,TNumNodes>::Initialize()
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo )
+void UPwElement<TDim,TNumNodes>::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -189,7 +189,7 @@ GeometryData::IntegrationMethod UPwElement<TDim,TNumNodes>::GetIntegrationMethod
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void UPwElement<TDim,TNumNodes>::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -213,7 +213,7 @@ void UPwElement<TDim,TNumNodes>::CalculateLocalSystem( MatrixType& rLeftHandSide
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void UPwElement<TDim,TNumNodes>::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY;
 
@@ -225,7 +225,7 @@ void UPwElement<TDim,TNumNodes>::CalculateLeftHandSide( MatrixType& rLeftHandSid
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void UPwElement<TDim,TNumNodes>::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -244,7 +244,7 @@ void UPwElement<TDim,TNumNodes>::CalculateRightHandSide( VectorType& rRightHandS
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwElement<2,3>::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void UPwElement<2,3>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -268,7 +268,7 @@ void UPwElement<2,3>::EquationIdVector( EquationIdVectorType& rResult, ProcessIn
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwElement<2,4>::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void UPwElement<2,4>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -292,7 +292,7 @@ void UPwElement<2,4>::EquationIdVector( EquationIdVectorType& rResult, ProcessIn
 //----------------------------------------------------------------------------------------
 
 template<  >
-void UPwElement<3,4>::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void UPwElement<3,4>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -317,7 +317,7 @@ void UPwElement<3,4>::EquationIdVector( EquationIdVectorType& rResult, ProcessIn
 //----------------------------------------------------------------------------------------
 
 template<  >
-void UPwElement<3,6>::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void UPwElement<3,6>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -342,7 +342,7 @@ void UPwElement<3,6>::EquationIdVector( EquationIdVectorType& rResult, ProcessIn
 //----------------------------------------------------------------------------------------
 
 template<  >
-void UPwElement<3,8>::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void UPwElement<3,8>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -367,7 +367,7 @@ void UPwElement<3,8>::EquationIdVector( EquationIdVectorType& rResult, ProcessIn
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void UPwElement<TDim,TNumNodes>::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -412,7 +412,7 @@ void UPwElement<TDim,TNumNodes>::CalculateMassMatrix( MatrixType& rMassMatrix, P
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::CalculateDampingMatrix(MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo)
+void UPwElement<TDim,TNumNodes>::CalculateDampingMatrix(MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo)
 {
     KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_element.cpp
@@ -155,11 +155,11 @@ void UPwElement<TDim,TNumNodes>::Initialize()
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwElement<TDim,TNumNodes>::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo )
+void UPwElement<TDim,TNumNodes>::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = this->GetGeometry();
+    const GeometryType& rGeom = this->GetGeometry();
     const unsigned int element_size = TNumNodes * (TDim + 1);
     unsigned int index = 0;
 
@@ -244,11 +244,11 @@ void UPwElement<TDim,TNumNodes>::CalculateRightHandSide( VectorType& rRightHandS
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwElement<2,3>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
+void UPwElement<2,3>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = this->GetGeometry();
+    const GeometryType& rGeom = this->GetGeometry();
     const unsigned int element_size = 3 * (2 + 1);
     unsigned int index = 0;
 
@@ -268,11 +268,11 @@ void UPwElement<2,3>::EquationIdVector( EquationIdVectorType& rResult, const Pro
 //----------------------------------------------------------------------------------------
 
 template< >
-void UPwElement<2,4>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
+void UPwElement<2,4>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = this->GetGeometry();
+    const GeometryType& rGeom = this->GetGeometry();
     const unsigned int element_size = 4 * (2 + 1);
     unsigned int index = 0;
 
@@ -292,11 +292,11 @@ void UPwElement<2,4>::EquationIdVector( EquationIdVectorType& rResult, const Pro
 //----------------------------------------------------------------------------------------
 
 template<  >
-void UPwElement<3,4>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
+void UPwElement<3,4>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = this->GetGeometry();
+    const GeometryType& rGeom = this->GetGeometry();
     const unsigned int element_size = 4 * (3 + 1);
     unsigned int index = 0;
 
@@ -317,11 +317,11 @@ void UPwElement<3,4>::EquationIdVector( EquationIdVectorType& rResult, const Pro
 //----------------------------------------------------------------------------------------
 
 template<  >
-void UPwElement<3,6>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
+void UPwElement<3,6>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = this->GetGeometry();
+    const GeometryType& rGeom = this->GetGeometry();
     const unsigned int element_size = 6 * (3 + 1);
     unsigned int index = 0;
 
@@ -342,11 +342,11 @@ void UPwElement<3,6>::EquationIdVector( EquationIdVectorType& rResult, const Pro
 //----------------------------------------------------------------------------------------
 
 template<  >
-void UPwElement<3,8>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
+void UPwElement<3,8>::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
-    GeometryType& rGeom = this->GetGeometry();
+    const GeometryType& rGeom = this->GetGeometry();
     const unsigned int element_size = 8 * (3 + 1);
     unsigned int index = 0;
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_element.hpp
@@ -68,7 +68,7 @@ public:
 
     void Initialize() override;
 
-    void GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) override;
+    void GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const override;
 
     GeometryData::IntegrationMethod GetIntegrationMethod() const override;
 
@@ -80,7 +80,7 @@ public:
 
     void CalculateRightHandSide(VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo ) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_element.hpp
@@ -37,7 +37,7 @@ class KRATOS_API(POROMECHANICS_APPLICATION) UPwElement : public Element
 public:
 
     KRATOS_CLASS_POINTER_DEFINITION( UPwElement );
-        
+
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     /// Default Constructor
@@ -45,12 +45,12 @@ public:
 
     /// Constructor using an array of nodes
     UPwElement(IndexType NewId, const NodesArrayType& ThisNodes) : Element(NewId, ThisNodes) {}
-    
+
     /// Constructor using Geometry
     UPwElement(IndexType NewId, GeometryType::Pointer pGeometry) : Element( NewId, pGeometry ) {}
-    
+
     /// Constructor using Properties
-    UPwElement(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties) : Element( NewId, pGeometry, pProperties ) 
+    UPwElement(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties) : Element( NewId, pGeometry, pProperties )
     {
         mThisIntegrationMethod = this->GetIntegrationMethod();
     }
@@ -59,37 +59,37 @@ public:
     virtual ~UPwElement() {}
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    
+
     Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
-    
+
     Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
-        
+
     int Check(const ProcessInfo& rCurrentProcessInfo) override;
-    
+
     void Initialize() override;
-    
-    void GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo ) override;
+
+    void GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) override;
 
     GeometryData::IntegrationMethod GetIntegrationMethod() const override;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,VectorType& rRightHandSideVector,ProcessInfo& rCurrentProcessInfo ) override;
-    
-    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,ProcessInfo& rCurrentProcessInfo ) override;
-    
-    void CalculateRightHandSide(VectorType& rRightHandSideVector,ProcessInfo& rCurrentProcessInfo ) override;
-    
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
-    
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
-    
-    void CalculateDampingMatrix(MatrixType& rDampingMatrix, ProcessInfo& rCurrentProcessInfo) override;
-    
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix,VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo ) override;
+
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,const ProcessInfo& rCurrentProcessInfo ) override;
+
+    void CalculateRightHandSide(VectorType& rRightHandSideVector,const ProcessInfo& rCurrentProcessInfo ) override;
+
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) override;
+
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
+
+    void CalculateDampingMatrix(MatrixType& rDampingMatrix, const ProcessInfo& rCurrentProcessInfo) override;
+
     void GetValuesVector(Vector& rValues, int Step = 0) override;
-    
+
     void GetFirstDerivativesVector(Vector& rValues, int Step = 0) override;
-    
+
     void GetSecondDerivativesVector(Vector& rValues, int Step = 0) override;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -97,41 +97,41 @@ public:
     void SetValuesOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-    
+
     void GetValueOnIntegrationPoints(const Variable<array_1d<double,3>>& rVariable, std::vector<array_1d<double,3>>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-    
+
     void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable, std::vector<ConstitutiveLaw::Pointer>& rValues,const ProcessInfo& rCurrentProcessInfo ) override;
-    
+
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 protected:
-    
+
     /// Member Variables
-    
+
     GeometryData::IntegrationMethod mThisIntegrationMethod;
-    
+
     std::vector<ConstitutiveLaw::Pointer> mConstitutiveLawVector;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    
+
     virtual void CalculateStiffnessMatrix( MatrixType& rStiffnessMatrix, const ProcessInfo& CurrentProcessInfo );
-    
+
     virtual void CalculateAll( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& CurrentProcessInfo );
 
     virtual void CalculateRHS( VectorType& rRightHandSideVector, const ProcessInfo& CurrentProcessInfo );
-    
+
     void CalculateIntegrationCoefficient(double& rIntegrationCoefficient, const double& detJ, const double& weight);
-    
+
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 private:
-    
+
     /// Serialization
-    
+
     friend class Serializer;
-    
+
     void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Element )
@@ -153,4 +153,4 @@ private:
 
 } // namespace Kratos
 
-#endif // KRATOS_U_PW_ELEMENT_H_INCLUDED  defined 
+#endif // KRATOS_U_PW_ELEMENT_H_INCLUDED  defined

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_FIC_element.hpp
@@ -33,7 +33,7 @@ class KRATOS_API(POROMECHANICS_APPLICATION) UPwSmallStrainFICElement : public UP
 {
 
 public:
-    
+
     KRATOS_CLASS_POINTER_DEFINITION( UPwSmallStrainFICElement );
 
     typedef std::size_t IndexType;
@@ -46,15 +46,15 @@ public:
     using UPwElement<TDim,TNumNodes>::mThisIntegrationMethod;
     using UPwElement<TDim,TNumNodes>::mConstitutiveLawVector;
     typedef typename UPwSmallStrainElement<TDim,TNumNodes>::ElementVariables ElementVariables;
-    
+
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     /// Default Constructor
     UPwSmallStrainFICElement(IndexType NewId = 0) : UPwSmallStrainElement<TDim,TNumNodes>( NewId ) {}
-    
+
     /// Constructor using an array of nodes
     UPwSmallStrainFICElement(IndexType NewId, const NodesArrayType& ThisNodes) : UPwSmallStrainElement<TDim,TNumNodes>(NewId, ThisNodes) {}
-    
+
     /// Constructor using Geometry
     UPwSmallStrainFICElement(IndexType NewId, GeometryType::Pointer pGeometry) : UPwSmallStrainElement<TDim,TNumNodes>(NewId, pGeometry) {}
 
@@ -65,35 +65,35 @@ public:
     ~UPwSmallStrainFICElement() override {}
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    
+
     Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
-    
+
     Element::Pointer Create(IndexType NewId, GeometryType::Pointer pGeom, PropertiesType::Pointer pProperties) const override;
-        
+
     void Initialize() override;
-    
+
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-   
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
-    
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
-    
+
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
+
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
+
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 protected:
-        
+
     struct FICElementVariables
     {
         /// Properties variables
         double ShearModulus;
-        
+
         /// Nodal variables
         array_1d< array_1d<double,TDim*TNumNodes> , TNumNodes > NodalShapeFunctionsGradients;
-        
+
         /// General elemental variables
         double ElementLength;
         Matrix VoigtMatrix;
-        
+
         /// Variables computed at each GP
         BoundedMatrix<double,TDim,TDim*TNumNodes> StrainGradients;
         array_1d<Vector,TNumNodes> ShapeFunctionsSecondOrderGradients;
@@ -104,60 +104,60 @@ protected:
         Matrix DimVoigtMatrix;
         BoundedMatrix<double,TDim,TDim*TNumNodes> DimUMatrix;
     };
-    
+
     /// Member Variables
-    
+
     array_1d< std::vector< array_1d<double,TNumNodes> > , TDim > mNodalConstitutiveTensor;
-    
+
     array_1d< array_1d<double,TNumNodes> , TDim > mNodalDtStress;
-    
-///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------    
-    
+
+///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
     void SaveGPConstitutiveTensor(array_1d<Matrix,TDim>& rConstitutiveTensorContainer, const Matrix& ConstitutiveMatrix, const unsigned int& GPoint);
-    
+
     void SaveGPDtStress(Matrix& rDtStressContainer, const Vector& StressVector, const unsigned int& GPoint);
-    
+
     void ExtrapolateGPConstitutiveTensor(const array_1d<Matrix,TDim>& ConstitutiveTensorContainer);
-    
+
     void ExtrapolateGPDtStress(const Matrix& DtStressContainer);
-    
-    
+
+
     void CalculateAll( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& CurrentProcessInfo ) override;
 
     void CalculateRHS( VectorType& rRightHandSideVector, const ProcessInfo& CurrentProcessInfo ) override;
 
     void InitializeFICElementVariables(FICElementVariables& rFICVariables, const GeometryType::ShapeFunctionsGradientsType& DN_DXContainer,
                                         const GeometryType& Geom,const PropertiesType& Prop, const ProcessInfo& CurrentProcessInfo);
-    
+
     void ExtrapolateShapeFunctionsGradients(array_1d< array_1d<double,TDim*TNumNodes> , TNumNodes >& rNodalShapeFunctionsGradients,
                                                 const GeometryType::ShapeFunctionsGradientsType& DN_DXContainer);
-    
+
     void CalculateElementLength(double& rElementLength, const GeometryType& Geom);
-    
+
     void InitializeSecondOrderTerms(FICElementVariables& rFICVariables);
-        
+
     void CalculateShapeFunctionsSecondOrderGradients(FICElementVariables& rFICVariables, ElementVariables& rVariables);
-    
-    
+
+
     void CalculateAndAddLHSStabilization(MatrixType& rLeftHandSideMatrix, ElementVariables& rVariables, FICElementVariables& rFICVariables);
 
     void CalculateAndAddStrainGradientMatrix(MatrixType& rLeftHandSideMatrix,ElementVariables& rVariables, FICElementVariables& rFICVariables);
-    
+
     void CalculateAndAddDtStressGradientMatrix(MatrixType& rLeftHandSideMatrix,ElementVariables& rVariables, FICElementVariables& rFICVariables);
-    
+
     void CalculateConstitutiveTensorGradients(FICElementVariables& rFICVariables, const ElementVariables& Variables);
-    
+
     void CalculateAndAddPressureGradientMatrix(MatrixType& rLeftHandSideMatrix,ElementVariables& rVariables, FICElementVariables& rFICVariables);
-    
+
 
     void CalculateAndAddRHSStabilization(VectorType& rRightHandSideVector, ElementVariables& rVariables, FICElementVariables& rFICVariables);
 
     void CalculateAndAddStrainGradientFlow(VectorType& rRightHandSideVector,ElementVariables& rVariables, FICElementVariables& rFICVariables);
-    
+
     void CalculateAndAddDtStressGradientFlow(VectorType& rRightHandSideVector,ElementVariables& rVariables, FICElementVariables& rFICVariables);
-    
+
     void CalculateDtStressGradients(FICElementVariables& rFICVariables, const ElementVariables& Variables);
-    
+
     void CalculateAndAddPressureGradientFlow(VectorType& rRightHandSideVector,ElementVariables& rVariables, FICElementVariables& rFICVariables);
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -167,11 +167,11 @@ private:
     /// Member Variables
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    
+
     /// Serialization
-    
+
     friend class Serializer;
-    
+
     void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Element )

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.cpp
@@ -100,7 +100,7 @@ int UPwSmallStrainElement<TDim,TNumNodes>::Check( const ProcessInfo& rCurrentPro
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
+void UPwSmallStrainElement<TDim,TNumNodes>::InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
     //Defining necessary variables
     const GeometryType& Geom = this->GetGeometry();
@@ -152,7 +152,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::InitializeNonLinearIteration(Process
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo)
+void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo)
 {
     this->InitializeNonLinearIteration(rCurrentProcessInfo);
 }
@@ -160,7 +160,7 @@ void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeNonLinearIteration(ProcessIn
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void UPwSmallStrainElement<TDim,TNumNodes>::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_element.hpp
@@ -70,11 +70,11 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void InitializeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void InitializeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
-    void FinalizeNonLinearIteration(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeNonLinearIteration(const ProcessInfo& rCurrentProcessInfo) override;
 
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.cpp
@@ -99,7 +99,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::Initialize()
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -161,7 +161,7 @@ void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::CalculateMassMatrix( Matrix
 //----------------------------------------------------------------------------------------
 
 template< unsigned int TDim, unsigned int TNumNodes >
-void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void UPwSmallStrainInterfaceElement<TDim,TNumNodes>::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/U_Pw_small_strain_interface_element.hpp
@@ -76,9 +76,9 @@ public:
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
 
 ///----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -193,7 +193,7 @@ void SmallStrainUPwDiffOrderElement::Initialize()
 
 //----------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUPwDiffOrderElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 
@@ -388,7 +388,7 @@ void SmallStrainUPwDiffOrderElement::CalculateMassMatrix( MatrixType& rMassMatri
 
 //----------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUPwDiffOrderElement::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo ) const
 {
     KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.cpp
@@ -193,7 +193,7 @@ void SmallStrainUPwDiffOrderElement::Initialize()
 
 //----------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::GetDofList( DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUPwDiffOrderElement::GetDofList( DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -242,7 +242,7 @@ void SmallStrainUPwDiffOrderElement::GetDofList( DofsVectorType& rElementalDofLi
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUPwDiffOrderElement::CalculateLocalSystem( MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -273,7 +273,7 @@ void SmallStrainUPwDiffOrderElement::CalculateLocalSystem( MatrixType& rLeftHand
 
 //----------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUPwDiffOrderElement::CalculateLeftHandSide( MatrixType& rLeftHandSideMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -284,7 +284,7 @@ void SmallStrainUPwDiffOrderElement::CalculateLeftHandSide( MatrixType& rLeftHan
 
 //----------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::CalculateRightHandSide( VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUPwDiffOrderElement::CalculateRightHandSide( VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo )
 {
     const GeometryType& rGeom = GetGeometry();
     const SizeType Dim = rGeom.WorkingSpaceDimension();
@@ -307,7 +307,7 @@ void SmallStrainUPwDiffOrderElement::CalculateRightHandSide( VectorType& rRightH
 
 //----------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::CalculateMassMatrix( MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUPwDiffOrderElement::CalculateMassMatrix( MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -388,7 +388,7 @@ void SmallStrainUPwDiffOrderElement::CalculateMassMatrix( MatrixType& rMassMatri
 
 //----------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::EquationIdVector( EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUPwDiffOrderElement::EquationIdVector( EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo )
 {
     KRATOS_TRY
 
@@ -446,7 +446,7 @@ void SmallStrainUPwDiffOrderElement::GetSecondDerivativesVector( Vector& rValues
 
 //----------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::FinalizeSolutionStep( ProcessInfo& rCurrentProcessInfo )
+void SmallStrainUPwDiffOrderElement::FinalizeSolutionStep( const ProcessInfo& rCurrentProcessInfo )
 {
     //Definition of variables
     ElementalVariables Variables;
@@ -906,7 +906,7 @@ void SmallStrainUPwDiffOrderElement::CalculateOnIntegrationPoints( const Variabl
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-void SmallStrainUPwDiffOrderElement::CalculateAll(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo,
+void SmallStrainUPwDiffOrderElement::CalculateAll(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo,
                                 bool CalculateLHSMatrixFlag, bool CalculateResidualVectorFlag)
 {
     KRATOS_TRY

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -59,7 +59,7 @@ public:
 
     void Initialize() override;
 
-    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) override;
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) const override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
@@ -71,7 +71,7 @@ public:
 
     void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) override;
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) const override;
 
     void GetSecondDerivativesVector(Vector& rValues, int Step = 0) override;
 

--- a/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
+++ b/applications/PoromechanicsApplication/custom_elements/small_strain_U_Pw_diff_order_element.hpp
@@ -41,58 +41,58 @@ public:
 
     // Default constructor
     SmallStrainUPwDiffOrderElement();
-    
+
     // Constructor 1
     SmallStrainUPwDiffOrderElement(IndexType NewId, GeometryType::Pointer pGeometry);
-    
+
     // Constructor 2
     SmallStrainUPwDiffOrderElement(IndexType NewId, GeometryType::Pointer pGeometry, PropertiesType::Pointer pProperties);
-    
+
     // Destructor
     virtual ~SmallStrainUPwDiffOrderElement();
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    
+
     Element::Pointer Create(IndexType NewId, NodesArrayType const& ThisNodes, PropertiesType::Pointer pProperties) const override;
 
     int Check(const ProcessInfo& rCurrentProcessInfo) override;
 
     void Initialize() override;
-    
-    void GetDofList(DofsVectorType& rElementalDofList, ProcessInfo& rCurrentProcessInfo) override;
-    
+
+    void GetDofList(DofsVectorType& rElementalDofList, const ProcessInfo& rCurrentProcessInfo) override;
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
-    
-    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,ProcessInfo& rCurrentProcessInfo ) override;
-    
-    void CalculateRightHandSide(VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo) override;
-    
-    void CalculateMassMatrix(MatrixType& rMassMatrix, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLocalSystem(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
 
-    void EquationIdVector(EquationIdVectorType& rResult, ProcessInfo& rCurrentProcessInfo) override;
+    void CalculateLeftHandSide(MatrixType& rLeftHandSideMatrix,const ProcessInfo& rCurrentProcessInfo ) override;
+
+    void CalculateRightHandSide(VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo) override;
+
+    void CalculateMassMatrix(MatrixType& rMassMatrix, const ProcessInfo& rCurrentProcessInfo) override;
+
+    void EquationIdVector(EquationIdVectorType& rResult, const ProcessInfo& rCurrentProcessInfo) override;
 
     void GetSecondDerivativesVector(Vector& rValues, int Step = 0) override;
 
-    void FinalizeSolutionStep(ProcessInfo& rCurrentProcessInfo) override;
-    
+    void FinalizeSolutionStep(const ProcessInfo& rCurrentProcessInfo) override;
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void SetValuesOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-    
+
     void SetValuesOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-    
+
     void SetValuesOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void GetValueOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-    
+
     void GetValueOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-    
+
     void GetValueOnIntegrationPoints(const Variable<Matrix>& rVariable, std::vector<Matrix>& rValues, const ProcessInfo& rCurrentProcessInfo) override;
-    
+
     void GetValueOnIntegrationPoints( const Variable<ConstitutiveLaw::Pointer>& rVariable, std::vector<ConstitutiveLaw::Pointer>& rValues,const ProcessInfo& rCurrentProcessInfo ) override;
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
@@ -100,9 +100,9 @@ public:
     void CalculateOnIntegrationPoints(const Variable<double>& rVariable, std::vector<double>& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
 
     void CalculateOnIntegrationPoints(const Variable<Vector>& rVariable, std::vector<Vector>& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
-    
+
     void CalculateOnIntegrationPoints(const Variable<Matrix >& rVariable, std::vector< Matrix >& rOutput, const ProcessInfo& rCurrentProcessInfo) override;
-    
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 protected:
@@ -126,18 +126,18 @@ protected:
         Vector StrainVector;
         Matrix ConstitutiveMatrix;
         Vector StressVector; //It is the "Effective Stress Vector": sigma'_ij = sigma_ij + alpha*pw*delta_ij
-        
+
         //Variables needed for consistency with the general constitutive law
         double detF;
         Matrix F;
-        
+
         //Nodal variables
         Vector BodyAcceleration;
         Vector DisplacementVector;
         Vector VelocityVector;
         Vector PressureVector;
         Vector PressureDtVector;
-        
+
         //Properties and processinfo variables
         double BiotCoefficient;
         double BiotModulusInverse;
@@ -146,66 +146,66 @@ protected:
         double NewmarkCoefficient1;
         double NewmarkCoefficient2;
     };
-    
+
     // Member Variables
-    
+
     GeometryData::IntegrationMethod mThisIntegrationMethod;
 
     std::vector<ConstitutiveLaw::Pointer> mConstitutiveLawVector;
-    
+
     Geometry< Node<3> >::Pointer mpPressureGeometry;
-    
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-    
-    void CalculateAll(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, ProcessInfo& rCurrentProcessInfo, 
+
+    void CalculateAll(MatrixType& rLeftHandSideMatrix, VectorType& rRightHandSideVector, const ProcessInfo& rCurrentProcessInfo,
                                 bool CalculateLHSMatrixFlag, bool CalculateResidualVectorFlag);
 
     void InitializeElementalVariables (ElementalVariables& rVariables, const ProcessInfo& rCurrentProcessInfo);
-    
+
     void InitializeNodalVariables (ElementalVariables& rVariables);
-    
+
     void InitializeProperties (ElementalVariables& rVariables);
-    
+
     void CalculateKinematics(ElementalVariables& rVariables, unsigned int PointNumber);
 
     void SetElementalVariables(ElementalVariables& rVariables,ConstitutiveLaw::Parameters& rConstitutiveParameters);
-    
+
     void CalculateIntegrationCoefficient(double& rIntegrationCoefficient, double detJ, double weight);
 
 
     void CalculateAndAddLHS(MatrixType& rLeftHandSideMatrix, ElementalVariables& rVariables);
-    
+
     void CalculateAndAddStiffnessMatrix(MatrixType& rLeftHandSideMatrix, ElementalVariables& rVariables);
-    
+
     void CalculateAndAddCouplingMatrix(MatrixType& rLeftHandSideMatrix, ElementalVariables& rVariables);
-    
+
     void CalculateAndAddCompressibilityMatrix(MatrixType& rLeftHandSideMatrix, ElementalVariables& rVariables);
-    
+
     void CalculateAndAddPermeabilityMatrix(MatrixType& rLeftHandSideMatrix, ElementalVariables& rVariables);
-    
-    
+
+
     void CalculateAndAddRHS(VectorType& rRightHandSideVector, ElementalVariables& rVariables);
-    
+
     void CalculateAndAddStiffnessForce(VectorType& rRightHandSideVector, ElementalVariables& rVariables);
-    
+
     void CalculateAndAddMixBodyForce(VectorType& rRightHandSideVector, ElementalVariables& rVariables);
-    
+
     void CalculateAndAddCouplingTerms(VectorType& rRightHandSideVector, ElementalVariables& rVariables);
-    
+
     void CalculateAndAddCompressibilityFlow(VectorType& rRightHandSideVector, ElementalVariables& rVariables);
-    
+
     void CalculateAndAddPermeabilityFlow(VectorType& rRightHandSideVector, ElementalVariables& rVariables);
-    
+
     void CalculateAndAddFluidBodyFlow(VectorType& rRightHandSideVector, ElementalVariables& rVariables);
-    
+
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 private:
-    
+
     // Serialization
-    
+
     friend class Serializer;
-    
+
     void save(Serializer& rSerializer) const override
     {
         KRATOS_SERIALIZE_SAVE_BASE_CLASS( rSerializer, Element )
@@ -215,10 +215,10 @@ private:
     {
         KRATOS_SERIALIZE_LOAD_BASE_CLASS( rSerializer, Element )
     }
-    
-    
+
+
     // Private Operations
-    
+
     template < class TValueType >
     inline void ThreadSafeNodeWrite(NodeType& rNode, const Variable<TValueType>& Var, const TValueType Value)
     {
@@ -226,9 +226,9 @@ private:
         rNode.FastGetSolutionStepValue(Var) = Value;
         rNode.UnSetLock();
     }
-    
+
 }; // Class SmallStrainUPwDiffOrderElement
 
 } // namespace Kratos
 
-#endif // KRATOS_SMALL_STRAIN_U_PW_DIFF_ORDER_ELEMENT_H_INCLUDED  defined 
+#endif // KRATOS_SMALL_STRAIN_U_PW_DIFF_ORDER_ELEMENT_H_INCLUDED  defined

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_dynamic_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_dynamic_U_Pw_scheme.hpp
@@ -145,7 +145,7 @@ public:
 // Note: this is in a parallel loop
 
     void CalculateSystemContributions(
-        Element::Pointer rCurrentElement,
+        Element& rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
@@ -155,17 +155,17 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentElement) -> CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement) -> CalculateMassMatrix(mMassMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateMassMatrix(mMassMatrix[thread],CurrentProcessInfo);
 
-        (rCurrentElement) -> CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
 
         this->AddDynamicsToLHS (LHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
         this->AddDynamicsToRHS (rCurrentElement, RHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement) -> EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -174,8 +174,8 @@ public:
 
 // Note: this is in a parallel loop
 
-    void Calculate_RHS_Contribution(
-        Element::Pointer rCurrentElement,
+    void CalculateRHSContribution(
+        Element& rCurrentElement,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
         const ProcessInfo& CurrentProcessInfo) override
@@ -184,15 +184,15 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentElement) -> CalculateRightHandSide(RHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateRightHandSide(RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement) -> CalculateMassMatrix(mMassMatrix[thread], CurrentProcessInfo);
+        rCurrentElement.CalculateMassMatrix(mMassMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement) -> CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
 
         this->AddDynamicsToRHS (rCurrentElement, RHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement) -> EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -201,8 +201,8 @@ public:
 
 // Note: this is in a parallel loop
 
-    void Calculate_LHS_Contribution(
-        Element::Pointer rCurrentElement,
+    void CalculateLHSContribution(
+        Element& rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         Element::EquationIdVectorType& EquationId,
         const ProcessInfo& CurrentProcessInfo) override
@@ -211,15 +211,15 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentElement) -> CalculateLeftHandSide(LHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateLeftHandSide(LHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement) -> CalculateMassMatrix(mMassMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateMassMatrix(mMassMatrix[thread],CurrentProcessInfo);
 
-        (rCurrentElement) -> CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
 
         this->AddDynamicsToLHS (LHS_Contribution, mMassMatrix[thread], mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement) -> EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -250,7 +250,7 @@ protected:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void AddDynamicsToRHS(Element::Pointer rCurrentElement,LocalSystemVectorType& RHS_Contribution,
+    void AddDynamicsToRHS(Element& rCurrentElement,LocalSystemVectorType& RHS_Contribution,
                             LocalSystemMatrixType& M,LocalSystemMatrixType& C,const ProcessInfo& CurrentProcessInfo)
     {
         int thread = OpenMPUtils::ThisThread();
@@ -258,7 +258,7 @@ protected:
         //adding inertia contribution
         if (M.size1() != 0)
         {
-            rCurrentElement->GetSecondDerivativesVector(mAccelerationVector[thread], 0);
+            rCurrentElement.GetSecondDerivativesVector(mAccelerationVector[thread], 0);
 
             noalias(RHS_Contribution) -= prod(M, mAccelerationVector[thread]);
         }
@@ -266,7 +266,7 @@ protected:
         //adding damping contribution
         if (C.size1() != 0)
         {
-            rCurrentElement->GetFirstDerivativesVector(mVelocityVector[thread], 0);
+            rCurrentElement.GetFirstDerivativesVector(mVelocityVector[thread], 0);
 
             noalias(RHS_Contribution) -= prod(C, mVelocityVector[thread]);
         }

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_dynamic_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_dynamic_U_Pw_scheme.hpp
@@ -149,7 +149,7 @@ public:
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -178,7 +178,7 @@ public:
         Element::Pointer rCurrentElement,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -205,7 +205,7 @@ public:
         Element::Pointer rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -237,7 +237,7 @@ protected:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void AddDynamicsToLHS(LocalSystemMatrixType& LHS_Contribution,LocalSystemMatrixType& M,LocalSystemMatrixType& C,ProcessInfo& CurrentProcessInfo)
+    void AddDynamicsToLHS(LocalSystemMatrixType& LHS_Contribution,LocalSystemMatrixType& M,LocalSystemMatrixType& C,const ProcessInfo& CurrentProcessInfo)
     {
         // adding mass contribution
         if (M.size1() != 0)
@@ -251,7 +251,7 @@ protected:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void AddDynamicsToRHS(Element::Pointer rCurrentElement,LocalSystemVectorType& RHS_Contribution,
-                            LocalSystemMatrixType& M,LocalSystemMatrixType& C,ProcessInfo& CurrentProcessInfo)
+                            LocalSystemMatrixType& M,LocalSystemMatrixType& C,const ProcessInfo& CurrentProcessInfo)
     {
         int thread = OpenMPUtils::ThisThread();
 

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
@@ -146,7 +146,7 @@ public:
         r_model_part.GetProcessInfo()[VELOCITY_COEFFICIENT] = mGamma/(mBeta*mDeltaTime);
         r_model_part.GetProcessInfo()[DT_PRESSURE_COEFFICIENT] = 1.0/(mTheta*mDeltaTime);
 
-        ProcessInfo& CurrentProcessInfo = r_model_part.GetProcessInfo();
+        const ProcessInfo& CurrentProcessInfo = r_model_part.GetProcessInfo();
 
         int NElems = static_cast<int>(r_model_part.Elements().size());
         ModelPart::ElementsContainerType::iterator el_begin = r_model_part.ElementsBegin();
@@ -193,7 +193,7 @@ public:
     {
         KRATOS_TRY
 
-        ProcessInfo& CurrentProcessInfo = r_model_part.GetProcessInfo();
+        const ProcessInfo& CurrentProcessInfo = r_model_part.GetProcessInfo();
 
         int NElems = static_cast<int>(r_model_part.Elements().size());
         ModelPart::ElementsContainerType::iterator el_begin = r_model_part.ElementsBegin();
@@ -228,7 +228,7 @@ public:
     {
         KRATOS_TRY
 
-        ProcessInfo& CurrentProcessInfo = r_model_part.GetProcessInfo();
+        const ProcessInfo& CurrentProcessInfo = r_model_part.GetProcessInfo();
 
         int NElems = static_cast<int>(r_model_part.Elements().size());
         ModelPart::ElementsContainerType::iterator el_begin = r_model_part.ElementsBegin();
@@ -339,7 +339,7 @@ public:
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -359,7 +359,7 @@ public:
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -378,7 +378,7 @@ public:
         Element::Pointer rCurrentElement,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -397,7 +397,7 @@ public:
         Condition::Pointer rCurrentCondition,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -416,7 +416,7 @@ public:
         Element::Pointer rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -435,7 +435,7 @@ public:
         Condition::Pointer rCurrentCondition,
         LocalSystemMatrixType& LHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_U_Pw_scheme.hpp
@@ -335,7 +335,7 @@ public:
 // Note: this is in a parallel loop
 
     void CalculateSystemContributions(
-        Element::Pointer rCurrentElement,
+        Element& rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
@@ -343,9 +343,9 @@ public:
     {
         KRATOS_TRY
 
-        (rCurrentElement) -> CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement) -> EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -354,8 +354,8 @@ public:
 
 // Note: this is in a parallel loop
 
-    void Condition_CalculateSystemContributions(
-        Condition::Pointer rCurrentCondition,
+    void CalculateSystemContributions(
+        Condition& rCurrentCondition,
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
@@ -363,9 +363,9 @@ public:
     {
         KRATOS_TRY
 
-        (rCurrentCondition) -> CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
+        rCurrentCondition.CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentCondition) -> EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentCondition.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -374,17 +374,17 @@ public:
 
 // Note: this is in a parallel loop
 
-    void Calculate_RHS_Contribution(
-        Element::Pointer rCurrentElement,
+    void CalculateRHSContribution(
+        Element& rCurrentElement,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
         const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
-        (rCurrentElement) -> CalculateRightHandSide(RHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateRightHandSide(RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement) -> EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -393,36 +393,17 @@ public:
 
 // Note: this is in a parallel loop
 
-    void Condition_Calculate_RHS_Contribution(
-        Condition::Pointer rCurrentCondition,
+    void CalculateRHSContribution(
+        Condition& rCurrentCondition,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
         const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
-        (rCurrentCondition) -> CalculateRightHandSide(RHS_Contribution, CurrentProcessInfo);
+        rCurrentCondition.CalculateRightHandSide(RHS_Contribution, CurrentProcessInfo);
 
-        (rCurrentCondition) -> EquationIdVector(EquationId, CurrentProcessInfo);
-
-        KRATOS_CATCH( "" )
-    }
-
-//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-
-// Note: this is in a parallel loop
-
-    void Calculate_LHS_Contribution(
-        Element::Pointer rCurrentElement,
-        LocalSystemMatrixType& LHS_Contribution,
-        Element::EquationIdVectorType& EquationId,
-        const ProcessInfo& CurrentProcessInfo) override
-    {
-        KRATOS_TRY
-
-        (rCurrentElement) -> CalculateLeftHandSide(LHS_Contribution,CurrentProcessInfo);
-
-        (rCurrentElement) -> EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentCondition.EquationIdVector(EquationId, CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -431,17 +412,36 @@ public:
 
 // Note: this is in a parallel loop
 
-    void Condition_Calculate_LHS_Contribution(
-        Condition::Pointer rCurrentCondition,
+    void CalculateLHSContribution(
+        Element& rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         Element::EquationIdVectorType& EquationId,
         const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
-        (rCurrentCondition) -> CalculateLeftHandSide(LHS_Contribution, CurrentProcessInfo);
+        rCurrentElement.CalculateLeftHandSide(LHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentCondition) -> EquationIdVector(EquationId, CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
+
+        KRATOS_CATCH( "" )
+    }
+
+//----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+
+// Note: this is in a parallel loop
+
+    void CalculateLHSContribution(
+        Condition& rCurrentCondition,
+        LocalSystemMatrixType& LHS_Contribution,
+        Element::EquationIdVectorType& EquationId,
+        const ProcessInfo& CurrentProcessInfo) override
+    {
+        KRATOS_TRY
+
+        rCurrentCondition.CalculateLeftHandSide(LHS_Contribution, CurrentProcessInfo);
+
+        rCurrentCondition.EquationIdVector(EquationId, CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_damped_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_damped_U_Pw_scheme.hpp
@@ -53,7 +53,7 @@ public:
 // Note: this is in a parallel loop
 
     void CalculateSystemContributions(
-        Element::Pointer rCurrentElement,
+        Element& rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
@@ -63,15 +63,15 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentElement) -> CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateLocalSystem(LHS_Contribution,RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement) -> CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
 
         this->AddDampingToLHS (LHS_Contribution, mDampingMatrix[thread], CurrentProcessInfo);
 
         this->AddDampingToRHS (rCurrentElement, RHS_Contribution, mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement) -> EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -80,8 +80,8 @@ public:
 
 // Note: this is in a parallel loop
 
-    void Calculate_RHS_Contribution(
-        Element::Pointer rCurrentElement,
+    void CalculateRHSContribution(
+        Element& rCurrentElement,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
         const ProcessInfo& CurrentProcessInfo) override
@@ -90,13 +90,13 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentElement) -> CalculateRightHandSide(RHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateRightHandSide(RHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement) -> CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
 
         this->AddDampingToRHS (rCurrentElement, RHS_Contribution, mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement) -> EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -105,8 +105,8 @@ public:
 
 // Note: this is in a parallel loop
 
-    void Calculate_LHS_Contribution(
-        Element::Pointer rCurrentElement,
+    void CalculateLHSContribution(
+        Element& rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         Element::EquationIdVectorType& EquationId,
         const ProcessInfo& CurrentProcessInfo) override
@@ -115,13 +115,13 @@ public:
 
         int thread = OpenMPUtils::ThisThread();
 
-        (rCurrentElement) -> CalculateLeftHandSide(LHS_Contribution,CurrentProcessInfo);
+        rCurrentElement.CalculateLeftHandSide(LHS_Contribution,CurrentProcessInfo);
 
-        (rCurrentElement) -> CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
+        rCurrentElement.CalculateDampingMatrix(mDampingMatrix[thread],CurrentProcessInfo);
 
         this->AddDampingToLHS (LHS_Contribution, mDampingMatrix[thread], CurrentProcessInfo);
 
-        (rCurrentElement) -> EquationIdVector(EquationId,CurrentProcessInfo);
+        rCurrentElement.EquationIdVector(EquationId,CurrentProcessInfo);
 
         KRATOS_CATCH( "" )
     }
@@ -146,7 +146,7 @@ protected:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void AddDampingToRHS(Element::Pointer rCurrentElement,LocalSystemVectorType& RHS_Contribution,
+    void AddDampingToRHS(Element& rCurrentElement,LocalSystemVectorType& RHS_Contribution,
                             LocalSystemMatrixType& C,const ProcessInfo& CurrentProcessInfo)
     {
         int thread = OpenMPUtils::ThisThread();
@@ -154,7 +154,7 @@ protected:
         //adding damping contribution
         if (C.size1() != 0)
         {
-            rCurrentElement->GetFirstDerivativesVector(mVelocityVector[thread], 0);
+            rCurrentElement.GetFirstDerivativesVector(mVelocityVector[thread], 0);
 
             noalias(RHS_Contribution) -= prod(C, mVelocityVector[thread]);
         }

--- a/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_damped_U_Pw_scheme.hpp
+++ b/applications/PoromechanicsApplication/custom_strategies/schemes/newmark_quasistatic_damped_U_Pw_scheme.hpp
@@ -57,7 +57,7 @@ public:
         LocalSystemMatrixType& LHS_Contribution,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -84,7 +84,7 @@ public:
         Element::Pointer rCurrentElement,
         LocalSystemVectorType& RHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -109,7 +109,7 @@ public:
         Element::Pointer rCurrentElement,
         LocalSystemMatrixType& LHS_Contribution,
         Element::EquationIdVectorType& EquationId,
-        ProcessInfo& CurrentProcessInfo) override
+        const ProcessInfo& CurrentProcessInfo) override
     {
         KRATOS_TRY
 
@@ -137,7 +137,7 @@ protected:
 
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-    void AddDampingToLHS(LocalSystemMatrixType& LHS_Contribution,LocalSystemMatrixType& C,ProcessInfo& CurrentProcessInfo)
+    void AddDampingToLHS(LocalSystemMatrixType& LHS_Contribution,LocalSystemMatrixType& C,const ProcessInfo& CurrentProcessInfo)
     {
         // adding damping contribution
         if (C.size1() != 0)
@@ -147,7 +147,7 @@ protected:
 //----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
     void AddDampingToRHS(Element::Pointer rCurrentElement,LocalSystemVectorType& RHS_Contribution,
-                            LocalSystemMatrixType& C,ProcessInfo& CurrentProcessInfo)
+                            LocalSystemMatrixType& C,const ProcessInfo& CurrentProcessInfo)
     {
         int thread = OpenMPUtils::ThisThread();
 

--- a/applications/PoromechanicsApplication/custom_utilities/initial_stress_2D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/initial_stress_2D_utilities.hpp
@@ -367,7 +367,7 @@ private:
         }
 
         // Calculate and Extrapolate Stresses
-        ProcessInfo& r_current_process_info = rCurrentModelPart.GetProcessInfo();
+        const ProcessInfo& r_current_process_info = rCurrentModelPart.GetProcessInfo();
         const auto it_elem_begin = rCurrentModelPart.ElementsBegin();
         #pragma omp parallel for
         for(int i=0; i<static_cast<int>(rCurrentModelPart.Elements().size()); ++i) {

--- a/applications/PoromechanicsApplication/custom_utilities/initial_stress_3D_utilities.hpp
+++ b/applications/PoromechanicsApplication/custom_utilities/initial_stress_3D_utilities.hpp
@@ -428,7 +428,7 @@ private:
         }
 
         // Calculate and Extrapolate Stresses
-        ProcessInfo& r_current_process_info = rCurrentModelPart.GetProcessInfo();
+        const ProcessInfo& r_current_process_info = rCurrentModelPart.GetProcessInfo();
         const auto it_elem_begin = rCurrentModelPart.ElementsBegin();
         #pragma omp parallel for
         for(int i=0; i<static_cast<int>(rCurrentModelPart.Elements().size()); ++i) {


### PR DESCRIPTION
**Description**
ProcessInfo is passed as const as required by [#7381](https://github.com/KratosMultiphysics/Kratos/issues/7381) .

**Changelog**
- ProcessInfo passed as const in elements, conditions and schemes
- The new methods in the elements, conditions and schemes are used to account for this change
