### PR TITLE
[CI] Adding ParMmg to CI

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -64,6 +64,16 @@ RUN apt-get update -y && apt-get upgrade -y && \
     make install && \
     rm -r /tmp/mmg_5_5_1 && \
     cd / && \
+    # install PARMMG
+    git clone --depth 1 https://github.com/MmgTools/ParMmg /tmp/ParMmg && \
+    mkdir /tmp/ParMmg/build && \
+    mkdir -p /external_libraries/mmg/ParMmg && \
+    cd /tmp/mmg_5_5_1/build && git checkout 4d272bb3d1a51d839a5fdfaa3eef93f340cafda3 && \
+    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/ParMmg" -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/external_libraries/mmg/mmg_5_5_1" \
+             -DMMG_BUILDDIR="/external_libraries/mmg/mmg_5_5_1/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include"  && \
+    make install && \
+    rm -r /tmp/ParMmg && \
+    cd / && \
     # remove some now unnecessary packages
     apt-get -y remove \
         gnupg2 \

--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -62,17 +62,16 @@ RUN apt-get update -y && apt-get upgrade -y && \
     cd /tmp/mmg_5_5_1/build && \
     cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make install && \
-    rm -r /tmp/mmg_5_5_1 && \
     cd / && \
     # install PARMMG
-    git clone --depth 1 https://github.com/MmgTools/ParMmg /tmp/ParMmg && \
-    mkdir /tmp/ParMmg/build && \
-    mkdir -p /external_libraries/mmg/ParMmg && \
-    cd /tmp/mmg_5_5_1/build && git checkout 4d272bb3d1a51d839a5fdfaa3eef93f340cafda3 && \
-    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/ParMmg" -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/external_libraries/mmg/mmg_5_5_1" \
-             -DMMG_BUILDDIR="/external_libraries/mmg/mmg_5_5_1/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include"  && \
+    git clone https://github.com/MmgTools/ParMmg /tmp/ParMmg_4d272bb && \
+    mkdir /tmp/ParMmg_4d272bb/build && \
+    mkdir -p /external_libraries/ParMmg_4d272bb && \
+    cd /tmp/ParMmg_4d272bb/build && git checkout 4d272bb3d1a51d839a5fdfaa3eef93f340cafda3 && \
+    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_4d272bb" -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_1" -DMMG_BUILDDIR="/tmp/mmg_5_5_1/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
     make install && \
-    rm -r /tmp/ParMmg && \
+    rm -r /tmp/mmg_5_5_1 && \
+    rm -r /tmp/ParMmg_4d272bb && \
     cd / && \
     # remove some now unnecessary packages
     apt-get -y remove \


### PR DESCRIPTION
**Description**
This PR adds the cloning and compilation of ParMmg, which depends on mmg v5.5.1, in order to test the Kratos interface that will be added in upcoming PRs.

This adds one of the latests stable commits, which will be updated as soon as a beta Release of ParMmg is ready. 

**Changelog**
- Adding ParMmg cloning and compilation to CI
