### PR TITLE
[CI] Remove env variables from dockerfile and compile mmg in custom folder

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -1,7 +1,7 @@
 FROM ubuntu:focal
 
 ENV HOME /root
-ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/external_libraries/mmg/mmg_5_5_1/lib:/external_libraries/ParMmg_4d272bb/lib
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/external_libraries/mmg/mmg_5_4_1/lib:/external_libraries/mmg/mmg_5_5_1/lib:/external_libraries/ParMmg_4d272bb/lib
 
 RUN apt-get update -y && apt-get upgrade -y && \
     apt-get -y install \
@@ -48,13 +48,22 @@ RUN apt-get update -y && apt-get upgrade -y && \
     pip3 install \
         numpy \
         scipy && \
-    # install MMG 5.4
+    # install MMG 5.4 (on /usr/local to be removed)
     git clone -b 'v5.4.1' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg && \
     mkdir /tmp/mmg/build && \
     cd /tmp/mmg/build && \
     cmake .. -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make install && \
     rm -r /tmp/mmg && \
+    cd / && \
+    # install MMG 5.4
+    git clone -b 'v5.4.1' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg_5_4_1 && \
+    mkdir /tmp/mmg_5_4_1/build && \
+    mkdir -p /external_libraries/mmg/mmg_5_4_1 && \
+    cd /tmp/mmg_5_4_1/build && \
+    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_4_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+    make install && \
+    rm -r /tmp/mmg_5_4_1 && \
     cd / && \
     # install MMG 5.5
     git clone -b 'v5.5.1' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg_5_5_1 && \

--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -1,7 +1,6 @@
 FROM ubuntu:focal
 
 ENV HOME /root
-ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/external_libraries/mmg/mmg_5_4_1/lib:/external_libraries/mmg/mmg_5_5_1/lib:/external_libraries/ParMmg_4d272bb/lib
 
 RUN apt-get update -y && apt-get upgrade -y && \
     apt-get -y install \
@@ -48,14 +47,6 @@ RUN apt-get update -y && apt-get upgrade -y && \
     pip3 install \
         numpy \
         scipy && \
-    # install MMG 5.4 (on /usr/local to be removed)
-    git clone -b 'v5.4.1' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg && \
-    mkdir /tmp/mmg/build && \
-    cd /tmp/mmg/build && \
-    cmake .. -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
-    make install && \
-    rm -r /tmp/mmg && \
-    cd / && \
     # install MMG 5.4
     git clone -b 'v5.4.1' --depth 1 https://github.com/MmgTools/mmg /tmp/mmg_5_4_1 && \
     mkdir /tmp/mmg_5_4_1/build && \


### PR DESCRIPTION
**Description**
This compiles MMG v5.4 in a custom folder.

I also remove the env variables from this file. If we want to keep two versions, there will be conflicts if boths paths are added to LD_LIBRARY_PATH.

To avoid conflicts (and unless there is another possibility), ENV variable will have to be assigned on each action:

https://github.com/KratosMultiphysics/Kratos/blob/6481b333821b77c680ceeeb4cdc11815fdbbf9a5/.github/workflows/ci.yml#L69-L74

with these lines

```
if [ ${{ matrix.compiler }} = gcc ]; then
    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/external_libraries/mmg/mmg_5_5_1/lib
elif [ ${{ matrix.compiler }} = clang ]; then
    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/external_libraries/mmg/mmg_5_4_1/lib
```

**Changelog**
- Remove env variables on docker file to avoid conflicts with different versions of the same library.
- Avoid compiling in /usr/local
