### PR TITLE
[Mapper] add option for user specified row sum tolerance

### DIFF
--- a/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.cpp
+++ b/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.cpp
@@ -225,7 +225,8 @@ void CouplingGeometryMapper<TSparseSpace, TDenseSpace>::InitializeInterface(Krat
     // Check row sum of pre-computed mapping matrices only
     if (precompute_mapping_matrix || dual_mortar) {
         const std::string base_file_name = "O_" + mrModelPartOrigin.Name() + "__D_" + mrModelPartDestination.Name() + ".mm";
-        MappingMatrixUtilities::CheckRowSum<TSparseSpace, TDenseSpace>(*mpMappingMatrix, base_file_name, true);
+        const double row_sum_tolerance = mMapperSettings["row_sum_tolerance"].GetDouble();
+        MappingMatrixUtilities::CheckRowSum<TSparseSpace, TDenseSpace>(*mpMappingMatrix, base_file_name, true, row_sum_tolerance);
     }
 }
 

--- a/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.h
+++ b/applications/MappingApplication/custom_mappers/coupling_geometry_mapper.h
@@ -323,6 +323,7 @@ private:
             "modeler_name"                  : "UNSPECIFIED",
             "modeler_parameters"            : {},
             "consistency_scaling"           : true,
+            "row_sum_tolerance"             : 1e-12,
             "linear_solver_settings"        : {}
         })");
     }

--- a/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
+++ b/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.cpp
@@ -144,7 +144,8 @@ template<>
 void CheckRowSum<SparseSpaceType, DenseSpaceType>(
     const typename SparseSpaceType::MatrixType& rM,
     const std::string& rBaseFileName,
-    const bool ThrowError)
+    const bool ThrowError,
+    const double Tolerance)
 {
     SparseSpaceType::VectorType unit_vector(SparseSpaceType::Size2(rM));
     SparseSpaceType::Set(unit_vector, 1.0);
@@ -155,7 +156,7 @@ void CheckRowSum<SparseSpaceType, DenseSpaceType>(
 
     bool write_mm_file = false;
     for (std::size_t i = 0; i < SparseSpaceType::Size(row_sums_vector); ++i) {
-        if (std::abs(row_sums_vector[i] - 1.0) > 1e-15) {
+        if (std::abs(row_sums_vector[i] - 1.0) > Tolerance) {
             KRATOS_WARNING("MappingMatrixAssembly") << "The row sum in row " << i << " is unequal 1.0: " << row_sums_vector[i] << std::endl;
             write_mm_file = true;
         }

--- a/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.h
+++ b/applications/MappingApplication/custom_utilities/mapping_matrix_utilities.h
@@ -48,7 +48,8 @@ template<class TSparseSpace, class TDenseSpace>
 void KRATOS_API(MAPPING_APPLICATION) CheckRowSum(
     const typename TSparseSpace::MatrixType& rM,
     const std::string& rBaseFileName,
-    const bool ThrowError = false);
+    const bool ThrowError = false,
+    const double Tolerance = 1e-15);
 
 }  // namespace MappinMatrixUtilities.
 


### PR DESCRIPTION
**Description**
Adds the option to specify a row sum tolerance for the mapper utils row_sum_check function. Since the coupling geoms mapper relies on point searches and shape function calcs, which all have their own tolerances, the original 1e-15 tol was probably too strict. This gives some flexibility to the user.
