### PR TITLE
[CoSim] specify sparse qr solver in tests

### DIFF
--- a/applications/CoSimulationApplication/tests/fem_fem/small_2d_plate/ProjectParametersA.json
+++ b/applications/CoSimulationApplication/tests/fem_fem/small_2d_plate/ProjectParametersA.json
@@ -22,6 +22,9 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
+        "linear_solver_settings"             : {
+            "solver_type" : "LinearSolversApplication.sparse_qr"
+        },
         "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,

--- a/applications/CoSimulationApplication/tests/fem_fem/small_2d_plate/ProjectParametersB.json
+++ b/applications/CoSimulationApplication/tests/fem_fem/small_2d_plate/ProjectParametersB.json
@@ -22,6 +22,9 @@
         "time_stepping"                      : {
             "time_step" : 1.1
         },
+        "linear_solver_settings"             : {
+            "solver_type" : "LinearSolversApplication.sparse_qr"
+        },
         "line_search"                        : false,
         "convergence_criterion"              : "residual_criterion",
         "displacement_relative_tolerance"    : 0.0001,


### PR DESCRIPTION
**Description**
@peterjwilson for some reason some solvers give problems in the CI (see #6900), hence we decided to use the `sparse_qr` solver

this should be the final step for making the CoSim tests work again in the CI
