### PR TITLE
[CI][Fix] Disabling include mmg

### DIFF
--- a/.github/workflows/configure.sh
+++ b/.github/workflows/configure.sh
@@ -68,7 +68,7 @@ ${KRATOS_CMAKE_OPTIONS_FLAGS} \
 -DBLAS_LIBRARIES="/usr/lib/x86_64-linux-gnu/blas/libblas.so.3" \
 -DLAPACK_LIBRARIES="/usr/lib/x86_64-linux-gnu/liblapack.so.3" \
 -DUSE_COTIRE=ON \
--DINCLUDE_MMG=ON                                    \
+-DINCLUDE_MMG=OFF                                    \
 -DMMG_ROOT="/usr/local/"                            \
 
 # Buid


### PR DESCRIPTION
**Description**
Temporary fix. Im quite sure the problem is that there are libraries being written in /usr/local + the one on /external_libraries.

I suggest to disable mmg, remove the /usr/local installation and enable mmg again. 

