### PR TITLE
[FastPR][MeshMoving] FM-ALE iterator copy warning fix

### DIFF
--- a/applications/MeshMovingApplication/custom_utilities/fixed_mesh_ale_utilities.cpp
+++ b/applications/MeshMovingApplication/custom_utilities/fixed_mesh_ale_utilities.cpp
@@ -463,7 +463,7 @@ namespace Kratos
 
         // Check that the moved virtual mesh has no negative Jacobian elements
 #ifdef KRATOS_DEBUG
-        for (const auto it_elem : mrVirtualModelPart.ElementsArray()) {
+        for (const auto& it_elem : mrVirtualModelPart.ElementsArray()) {
             KRATOS_ERROR_IF((it_elem->GetGeometry()).Area() < 0.0) << "Element " << it_elem->Id() << " in virtual model part has negative jacobian." << std::endl;
         }
 #endif


### PR DESCRIPTION
**Description**
Iterator copy warning fix.

Please mark the PR with appropriate tags: 
- Application
- FastPR
- Warning

**Changelog**
- Chance copy by reference in iterator.
