### PR TITLE
[FastPR][Fluid] Remove ExternalSolversApplication leftovers

### DIFF
--- a/applications/FluidDynamicsApplication/tests/EmbeddedCouette2DTest/EmbeddedAusasCouette2DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedCouette2DTest/EmbeddedAusasCouette2DTestParameters.json
@@ -58,7 +58,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu",
+            "solver_type"         : "LinearSolversApplication.sparse_lu",
             "verbosity"           : 0
         },
         "volume_model_part_name"       : "Parts_Fluid",

--- a/applications/FluidDynamicsApplication/tests/EmbeddedCouette2DTest/EmbeddedAusasDevelopmentCouette2DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedCouette2DTest/EmbeddedAusasDevelopmentCouette2DTestParameters.json
@@ -58,7 +58,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu",
+            "solver_type"         : "LinearSolversApplication.sparse_lu",
             "verbosity"           : 0
         },
         "volume_model_part_name"       : "Parts_Fluid",

--- a/applications/FluidDynamicsApplication/tests/EmbeddedCouette2DTest/EmbeddedCouette2DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedCouette2DTest/EmbeddedCouette2DTestParameters.json
@@ -58,7 +58,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu",
+            "solver_type"         : "LinearSolversApplication.sparse_lu",
             "verbosity"           : 0
         },
         "volume_model_part_name"       : "Parts_Fluid",

--- a/applications/FluidDynamicsApplication/tests/EmbeddedCouette2DTest/EmbeddedDevelopmentCouette2DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedCouette2DTest/EmbeddedDevelopmentCouette2DTestParameters.json
@@ -58,7 +58,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu",
+            "solver_type"         : "LinearSolversApplication.sparse_lu",
             "verbosity"           : 0
         },
         "volume_model_part_name"       : "Parts_Fluid",

--- a/applications/FluidDynamicsApplication/tests/EmbeddedCouette3DTest/EmbeddedAusasCouette3DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedCouette3DTest/EmbeddedAusasCouette3DTestParameters.json
@@ -58,7 +58,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type": "ExternalSolversApplication.super_lu",
+            "solver_type": "LinearSolversApplication.sparse_lu",
             "verbosity": 0
         },
         "volume_model_part_name"       : "Parts_Fluid",

--- a/applications/FluidDynamicsApplication/tests/EmbeddedCouette3DTest/EmbeddedAusasDevelopmentCouette3DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedCouette3DTest/EmbeddedAusasDevelopmentCouette3DTestParameters.json
@@ -58,7 +58,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type": "ExternalSolversApplication.super_lu",
+            "solver_type": "LinearSolversApplication.sparse_lu",
             "verbosity": 0
         },
         "volume_model_part_name"       : "Parts_Fluid",

--- a/applications/FluidDynamicsApplication/tests/EmbeddedCouette3DTest/EmbeddedCouette3DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedCouette3DTest/EmbeddedCouette3DTestParameters.json
@@ -58,7 +58,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type": "ExternalSolversApplication.super_lu",
+            "solver_type": "LinearSolversApplication.sparse_lu",
             "verbosity": 0
         },
         "volume_model_part_name"       : "Parts_Fluid",

--- a/applications/FluidDynamicsApplication/tests/EmbeddedCouette3DTest/EmbeddedDevelopmentCouette3DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedCouette3DTest/EmbeddedDevelopmentCouette3DTestParameters.json
@@ -58,7 +58,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type": "ExternalSolversApplication.super_lu",
+            "solver_type": "LinearSolversApplication.sparse_lu",
             "verbosity": 0
         },
         "volume_model_part_name"       : "Parts_Fluid",

--- a/applications/FluidDynamicsApplication/tests/EmbeddedCouetteImposed2DTest/EmbeddedCouetteImposed2DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedCouetteImposed2DTest/EmbeddedCouetteImposed2DTestParameters.json
@@ -55,7 +55,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu"
+            "solver_type"         : "LinearSolversApplication.sparse_lu"
         },
         "volume_model_part_name"       : "Parts_Fluid",
         "skin_parts"                   : ["Inlet","Outlet2D","Top2D","Bottom2D"],

--- a/applications/FluidDynamicsApplication/tests/EmbeddedCouetteImposed3DTest/EmbeddedCouetteImposed3DTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedCouetteImposed3DTest/EmbeddedCouetteImposed3DTestParameters.json
@@ -55,7 +55,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu"
+            "solver_type"         : "LinearSolversApplication.sparse_lu"
         },
         "volume_model_part_name"       : "Parts_Fluid",
         "skin_parts"                   : ["Inlet","Outlet3D","Sides3D","Bot3D"],

--- a/applications/FluidDynamicsApplication/tests/EmbeddedReservoirTest/EmbeddedReservoir2DTest_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedReservoirTest/EmbeddedReservoir2DTest_parameters.json
@@ -49,7 +49,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu"
+            "solver_type"         : "LinearSolversApplication.sparse_lu"
         },
         "volume_model_part_name"       : "Parts_Fluid",
         "skin_parts"                   : ["Outlet2D","NoSlip2D"],

--- a/applications/FluidDynamicsApplication/tests/EmbeddedReservoirTest/EmbeddedReservoir3DTest_parameters.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedReservoirTest/EmbeddedReservoir3DTest_parameters.json
@@ -49,7 +49,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu"
+            "solver_type"         : "LinearSolversApplication.sparse_lu"
         },
         "volume_model_part_name"       : "Parts_Fluid",
         "skin_parts"                   : ["Outlet3D","NoSlip3D"],

--- a/applications/FluidDynamicsApplication/tests/EmbeddedVelocityInletEmulationTest/EmbeddedVelocityInletEmulationTest.json
+++ b/applications/FluidDynamicsApplication/tests/EmbeddedVelocityInletEmulationTest/EmbeddedVelocityInletEmulationTest.json
@@ -36,7 +36,7 @@
         "formulation"                 : {
         },
         "linear_solver_settings": {
-            "solver_type": "ExternalSolversApplication.super_lu"
+            "solver_type": "LinearSolversApplication.sparse_lu"
         }
     },
     "processes"        : {

--- a/applications/FluidDynamicsApplication/tests/ManufacturedSolutionTest/ManufacturedSolutionTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/ManufacturedSolutionTest/ManufacturedSolutionTestParameters.json
@@ -51,7 +51,7 @@
         "relative_pressure_tolerance"  : 1e-5,
         "absolute_pressure_tolerance"  : 1e-7,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu"
+            "solver_type"         : "LinearSolversApplication.sparse_lu"
         },
         "volume_model_part_name"       : "Parts_Fluid",
         "skin_parts"                   : ["Inlet2D_Contour"],

--- a/applications/FluidDynamicsApplication/tests/NavierStokesWallConditionTest/NavierStokesWallConditionTestParameters.json
+++ b/applications/FluidDynamicsApplication/tests/NavierStokesWallConditionTest/NavierStokesWallConditionTestParameters.json
@@ -50,7 +50,7 @@
         "relative_pressure_tolerance"  : 1e-3,
         "absolute_pressure_tolerance"  : 1e-5,
         "linear_solver_settings"       : {
-            "solver_type"         : "ExternalSolversApplication.super_lu"
+            "solver_type"         : "LinearSolversApplication.sparse_lu"
         },
         "volume_model_part_name"       : "Parts_Fluid",
         "skin_parts"                   : ["Outlet2D_Inlet","Outlet2D_Outlet","Slip2D_Slip","NoSlip2D_NoSlip"],

--- a/applications/FluidDynamicsApplication/tests/TwoFluidStaticPoolTest/TwoFluidStaticPoolTest2D.json
+++ b/applications/FluidDynamicsApplication/tests/TwoFluidStaticPoolTest/TwoFluidStaticPoolTest2D.json
@@ -32,7 +32,7 @@
             "time_step"           : 0.01
         },
         "linear_solver_settings" : {
-            "solver_type" : "ExternalSolversApplication.super_lu",
+            "solver_type" : "LinearSolversApplication.sparse_lu",
             "smoother_type" :"damped_jacobi",
             "krylov_type" : "lgmres",
             "coarsening_type" : "aggregation",

--- a/applications/FluidDynamicsApplication/tests/TwoFluidStaticPoolTest/TwoFluidStaticPoolTest3D.json
+++ b/applications/FluidDynamicsApplication/tests/TwoFluidStaticPoolTest/TwoFluidStaticPoolTest3D.json
@@ -32,7 +32,7 @@
             "time_step"           : 0.01
         },
         "linear_solver_settings" : {
-            "solver_type" : "ExternalSolversApplication.super_lu",
+            "solver_type" : "LinearSolversApplication.sparse_lu",
             "smoother_type" : "damped_jacobi",
             "krylov_type" : "lgmres",
             "coarsening_type" : "aggregation",

--- a/applications/FluidDynamicsApplication/tests/adjoint_fluid_test.py
+++ b/applications/FluidDynamicsApplication/tests/adjoint_fluid_test.py
@@ -1,7 +1,6 @@
 import KratosMultiphysics as km
 
 import KratosMultiphysics.kratos_utilities as kratos_utilities
-hdf5_is_available = kratos_utilities.CheckIfApplicationsAvailable("HDF5Application")
 
 from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
 from KratosMultiphysics.FluidDynamicsApplication.adjoint_fluid_analysis import AdjointFluidAnalysis
@@ -10,7 +9,7 @@ import KratosMultiphysics.KratosUnittest as UnitTest
 
 import os
 
-@UnitTest.skipIf(not hdf5_is_available, "HDF5Application is not available")
+@UnitTest.skipIfApplicationsNotAvailable("HDF5Application")
 class AdjointFluidTest(UnitTest.TestCase):
 
     def setUp(self):

--- a/applications/FluidDynamicsApplication/tests/adjoint_fluid_test.py
+++ b/applications/FluidDynamicsApplication/tests/adjoint_fluid_test.py
@@ -10,7 +10,7 @@ import KratosMultiphysics.KratosUnittest as UnitTest
 
 import os
 
-@UnitTest.skipUnless(hdf5_is_available, "HDF5Application is not available")
+@KratosUnittest.skipIf(not hdf5_is_available, "HDF5Application is not available")
 class AdjointFluidTest(UnitTest.TestCase):
 
     def setUp(self):

--- a/applications/FluidDynamicsApplication/tests/adjoint_fluid_test.py
+++ b/applications/FluidDynamicsApplication/tests/adjoint_fluid_test.py
@@ -10,7 +10,7 @@ import KratosMultiphysics.KratosUnittest as UnitTest
 
 import os
 
-@KratosUnittest.skipIf(not hdf5_is_available, "HDF5Application is not available")
+@UnitTest.skipIf(not hdf5_is_available, "HDF5Application is not available")
 class AdjointFluidTest(UnitTest.TestCase):
 
     def setUp(self):

--- a/applications/FluidDynamicsApplication/tests/buoyancy_test.py
+++ b/applications/FluidDynamicsApplication/tests/buoyancy_test.py
@@ -10,7 +10,7 @@ if have_convection_diffusion:
 
 import KratosMultiphysics.FluidDynamicsApplication.navier_stokes_solver_vmsmonolithic as navier_stokes_solver
 
-@KratosUnittest.skipIf(not have_convection_diffusion,"Missing required application: ConvectionDiffusionApplication")
+@UnitTest.skipIf(not have_convection_diffusion,"Missing required application: ConvectionDiffusionApplication")
 class BuoyancyTest(UnitTest.TestCase):
 
     def setUp(self):

--- a/applications/FluidDynamicsApplication/tests/buoyancy_test.py
+++ b/applications/FluidDynamicsApplication/tests/buoyancy_test.py
@@ -10,7 +10,7 @@ if have_convection_diffusion:
 
 import KratosMultiphysics.FluidDynamicsApplication.navier_stokes_solver_vmsmonolithic as navier_stokes_solver
 
-@UnitTest.skipIf(not have_convection_diffusion,"Missing required application: ConvectionDiffusionApplication")
+@UnitTest.skipIfApplicationsNotAvailable("ConvectionDiffusionApplication")
 class BuoyancyTest(UnitTest.TestCase):
 
     def setUp(self):

--- a/applications/FluidDynamicsApplication/tests/buoyancy_test.py
+++ b/applications/FluidDynamicsApplication/tests/buoyancy_test.py
@@ -10,7 +10,7 @@ if have_convection_diffusion:
 
 import KratosMultiphysics.FluidDynamicsApplication.navier_stokes_solver_vmsmonolithic as navier_stokes_solver
 
-@UnitTest.skipUnless(have_convection_diffusion,"Missing required application: ConvectionDiffusionApplication")
+@KratosUnittest.skipIf(not have_convection_diffusion,"Missing required application: ConvectionDiffusionApplication")
 class BuoyancyTest(UnitTest.TestCase):
 
     def setUp(self):

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
@@ -8,7 +8,7 @@ from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_f
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@UnitTest.skipUnless(have_external_solvers,"Missing required application: LinearSolversApplication")
+@KratosUnittest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedCouetteImposedTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
@@ -6,9 +6,9 @@ import KratosMultiphysics.kratos_utilities as KratosUtilities
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_fluid
 
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
+have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
+@UnitTest.skipUnless(have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedCouetteImposedTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
@@ -8,7 +8,7 @@ from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_f
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@KratosUnittest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
+@UnitTest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedCouetteImposedTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_imposed_test.py
@@ -6,9 +6,7 @@ import KratosMultiphysics.kratos_utilities as KratosUtilities
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_fluid
 
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
-
-@UnitTest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
+@UnitTest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class EmbeddedCouetteImposedTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
@@ -6,9 +6,7 @@ from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_f
 
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
-
-@UnitTest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
+@UnitTest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class EmbeddedCouetteTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
@@ -8,7 +8,7 @@ import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@KratosUnittest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
+@UnitTest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedCouetteTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
@@ -6,9 +6,9 @@ from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_f
 
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
+have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
+@UnitTest.skipUnless(have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedCouetteTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_couette_test.py
@@ -8,7 +8,7 @@ import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@UnitTest.skipUnless(have_external_solvers,"Missing required application: LinearSolversApplication")
+@KratosUnittest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedCouetteTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_piston_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_piston_test.py
@@ -85,8 +85,7 @@ class CustomFluidDynamicsAnalysis(FluidDynamicsAnalysis):
         if self.print_output:
             super(CustomFluidDynamicsAnalysis,self).OutputSolutionStep()
 
-
-@UnitTest.skipIf(not have_mesh_moving,"Missing required application: MeshMovingApplication")
+@UnitTest.skipIfApplicationsNotAvailable("MeshMovingApplication")
 class EmbeddedPistonTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_piston_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_piston_test.py
@@ -86,7 +86,7 @@ class CustomFluidDynamicsAnalysis(FluidDynamicsAnalysis):
             super(CustomFluidDynamicsAnalysis,self).OutputSolutionStep()
 
 
-@UnitTest.skipUnless(have_mesh_moving,"Missing required application: MeshMovingApplication")
+@KratosUnittest.skipIf(not have_mesh_moving,"Missing required application: MeshMovingApplication")
 class EmbeddedPistonTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_piston_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_piston_test.py
@@ -86,7 +86,7 @@ class CustomFluidDynamicsAnalysis(FluidDynamicsAnalysis):
             super(CustomFluidDynamicsAnalysis,self).OutputSolutionStep()
 
 
-@KratosUnittest.skipIf(not have_mesh_moving,"Missing required application: MeshMovingApplication")
+@UnitTest.skipIf(not have_mesh_moving,"Missing required application: MeshMovingApplication")
 class EmbeddedPistonTest(UnitTest.TestCase):
 
     # Embedded element tests

--- a/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
@@ -6,9 +6,7 @@ import KratosMultiphysics.kratos_utilities as KratosUtilities
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 import KratosMultiphysics.FluidDynamicsApplication.python_solvers_wrapper_fluid as python_solvers_wrapper_fluid
 
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
-
-@UnitTest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
+@UnitTest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class EmbeddedReservoirTest(UnitTest.TestCase):
     def testEmbeddedReservoir2D(self):
         self.distance = 0.5

--- a/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
@@ -8,7 +8,7 @@ import KratosMultiphysics.FluidDynamicsApplication.python_solvers_wrapper_fluid 
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@UnitTest.skipUnless(have_external_solvers,"Missing required application: LinearSolversApplication")
+@KratosUnittest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedReservoirTest(UnitTest.TestCase):
     def testEmbeddedReservoir2D(self):
         self.distance = 0.5

--- a/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
@@ -8,7 +8,7 @@ import KratosMultiphysics.FluidDynamicsApplication.python_solvers_wrapper_fluid 
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@KratosUnittest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
+@UnitTest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedReservoirTest(UnitTest.TestCase):
     def testEmbeddedReservoir2D(self):
         self.distance = 0.5

--- a/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_reservoir_test.py
@@ -6,9 +6,9 @@ import KratosMultiphysics.kratos_utilities as KratosUtilities
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 import KratosMultiphysics.FluidDynamicsApplication.python_solvers_wrapper_fluid as python_solvers_wrapper_fluid
 
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
+have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
+@UnitTest.skipUnless(have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedReservoirTest(UnitTest.TestCase):
     def testEmbeddedReservoir2D(self):
         self.distance = 0.5

--- a/applications/FluidDynamicsApplication/tests/embedded_velocity_inlet_emulation_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_velocity_inlet_emulation_test.py
@@ -1,14 +1,14 @@
 import KratosMultiphysics
 import KratosMultiphysics.FluidDynamicsApplication
 import KratosMultiphysics.kratos_utilities as KratosUtilities
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
+have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
 import sys
 import KratosMultiphysics.KratosUnittest as UnitTest
 
 from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
 
-@UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
+@UnitTest.skipUnless(have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedVelocityInletEmulationTest(UnitTest.TestCase):
     def testEmbeddedVelocityInletEmulationSymbolic2D(self):
         self.print_output = False

--- a/applications/FluidDynamicsApplication/tests/embedded_velocity_inlet_emulation_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_velocity_inlet_emulation_test.py
@@ -8,7 +8,7 @@ import KratosMultiphysics.KratosUnittest as UnitTest
 
 from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
 
-@KratosUnittest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
+@UnitTest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedVelocityInletEmulationTest(UnitTest.TestCase):
     def testEmbeddedVelocityInletEmulationSymbolic2D(self):
         self.print_output = False

--- a/applications/FluidDynamicsApplication/tests/embedded_velocity_inlet_emulation_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_velocity_inlet_emulation_test.py
@@ -1,14 +1,13 @@
 import KratosMultiphysics
 import KratosMultiphysics.FluidDynamicsApplication
 import KratosMultiphysics.kratos_utilities as KratosUtilities
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
 import sys
 import KratosMultiphysics.KratosUnittest as UnitTest
 
 from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
 
-@UnitTest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
+@UnitTest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class EmbeddedVelocityInletEmulationTest(UnitTest.TestCase):
     def testEmbeddedVelocityInletEmulationSymbolic2D(self):
         self.print_output = False

--- a/applications/FluidDynamicsApplication/tests/embedded_velocity_inlet_emulation_test.py
+++ b/applications/FluidDynamicsApplication/tests/embedded_velocity_inlet_emulation_test.py
@@ -8,7 +8,7 @@ import KratosMultiphysics.KratosUnittest as UnitTest
 
 from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import FluidDynamicsAnalysis
 
-@UnitTest.skipUnless(have_external_solvers,"Missing required application: LinearSolversApplication")
+@KratosUnittest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
 class EmbeddedVelocityInletEmulationTest(UnitTest.TestCase):
     def testEmbeddedVelocityInletEmulationSymbolic2D(self):
         self.print_output = False

--- a/applications/FluidDynamicsApplication/tests/manufactured_solution_test.py
+++ b/applications/FluidDynamicsApplication/tests/manufactured_solution_test.py
@@ -10,9 +10,9 @@ import KratosMultiphysics.kratos_utilities as KratosUtilities
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_fluid
 
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
+have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@KratosUnittest.skipUnless(have_external_solvers, "Missing required application: ExternalSolversApplication")
+@KratosUnittest.skipUnless(have_external_solvers, "Missing required application: LinearSolversApplication")
 class ManufacturedSolutionTest(KratosUnittest.TestCase):
     def testManufacturedSolution(self):
         self.runTest()

--- a/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
+++ b/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
@@ -8,7 +8,7 @@ import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@UnitTest.skipUnless(have_external_solvers,"Missing required application: LinearSolversApplication")
+@KratosUnittest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
 class NavierStokesWallConditionTest(UnitTest.TestCase):
     def testNavierStokesWallCondition(self):
         self.setUp()

--- a/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
+++ b/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
@@ -6,9 +6,7 @@ from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_f
 
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
-
-@UnitTest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
+@UnitTest.skipIfApplicationsNotAvailable("LinearSolversApplication")
 class NavierStokesWallConditionTest(UnitTest.TestCase):
     def testNavierStokesWallCondition(self):
         self.setUp()

--- a/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
+++ b/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
@@ -8,7 +8,7 @@ import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
 have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@KratosUnittest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
+@UnitTest.skipIf(not have_external_solvers,"Missing required application: LinearSolversApplication")
 class NavierStokesWallConditionTest(UnitTest.TestCase):
     def testNavierStokesWallCondition(self):
         self.setUp()

--- a/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
+++ b/applications/FluidDynamicsApplication/tests/navier_stokes_wall_condition_test.py
@@ -6,9 +6,9 @@ from KratosMultiphysics.FluidDynamicsApplication import python_solvers_wrapper_f
 
 import KratosMultiphysics.FluidDynamicsApplication as KratosFluid
 
-have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("ExternalSolversApplication")
+have_external_solvers = KratosUtilities.CheckIfApplicationsAvailable("LinearSolversApplication")
 
-@UnitTest.skipUnless(have_external_solvers,"Missing required application: ExternalSolversApplication")
+@UnitTest.skipUnless(have_external_solvers,"Missing required application: LinearSolversApplication")
 class NavierStokesWallConditionTest(UnitTest.TestCase):
     def testNavierStokesWallCondition(self):
         self.setUp()

--- a/applications/FluidDynamicsApplication/tests/two_fluid_hydrostatic_pool_test.py
+++ b/applications/FluidDynamicsApplication/tests/two_fluid_hydrostatic_pool_test.py
@@ -6,7 +6,7 @@ from fluid_dynamics_analysis import FluidDynamicsAnalysis
 import KratosMultiphysics.kratos_utilities as kratos_utils
 
 try:
-    import KratosMultiphysics.ExternalSolversApplication
+    import KratosMultiphysics.LinearSolversApplication
     have_external_solvers = True
 except ImportError as e:
     have_external_solvers = False

--- a/applications/FluidDynamicsApplication/tests/two_fluid_mass_conservation_test.py
+++ b/applications/FluidDynamicsApplication/tests/two_fluid_mass_conservation_test.py
@@ -6,7 +6,7 @@ from KratosMultiphysics.FluidDynamicsApplication.fluid_dynamics_analysis import 
 import KratosMultiphysics.kratos_utilities as kratos_utils
 
 try:
-    import KratosMultiphysics.ExternalSolversApplication
+    import KratosMultiphysics.LinearSolversApplication
     have_external_solvers = True
 except ImportError as e:
     have_external_solvers = False


### PR DESCRIPTION
**Description**
There were some tests trying to use the SuperLU from the `ExternalSolversApplication`. As this application is no longer used, the tests were automatically skipped. With this changes they're run again.

Please mark the PR with appropriate tags: 
- Applications
- Testing
- Deprecated
- Legacy

**Changelog**
- Use LU solver from `LinearSolversApplication`.
