### PR TITLE
Fix memory tests

### DIFF
--- a/kratos/tests/cpp_tests/sources/test_chunk.cpp
+++ b/kratos/tests/cpp_tests/sources/test_chunk.cpp
@@ -28,22 +28,32 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(ChunkInitialize, KratosCoreFastSuite)
 		{
-			int max_threads = OpenMPUtils::GetNumThreads();
+			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
+
+			std::size_t block_size_in_bytes = 5; // the aligned block size is 8
+			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
+			std::size_t chunk_size_in_bytes = header_size + 1024;
+
+			Chunk chunk(block_size_in_bytes, chunk_size_in_bytes);
+			chunk.Initialize();
+
+			std::size_t block_size_after_alignment = 8;
+			std::size_t available_blocks_should_be = (chunk_size_in_bytes - 2* max_threads * sizeof(Chunk::SizeType)) / block_size_after_alignment;
+			KRATOS_CHECK_EQUAL(chunk.GetNumberOfAvailableBlocks(), available_blocks_should_be) << " Available block :" << chunk.GetNumberOfAvailableBlocks() << " vs " << available_blocks_should_be;
+		}
+
+		KRATOS_TEST_CASE_IN_SUITE(ChunkInitializeSmallBlock, KratosCoreFastSuite)
+		{
+			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
 
 			std::size_t block_size_in_bytes = 5; // the aligned block size is 8
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
 			std::size_t chunk_size_in_bytes = header_size + 5;
+
 			Chunk too_small_chunk(block_size_in_bytes, chunk_size_in_bytes);
 			too_small_chunk.Initialize();
+
 			KRATOS_CHECK_EQUAL(too_small_chunk.GetNumberOfAvailableBlocks(), 0) << " Available block :" << too_small_chunk.GetNumberOfAvailableBlocks();
-
-			chunk_size_in_bytes = header_size + 1024;
-			Chunk chunk(block_size_in_bytes, chunk_size_in_bytes);
-			chunk.Initialize();
-			std::size_t block_size_after_alignment = 8;
-			std::size_t available_blocks_should_be = (chunk_size_in_bytes - 2* max_threads * sizeof(Chunk::SizeType)) / block_size_after_alignment;
-			KRATOS_CHECK_EQUAL(chunk.GetNumberOfAvailableBlocks(), available_blocks_should_be) << " Available block :" << chunk.GetNumberOfAvailableBlocks() << " vs " << available_blocks_should_be;
-
 		}
 
 		KRATOS_TEST_CASE_IN_SUITE(ChunkAllocateDeallocate, KratosCoreFastSuite)

--- a/kratos/tests/cpp_tests/sources/test_chunk.cpp
+++ b/kratos/tests/cpp_tests/sources/test_chunk.cpp
@@ -56,6 +56,47 @@ namespace Kratos {
 			KRATOS_CHECK_EQUAL(too_small_chunk.GetNumberOfAvailableBlocks(), 0) << " Available block :" << too_small_chunk.GetNumberOfAvailableBlocks();
 		}
 
+		KRATOS_TEST_CASE_IN_SUITE(ChunkParallelInitialize, KratosCoreFastSuite)
+		{
+			int max_threads = OpenMPUtils::GetNumThreads();
+
+			std::size_t block_size_in_bytes = 5; // the aligned block size is 8
+			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
+			std::size_t chunk_size_in_bytes = header_size + 1024;
+
+			std::size_t block_size_after_alignment = 8;
+			std::size_t available_blocks_should_be = (chunk_size_in_bytes - 2* max_threads * sizeof(Chunk::SizeType)) / block_size_after_alignment;
+
+			auto repeat_number = 10;
+			#pragma omp parallel for
+			for (auto i_repeat = 0; i_repeat < repeat_number; i_repeat++)
+			{
+				Chunk chunk(block_size_in_bytes, chunk_size_in_bytes);
+				chunk.Initialize();
+
+				KRATOS_CHECK_EQUAL(chunk.GetNumberOfAvailableBlocks(), available_blocks_should_be) << " Available block :" << chunk.GetNumberOfAvailableBlocks() << " vs " << available_blocks_should_be;
+			}
+		}
+
+		KRATOS_TEST_CASE_IN_SUITE(ChunkParallelInitializeSmallBlock, KratosCoreFastSuite)
+		{
+			int max_threads = OpenMPUtils::GetNumThreads();
+
+			std::size_t block_size_in_bytes = 5; // the aligned block size is 8
+			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
+			std::size_t chunk_size_in_bytes = header_size + 5;
+
+			auto repeat_number = 10;
+			#pragma omp parallel for
+			for (auto i_repeat = 0; i_repeat < repeat_number; i_repeat++)
+			{
+				Chunk too_small_chunk(block_size_in_bytes, chunk_size_in_bytes);
+				too_small_chunk.Initialize();
+
+				KRATOS_CHECK_EQUAL(too_small_chunk.GetNumberOfAvailableBlocks(), 0) << " Available block :" << too_small_chunk.GetNumberOfAvailableBlocks();
+			}
+		}
+
 		KRATOS_TEST_CASE_IN_SUITE(ChunkAllocateDeallocate, KratosCoreFastSuite)
 		{
 			int max_threads = OpenMPUtils::GetNumThreads();
@@ -86,11 +127,12 @@ namespace Kratos {
 			int max_threads = OpenMPUtils::GetNumThreads();
 			std::size_t block_size_in_bytes = 5;
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
-		  std::size_t chunk_size_in_bytes =  header_size + 1024;
+		  	std::size_t chunk_size_in_bytes =  header_size + 1024;
 
 			auto repeat_number = 10;
 			std::stringstream buffer;
-#pragma omp parallel for
+			
+			#pragma omp parallel for
 			for (auto i_repeat = 0; i_repeat < repeat_number; i_repeat++)
 			{
 				try {
@@ -126,14 +168,14 @@ namespace Kratos {
 			int max_threads = OpenMPUtils::GetNumThreads();
 			std::size_t block_size_in_bytes = 5;
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
-		  std::size_t chunk_size_in_bytes =  header_size + 1024;
+		  	std::size_t chunk_size_in_bytes =  header_size + 1024;
 
 		  	// KRATOS_ERROR << max_threads << " -- " << OpenMPUtils::GetNumThreads() << std::endl;
 
 			auto repeat_number = 100;
 			std::stringstream buffer;
 
-#pragma omp parallel for
+			#pragma omp parallel for
 			for (auto i_repeat = 0; i_repeat < repeat_number; i_repeat++)
 			{
 				try {

--- a/kratos/tests/cpp_tests/sources/test_chunk.cpp
+++ b/kratos/tests/cpp_tests/sources/test_chunk.cpp
@@ -28,7 +28,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(ChunkInitialize, KratosCoreFastSuite)
 		{
-			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
+			int max_threads = OpenMPUtils::GetNumThreads();
 
 			std::size_t block_size_in_bytes = 5; // the aligned block size is 8
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
@@ -48,7 +48,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(ChunkAllocateDeallocate, KratosCoreFastSuite)
 		{
-			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
+			int max_threads = OpenMPUtils::GetNumThreads();
 			std::size_t block_size_in_bytes = 5;
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
 		  std::size_t chunk_size_in_bytes =  header_size + 1024;
@@ -73,7 +73,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(ChunkParallelAllocate, KratosCoreFastSuite)
 		{
-			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
+			int max_threads = OpenMPUtils::GetNumThreads();
 			std::size_t block_size_in_bytes = 5;
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
 		  std::size_t chunk_size_in_bytes =  header_size + 1024;
@@ -113,10 +113,12 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(ChunkParallelAllocateDeallocate, EXCLUDED_KratosCoreFastSuite)
 		{
-			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
+			int max_threads = OpenMPUtils::GetNumThreads();
 			std::size_t block_size_in_bytes = 5;
 			std::size_t header_size = 2 * max_threads * sizeof(Chunk::SizeType);
 		  std::size_t chunk_size_in_bytes =  header_size + 1024;
+
+		  	// KRATOS_ERROR << max_threads << " -- " << OpenMPUtils::GetNumThreads() << std::endl;
 
 			auto repeat_number = 100;
 			std::stringstream buffer;

--- a/kratos/tests/cpp_tests/sources/test_memory_pool.cpp
+++ b/kratos/tests/cpp_tests/sources/test_memory_pool.cpp
@@ -26,7 +26,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(FixedSizeMemoryPoolConstruction, KratosCoreFastSuite)
 		{
-			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
+			int max_threads = OpenMPUtils::GetNumThreads();
 			std::size_t block_size = 5;
 			std::size_t default_chunk_size = 1024 * 1024; // 1M
 			FixedSizeMemoryPool fixed_size_memory_pool(block_size);
@@ -38,7 +38,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(FixedSizeMemoryPoolAllocationDeallocation, KratosCoreFastSuite)
 		{
-			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
+			int max_threads = OpenMPUtils::GetNumThreads();
 			std::size_t block_size = 15;
 			std::size_t default_chunk_size = 1024 * 1024; // 1M
 			std::size_t number_of_blocks = (default_chunk_size - 2 * max_threads * sizeof(Chunk::SizeType)) / 16;
@@ -69,7 +69,7 @@ namespace Kratos {
 
 		//KRATOS_TEST_CASE_IN_SUITE(FixedSizeMemoryPoolStressTest, KratosCoreStressSuite)
 		//{
-		//	int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
+		//	int max_threads = OpenMPUtils::GetNumThreads();
 		//	std::size_t block_size = 64;
 		//	std::size_t default_chunk_size = 1024 * 1024;// 1M
 		//	std::size_t number_of_blocks = (default_chunk_size - 2 * max_threads * sizeof(Chunk::SizeType)) / 64;

--- a/kratos/tests/cpp_tests/sources/test_memory_pool.cpp
+++ b/kratos/tests/cpp_tests/sources/test_memory_pool.cpp
@@ -26,7 +26,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(FixedSizeMemoryPoolConstruction, KratosCoreFastSuite)
 		{
-			int max_threads = OpenMPUtils::GetNumThreads();
+			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
 			std::size_t block_size = 5;
 			std::size_t default_chunk_size = 1024 * 1024; // 1M
 			FixedSizeMemoryPool fixed_size_memory_pool(block_size);
@@ -38,7 +38,7 @@ namespace Kratos {
 
 		KRATOS_TEST_CASE_IN_SUITE(FixedSizeMemoryPoolAllocationDeallocation, KratosCoreFastSuite)
 		{
-			int max_threads = OpenMPUtils::GetNumThreads();
+			int max_threads = OpenMPUtils::GetCurrentNumberOfThreads();
 			std::size_t block_size = 15;
 			std::size_t default_chunk_size = 1024 * 1024; // 1M
 			std::size_t number_of_blocks = (default_chunk_size - 2 * max_threads * sizeof(Chunk::SizeType)) / 16;


### PR DESCRIPTION
**Description**
Fixes chunk tests.

Probably the confusion was because `LockObject::GetNumberOfThreads` is translated to `OpenMPUtils::GetNumThreads` instead of `OpenMPUtils::GetCurrentNumberOfThreads` which was causing that `max_threads` in the tests to be evaluated always to 1.

I've also extended the chunk tests so it checks initialization both for the single thread case and with OpenMp. This should give a hint on what the value of max_threads should be if it happens again.

@RezaNajian could you confirm you no longer get the error? I've tried up to 128 and seems to be ok.

@pooyan-dadvand I suspect something similar could happen to the memory pool tests (the disabled one to be precise), but I do not fully understand them, maybe its worth to take a look.

Fixes #7743

**Changelog**
- Fix chunk tests.
