### PR TITLE
[FluidDynamics] Slip process use generic algo for normals

### DIFF
--- a/applications/FluidDynamicsApplication/python_scripts/apply_slip_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_slip_process.py
@@ -51,11 +51,11 @@ class ApplySlipProcess(KratosMultiphysics.Process):
     def ExecuteInitialize(self):
         # Compute the normal on the nodes of interest -
         # Note that the model part employed here is supposed to only have slip "conditions"
-        consider_unit_normal = True
-        KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, consider_unit_normal)
+        enforce_generic_algorithm = True
+        KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, enforce_generic_algorithm)
 
     def ExecuteInitializeSolutionStep(self):
         # Recompute the normals if needed
         if self.avoid_recomputing_normals == False:
-            consider_unit_normal = True
-            KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, consider_unit_normal)
+            enforce_generic_algorithm = True
+            KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, enforce_generic_algorithm)

--- a/applications/FluidDynamicsApplication/python_scripts/apply_slip_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_slip_process.py
@@ -56,4 +56,5 @@ class ApplySlipProcess(KratosMultiphysics.Process):
     def ExecuteInitializeSolutionStep(self):
         # Recompute the normals if needed
         if self.avoid_recomputing_normals == False:
-            KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, True)
+            consider_unit_normal = True
+            KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, consider_unit_normal)

--- a/applications/FluidDynamicsApplication/python_scripts/apply_slip_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_slip_process.py
@@ -51,7 +51,8 @@ class ApplySlipProcess(KratosMultiphysics.Process):
     def ExecuteInitialize(self):
         # Compute the normal on the nodes of interest -
         # Note that the model part employed here is supposed to only have slip "conditions"
-        KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, True)
+        consider_unit_normal = True
+        KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, consider_unit_normal)
 
     def ExecuteInitializeSolutionStep(self):
         # Recompute the normals if needed

--- a/applications/FluidDynamicsApplication/python_scripts/apply_slip_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_slip_process.py
@@ -51,9 +51,11 @@ class ApplySlipProcess(KratosMultiphysics.Process):
     def ExecuteInitialize(self):
         # Compute the normal on the nodes of interest -
         # Note that the model part employed here is supposed to only have slip "conditions"
-        KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, True)
+        consider_unit_normal = True
+        KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, consider_unit_normal)
 
     def ExecuteInitializeSolutionStep(self):
         # Recompute the normals if needed
+        consider_unit_normal = True
         if self.avoid_recomputing_normals == False:
-            KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, True)
+            KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, consider_unit_normal)

--- a/applications/FluidDynamicsApplication/python_scripts/apply_slip_process.py
+++ b/applications/FluidDynamicsApplication/python_scripts/apply_slip_process.py
@@ -51,9 +51,9 @@ class ApplySlipProcess(KratosMultiphysics.Process):
     def ExecuteInitialize(self):
         # Compute the normal on the nodes of interest -
         # Note that the model part employed here is supposed to only have slip "conditions"
-        KratosMultiphysics.NormalCalculationUtils().CalculateOnSimplex(self.model_part, self.model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE])
+        KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, True)
 
     def ExecuteInitializeSolutionStep(self):
         # Recompute the normals if needed
         if self.avoid_recomputing_normals == False:
-            KratosMultiphysics.NormalCalculationUtils().CalculateOnSimplex(self.model_part, self.model_part.ProcessInfo[KratosMultiphysics.DOMAIN_SIZE])
+            KratosMultiphysics.NormalCalculationUtils().CalculateNormals(self.model_part, True)


### PR DESCRIPTION
Use the generic algorithm for normal computation. This is to enable the use of the slip process on quads.


@rubenzorrilla @ddiezrod @KratosMultiphysics/altair 
