### PR TITLE
[CI] Avoid scotch on mmg installations

### DIFF
--- a/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
+++ b/scripts/docker_files/docker_file_ci_ubuntu_20_04/DockerFile
@@ -1,6 +1,7 @@
 FROM ubuntu:focal
 
 ENV HOME /root
+ENV LD_LIBRARY_PATH ${LD_LIBRARY_PATH}:/external_libraries/mmg/mmg_5_4_1/lib:/external_libraries/mmg/mmg_5_5_1/lib:/external_libraries/ParMmg_4d272bb/lib
 
 RUN apt-get update -y && apt-get upgrade -y && \
     apt-get -y install \
@@ -61,7 +62,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
     mkdir /tmp/mmg_5_5_1/build && \
     mkdir -p /external_libraries/mmg/mmg_5_5_1 && \
     cd /tmp/mmg_5_5_1/build && \
-    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
+    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/mmg/mmg_5_5_1" -DUSE_SCOTCH=OFF -DLIBMMG3D_SHARED=ON -DLIBMMG2D_SHARED=ON -DLIBMMGS_SHARED=ON -DLIBMMG_SHARED=ON && \
     make install && \
     cd / && \
     # install PARMMG
@@ -69,7 +70,7 @@ RUN apt-get update -y && apt-get upgrade -y && \
     mkdir /tmp/ParMmg_4d272bb/build && \
     mkdir -p /external_libraries/ParMmg_4d272bb && \
     cd /tmp/ParMmg_4d272bb/build && git checkout 4d272bb3d1a51d839a5fdfaa3eef93f340cafda3 && \
-    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_4d272bb" -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_1" -DMMG_BUILDDIR="/tmp/mmg_5_5_1/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
+    cmake .. -DCMAKE_INSTALL_PREFIX="/external_libraries/ParMmg_4d272bb" -DUSE_SCOTCH=OFF -DLIBPARMMG_SHARED=ON -DDOWNLOAD_MMG=OFF -DMMG_DIR="/tmp/mmg_5_5_1" -DMMG_BUILDDIR="/tmp/mmg_5_5_1/build" -DDOWNLOAD_METIS=OFF -DMETIS_DIR="/usr/include" && \
     make install && \
     rm -r /tmp/mmg_5_5_1 && \
     rm -r /tmp/ParMmg_4d272bb && \


### PR DESCRIPTION
**Description**
Scotch was enabled by default on v5.5 which was causing our tests to fail. 

Also, I tested (on the docker) having all libs paths in the ENV variable and there was no issue so I am putting all here.

In any case, since MMG tests are disabled this _should not_ block our CI again until we enable MMG tests again. 
**Changelog**
- Adding ENV variable on container
- Disabling scotch on MMG installations 