### PR TITLE
Fixing install problem with spaces

### DIFF
--- a/cmake_modules/install_function.cmake
+++ b/cmake_modules/install_function.cmake
@@ -1,7 +1,7 @@
 # This functin installs a symbolic link
 macro(install_symlink filepath sympath symfile)
     install(DIRECTORY DESTINATION ${sympath})
-    install(CODE "execute_process(COMMAND ${CMAKE_COMMAND} -E create_symlink ${filepath} ${sympath}/${symfile})")
+    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -E create_symlink ${filepath} ${sympath}/${symfile})")
 endmacro(install_symlink)
 
 # This function install a symlinc to an entire directory


### PR DESCRIPTION
**Description**
Fixes a problem that appears if CMake is invoked through a path containing spaces in windows while installing using symlinks.

Thx @jrubiogonzalez for discovering that!

**Changelog**
- Fixed install bug in windows when CMake tool is located in certain paths containing spaces.
