### PR TITLE
[Core] Add compatibility to python 3.5 time_based_ascii_file_writer_utility.py

### DIFF
--- a/kratos/python_scripts/time_based_ascii_file_writer_utility.py
+++ b/kratos/python_scripts/time_based_ascii_file_writer_utility.py
@@ -64,7 +64,7 @@ class TimeBasedAsciiFileWriterUtility:
                 self.file = self.__InitializeOutputFile(file_header)
 
     def __OpenOutputFile(self):
-        return open(self.file_name,"w", buffering=self.write_buffer_size)
+        return open(str(self.file_name),"w", buffering=self.write_buffer_size)
 
     def __InitializeOutputFile(self, file_header):
         output_file = self.__OpenOutputFile()
@@ -76,7 +76,7 @@ class TimeBasedAsciiFileWriterUtility:
             return None
 
         try: # We try to open the file and transfer the info
-            with open(self.file_name,'r') as out_file:
+            with open(str(self.file_name),'r') as out_file:
                 lines_existing_file = out_file.readlines()
 
             # search for time, return false if it was not found


### PR DESCRIPTION
**Description**
Possible solution to #7833 

Taken from: https://stackoverflow.com/questions/42694112/when-using-pathlib-getting-error-typeerror-invalid-file-posixpathexample-t
- Converting to string path object before open()

closes #7833