### PR TITLE
[Core] Model part Check() const ProcessInfo

### DIFF
--- a/kratos/includes/model_part.h
+++ b/kratos/includes/model_part.h
@@ -1675,7 +1675,7 @@ public:
     }
 
     /// run input validation
-    virtual int Check( ProcessInfo& rCurrentProcessInfo ) const;
+    virtual int Check(const ProcessInfo& rCurrentProcessInfo) const;
 
     ///@}
     ///@name Access

--- a/kratos/sources/model_part.cpp
+++ b/kratos/sources/model_part.cpp
@@ -1825,7 +1825,7 @@ void ModelPart::SetBufferSizeSubModelParts(ModelPart::IndexType NewBufferSize)
 }
 
 /// run input validation
-int ModelPart::Check(ProcessInfo& rCurrentProcessInfo) const
+int ModelPart::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
     int err = 0;


### PR DESCRIPTION
**Description**
Makes `const` the `ProcessInfo` in the `ModelPart` `Check` to avoid the warning.

Please mark the PR with appropriate tags: 
- Warning
- FastPR
- Inconsistent

**Changelog**
- Add `const` specifier to `ProcessInfo` argument
