### PR TITLE
[Core] Additional Remove KRATOS_ERRORs to allow for mixed dimension couplings (eg. point on a line)

### DIFF
--- a/kratos/geometries/coupling_geometry.h
+++ b/kratos/geometries/coupling_geometry.h
@@ -76,9 +76,6 @@ public:
         GeometryPointer pSlaveGeometry)
         : BaseType(PointsArrayType(), &(pMasterGeometry->GetGeometryData()))
     {
-        KRATOS_DEBUG_ERROR_IF(pMasterGeometry->Dimension() != pSlaveGeometry->Dimension())
-            << "Geometries of different dimensional size!" << std::endl;
-
         mpGeometries.resize(2);
 
         mpGeometries[0] = pMasterGeometry;


### PR DESCRIPTION
**Description**
Refer #7784 which missed a KRATOS_ERROR to be removed - captured in this PR.