### PR TITLE
[Fluid] const Check() clang warnings

### DIFF
--- a/applications/FluidDynamicsApplication/custom_elements/bingham_fluid.h
+++ b/applications/FluidDynamicsApplication/custom_elements/bingham_fluid.h
@@ -161,23 +161,6 @@ public:
         return Kratos::make_intrusive< BinghamFluid<TBaseElement> >(NewId,pGeom,pProperties);
     }
 
-    int Check(const ProcessInfo& rCurrentProcessInfo) override
-    {
-        KRATOS_TRY;
-
-        int Error = 0;
-
-        // Check that any required model parameters are defined
-
-
-        // Call the underlying element's check routine
-        Error = TBaseElement::Check(rCurrentProcessInfo);
-
-        return Error;
-
-        KRATOS_CATCH("");
-    }
-
     ///@}
     ///@name Access
     ///@{
@@ -280,9 +263,9 @@ protected:
         double GammaDot = this->EquivalentStrainRate(rDN_DX);
 
         double YieldStress = rProcessInfo[YIELD_STRESS];
-                        
+
         double m = rProcessInfo[REGULARIZATION_COEFFICIENT];
-        
+
         if (GammaDot > 1e-12) // Normal behaviour
         {
             double Regularization = 1.0 - std::exp(-m*GammaDot);

--- a/applications/FluidDynamicsApplication/custom_elements/compressible_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/compressible_navier_stokes.h
@@ -245,7 +245,7 @@ public:
      * @return 0 if no errors were found.
      */
 
-    int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override
     {
         KRATOS_TRY
 

--- a/applications/FluidDynamicsApplication/custom_elements/compressible_navier_stokes_explicit.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/compressible_navier_stokes_explicit.cpp
@@ -145,7 +145,7 @@ void CompressibleNavierStokesExplicit<3>::GetDofList(
 }
 
 template <unsigned int TDim, unsigned int TNumNodes, unsigned int TBlockSize>
-int CompressibleNavierStokesExplicit<TDim, TNumNodes, TBlockSize>::Check(const ProcessInfo &rCurrentProcessInfo)
+int CompressibleNavierStokesExplicit<TDim, TNumNodes, TBlockSize>::Check(const ProcessInfo &rCurrentProcessInfo) const
 {
     KRATOS_TRY
 

--- a/applications/FluidDynamicsApplication/custom_elements/compressible_navier_stokes_explicit.h
+++ b/applications/FluidDynamicsApplication/custom_elements/compressible_navier_stokes_explicit.h
@@ -215,7 +215,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Access

--- a/applications/FluidDynamicsApplication/custom_elements/d_vms.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/d_vms.cpp
@@ -177,7 +177,7 @@ void DVMS<TElementData>::InitializeNonLinearIteration(ProcessInfo &rCurrentProce
 // Inquiry
 
 template< class TElementData >
-int DVMS<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo)
+int DVMS<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo) const
 {
     int out = QSVMS<TElementData>::Check(rCurrentProcessInfo);
     KRATOS_ERROR_IF_NOT(out == 0)

--- a/applications/FluidDynamicsApplication/custom_elements/d_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/d_vms.h
@@ -231,7 +231,7 @@ public:
     ///@name Inquiry
     ///@{
 
-    int Check(const ProcessInfo &rCurrentProcessInfo) override;
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Input and output

--- a/applications/FluidDynamicsApplication/custom_elements/dpg_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/dpg_vms.h
@@ -1012,7 +1012,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override
     {
         KRATOS_TRY
         // Perform basic element checks

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_ausas_navier_stokes.h
@@ -240,7 +240,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override {
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override {
         KRATOS_TRY;
 
         // Perform basic element checks

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.cpp
@@ -240,8 +240,7 @@ void EmbeddedFluidElement<TBaseElement>::GetValueOnIntegrationPoints(
 // Inquiry
 
 template <class TBaseElement>
-int EmbeddedFluidElement<TBaseElement>::Check(
-    const ProcessInfo &rCurrentProcessInfo)
+int EmbeddedFluidElement<TBaseElement>::Check(const ProcessInfo &rCurrentProcessInfo) const
 {
 
     int out = EmbeddedElementData::Check(*this,rCurrentProcessInfo);

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element.h
@@ -266,7 +266,7 @@ public:
     ///@name Inquiry
     ///@{
 
-    int Check(const ProcessInfo &rCurrentProcessInfo) override;
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Input and output

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.cpp
@@ -219,7 +219,7 @@ void EmbeddedFluidElementDiscontinuous<TBaseElement>::Calculate(
 // Inquiry
 
 template <class TBaseElement>
-int EmbeddedFluidElementDiscontinuous<TBaseElement>::Check(const ProcessInfo& rCurrentProcessInfo)
+int EmbeddedFluidElementDiscontinuous<TBaseElement>::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     int out = EmbeddedDiscontinuousElementData::Check(*this, rCurrentProcessInfo);
     KRATOS_ERROR_IF_NOT(out == 0)

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_fluid_element_discontinuous.h
@@ -249,7 +249,7 @@ public:
     ///@name Inquiry
     ///@{
 
-    int Check(const ProcessInfo &rCurrentProcessInfo) override;
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Input and output

--- a/applications/FluidDynamicsApplication/custom_elements/embedded_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/embedded_navier_stokes.h
@@ -360,7 +360,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    int Check(const ProcessInfo &rCurrentProcessInfo) override
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override
     {
         KRATOS_TRY;
 

--- a/applications/FluidDynamicsApplication/custom_elements/fic.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/fic.cpp
@@ -91,7 +91,7 @@ void FIC<TElementData>::Calculate(const Variable<Matrix>& rVariable,
 // Inquiry
 
 template< class TElementData >
-int FIC<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo)
+int FIC<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo) const
 {
     int out = FluidElement<TElementData>::Check(rCurrentProcessInfo);
     KRATOS_ERROR_IF_NOT(out == 0)
@@ -101,9 +101,10 @@ int FIC<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo)
     // Extra variables
     KRATOS_CHECK_VARIABLE_KEY(ACCELERATION);
 
+    const auto& r_geom = this->GetGeometry();
     for(unsigned int i=0; i<NumNodes; ++i)
     {
-        Node<3>& rNode = this->GetGeometry()[i];
+        const auto& rNode = r_geom[i];
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ACCELERATION,rNode);
     }
 

--- a/applications/FluidDynamicsApplication/custom_elements/fic.h
+++ b/applications/FluidDynamicsApplication/custom_elements/fic.h
@@ -223,7 +223,7 @@ public:
     ///@name Inquiry
     ///@{
 
-    int Check(const ProcessInfo &rCurrentProcessInfo) override;
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Input and output

--- a/applications/FluidDynamicsApplication/custom_elements/fractional_step.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/fractional_step.cpp
@@ -791,7 +791,7 @@ void FractionalStep<TDim>::CalculateEndOfStepSystem(MatrixType& rLeftHandSideMat
 
 
 template< unsigned int TDim >
-int FractionalStep<TDim>::Check(const ProcessInfo &rCurrentProcessInfo)
+int FractionalStep<TDim>::Check(const ProcessInfo &rCurrentProcessInfo) const
 {
     KRATOS_TRY;
 
@@ -820,7 +820,7 @@ int FractionalStep<TDim>::Check(const ProcessInfo &rCurrentProcessInfo)
     // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom
     for(unsigned int i=0; i<this->GetGeometry().size(); ++i)
     {
-        Node<3> &rNode = this->GetGeometry()[i];
+        const auto &rNode = this->GetGeometry()[i];
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY,rNode);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE,rNode);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(BODY_FORCE,rNode);

--- a/applications/FluidDynamicsApplication/custom_elements/fractional_step.h
+++ b/applications/FluidDynamicsApplication/custom_elements/fractional_step.h
@@ -1,10 +1,10 @@
-//    |  /           | 
-//    ' /   __| _` | __|  _ \   __| 
+//    |  /           |
+//    ' /   __| _` | __|  _ \   __|
 //    . \  |   (   | |   (   |\__ \.
-//   _|\_\_|  \__,_|\__|\___/ ____/ 
-//                   Multi-Physics  
+//   _|\_\_|  \__,_|\__|\___/ ____/
+//                   Multi-Physics
 //
-//  License:		 BSD License 
+//  License:		 BSD License
 //					 Kratos default license: kratos/license.txt
 //
 //  Main authors:    Jordi Cotela
@@ -173,7 +173,7 @@ namespace Kratos
 	    {
             return Kratos::make_intrusive< FractionalStep<TDim> >(NewId, this->GetGeometry().Create(ThisNodes), pProperties);
 	    }
-	
+
         /**
          * Returns a pointer to a new FractionalStep element, created using given input
          * @param NewId the ID of the new element
@@ -181,12 +181,12 @@ namespace Kratos
          * @param pProperties the properties assigned to the new element
          * @return a Pointer to the new element
          */
-		
+
         Element::Pointer Create(IndexType NewId, Element::GeometryType::Pointer pGeom, Element::PropertiesType::Pointer pProperties) const override
         {
             return Kratos::make_intrusive< FractionalStep<TDim> >(NewId, pGeom, pProperties);
         }
-        
+
         /**
          * Clones the selected element variables, creating a new one
          * @param NewId the ID of the new element
@@ -194,17 +194,17 @@ namespace Kratos
          * @param pProperties the properties assigned to the new element
          * @return a Pointer to the new element
          */
-        
+
         Element::Pointer Clone(IndexType NewId, NodesArrayType const& rThisNodes) const override
         {
             Element::Pointer pNewElement = Create(NewId, GetGeometry().Create( rThisNodes ), pGetProperties() );
-            
+
             pNewElement->SetData(this->GetData());
             pNewElement->SetFlags(this->GetFlags());
-            
+
             return pNewElement;
         }
-        
+
         void Initialize() override;
 
         /// Initializes the element and all geometric information required for the problem.
@@ -274,7 +274,7 @@ namespace Kratos
         void GetDofList(DofsVectorType& rElementalDofList,
                                 ProcessInfo& rCurrentProcessInfo) override;
 
-    
+
         GeometryData::IntegrationMethod GetIntegrationMethod() const override;
 
         /// Obtain an array_1d<double,3> elemental variable, evaluated on gauss points.
@@ -353,7 +353,7 @@ namespace Kratos
          * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
          * @return 0 if no errors were found.
          */
-        int Check(const ProcessInfo& rCurrentProcessInfo) override;
+        int Check(const ProcessInfo& rCurrentProcessInfo) const override;
 
         ///@}
         ///@name Inquiry
@@ -633,17 +633,17 @@ namespace Kratos
         {
             GeometryType& rGeom = this->GetGeometry();
             const SizeType NumNodes = rGeom.PointsNumber();
-	    
+
 			const double& var = rGeom[0].FastGetSolutionStepValue(Var);
 			for (SizeType d = 0; d < TDim; ++d)
 				rResult[d] = rDN_DX(0,d) * var;
-			
+
 			for(SizeType i = 1; i < NumNodes; i++)
 			{
 			  const double& var = rGeom[i].FastGetSolutionStepValue(Var);
 			  for (SizeType d = 0; d < TDim; ++d)
 						rResult[d] += rDN_DX(i,d) * var;
-				
+
 			}
 		}
 

--- a/applications/FluidDynamicsApplication/custom_elements/herschel_bulkley_fluid.h
+++ b/applications/FluidDynamicsApplication/custom_elements/herschel_bulkley_fluid.h
@@ -162,24 +162,6 @@ public:
         return Kratos::make_intrusive< HerschelBulkleyFluid<TBaseElement> >(NewId,pGeom,pProperties);
     }
 
-
-    int Check(const ProcessInfo& rCurrentProcessInfo) override
-    {
-        KRATOS_TRY;
-
-        int Error = 0;
-
-        // Check that any required model parameters are defined
-
-
-        // Call the underlying element's check routine
-        Error = TBaseElement::Check(rCurrentProcessInfo);
-
-        return Error;
-
-        KRATOS_CATCH("");
-    }
-
     ///@}
     ///@name Access
     ///@{

--- a/applications/FluidDynamicsApplication/custom_elements/navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/navier_stokes.h
@@ -236,7 +236,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override
     {
         KRATOS_TRY
 

--- a/applications/FluidDynamicsApplication/custom_elements/qs_vms.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/qs_vms.cpp
@@ -95,7 +95,7 @@ void QSVMS<TElementData>::Calculate(const Variable<Matrix>& rVariable,
 // Inquiry
 
 template< class TElementData >
-int QSVMS<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo)
+int QSVMS<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo) const
 {
     int out = FluidElement<TElementData>::Check(rCurrentProcessInfo);
     KRATOS_ERROR_IF_NOT(out == 0)
@@ -110,9 +110,10 @@ int QSVMS<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo)
     KRATOS_CHECK_VARIABLE_KEY(SUBSCALE_VELOCITY);
     KRATOS_CHECK_VARIABLE_KEY(SUBSCALE_PRESSURE);
 
-    for(unsigned int i=0; i<NumNodes; ++i)
+    const auto &r_geom = this->GetGeometry();
+    for (unsigned int i = 0; i < NumNodes; ++i)
     {
-        Node<3>& rNode = this->GetGeometry()[i];
+        const auto& rNode = r_geom[i];
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ACCELERATION,rNode);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(NODAL_AREA,rNode);
     }

--- a/applications/FluidDynamicsApplication/custom_elements/qs_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/qs_vms.h
@@ -219,7 +219,7 @@ public:
     ///@name Inquiry
     ///@{
 
-    int Check(const ProcessInfo &rCurrentProcessInfo) override;
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Input and output

--- a/applications/FluidDynamicsApplication/custom_elements/qs_vms_dem_coupled.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/qs_vms_dem_coupled.cpp
@@ -69,16 +69,17 @@ Element::Pointer QSVMSDEMCoupled<TElementData>::Create(IndexType NewId,GeometryT
 // Inquiry
 
 template< class TElementData >
-int QSVMSDEMCoupled<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo)
+int QSVMSDEMCoupled<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo) const
 {
     int out = QSVMS<TElementData>::Check(rCurrentProcessInfo);
     KRATOS_ERROR_IF_NOT(out == 0)
         << "Error in base class Check for Element " << this->Info() << std::endl
         << "Error code is " << out << std::endl;
 
-    for(unsigned int i=0; i<NumNodes; ++i)
+    const auto &r_geom = this->GetGeometry();
+    for (unsigned int i = 0; i < NumNodes; ++i)
     {
-        Node<3>& rNode = this->GetGeometry()[i];
+        const auto& rNode = r_geom[i];
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(ACCELERATION,rNode);
         KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(NODAL_AREA,rNode);
     }

--- a/applications/FluidDynamicsApplication/custom_elements/qs_vms_dem_coupled.h
+++ b/applications/FluidDynamicsApplication/custom_elements/qs_vms_dem_coupled.h
@@ -206,7 +206,7 @@ public:
     ///@name Inquiry
     ///@{
 
-    int Check(const ProcessInfo &rCurrentProcessInfo) override;
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Input and output

--- a/applications/FluidDynamicsApplication/custom_elements/spalart_allmaras.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/spalart_allmaras.cpp
@@ -17,7 +17,7 @@ Element::Pointer SpalartAllmaras::Create(IndexType NewId,GeometryType::Pointer p
     return Kratos::make_intrusive<SpalartAllmaras>(NewId, pGeom, pProperties);
 }
 
-int SpalartAllmaras::Check(const ProcessInfo &rCurrentProcessInfo)
+int SpalartAllmaras::Check(const ProcessInfo &rCurrentProcessInfo) const
 {
     KRATOS_TRY;
 

--- a/applications/FluidDynamicsApplication/custom_elements/spalart_allmaras.h
+++ b/applications/FluidDynamicsApplication/custom_elements/spalart_allmaras.h
@@ -126,7 +126,7 @@ public:
     /// Check that all required data containers are properly initialized and registered in Kratos
     /** @return 0 if no errors are detected.
       */
-    int Check(const ProcessInfo &rCurrentProcessInfo) override;
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override;
 
     /// Calculate Shape function derivatives for the element
     void Initialize() override;

--- a/applications/FluidDynamicsApplication/custom_elements/symbolic_navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/symbolic_navier_stokes.cpp
@@ -49,7 +49,8 @@ Element::Pointer SymbolicNavierStokes<TElementData>::Create(IndexType NewId,Geom
 // Public Inquiry
 
 template <class TElementData>
-int SymbolicNavierStokes<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo) {
+int SymbolicNavierStokes<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo) const
+{
 
     KRATOS_TRY;
     int out = FluidElement<TElementData>::Check(rCurrentProcessInfo);

--- a/applications/FluidDynamicsApplication/custom_elements/symbolic_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/symbolic_navier_stokes.h
@@ -175,7 +175,7 @@ public:
     ///@name Inquiry
     ///@{
 
-    int Check(const ProcessInfo &rCurrentProcessInfo) override;
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Input and output

--- a/applications/FluidDynamicsApplication/custom_elements/symbolic_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/symbolic_stokes.cpp
@@ -84,7 +84,7 @@ Element::Pointer SymbolicStokes<TElementData>::Create(
 // Public Inquiry
 
 template <class TElementData>
-int SymbolicStokes<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo)
+int SymbolicStokes<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo) const
 {
     KRATOS_TRY;
     int out = FluidElement<TElementData>::Check(rCurrentProcessInfo);

--- a/applications/FluidDynamicsApplication/custom_elements/symbolic_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/symbolic_stokes.h
@@ -187,7 +187,7 @@ public:
     ///@name Inquiry
     ///@{
 
-    int Check(const ProcessInfo &rCurrentProcessInfo) override;
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Input and output

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.cpp
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.cpp
@@ -189,7 +189,7 @@ void TwoFluidNavierStokes<TElementData>::CalculateRightHandSide(
 // Public Inquiry
 
 template <class TElementData>
-int TwoFluidNavierStokes<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo)
+int TwoFluidNavierStokes<TElementData>::Check(const ProcessInfo &rCurrentProcessInfo) const
 {
     KRATOS_TRY;
     int out = FluidElement<TElementData>::Check(rCurrentProcessInfo);

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_navier_stokes.h
@@ -187,7 +187,7 @@ public:
      * current element check implementations
      * @param rCurrentProcessInfo reference to the current process info
      */
-    int Check(const ProcessInfo &rCurrentProcessInfo) override;
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override;
 
     ///@}
     ///@name Inquiry

--- a/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/two_fluid_vms.h
@@ -631,7 +631,7 @@ KRATOS_WATCH(Ngauss);  */
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override
     {
         KRATOS_TRY
         // Perform basic element checks

--- a/applications/FluidDynamicsApplication/custom_elements/vms.h
+++ b/applications/FluidDynamicsApplication/custom_elements/vms.h
@@ -827,7 +827,7 @@ public:
      * @param rCurrentProcessInfo The ProcessInfo of the ModelPart that contains this element.
      * @return 0 if no errors were found.
      */
-    int Check(const ProcessInfo& rCurrentProcessInfo) override
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override
     {
         KRATOS_TRY
 
@@ -859,7 +859,7 @@ public:
         // Check that the element's nodes contain all required SolutionStepData and Degrees of freedom
         for(unsigned int i=0; i<this->GetGeometry().size(); ++i)
         {
-            Node<3> &rNode = this->GetGeometry()[i];
+            const auto &rNode = this->GetGeometry()[i];
             KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(VELOCITY,rNode);
             KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(PRESSURE,rNode);
             KRATOS_CHECK_VARIABLE_IN_NODAL_DATA(MESH_VELOCITY,rNode);

--- a/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
@@ -238,13 +238,12 @@ public:
      *
      * @return 0 after successful completion.
      */
-    int Check(const ProcessInfo &/*rCurrentProcessInfo*/) const override
+    int Check(const ProcessInfo &rCurrentProcessInfo) const override
     {
         KRATOS_TRY
 
         // Check the element id and geometry.
-        ProcessInfo UnusedProcessInfo;
-        int ReturnValue = Element::Check(UnusedProcessInfo);
+        int ReturnValue = Element::Check(rCurrentProcessInfo);
 
         // Check if adjoint and fluid variables are defined.
         if (ADJOINT_FLUID_VECTOR_1.Key() == 0)

--- a/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
@@ -238,7 +238,7 @@ public:
      *
      * @return 0 after successful completion.
      */
-    int Check(const ProcessInfo &/*rCurrentProcessInfo*/) override
+    int Check(const ProcessInfo &/*rCurrentProcessInfo*/) const override
     {
         KRATOS_TRY
 

--- a/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
+++ b/applications/FluidDynamicsApplication/custom_elements/vms_adjoint_element.h
@@ -245,36 +245,6 @@ public:
         // Check the element id and geometry.
         int ReturnValue = Element::Check(rCurrentProcessInfo);
 
-        // Check if adjoint and fluid variables are defined.
-        if (ADJOINT_FLUID_VECTOR_1.Key() == 0)
-            KRATOS_THROW_ERROR(std::invalid_argument,
-                    "ADJOINT_FLUID_VECTOR_1 Key is 0. "
-                    "Check if the application was correctly registered.","");
-        if (ADJOINT_FLUID_VECTOR_2.Key() == 0)
-            KRATOS_THROW_ERROR(std::invalid_argument,
-                    "ADJOINT_FLUID_VECTOR_2 Key is 0. "
-                    "Check if the application was correctly registered.","");
-        if (ADJOINT_FLUID_VECTOR_3.Key() == 0)
-            KRATOS_THROW_ERROR(std::invalid_argument,
-                    "ADJOINT_FLUID_VECTOR_3 Key is 0. "
-                    "Check if the application was correctly registered.","");
-        if (ADJOINT_FLUID_SCALAR_1.Key() == 0)
-            KRATOS_THROW_ERROR(std::invalid_argument,
-                    "ADJOINT_FLUID_SCALAR_1 Key is 0. "
-                    "Check if the application was correctly registered.","");
-        if (VELOCITY.Key() == 0)
-            KRATOS_THROW_ERROR(std::invalid_argument,
-                    "VELOCITY Key is 0. "
-                    "Check if the application was correctly registered.","");
-        if (ACCELERATION.Key() == 0)
-            KRATOS_THROW_ERROR(std::invalid_argument,
-                    "ACCELERATION Key is 0. "
-                    "Check if the application was correctly registered.","");
-        if (PRESSURE.Key() == 0)
-            KRATOS_THROW_ERROR(std::invalid_argument,
-                    "PRESSURE Key is 0. "
-                    "Check if the application was correctly registered.","");
-
         // Check if the nodes have adjoint and fluid variables and adjoint dofs.
         for (IndexType iNode = 0; iNode < this->GetGeometry().size(); ++iNode)
         {


### PR DESCRIPTION
**Description**
Making the `Check` function `const` in the `FluidDynamicsApplication` elements. These changes go in the Kratos core line and avoid the Clang compiler override ambiguity warning.

Please mark the PR with appropriate tags: 
- Applications
- Warning
- Clang
- FastPR

**Changelog**
- Adding `const` specifier to the `Check` method of the `FluidDynamicsApplication` elements.
