### PR TITLE
[CI] Adding MMG and ParMmg lib to env variable.

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -1,6 +1,7 @@
 FROM ubuntu:focal
 
 ENV HOME /root
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/external_libraries/mmg/mmg_5_5_1/lib:/external_libraries/ParMmg_4d272bb/lib
 
 RUN apt-get update -y && apt-get upgrade -y && \
     apt-get -y install \


### PR DESCRIPTION
**Description**
This adds the lib folder of mmg/parmmg to the LD_LIBRARY_PATH ENV variable. I thought I could do this on the file we run the tests, but it is cleanar to do it here only once. 

This will be needed to run tests with  mmg v5.5 and ParMmg. 

This was not needed previously because mmg was being compiled on /usr/local.

**Changelog**
- Added lib mmg and parmmg folder to LD_LIBRARY_PATH
