### PR TITLE
[FastPR][PotFlow] Const check warnings

### DIFF
--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.cpp
@@ -132,7 +132,7 @@ ModifiedShapeFunctions::Pointer EmbeddedCompressiblePotentialFlowElement<3,4>::p
 // Inquiry
 
 template <int Dim, int NumNodes>
-int EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::Check(const ProcessInfo& rCurrentProcessInfo)
+int EmbeddedCompressiblePotentialFlowElement<Dim, NumNodes>::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_compressible_potential_flow_element.h
@@ -115,7 +115,7 @@ public:
                               VectorType& rRightHandSideVector,
                               const ProcessInfo& rCurrentProcessInfo) override;
 
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
     /// Turn back information as a string.
     std::string Info() const override;
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.cpp
@@ -218,7 +218,7 @@ ModifiedShapeFunctions::Pointer EmbeddedIncompressiblePotentialFlowElement<3,4>:
 // Inquiry
 
 template <int Dim, int NumNodes>
-int EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Check(const ProcessInfo& rCurrentProcessInfo)
+int EmbeddedIncompressiblePotentialFlowElement<Dim, NumNodes>::Check(const ProcessInfo& rCurrentProcessInfo) const
 {
     KRATOS_TRY
 

--- a/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.h
+++ b/applications/CompressiblePotentialFlowApplication/custom_elements/embedded_incompressible_potential_flow_element.h
@@ -115,7 +115,7 @@ public:
                               VectorType& rRightHandSideVector,
                               const ProcessInfo& rCurrentProcessInfo) override;
 
-    int Check(const ProcessInfo& rCurrentProcessInfo) override;
+    int Check(const ProcessInfo& rCurrentProcessInfo) const override;
     /// Turn back information as a string.
     std::string Info() const override;
 


### PR DESCRIPTION
**Description**
Remove `Check` const-warnings

Please mark the PR with appropriate tags: 
- Applications
- Warning
- FastPR

**Changelog**
- Add `const` version of `Check` method.
