### PR TITLE
[CoSim] improve data comm to ext solvers

### DIFF
--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_accelerator.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_accelerator.py
@@ -5,7 +5,7 @@ import KratosMultiphysics as KM
 import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
 import KratosMultiphysics.CoSimulationApplication.colors as colors
 
-class CoSimulationConvergenceAccelerator(object):
+class CoSimulationConvergenceAccelerator:
     """Baseclass for the convergence acceleratos used for CoSimulation
     Relaxes the solution to increase the speed of convergence in a (strongly) coupled simulation
 

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_criteria.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_convergence_criteria.py
@@ -5,7 +5,7 @@ import KratosMultiphysics as KM
 import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
 import KratosMultiphysics.CoSimulationApplication.colors as colors
 
-class CoSimulationConvergenceCriteria(object):
+class CoSimulationConvergenceCriteria:
     """Baseclass for the convergence criteria used for CoSimulation
     Checks if convergence was achieved in a (strongly) coupled simulation
     """

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupled_solver.py
@@ -239,15 +239,6 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
                     cs_tools.cs_print_info("  Skipped", 'not in interval')
                 return
 
-            if from_solver_data.is_outdated:
-                # Importing data from external solvers (if it is outdated)
-                from_solver_data_config = {
-                    "type" : "coupling_interface_data",
-                    "interface_data" : from_solver_data
-                }
-                from_solver.ImportData(from_solver_data_config)
-                from_solver_data.is_outdated = False
-
             # perform the data transfer
             self.__ExecuteCouplingOperations(i_data["before_data_transfer_operations"])
 
@@ -256,13 +247,6 @@ class CoSimulationCoupledSolver(CoSimulationSolverWrapper):
             self.__GetDataTransferOperator(data_transfer_operator_name).TransferData(from_solver_data, to_solver_data, i_data["data_transfer_operator_options"])
 
             self.__ExecuteCouplingOperations(i_data["after_data_transfer_operations"])
-
-            # Exporting data to external solvers
-            to_solver_data_config = {
-                "type" : "coupling_interface_data",
-                "interface_data" : to_solver_data
-            }
-            to_solver.ExportData(to_solver_data_config)
 
 
     def __GetDataTransferOperator(self, data_transfer_operator_name):

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_coupling_operation.py
@@ -4,7 +4,7 @@ import KratosMultiphysics as KM
 # CoSimulation imports
 from KratosMultiphysics.CoSimulationApplication.co_simulation_tools import SettingsTypeCheck
 
-class CoSimulationCouplingOperation(object):
+class CoSimulationCouplingOperation:
     """Baseclass for the coupling operations used for CoSimulation
     This class can be used to customize the behavior of the CoSimulation,
     by providing a large interface and access to the solvers/models

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_data_transfer_operator.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_data_transfer_operator.py
@@ -1,7 +1,7 @@
 # Importing the Kratos Library
 import KratosMultiphysics as KM
 
-class CoSimulationDataTransferOperator(object):
+class CoSimulationDataTransferOperator:
     """Baseclass for the data transfer operators used for CoSimulation
     It transfers data from one interface to another. This can e.g. be mapping or a copy of values.
     """

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_io.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_io.py
@@ -4,7 +4,7 @@ import KratosMultiphysics as KM
 def Create(settings, model, solver_name):
     raise Exception('"CoSimulationIO" is a baseclass and cannot be used directly!')
 
-class CoSimulationIO(object):
+class CoSimulationIO:
     """Baseclass defining the interface for the input and output methods
     for the communication with external solvers
     """

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_predictor.py
@@ -5,7 +5,7 @@ import KratosMultiphysics as KM
 import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tools
 import KratosMultiphysics.CoSimulationApplication.colors as colors
 
-class CoSimulationPredictor(object):
+class CoSimulationPredictor:
     """Baseclass for the predictors used for CoSimulation
     It predicts the solution of the next step at the beginning of a step
     """

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -10,7 +10,7 @@ import KratosMultiphysics.CoSimulationApplication.colors as colors
 def Create(settings, name):
     raise Exception('"CoSimulationSolverWrapper" is a baseclass and cannot be used directly!')
 
-class CoSimulationSolverWrapper(object):
+class CoSimulationSolverWrapper:
     """Baseclass for the solver wrappers used for CoSimulation
     It wraps solvers used in the CoSimulation
     """

--- a/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
+++ b/applications/CoSimulationApplication/python_scripts/base_classes/co_simulation_solver_wrapper.py
@@ -83,8 +83,7 @@ class CoSimulationSolverWrapper(object):
         pass
 
     def SolveSolutionStep(self):
-        for data in self.data_dict.values():
-            data.is_outdated = True
+        pass
 
 
     def CreateIO(self, io_echo_level):

--- a/applications/CoSimulationApplication/python_scripts/coupling_interface_data.py
+++ b/applications/CoSimulationApplication/python_scripts/coupling_interface_data.py
@@ -7,7 +7,7 @@ import KratosMultiphysics.CoSimulationApplication.co_simulation_tools as cs_tool
 # Other imports
 import numpy as np
 
-class CouplingInterfaceData(object):
+class CouplingInterfaceData:
     """This class serves as interface to the data structure (Model and ModelPart)
     that holds the data used during CoSimulation
     """
@@ -19,7 +19,6 @@ class CouplingInterfaceData(object):
         self.model = model
         self.name = name
         self.solver_name = solver_name
-        self.is_outdated = True
         self.is_initialized = False
         self.model_part_name = self.settings["model_part_name"].GetString()
 

--- a/applications/CoSimulationApplication/tests/ping_pong_test/cosim_ping_pong_parameters.json
+++ b/applications/CoSimulationApplication/tests/ping_pong_test/cosim_ping_pong_parameters.json
@@ -53,7 +53,9 @@
                 "solver_wrapper_settings" : {
                     "main_model_part_name" : "ping",
                     "domain_size" : 2,
-                    "executable_name"  : "../../../../cmake_build/applications/CoSimulationApplication/ping"
+                    "executable_name"  : "../../../../cmake_build/applications/CoSimulationApplication/ping",
+                    "export_data"      : ["send_data"],
+                    "import_data"      : ["recv_data"]
                 },
                 "io_settings":{
                     "type":"cpp_ping_pong.ping_pong_io"
@@ -77,7 +79,9 @@
                 "solver_wrapper_settings" : {
                     "main_model_part_name" : "pong",
                     "domain_size" : 2,
-                    "executable_name"  : "../../../../cmake_build/applications/CoSimulationApplication/pong"
+                    "executable_name"  : "../../../../cmake_build/applications/CoSimulationApplication/pong",
+                    "export_data"      : ["send_data"],
+                    "import_data"      : ["recv_data"]
                 },
                 "io_settings":{
                     "type":"cpp_ping_pong.ping_pong_io"

--- a/applications/CoSimulationApplication/tests/test_ping_pong_coupling.py
+++ b/applications/CoSimulationApplication/tests/test_ping_pong_coupling.py
@@ -1,4 +1,5 @@
 import KratosMultiphysics as KM
+from KratosMultiphysics.kratos_utilities import DeleteFileIfExisting
 
 import KratosMultiphysics.KratosUnittest as KratosUnittest
 
@@ -27,11 +28,12 @@ class TestPingPong(KratosUnittest.TestCase):
         self._createTest("ping_pong_test", "cosim_ping_pong_parameters")
         CoSimulationAnalysis(self.cosim_parameters).Run()
 
-        #TODO: temporary figure out how to properly do it.
-        os.remove('ping.log')
-        os.remove('pong.log')
-        os.remove('EMPIRE_datafield_pong_recv_data.dat')
-        os.remove('EMPIRE_datafield_ping_recv_data.dat')
+        DeleteFileIfExisting('ping.log')
+        DeleteFileIfExisting('pong.log')
+        DeleteFileIfExisting('EMPIRE_datafield_pong_send_data.dat')
+        DeleteFileIfExisting('EMPIRE_datafield_ping_send_data.dat')
+        DeleteFileIfExisting('EMPIRE_datafield_pong_recv_data.dat')
+        DeleteFileIfExisting('EMPIRE_datafield_ping_recv_data.dat')
 
 
 


### PR DESCRIPTION
**Description**
@inigolcanalejo noticed that for some configurations certain steps like acceleration are not working properly when using an external solver. This is caused because the communication to external solvers happens "implicitly" and a bit hidden in the `CoupledSolver`

This PR improves this in the sense that now the `SolverWrapper` for the external solver has to take care of the communication of data to the external solver (in `SolveSolutionStep`)

This is achieved by removing the above mentioned implicit communication.
For Kratos solvers this doesn't play make a difference, for external solvers this is a breaking change. Since @inigolcanalejo an myself are the only users of this so far we decided to do this now.

It shall also be note that with this change the data of external solvers must be imported to Kratos, which might not always be desired. E.g. using the CoSimIO the communication could happen directly between solvers without going through Kratos.
=> we already have a concept of bringing this back in the future