### PR TITLE
Improving test runner

### DIFF
--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -5,6 +5,7 @@ import re
 import sys
 import getopt
 import subprocess
+
 from importlib import import_module
 
 import KratosMultiphysics as KtsMp
@@ -28,11 +29,6 @@ def Usage():
     ]
     for l in lines:
         KtsMp.Logger.PrintInfo(l) # using the logger to only print once in MPI
-
-
-def handler(signum, frame):
-    raise Exception("End of time")
-
 
 class Commander(object):
     def __init__(self):
@@ -120,6 +116,7 @@ class Commander(object):
                         process_stdout, process_stderr = self.process.communicate(timeout=timer)
                     except TimeoutExpired:
                         # Timeout reached
+                        self.process.kill()
                         print('[Error]: Tests for {} took too long. Process Killed.'.format(application), file=sys.stderr)
                         self.exitCode = 1
                     else:

--- a/kratos/python_scripts/run_tests.py
+++ b/kratos/python_scripts/run_tests.py
@@ -30,6 +30,7 @@ def Usage():
     for l in lines:
         KtsMp.Logger.PrintInfo(l) # using the logger to only print once in MPI
 
+
 class Commander(object):
     def __init__(self):
         self.process = None
@@ -114,7 +115,7 @@ class Commander(object):
                     # and capture the first exit code different from OK
                     try:
                         process_stdout, process_stderr = self.process.communicate(timeout=timer)
-                    except TimeoutExpired:
+                    except subprocess.TimeoutExpired:
                         # Timeout reached
                         self.process.kill()
                         print('[Error]: Tests for {} took too long. Process Killed.'.format(application), file=sys.stderr)
@@ -177,7 +178,6 @@ def print_summary(exit_codes):
     sys.stderr.flush()
 
 def main():
-
     # Define the command
     cmd = os.path.join(os.path.dirname(KtsUtls.GetKratosMultiphysicsPath()), 'runkratos')
 


### PR DESCRIPTION
**Description**
Replaces thread timeout with subprocess timeout. It was not possible before because we had to support 2.7 but its not longer the case (Also didn't know that existed. Thx @philbucher)

**Changelog**
- Removing threads from the test runner
